### PR TITLE
Add controls crud

### DIFF
--- a/apps/console/src/pages/organizations/OrganizationBreadcrumb.tsx
+++ b/apps/console/src/pages/organizations/OrganizationBreadcrumb.tsx
@@ -375,7 +375,23 @@ function BreadcrumbMeasureView() {
   );
 }
 
-function BreadcrumbControl() {
+function BreadcrumbControlNew() {
+  const { organizationId, frameworkId } = useParams();
+  return (
+    <>
+      <BreadcrumbSeparator />
+      <BreadcrumbItem>
+        <BreadcrumbNavLink
+          to={`/organizations/${organizationId}/frameworks/${frameworkId}/controls/new`}
+        >
+          New Control
+        </BreadcrumbNavLink>
+      </BreadcrumbItem>
+    </>
+  );
+}
+
+function BreadcrumbControlExisting() {
   const { organizationId, frameworkId, controlId } = useParams();
   const data = useLazyLoadQuery<OrganizationBreadcrumbBreadcrumbControlQuery>(
     graphql`
@@ -383,7 +399,7 @@ function BreadcrumbControl() {
         control: node(id: $controlId) {
           id
           ... on Control {
-            referenceId
+            sectionTitle
           }
         }
       }
@@ -399,10 +415,24 @@ function BreadcrumbControl() {
         <BreadcrumbNavLink
           to={`/organizations/${organizationId}/frameworks/${frameworkId}/controls/${controlId}`}
         >
-          {data.control?.referenceId}
+          {data.control?.sectionTitle}
         </BreadcrumbNavLink>
       </BreadcrumbItem>
     </>
+  );
+}
+
+function BreadcrumbControl() {
+  const { controlId } = useParams();
+
+  if (controlId === "new") {
+    return <BreadcrumbControlNew />;
+  }
+
+  return (
+    <Suspense>
+      <BreadcrumbControlExisting />
+    </Suspense>
   );
 }
 

--- a/apps/console/src/pages/organizations/Routes.tsx
+++ b/apps/console/src/pages/organizations/Routes.tsx
@@ -11,6 +11,8 @@ import { FrameworkListPage } from "./frameworks/FrameworkListPage";
 import { FrameworkPage } from "./frameworks/FrameworkPage";
 import { NewFrameworkPage } from "./frameworks/NewFrameworkPage";
 import { ControlPage } from "./frameworks/controls/ControlPage";
+import { EditControlPage } from "./frameworks/controls/EditControlPage";
+import { NewControlPage } from "./frameworks/controls/NewControlPage";
 import { EditMeasurePage } from "./measures/EditMeasurePage";
 import { MeasureListPage } from "./measures/MeasureListPage";
 import { MeasurePage } from "./measures/MeasurePage";
@@ -50,7 +52,9 @@ export function OrganizationsRoutes() {
         <Route path="frameworks/:frameworkId/*">
           <Route element={<FrameworkLayout />}>
             <Route index element={<FrameworkPage />} />
+            <Route path="controls/new" element={<NewControlPage />} />
             <Route path="controls/:controlId" element={<ControlPage />} />
+            <Route path="controls/:controlId/edit" element={<EditControlPage />} />
           </Route>
           <Route path="edit" element={<EditFrameworkPage />} />
           <Route path="*" element={<NotFoundPage />} />

--- a/apps/console/src/pages/organizations/__generated__/OrganizationBreadcrumbBreadcrumbControlQuery.graphql.ts
+++ b/apps/console/src/pages/organizations/__generated__/OrganizationBreadcrumbBreadcrumbControlQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f8a8d22a1da9cce219c0c3be9293fe47>>
+ * @generated SignedSource<<07652bb5a37a4cdf28c0df2f627ada0e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,7 +15,7 @@ export type OrganizationBreadcrumbBreadcrumbControlQuery$variables = {
 export type OrganizationBreadcrumbBreadcrumbControlQuery$data = {
   readonly control: {
     readonly id: string;
-    readonly referenceId?: string;
+    readonly sectionTitle?: string;
   };
 };
 export type OrganizationBreadcrumbBreadcrumbControlQuery = {
@@ -52,7 +52,7 @@ v3 = {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
-      "name": "referenceId",
+      "name": "sectionTitle",
       "storageKey": null
     }
   ],
@@ -112,16 +112,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d46d6f288bc94595c84a4c028ba15f83",
+    "cacheID": "6d3e964652b3f13d0524f2db09668d7d",
     "id": null,
     "metadata": {},
     "name": "OrganizationBreadcrumbBreadcrumbControlQuery",
     "operationKind": "query",
-    "text": "query OrganizationBreadcrumbBreadcrumbControlQuery(\n  $controlId: ID!\n) {\n  control: node(id: $controlId) {\n    __typename\n    id\n    ... on Control {\n      referenceId\n    }\n  }\n}\n"
+    "text": "query OrganizationBreadcrumbBreadcrumbControlQuery(\n  $controlId: ID!\n) {\n  control: node(id: $controlId) {\n    __typename\n    id\n    ... on Control {\n      sectionTitle\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "dd4a9837ee450c35961ee67d3213c017";
+(node as any).hash = "04f863d003032971d0490bf0d0c90fce";
 
 export default node;

--- a/apps/console/src/pages/organizations/frameworks/FrameworkLayoutView.tsx
+++ b/apps/console/src/pages/organizations/frameworks/FrameworkLayoutView.tsx
@@ -24,6 +24,7 @@ import { PageTemplate } from "@/components/PageTemplate";
 import { FrameworkLayoutViewSkeleton } from "./FrameworkLayout";
 import { ControlList } from "./FrameworkLayoutView/ControlList";
 import { FrameworkLayoutViewExportAuditMutation } from "./__generated__/FrameworkLayoutViewExportAuditMutation.graphql";
+import { Plus } from "lucide-react";
 
 const FrameworkLayoutViewQuery = graphql`
   query FrameworkLayoutViewQuery($frameworkId: ID!) {
@@ -35,12 +36,12 @@ const FrameworkLayoutViewQuery = graphql`
         ...ControlList_List
         firstControl: controls(
           first: 1
-          orderBy: { field: CREATED_AT, direction: ASC }
+          orderBy: { field: SECTION_TITLE, direction: ASC }
         ) @connection(key: "FrameworkLayoutView_firstControl") {
           edges {
             node {
               id
-              referenceId
+              sectionTitle
               name
             }
           }
@@ -153,6 +154,14 @@ function FrameworkLayoutViewContent({
       description={framework.description || ""}
       actions={
         <div className="flex gap-4">
+          <Button variant="secondary" asChild>
+            <Link
+              to={`/organizations/${organizationId}/frameworks/${framework.id}/controls/new`}
+            >
+              <Plus className="w-3 h-4 mr-2" />
+              Create Control
+            </Link>
+          </Button>
           <Button variant="secondary" asChild>
             <Link
               to={`/organizations/${organizationId}/frameworks/${framework.id}/edit`}

--- a/apps/console/src/pages/organizations/frameworks/FrameworkLayoutView/ControlList.tsx
+++ b/apps/console/src/pages/organizations/frameworks/FrameworkLayoutView/ControlList.tsx
@@ -7,12 +7,12 @@ const maxControlNameLength = 80;
 
 export const controlListFragment = graphql`
   fragment ControlList_List on Framework {
-    controls(first: 100, orderBy: { field: CREATED_AT, direction: ASC })
+    controls(first: 100, orderBy: { field: SECTION_TITLE, direction: ASC })
       @connection(key: "FrameworkView_controls") {
       edges {
         node {
           id
-          referenceId
+          sectionTitle
           name
         }
       }
@@ -37,10 +37,6 @@ export function ControlList(props: ControlListProps) {
     fragmentKey,
   );
 
-  if (controls.edges.length === 0) {
-    return "No controls available for this framework";
-  }
-
   return (
     <aside
       className={cn(
@@ -48,43 +44,49 @@ export function ControlList(props: ControlListProps) {
         className,
       )}
     >
-      {controls.edges.map(({ node: control }, i) => (
-        <NavLink
-          key={control.id}
-          to={`/organizations/${organizationId}/frameworks/${frameworkId}/controls/${control.id}`}
-          className={({ isActive }) =>
-            cn(
-              "block pl-8 pr-4 py-4 border-b hover:bg-h-subtle-bg",
-              (isActive || (i === 0 && !controlId)) && "bg-subtle-bg",
-            )
-          }
-        >
-          {({ isActive }) => {
-            return (
-              <>
-                <div
-                  className={cn(
-                    "inline-block font-mono text-sm px-1 py-0.25 rounded-sm bg-highlight-bg border font-semibold",
-                    isActive && "font-bold bg-active-bg border-mid-b",
-                  )}
-                >
-                  {control.referenceId}
-                </div>
-                <div
-                  className={cn(
-                    "text-sm leading-none break-words mt-2",
-                    isActive && "font-medium",
-                  )}
-                >
-                  {control.name.length > maxControlNameLength
-                    ? `${control.name.slice(0, maxControlNameLength - 2)}…`
-                    : control.name}
-                </div>
-              </>
-            );
-          }}
-        </NavLink>
-      ))}
+      {controls.edges.length === 0 ? (
+        <div className="p-8 text-center text-tertiary">
+          No controls available for this framework. Create one to get started.
+        </div>
+      ) : (
+        controls.edges.map(({ node: control }, i) => (
+          <NavLink
+            key={control.id}
+            to={`/organizations/${organizationId}/frameworks/${frameworkId}/controls/${control.id}`}
+            className={({ isActive }) =>
+              cn(
+                "block pl-8 pr-4 py-4 border-b hover:bg-h-subtle-bg",
+                (isActive || (i === 0 && !controlId)) && "bg-subtle-bg",
+              )
+            }
+          >
+            {({ isActive }) => {
+              return (
+                <>
+                  <div
+                    className={cn(
+                      "inline-block font-mono text-sm px-1 py-0.25 rounded-sm bg-highlight-bg border font-semibold",
+                      isActive && "font-bold bg-active-bg border-mid-b",
+                    )}
+                  >
+                    {control.sectionTitle}
+                  </div>
+                  <div
+                    className={cn(
+                      "text-sm leading-none break-words mt-2",
+                      isActive && "font-medium",
+                    )}
+                  >
+                    {control.name.length > maxControlNameLength
+                      ? `${control.name.slice(0, maxControlNameLength - 2)}…`
+                      : control.name}
+                  </div>
+                </>
+              );
+            }}
+          </NavLink>
+        ))
+      )}
     </aside>
   );
 }

--- a/apps/console/src/pages/organizations/frameworks/FrameworkLayoutView/__generated__/ControlList_List.graphql.ts
+++ b/apps/console/src/pages/organizations/frameworks/FrameworkLayoutView/__generated__/ControlList_List.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a3e361b3b8152318476292098dd890f4>>
+ * @generated SignedSource<<35014a0564ea29edf018bcd38b2f3edf>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,7 +16,7 @@ export type ControlList_List$data = {
       readonly node: {
         readonly id: string;
         readonly name: string;
-        readonly referenceId: string;
+        readonly sectionTitle: string;
       };
     }>;
   };
@@ -52,7 +52,7 @@ const node: ReaderFragment = {
           "name": "orderBy",
           "value": {
             "direction": "ASC",
-            "field": "CREATED_AT"
+            "field": "SECTION_TITLE"
           }
         }
       ],
@@ -88,7 +88,7 @@ const node: ReaderFragment = {
                   "alias": null,
                   "args": null,
                   "kind": "ScalarField",
-                  "name": "referenceId",
+                  "name": "sectionTitle",
                   "storageKey": null
                 },
                 {
@@ -144,13 +144,13 @@ const node: ReaderFragment = {
           "storageKey": null
         }
       ],
-      "storageKey": "__FrameworkView_controls_connection(orderBy:{\"direction\":\"ASC\",\"field\":\"CREATED_AT\"})"
+      "storageKey": "__FrameworkView_controls_connection(orderBy:{\"direction\":\"ASC\",\"field\":\"SECTION_TITLE\"})"
     }
   ],
   "type": "Framework",
   "abstractKey": null
 };
 
-(node as any).hash = "aa95219172d60909d7a503d246e0f4f5";
+(node as any).hash = "14a919a4a894eeec4bed03c918f9e4d8";
 
 export default node;

--- a/apps/console/src/pages/organizations/frameworks/__generated__/FrameworkLayoutViewQuery.graphql.ts
+++ b/apps/console/src/pages/organizations/frameworks/__generated__/FrameworkLayoutViewQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4f0c7f7d3fb0272b838162d615ba905b>>
+ * @generated SignedSource<<483ff3a5c2b7785a8b8b8d308065a7de>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -21,7 +21,7 @@ export type FrameworkLayoutViewQuery$data = {
         readonly node: {
           readonly id: string;
           readonly name: string;
-          readonly referenceId: string;
+          readonly sectionTitle: string;
         };
       }>;
     };
