### PR TITLE
Add fulltext search on risks, documents, and measures

### DIFF
--- a/pkg/coredata/document.go
+++ b/pkg/coredata/document.go
@@ -102,6 +102,7 @@ func (p *Documents) LoadByOrganizationID(
 	scope Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[DocumentOrderField],
+	filter *DocumentFilter,
 ) error {
 	q := `
 SELECT
@@ -119,12 +120,14 @@ WHERE
     %s
     AND organization_id = @organization_id
     AND %s
+    AND %s
 `
 
-	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+	q = fmt.Sprintf(q, scope.SQLFragment(), filter.SQLFragment(), cursor.SQLFragment())
 
-	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	args := pgx.NamedArgs{"organization_id": organizationID}
 	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, filter.SQLArguments())
 	maps.Copy(args, cursor.SQLArguments())
 
 	rows, err := conn.Query(ctx, q, args)
@@ -249,6 +252,7 @@ func (p *Documents) LoadByControlID(
 	scope Scoper,
 	controlID gid.GID,
 	cursor *page.Cursor[DocumentOrderField],
+	filter *DocumentFilter,
 ) error {
 	q := `
 WITH plcs AS (
@@ -282,11 +286,13 @@ FROM
 	plcs
 WHERE %s
 	AND %s
+	AND %s
 `
-	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+	q = fmt.Sprintf(q, scope.SQLFragment(), filter.SQLFragment(), cursor.SQLFragment())
 
-	args := pgx.StrictNamedArgs{"control_id": controlID}
+	args := pgx.NamedArgs{"control_id": controlID}
 	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, filter.SQLArguments())
 	maps.Copy(args, cursor.SQLArguments())
 
 	rows, err := conn.Query(ctx, q, args)
@@ -310,6 +316,7 @@ func (p *Documents) LoadByRiskID(
 	scope Scoper,
 	riskID gid.GID,
 	cursor *page.Cursor[DocumentOrderField],
+	filter *DocumentFilter,
 ) error {
 	q := `
 WITH plcs AS (
@@ -343,11 +350,13 @@ FROM
 	plcs
 WHERE %s
 	AND %s
+	AND %s
 `
-	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+	q = fmt.Sprintf(q, scope.SQLFragment(), filter.SQLFragment(), cursor.SQLFragment())
 
-	args := pgx.StrictNamedArgs{"risk_id": riskID}
+	args := pgx.NamedArgs{"risk_id": riskID}
 	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, filter.SQLArguments())
 	maps.Copy(args, cursor.SQLArguments())
 
 	rows, err := conn.Query(ctx, q, args)

