### PR TITLE
Fix measure percentage

### DIFF
--- a/packages/ui/src/Molecules/MeasureImplementation/MeasureImplementation.tsx
+++ b/packages/ui/src/Molecules/MeasureImplementation/MeasureImplementation.tsx
@@ -49,9 +49,11 @@ export function MeasureImplementation({ measures, className }: Props) {
                 ))}
             </div>
             <div className="flex gap-4 text-sm">
-                <div className="mr-auto">
-                    {percent}% {__("Complete")}
-                </div>
+                {!isNaN(percent) && (
+                    <div className="mr-auto">
+                        {percent}% {__("Complete")}
+                    </div>
+                )}
                 {measureStates.map((state) => (
                     <div
                         key={state}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed a bug where the measure completion percentage showed "NaN%" when the value was not a number. Now, the percentage only appears when valid.

<!-- End of auto-generated description by cubic. -->