@@ -76,7 +76,7 @@ v5 = {
   "name": "orderBy",
   "value": {
     "direction": "ASC",
-    "field": "CREATED_AT"
+    "field": "SECTION_TITLE"
   }
 },
 v6 = {
@@ -108,7 +108,7 @@ v7 = [
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "referenceId",
+            "name": "sectionTitle",
             "storageKey": null
           },
           (v3/*: any*/),
@@ -207,7 +207,7 @@ return {
                 "name": "__FrameworkLayoutView_firstControl_connection",
                 "plural": false,
                 "selections": (v7/*: any*/),
-                "storageKey": "__FrameworkLayoutView_firstControl_connection(orderBy:{\"direction\":\"ASC\",\"field\":\"CREATED_AT\"})"
+                "storageKey": "__FrameworkLayoutView_firstControl_connection(orderBy:{\"direction\":\"ASC\",\"field\":\"SECTION_TITLE\"})"
               }
             ],
             "type": "Framework",
@@ -249,7 +249,7 @@ return {
                 "name": "controls",
                 "plural": false,
                 "selections": (v7/*: any*/),
-                "storageKey": "controls(first:100,orderBy:{\"direction\":\"ASC\",\"field\":\"CREATED_AT\"})"
+                "storageKey": "controls(first:100,orderBy:{\"direction\":\"ASC\",\"field\":\"SECTION_TITLE\"})"
               },
               {
                 "alias": null,
@@ -268,7 +268,7 @@ return {
                 "name": "controls",
                 "plural": false,
                 "selections": (v7/*: any*/),
-                "storageKey": "controls(first:1,orderBy:{\"direction\":\"ASC\",\"field\":\"CREATED_AT\"})"
+                "storageKey": "controls(first:1,orderBy:{\"direction\":\"ASC\",\"field\":\"SECTION_TITLE\"})"
               },
               {
                 "alias": "firstControl",
@@ -289,7 +289,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "98ca0e0c503bb7c5e3e538e8831eeefa",
+    "cacheID": "2fd37cafbd7284ade592b0cb2e7046ee",
     "id": null,
     "metadata": {
       "connection": [
@@ -306,11 +306,11 @@ return {
     },
     "name": "FrameworkLayoutViewQuery",
     "operationKind": "query",
-    "text": "query FrameworkLayoutViewQuery(\n  $frameworkId: ID!\n) {\n  node(id: $frameworkId) {\n    __typename\n    id\n    ... on Framework {\n      name\n      description\n      ...ControlList_List\n      firstControl: controls(first: 1, orderBy: {field: CREATED_AT, direction: ASC}) {\n        edges {\n          node {\n            id\n            referenceId\n            name\n            __typename\n          }\n          cursor\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n    }\n  }\n}\n\nfragment ControlList_List on Framework {\n  controls(first: 100, orderBy: {field: CREATED_AT, direction: ASC}) {\n    edges {\n      node {\n        id\n        referenceId\n        name\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query FrameworkLayoutViewQuery(\n  $frameworkId: ID!\n) {\n  node(id: $frameworkId) {\n    __typename\n    id\n    ... on Framework {\n      name\n      description\n      ...ControlList_List\n      firstControl: controls(first: 1, orderBy: {field: SECTION_TITLE, direction: ASC}) {\n        edges {\n          node {\n            id\n            sectionTitle\n            name\n            __typename\n          }\n          cursor\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n    }\n  }\n}\n\nfragment ControlList_List on Framework {\n  controls(first: 100, orderBy: {field: SECTION_TITLE, direction: ASC}) {\n    edges {\n      node {\n        id\n        sectionTitle\n        name\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "1935177e374d21015e102745c4d51e94";
+(node as any).hash = "45b60ab441af6a1c4543532be7f40d84";
 
 export default node;

--- a/apps/console/src/pages/organizations/frameworks/__generated__/FrameworkViewQuery.graphql.ts
+++ b/apps/console/src/pages/organizations/frameworks/__generated__/FrameworkViewQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2f29bc26fdb324cad6eb8d7bdd48447f>>
+ * @generated SignedSource<<878dff73b0684026603de1884d9f5ed9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -250,7 +250,7 @@ return {
                             "alias": null,
                             "args": null,
                             "kind": "ScalarField",
-                            "name": "referenceId",
+                            "name": "sectionTitle",
                             "storageKey": null
                           },
                           (v6/*: any*/)
@@ -286,7 +286,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c7d856630ed8706055e1ff572d0e7293",
+    "cacheID": "58ce0c4b37adb468f356e1296948150e",
     "id": null,
     "metadata": {
       "connection": [
@@ -303,7 +303,7 @@ return {
     },
     "name": "FrameworkViewQuery",
     "operationKind": "query",
-    "text": "query FrameworkViewQuery(\n  $frameworkId: ID!\n) {\n  node(id: $frameworkId) {\n    __typename\n    id\n    ... on Framework {\n      name\n      description\n      firstControl: controls(first: 1, orderBy: {field: CREATED_AT, direction: ASC}) {\n        edges {\n          node {\n            ...ControlFragment_Control\n            id\n            __typename\n          }\n          cursor\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n    }\n  }\n}\n\nfragment ControlFragment_Control on Control {\n  id\n  description\n  name\n  referenceId\n}\n"
+    "text": "query FrameworkViewQuery(\n  $frameworkId: ID!\n) {\n  node(id: $frameworkId) {\n    __typename\n    id\n    ... on Framework {\n      name\n      description\n      firstControl: controls(first: 1, orderBy: {field: CREATED_AT, direction: ASC}) {\n        edges {\n          node {\n            ...ControlFragment_Control\n            id\n            __typename\n          }\n          cursor\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n    }\n  }\n}\n\nfragment ControlFragment_Control on Control {\n  id\n  description\n  name\n  sectionTitle\n}\n"
   }
 };
 })();

--- a/apps/console/src/pages/organizations/frameworks/controls/ControlPage.tsx
+++ b/apps/console/src/pages/organizations/frameworks/controls/ControlPage.tsx
@@ -1,38 +1,20 @@
-import { Card, CardContent } from "@/components/ui/card";
-import { Suspense } from "react";
-import { useLocation } from "react-router";
-import { lazy } from "@probo/react-lazy";
-import ErrorBoundary from "@/components/ErrorBoundary";
+import { Loader2 } from "lucide-react";
+import { lazy, Suspense } from "react";
 
 const ControlView = lazy(() => import("./ControlView"));
 
 export function ControlViewSkeleton() {
   return (
-    <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-      {[1, 2, 3].map((i) => (
-        <Card key={i}>
-          <CardContent className="p-6">
-            <div className="relative mb-6">
-              <div className="bg-subtle-bg w-24 h-24 rounded-full animate-pulse mb-4" />
-              <div className="h-6 w-48 bg-subtle-bg animate-pulse rounded mb-2" />
-              <div className="h-20 w-full bg-subtle-bg animate-pulse rounded" />
-            </div>
-            <div className="h-4 w-32 bg-subtle-bg animate-pulse rounded" />
-          </CardContent>
-        </Card>
-      ))}
+    <div className="flex items-center justify-center h-full">
+      <Loader2 className="w-8 h-8 animate-spin text-info" />
     </div>
   );
 }
 
 export function ControlPage() {
-  const location = useLocation();
-
   return (
-    <Suspense key={location.pathname} fallback={<ControlViewSkeleton />}>
-      <ErrorBoundary key={location.pathname}>
-        <ControlView />
-      </ErrorBoundary>
+    <Suspense fallback={<ControlViewSkeleton />}>
+      <ControlView />
     </Suspense>
   );
 }

--- a/apps/console/src/pages/organizations/frameworks/controls/EditControlPage.tsx
+++ b/apps/console/src/pages/organizations/frameworks/controls/EditControlPage.tsx
@@ -1,0 +1,14 @@
+import { Loader2 } from "lucide-react";
+import EditControlView from "./EditControlView";
+
+export function EditControlViewSkeleton() {
+  return (
+    <div className="flex items-center justify-center h-full">
+      <Loader2 className="w-8 h-8 animate-spin text-info" />
+    </div>
+  );
+}
+
+export function EditControlPage() {
+  return <EditControlView />;
+}

--- a/apps/console/src/pages/organizations/frameworks/controls/EditControlView.tsx
+++ b/apps/console/src/pages/organizations/frameworks/controls/EditControlView.tsx
@@ -1,0 +1,201 @@
+import { Suspense, useEffect, useState } from "react";
+import {
+  graphql,
+  PreloadedQuery,
+  useMutation,
+  usePreloadedQuery,
+  useQueryLoader,
+} from "react-relay";
+import { useParams, useNavigate } from "react-router";
+import { useToast } from "@/hooks/use-toast";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Loader2 } from "lucide-react";
+import { EditControlViewSkeleton } from "./EditControlPage";
+import { EditControlViewQuery } from "./__generated__/EditControlViewQuery.graphql";
+
+const editControlViewQuery = graphql`
+  query EditControlViewQuery($controlId: ID!) {
+    control: node(id: $controlId) {
+      ... on Control {
+        id
+        name
+        description
+        sectionTitle
+      }
+    }
+  }
+`;
+
+const updateControlMutation = graphql`
+  mutation EditControlViewUpdateControlMutation($input: UpdateControlInput!) {
+    updateControl(input: $input) {
+      control {
+        id
+        name
+        description
+        sectionTitle
+      }
+    }
+  }
+`;
+
+function EditControlViewContent({
+  queryRef,
+}: {
+  queryRef: PreloadedQuery<EditControlViewQuery>;
+}) {
+  const { organizationId, frameworkId } = useParams<{
+    organizationId: string;
+    frameworkId: string;
+  }>();
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const data = usePreloadedQuery(editControlViewQuery, queryRef);
+  const [isLoading, setIsLoading] = useState(false);
+  const [commitUpdateControl] = useMutation(updateControlMutation);
+
+  if (!data.control) {
+    return <EditControlViewSkeleton />;
+  }
+
+  const [formData, setFormData] = useState({
+    name: data.control.name || "",
+    description: data.control.description || "",
+    sectionTitle: data.control.sectionTitle || "",
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+
+    commitUpdateControl({
+      variables: {
+        input: {
+          id: data.control.id,
+          name: formData.name,
+          description: formData.description,
+          sectionTitle: formData.sectionTitle,
+        },
+      },
+      onCompleted: (_, errors) => {
+        setIsLoading(false);
+
+        if (errors) {
+          console.error("Error updating control:", errors);
+          toast({
+            title: "Error",
+            description: "Failed to update control. Please try again.",
+            variant: "destructive",
+          });
+          return;
+        }
+
+        toast({
+          title: "Success",
+          description: "Control updated successfully.",
+        });
+
+        navigate(`/organizations/${organizationId}/frameworks/${frameworkId}/controls/${data.control.id}`);
+      },
+      onError: (error) => {
+        setIsLoading(false);
+        console.error("Error updating control:", error);
+        toast({
+          title: "Error",
+          description: "Failed to update control. Please try again.",
+          variant: "destructive",
+        });
+      },
+    });
+  };
+
+  return (
+    <div className="container py-10">
+      <div className="max-w-2xl mx-auto">
+        <h1 className="text-3xl font-bold mb-8">Edit Control</h1>
+
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div>
+            <label className="block text-sm font-medium mb-2">Section Title</label>
+            <Input
+              value={formData.sectionTitle}
+              onChange={(e) =>
+                setFormData((prev) => ({ ...prev, sectionTitle: e.target.value }))
+              }
+              required
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-2">Name</label>
+            <Input
+              value={formData.name}
+              onChange={(e) =>
+                setFormData((prev) => ({ ...prev, name: e.target.value }))
+              }
+              required
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-2">Description</label>
+            <Textarea
+              value={formData.description}
+              onChange={(e) =>
+                setFormData((prev) => ({ ...prev, description: e.target.value }))
+              }
+              required
+              rows={5}
+            />
+          </div>
+
+          <div className="flex justify-end gap-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() =>
+                navigate(
+                  `/organizations/${organizationId}/frameworks/${frameworkId}/controls/${data.control.id}`
+                )
+              }
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isLoading}>
+              {isLoading ? (
+                <>
+                  <Loader2 className="w-4 h-4 animate-spin mr-2" />
+                  Saving...
+                </>
+              ) : (
+                "Save Changes"
+              )}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default function EditControlView({ controlId }: { controlId?: string }) {
+  const { controlId: controlIdParam } = useParams();
+  const [queryRef, loadQuery] =
+    useQueryLoader<EditControlViewQuery>(editControlViewQuery);
+
+  useEffect(() => {
+    loadQuery({ controlId: (controlId ?? controlIdParam)! });
+  }, [loadQuery, controlId, controlIdParam]);
+
+  if (!queryRef) {
+    return <EditControlViewSkeleton />;
+  }
+
+  return (
+    <Suspense fallback={<EditControlViewSkeleton />}>
+      <EditControlViewContent queryRef={queryRef} />
+    </Suspense>
+  );
+}

--- a/apps/console/src/pages/organizations/frameworks/controls/NewControlPage.tsx
+++ b/apps/console/src/pages/organizations/frameworks/controls/NewControlPage.tsx
@@ -1,0 +1,14 @@
+import { Loader2 } from "lucide-react";
+import NewControlView from "./NewControlView";
+
+export function NewControlViewSkeleton() {
+  return (
+    <div className="flex items-center justify-center h-full">
+      <Loader2 className="w-8 h-8 animate-spin text-info" />
+    </div>
+  );
+}
+
+export function NewControlPage() {
+  return <NewControlView />;
+}

--- a/apps/console/src/pages/organizations/frameworks/controls/NewControlView.tsx
+++ b/apps/console/src/pages/organizations/frameworks/controls/NewControlView.tsx
@@ -1,0 +1,202 @@
+import { useState } from "react";
+import { graphql, useMutation } from "react-relay";
+import { generateUniqueClientID } from "relay-runtime";
+import { useNavigate, useParams } from "react-router";
+import { useToast } from "@/hooks/use-toast";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Loader2, AlertCircle } from "lucide-react";
+import { NewControlViewCreateControlMutation } from "./__generated__/NewControlViewCreateControlMutation.graphql";
+
+const createControlMutation = graphql`
+  mutation NewControlViewCreateControlMutation($input: CreateControlInput!) {
+    createControl(input: $input) {
+      controlEdge {
+        node {
+          id
+          name
+          description
+          sectionTitle
+        }
+      }
+    }
+  }
+`;
+
+export default function NewControlView() {
+  const { organizationId, frameworkId } = useParams<{
+    organizationId: string;
+    frameworkId: string;
+  }>();
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const [isLoading, setIsLoading] = useState(false);
+  const [commitCreateControl] = useMutation<NewControlViewCreateControlMutation>(
+    createControlMutation
+  );
+
+  // Validate required URL parameters
+  if (!organizationId || !frameworkId) {
+    return (
+      <div className="container py-10">
+        <div className="max-w-2xl mx-auto">
+          <div className="flex items-center gap-2 p-4 border border-red-200 bg-red-50 rounded-md text-red-700">
+            <AlertCircle className="w-5 h-5" />
+            <p>Missing required URL parameters. Please check the URL and try again.</p>
+          </div>
+          <div className="mt-4">
+            <Button
+              variant="outline"
+              onClick={() => navigate('/organizations')}
+            >
+              Return to Organizations
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const [formData, setFormData] = useState({
+    name: "",
+    description: "",
+    sectionTitle: "",
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+
+    commitCreateControl({
+      variables: {
+        input: {
+          frameworkId,
+          name: formData.name,
+          description: formData.description,
+          sectionTitle: formData.sectionTitle,
+        },
+      },
+      onCompleted: (response, errors) => {
+        setIsLoading(false);
+
+        if (errors) {
+          console.error("Error creating control:", errors);
+          toast({
+            title: "Error",
+            description: "Failed to create control. Please try again.",
+            variant: "destructive",
+          });
+          return;
+        }
+
+        const controlId = response.createControl.controlEdge.node.id;
+        toast({
+          title: "Success",
+          description: "Control created successfully.",
+        });
+
+        navigate(
+          `/organizations/${organizationId}/frameworks/${frameworkId}/controls/${controlId}?t=${Date.now()}`,
+          { replace: true }
+        );
+      },
+      onError: (error) => {
+        setIsLoading(false);
+        console.error("Error creating control:", error);
+        toast({
+          title: "Error",
+          description: "Failed to create control. Please try again.",
+          variant: "destructive",
+        });
+      },
+      updater: (store) => {
+        const payload = store.getRootField('createControl');
+        const newControl = payload.getLinkedRecord('controlEdge').getLinkedRecord('node');
+
+        const framework = store.get(frameworkId);
+        if (framework) {
+          const controls = framework.getLinkedRecord('controls');
+          if (controls) {
+            const edges = controls.getLinkedRecords('edges') || [];
+            const newEdgeId = generateUniqueClientID();
+            const newEdge = store.create(newEdgeId, 'ControlEdge');
+            newEdge.setLinkedRecord(newControl, 'node');
+            controls.setLinkedRecords([newEdge, ...edges], 'edges');
+          }
+        }
+      }
+    });
+  };
+
+  return (
+    <div className="container py-10">
+      <div className="max-w-2xl mx-auto">
+        <h1 className="text-3xl font-bold mb-8">Create Control</h1>
+
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div>
+            <label className="block text-sm font-medium mb-2">Section Title</label>
+            <Input
+              value={formData.sectionTitle}
+              onChange={(e) =>
+                setFormData((prev) => ({ ...prev, sectionTitle: e.target.value }))
+              }
+              required
+              placeholder="e.g. CTRL-001"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-2">Name</label>
+            <Input
+              value={formData.name}
+              onChange={(e) =>
+                setFormData((prev) => ({ ...prev, name: e.target.value }))
+              }
+              required
+              placeholder="Enter control name"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-2">Description</label>
+            <Textarea
+              value={formData.description}
+              onChange={(e) =>
+                setFormData((prev) => ({ ...prev, description: e.target.value }))
+              }
+              required
+              rows={5}
+              placeholder="Describe the control"
+            />
+          </div>
+
+          <div className="flex justify-end gap-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() =>
+                navigate(
+                  `/organizations/${organizationId}/frameworks/${frameworkId}`
+                )
+              }
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isLoading}>
+              {isLoading ? (
+                <>
+                  <Loader2 className="w-4 h-4 animate-spin mr-2" />
+                  Creating...
+                </>
+              ) : (
+                "Create Control"
+              )}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/console/src/pages/organizations/frameworks/controls/__generated__/ControlDeleteMutation.graphql.ts
+++ b/apps/console/src/pages/organizations/frameworks/controls/__generated__/ControlDeleteMutation.graphql.ts
@@ -1,0 +1,132 @@
+/**
+ * @generated SignedSource<<210832f4f838924747194254c58b57a4>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type DeleteControlInput = {
+  controlId: string;
+};
+export type ControlDeleteMutation$variables = {
+  connections: ReadonlyArray<string>;
+  input: DeleteControlInput;
+};
+export type ControlDeleteMutation$data = {
+  readonly deleteControl: {
+    readonly deletedControlId: string;
+  };
+};
+export type ControlDeleteMutation = {
+  response: ControlDeleteMutation$data;
+  variables: ControlDeleteMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "deletedControlId",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ControlDeleteMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteControlPayload",
+        "kind": "LinkedField",
+        "name": "deleteControl",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "ControlDeleteMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteControlPayload",
+        "kind": "LinkedField",
+        "name": "deleteControl",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "deleteEdge",
+            "key": "",
+            "kind": "ScalarHandle",
+            "name": "deletedControlId",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "2d95c1ff9328afa01b0f24d1910898d1",
+    "id": null,
+    "metadata": {},
+    "name": "ControlDeleteMutation",
+    "operationKind": "mutation",
+    "text": "mutation ControlDeleteMutation(\n  $input: DeleteControlInput!\n) {\n  deleteControl(input: $input) {\n    deletedControlId\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "a1e347241b41977cdea4a31d371e8770";
+
+export default node;

--- a/apps/console/src/pages/organizations/frameworks/controls/__generated__/ControlFragment_Control.graphql.ts
+++ b/apps/console/src/pages/organizations/frameworks/controls/__generated__/ControlFragment_Control.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8c59833cd4588accdf1d316d9e494d26>>
+ * @generated SignedSource<<50304bfb34b0581895a71491f521c273>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,7 +14,7 @@ export type ControlFragment_Control$data = {
   readonly description: string;
   readonly id: string;
   readonly name: string;
-  readonly referenceId: string;
+  readonly sectionTitle: string;
   readonly " $fragmentType": "ControlFragment_Control";
 };
 export type ControlFragment_Control$key = {
@@ -53,7 +53,7 @@ const node: ReaderFragment = {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
-      "name": "referenceId",
+      "name": "sectionTitle",
       "storageKey": null
     }
   ],
@@ -61,6 +61,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "ccbc9d6743d45b9a4049b661a1f0ad57";
+(node as any).hash = "b04ce9de2a583d415011d88563120b09";
 
 export default node;

--- a/apps/console/src/pages/organizations/frameworks/controls/__generated__/EditControlPageUpdateControlMutation.graphql.ts
+++ b/apps/console/src/pages/organizations/frameworks/controls/__generated__/EditControlPageUpdateControlMutation.graphql.ts
@@ -1,0 +1,132 @@
+/**
+ * @generated SignedSource<<2e60fc1d41d307f288d47b07d4651997>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type UpdateControlInput = {
+  description?: string | null | undefined;
+  id: string;
+  name?: string | null | undefined;
+  referenceId?: string | null | undefined;
+};
+export type EditControlPageUpdateControlMutation$variables = {
+  input: UpdateControlInput;
+};
+export type EditControlPageUpdateControlMutation$data = {
+  readonly updateControl: {
+    readonly control: {
+      readonly description: string;
+      readonly id: string;
+      readonly name: string;
+      readonly referenceId: string;
+    };
+  };
+};
+export type EditControlPageUpdateControlMutation = {
+  response: EditControlPageUpdateControlMutation$data;
+  variables: EditControlPageUpdateControlMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "UpdateControlPayload",
+    "kind": "LinkedField",
+    "name": "updateControl",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Control",
+        "kind": "LinkedField",
+        "name": "control",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "description",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "referenceId",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "EditControlPageUpdateControlMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "EditControlPageUpdateControlMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "62ebcc3fcdb6bf1b1c585227e6555095",
+    "id": null,
+    "metadata": {},
+    "name": "EditControlPageUpdateControlMutation",
+    "operationKind": "mutation",
+    "text": "mutation EditControlPageUpdateControlMutation(\n  $input: UpdateControlInput!\n) {\n  updateControl(input: $input) {\n    control {\n      id\n      name\n      description\n      referenceId\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "2a3daa12db6c6ceac41ffb25be14760f";
+
+export default node;

--- a/apps/console/src/pages/organizations/frameworks/controls/__generated__/EditControlViewQuery.graphql.ts
+++ b/apps/console/src/pages/organizations/frameworks/controls/__generated__/EditControlViewQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<53940cf77492a6c53c699caeb14b1b54>>
+ * @generated SignedSource<<1e68e8f32977bfde6529ccb4244dd679>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,19 +9,20 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-import { FragmentRefs } from "relay-runtime";
-export type ControlViewQuery$variables = {
+export type EditControlViewQuery$variables = {
   controlId: string;
 };
-export type ControlViewQuery$data = {
-  readonly node: {
-    readonly id: string;
-    readonly " $fragmentSpreads": FragmentRefs<"ControlFragment_Control">;
+export type EditControlViewQuery$data = {
+  readonly control: {
+    readonly description?: string;
+    readonly id?: string;
+    readonly name?: string;
+    readonly sectionTitle?: string;
   };
 };
-export type ControlViewQuery = {
-  response: ControlViewQuery$data;
-  variables: ControlViewQuery$variables;
+export type EditControlViewQuery = {
+  response: EditControlViewQuery$data;
+  variables: EditControlViewQuery$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -45,27 +46,53 @@ v2 = {
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "description",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "sectionTitle",
+  "storageKey": null
 };
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "ControlViewQuery",
+    "name": "EditControlViewQuery",
     "selections": [
       {
-        "alias": null,
+        "alias": "control",
         "args": (v1/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v2/*: any*/),
           {
-            "args": null,
-            "kind": "FragmentSpread",
-            "name": "ControlFragment_Control"
+            "kind": "InlineFragment",
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/)
+            ],
+            "type": "Control",
+            "abstractKey": null
           }
         ],
         "storageKey": null
