### PR TITLE
Fix tenant Ids

### DIFF
--- a/pkg/usrmgr/usrmgr.go
+++ b/pkg/usrmgr/usrmgr.go
@@ -523,7 +523,7 @@ func (s Service) ListTenantsForUserID(
 		return nil, err
 	}
 
-	tenantIDs := make([]gid.TenantID, len(uos))
+	tenantIDs := make([]gid.TenantID, 0, len(uos))
 	for _, uo := range uos {
 		tenantIDs = append(tenantIDs, uo.OrganizationID.TenantID())
 	}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed a bug where the tenant ID list could be pre-filled with empty values when listing tenants for a user.

<!-- End of auto-generated description by cubic. -->

