### PR TITLE
Move evidence to measure level

### DIFF
--- a/apps/console/src/pages/organizations/measures/MeasureView.tsx.bak
+++ b/apps/console/src/pages/organizations/measures/MeasureView.tsx.bak
@@ -1434,15 +1434,9 @@ function MeasureViewContent({
   const confirmDeleteEvidence = () => {
     if (!evidenceToDelete) return;
 
-    let evidenceConnectionId;
-    
-    // If taskId is empty, it's a measure-level evidence
-    if (!evidenceToDelete.taskId) {
-      evidenceConnectionId = getMeasureEvidenceConnectionId();
-    } else {
-      // Otherwise it's a task-level evidence
-      evidenceConnectionId = getEvidenceConnectionId(evidenceToDelete.taskId);
-    }
+    const evidenceConnectionId = getEvidenceConnectionId(
+      evidenceToDelete.taskId
+    );
 
     deleteEvidence({
       variables: {
@@ -1454,10 +1448,6 @@ function MeasureViewContent({
       onCompleted: () => {
         setIsDeleteEvidenceOpen(false);
         setEvidenceToDelete(null);
-        toast({
-          title: "Evidence deleted",
-          description: "Evidence has been deleted successfully.",
-        });
       },
       onError: (error) => {
         toast({
@@ -2020,6 +2010,7 @@ function MeasureViewContent({
   return (
     <PageTemplate
       title={data.measure?.name || "Measure"}
+      description={data.measure?.description}
       actions={
         <div className="flex gap-2">
           <Button
@@ -2438,306 +2429,9 @@ function MeasureViewContent({
             <TabsContent value="link" className="space-y-4 pt-4">
               <div className="space-y-4">
                 <div className="grid w-full items-center gap-1.5">
-                  <Label htmlFor="evidence-url">URL</Label>
+                  <Label htmlFor="evidence-name">Name</Label>
                   <Input
-                    id="evidence-url"
-                    value={linkEvidenceUrl}
-                    onChange={(e) => setLinkEvidenceUrl(e.target.value)}
-                    placeholder="https://example.com"
-                    type="url"
-                  />
-                </div>
-
-                <div className="grid w-full items-center gap-1.5">
-                  <Label htmlFor="evidence-description">
-                    Description (optional)
-                  </Label>
-                  <Textarea
-                    id="evidence-description"
-                    value={linkEvidenceDescription}
-                    onChange={(e) => setLinkEvidenceDescription(e.target.value)}
-                    placeholder="Describe this evidence (optional)"
-                    className="min-h-[100px]"
-                  />
-                </div>
-              </div>
-            </TabsContent>
-          </Tabs>
-
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setEvidenceDialogOpen(false)}
-            >
-              Cancel
-            </Button>
-            {activeTab === "link" && (
-              <Button onClick={handleLinkEvidenceSubmit}>Add Link</Button>
-            )}
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      {/* Hidden file input for direct uploads */}
-      <input
-        type="file"
-        ref={hiddenFileInputRef}
-        onChange={handleFileSelected}
-        style={{ display: "none" }}
-        accept="image/*,.pdf,.doc,.docx,.xls,.xlsx,.txt"
-      />
-
-      {/* Delete Task Confirmation Dialog */}
-      <Dialog open={isDeleteTaskOpen} onOpenChange={setIsDeleteTaskOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Delete Task</DialogTitle>
-            <DialogDescription>
-              Are you sure you want to delete the task &quot;
-              {taskToDelete?.name}&quot;? This action cannot be undone.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setIsDeleteTaskOpen(false)}
-            >
-              Cancel
-            </Button>
-            <Button variant="destructive" onClick={confirmDeleteTask}>
-              Delete
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      {/* Add the Preview Modal */}
-      <Dialog open={isPreviewModalOpen} onOpenChange={setIsPreviewModalOpen}>
-        <DialogContent className="sm:max-w-4xl">
-          <DialogHeader>
-            <DialogTitle className="flex items-center justify-between">
-              <span>{previewEvidence?.filename}</span>
-            </DialogTitle>
-            <DialogDescription>
-              Preview of the evidence file. You can view or download the file
-              from here.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="flex flex-col items-center justify-center min-h-[300px] bg-invert-bg rounded-md p-4">
-            {isLoadingFileUrl ? (
-              <div className="flex flex-col items-center gap-2">
-                <Loader2 className="w-8 h-8 animate-spin text-blue-500" />
-                <p className="text-secondary">Loading preview...</p>
-              </div>
-            ) : previewEvidence?.fileUrl ? (
-              previewEvidence.mimeType.startsWith("image/") ? (
-                <img
-                  src={previewEvidence.fileUrl}
-                  alt={previewEvidence.filename}
-                  className="max-h-[70vh] object-contain"
-                />
-              ) : previewEvidence.mimeType.includes("pdf") ? (
-                <iframe
-                  src={previewEvidence.fileUrl}
-                  className="w-full h-[70vh]"
-                  title={previewEvidence.filename}
-                />
-              ) : (
-                <div className="flex flex-col items-center gap-4">
-                  <FileGeneric className="w-16 h-16 text-tertiary" />
-                  <p className="text-secondary">
-                    Preview not available for this file type
-                  </p>
-                  <Button
-                    onClick={() => {
-                      if (previewEvidence?.fileUrl) {
-                        window.open(previewEvidence.fileUrl, "_blank");
-                      }
-                    }}
-                  >
-                    Download File
-                  </Button>
-                </div>
-              )
-            ) : (
-              <div className="flex flex-col items-center gap-2">
-                <FileGeneric className="w-12 h-12 text-tertiary" />
-                <p className="text-secondary">Failed to load preview</p>
-              </div>
-            )}
-          </div>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setIsPreviewModalOpen(false)}
-            >
-              Close
-            </Button>
-            {previewEvidence?.fileUrl && (
-              <Button
-                onClick={() => {
-                  if (previewEvidence?.fileUrl) {
-                    window.open(previewEvidence.fileUrl, "_blank");
-                  }
-                }}
-              >
-                Download
-              </Button>
-            )}
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      {/* Add Delete Evidence Confirmation Dialog */}
-      <Dialog
-        open={isDeleteEvidenceOpen}
-        onOpenChange={setIsDeleteEvidenceOpen}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Delete Evidence</DialogTitle>
-            <DialogDescription>
-              Are you sure you want to delete the evidence &quot;
-              {evidenceToDelete?.filename}&quot;? This action cannot be undone.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setIsDeleteEvidenceOpen(false)}
-            >
-              Cancel
-            </Button>
-            <Button variant="destructive" onClick={confirmDeleteEvidence}>
-              Delete
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      {/* Fulfill Evidence Dialog */}
-      <Dialog
-        open={fulfillEvidenceDialogOpen}
-        onOpenChange={setFulfillEvidenceDialogOpen}
-      >
-        <DialogContent className="sm:max-w-[525px]">
-          <DialogHeader>
-            <DialogTitle>Fulfill Evidence</DialogTitle>
-            <DialogDescription>
-              Provide the requested evidence: {evidenceToFulfill?.filename}
-            </DialogDescription>
-          </DialogHeader>
-
-          <Tabs
-            value={activeTab}
-            onValueChange={(value: string) =>
-              setActiveTab(value as "file" | "link")
-            }
-          >
-            <TabsList className="grid w-full grid-cols-2">
-              <TabsTrigger value="file">Document</TabsTrigger>
-              <TabsTrigger value="link">Link</TabsTrigger>
-            </TabsList>
-
-            <TabsContent value="file" className="space-y-4">
-              <div className="space-y-4 pt-4">
-                <p>Upload a document to fulfill this evidence request.</p>
-                <Button
-                  onClick={() => {
-                    if (hiddenFileInputRef.current) {
-                      // Set a temp onchange handler for the file input
-                      const originalOnChange =
-                        hiddenFileInputRef.current.onchange;
-                      hiddenFileInputRef.current.onchange = (e) => {
-                        hiddenFileInputRef.current!.onchange = originalOnChange;
-                        handleFulfillEvidenceWithFile({
-                          target: {
-                            files: (e.target as HTMLInputElement)?.files,
-                          },
-                        } as React.ChangeEvent<HTMLInputElement>);
-                      };
-                      hiddenFileInputRef.current.click();
-                      setFulfillEvidenceDialogOpen(false);
-                    }
-                  }}
-                  className="w-full"
-                >
-                  Select Document
-                </Button>
-              </div>
-            </TabsContent>
-
-            <TabsContent value="link" className="space-y-4 pt-4">
-              <div className="space-y-4">
-                <div className="grid w-full items-center gap-1.5">
-                  <Label htmlFor="evidence-url">URL</Label>
-                  <Input
-                    id="evidence-url"
-                    value={linkEvidenceUrl}
-                    onChange={(e) => setLinkEvidenceUrl(e.target.value)}
-                    placeholder="https://example.com"
-                    type="url"
-                  />
-                </div>
-
-                <div className="grid w-full items-center gap-1.5">
-                  <Label htmlFor="evidence-description">
-                    Description (optional)
-                  </Label>
-                  <Textarea
-                    id="evidence-description"
-                    value={linkEvidenceDescription}
-                    onChange={(e) => setLinkEvidenceDescription(e.target.value)}
-                    placeholder="Describe this evidence (optional)"
-                    className="min-h-[100px]"
-                  />
-                </div>
-              </div>
-            </TabsContent>
-          </Tabs>
-
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setFulfillEvidenceDialogOpen(false)}
-            >
-              Cancel
-            </Button>
-            {activeTab === "link" && (
-              <Button onClick={handleFulfillEvidenceWithLink}>
-                Submit Link
-              </Button>
-            )}
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      {/* Delete Measure Confirmation Dialog */}
-      <Dialog open={isDeleteMeasureOpen} onOpenChange={setIsDeleteMeasureOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Delete Measure</DialogTitle>
-            <DialogDescription>
-              Are you sure you want to delete this measure? This action cannot be undone.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setIsDeleteMeasureOpen(false)}
-            >
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={confirmDeleteMeasure}
-              disabled={isDeletingMeasure}
-            >
-              {isDeletingMeasure ? "Deleting..." : "Delete"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+                    id="evidence-name"
     </PageTemplate>
   );
 }

--- a/apps/console/src/pages/organizations/measures/__generated__/MeasureViewQuery.graphql.ts
+++ b/apps/console/src/pages/organizations/measures/__generated__/MeasureViewQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<63dbc912431a9ea23a2ce515ba95af86>>
+ * @generated SignedSource<<03d8e2eca1cc7ffaf797c66ef7fa11c1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -20,6 +20,22 @@ export type MeasureViewQuery$data = {
   readonly measure: {
     readonly category?: string;
     readonly description?: string;
+    readonly evidences?: {
+      readonly __id: string;
+      readonly edges: ReadonlyArray<{
+        readonly node: {
+          readonly createdAt: string;
+          readonly description: string;
+          readonly filename: string;
+          readonly id: string;
+          readonly mimeType: string;
+          readonly size: number;
+          readonly state: EvidenceState;
+          readonly type: EvidenceType;
+          readonly url: string | null | undefined;
+        };
+      }>;
+    };
     readonly id: string;
     readonly name?: string;
     readonly state?: MeasureState;
@@ -117,50 +133,17 @@ v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "timeEstimate",
-  "storageKey": null
-},
-v8 = {
-  "alias": null,
-  "args": null,
-  "concreteType": "People",
-  "kind": "LinkedField",
-  "name": "assignedTo",
-  "plural": false,
-  "selections": [
-    (v2/*: any*/),
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "fullName",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "primaryEmailAddress",
-      "storageKey": null
-    }
-  ],
-  "storageKey": null
-},
-v9 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v10 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v11 = {
+v9 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -185,7 +168,7 @@ v11 = {
   ],
   "storageKey": null
 },
-v12 = {
+v10 = {
   "kind": "ClientExtension",
   "selections": [
     {
@@ -197,7 +180,7 @@ v12 = {
     }
   ]
 },
-v13 = [
+v11 = [
   {
     "alias": null,
     "args": null,
@@ -259,17 +242,50 @@ v13 = [
             "storageKey": null
           },
           (v4/*: any*/),
-          (v9/*: any*/)
+          (v7/*: any*/)
         ],
         "storageKey": null
       },
-      (v10/*: any*/)
+      (v8/*: any*/)
     ],
     "storageKey": null
   },
-  (v11/*: any*/),
-  (v12/*: any*/)
+  (v9/*: any*/),
+  (v10/*: any*/)
 ],
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "timeEstimate",
+  "storageKey": null
+},
+v13 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "People",
+  "kind": "LinkedField",
+  "name": "assignedTo",
+  "plural": false,
+  "selections": [
+    (v2/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "fullName",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "primaryEmailAddress",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
 v14 = [
   {
     "kind": "Literal",
@@ -308,6 +324,16 @@ return {
               (v5/*: any*/),
               (v6/*: any*/),
               {
+                "alias": "evidences",
+                "args": null,
+                "concreteType": "EvidenceConnection",
+                "kind": "LinkedField",
+                "name": "__MeasureView_evidences_connection",
+                "plural": false,
+                "selections": (v11/*: any*/),
+                "storageKey": null
+              },
+              {
                 "alias": "tasks",
                 "args": null,
                 "concreteType": "TaskConnection",
@@ -335,28 +361,28 @@ return {
                           (v3/*: any*/),
                           (v4/*: any*/),
                           (v5/*: any*/),
-                          (v7/*: any*/),
-                          (v8/*: any*/),
+                          (v12/*: any*/),
+                          (v13/*: any*/),
                           {
                             "alias": "evidences",
                             "args": null,
                             "concreteType": "EvidenceConnection",
                             "kind": "LinkedField",
-                            "name": "__MeasureView_evidences_connection",
+                            "name": "__MeasureView_task_evidences_connection",
                             "plural": false,
-                            "selections": (v13/*: any*/),
+                            "selections": (v11/*: any*/),
                             "storageKey": null
                           },
-                          (v9/*: any*/)
+                          (v7/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v10/*: any*/)
+                      (v8/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v11/*: any*/),
-                  (v12/*: any*/)
+                  (v9/*: any*/),
+                  (v10/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -385,7 +411,7 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v9/*: any*/),
+          (v7/*: any*/),
           (v2/*: any*/),
           {
             "kind": "InlineFragment",
@@ -394,6 +420,25 @@ return {
               (v4/*: any*/),
               (v5/*: any*/),
               (v6/*: any*/),
+              {
+                "alias": null,
+                "args": (v14/*: any*/),
+                "concreteType": "EvidenceConnection",
+                "kind": "LinkedField",
+                "name": "evidences",
+                "plural": false,
+                "selections": (v11/*: any*/),
+                "storageKey": "evidences(first:100)"
+              },
+              {
+                "alias": null,
+                "args": (v14/*: any*/),
+                "filters": null,
+                "handle": "connection",
+                "key": "MeasureView_evidences",
+                "kind": "LinkedHandle",
+                "name": "evidences"
+              },
               {
                 "alias": null,
                 "args": (v14/*: any*/),
@@ -422,8 +467,8 @@ return {
                           (v3/*: any*/),
                           (v4/*: any*/),
                           (v5/*: any*/),
-                          (v7/*: any*/),
-                          (v8/*: any*/),
+                          (v12/*: any*/),
+                          (v13/*: any*/),
                           {
                             "alias": null,
                             "args": (v15/*: any*/),
@@ -431,7 +476,7 @@ return {
                             "kind": "LinkedField",
                             "name": "evidences",
                             "plural": false,
-                            "selections": (v13/*: any*/),
+                            "selections": (v11/*: any*/),
                             "storageKey": "evidences(first:50)"
                           },
                           {
@@ -439,20 +484,20 @@ return {
                             "args": (v15/*: any*/),
                             "filters": null,
                             "handle": "connection",
-                            "key": "MeasureView_evidences",
+                            "key": "MeasureView_task_evidences",
                             "kind": "LinkedHandle",
                             "name": "evidences"
                           },
-                          (v9/*: any*/)
+                          (v7/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v10/*: any*/)
+                      (v8/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v11/*: any*/),
-                  (v12/*: any*/)
+                  (v9/*: any*/),
+                  (v10/*: any*/)
                 ],
                 "storageKey": "tasks(first:100)"
               },
@@ -475,10 +520,19 @@ return {
     ]
   },
   "params": {
-    "cacheID": "9c4b0f0032102448259ea5deb2b9d57a",
+    "cacheID": "d3e4d9723d12bce8158b83eb76d05a90",
     "id": null,
     "metadata": {
       "connection": [
+        {
+          "count": null,
+          "cursor": null,
+          "direction": "forward",
+          "path": [
+            "measure",
+            "evidences"
+          ]
+        },
         {
           "count": null,
           "cursor": null,
@@ -498,11 +552,11 @@ return {
     },
     "name": "MeasureViewQuery",
     "operationKind": "query",
-    "text": "query MeasureViewQuery(\n  $measureId: ID!\n) {\n  measure: node(id: $measureId) {\n    __typename\n    id\n    ... on Measure {\n      name\n      description\n      state\n      category\n      tasks(first: 100) {\n        edges {\n          node {\n            id\n            name\n            description\n            state\n            timeEstimate\n            assignedTo {\n              id\n              fullName\n              primaryEmailAddress\n            }\n            evidences(first: 50) {\n              edges {\n                node {\n                  id\n                  mimeType\n                  filename\n                  size\n                  state\n                  type\n                  url\n                  createdAt\n                  description\n                  __typename\n                }\n                cursor\n              }\n              pageInfo {\n                endCursor\n                hasNextPage\n              }\n            }\n            __typename\n          }\n          cursor\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query MeasureViewQuery(\n  $measureId: ID!\n) {\n  measure: node(id: $measureId) {\n    __typename\n    id\n    ... on Measure {\n      name\n      description\n      state\n      category\n      evidences(first: 100) {\n        edges {\n          node {\n            id\n            mimeType\n            filename\n            size\n            state\n            type\n            url\n            createdAt\n            description\n            __typename\n          }\n          cursor\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n      tasks(first: 100) {\n        edges {\n          node {\n            id\n            name\n            description\n            state\n            timeEstimate\n            assignedTo {\n              id\n              fullName\n              primaryEmailAddress\n            }\n            evidences(first: 50) {\n              edges {\n                node {\n                  id\n                  mimeType\n                  filename\n                  size\n                  state\n                  type\n                  url\n                  createdAt\n                  description\n                  __typename\n                }\n                cursor\n              }\n              pageInfo {\n                endCursor\n                hasNextPage\n              }\n            }\n            __typename\n          }\n          cursor\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "0de1c02cbaf76feae0ecdbd93f530fa7";
+(node as any).hash = "288412cccb1f4c14b1852504e5536af1";
 
 export default node;

--- a/apps/console/src/pages/organizations/measures/__generated__/MeasureViewRequestEvidenceMutation.graphql.ts
+++ b/apps/console/src/pages/organizations/measures/__generated__/MeasureViewRequestEvidenceMutation.graphql.ts
@@ -1,0 +1,235 @@
+/**
+ * @generated SignedSource<<2f767da45cb75ea7cc61932efa7bf802>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type EvidenceState = "FULFILLED" | "REQUESTED";
+export type EvidenceType = "FILE" | "LINK";
+export type RequestEvidenceInput = {
+  description: string;
+  name: string;
+  taskId: string;
+  type: EvidenceType;
+};
+export type MeasureViewRequestEvidenceMutation$variables = {
+  connections: ReadonlyArray<string>;
+  input: RequestEvidenceInput;
+};
+export type MeasureViewRequestEvidenceMutation$data = {
+  readonly requestEvidence: {
+    readonly evidenceEdge: {
+      readonly node: {
+        readonly createdAt: string;
+        readonly description: string;
+        readonly fileUrl: string | null | undefined;
+        readonly filename: string;
+        readonly id: string;
+        readonly mimeType: string;
+        readonly size: number;
+        readonly state: EvidenceState;
+        readonly type: EvidenceType;
+        readonly url: string | null | undefined;
+      };
+    };
+  };
+};
+export type MeasureViewRequestEvidenceMutation = {
+  response: MeasureViewRequestEvidenceMutation$data;
+  variables: MeasureViewRequestEvidenceMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "EvidenceEdge",
+  "kind": "LinkedField",
+  "name": "evidenceEdge",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Evidence",
+      "kind": "LinkedField",
+      "name": "node",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "id",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "filename",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "fileUrl",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "mimeType",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "type",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "url",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "size",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "state",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "createdAt",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "description",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "MeasureViewRequestEvidenceMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "RequestEvidencePayload",
+        "kind": "LinkedField",
+        "name": "requestEvidence",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "MeasureViewRequestEvidenceMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "RequestEvidencePayload",
+        "kind": "LinkedField",
+        "name": "requestEvidence",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "appendEdge",
+            "key": "",
+            "kind": "LinkedHandle",
+            "name": "evidenceEdge",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "69f2291555b3826b1b29fea6d2380e04",
+    "id": null,
+    "metadata": {},
+    "name": "MeasureViewRequestEvidenceMutation",
+    "operationKind": "mutation",
+    "text": "mutation MeasureViewRequestEvidenceMutation(\n  $input: RequestEvidenceInput!\n) {\n  requestEvidence(input: $input) {\n    evidenceEdge {\n      node {\n        id\n        filename\n        fileUrl\n        mimeType\n        type\n        url\n        size\n        state\n        createdAt\n        description\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "7921deec93c923a9cd14969dad6ecfd7";
+
+export default node;

--- a/apps/console/src/pages/organizations/measures/__generated__/MeasureViewUploadMeasureEvidenceMutation.graphql.ts
+++ b/apps/console/src/pages/organizations/measures/__generated__/MeasureViewUploadMeasureEvidenceMutation.graphql.ts
@@ -1,0 +1,233 @@
+/**
+ * @generated SignedSource<<97ff04190e08df7c9b3288e067787348>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type EvidenceState = "FULFILLED" | "REQUESTED";
+export type EvidenceType = "FILE" | "LINK";
+export type UploadMeasureEvidenceInput = {
+  file: any;
+  measureId: string;
+};
+export type MeasureViewUploadMeasureEvidenceMutation$variables = {
+  connections: ReadonlyArray<string>;
+  input: UploadMeasureEvidenceInput;
+};
+export type MeasureViewUploadMeasureEvidenceMutation$data = {
+  readonly uploadMeasureEvidence: {
+    readonly evidenceEdge: {
+      readonly node: {
+        readonly createdAt: string;
+        readonly description: string;
+        readonly fileUrl: string | null | undefined;
+        readonly filename: string;
+        readonly id: string;
+        readonly mimeType: string;
+        readonly size: number;
+        readonly state: EvidenceState;
+        readonly type: EvidenceType;
+        readonly url: string | null | undefined;
+      };
+    };
+  };
+};
+export type MeasureViewUploadMeasureEvidenceMutation = {
+  response: MeasureViewUploadMeasureEvidenceMutation$data;
+  variables: MeasureViewUploadMeasureEvidenceMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "EvidenceEdge",
+  "kind": "LinkedField",
+  "name": "evidenceEdge",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Evidence",
+      "kind": "LinkedField",
+      "name": "node",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "id",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "filename",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "fileUrl",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "mimeType",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "type",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "url",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "size",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "state",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "createdAt",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "description",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "MeasureViewUploadMeasureEvidenceMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "UploadMeasureEvidencePayload",
+        "kind": "LinkedField",
+        "name": "uploadMeasureEvidence",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "MeasureViewUploadMeasureEvidenceMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "UploadMeasureEvidencePayload",
+        "kind": "LinkedField",
+        "name": "uploadMeasureEvidence",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "appendEdge",
+            "key": "",
+            "kind": "LinkedHandle",
+            "name": "evidenceEdge",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "2f033ec4a33f6d9c980702630822c8ca",
+    "id": null,
+    "metadata": {},
+    "name": "MeasureViewUploadMeasureEvidenceMutation",
+    "operationKind": "mutation",
+    "text": "mutation MeasureViewUploadMeasureEvidenceMutation(\n  $input: UploadMeasureEvidenceInput!\n) {\n  uploadMeasureEvidence(input: $input) {\n    evidenceEdge {\n      node {\n        id\n        filename\n        fileUrl\n        mimeType\n        type\n        url\n        size\n        state\n        createdAt\n        description\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "af05defd4ec39b5d3f17aebce2a84c65";
+
+export default node;

--- a/apps/console/src/pages/organizations/measures/__generated__/MeasureViewUploadTaskEvidenceMutation.graphql.ts
+++ b/apps/console/src/pages/organizations/measures/__generated__/MeasureViewUploadTaskEvidenceMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e5042f900955d846dd86ad6b78d60518>>
+ * @generated SignedSource<<4539152ef13af3aca3a79891c5b81a79>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,20 +11,16 @@
 import { ConcreteRequest } from 'relay-runtime';
 export type EvidenceState = "FULFILLED" | "REQUESTED";
 export type EvidenceType = "FILE" | "LINK";
-export type CreateEvidenceInput = {
-  description: string;
-  file?: any | null | undefined;
-  name: string;
+export type UploadTaskEvidenceInput = {
+  file: any;
   taskId: string;
-  type: EvidenceType;
-  url?: string | null | undefined;
 };
-export type MeasureViewCreateEvidenceMutation$variables = {
+export type MeasureViewUploadTaskEvidenceMutation$variables = {
   connections: ReadonlyArray<string>;
-  input: CreateEvidenceInput;
+  input: UploadTaskEvidenceInput;
 };
-export type MeasureViewCreateEvidenceMutation$data = {
-  readonly createEvidence: {
+export type MeasureViewUploadTaskEvidenceMutation$data = {
+  readonly uploadTaskEvidence: {
     readonly evidenceEdge: {
       readonly node: {
         readonly createdAt: string;
@@ -41,9 +37,9 @@ export type MeasureViewCreateEvidenceMutation$data = {
     };
   };
 };
-export type MeasureViewCreateEvidenceMutation = {
-  response: MeasureViewCreateEvidenceMutation$data;
-  variables: MeasureViewCreateEvidenceMutation$variables;
+export type MeasureViewUploadTaskEvidenceMutation = {
+  response: MeasureViewUploadTaskEvidenceMutation$data;
+  variables: MeasureViewUploadTaskEvidenceMutation$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -164,14 +160,14 @@ return {
     ],
     "kind": "Fragment",
     "metadata": null,
-    "name": "MeasureViewCreateEvidenceMutation",
+    "name": "MeasureViewUploadTaskEvidenceMutation",
     "selections": [
       {
         "alias": null,
         "args": (v2/*: any*/),
-        "concreteType": "CreateEvidencePayload",
+        "concreteType": "UploadTaskEvidencePayload",
         "kind": "LinkedField",
-        "name": "createEvidence",
+        "name": "uploadTaskEvidence",
         "plural": false,
         "selections": [
           (v3/*: any*/)
@@ -189,14 +185,14 @@ return {
       (v0/*: any*/)
     ],
     "kind": "Operation",
-    "name": "MeasureViewCreateEvidenceMutation",
+    "name": "MeasureViewUploadTaskEvidenceMutation",
     "selections": [
       {
         "alias": null,
         "args": (v2/*: any*/),
-        "concreteType": "CreateEvidencePayload",
+        "concreteType": "UploadTaskEvidencePayload",
         "kind": "LinkedField",
-        "name": "createEvidence",
+        "name": "uploadTaskEvidence",
         "plural": false,
         "selections": [
           (v3/*: any*/),
@@ -222,16 +218,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "25b9947aa09d7b4c60886f149b06cc6e",
+    "cacheID": "2c18eec6e7e3d428ad6fbdf4c52ccf94",
     "id": null,
     "metadata": {},
-    "name": "MeasureViewCreateEvidenceMutation",
+    "name": "MeasureViewUploadTaskEvidenceMutation",
     "operationKind": "mutation",
-    "text": "mutation MeasureViewCreateEvidenceMutation(\n  $input: CreateEvidenceInput!\n) {\n  createEvidence(input: $input) {\n    evidenceEdge {\n      node {\n        id\n        filename\n        fileUrl\n        mimeType\n        type\n        url\n        size\n        state\n        createdAt\n        description\n      }\n    }\n  }\n}\n"
+    "text": "mutation MeasureViewUploadTaskEvidenceMutation(\n  $input: UploadTaskEvidenceInput!\n) {\n  uploadTaskEvidence(input: $input) {\n    evidenceEdge {\n      node {\n        id\n        filename\n        fileUrl\n        mimeType\n        type\n        url\n        size\n        state\n        createdAt\n        description\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "bc59ec67230776eeb60a389a8360b0af";
+(node as any).hash = "3649fc872c9f58d4ffd0181b0316c812";
 
 export default node;

--- a/pkg/coredata/migrations/20250503T142200Z.sql
+++ b/pkg/coredata/migrations/20250503T142200Z.sql
@@ -1,0 +1,9 @@
+ALTER TABLE evidences ALTER COLUMN task_id DROP NOT NULL;
+ALTER TABLE evidences ADD COLUMN measure_id TEXT REFERENCES measures(id);
+
+UPDATE evidences e
+SET measure_id = t.measure_id
+FROM tasks t
+WHERE e.task_id = t.id AND e.measure_id IS NULL;
+
+ALTER TABLE evidences ALTER COLUMN measure_id SET NOT NULL;

--- a/pkg/probo/mesure_service.go
+++ b/pkg/probo/mesure_service.go
@@ -188,7 +188,7 @@ func (s MeasureService) Import(
 						evidence := &coredata.Evidence{
 							State:       coredata.EvidenceStateRequested,
 							ID:          evidenceID,
-							TaskID:      task.ID,
+							TaskID:      &task.ID,
 							ReferenceID: req.Measures[i].Tasks[j].RequestedEvidences[k].ReferenceID,
 							Type:        req.Measures[i].Tasks[j].RequestedEvidences[k].Type,
 							Description: req.Measures[i].Tasks[j].RequestedEvidences[k].Name,

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -596,6 +596,14 @@ type Measure implements Node {
   description: String!
   state: MeasureState!
 
+  evidences(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+    orderBy: EvidenceOrder
+  ): EvidenceConnection! @goField(forceResolver: true)
+
   tasks(
     first: Int
     after: CursorKey
@@ -987,8 +995,9 @@ type Mutation {
   # Evidence mutations
   requestEvidence(input: RequestEvidenceInput!): RequestEvidencePayload!
   fulfillEvidence(input: FulfillEvidenceInput!): FulfillEvidencePayload!
-  createEvidence(input: CreateEvidenceInput!): CreateEvidencePayload!
   deleteEvidence(input: DeleteEvidenceInput!): DeleteEvidencePayload!
+  uploadTaskEvidence(input: UploadTaskEvidenceInput!): UploadTaskEvidencePayload!
+  uploadMeasureEvidence(input: UploadMeasureEvidenceInput!): UploadMeasureEvidencePayload!
 
   # Vendor Compliance Report mutations
   uploadVendorComplianceReport(
@@ -1651,4 +1660,22 @@ input SendSigningNotificationsInput {
 
 type SendSigningNotificationsPayload {
   success: Boolean!
+}
+
+type UploadTaskEvidencePayload {
+  evidenceEdge: EvidenceEdge!
+}
+
+type UploadMeasureEvidencePayload {
+  evidenceEdge: EvidenceEdge!
+}
+
+input UploadTaskEvidenceInput {
+  taskId: ID!
+  file: Upload!
+}
+
+input UploadMeasureEvidenceInput {
+  measureId: ID!
+  file: Upload!
 }

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -473,6 +473,7 @@ type Measure struct {
 	Name        string                `json:"name"`
 	Description string                `json:"description"`
 	State       coredata.MeasureState `json:"state"`
+	Evidences   *EvidenceConnection   `json:"evidences"`
 	Tasks       *TaskConnection       `json:"tasks"`
 	Risks       *RiskConnection       `json:"risks"`
 	Controls    *ControlConnection    `json:"controls"`
@@ -884,6 +885,24 @@ type UpdateVendorInput struct {
 
 type UpdateVendorPayload struct {
 	Vendor *Vendor `json:"vendor"`
+}
+
+type UploadMeasureEvidenceInput struct {
+	MeasureID gid.GID        `json:"measureId"`
+	File      graphql.Upload `json:"file"`
+}
+
+type UploadMeasureEvidencePayload struct {
+	EvidenceEdge *EvidenceEdge `json:"evidenceEdge"`
+}
+
+type UploadTaskEvidenceInput struct {
+	TaskID gid.GID        `json:"taskId"`
+	File   graphql.Upload `json:"file"`
+}
+
+type UploadTaskEvidencePayload struct {
+	EvidenceEdge *EvidenceEdge `json:"evidenceEdge"`
 }
 
 type UploadVendorComplianceReportInput struct {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Moved evidence from the task level to the measure level, allowing evidence to be linked directly to measures instead of tasks.

- **Migration**
  - Database migration adds a measure_id column to evidences and updates existing records.
  - API and UI updated to support uploading and viewing evidence at the measure level.

<!-- End of auto-generated description by mrge. -->

