### PR TITLE
Sync Tempo Config with Compose File

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -74,7 +74,7 @@ services:
       - "4317:4317"
     volumes:
       - "./compose/tempo/tempo.yaml:/etc/tempo.yaml:ro"
-      - "tempo-data:/var/db/tempo:rw"
+      - "tempo-data:/var/tempo:rw"
 
 volumes:
   postgres-data:

--- a/compose/tempo/tempo.yaml
+++ b/compose/tempo/tempo.yaml
@@ -24,13 +24,13 @@ storage:
   trace:
     backend: "local"
     local:
-      path: "/var/db/tempo"
+      path: "/var/tempo/blocks"
     block:
       bloom_filter_false_positive: .05
       v2_index_downsample_bytes: 1000
       v2_encoding: "zstd"
     wal:
-      path: "/var/db/tempo/wal"
+      path: "/var/tempo/wal"
       v2_encoding: "snappy"
     pool:
       max_workers: 100


### PR DESCRIPTION
While there are definitely other solutions, the selected solution copies the `tempo` source:
https://github.com/grafana/tempo/tree/main/example/docker-compose/local

The paths in the compose file and the tempo config have been aligned.
