### PR TITLE
Fix vendor update

### DIFF
--- a/pkg/probo/vendor_service.go
+++ b/pkg/probo/vendor_service.go
@@ -197,21 +197,19 @@ func (s VendorService) Update(
 				vendor.TrustPageURL = req.TrustPageURL
 			}
 
-			businessOwner := &coredata.People{}
-			if err := businessOwner.LoadByID(ctx, conn, s.svc.scope, *req.BusinessOwnerID); err != nil {
-				return fmt.Errorf("cannot load business owner: %w", err)
-			}
-
 			if req.BusinessOwnerID != nil {
+				businessOwner := &coredata.People{}
+				if err := businessOwner.LoadByID(ctx, conn, s.svc.scope, *req.BusinessOwnerID); err != nil {
+					return fmt.Errorf("cannot load business owner: %w", err)
+				}
 				vendor.BusinessOwnerID = &businessOwner.ID
 			}
 
-			securityOwner := &coredata.People{}
-			if err := securityOwner.LoadByID(ctx, conn, s.svc.scope, *req.SecurityOwnerID); err != nil {
-				return fmt.Errorf("cannot load security owner: %w", err)
-			}
-
 			if req.SecurityOwnerID != nil {
+				securityOwner := &coredata.People{}
+				if err := securityOwner.LoadByID(ctx, conn, s.svc.scope, *req.SecurityOwnerID); err != nil {
+					return fmt.Errorf("cannot load security owner: %w", err)
+				}
 				vendor.SecurityOwnerID = &securityOwner.ID
 			}
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed a bug in the vendor update logic to only load business and security owners when their IDs are provided.

<!-- End of auto-generated description by cubic. -->

