### PR TITLE
Change css class – Options are hidden in Vendors Risk Assessment #96

### DIFF
--- a/apps/console/src/pages/organizations/vendors/VendorView.tsx
+++ b/apps/console/src/pages/organizations/vendors/VendorView.tsx
@@ -1018,17 +1018,12 @@ function RiskAssessmentsTable({
                     </span>
                   </td>
                   <td className="text-right pr-6 py-3">
-                    <div
-                      className="relative"
-                      ref={showDropdown === assessment?.id ? dropdownRef : null}
-                    >
+                    <div className="relative" ref={showDropdown === assessment?.id ? dropdownRef : null}>
                       <button
                         className="rounded-full w-8 h-8 flex items-center justify-center hover:bg-[rgba(2,42,2,0.03)]"
                         onClick={() =>
                           setShowDropdown(
-                            showDropdown === assessment?.id
-                              ? null
-                              : assessment?.id,
+                            showDropdown === assessment?.id ? null : assessment?.id
                           )
                         }
                       >
@@ -1054,12 +1049,9 @@ function RiskAssessmentsTable({
                         </svg>
                       </button>
                       {showDropdown === assessment?.id && (
-                        <div
-                          className="absolute right-0 mt-1 bg-white rounded-md shadow-lg border border-[#ECEFEC] z-10"
-                          style={{ bottom: "100%", marginBottom: "5px" }}
-                        >
+                        <div className="absolute right-0 bottom-full mb-2 bg-white rounded-md shadow-lg border border-[#ECEFEC] z-10 w-32">
                           <button
-                            className="w-full text-left px-4 py-2 text-sm hover:bg-[rgba(2,42,2,0.03)]"
+                            className="w-full text-left px-4 py-2 text-sm hover:bg-[rgba(2,42,2,0.03)] whitespace-nowrap"
                             onClick={() => handleViewDetails(assessment)}
                           >
                             View details


### PR DESCRIPTION
<img width="1186" alt="Screenshot 2025-06-09 at 7 55 57 PM" src="https://github.com/user-attachments/assets/29c2fc26-61ac-4276-bde7-cb0c93b8fdbd" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a CSS issue that caused the options dropdown to be hidden in the Vendors Risk Assessment table. The dropdown now displays correctly above the button.

<!-- End of auto-generated description by cubic. -->

