### PR TITLE
Clear relay cache on login

### DIFF
--- a/apps/console/src/pages/auth/LoginPage.tsx
+++ b/apps/console/src/pages/auth/LoginPage.tsx
@@ -2,6 +2,7 @@ import { useTranslate } from "@probo/i18n";
 import { Button, Field, useToast } from "@probo/ui";
 import type { FormEventHandler } from "react";
 import { Link, useNavigate } from "react-router";
+import { clearRelayStore } from "/providers/RelayProviders";
 
 export default function LoginPage() {
   const { __ } = useTranslate();
@@ -26,7 +27,7 @@ export default function LoginPage() {
           const error = await res.json();
           throw new Error(error.message || __("Failed to login"));
         }
-
+        clearRelayStore();
         navigate("/");
       })
       .catch((e) => {

--- a/apps/console/src/providers/RelayProviders.tsx
+++ b/apps/console/src/providers/RelayProviders.tsx
@@ -119,6 +119,13 @@ export const relayEnvironment = new Environment({
   store,
 });
 
+export const clearRelayStore = () => {
+  const source = relayEnvironment.getStore().getSource();
+  if (source instanceof Map) {
+    source.clear();
+  }
+};
+
 /**
  * Provider for relay with the probo environment
  */


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Cleared the Relay cache after a successful login to prevent stale data from appearing in the app.

<!-- End of auto-generated description by cubic. -->

