### PR TITLE
Add validation for contract dates

### DIFF
--- a/apps/console/src/pages/organizations/people/NewPeopleView.tsx
+++ b/apps/console/src/pages/organizations/people/NewPeopleView.tsx
@@ -151,6 +151,23 @@ function NewPeopleViewContent() {
           description: error.message || "Failed to create person",
           variant: "destructive",
         });
+
+        const defaultErrorValues = {
+          title: "Error",
+          description: error.message || "Failed to save changes",
+          variant: "destructive" as const
+        };
+
+        if (error.message?.includes("contract end date must be after or equal to start date")) {
+          toast({
+            ...defaultErrorValues,
+            description:
+              "Contract end date must be after or equal to start date.",
+          });
+        }
+        else {
+          toast(defaultErrorValues);
+        }
       },
     });
   };

--- a/apps/console/src/pages/organizations/people/PeopleView.tsx
+++ b/apps/console/src/pages/organizations/people/PeopleView.tsx
@@ -143,20 +143,28 @@ function PeopleViewContent({
         setEditedFields(new Set());
       },
       onError: (error) => {
+        const defaultErrorValues = {
+          title: "Error",
+          description: error.message || "Failed to save changes",
+          variant: "destructive" as const
+        };
+
         if (error.message?.includes("concurrent modification")) {
           toast({
-            title: "Error",
-            description:
-              "Someone else modified this person. Reloading latest data.",
-            variant: "destructive",
+            ...defaultErrorValues,
+            description: "Someone else modified this person. Reloading latest data.",
           });
           loadQuery({ peopleId: data.node.id! });
-        } else {
+        }
+        else if (error.message?.includes("contract end date must be after or equal to start date")) {
           toast({
-            title: "Error",
-            description: error.message || "Failed to save changes",
-            variant: "destructive",
+            ...defaultErrorValues,
+            description:
+              "Contract end date must be after or equal to start date.",
           });
+        }
+        else {
+          toast(defaultErrorValues);
         }
       },
     });

--- a/pkg/probo/people_service.go
+++ b/pkg/probo/people_service.go
@@ -161,6 +161,12 @@ func (s PeopleService) Update(
 				people.ContractEndDate = *req.ContractEndDate
 			}
 
+			if people.ContractStartDate != nil && people.ContractEndDate != nil {
+				if people.ContractEndDate.Before(*people.ContractStartDate) {
+					return fmt.Errorf("contract end date must be after or equal to start date")
+				}
+			}
+
 			people.UpdatedAt = time.Now()
 
 			return people.Update(ctx, conn, s.svc.scope)
@@ -176,6 +182,12 @@ func (s PeopleService) Create(
 	ctx context.Context,
 	req CreatePeopleRequest,
 ) (*coredata.People, error) {
+	if req.ContractStartDate != nil && req.ContractEndDate != nil {
+		if req.ContractEndDate.Before(*req.ContractStartDate) {
+			return nil, fmt.Errorf("contract end date must be after or equal to start date")
+		}
+	}
+
 	now := time.Now()
 	peopleID := gid.New(s.svc.scope.GetTenantID(), coredata.PeopleEntityType)
 


### PR DESCRIPTION
Added validation to ensure contract end dates are not before start dates when creating or updating people records.

- **Chore**
  - Shows a clear error message in the UI if the contract end date is before the start date.

