### PR TITLE
Add level position to people

### DIFF
--- a/apps/console/src/pages/organizations/people/NewPeopleView.tsx
+++ b/apps/console/src/pages/organizations/people/NewPeopleView.tsx
@@ -79,6 +79,7 @@ function NewPeopleViewContent() {
     primaryEmailAddress: "",
     additionalEmailAddresses: [] as string[],
     kind: "EMPLOYEE" as "EMPLOYEE" | "CONTRACTOR" | "SERVICE_ACCOUNT",
+    position: "",
     contractStartDate: "",
     contractEndDate: "",
   });
@@ -133,6 +134,7 @@ function NewPeopleViewContent() {
           primaryEmailAddress: formData.primaryEmailAddress,
           additionalEmailAddresses: formData.additionalEmailAddresses,
           kind: formData.kind,
+          position: formData.position,
           contractStartDate: formData.contractStartDate ? new Date(formData.contractStartDate).toISOString() : null,
           contractEndDate: formData.contractEndDate ? new Date(formData.contractEndDate).toISOString() : null,
         },
@@ -293,6 +295,13 @@ function NewPeopleViewContent() {
                     </button>
                   </div>
                 </div>
+
+                <EditableField
+                  label="Position"
+                  value={formData.position}
+                  type="text"
+                  onChange={(value) => handleFieldChange("position", value)}
+                />
 
                 <EditableField
                   label="Contract Start Date"

--- a/apps/console/src/pages/organizations/people/PeopleView.tsx
+++ b/apps/console/src/pages/organizations/people/PeopleView.tsx
@@ -35,6 +35,7 @@ const peopleViewQuery = graphql`
         primaryEmailAddress
         additionalEmailAddresses
         kind
+        position
         contractStartDate
         contractEndDate
         createdAt
@@ -53,6 +54,7 @@ const updatePeopleMutation = graphql`
         primaryEmailAddress
         additionalEmailAddresses
         kind
+        position
         contractStartDate
         contractEndDate
         updatedAt
@@ -104,6 +106,7 @@ function PeopleViewContent({
     primaryEmailAddress: data.node.primaryEmailAddress || "",
     additionalEmailAddresses: data.node.additionalEmailAddresses || [],
     kind: data.node.kind,
+    position: data.node.position || "",
     contractStartDate: data.node.contractStartDate
       ? new Date(data.node.contractStartDate).toISOString().split('T')[0]
       : "",
@@ -119,6 +122,7 @@ function PeopleViewContent({
   const handleSave = useCallback(() => {
     const formattedData = {
       ...formData,
+      position: formData.position,
       contractStartDate: formData.contractStartDate
         ? new Date(formData.contractStartDate).toISOString()
         : null,
@@ -184,6 +188,7 @@ function PeopleViewContent({
       primaryEmailAddress: data.node.primaryEmailAddress || "",
       additionalEmailAddresses: data.node.additionalEmailAddresses || [],
       kind: data.node.kind,
+      position: data.node.position || "",
       contractStartDate: data.node.contractStartDate
         ? new Date(data.node.contractStartDate).toISOString().split('T')[0]
         : "",
@@ -289,6 +294,12 @@ function PeopleViewContent({
                     </SelectContent>
                   </Select>
                 </div>
+                <EditableField
+                  label="Position"
+                  value={formData.position}
+                  type="text"
+                  onChange={(value) => handleFieldChange("position", value)}
+                />
                 <EditableField
                   label="Contract Start Date"
                   value={formData.contractStartDate || ""}

--- a/apps/console/src/pages/organizations/people/__generated__/NewPeopleViewCreatePeopleMutation.graphql.ts
+++ b/apps/console/src/pages/organizations/people/__generated__/NewPeopleViewCreatePeopleMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ca6b9dbed6835dd4a9705fe3a90c4b19>>
+ * @generated SignedSource<<b40eaab1027be24a4646edc68e88ad55>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -17,6 +17,7 @@ export type CreatePeopleInput = {
   fullName: string;
   kind: PeopleKind;
   organizationId: string;
+  position?: string | null | undefined;
   primaryEmailAddress: string;
 };
 export type NewPeopleViewCreatePeopleMutation$variables = {

--- a/apps/console/src/pages/organizations/people/__generated__/PeopleViewQuery.graphql.ts
+++ b/apps/console/src/pages/organizations/people/__generated__/PeopleViewQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<891422de01f5f1b88dc80d294c116c24>>
+ * @generated SignedSource<<37efdd3db937745faa9302820895d0d6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -22,6 +22,7 @@ export type PeopleViewQuery$data = {
     readonly fullName?: string;
     readonly id?: string;
     readonly kind?: PeopleKind;
+    readonly position?: string | null | undefined;
     readonly primaryEmailAddress?: string;
     readonly updatedAt?: string;
   };
@@ -85,24 +86,31 @@ v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "contractStartDate",
+  "name": "position",
   "storageKey": null
 },
 v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "contractEndDate",
+  "name": "contractStartDate",
   "storageKey": null
 },
 v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "createdAt",
+  "name": "contractEndDate",
   "storageKey": null
 },
 v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+},
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -135,7 +143,8 @@ return {
               (v7/*: any*/),
               (v8/*: any*/),
               (v9/*: any*/),
-              (v10/*: any*/)
+              (v10/*: any*/),
+              (v11/*: any*/)
             ],
             "type": "People",
             "abstractKey": null
@@ -179,7 +188,8 @@ return {
               (v7/*: any*/),
               (v8/*: any*/),
               (v9/*: any*/),
-              (v10/*: any*/)
+              (v10/*: any*/),
+              (v11/*: any*/)
             ],
             "type": "People",
             "abstractKey": null
@@ -190,16 +200,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1a6ca0fa62d60fd18c26a5e3c868f41f",
+    "cacheID": "1ded40b8c43eb2a616f68f73e57d8e9f",
     "id": null,
     "metadata": {},
     "name": "PeopleViewQuery",
     "operationKind": "query",
-    "text": "query PeopleViewQuery(\n  $peopleId: ID!\n) {\n  node(id: $peopleId) {\n    __typename\n    ... on People {\n      id\n      fullName\n      primaryEmailAddress\n      additionalEmailAddresses\n      kind\n      contractStartDate\n      contractEndDate\n      createdAt\n      updatedAt\n    }\n    id\n  }\n}\n"
+    "text": "query PeopleViewQuery(\n  $peopleId: ID!\n) {\n  node(id: $peopleId) {\n    __typename\n    ... on People {\n      id\n      fullName\n      primaryEmailAddress\n      additionalEmailAddresses\n      kind\n      position\n      contractStartDate\n      contractEndDate\n      createdAt\n      updatedAt\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "473792157216aa14cc6e4e3e0393090b";
+(node as any).hash = "406c23468d2624429d4174a37ff4abc1";
 
 export default node;

--- a/apps/console/src/pages/organizations/people/__generated__/PeopleViewUpdatePeopleMutation.graphql.ts
+++ b/apps/console/src/pages/organizations/people/__generated__/PeopleViewUpdatePeopleMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<86a82de5c4344cc14a120155388e4a6f>>
+ * @generated SignedSource<<ca7c481401202c2276b4212dfffd54d4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -17,6 +17,7 @@ export type UpdatePeopleInput = {
   fullName?: string | null | undefined;
   id: string;
   kind?: PeopleKind | null | undefined;
+  position?: string | null | undefined;
   primaryEmailAddress?: string | null | undefined;
 };
 export type PeopleViewUpdatePeopleMutation$variables = {
@@ -31,6 +32,7 @@ export type PeopleViewUpdatePeopleMutation$data = {
       readonly fullName: string;
       readonly id: string;
       readonly kind: PeopleKind;
+      readonly position: string | null | undefined;
       readonly primaryEmailAddress: string;
       readonly updatedAt: string;
     };
@@ -111,6 +113,13 @@ v1 = [
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "position",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "contractStartDate",
             "storageKey": null
           },
@@ -153,16 +162,16 @@ return {
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "398ebbc7659400cbc5d0a750ee7e66b5",
+    "cacheID": "d3bc10093e65e1a612f22687ee2fffed",
     "id": null,
     "metadata": {},
     "name": "PeopleViewUpdatePeopleMutation",
     "operationKind": "mutation",
-    "text": "mutation PeopleViewUpdatePeopleMutation(\n  $input: UpdatePeopleInput!\n) {\n  updatePeople(input: $input) {\n    people {\n      id\n      fullName\n      primaryEmailAddress\n      additionalEmailAddresses\n      kind\n      contractStartDate\n      contractEndDate\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation PeopleViewUpdatePeopleMutation(\n  $input: UpdatePeopleInput!\n) {\n  updatePeople(input: $input) {\n    people {\n      id\n      fullName\n      primaryEmailAddress\n      additionalEmailAddresses\n      kind\n      position\n      contractStartDate\n      contractEndDate\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "686c8546329ae29bd2880b0b1da9f20c";
+(node as any).hash = "af9cd62a7e73738d72e3ab9ad5ecdc10";
 
 export default node;

--- a/pkg/coredata/people.go
+++ b/pkg/coredata/people.go
@@ -36,6 +36,7 @@ type (
 		FullName                 string     `db:"full_name"`
 		PrimaryEmailAddress      string     `db:"primary_email_address"`
 		AdditionalEmailAddresses []string   `db:"additional_email_addresses"`
+		Position                 *string    `db:"position"`
 		ContractStartDate        *time.Time `db:"contract_start_date"`
 		ContractEndDate          *time.Time `db:"contract_end_date"`
 		CreatedAt                time.Time  `db:"created_at"`
@@ -79,6 +80,7 @@ SELECT
     full_name,
     primary_email_address,
     additional_email_addresses,
+    position,
     contract_start_date,
     contract_end_date,
     created_at,
@@ -126,6 +128,7 @@ func (p *People) LoadByEmail(
 		full_name,
 		primary_email_address,
 		additional_email_addresses,
+		position,
 		contract_start_date,
 		contract_end_date,
 		created_at,
@@ -177,6 +180,7 @@ SELECT
     full_name,
     primary_email_address,
     additional_email_addresses,
+    position,
     contract_start_date,
     contract_end_date,
     created_at,
@@ -229,6 +233,7 @@ INSERT INTO
         full_name,
         primary_email_address,
         additional_email_addresses,
+        position,
         contract_start_date,
         contract_end_date,
         created_at,
@@ -243,6 +248,7 @@ VALUES (
     @full_name,
     @primary_email_address,
     @additional_email_addresses,
+    @position,
     @contract_start_date,
     @contract_end_date,
     @created_at,
@@ -259,6 +265,7 @@ VALUES (
 		"full_name":                  p.FullName,
 		"primary_email_address":      p.PrimaryEmailAddress,
 		"additional_email_addresses": p.AdditionalEmailAddresses,
+		"position":                   p.Position,
 		"contract_start_date":        p.ContractStartDate,
 		"contract_end_date":          p.ContractEndDate,
 		"created_at":                 p.CreatedAt,
@@ -302,6 +309,7 @@ SELECT
     full_name,
     primary_email_address,
     additional_email_addresses,
+    position,
     contract_start_date,
     contract_end_date,
     created_at,
@@ -347,6 +355,7 @@ UPDATE peoples SET
 	primary_email_address = @primary_email_address,
 	additional_email_addresses = @additional_email_addresses,
 	kind = @kind,
+	position = @position,
 	contract_start_date = @contract_start_date,
 	contract_end_date = @contract_end_date,
 	updated_at = @updated_at
@@ -362,6 +371,7 @@ WHERE %s
 		"primary_email_address":      p.PrimaryEmailAddress,
 		"additional_email_addresses": p.AdditionalEmailAddresses,
 		"kind":                       p.Kind,
+		"position":                   p.Position,
 		"contract_start_date":        p.ContractStartDate,
 		"contract_end_date":          p.ContractEndDate,
 		"updated_at":                 p.UpdatedAt,
@@ -401,6 +411,7 @@ SELECT
 	full_name,
 	primary_email_address,
 	additional_email_addresses,
+	position,
 	contract_start_date,
 	contract_end_date,
 	created_at,

--- a/pkg/probo/people_service.go
+++ b/pkg/probo/people_service.go
@@ -37,6 +37,7 @@ type (
 		FullName                 *string
 		PrimaryEmailAddress      *string
 		AdditionalEmailAddresses *[]string
+		Position                 **string
 		ContractStartDate        **time.Time
 		ContractEndDate          **time.Time
 	}
@@ -48,6 +49,7 @@ type (
 		PrimaryEmailAddress      string
 		AdditionalEmailAddresses []string
 		Kind                     coredata.PeopleKind
+		Position                 *string
 		ContractStartDate        *time.Time
 		ContractEndDate          *time.Time
 	}
@@ -153,6 +155,10 @@ func (s PeopleService) Update(
 				people.AdditionalEmailAddresses = *req.AdditionalEmailAddresses
 			}
 
+			if req.Position != nil {
+				people.Position = *req.Position
+			}
+
 			if req.ContractStartDate != nil {
 				people.ContractStartDate = *req.ContractStartDate
 			}
@@ -200,6 +206,7 @@ func (s PeopleService) Create(
 		PrimaryEmailAddress:      req.PrimaryEmailAddress,
 		AdditionalEmailAddresses: req.AdditionalEmailAddresses,
 		UserID:                   req.UserID,
+		Position:                 req.Position,
 		ContractStartDate:        req.ContractStartDate,
 		ContractEndDate:          req.ContractEndDate,
 		CreatedAt:                now,

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -529,6 +529,7 @@ type People implements Node {
   primaryEmailAddress: String!
   additionalEmailAddresses: [String!]!
   kind: PeopleKind!
+  position: String
   contractStartDate: Datetime
   contractEndDate: Datetime
   createdAt: Datetime!
@@ -1154,6 +1155,7 @@ input CreatePeopleInput {
   primaryEmailAddress: String!
   additionalEmailAddresses: [String!]
   kind: PeopleKind!
+  position: String
   contractStartDate: Datetime
   contractEndDate: Datetime
 }
@@ -1164,6 +1166,7 @@ input UpdatePeopleInput {
   primaryEmailAddress: String
   additionalEmailAddresses: [String!]
   kind: PeopleKind
+  position: String
   contractStartDate: Datetime
   contractEndDate: Datetime
 }

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -425,6 +425,7 @@ type ComplexityRoot struct {
 		FullName                 func(childComplexity int) int
 		ID                       func(childComplexity int) int
 		Kind                     func(childComplexity int) int
+		Position                 func(childComplexity int) int
 		PrimaryEmailAddress      func(childComplexity int) int
 		UpdatedAt                func(childComplexity int) int
 	}
@@ -2595,6 +2596,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.People.Kind(childComplexity), true
 
+	case "People.position":
+		if e.complexity.People.Position == nil {
+			break
+		}
+
+		return e.complexity.People.Position(childComplexity), true
+
 	case "People.primaryEmailAddress":
 		if e.complexity.People.PrimaryEmailAddress == nil {
 			break
@@ -4580,6 +4588,7 @@ type People implements Node {
   primaryEmailAddress: String!
   additionalEmailAddresses: [String!]!
   kind: PeopleKind!
+  position: String
   contractStartDate: Datetime
   contractEndDate: Datetime
   createdAt: Datetime!
@@ -5205,6 +5214,7 @@ input CreatePeopleInput {
   primaryEmailAddress: String!
   additionalEmailAddresses: [String!]
   kind: PeopleKind!
+  position: String
   contractStartDate: Datetime
   contractEndDate: Datetime
 }
@@ -5215,6 +5225,7 @@ input UpdatePeopleInput {
   primaryEmailAddress: String
   additionalEmailAddresses: [String!]
   kind: PeopleKind
+  position: String
   contractStartDate: Datetime
   contractEndDate: Datetime
 }
@@ -19540,6 +19551,47 @@ func (ec *executionContext) fieldContext_People_kind(_ context.Context, field gr
 	return fc, nil
 }
 
+func (ec *executionContext) _People_position(ctx context.Context, field graphql.CollectedField, obj *types.People) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_People_position(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Position, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_People_position(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "People",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _People_contractStartDate(ctx context.Context, field graphql.CollectedField, obj *types.People) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_People_contractStartDate(ctx, field)
 	if err != nil {
@@ -19907,6 +19959,8 @@ func (ec *executionContext) fieldContext_PeopleEdge_node(_ context.Context, fiel
 				return ec.fieldContext_People_additionalEmailAddresses(ctx, field)
 			case "kind":
 				return ec.fieldContext_People_kind(ctx, field)
+			case "position":
+				return ec.fieldContext_People_position(ctx, field)
 			case "contractStartDate":
 				return ec.fieldContext_People_contractStartDate(ctx, field)
 			case "contractEndDate":
@@ -20144,6 +20198,8 @@ func (ec *executionContext) fieldContext_Policy_owner(_ context.Context, field g
 				return ec.fieldContext_People_additionalEmailAddresses(ctx, field)
 			case "kind":
 				return ec.fieldContext_People_kind(ctx, field)
+			case "position":
+				return ec.fieldContext_People_position(ctx, field)
 			case "contractStartDate":
 				return ec.fieldContext_People_contractStartDate(ctx, field)
 			case "contractEndDate":
@@ -21050,6 +21106,8 @@ func (ec *executionContext) fieldContext_PolicyVersion_publishedBy(_ context.Con
 				return ec.fieldContext_People_additionalEmailAddresses(ctx, field)
 			case "kind":
 				return ec.fieldContext_People_kind(ctx, field)
+			case "position":
+				return ec.fieldContext_People_position(ctx, field)
 			case "contractStartDate":
 				return ec.fieldContext_People_contractStartDate(ctx, field)
 			case "contractEndDate":
@@ -21615,6 +21673,8 @@ func (ec *executionContext) fieldContext_PolicyVersionSignature_signedBy(_ conte
 				return ec.fieldContext_People_additionalEmailAddresses(ctx, field)
 			case "kind":
 				return ec.fieldContext_People_kind(ctx, field)
+			case "position":
+				return ec.fieldContext_People_position(ctx, field)
 			case "contractStartDate":
 				return ec.fieldContext_People_contractStartDate(ctx, field)
 			case "contractEndDate":
@@ -21764,6 +21824,8 @@ func (ec *executionContext) fieldContext_PolicyVersionSignature_requestedBy(_ co
 				return ec.fieldContext_People_additionalEmailAddresses(ctx, field)
 			case "kind":
 				return ec.fieldContext_People_kind(ctx, field)
+			case "position":
+				return ec.fieldContext_People_position(ctx, field)
 			case "contractStartDate":
 				return ec.fieldContext_People_contractStartDate(ctx, field)
 			case "contractEndDate":
@@ -23169,6 +23231,8 @@ func (ec *executionContext) fieldContext_Risk_owner(_ context.Context, field gra
 				return ec.fieldContext_People_additionalEmailAddresses(ctx, field)
 			case "kind":
 				return ec.fieldContext_People_kind(ctx, field)
+			case "position":
+				return ec.fieldContext_People_position(ctx, field)
 			case "contractStartDate":
 				return ec.fieldContext_People_contractStartDate(ctx, field)
 			case "contractEndDate":
@@ -24156,6 +24220,8 @@ func (ec *executionContext) fieldContext_Task_assignedTo(_ context.Context, fiel
 				return ec.fieldContext_People_additionalEmailAddresses(ctx, field)
 			case "kind":
 				return ec.fieldContext_People_kind(ctx, field)
+			case "position":
+				return ec.fieldContext_People_position(ctx, field)
 			case "contractStartDate":
 				return ec.fieldContext_People_contractStartDate(ctx, field)
 			case "contractEndDate":
@@ -24994,6 +25060,8 @@ func (ec *executionContext) fieldContext_UpdatePeoplePayload_people(_ context.Co
 				return ec.fieldContext_People_additionalEmailAddresses(ctx, field)
 			case "kind":
 				return ec.fieldContext_People_kind(ctx, field)
+			case "position":
+				return ec.fieldContext_People_position(ctx, field)
 			case "contractStartDate":
 				return ec.fieldContext_People_contractStartDate(ctx, field)
 			case "contractEndDate":
@@ -25799,6 +25867,8 @@ func (ec *executionContext) fieldContext_User_people(ctx context.Context, field 
 				return ec.fieldContext_People_additionalEmailAddresses(ctx, field)
 			case "kind":
 				return ec.fieldContext_People_kind(ctx, field)
+			case "position":
+				return ec.fieldContext_People_position(ctx, field)
 			case "contractStartDate":
 				return ec.fieldContext_People_contractStartDate(ctx, field)
 			case "contractEndDate":
@@ -26402,6 +26472,8 @@ func (ec *executionContext) fieldContext_Vendor_businessOwner(_ context.Context,
 				return ec.fieldContext_People_additionalEmailAddresses(ctx, field)
 			case "kind":
 				return ec.fieldContext_People_kind(ctx, field)
+			case "position":
+				return ec.fieldContext_People_position(ctx, field)
 			case "contractStartDate":
 				return ec.fieldContext_People_contractStartDate(ctx, field)
 			case "contractEndDate":
@@ -26463,6 +26535,8 @@ func (ec *executionContext) fieldContext_Vendor_securityOwner(_ context.Context,
 				return ec.fieldContext_People_additionalEmailAddresses(ctx, field)
 			case "kind":
 				return ec.fieldContext_People_kind(ctx, field)
+			case "position":
+				return ec.fieldContext_People_position(ctx, field)
 			case "contractStartDate":
 				return ec.fieldContext_People_contractStartDate(ctx, field)
 			case "contractEndDate":
@@ -28130,6 +28204,8 @@ func (ec *executionContext) fieldContext_VendorRiskAssessment_assessedBy(_ conte
 				return ec.fieldContext_People_additionalEmailAddresses(ctx, field)
 			case "kind":
 				return ec.fieldContext_People_kind(ctx, field)
+			case "position":
+				return ec.fieldContext_People_position(ctx, field)
 			case "contractStartDate":
 				return ec.fieldContext_People_contractStartDate(ctx, field)
 			case "contractEndDate":
@@ -31143,7 +31219,7 @@ func (ec *executionContext) unmarshalInputCreatePeopleInput(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"organizationId", "fullName", "primaryEmailAddress", "additionalEmailAddresses", "kind", "contractStartDate", "contractEndDate"}
+	fieldsInOrder := [...]string{"organizationId", "fullName", "primaryEmailAddress", "additionalEmailAddresses", "kind", "position", "contractStartDate", "contractEndDate"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -31185,6 +31261,13 @@ func (ec *executionContext) unmarshalInputCreatePeopleInput(ctx context.Context,
 				return it, err
 			}
 			it.Kind = data
+		case "position":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("position"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Position = data
 		case "contractStartDate":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("contractStartDate"))
 			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)
@@ -32979,7 +33062,7 @@ func (ec *executionContext) unmarshalInputUpdatePeopleInput(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "fullName", "primaryEmailAddress", "additionalEmailAddresses", "kind", "contractStartDate", "contractEndDate"}
+	fieldsInOrder := [...]string{"id", "fullName", "primaryEmailAddress", "additionalEmailAddresses", "kind", "position", "contractStartDate", "contractEndDate"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -33021,6 +33104,13 @@ func (ec *executionContext) unmarshalInputUpdatePeopleInput(ctx context.Context,
 				return it, err
 			}
 			it.Kind = data
+		case "position":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("position"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Position = data
 		case "contractStartDate":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("contractStartDate"))
 			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)
@@ -37445,6 +37535,8 @@ func (ec *executionContext) _People(ctx context.Context, sel ast.SelectionSet, o
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "position":
+			out.Values[i] = ec._People_position(ctx, field, obj)
 		case "contractStartDate":
 			out.Values[i] = ec._People_contractStartDate(ctx, field, obj)
 		case "contractEndDate":

--- a/pkg/server/api/console/v1/types/people.go
+++ b/pkg/server/api/console/v1/types/people.go
@@ -50,6 +50,7 @@ func NewPeople(p *coredata.People) *People {
 		PrimaryEmailAddress:      p.PrimaryEmailAddress,
 		AdditionalEmailAddresses: p.AdditionalEmailAddresses,
 		Kind:                     p.Kind,
+		Position:                 p.Position,
 		ContractStartDate:        p.ContractStartDate,
 		ContractEndDate:          p.ContractEndDate,
 		CreatedAt:                p.CreatedAt,

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -164,6 +164,7 @@ type CreatePeopleInput struct {
 	PrimaryEmailAddress      string              `json:"primaryEmailAddress"`
 	AdditionalEmailAddresses []string            `json:"additionalEmailAddresses,omitempty"`
 	Kind                     coredata.PeopleKind `json:"kind"`
+	Position                 *string             `json:"position,omitempty"`
 	ContractStartDate        *time.Time          `json:"contractStartDate,omitempty"`
 	ContractEndDate          *time.Time          `json:"contractEndDate,omitempty"`
 }
@@ -569,6 +570,7 @@ type People struct {
 	PrimaryEmailAddress      string              `json:"primaryEmailAddress"`
 	AdditionalEmailAddresses []string            `json:"additionalEmailAddresses"`
 	Kind                     coredata.PeopleKind `json:"kind"`
+	Position                 *string             `json:"position,omitempty"`
 	ContractStartDate        *time.Time          `json:"contractStartDate,omitempty"`
 	ContractEndDate          *time.Time          `json:"contractEndDate,omitempty"`
 	CreatedAt                time.Time           `json:"createdAt"`
@@ -837,6 +839,7 @@ type UpdatePeopleInput struct {
 	PrimaryEmailAddress      *string              `json:"primaryEmailAddress,omitempty"`
 	AdditionalEmailAddresses []string             `json:"additionalEmailAddresses,omitempty"`
 	Kind                     *coredata.PeopleKind `json:"kind,omitempty"`
+	Position                 *string              `json:"position,omitempty"`
 	ContractStartDate        *time.Time           `json:"contractStartDate,omitempty"`
 	ContractEndDate          *time.Time           `json:"contractEndDate,omitempty"`
 }

--- a/pkg/server/api/console/v1/v1_resolver.go
+++ b/pkg/server/api/console/v1/v1_resolver.go
@@ -424,6 +424,7 @@ func (r *mutationResolver) CreatePeople(ctx context.Context, input types.CreateP
 		PrimaryEmailAddress:      input.PrimaryEmailAddress,
 		AdditionalEmailAddresses: []string{},
 		Kind:                     input.Kind,
+		Position:                 input.Position,
 		ContractStartDate:        input.ContractStartDate,
 		ContractEndDate:          input.ContractEndDate,
 	})
@@ -447,6 +448,7 @@ func (r *mutationResolver) UpdatePeople(ctx context.Context, input types.UpdateP
 		PrimaryEmailAddress:      input.PrimaryEmailAddress,
 		AdditionalEmailAddresses: &input.AdditionalEmailAddresses,
 		Kind:                     input.Kind,
+		Position:                 &input.Position,
 		ContractStartDate:        &input.ContractStartDate,
 		ContractEndDate:          &input.ContractEndDate,
 	})


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added a new "level position" field to people records, allowing users to set and update a person's level or role in the organization.

- **New Features**
  - Added "level position" input to the people creation and edit forms.
  - Updated backend, API, and database to support storing and retrieving the new field.

<!-- End of auto-generated description by cubic. -->

