### PR TITLE
Reset controls framework foreign key

### DIFF
--- a/pkg/coredata/migrations/20250716T155448Z.sql
+++ b/pkg/coredata/migrations/20250716T155448Z.sql
@@ -1,0 +1,10 @@
+ALTER TABLE controls DROP CONSTRAINT IF EXISTS controls_framework_id_fkey;
+
+DELETE FROM controls
+WHERE framework_id NOT IN (SELECT id FROM frameworks);
+
+ALTER TABLE controls
+ADD CONSTRAINT controls_framework_id_fkey
+    FOREIGN KEY (framework_id)
+    REFERENCES frameworks(id)
+    ON DELETE CASCADE;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Reset the foreign key on the controls table to ensure all controls reference existing frameworks and to enable cascading deletes.

- **Migration**
  - Removes invalid controls with missing frameworks.
  - Re-adds the foreign key with ON DELETE CASCADE.

<!-- End of auto-generated description by cubic. -->