--- a/pkg/coredata/document_filter.go
+++ b/pkg/coredata/document_filter.go
@@ -19,24 +19,24 @@ import (
 )
 
 type (
-	ControlFilter struct {
+	DocumentFilter struct {
 		query *string
 	}
 )
 
-func NewControlFilter(query *string) *ControlFilter {
-	return &ControlFilter{
+func NewDocumentFilter(query *string) *DocumentFilter {
+	return &DocumentFilter{
 		query: query,
 	}
 }
 
-func (f *ControlFilter) SQLArguments() pgx.NamedArgs {
+func (f *DocumentFilter) SQLArguments() pgx.NamedArgs {
 	return pgx.NamedArgs{
 		"query": f.query,
 	}
 }
 
-func (f *ControlFilter) SQLFragment() string {
+func (f *DocumentFilter) SQLFragment() string {
 	if f.query == nil || *f.query == "" {
 		return "TRUE"
 	}

--- a/pkg/coredata/measure.go
+++ b/pkg/coredata/measure.go
@@ -58,6 +58,7 @@ func (m *Measures) LoadByRiskID(
 	scope Scoper,
 	riskID gid.GID,
 	cursor *page.Cursor[MeasureOrderField],
+	filter *MeasureFilter,
 ) error {
 	q := `
 WITH msrs AS (
@@ -93,11 +94,13 @@ FROM
 	msrs
 WHERE %s
 	AND %s
+	AND %s
 `
-	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+	q = fmt.Sprintf(q, scope.SQLFragment(), filter.SQLFragment(), cursor.SQLFragment())
 
-	args := pgx.StrictNamedArgs{"risk_id": riskID}
+	args := pgx.NamedArgs{"risk_id": riskID}
 	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, filter.SQLArguments())
 	maps.Copy(args, cursor.SQLArguments())
 
 	rows, err := conn.Query(ctx, q, args)
@@ -121,6 +124,7 @@ func (m *Measures) LoadByControlID(
 	scope Scoper,
 	controlID gid.GID,
 	cursor *page.Cursor[MeasureOrderField],
+	filter *MeasureFilter,
 ) error {
 	q := `
 WITH mtgtns AS (
@@ -156,11 +160,13 @@ FROM
 	mtgtns
 WHERE %s
 	AND %s
+	AND %s
 `
-	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+	q = fmt.Sprintf(q, scope.SQLFragment(), filter.SQLFragment(), cursor.SQLFragment())
 
-	args := pgx.StrictNamedArgs{"control_id": controlID}
+	args := pgx.NamedArgs{"control_id": controlID}
 	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, filter.SQLArguments())
 	maps.Copy(args, cursor.SQLArguments())
 
 	rows, err := conn.Query(ctx, q, args)
@@ -184,6 +190,7 @@ func (m *Measures) LoadByOrganizationID(
 	scope Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[MeasureOrderField],
+	filter *MeasureFilter,
 ) error {
 	q := `
 SELECT
@@ -202,11 +209,13 @@ WHERE
     %s
     AND organization_id = @organization_id
     AND %s
+    AND %s
 `
-	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+	q = fmt.Sprintf(q, scope.SQLFragment(), filter.SQLFragment(), cursor.SQLFragment())
 
-	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	args := pgx.NamedArgs{"organization_id": organizationID}
 	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, filter.SQLArguments())
 	maps.Copy(args, cursor.SQLArguments())
 
 	rows, err := conn.Query(ctx, q, args)

--- a/pkg/coredata/measure_filter.go
+++ b/pkg/coredata/measure_filter.go
@@ -19,24 +19,24 @@ import (
 )
 
 type (
-	ControlFilter struct {
+	MeasureFilter struct {
 		query *string
 	}
 )
 
-func NewControlFilter(query *string) *ControlFilter {
-	return &ControlFilter{
+func NewMeasureFilter(query *string) *MeasureFilter {
+	return &MeasureFilter{
 		query: query,
 	}
 }
 
-func (f *ControlFilter) SQLArguments() pgx.NamedArgs {
+func (f *MeasureFilter) SQLArguments() pgx.NamedArgs {
 	return pgx.NamedArgs{
 		"query": f.query,
 	}
 }
 
-func (f *ControlFilter) SQLFragment() string {
+func (f *MeasureFilter) SQLFragment() string {
 	if f.query == nil || *f.query == "" {
 		return "TRUE"
 	}

--- a/pkg/coredata/migrations/20250609T212605Z.sql
+++ b/pkg/coredata/migrations/20250609T212605Z.sql
@@ -1,0 +1,26 @@
+ALTER TABLE documents ADD COLUMN search_vector tsvector
+GENERATED ALWAYS AS (
+    to_tsvector('simple',
+        COALESCE(title, '')
+    )
+) STORED;
+
+CREATE INDEX documents_search_idx ON documents USING gin(search_vector);
+
+ALTER TABLE measures ADD COLUMN search_vector tsvector
+GENERATED ALWAYS AS (
+    to_tsvector('simple',
+        COALESCE(name, '')
+    )
+) STORED;
+
+CREATE INDEX measures_search_idx ON measures USING gin(search_vector);
+
+ALTER TABLE risks ADD COLUMN search_vector tsvector
+GENERATED ALWAYS AS (
+    to_tsvector('simple',
+        COALESCE(name, '')
+    )
+) STORED;
+
+CREATE INDEX risks_search_idx ON risks USING gin(search_vector);

--- a/pkg/coredata/risk.go
+++ b/pkg/coredata/risk.go
@@ -74,6 +74,7 @@ func (r *Risks) LoadByMeasureID(
 	scope Scoper,
 	measureID gid.GID,
 	cursor *page.Cursor[RiskOrderField],
+	filter *RiskFilter,
 ) error {
 	q := `
 WITH rsks AS (
@@ -123,11 +124,14 @@ FROM
 	rsks
 WHERE %s
 	AND %s
+	AND %s
 `
-	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+	q = fmt.Sprintf(q, scope.SQLFragment(), filter.SQLFragment(), cursor.SQLFragment())
 
 	args := pgx.NamedArgs{"measure_id": measureID}
 	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, filter.SQLArguments())
+	maps.Copy(args, cursor.SQLArguments())
 
 	rows, err := conn.Query(ctx, q, args)
 	if err != nil {
@@ -150,6 +154,7 @@ func (r *Risks) LoadByOrganizationID(
 	scope Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[RiskOrderField],
+	filter *RiskFilter,
 ) error {
 	q := `
 SELECT
@@ -173,11 +178,13 @@ FROM risks
 WHERE %s
 	AND organization_id = @organization_id
 	AND %s
+	AND %s
 `
-	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+	q = fmt.Sprintf(q, scope.SQLFragment(), filter.SQLFragment(), cursor.SQLFragment())
 
-	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	args := pgx.NamedArgs{"organization_id": organizationID}
 	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, filter.SQLArguments())
 	maps.Copy(args, cursor.SQLArguments())
 
 	rows, err := conn.Query(ctx, q, args)

--- a/pkg/coredata/risk_filter.go
+++ b/pkg/coredata/risk_filter.go
@@ -19,24 +19,24 @@ import (
 )
 
 type (
-	ControlFilter struct {
+	RiskFilter struct {
 		query *string
 	}
 )
 
-func NewControlFilter(query *string) *ControlFilter {
-	return &ControlFilter{
+func NewRiskFilter(query *string) *RiskFilter {
+	return &RiskFilter{
 		query: query,
 	}
 }
 
-func (f *ControlFilter) SQLArguments() pgx.NamedArgs {
+func (f *RiskFilter) SQLArguments() pgx.NamedArgs {
 	return pgx.NamedArgs{
 		"query": f.query,
 	}
 }
 
-func (f *ControlFilter) SQLFragment() string {
+func (f *RiskFilter) SQLFragment() string {
 	if f.query == nil || *f.query == "" {
 		return "TRUE"
 	}

--- a/pkg/probo/document_service.go
+++ b/pkg/probo/document_service.go
@@ -660,6 +660,7 @@ func (s *DocumentService) ListByOrganizationID(
 	ctx context.Context,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.DocumentOrderField],
+	filter *coredata.DocumentFilter,
 ) (*page.Page[*coredata.Document, coredata.DocumentOrderField], error) {
 	var documents coredata.Documents
 
@@ -672,6 +673,7 @@ func (s *DocumentService) ListByOrganizationID(
 				s.svc.scope,
 				organizationID,
 				cursor,
+				filter,
 			)
 		},
 	)
@@ -687,13 +689,14 @@ func (s *DocumentService) ListForControlID(
 	ctx context.Context,
 	controlID gid.GID,
 	cursor *page.Cursor[coredata.DocumentOrderField],
+	filter *coredata.DocumentFilter,
 ) (*page.Page[*coredata.Document, coredata.DocumentOrderField], error) {
 	var documents coredata.Documents
 
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(conn pg.Conn) error {
-			return documents.LoadByControlID(ctx, conn, s.svc.scope, controlID, cursor)
+			return documents.LoadByControlID(ctx, conn, s.svc.scope, controlID, cursor, filter)
 		},
 	)
 
@@ -708,13 +711,14 @@ func (s *DocumentService) ListForRiskID(
 	ctx context.Context,
 	riskID gid.GID,
 	cursor *page.Cursor[coredata.DocumentOrderField],
+	filter *coredata.DocumentFilter,
 ) (*page.Page[*coredata.Document, coredata.DocumentOrderField], error) {
 	var documents coredata.Documents
 
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(conn pg.Conn) error {
-			return documents.LoadByRiskID(ctx, conn, s.svc.scope, riskID, cursor)
+			return documents.LoadByRiskID(ctx, conn, s.svc.scope, riskID, cursor, filter)
 		},
 	)
 

--- a/pkg/probo/framework_service.go
+++ b/pkg/probo/framework_service.go
@@ -323,7 +323,7 @@ func (s FrameworkService) ExportAudit(
 					},
 				)
 
-				if err := measures.LoadByControlID(ctx, conn, s.svc.scope, control.ID, cursor); err != nil {
+				if err := measures.LoadByControlID(ctx, conn, s.svc.scope, control.ID, cursor, coredata.NewMeasureFilter(nil)); err != nil {
 					return fmt.Errorf("cannot load measures: %w", err)
 				}
 
@@ -339,7 +339,7 @@ func (s FrameworkService) ExportAudit(
 					},
 				)
 
-				if err := documents.LoadByControlID(ctx, conn, s.svc.scope, control.ID, cursor2); err != nil {
+				if err := documents.LoadByControlID(ctx, conn, s.svc.scope, control.ID, cursor2, coredata.NewDocumentFilter(nil)); err != nil {
 					return fmt.Errorf("cannot load documents: %w", err)
 				}
 

--- a/pkg/probo/measure_service.go
+++ b/pkg/probo/measure_service.go
@@ -73,6 +73,7 @@ func (s MeasureService) ListForRiskID(
 	ctx context.Context,
 	riskID gid.GID,
 	cursor *page.Cursor[coredata.MeasureOrderField],
+	filter *coredata.MeasureFilter,
 ) (*page.Page[*coredata.Measure, coredata.MeasureOrderField], error) {
 	var measures coredata.Measures
 	risk := &coredata.Risk{}
@@ -84,7 +85,7 @@ func (s MeasureService) ListForRiskID(
 				return fmt.Errorf("cannot load risk: %w", err)
 			}
 
-			err := measures.LoadByRiskID(ctx, conn, s.svc.scope, risk.ID, cursor)
+			err := measures.LoadByRiskID(ctx, conn, s.svc.scope, risk.ID, cursor, filter)
 			if err != nil {
 				return fmt.Errorf("cannot load measures: %w", err)
 			}
@@ -104,6 +105,7 @@ func (s MeasureService) ListForControlID(
 	ctx context.Context,
 	controlID gid.GID,
 	cursor *page.Cursor[coredata.MeasureOrderField],
+	filter *coredata.MeasureFilter,
 ) (*page.Page[*coredata.Measure, coredata.MeasureOrderField], error) {
 	var measures coredata.Measures
 	control := &coredata.Control{}
@@ -115,7 +117,7 @@ func (s MeasureService) ListForControlID(
 				return fmt.Errorf("cannot load control: %w", err)
 			}
 
-			err := measures.LoadByControlID(ctx, conn, s.svc.scope, control.ID, cursor)
+			err := measures.LoadByControlID(ctx, conn, s.svc.scope, control.ID, cursor, filter)
 			if err != nil {
 				return fmt.Errorf("cannot load measures: %w", err)
 			}
@@ -321,6 +323,7 @@ func (s MeasureService) ListForOrganizationID(
 	ctx context.Context,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.MeasureOrderField],
+	filter *coredata.MeasureFilter,
 ) (*page.Page[*coredata.Measure, coredata.MeasureOrderField], error) {
 	var measures coredata.Measures
 	organization := &coredata.Organization{}
@@ -338,6 +341,7 @@ func (s MeasureService) ListForOrganizationID(
 				s.svc.scope,
 				organization.ID,
 				cursor,
+				filter,
 			)
 			if err != nil {
 				return fmt.Errorf("cannot load measures: %w", err)

--- a/pkg/probo/risk_service.go
+++ b/pkg/probo/risk_service.go
@@ -63,13 +63,14 @@ func (s RiskService) ListForMeasureID(
 	ctx context.Context,
 	measureID gid.GID,
 	cursor *page.Cursor[coredata.RiskOrderField],
+	filter *coredata.RiskFilter,
 ) (*page.Page[*coredata.Risk, coredata.RiskOrderField], error) {
 	var risks coredata.Risks
 
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(conn pg.Conn) error {
-			return risks.LoadByMeasureID(ctx, conn, s.svc.scope, measureID, cursor)
+			return risks.LoadByMeasureID(ctx, conn, s.svc.scope, measureID, cursor, filter)
 		},
 	)
 
@@ -394,6 +395,7 @@ func (s RiskService) ListForOrganizationID(
 	ctx context.Context,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.RiskOrderField],
+	filter *coredata.RiskFilter,
 ) (*page.Page[*coredata.Risk, coredata.RiskOrderField], error) {
 	var risks coredata.Risks
 
@@ -406,6 +408,7 @@ func (s RiskService) ListForOrganizationID(
 				s.svc.scope,
 				organizationID,
 				cursor,
+				filter,
 			)
 		},
 	)

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -498,6 +498,18 @@ input ControlFilter {
   query: String
 }
 
+input DocumentFilter {
+  query: String
+}
+
+input MeasureFilter {
+  query: String
+}
+
+input RiskFilter {
+  query: String
+}
+
 # Core Types
 type Organization implements Node {
   id: ID!
@@ -559,6 +571,7 @@ type Organization implements Node {
     last: Int
     before: CursorKey
     orderBy: DocumentOrder
+    filter: DocumentFilter
   ): DocumentConnection! @goField(forceResolver: true)
 
   measures(
@@ -567,6 +580,7 @@ type Organization implements Node {
     last: Int
     before: CursorKey
     orderBy: MeasureOrder
+    filter: MeasureFilter
   ): MeasureConnection! @goField(forceResolver: true)
 
   risks(
@@ -575,6 +589,7 @@ type Organization implements Node {
     last: Int
     before: CursorKey
     orderBy: RiskOrder
+    filter: RiskFilter
   ): RiskConnection! @goField(forceResolver: true)
 
   tasks(
@@ -726,6 +741,7 @@ type Control implements Node {
     last: Int
     before: CursorKey
     orderBy: MeasureOrder
+    filter: MeasureFilter
   ): MeasureConnection! @goField(forceResolver: true)
 
   documents(
@@ -734,6 +750,7 @@ type Control implements Node {
     last: Int
     before: CursorKey
     orderBy: DocumentOrder
+    filter: DocumentFilter
   ): DocumentConnection! @goField(forceResolver: true)
 
   createdAt: Datetime!
@@ -769,6 +786,7 @@ type Measure implements Node {
     last: Int
     before: CursorKey
     orderBy: RiskOrder
+    filter: RiskFilter
   ): RiskConnection! @goField(forceResolver: true)
 
   controls(
@@ -880,6 +898,7 @@ type Risk implements Node {
     last: Int
     before: CursorKey
     orderBy: MeasureOrder
+    filter: MeasureFilter
   ): MeasureConnection! @goField(forceResolver: true)
 
   documents(
@@ -888,6 +907,7 @@ type Risk implements Node {
     last: Int
     before: CursorKey
     orderBy: DocumentOrder
+    filter: DocumentFilter
   ): DocumentConnection! @goField(forceResolver: true)
 
   controls(

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -124,10 +124,10 @@ type ComplexityRoot struct {
 	Control struct {
 		CreatedAt    func(childComplexity int) int
 		Description  func(childComplexity int) int
-		Documents    func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy) int
+		Documents    func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy, filter *types.DocumentFilter) int
 		Framework    func(childComplexity int) int
 		ID           func(childComplexity int) int
-		Measures     func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy) int
+		Measures     func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy, filter *types.MeasureFilter) int
 		Name         func(childComplexity int) int
 		SectionTitle func(childComplexity int) int
 		UpdatedAt    func(childComplexity int) int
@@ -459,7 +459,7 @@ type ComplexityRoot struct {
 		Evidences   func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.EvidenceOrderBy) int
 		ID          func(childComplexity int) int
 		Name        func(childComplexity int) int
-		Risks       func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskOrderBy) int
+		Risks       func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskOrderBy, filter *types.RiskFilter) int
 		State       func(childComplexity int) int
 		Tasks       func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TaskOrderBy) int
 		UpdatedAt   func(childComplexity int) int
@@ -547,14 +547,14 @@ type ComplexityRoot struct {
 		Controls   func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ControlOrderBy, filter *types.ControlFilter) int
 		CreatedAt  func(childComplexity int) int
 		Data       func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DatumOrder) int
-		Documents  func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy) int
+		Documents  func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy, filter *types.DocumentFilter) int
 		Frameworks func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.FrameworkOrderBy) int
 		ID         func(childComplexity int) int
 		LogoURL    func(childComplexity int) int
-		Measures   func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy) int
+		Measures   func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy, filter *types.MeasureFilter) int
 		Name       func(childComplexity int) int
 		Peoples    func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.PeopleOrderBy) int
-		Risks      func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskOrderBy) int
+		Risks      func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskOrderBy, filter *types.RiskFilter) int
 		Tasks      func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TaskOrderBy) int
 		UpdatedAt  func(childComplexity int) int
 		Users      func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.UserOrderBy) int
@@ -628,12 +628,12 @@ type ComplexityRoot struct {
 		Controls           func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ControlOrderBy, filter *types.ControlFilter) int
 		CreatedAt          func(childComplexity int) int
 		Description        func(childComplexity int) int
-		Documents          func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy) int
+		Documents          func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy, filter *types.DocumentFilter) int
 		ID                 func(childComplexity int) int
 		InherentImpact     func(childComplexity int) int
 		InherentLikelihood func(childComplexity int) int
 		InherentRiskScore  func(childComplexity int) int
-		Measures           func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy) int
+		Measures           func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy, filter *types.MeasureFilter) int
 		Name               func(childComplexity int) int
 		Note               func(childComplexity int) int
 		Organization       func(childComplexity int) int
@@ -871,8 +871,8 @@ type AssetResolver interface {
 }
 type ControlResolver interface {
 	Framework(ctx context.Context, obj *types.Control) (*types.Framework, error)
-	Measures(ctx context.Context, obj *types.Control, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy) (*types.MeasureConnection, error)
-	Documents(ctx context.Context, obj *types.Control, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy) (*types.DocumentConnection, error)
+	Measures(ctx context.Context, obj *types.Control, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy, filter *types.MeasureFilter) (*types.MeasureConnection, error)
+	Documents(ctx context.Context, obj *types.Control, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy, filter *types.DocumentFilter) (*types.DocumentConnection, error)
 }
 type DatumResolver interface {
 	Owner(ctx context.Context, obj *types.Datum) (*types.People, error)
@@ -912,7 +912,7 @@ type FrameworkResolver interface {
 type MeasureResolver interface {
 	Evidences(ctx context.Context, obj *types.Measure, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.EvidenceOrderBy) (*types.EvidenceConnection, error)
 	Tasks(ctx context.Context, obj *types.Measure, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TaskOrderBy) (*types.TaskConnection, error)
-	Risks(ctx context.Context, obj *types.Measure, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskOrderBy) (*types.RiskConnection, error)
+	Risks(ctx context.Context, obj *types.Measure, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskOrderBy, filter *types.RiskFilter) (*types.RiskConnection, error)
 	Controls(ctx context.Context, obj *types.Measure, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ControlOrderBy, filter *types.ControlFilter) (*types.ControlConnection, error)
 }
 type MutationResolver interface {
@@ -988,9 +988,9 @@ type OrganizationResolver interface {
 	Controls(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ControlOrderBy, filter *types.ControlFilter) (*types.ControlConnection, error)
 	Vendors(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.VendorOrderBy) (*types.VendorConnection, error)
 	Peoples(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.PeopleOrderBy) (*types.PeopleConnection, error)
-	Documents(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy) (*types.DocumentConnection, error)
-	Measures(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy) (*types.MeasureConnection, error)
-	Risks(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskOrderBy) (*types.RiskConnection, error)
+	Documents(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy, filter *types.DocumentFilter) (*types.DocumentConnection, error)
+	Measures(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy, filter *types.MeasureFilter) (*types.MeasureConnection, error)
+	Risks(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskOrderBy, filter *types.RiskFilter) (*types.RiskConnection, error)
 	Tasks(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TaskOrderBy) (*types.TaskConnection, error)
 	Assets(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AssetOrder) (*types.AssetConnection, error)
 	Data(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DatumOrder) (*types.DatumConnection, error)
@@ -1002,8 +1002,8 @@ type QueryResolver interface {
 type RiskResolver interface {
 	Owner(ctx context.Context, obj *types.Risk) (*types.People, error)
 	Organization(ctx context.Context, obj *types.Risk) (*types.Organization, error)
-	Measures(ctx context.Context, obj *types.Risk, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy) (*types.MeasureConnection, error)
-	Documents(ctx context.Context, obj *types.Risk, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy) (*types.DocumentConnection, error)
+	Measures(ctx context.Context, obj *types.Risk, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy, filter *types.MeasureFilter) (*types.MeasureConnection, error)
+	Documents(ctx context.Context, obj *types.Risk, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy, filter *types.DocumentFilter) (*types.DocumentConnection, error)
 	Controls(ctx context.Context, obj *types.Risk, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ControlOrderBy, filter *types.ControlFilter) (*types.ControlConnection, error)
 }
 type TaskResolver interface {
@@ -1273,7 +1273,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Control.Documents(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.DocumentOrderBy)), true
+		return e.complexity.Control.Documents(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.DocumentOrderBy), args["filter"].(*types.DocumentFilter)), true
 
 	case "Control.framework":
 		if e.complexity.Control.Framework == nil {
@@ -1299,7 +1299,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Control.Measures(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.MeasureOrderBy)), true
+		return e.complexity.Control.Measures(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.MeasureOrderBy), args["filter"].(*types.MeasureFilter)), true
 
 	case "Control.name":
 		if e.complexity.Control.Name == nil {
@@ -2382,7 +2382,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Measure.Risks(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.RiskOrderBy)), true
+		return e.complexity.Measure.Risks(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.RiskOrderBy), args["filter"].(*types.RiskFilter)), true
 
 	case "Measure.state":
 		if e.complexity.Measure.State == nil {
@@ -3259,7 +3259,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Organization.Documents(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.DocumentOrderBy)), true
+		return e.complexity.Organization.Documents(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.DocumentOrderBy), args["filter"].(*types.DocumentFilter)), true
 
 	case "Organization.frameworks":
 		if e.complexity.Organization.Frameworks == nil {
@@ -3297,7 +3297,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Organization.Measures(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.MeasureOrderBy)), true
+		return e.complexity.Organization.Measures(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.MeasureOrderBy), args["filter"].(*types.MeasureFilter)), true
 
 	case "Organization.name":
 		if e.complexity.Organization.Name == nil {
@@ -3328,7 +3328,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Organization.Risks(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.RiskOrderBy)), true
+		return e.complexity.Organization.Risks(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.RiskOrderBy), args["filter"].(*types.RiskFilter)), true
 
 	case "Organization.tasks":
 		if e.complexity.Organization.Tasks == nil {
@@ -3624,7 +3624,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Risk.Documents(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.DocumentOrderBy)), true
+		return e.complexity.Risk.Documents(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.DocumentOrderBy), args["filter"].(*types.DocumentFilter)), true
 
 	case "Risk.id":
 		if e.complexity.Risk.ID == nil {
@@ -3664,7 +3664,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Risk.Measures(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.MeasureOrderBy)), true
+		return e.complexity.Risk.Measures(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.MeasureOrderBy), args["filter"].(*types.MeasureFilter)), true
 
 	case "Risk.name":
 		if e.complexity.Risk.Name == nil {
@@ -4553,6 +4553,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputDeleteTaskInput,
 		ec.unmarshalInputDeleteVendorComplianceReportInput,
 		ec.unmarshalInputDeleteVendorInput,
+		ec.unmarshalInputDocumentFilter,
 		ec.unmarshalInputDocumentOrder,
 		ec.unmarshalInputDocumentVersionFilter,
 		ec.unmarshalInputDocumentVersionOrder,
@@ -4565,6 +4566,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputImportFrameworkInput,
 		ec.unmarshalInputImportMeasureInput,
 		ec.unmarshalInputInviteUserInput,
+		ec.unmarshalInputMeasureFilter,
 		ec.unmarshalInputMeasureOrder,
 		ec.unmarshalInputOrganizationOrder,
 		ec.unmarshalInputPeopleOrder,
@@ -4572,6 +4574,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputRemoveUserInput,
 		ec.unmarshalInputRequestEvidenceInput,
 		ec.unmarshalInputRequestSignatureInput,
+		ec.unmarshalInputRiskFilter,
 		ec.unmarshalInputRiskOrder,
 		ec.unmarshalInputSendSigningNotificationsInput,
 		ec.unmarshalInputTaskOrder,
@@ -5192,6 +5195,18 @@ input ControlFilter {
   query: String
 }
 
+input DocumentFilter {
+  query: String
+}
+
+input MeasureFilter {
+  query: String
+}
+
+input RiskFilter {
+  query: String
+}
+
 # Core Types
 type Organization implements Node {
   id: ID!
@@ -5253,6 +5268,7 @@ type Organization implements Node {
     last: Int
     before: CursorKey
     orderBy: DocumentOrder
+    filter: DocumentFilter
   ): DocumentConnection! @goField(forceResolver: true)
 
   measures(
@@ -5261,6 +5277,7 @@ type Organization implements Node {
     last: Int
     before: CursorKey
     orderBy: MeasureOrder
+    filter: MeasureFilter
   ): MeasureConnection! @goField(forceResolver: true)
 
   risks(
@@ -5269,6 +5286,7 @@ type Organization implements Node {
     last: Int
     before: CursorKey
     orderBy: RiskOrder
+    filter: RiskFilter
   ): RiskConnection! @goField(forceResolver: true)
 
   tasks(
@@ -5420,6 +5438,7 @@ type Control implements Node {
     last: Int
     before: CursorKey
     orderBy: MeasureOrder
+    filter: MeasureFilter
   ): MeasureConnection! @goField(forceResolver: true)
 
   documents(
@@ -5428,6 +5447,7 @@ type Control implements Node {
     last: Int
     before: CursorKey
     orderBy: DocumentOrder
+    filter: DocumentFilter
   ): DocumentConnection! @goField(forceResolver: true)
 
   createdAt: Datetime!
@@ -5463,6 +5483,7 @@ type Measure implements Node {
     last: Int
     before: CursorKey
     orderBy: RiskOrder
+    filter: RiskFilter
   ): RiskConnection! @goField(forceResolver: true)
 
   controls(
@@ -5574,6 +5595,7 @@ type Risk implements Node {
     last: Int
     before: CursorKey
     orderBy: MeasureOrder
+    filter: MeasureFilter
   ): MeasureConnection! @goField(forceResolver: true)
 
   documents(
@@ -5582,6 +5604,7 @@ type Risk implements Node {
     last: Int
     before: CursorKey
     orderBy: DocumentOrder
+    filter: DocumentFilter
   ): DocumentConnection! @goField(forceResolver: true)
 
   controls(
@@ -6916,6 +6939,11 @@ func (ec *executionContext) field_Control_documents_args(ctx context.Context, ra
 		return nil, err
 	}
 	args["orderBy"] = arg4
+	arg5, err := ec.field_Control_documents_argsFilter(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["filter"] = arg5
 	return args, nil
 }
 func (ec *executionContext) field_Control_documents_argsFirst(
@@ -6983,6 +7011,19 @@ func (ec *executionContext) field_Control_documents_argsOrderBy(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Control_documents_argsFilter(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*types.DocumentFilter, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("filter"))
+	if tmp, ok := rawArgs["filter"]; ok {
+		return ec.unmarshalODocumentFilter2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDocumentFilter(ctx, tmp)
+	}
+
+	var zeroVal *types.DocumentFilter
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Control_measures_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -7011,6 +7052,11 @@ func (ec *executionContext) field_Control_measures_args(ctx context.Context, raw
 		return nil, err
 	}
 	args["orderBy"] = arg4
+	arg5, err := ec.field_Control_measures_argsFilter(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["filter"] = arg5
 	return args, nil
 }
 func (ec *executionContext) field_Control_measures_argsFirst(
@@ -7075,6 +7121,19 @@ func (ec *executionContext) field_Control_measures_argsOrderBy(
 	}
 
 	var zeroVal *types.MeasureOrderBy
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Control_measures_argsFilter(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*types.MeasureFilter, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("filter"))
+	if tmp, ok := rawArgs["filter"]; ok {
+		return ec.unmarshalOMeasureFilter2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐMeasureFilter(ctx, tmp)
+	}
+
+	var zeroVal *types.MeasureFilter
 	return zeroVal, nil
 }
 
@@ -7843,6 +7902,11 @@ func (ec *executionContext) field_Measure_risks_args(ctx context.Context, rawArg
 		return nil, err
 	}
 	args["orderBy"] = arg4
+	arg5, err := ec.field_Measure_risks_argsFilter(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["filter"] = arg5
 	return args, nil
 }
 func (ec *executionContext) field_Measure_risks_argsFirst(
@@ -7907,6 +7971,19 @@ func (ec *executionContext) field_Measure_risks_argsOrderBy(
 	}
 
 	var zeroVal *types.RiskOrderBy
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Measure_risks_argsFilter(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*types.RiskFilter, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("filter"))
+	if tmp, ok := rawArgs["filter"]; ok {
+		return ec.unmarshalORiskFilter2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐRiskFilter(ctx, tmp)
+	}
+
+	var zeroVal *types.RiskFilter
 	return zeroVal, nil
 }
 
@@ -9880,6 +9957,11 @@ func (ec *executionContext) field_Organization_documents_args(ctx context.Contex
 		return nil, err
 	}
 	args["orderBy"] = arg4
+	arg5, err := ec.field_Organization_documents_argsFilter(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["filter"] = arg5
 	return args, nil
 }
 func (ec *executionContext) field_Organization_documents_argsFirst(
@@ -9944,6 +10026,19 @@ func (ec *executionContext) field_Organization_documents_argsOrderBy(
 	}
 
 	var zeroVal *types.DocumentOrderBy
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_documents_argsFilter(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*types.DocumentFilter, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("filter"))
+	if tmp, ok := rawArgs["filter"]; ok {
+		return ec.unmarshalODocumentFilter2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDocumentFilter(ctx, tmp)
+	}
+
+	var zeroVal *types.DocumentFilter
 	return zeroVal, nil
 }
 
@@ -10070,6 +10165,11 @@ func (ec *executionContext) field_Organization_measures_args(ctx context.Context
 		return nil, err
 	}
 	args["orderBy"] = arg4
+	arg5, err := ec.field_Organization_measures_argsFilter(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["filter"] = arg5
 	return args, nil
 }
 func (ec *executionContext) field_Organization_measures_argsFirst(
@@ -10134,6 +10234,19 @@ func (ec *executionContext) field_Organization_measures_argsOrderBy(
 	}
 
 	var zeroVal *types.MeasureOrderBy
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_measures_argsFilter(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*types.MeasureFilter, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("filter"))
+	if tmp, ok := rawArgs["filter"]; ok {
+		return ec.unmarshalOMeasureFilter2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐMeasureFilter(ctx, tmp)
+	}
+
+	var zeroVal *types.MeasureFilter
 	return zeroVal, nil
 }
 
@@ -10260,6 +10373,11 @@ func (ec *executionContext) field_Organization_risks_args(ctx context.Context, r
 		return nil, err
 	}
 	args["orderBy"] = arg4
+	arg5, err := ec.field_Organization_risks_argsFilter(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["filter"] = arg5
 	return args, nil
 }
 func (ec *executionContext) field_Organization_risks_argsFirst(
@@ -10324,6 +10442,19 @@ func (ec *executionContext) field_Organization_risks_argsOrderBy(
 	}
 
 	var zeroVal *types.RiskOrderBy
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_risks_argsFilter(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*types.RiskFilter, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("filter"))
+	if tmp, ok := rawArgs["filter"]; ok {
+		return ec.unmarshalORiskFilter2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐRiskFilter(ctx, tmp)
+	}
+
+	var zeroVal *types.RiskFilter
 	return zeroVal, nil
 }
 
@@ -10799,6 +10930,11 @@ func (ec *executionContext) field_Risk_documents_args(ctx context.Context, rawAr
 		return nil, err
 	}
 	args["orderBy"] = arg4
+	arg5, err := ec.field_Risk_documents_argsFilter(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["filter"] = arg5
 	return args, nil
 }
 func (ec *executionContext) field_Risk_documents_argsFirst(
@@ -10866,6 +11002,19 @@ func (ec *executionContext) field_Risk_documents_argsOrderBy(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Risk_documents_argsFilter(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*types.DocumentFilter, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("filter"))
+	if tmp, ok := rawArgs["filter"]; ok {
+		return ec.unmarshalODocumentFilter2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDocumentFilter(ctx, tmp)
+	}
+
+	var zeroVal *types.DocumentFilter
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Risk_measures_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -10894,6 +11043,11 @@ func (ec *executionContext) field_Risk_measures_args(ctx context.Context, rawArg
 		return nil, err
 	}
 	args["orderBy"] = arg4
+	arg5, err := ec.field_Risk_measures_argsFilter(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["filter"] = arg5
 	return args, nil
 }
 func (ec *executionContext) field_Risk_measures_argsFirst(
@@ -10958,6 +11112,19 @@ func (ec *executionContext) field_Risk_measures_argsOrderBy(
 	}
 
 	var zeroVal *types.MeasureOrderBy
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Risk_measures_argsFilter(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*types.MeasureFilter, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("filter"))
+	if tmp, ok := rawArgs["filter"]; ok {
+		return ec.unmarshalOMeasureFilter2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐMeasureFilter(ctx, tmp)
+	}
+
+	var zeroVal *types.MeasureFilter
 	return zeroVal, nil
 }
 
@@ -13121,7 +13288,7 @@ func (ec *executionContext) _Control_measures(ctx context.Context, field graphql
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Control().Measures(rctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey), fc.Args["orderBy"].(*types.MeasureOrderBy))
+		return ec.resolvers.Control().Measures(rctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey), fc.Args["orderBy"].(*types.MeasureOrderBy), fc.Args["filter"].(*types.MeasureFilter))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -13182,7 +13349,7 @@ func (ec *executionContext) _Control_documents(ctx context.Context, field graphq
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Control().Documents(rctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey), fc.Args["orderBy"].(*types.DocumentOrderBy))
+		return ec.resolvers.Control().Documents(rctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey), fc.Args["orderBy"].(*types.DocumentOrderBy), fc.Args["filter"].(*types.DocumentFilter))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -20573,7 +20740,7 @@ func (ec *executionContext) _Measure_risks(ctx context.Context, field graphql.Co
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Measure().Risks(rctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey), fc.Args["orderBy"].(*types.RiskOrderBy))
+		return ec.resolvers.Measure().Risks(rctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey), fc.Args["orderBy"].(*types.RiskOrderBy), fc.Args["filter"].(*types.RiskFilter))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -25231,7 +25398,7 @@ func (ec *executionContext) _Organization_documents(ctx context.Context, field g
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Organization().Documents(rctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey), fc.Args["orderBy"].(*types.DocumentOrderBy))
+		return ec.resolvers.Organization().Documents(rctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey), fc.Args["orderBy"].(*types.DocumentOrderBy), fc.Args["filter"].(*types.DocumentFilter))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -25292,7 +25459,7 @@ func (ec *executionContext) _Organization_measures(ctx context.Context, field gr
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Organization().Measures(rctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey), fc.Args["orderBy"].(*types.MeasureOrderBy))
+		return ec.resolvers.Organization().Measures(rctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey), fc.Args["orderBy"].(*types.MeasureOrderBy), fc.Args["filter"].(*types.MeasureFilter))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -25353,7 +25520,7 @@ func (ec *executionContext) _Organization_risks(ctx context.Context, field graph
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Organization().Risks(rctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey), fc.Args["orderBy"].(*types.RiskOrderBy))
+		return ec.resolvers.Organization().Risks(rctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey), fc.Args["orderBy"].(*types.RiskOrderBy), fc.Args["filter"].(*types.RiskFilter))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -27921,7 +28088,7 @@ func (ec *executionContext) _Risk_measures(ctx context.Context, field graphql.Co
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Risk().Measures(rctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey), fc.Args["orderBy"].(*types.MeasureOrderBy))
+		return ec.resolvers.Risk().Measures(rctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey), fc.Args["orderBy"].(*types.MeasureOrderBy), fc.Args["filter"].(*types.MeasureFilter))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -27982,7 +28149,7 @@ func (ec *executionContext) _Risk_documents(ctx context.Context, field graphql.C
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Risk().Documents(rctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey), fc.Args["orderBy"].(*types.DocumentOrderBy))
+		return ec.resolvers.Risk().Documents(rctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey), fc.Args["orderBy"].(*types.DocumentOrderBy), fc.Args["filter"].(*types.DocumentFilter))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -37564,6 +37731,33 @@ func (ec *executionContext) unmarshalInputDeleteVendorInput(ctx context.Context,
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputDocumentFilter(ctx context.Context, obj any) (types.DocumentFilter, error) {
+	var it types.DocumentFilter
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"query"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "query":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("query"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Query = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputDocumentOrder(ctx context.Context, obj any) (types.DocumentOrderBy, error) {
 	var it types.DocumentOrderBy
 	asMap := map[string]any{}
@@ -37972,6 +38166,33 @@ func (ec *executionContext) unmarshalInputInviteUserInput(ctx context.Context, o
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputMeasureFilter(ctx context.Context, obj any) (types.MeasureFilter, error) {
+	var it types.MeasureFilter
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"query"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "query":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("query"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Query = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputMeasureOrder(ctx context.Context, obj any) (types.MeasureOrderBy, error) {
 	var it types.MeasureOrderBy
 	asMap := map[string]any{}
@@ -38218,6 +38439,33 @@ func (ec *executionContext) unmarshalInputRequestSignatureInput(ctx context.Cont
 				return it, err
 			}
 			it.SignatoryID = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputRiskFilter(ctx context.Context, obj any) (types.RiskFilter, error) {
+	var it types.RiskFilter
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"query"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "query":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("query"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Query = data
 		}
 	}
 
@@ -52473,6 +52721,14 @@ func (ec *executionContext) unmarshalODatumOrder2ᚖgithubᚗcomᚋgetproboᚋpr
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalODocumentFilter2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDocumentFilter(ctx context.Context, v any) (*types.DocumentFilter, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputDocumentFilter(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalODocumentOrder2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDocumentOrderBy(ctx context.Context, v any) (*types.DocumentOrderBy, error) {
 	if v == nil {
 		return nil, nil
@@ -52680,6 +52936,14 @@ func (ec *executionContext) marshalOMeasure2ᚖgithubᚗcomᚋgetproboᚋprobo�
 	return ec._Measure(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalOMeasureFilter2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐMeasureFilter(ctx context.Context, v any) (*types.MeasureFilter, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputMeasureFilter(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalOMeasureOrder2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐMeasureOrderBy(ctx context.Context, v any) (*types.MeasureOrderBy, error) {
 	if v == nil {
 		return nil, nil
@@ -52774,6 +53038,14 @@ func (ec *executionContext) unmarshalOPeopleOrder2ᚖgithubᚗcomᚋgetproboᚋp
 		return nil, nil
 	}
 	res, err := ec.unmarshalInputPeopleOrder(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalORiskFilter2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐRiskFilter(ctx context.Context, v any) (*types.RiskFilter, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputRiskFilter(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -548,6 +548,10 @@ type DocumentEdge struct {
 	Node   *Document      `json:"node"`
 }
 
+type DocumentFilter struct {
+	Query *string `json:"query,omitempty"`
+}
+
 type DocumentVersion struct {
 	ID          gid.GID                             `json:"id"`
 	Document    *Document                           `json:"document"`
@@ -745,6 +749,10 @@ type MeasureEdge struct {
 	Node   *Measure       `json:"node"`
 }
 
+type MeasureFilter struct {
+	Query *string `json:"query,omitempty"`
+}
+
 type Mutation struct {
 }
 
@@ -894,6 +902,10 @@ type RiskConnection struct {
 type RiskEdge struct {
 	Cursor page.CursorKey `json:"cursor"`
 	Node   *Risk          `json:"node"`
+}
+
+type RiskFilter struct {
+	Query *string `json:"query,omitempty"`
 }
 
 type SendSigningNotificationsInput struct {

--- a/pkg/server/api/console/v1/v1_resolver.go
+++ b/pkg/server/api/console/v1/v1_resolver.go
@@ -108,7 +108,7 @@ func (r *controlResolver) Framework(ctx context.Context, obj *types.Control) (*t
 }
 
 // Measures is the resolver for the measures field.
-func (r *controlResolver) Measures(ctx context.Context, obj *types.Control, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy) (*types.MeasureConnection, error) {
+func (r *controlResolver) Measures(ctx context.Context, obj *types.Control, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy, filter *types.MeasureFilter) (*types.MeasureConnection, error) {
 	svc := GetTenantService(ctx, r.proboSvc, obj.ID.TenantID())
 
 	pageOrderBy := page.OrderBy[coredata.MeasureOrderField]{
@@ -124,7 +124,12 @@ func (r *controlResolver) Measures(ctx context.Context, obj *types.Control, firs
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := svc.Measures.ListForControlID(ctx, obj.ID, cursor)
+	var measureFilter = coredata.NewMeasureFilter(nil)
+	if filter != nil {
+		measureFilter = coredata.NewMeasureFilter(filter.Query)
+	}
+
+	page, err := svc.Measures.ListForControlID(ctx, obj.ID, cursor, measureFilter)
 	if err != nil {
 		return nil, fmt.Errorf("cannot list measures: %w", err)
 	}
@@ -133,7 +138,7 @@ func (r *controlResolver) Measures(ctx context.Context, obj *types.Control, firs
 }
 
 // Documents is the resolver for the documents field.
-func (r *controlResolver) Documents(ctx context.Context, obj *types.Control, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy) (*types.DocumentConnection, error) {
+func (r *controlResolver) Documents(ctx context.Context, obj *types.Control, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy, filter *types.DocumentFilter) (*types.DocumentConnection, error) {
 	svc := GetTenantService(ctx, r.proboSvc, obj.ID.TenantID())
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
@@ -149,7 +154,12 @@ func (r *controlResolver) Documents(ctx context.Context, obj *types.Control, fir
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := svc.Documents.ListForControlID(ctx, obj.ID, cursor)
+	var documentFilter = coredata.NewDocumentFilter(nil)
+	if filter != nil {
+		documentFilter = coredata.NewDocumentFilter(filter.Query)
+	}
+
+	page, err := svc.Documents.ListForControlID(ctx, obj.ID, cursor, documentFilter)
 	if err != nil {
 		return nil, fmt.Errorf("cannot list documents: %w", err)
 	}
@@ -585,7 +595,7 @@ func (r *measureResolver) Tasks(ctx context.Context, obj *types.Measure, first *
 }
 
 // Risks is the resolver for the risks field.
-func (r *measureResolver) Risks(ctx context.Context, obj *types.Measure, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskOrderBy) (*types.RiskConnection, error) {
+func (r *measureResolver) Risks(ctx context.Context, obj *types.Measure, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskOrderBy, filter *types.RiskFilter) (*types.RiskConnection, error) {
 	svc := GetTenantService(ctx, r.proboSvc, obj.ID.TenantID())
 
 	pageOrderBy := page.OrderBy[coredata.RiskOrderField]{
@@ -601,7 +611,12 @@ func (r *measureResolver) Risks(ctx context.Context, obj *types.Measure, first *
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := svc.Risks.ListForMeasureID(ctx, obj.ID, cursor)
+	var riskFilter = coredata.NewRiskFilter(nil)
+	if filter != nil {
+		riskFilter = coredata.NewRiskFilter(filter.Query)
+	}
+
+	page, err := svc.Risks.ListForMeasureID(ctx, obj.ID, cursor, riskFilter)
 	if err != nil {
 		return nil, fmt.Errorf("cannot list measure risks: %w", err)
 	}
@@ -2055,7 +2070,7 @@ func (r *organizationResolver) Peoples(ctx context.Context, obj *types.Organizat
 }
 
 // Documents is the resolver for the documents field.
-func (r *organizationResolver) Documents(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy) (*types.DocumentConnection, error) {
+func (r *organizationResolver) Documents(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy, filter *types.DocumentFilter) (*types.DocumentConnection, error) {
 	svc := GetTenantService(ctx, r.proboSvc, obj.ID.TenantID())
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
@@ -2071,7 +2086,12 @@ func (r *organizationResolver) Documents(ctx context.Context, obj *types.Organiz
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := svc.Documents.ListByOrganizationID(ctx, obj.ID, cursor)
+	var documentFilter = coredata.NewDocumentFilter(nil)
+	if filter != nil {
+		documentFilter = coredata.NewDocumentFilter(filter.Query)
+	}
+
+	page, err := svc.Documents.ListByOrganizationID(ctx, obj.ID, cursor, documentFilter)
 	if err != nil {
 		panic(fmt.Errorf("cannot list organization documents: %w", err))
 	}
@@ -2080,7 +2100,7 @@ func (r *organizationResolver) Documents(ctx context.Context, obj *types.Organiz
 }
 
 // Measures is the resolver for the measures field.
-func (r *organizationResolver) Measures(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy) (*types.MeasureConnection, error) {
+func (r *organizationResolver) Measures(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy, filter *types.MeasureFilter) (*types.MeasureConnection, error) {
 	svc := GetTenantService(ctx, r.proboSvc, obj.ID.TenantID())
 
 	pageOrderBy := page.OrderBy[coredata.MeasureOrderField]{
@@ -2096,7 +2116,12 @@ func (r *organizationResolver) Measures(ctx context.Context, obj *types.Organiza
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := svc.Measures.ListForOrganizationID(ctx, obj.ID, cursor)
+	var measureFilter = coredata.NewMeasureFilter(nil)
+	if filter != nil {
+		measureFilter = coredata.NewMeasureFilter(filter.Query)
+	}
+
+	page, err := svc.Measures.ListForOrganizationID(ctx, obj.ID, cursor, measureFilter)
 	if err != nil {
 		panic(fmt.Errorf("cannot list organization measures: %w", err))
 	}
@@ -2105,7 +2130,7 @@ func (r *organizationResolver) Measures(ctx context.Context, obj *types.Organiza
 }
 
 // Risks is the resolver for the risks field.
-func (r *organizationResolver) Risks(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskOrderBy) (*types.RiskConnection, error) {
+func (r *organizationResolver) Risks(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskOrderBy, filter *types.RiskFilter) (*types.RiskConnection, error) {
 	svc := GetTenantService(ctx, r.proboSvc, obj.ID.TenantID())
 
 	pageOrderBy := page.OrderBy[coredata.RiskOrderField]{
@@ -2121,7 +2146,12 @@ func (r *organizationResolver) Risks(ctx context.Context, obj *types.Organizatio
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := svc.Risks.ListForOrganizationID(ctx, obj.ID, cursor)
+	var riskFilter = coredata.NewRiskFilter(nil)
+	if filter != nil {
+		riskFilter = coredata.NewRiskFilter(filter.Query)
+	}
+
+	page, err := svc.Risks.ListForOrganizationID(ctx, obj.ID, cursor, riskFilter)
 	if err != nil {
 		panic(fmt.Errorf("cannot list organization risks: %w", err))
 	}
@@ -2363,7 +2393,7 @@ func (r *riskResolver) Organization(ctx context.Context, obj *types.Risk) (*type
 }
 
 // Measures is the resolver for the measures field.
-func (r *riskResolver) Measures(ctx context.Context, obj *types.Risk, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy) (*types.MeasureConnection, error) {
+func (r *riskResolver) Measures(ctx context.Context, obj *types.Risk, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy, filter *types.MeasureFilter) (*types.MeasureConnection, error) {
 	svc := GetTenantService(ctx, r.proboSvc, obj.ID.TenantID())
 
 	pageOrderBy := page.OrderBy[coredata.MeasureOrderField]{
@@ -2379,7 +2409,12 @@ func (r *riskResolver) Measures(ctx context.Context, obj *types.Risk, first *int
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := svc.Measures.ListForRiskID(ctx, obj.ID, cursor)
+	var measureFilter = coredata.NewMeasureFilter(nil)
+	if filter != nil {
+		measureFilter = coredata.NewMeasureFilter(filter.Query)
+	}
+
+	page, err := svc.Measures.ListForRiskID(ctx, obj.ID, cursor, measureFilter)
 	if err != nil {
 		panic(fmt.Errorf("cannot list risk measures: %w", err))
 	}
@@ -2388,7 +2423,7 @@ func (r *riskResolver) Measures(ctx context.Context, obj *types.Risk, first *int
 }
 
 // Documents is the resolver for the documents field.
-func (r *riskResolver) Documents(ctx context.Context, obj *types.Risk, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy) (*types.DocumentConnection, error) {
+func (r *riskResolver) Documents(ctx context.Context, obj *types.Risk, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy, filter *types.DocumentFilter) (*types.DocumentConnection, error) {
 	svc := GetTenantService(ctx, r.proboSvc, obj.ID.TenantID())
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
@@ -2404,7 +2439,12 @@ func (r *riskResolver) Documents(ctx context.Context, obj *types.Risk, first *in
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := svc.Documents.ListForRiskID(ctx, obj.ID, cursor)
+	var documentFilter = coredata.NewDocumentFilter(nil)
+	if filter != nil {
+		documentFilter = coredata.NewDocumentFilter(filter.Query)
+	}
+
+	page, err := svc.Documents.ListForRiskID(ctx, obj.ID, cursor, documentFilter)
 	if err != nil {
 		panic(fmt.Errorf("cannot list risk documents: %w", err))
 	}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added full-text search support for risks, documents, and measures, allowing users to filter these entities by a search query in the API.

- **New Features**
  - Added `filter` input with a `query` field to GraphQL queries for risks, documents, and measures.
  - Updated database schema to include full-text search indexes for these entities.

<!-- End of auto-generated description by cubic. -->

