### PR TITLE
Import framework from json

### DIFF
--- a/apps/console/src/pages/organizations/frameworks/FrameworkListView.tsx
+++ b/apps/console/src/pages/organizations/frameworks/FrameworkListView.tsx
@@ -10,7 +10,7 @@ import { Link, useParams } from "react-router";
 import type { FrameworkListViewQuery as FrameworkListViewQueryType } from "./__generated__/FrameworkListViewQuery.graphql";
 import { PageTemplate } from "@/components/PageTemplate";
 import { FrameworkListViewSkeleton } from "./FrameworkListPage";
-import { FrameworkImportDropdown } from "./ImportFrameworkDialog";
+import { FrameworkImportDropdown, FrameworkImportButton } from "./ImportFrameworkDialog";
 
 const FrameworkListViewQuery = graphql`
   query FrameworkListViewQuery($organizationId: ID!) {
@@ -44,7 +44,12 @@ function FrameworkListViewContent({
     <PageTemplate
       title="Frameworks"
       description="Manage your compliance frameworks"
-      actions={<FrameworkImportDropdown />}
+      actions={
+        <div className="flex gap-4">
+          <FrameworkImportButton />
+          <FrameworkImportDropdown />
+        </div>
+      }
     >
       <div className="space-y-6">
         <Card>


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added the ability to import compliance frameworks from a JSON file in the Frameworks list view.

- **New Features**
  - Added an "Import Framework" button that lets users upload a JSON file to import a framework.
  - Shows success or error messages after import.

<!-- End of auto-generated description by cubic. -->