@@ -78,10 +105,10 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "ControlViewQuery",
+    "name": "EditControlViewQuery",
     "selections": [
       {
-        "alias": null,
+        "alias": "control",
         "args": (v1/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
@@ -99,27 +126,9 @@ return {
           {
             "kind": "InlineFragment",
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "description",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "name",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "sectionTitle",
-                "storageKey": null
-              }
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/)
             ],
             "type": "Control",
             "abstractKey": null
@@ -130,16 +139,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "5afaae7974871ebac2058831d084514e",
+    "cacheID": "0b532a5fff1f69df57220aa122e32e18",
     "id": null,
     "metadata": {},
-    "name": "ControlViewQuery",
+    "name": "EditControlViewQuery",
     "operationKind": "query",
-    "text": "query ControlViewQuery(\n  $controlId: ID!\n) {\n  node(id: $controlId) {\n    __typename\n    id\n    ...ControlFragment_Control\n  }\n}\n\nfragment ControlFragment_Control on Control {\n  id\n  description\n  name\n  sectionTitle\n}\n"
+    "text": "query EditControlViewQuery(\n  $controlId: ID!\n) {\n  control: node(id: $controlId) {\n    __typename\n    ... on Control {\n      id\n      name\n      description\n      sectionTitle\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "ea6b1e9919c960be158d2f48aa3b4254";
+(node as any).hash = "83b8034c722cd3fe442906b74a1613d3";
 
 export default node;

--- a/apps/console/src/pages/organizations/frameworks/controls/__generated__/EditControlViewUpdateControlMutation.graphql.ts
+++ b/apps/console/src/pages/organizations/frameworks/controls/__generated__/EditControlViewUpdateControlMutation.graphql.ts
@@ -1,0 +1,132 @@
+/**
+ * @generated SignedSource<<b8d91f33ada88a0656ae9637ebae06a3>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type UpdateControlInput = {
+  description?: string | null | undefined;
+  id: string;
+  name?: string | null | undefined;
+  sectionTitle?: string | null | undefined;
+};
+export type EditControlViewUpdateControlMutation$variables = {
+  input: UpdateControlInput;
+};
+export type EditControlViewUpdateControlMutation$data = {
+  readonly updateControl: {
+    readonly control: {
+      readonly description: string;
+      readonly id: string;
+      readonly name: string;
+      readonly sectionTitle: string;
+    };
+  };
+};
+export type EditControlViewUpdateControlMutation = {
+  response: EditControlViewUpdateControlMutation$data;
+  variables: EditControlViewUpdateControlMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "UpdateControlPayload",
+    "kind": "LinkedField",
+    "name": "updateControl",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Control",
+        "kind": "LinkedField",
+        "name": "control",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "description",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "sectionTitle",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "EditControlViewUpdateControlMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "EditControlViewUpdateControlMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "266ebf922cda80bcc5d0384f37b2d3fa",
+    "id": null,
+    "metadata": {},
+    "name": "EditControlViewUpdateControlMutation",
+    "operationKind": "mutation",
+    "text": "mutation EditControlViewUpdateControlMutation(\n  $input: UpdateControlInput!\n) {\n  updateControl(input: $input) {\n    control {\n      id\n      name\n      description\n      sectionTitle\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "5f232d3fbab52a0bb165bfa58c09bc67";
+
+export default node;

--- a/apps/console/src/pages/organizations/frameworks/controls/__generated__/NewControlViewCreateControlMutation.graphql.ts
+++ b/apps/console/src/pages/organizations/frameworks/controls/__generated__/NewControlViewCreateControlMutation.graphql.ts
@@ -1,0 +1,145 @@
+/**
+ * @generated SignedSource<<bbcc1a7901aa7dd7639e83dfb6590fa5>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type CreateControlInput = {
+  description: string;
+  frameworkId: string;
+  name: string;
+  sectionTitle: string;
+};
+export type NewControlViewCreateControlMutation$variables = {
+  input: CreateControlInput;
+};
+export type NewControlViewCreateControlMutation$data = {
+  readonly createControl: {
+    readonly controlEdge: {
+      readonly node: {
+        readonly description: string;
+        readonly id: string;
+        readonly name: string;
+        readonly sectionTitle: string;
+      };
+    };
+  };
+};
+export type NewControlViewCreateControlMutation = {
+  response: NewControlViewCreateControlMutation$data;
+  variables: NewControlViewCreateControlMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "CreateControlPayload",
+    "kind": "LinkedField",
+    "name": "createControl",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "ControlEdge",
+        "kind": "LinkedField",
+        "name": "controlEdge",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Control",
+            "kind": "LinkedField",
+            "name": "node",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "id",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "description",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "sectionTitle",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "NewControlViewCreateControlMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "NewControlViewCreateControlMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "2005ccdbeac4998dc5bea71013f4cb5d",
+    "id": null,
+    "metadata": {},
+    "name": "NewControlViewCreateControlMutation",
+    "operationKind": "mutation",
+    "text": "mutation NewControlViewCreateControlMutation(\n  $input: CreateControlInput!\n) {\n  createControl(input: $input) {\n    controlEdge {\n      node {\n        id\n        name\n        description\n        sectionTitle\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "354415d46fd5d1b15c029b96452054d3";
+
+export default node;

--- a/apps/console/src/pages/organizations/measures/MeasureView.tsx
+++ b/apps/console/src/pages/organizations/measures/MeasureView.tsx
@@ -396,7 +396,7 @@ const frameworksQuery = graphql`
                 edges {
                   node {
                     id
-                    referenceId
+                    sectionTitle
                     name
                     description
                   }
@@ -419,7 +419,7 @@ const linkedControlsQuery = graphql`
           edges {
             node {
               id
-              referenceId
+              sectionTitle
               name
               description
             }
@@ -2087,7 +2087,7 @@ function MeasureViewContent({
     const lowerQuery = controlSearchQuery.toLowerCase();
     return controls.filter(
       (control) =>
-        control.referenceId.toLowerCase().includes(lowerQuery) ||
+        control.sectionTitle.toLowerCase().includes(lowerQuery) ||
         control.name.toLowerCase().includes(lowerQuery) ||
         (control.description &&
           control.description.toLowerCase().includes(lowerQuery))
@@ -2733,7 +2733,7 @@ function MeasureViewContent({
                               <div className="flex items-center gap-2">
                                 <ShieldCheck className="w-4 h-4 text-green-600" />
                                 <span className="font-medium">
-                                  {control.referenceId}
+                                  {control.sectionTitle}
                                 </span>
                               </div>
                             </td>
@@ -3829,7 +3829,7 @@ function MeasureViewContent({
                             <div className="flex items-center gap-2">
                               <ShieldCheck className="w-4 h-4 text-green-600" />
                               <span className="font-medium">
-                                {control.referenceId}
+                                {control.sectionTitle}
                               </span>
                             </div>
                           </td>

--- a/apps/console/src/pages/organizations/measures/__generated__/MeasureViewFrameworksQuery.graphql.ts
+++ b/apps/console/src/pages/organizations/measures/__generated__/MeasureViewFrameworksQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f3d959452f28259f74fc44f4c1eedcb2>>
+ * @generated SignedSource<<dbee9bd358b3985bd5ae5f8630474534>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -23,7 +23,7 @@ export type MeasureViewFrameworksQuery$data = {
                 readonly description: string;
                 readonly id: string;
                 readonly name: string;
-                readonly referenceId: string;
+                readonly sectionTitle: string;
               };
             }>;
           };
@@ -130,7 +130,7 @@ v7 = [
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "referenceId",
+            "name": "sectionTitle",
             "storageKey": null
           },
           (v3/*: any*/),
@@ -331,7 +331,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f32215939196e9e13f1347b57111f5cb",
+    "cacheID": "5dc8707d458fdb4ab9cf4967b716b85e",
     "id": null,
     "metadata": {
       "connection": [
@@ -354,11 +354,11 @@ return {
     },
     "name": "MeasureViewFrameworksQuery",
     "operationKind": "query",
-    "text": "query MeasureViewFrameworksQuery(\n  $organizationId: ID!\n) {\n  organization: node(id: $organizationId) {\n    __typename\n    id\n    ... on Organization {\n      frameworks(first: 100) {\n        edges {\n          node {\n            id\n            name\n            controls(first: 100) {\n              edges {\n                node {\n                  id\n                  referenceId\n                  name\n                  description\n                  __typename\n                }\n                cursor\n              }\n              pageInfo {\n                endCursor\n                hasNextPage\n              }\n            }\n            __typename\n          }\n          cursor\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query MeasureViewFrameworksQuery(\n  $organizationId: ID!\n) {\n  organization: node(id: $organizationId) {\n    __typename\n    id\n    ... on Organization {\n      frameworks(first: 100) {\n        edges {\n          node {\n            id\n            name\n            controls(first: 100) {\n              edges {\n                node {\n                  id\n                  sectionTitle\n                  name\n                  description\n                  __typename\n                }\n                cursor\n              }\n              pageInfo {\n                endCursor\n                hasNextPage\n              }\n            }\n            __typename\n          }\n          cursor\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "f1183b14c80a91b160f222af00d49b6f";
+(node as any).hash = "106bc944729f346777ecf0182ac41ad3";
 
 export default node;

--- a/apps/console/src/pages/organizations/measures/__generated__/MeasureViewLinkedControlsQuery.graphql.ts
+++ b/apps/console/src/pages/organizations/measures/__generated__/MeasureViewLinkedControlsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9b551f9e8f59a5ffe5c00700cdb59c88>>
+ * @generated SignedSource<<c82317e2abf68f766fe616c69437f338>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -20,7 +20,7 @@ export type MeasureViewLinkedControlsQuery$data = {
           readonly description: string;
           readonly id: string;
           readonly name: string;
-          readonly referenceId: string;
+          readonly sectionTitle: string;
         };
       }>;
     };
@@ -83,7 +83,7 @@ v4 = [
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "referenceId",
+            "name": "sectionTitle",
             "storageKey": null
           },
           {
@@ -235,7 +235,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b4f524eea7ce57decf321b7efacdaa03",
+    "cacheID": "1d1f61565fa1616f441ad54c7b590200",
     "id": null,
     "metadata": {
       "connection": [
@@ -252,11 +252,11 @@ return {
     },
     "name": "MeasureViewLinkedControlsQuery",
     "operationKind": "query",
-    "text": "query MeasureViewLinkedControlsQuery(\n  $measureId: ID!\n) {\n  measure: node(id: $measureId) {\n    __typename\n    id\n    ... on Measure {\n      controls(first: 100) {\n        edges {\n          node {\n            id\n            referenceId\n            name\n            description\n            __typename\n          }\n          cursor\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query MeasureViewLinkedControlsQuery(\n  $measureId: ID!\n) {\n  measure: node(id: $measureId) {\n    __typename\n    id\n    ... on Measure {\n      controls(first: 100) {\n        edges {\n          node {\n            id\n            sectionTitle\n            name\n            description\n            __typename\n          }\n          cursor\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "5dfd96b1ab2edc5c8c654346046a968f";
+(node as any).hash = "5553b0d4c34e498e432315f8fa1dd805";
 
 export default node;

--- a/apps/console/src/pages/organizations/risks/ShowRiskView.tsx
+++ b/apps/console/src/pages/organizations/risks/ShowRiskView.tsx
@@ -110,7 +110,7 @@ const showRiskViewQuery = graphql`
           edges {
             node {
               id
-              referenceId
+              sectionTitle
               name
               description
               createdAt
@@ -1211,7 +1211,7 @@ function ShowRiskViewContent({
                             to={`/organizations/${organizationId}/controls/${control.id}`}
                             className="font-medium text-blue-600 hover:underline"
                           >
-                            {control.referenceId} - {control.name}
+                            {control.sectionTitle} - {control.name}
                           </Link>
                         </TableCell>
                       </TableRow>

--- a/apps/console/src/pages/organizations/risks/__generated__/ShowRiskViewQuery.graphql.ts
+++ b/apps/console/src/pages/organizations/risks/__generated__/ShowRiskViewQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d43ef1981a6db6f7813e6587e3eaf192>>
+ * @generated SignedSource<<b49e4f8dc994a66c6e6c9450126028f5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -23,7 +23,7 @@ export type ShowRiskViewQuery$data = {
           readonly description: string;
           readonly id: string;
           readonly name: string;
-          readonly referenceId: string;
+          readonly sectionTitle: string;
         };
       }>;
     };
@@ -323,7 +323,7 @@ v19 = [
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "referenceId",
+            "name": "sectionTitle",
             "storageKey": null
           },
           (v3/*: any*/),
@@ -514,7 +514,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "9d1057cf6eac37c07ed841a80a4604b9",
+    "cacheID": "fe20c6f4cd1e70c14bb099af7ecfffc2",
     "id": null,
     "metadata": {
       "connection": [
@@ -549,11 +549,11 @@ return {
     },
     "name": "ShowRiskViewQuery",
     "operationKind": "query",
-    "text": "query ShowRiskViewQuery(\n  $riskId: ID!\n) {\n  node(id: $riskId) {\n    __typename\n    id\n    ... on Risk {\n      name\n      description\n      treatment\n      owner {\n        id\n        fullName\n      }\n      inherentLikelihood\n      inherentImpact\n      residualLikelihood\n      residualImpact\n      note\n      createdAt\n      updatedAt\n      measures(first: 100) {\n        edges {\n          node {\n            id\n            name\n            description\n            category\n            createdAt\n            state\n            __typename\n          }\n          cursor\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n      documents(first: 100) {\n        edges {\n          node {\n            id\n            title\n            createdAt\n            __typename\n          }\n          cursor\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n      controls(first: 100) {\n        edges {\n          node {\n            id\n            referenceId\n            name\n            description\n            createdAt\n            __typename\n          }\n          cursor\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query ShowRiskViewQuery(\n  $riskId: ID!\n) {\n  node(id: $riskId) {\n    __typename\n    id\n    ... on Risk {\n      name\n      description\n      treatment\n      owner {\n        id\n        fullName\n      }\n      inherentLikelihood\n      inherentImpact\n      residualLikelihood\n      residualImpact\n      note\n      createdAt\n      updatedAt\n      measures(first: 100) {\n        edges {\n          node {\n            id\n            name\n            description\n            category\n            createdAt\n            state\n            __typename\n          }\n          cursor\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n      documents(first: 100) {\n        edges {\n          node {\n            id\n            title\n            createdAt\n            __typename\n          }\n          cursor\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n      controls(first: 100) {\n        edges {\n          node {\n            id\n            sectionTitle\n            name\n            description\n            createdAt\n            __typename\n          }\n          cursor\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "96763bbbebd3aa29a02fcf1e6e782293";
+(node as any).hash = "f1695786e4eb823466d6ebee4555cd9b";
 
 export default node;

--- a/pkg/coredata/control_order_field.go
+++ b/pkg/coredata/control_order_field.go
@@ -19,11 +19,19 @@ type (
 )
 
 const (
-	ControlOrderFieldCreatedAt ControlOrderField = "CREATED_AT"
+	ControlOrderFieldCreatedAt    ControlOrderField = "CREATED_AT"
+	ControlOrderFieldSectionTitle ControlOrderField = "SECTION_TITLE"
 )
 
 func (p ControlOrderField) Column() string {
-	return string(p)
+	switch p {
+	case ControlOrderFieldCreatedAt:
+		return "created_at"
+	case ControlOrderFieldSectionTitle:
+		return "section_title_sort_key(section_title)"
+	default:
+		return string(p)
+	}
 }
 
 func (p ControlOrderField) String() string {

--- a/pkg/coredata/migrations/20250605T233149Z.sql
+++ b/pkg/coredata/migrations/20250605T233149Z.sql
@@ -1,0 +1,34 @@
+ALTER TABLE controls DROP COLUMN version;
+
+ALTER TABLE controls RENAME COLUMN reference_id TO section_title;
+
+CREATE OR REPLACE FUNCTION section_title_sort_key(text) RETURNS text AS $$
+DECLARE
+    result text := '';
+    matches text[];
+    remainder text := $1;
+BEGIN
+    WHILE remainder ~ '\d+' LOOP
+        -- Extract text before the number
+        result := result || substring(remainder FROM '^[^\d]*');
+
+        -- Extract and pad the next number
+        matches := regexp_matches(remainder, '(\d+)', '');  -- captures the first number
+        IF matches IS NOT NULL THEN
+            result := result || lpad(matches[1], 10, '0');
+            -- Remove processed part from remainder
+            remainder := substring(remainder FROM '\d+(.*)$');
+        ELSE
+            EXIT;
+        END IF;
+    END LOOP;
+
+    -- Append any remaining non-digit text
+    result := result || remainder;
+
+    RETURN result;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE STRICT;
+
+COMMENT ON FUNCTION section_title_sort_key(text) IS
+    'Converts numbers in strings to zero-padded format for natural sorting';

--- a/pkg/probo/control_service.go
+++ b/pkg/probo/control_service.go
@@ -31,17 +31,18 @@ type (
 	}
 
 	CreateControlRequest struct {
-		ID          gid.GID
-		FrameworkID gid.GID
-		Name        string
-		Description string
+		ID           gid.GID
+		FrameworkID  gid.GID
+		Name         string
+		Description  string
+		SectionTitle string
 	}
 
 	UpdateControlRequest struct {
-		ID              gid.GID
-		ExpectedVersion int
-		Name            *string
-		Description     *string
+		ID           gid.GID
+		Name         *string
+		Description  *string
+		SectionTitle *string
 	}
 
 	ConnectControlToMitigationRequest struct {
@@ -263,13 +264,14 @@ func (s ControlService) Create(
 	framework := &coredata.Framework{}
 
 	control := &coredata.Control{
-		ID:          req.ID,
-		FrameworkID: req.FrameworkID,
-		TenantID:    s.svc.scope.GetTenantID(),
-		Name:        req.Name,
-		Description: req.Description,
-		CreatedAt:   now,
-		UpdatedAt:   now,
+		ID:           gid.New(s.svc.scope.GetTenantID(), coredata.ControlEntityType),
+		FrameworkID:  req.FrameworkID,
+		TenantID:     s.svc.scope.GetTenantID(),
+		Name:         req.Name,
+		Description:  req.Description,
+		SectionTitle: req.SectionTitle,
+		CreatedAt:    now,
+		UpdatedAt:    now,
 	}
 
 	err := s.svc.pg.WithTx(
@@ -317,9 +319,9 @@ func (s ControlService) Update(
 	req UpdateControlRequest,
 ) (*coredata.Control, error) {
 	params := coredata.UpdateControlParams{
-		ExpectedVersion: req.ExpectedVersion,
-		Name:            req.Name,
-		Description:     req.Description,
+		Name:         req.Name,
+		Description:  req.Description,
+		SectionTitle: req.SectionTitle,
 	}
 
 	control := &coredata.Control{ID: req.ID}

--- a/pkg/probo/measure_service.go
+++ b/pkg/probo/measure_service.go
@@ -235,7 +235,7 @@ func (s MeasureService) Import(
 					}
 
 					control := &coredata.Control{}
-					if err := control.LoadByFrameworkIDAndReferenceID(ctx, tx, s.svc.scope, framework.ID, standard.Control); err != nil {
+					if err := control.LoadByFrameworkIDAndSectionTitle(ctx, tx, s.svc.scope, framework.ID, standard.Control); err != nil {
 						continue
 					}
 

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -169,6 +169,10 @@ enum ControlOrderField
     @goEnum(
       value: "github.com/getprobo/probo/pkg/coredata.ControlOrderFieldCreatedAt"
     )
+  SECTION_TITLE
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ControlOrderFieldSectionTitle"
+    )
 }
 
 enum MeasureOrderField
@@ -683,7 +687,7 @@ type Framework implements Node {
 
 type Control implements Node {
   id: ID!
-  referenceId: String!
+  sectionTitle: String!
   name: String!
   description: String!
 
@@ -1086,6 +1090,11 @@ type Mutation {
   updateFramework(input: UpdateFrameworkInput!): UpdateFrameworkPayload!
   importFramework(input: ImportFrameworkInput!): ImportFrameworkPayload!
   deleteFramework(input: DeleteFrameworkInput!): DeleteFrameworkPayload!
+
+  # Control mutations
+  createControl(input: CreateControlInput!): CreateControlPayload!
+  updateControl(input: UpdateControlInput!): UpdateControlPayload!
+  deleteControl(input: DeleteControlInput!): DeleteControlPayload!
 
   # Measure mutations
   createMeasure(input: CreateMeasureInput!): CreateMeasurePayload!
@@ -1502,6 +1511,24 @@ input RemoveUserInput {
   userId: ID!
 }
 
+input CreateControlInput {
+  frameworkId: ID!
+  sectionTitle: String!
+  name: String!
+  description: String!
+}
+
+input UpdateControlInput {
+  id: ID!
+  sectionTitle: String
+  name: String
+  description: String
+}
+
+input DeleteControlInput {
+  controlId: ID!
+}
+
 # Payload Types
 type CreateOrganizationPayload {
   organizationEdge: OrganizationEdge!
@@ -1513,6 +1540,18 @@ type UpdateOrganizationPayload {
 
 type DeleteOrganizationPayload {
   deletedOrganizationId: ID!
+}
+
+type CreateControlPayload {
+  controlEdge: ControlEdge!
+}
+
+type UpdateControlPayload {
+  control: Control!
+}
+
+type DeleteControlPayload {
+  deletedControlId: ID!
 }
 
 type CreateVendorPayload {

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -130,15 +130,15 @@ type ComplexityRoot struct {
 	}
 
 	Control struct {
-		CreatedAt   func(childComplexity int) int
-		Description func(childComplexity int) int
-		Documents   func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy) int
-		Framework   func(childComplexity int) int
-		ID          func(childComplexity int) int
-		Measures    func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy) int
-		Name        func(childComplexity int) int
-		ReferenceID func(childComplexity int) int
-		UpdatedAt   func(childComplexity int) int
+		CreatedAt    func(childComplexity int) int
+		Description  func(childComplexity int) int
+		Documents    func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy) int
+		Framework    func(childComplexity int) int
+		ID           func(childComplexity int) int
+		Measures     func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy) int
+		Name         func(childComplexity int) int
+		SectionTitle func(childComplexity int) int
+		UpdatedAt    func(childComplexity int) int
 	}
 
 	ControlConnection struct {
@@ -163,6 +163,10 @@ type ComplexityRoot struct {
 	CreateControlMeasureMappingPayload struct {
 		ControlEdge func(childComplexity int) int
 		MeasureEdge func(childComplexity int) int
+	}
+
+	CreateControlPayload struct {
+		ControlEdge func(childComplexity int) int
 	}
 
 	CreateDatumPayload struct {
@@ -257,6 +261,10 @@ type ComplexityRoot struct {
 	DeleteControlMeasureMappingPayload struct {
 		DeletedControlID func(childComplexity int) int
 		DeletedMeasureID func(childComplexity int) int
+	}
+
+	DeleteControlPayload struct {
+		DeletedControlID func(childComplexity int) int
 	}
 
 	DeleteDatumPayload struct {
@@ -486,6 +494,7 @@ type ComplexityRoot struct {
 		AssignTask                   func(childComplexity int, input types.AssignTaskInput) int
 		ConfirmEmail                 func(childComplexity int, input types.ConfirmEmailInput) int
 		CreateAsset                  func(childComplexity int, input types.CreateAssetInput) int
+		CreateControl                func(childComplexity int, input types.CreateControlInput) int
 		CreateControlDocumentMapping func(childComplexity int, input types.CreateControlDocumentMappingInput) int
 		CreateControlMeasureMapping  func(childComplexity int, input types.CreateControlMeasureMappingInput) int
 		CreateDatum                  func(childComplexity int, input types.CreateDatumInput) int
@@ -502,6 +511,7 @@ type ComplexityRoot struct {
 		CreateVendor                 func(childComplexity int, input types.CreateVendorInput) int
 		CreateVendorRiskAssessment   func(childComplexity int, input types.CreateVendorRiskAssessmentInput) int
 		DeleteAsset                  func(childComplexity int, input types.DeleteAssetInput) int
+		DeleteControl                func(childComplexity int, input types.DeleteControlInput) int
 		DeleteControlDocumentMapping func(childComplexity int, input types.DeleteControlDocumentMappingInput) int
 		DeleteControlMeasureMapping  func(childComplexity int, input types.DeleteControlMeasureMappingInput) int
 		DeleteDatum                  func(childComplexity int, input types.DeleteDatumInput) int
@@ -532,6 +542,7 @@ type ComplexityRoot struct {
 		SendSigningNotifications     func(childComplexity int, input types.SendSigningNotificationsInput) int
 		UnassignTask                 func(childComplexity int, input types.UnassignTaskInput) int
 		UpdateAsset                  func(childComplexity int, input types.UpdateAssetInput) int
+		UpdateControl                func(childComplexity int, input types.UpdateControlInput) int
 		UpdateDatum                  func(childComplexity int, input types.UpdateDatumInput) int
 		UpdateDocument               func(childComplexity int, input types.UpdateDocumentInput) int
 		UpdateDocumentVersion        func(childComplexity int, input types.UpdateDocumentVersionInput) int
@@ -708,6 +719,10 @@ type ComplexityRoot struct {
 
 	UpdateAssetPayload struct {
 		Asset func(childComplexity int) int
+	}
+
+	UpdateControlPayload struct {
+		Control func(childComplexity int) int
 	}
 
 	UpdateDatumPayload struct {
@@ -941,6 +956,9 @@ type MutationResolver interface {
 	UpdateFramework(ctx context.Context, input types.UpdateFrameworkInput) (*types.UpdateFrameworkPayload, error)
 	ImportFramework(ctx context.Context, input types.ImportFrameworkInput) (*types.ImportFrameworkPayload, error)
 	DeleteFramework(ctx context.Context, input types.DeleteFrameworkInput) (*types.DeleteFrameworkPayload, error)
+	CreateControl(ctx context.Context, input types.CreateControlInput) (*types.CreateControlPayload, error)
+	UpdateControl(ctx context.Context, input types.UpdateControlInput) (*types.UpdateControlPayload, error)
+	DeleteControl(ctx context.Context, input types.DeleteControlInput) (*types.DeleteControlPayload, error)
 	CreateMeasure(ctx context.Context, input types.CreateMeasureInput) (*types.CreateMeasurePayload, error)
 	UpdateMeasure(ctx context.Context, input types.UpdateMeasureInput) (*types.UpdateMeasurePayload, error)
 	ImportMeasure(ctx context.Context, input types.ImportMeasureInput) (*types.ImportMeasurePayload, error)
@@ -1332,12 +1350,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Control.Name(childComplexity), true
 
-	case "Control.referenceId":
-		if e.complexity.Control.ReferenceID == nil {
+	case "Control.sectionTitle":
+		if e.complexity.Control.SectionTitle == nil {
 			break
 		}
 
-		return e.complexity.Control.ReferenceID(childComplexity), true
+		return e.complexity.Control.SectionTitle(childComplexity), true
 
 	case "Control.updatedAt":
 		if e.complexity.Control.UpdatedAt == nil {
@@ -1408,6 +1426,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.CreateControlMeasureMappingPayload.MeasureEdge(childComplexity), true
+
+	case "CreateControlPayload.controlEdge":
+		if e.complexity.CreateControlPayload.ControlEdge == nil {
+			break
+		}
+
+		return e.complexity.CreateControlPayload.ControlEdge(childComplexity), true
 
 	case "CreateDatumPayload.datumEdge":
 		if e.complexity.CreateDatumPayload.DatumEdge == nil {
@@ -1651,6 +1676,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.DeleteControlMeasureMappingPayload.DeletedMeasureID(childComplexity), true
+
+	case "DeleteControlPayload.deletedControlId":
+		if e.complexity.DeleteControlPayload.DeletedControlID == nil {
+			break
+		}
+
+		return e.complexity.DeleteControlPayload.DeletedControlID(childComplexity), true
 
 	case "DeleteDatumPayload.deletedDatumId":
 		if e.complexity.DeleteDatumPayload.DeletedDatumID == nil {
@@ -2527,6 +2559,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.CreateAsset(childComplexity, args["input"].(types.CreateAssetInput)), true
 
+	case "Mutation.createControl":
+		if e.complexity.Mutation.CreateControl == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_createControl_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreateControl(childComplexity, args["input"].(types.CreateControlInput)), true
+
 	case "Mutation.createControlDocumentMapping":
 		if e.complexity.Mutation.CreateControlDocumentMapping == nil {
 			break
@@ -2718,6 +2762,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.DeleteAsset(childComplexity, args["input"].(types.DeleteAssetInput)), true
+
+	case "Mutation.deleteControl":
+		if e.complexity.Mutation.DeleteControl == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_deleteControl_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteControl(childComplexity, args["input"].(types.DeleteControlInput)), true
 
 	case "Mutation.deleteControlDocumentMapping":
 		if e.complexity.Mutation.DeleteControlDocumentMapping == nil {
@@ -3078,6 +3134,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.UpdateAsset(childComplexity, args["input"].(types.UpdateAssetInput)), true
+
+	case "Mutation.updateControl":
+		if e.complexity.Mutation.UpdateControl == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_updateControl_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UpdateControl(childComplexity, args["input"].(types.UpdateControlInput)), true
 
 	case "Mutation.updateDatum":
 		if e.complexity.Mutation.UpdateDatum == nil {
@@ -3952,6 +4020,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.UpdateAssetPayload.Asset(childComplexity), true
 
+	case "UpdateControlPayload.control":
+		if e.complexity.UpdateControlPayload.Control == nil {
+			break
+		}
+
+		return e.complexity.UpdateControlPayload.Control(childComplexity), true
+
 	case "UpdateDatumPayload.datum":
 		if e.complexity.UpdateDatumPayload.Datum == nil {
 			break
@@ -4557,6 +4632,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputControlOrder,
 		ec.unmarshalInputCreateAssetInput,
 		ec.unmarshalInputCreateControlDocumentMappingInput,
+		ec.unmarshalInputCreateControlInput,
 		ec.unmarshalInputCreateControlMeasureMappingInput,
 		ec.unmarshalInputCreateDatumInput,
 		ec.unmarshalInputCreateDocumentInput,
@@ -4575,6 +4651,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputDatumOrder,
 		ec.unmarshalInputDeleteAssetInput,
 		ec.unmarshalInputDeleteControlDocumentMappingInput,
+		ec.unmarshalInputDeleteControlInput,
 		ec.unmarshalInputDeleteControlMeasureMappingInput,
 		ec.unmarshalInputDeleteDatumInput,
 		ec.unmarshalInputDeleteDocumentInput,
@@ -4615,6 +4692,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputTaskOrder,
 		ec.unmarshalInputUnassignTaskInput,
 		ec.unmarshalInputUpdateAssetInput,
+		ec.unmarshalInputUpdateControlInput,
 		ec.unmarshalInputUpdateDatumInput,
 		ec.unmarshalInputUpdateDocumentInput,
 		ec.unmarshalInputUpdateDocumentVersionInput,
@@ -4899,6 +4977,10 @@ enum ControlOrderField
   CREATED_AT
     @goEnum(
       value: "github.com/getprobo/probo/pkg/coredata.ControlOrderFieldCreatedAt"
+    )
+  SECTION_TITLE
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ControlOrderFieldSectionTitle"
     )
 }
 
@@ -5414,7 +5496,7 @@ type Framework implements Node {
 
 type Control implements Node {
   id: ID!
-  referenceId: String!
+  sectionTitle: String!
   name: String!
   description: String!
 
@@ -5817,6 +5899,11 @@ type Mutation {
   updateFramework(input: UpdateFrameworkInput!): UpdateFrameworkPayload!
   importFramework(input: ImportFrameworkInput!): ImportFrameworkPayload!
   deleteFramework(input: DeleteFrameworkInput!): DeleteFrameworkPayload!
+
+  # Control mutations
+  createControl(input: CreateControlInput!): CreateControlPayload!
+  updateControl(input: UpdateControlInput!): UpdateControlPayload!
+  deleteControl(input: DeleteControlInput!): DeleteControlPayload!
 
   # Measure mutations
   createMeasure(input: CreateMeasureInput!): CreateMeasurePayload!
@@ -6233,6 +6320,24 @@ input RemoveUserInput {
   userId: ID!
 }
 
+input CreateControlInput {
+  frameworkId: ID!
+  sectionTitle: String!
+  name: String!
+  description: String!
+}
+
+input UpdateControlInput {
+  id: ID!
+  sectionTitle: String
+  name: String
+  description: String
+}
+
+input DeleteControlInput {
+  controlId: ID!
+}
+
 # Payload Types
 type CreateOrganizationPayload {
   organizationEdge: OrganizationEdge!
@@ -6244,6 +6349,18 @@ type UpdateOrganizationPayload {
 
 type DeleteOrganizationPayload {
   deletedOrganizationId: ID!
+}
+
+type CreateControlPayload {
+  controlEdge: ControlEdge!
+}
+
+type UpdateControlPayload {
+  control: Control!
+}
+
+type DeleteControlPayload {
+  deletedControlId: ID!
 }
 
 type CreateVendorPayload {
@@ -8154,6 +8271,29 @@ func (ec *executionContext) field_Mutation_createControlMeasureMapping_argsInput
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation_createControl_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_createControl_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_createControl_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.CreateControlInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNCreateControlInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateControlInput(ctx, tmp)
+	}
+
+	var zeroVal types.CreateControlInput
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation_createDatum_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -8519,6 +8659,29 @@ func (ec *executionContext) field_Mutation_deleteControlMeasureMapping_argsInput
 	}
 
 	var zeroVal types.DeleteControlMeasureMappingInput
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_deleteControl_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_deleteControl_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_deleteControl_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.DeleteControlInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNDeleteControlInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteControlInput(ctx, tmp)
+	}
+
+	var zeroVal types.DeleteControlInput
 	return zeroVal, nil
 }
 
@@ -9163,6 +9326,29 @@ func (ec *executionContext) field_Mutation_updateAsset_argsInput(
 	}
 
 	var zeroVal types.UpdateAssetInput
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_updateControl_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_updateControl_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_updateControl_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.UpdateControlInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNUpdateControlInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateControlInput(ctx, tmp)
+	}
+
+	var zeroVal types.UpdateControlInput
 	return zeroVal, nil
 }
 
@@ -12923,8 +13109,8 @@ func (ec *executionContext) fieldContext_Control_id(_ context.Context, field gra
 	return fc, nil
 }
 
-func (ec *executionContext) _Control_referenceId(ctx context.Context, field graphql.CollectedField, obj *types.Control) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Control_referenceId(ctx, field)
+func (ec *executionContext) _Control_sectionTitle(ctx context.Context, field graphql.CollectedField, obj *types.Control) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Control_sectionTitle(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -12937,7 +13123,7 @@ func (ec *executionContext) _Control_referenceId(ctx context.Context, field grap
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.ReferenceID, nil
+		return obj.SectionTitle, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -12954,7 +13140,7 @@ func (ec *executionContext) _Control_referenceId(ctx context.Context, field grap
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Control_referenceId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Control_sectionTitle(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Control",
 		Field:      field,
@@ -13514,8 +13700,8 @@ func (ec *executionContext) fieldContext_ControlEdge_node(_ context.Context, fie
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_Control_id(ctx, field)
-			case "referenceId":
-				return ec.fieldContext_Control_referenceId(ctx, field)
+			case "sectionTitle":
+				return ec.fieldContext_Control_sectionTitle(ctx, field)
 			case "name":
 				return ec.fieldContext_Control_name(ctx, field)
 			case "description":
@@ -13782,6 +13968,56 @@ func (ec *executionContext) fieldContext_CreateControlMeasureMappingPayload_meas
 				return ec.fieldContext_MeasureEdge_node(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type MeasureEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CreateControlPayload_controlEdge(ctx context.Context, field graphql.CollectedField, obj *types.CreateControlPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CreateControlPayload_controlEdge(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ControlEdge, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.ControlEdge)
+	fc.Result = res
+	return ec.marshalNControlEdge2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐControlEdge(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CreateControlPayload_controlEdge(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CreateControlPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "cursor":
+				return ec.fieldContext_ControlEdge_cursor(ctx, field)
+			case "node":
+				return ec.fieldContext_ControlEdge_node(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ControlEdge", field.Name)
 		},
 	}
 	return fc, nil
@@ -15482,6 +15718,50 @@ func (ec *executionContext) _DeleteControlMeasureMappingPayload_deletedMeasureId
 func (ec *executionContext) fieldContext_DeleteControlMeasureMappingPayload_deletedMeasureId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "DeleteControlMeasureMappingPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DeleteControlPayload_deletedControlId(ctx context.Context, field graphql.CollectedField, obj *types.DeleteControlPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DeleteControlPayload_deletedControlId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DeletedControlID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(gid.GID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DeleteControlPayload_deletedControlId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DeleteControlPayload",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -21875,6 +22155,183 @@ func (ec *executionContext) fieldContext_Mutation_deleteFramework(ctx context.Co
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_deleteFramework_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_createControl(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_createControl(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateControl(rctx, fc.Args["input"].(types.CreateControlInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.CreateControlPayload)
+	fc.Result = res
+	return ec.marshalNCreateControlPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateControlPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_createControl(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "controlEdge":
+				return ec.fieldContext_CreateControlPayload_controlEdge(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CreateControlPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_createControl_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_updateControl(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_updateControl(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UpdateControl(rctx, fc.Args["input"].(types.UpdateControlInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.UpdateControlPayload)
+	fc.Result = res
+	return ec.marshalNUpdateControlPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateControlPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_updateControl(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "control":
+				return ec.fieldContext_UpdateControlPayload_control(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UpdateControlPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_updateControl_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_deleteControl(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_deleteControl(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteControl(rctx, fc.Args["input"].(types.DeleteControlInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.DeleteControlPayload)
+	fc.Result = res
+	return ec.marshalNDeleteControlPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteControlPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_deleteControl(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "deletedControlId":
+				return ec.fieldContext_DeleteControlPayload_deletedControlId(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DeleteControlPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_deleteControl_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -29646,6 +30103,70 @@ func (ec *executionContext) fieldContext_UpdateAssetPayload_asset(_ context.Cont
 	return fc, nil
 }
 
+func (ec *executionContext) _UpdateControlPayload_control(ctx context.Context, field graphql.CollectedField, obj *types.UpdateControlPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UpdateControlPayload_control(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Control, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.Control)
+	fc.Result = res
+	return ec.marshalNControl2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐControl(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UpdateControlPayload_control(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UpdateControlPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Control_id(ctx, field)
+			case "sectionTitle":
+				return ec.fieldContext_Control_sectionTitle(ctx, field)
+			case "name":
+				return ec.fieldContext_Control_name(ctx, field)
+			case "description":
+				return ec.fieldContext_Control_description(ctx, field)
+			case "framework":
+				return ec.fieldContext_Control_framework(ctx, field)
+			case "measures":
+				return ec.fieldContext_Control_measures(ctx, field)
+			case "documents":
+				return ec.fieldContext_Control_documents(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Control_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Control_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Control", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _UpdateDatumPayload_datum(ctx context.Context, field graphql.CollectedField, obj *types.UpdateDatumPayload) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_UpdateDatumPayload_datum(ctx, field)
 	if err != nil {
@@ -36254,6 +36775,54 @@ func (ec *executionContext) unmarshalInputCreateControlDocumentMappingInput(ctx 
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputCreateControlInput(ctx context.Context, obj any) (types.CreateControlInput, error) {
+	var it types.CreateControlInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"frameworkId", "sectionTitle", "name", "description"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "frameworkId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("frameworkId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.FrameworkID = data
+		case "sectionTitle":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("sectionTitle"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SectionTitle = data
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "description":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Description = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputCreateControlMeasureMappingInput(ctx context.Context, obj any) (types.CreateControlMeasureMappingInput, error) {
 	var it types.CreateControlMeasureMappingInput
 	asMap := map[string]any{}
@@ -37217,6 +37786,33 @@ func (ec *executionContext) unmarshalInputDeleteControlDocumentMappingInput(ctx 
 				return it, err
 			}
 			it.DocumentID = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputDeleteControlInput(ctx context.Context, obj any) (types.DeleteControlInput, error) {
+	var it types.DeleteControlInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"controlId"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "controlId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("controlId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ControlID = data
 		}
 	}
 
@@ -38542,6 +39138,54 @@ func (ec *executionContext) unmarshalInputUpdateAssetInput(ctx context.Context, 
 				return it, err
 			}
 			it.VendorIds = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputUpdateControlInput(ctx context.Context, obj any) (types.UpdateControlInput, error) {
+	var it types.UpdateControlInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id", "sectionTitle", "name", "description"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ID = data
+		case "sectionTitle":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("sectionTitle"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SectionTitle = data
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "description":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Description = data
 		}
 	}
 
@@ -40285,8 +40929,8 @@ func (ec *executionContext) _Control(ctx context.Context, sel ast.SelectionSet, 
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
-		case "referenceId":
-			out.Values[i] = ec._Control_referenceId(ctx, field, obj)
+		case "sectionTitle":
+			out.Values[i] = ec._Control_sectionTitle(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
@@ -40630,6 +41274,45 @@ func (ec *executionContext) _CreateControlMeasureMappingPayload(ctx context.Cont
 			}
 		case "measureEdge":
 			out.Values[i] = ec._CreateControlMeasureMappingPayload_measureEdge(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var createControlPayloadImplementors = []string{"CreateControlPayload"}
+
+func (ec *executionContext) _CreateControlPayload(ctx context.Context, sel ast.SelectionSet, obj *types.CreateControlPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, createControlPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CreateControlPayload")
+		case "controlEdge":
+			out.Values[i] = ec._CreateControlPayload_controlEdge(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -41573,6 +42256,45 @@ func (ec *executionContext) _DeleteControlMeasureMappingPayload(ctx context.Cont
 			}
 		case "deletedMeasureId":
 			out.Values[i] = ec._DeleteControlMeasureMappingPayload_deletedMeasureId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var deleteControlPayloadImplementors = []string{"DeleteControlPayload"}
+
+func (ec *executionContext) _DeleteControlPayload(ctx context.Context, sel ast.SelectionSet, obj *types.DeleteControlPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, deleteControlPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("DeleteControlPayload")
+		case "deletedControlId":
+			out.Values[i] = ec._DeleteControlPayload_deletedControlId(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -44132,6 +44854,27 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "createControl":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_createControl(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "updateControl":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_updateControl(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "deleteControl":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_deleteControl(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "createMeasure":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_createMeasure(ctx, field)
@@ -46411,6 +47154,45 @@ func (ec *executionContext) _UpdateAssetPayload(ctx context.Context, sel ast.Sel
 			out.Values[i] = graphql.MarshalString("UpdateAssetPayload")
 		case "asset":
 			out.Values[i] = ec._UpdateAssetPayload_asset(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var updateControlPayloadImplementors = []string{"UpdateControlPayload"}
+
+func (ec *executionContext) _UpdateControlPayload(ctx context.Context, sel ast.SelectionSet, obj *types.UpdateControlPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, updateControlPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("UpdateControlPayload")
+		case "control":
+			out.Values[i] = ec._UpdateControlPayload_control(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -48830,10 +49612,12 @@ func (ec *executionContext) marshalNControlOrderField2githubᚗcomᚋgetproboᚋ
 
 var (
 	unmarshalNControlOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐControlOrderField = map[string]coredata.ControlOrderField{
-		"CREATED_AT": coredata.ControlOrderFieldCreatedAt,
+		"CREATED_AT":    coredata.ControlOrderFieldCreatedAt,
+		"SECTION_TITLE": coredata.ControlOrderFieldSectionTitle,
 	}
 	marshalNControlOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐControlOrderField = map[coredata.ControlOrderField]string{
-		coredata.ControlOrderFieldCreatedAt: "CREATED_AT",
+		coredata.ControlOrderFieldCreatedAt:    "CREATED_AT",
+		coredata.ControlOrderFieldSectionTitle: "SECTION_TITLE",
 	}
 )
 
@@ -48875,6 +49659,11 @@ func (ec *executionContext) marshalNCreateControlDocumentMappingPayload2ᚖgithu
 	return ec._CreateControlDocumentMappingPayload(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNCreateControlInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateControlInput(ctx context.Context, v any) (types.CreateControlInput, error) {
+	res, err := ec.unmarshalInputCreateControlInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNCreateControlMeasureMappingInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateControlMeasureMappingInput(ctx context.Context, v any) (types.CreateControlMeasureMappingInput, error) {
 	res, err := ec.unmarshalInputCreateControlMeasureMappingInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -48892,6 +49681,20 @@ func (ec *executionContext) marshalNCreateControlMeasureMappingPayload2ᚖgithub
 		return graphql.Null
 	}
 	return ec._CreateControlMeasureMappingPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNCreateControlPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateControlPayload(ctx context.Context, sel ast.SelectionSet, v types.CreateControlPayload) graphql.Marshaler {
+	return ec._CreateControlPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNCreateControlPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateControlPayload(ctx context.Context, sel ast.SelectionSet, v *types.CreateControlPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._CreateControlPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNCreateDatumInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateDatumInput(ctx context.Context, v any) (types.CreateDatumInput, error) {
@@ -49383,6 +50186,11 @@ func (ec *executionContext) marshalNDeleteControlDocumentMappingPayload2ᚖgithu
 	return ec._DeleteControlDocumentMappingPayload(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNDeleteControlInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteControlInput(ctx context.Context, v any) (types.DeleteControlInput, error) {
+	res, err := ec.unmarshalInputDeleteControlInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNDeleteControlMeasureMappingInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteControlMeasureMappingInput(ctx context.Context, v any) (types.DeleteControlMeasureMappingInput, error) {
 	res, err := ec.unmarshalInputDeleteControlMeasureMappingInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -49400,6 +50208,20 @@ func (ec *executionContext) marshalNDeleteControlMeasureMappingPayload2ᚖgithub
 		return graphql.Null
 	}
 	return ec._DeleteControlMeasureMappingPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNDeleteControlPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteControlPayload(ctx context.Context, sel ast.SelectionSet, v types.DeleteControlPayload) graphql.Marshaler {
+	return ec._DeleteControlPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNDeleteControlPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteControlPayload(ctx context.Context, sel ast.SelectionSet, v *types.DeleteControlPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._DeleteControlPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNDeleteDatumInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteDatumInput(ctx context.Context, v any) (types.DeleteDatumInput, error) {
@@ -51392,6 +52214,25 @@ func (ec *executionContext) marshalNUpdateAssetPayload2ᚖgithubᚗcomᚋgetprob
 		return graphql.Null
 	}
 	return ec._UpdateAssetPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNUpdateControlInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateControlInput(ctx context.Context, v any) (types.UpdateControlInput, error) {
+	res, err := ec.unmarshalInputUpdateControlInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNUpdateControlPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateControlPayload(ctx context.Context, sel ast.SelectionSet, v types.UpdateControlPayload) graphql.Marshaler {
+	return ec._UpdateControlPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNUpdateControlPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateControlPayload(ctx context.Context, sel ast.SelectionSet, v *types.UpdateControlPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._UpdateControlPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNUpdateDatumInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateDatumInput(ctx context.Context, v any) (types.UpdateDatumInput, error) {

--- a/pkg/server/api/console/v1/types/control.go
+++ b/pkg/server/api/console/v1/types/control.go
@@ -45,11 +45,11 @@ func NewControlEdge(c *coredata.Control, orderBy coredata.ControlOrderField) *Co
 
 func NewControl(c *coredata.Control) *Control {
 	return &Control{
-		ID:          c.ID,
-		ReferenceID: c.ReferenceID,
-		Name:        c.Name,
-		Description: c.Description,
-		CreatedAt:   c.CreatedAt,
-		UpdatedAt:   c.UpdatedAt,
+		ID:           c.ID,
+		SectionTitle: c.SectionTitle,
+		Name:         c.Name,
+		Description:  c.Description,
+		CreatedAt:    c.CreatedAt,
+		UpdatedAt:    c.UpdatedAt,
 	}
 }

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -119,15 +119,15 @@ type ConnectorOrder struct {
 }
 
 type Control struct {
-	ID          gid.GID             `json:"id"`
-	ReferenceID string              `json:"referenceId"`
-	Name        string              `json:"name"`
-	Description string              `json:"description"`
-	Framework   *Framework          `json:"framework"`
-	Measures    *MeasureConnection  `json:"measures"`
-	Documents   *DocumentConnection `json:"documents"`
-	CreatedAt   time.Time           `json:"createdAt"`
-	UpdatedAt   time.Time           `json:"updatedAt"`
+	ID           gid.GID             `json:"id"`
+	SectionTitle string              `json:"sectionTitle"`
+	Name         string              `json:"name"`
+	Description  string              `json:"description"`
+	Framework    *Framework          `json:"framework"`
+	Measures     *MeasureConnection  `json:"measures"`
+	Documents    *DocumentConnection `json:"documents"`
+	CreatedAt    time.Time           `json:"createdAt"`
+	UpdatedAt    time.Time           `json:"updatedAt"`
 }
 
 func (Control) IsNode()             {}
@@ -168,6 +168,13 @@ type CreateControlDocumentMappingPayload struct {
 	DocumentEdge *DocumentEdge `json:"documentEdge"`
 }
 
+type CreateControlInput struct {
+	FrameworkID  gid.GID `json:"frameworkId"`
+	SectionTitle string  `json:"sectionTitle"`
+	Name         string  `json:"name"`
+	Description  string  `json:"description"`
+}
+
 type CreateControlMeasureMappingInput struct {
 	ControlID gid.GID `json:"controlId"`
 	MeasureID gid.GID `json:"measureId"`
@@ -176,6 +183,10 @@ type CreateControlMeasureMappingInput struct {
 type CreateControlMeasureMappingPayload struct {
 	ControlEdge *ControlEdge `json:"controlEdge"`
 	MeasureEdge *MeasureEdge `json:"measureEdge"`
+}
+
+type CreateControlPayload struct {
+	ControlEdge *ControlEdge `json:"controlEdge"`
 }
 
 type CreateDatumInput struct {
@@ -406,6 +417,10 @@ type DeleteControlDocumentMappingPayload struct {
 	DeletedDocumentID gid.GID `json:"deletedDocumentId"`
 }
 
+type DeleteControlInput struct {
+	ControlID gid.GID `json:"controlId"`
+}
+
 type DeleteControlMeasureMappingInput struct {
 	ControlID gid.GID `json:"controlId"`
 	MeasureID gid.GID `json:"measureId"`
@@ -414,6 +429,10 @@ type DeleteControlMeasureMappingInput struct {
 type DeleteControlMeasureMappingPayload struct {
 	DeletedControlID gid.GID `json:"deletedControlId"`
 	DeletedMeasureID gid.GID `json:"deletedMeasureId"`
+}
+
+type DeleteControlPayload struct {
+	DeletedControlID gid.GID `json:"deletedControlId"`
 }
 
 type DeleteDatumInput struct {
@@ -978,6 +997,17 @@ type UpdateAssetInput struct {
 
 type UpdateAssetPayload struct {
 	Asset *Asset `json:"asset"`
+}
+
+type UpdateControlInput struct {
+	ID           gid.GID `json:"id"`
+	SectionTitle *string `json:"sectionTitle,omitempty"`
+	Name         *string `json:"name,omitempty"`
+	Description  *string `json:"description,omitempty"`
+}
+
+type UpdateControlPayload struct {
+	Control *Control `json:"control"`
 }
 
 type UpdateDatumInput struct {

--- a/pkg/server/api/console/v1/v1_resolver.go
+++ b/pkg/server/api/console/v1/v1_resolver.go
@@ -967,6 +967,59 @@ func (r *mutationResolver) DeleteFramework(ctx context.Context, input types.Dele
 	}, nil
 }
 
+// CreateControl is the resolver for the createControl field.
+func (r *mutationResolver) CreateControl(ctx context.Context, input types.CreateControlInput) (*types.CreateControlPayload, error) {
+	svc := GetTenantService(ctx, r.proboSvc, input.FrameworkID.TenantID())
+
+	control, err := svc.Controls.Create(ctx, probo.CreateControlRequest{
+		FrameworkID:  input.FrameworkID,
+		Name:         input.Name,
+		Description:  input.Description,
+		SectionTitle: input.SectionTitle,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot create control: %w", err)
+	}
+
+	return &types.CreateControlPayload{
+		ControlEdge: types.NewControlEdge(control, coredata.ControlOrderFieldCreatedAt),
+	}, nil
+}
+
+// UpdateControl is the resolver for the updateControl field.
+func (r *mutationResolver) UpdateControl(ctx context.Context, input types.UpdateControlInput) (*types.UpdateControlPayload, error) {
+	svc := GetTenantService(ctx, r.proboSvc, input.ID.TenantID())
+
+	control, err := svc.Controls.Update(ctx, probo.UpdateControlRequest{
+		ID:           input.ID,
+		Name:         input.Name,
+		Description:  input.Description,
+		SectionTitle: input.SectionTitle,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("cannot update control: %w", err)
+	}
+
+	return &types.UpdateControlPayload{
+		Control: types.NewControl(control),
+	}, nil
+}
+
+// DeleteControl is the resolver for the deleteControl field.
+func (r *mutationResolver) DeleteControl(ctx context.Context, input types.DeleteControlInput) (*types.DeleteControlPayload, error) {
+	svc := GetTenantService(ctx, r.proboSvc, input.ControlID.TenantID())
+
+	err := svc.Controls.Delete(ctx, input.ControlID)
+	if err != nil {
+		return nil, fmt.Errorf("cannot delete control: %w", err)
+	}
+
+	return &types.DeleteControlPayload{
+		DeletedControlID: input.ControlID,
+	}, nil
+}
+
 // // CreateMeasure is the resolver for the createMeasure field.
 func (r *mutationResolver) CreateMeasure(ctx context.Context, input types.CreateMeasureInput) (*types.CreateMeasurePayload, error) {
 	svc := GetTenantService(ctx, r.proboSvc, input.OrganizationID.TenantID())


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added full create, read, update, and delete (CRUD) support for controls in frameworks, including UI pages and GraphQL mutations.

- **New Features**
  - Users can add, edit, and delete controls from the framework UI.
  - Controls are now sorted and referenced by section title instead of reference ID.
  - Added backend mutations and database migration to support section title and improved sorting.

<!-- End of auto-generated description by cubic. -->

