### PR TITLE
Add trust center front

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ sbom.json
 sbom-docker.json
 *_sbom.json
 *.out
+*.DS_Store

--- a/apps/console/src/components/trustCenter/PublicTrustCenterAudits.tsx
+++ b/apps/console/src/components/trustCenter/PublicTrustCenterAudits.tsx
@@ -1,0 +1,123 @@
+import {
+  Card,
+  Tr,
+  Td,
+  Table,
+  Thead,
+  Tbody,
+  Th,
+  Button,
+  IconArrowDown,
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { sprintf } from "@probo/helpers";
+import { FrameworkLogo } from "/components/FrameworkLogo";
+
+type Audit = {
+  id: string;
+  framework: {
+    name: string;
+  };
+  validFrom: string;
+  validUntil: string | null;
+  state: string;
+  createdAt: string;
+  report: {
+    id: string;
+    filename: string;
+    downloadUrl: string | null;
+  } | null;
+  reportUrl: string | null;
+};
+
+type Props = {
+  audits: Audit[];
+  organizationName: string;
+};
+
+export function PublicTrustCenterAudits({ audits, organizationName }: Props) {
+  const { __ } = useTranslate();
+
+  if (audits.length === 0) {
+    return (
+      <Card padded>
+        <div className="text-center py-8">
+          <h2 className="text-xl font-semibold text-txt-primary mb-2">
+            {__("Compliance")}
+          </h2>
+          <p className="text-txt-secondary">
+            {__("No compliance reports are currently available.")}
+          </p>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card padded className="space-y-4">
+      <div>
+        <h2 className="text-xl font-semibold text-txt-primary">
+          {__("Compliance")}
+        </h2>
+        <p className="text-sm text-txt-secondary mt-1">
+          {sprintf(__("%s is compliant with the following frameworks"), organizationName)}
+        </p>
+      </div>
+
+      <Table>
+        <Thead>
+          <Tr>
+            <Th>{__("Framework")}</Th>
+            <Th>{__("Report")}</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {audits.map((audit) => {
+            const hasReport = audit.report || audit.reportUrl;
+            const downloadUrl = audit.report?.downloadUrl || audit.reportUrl;
+            const reportName = audit.report?.filename || __("Compliance Report");
+
+            return (
+              <Tr key={audit.id}>
+                <Td>
+                  <div className="flex items-center gap-3">
+                    <div className="flex-shrink-0">
+                      <div className="w-8 h-8 [&>img]:w-8 [&>img]:h-8 [&>div]:w-8 [&>div]:h-8">
+                        <FrameworkLogo name={audit.framework.name} />
+                      </div>
+                    </div>
+                    <div className="font-medium">
+                      {audit.framework.name}
+                    </div>
+                  </div>
+                </Td>
+                <Td>
+                  {hasReport && downloadUrl ? (
+                    <Button
+                      variant="secondary"
+                      icon={IconArrowDown}
+                      onClick={() => {
+                        const link = document.createElement('a');
+                        link.href = downloadUrl;
+                        link.download = reportName;
+                        document.body.appendChild(link);
+                        link.click();
+                        document.body.removeChild(link);
+                      }}
+                    >
+                      {__("Download")}
+                    </Button>
+                  ) : (
+                    <span className="text-txt-tertiary text-sm">
+                      {__("Not available")}
+                    </span>
+                  )}
+                </Td>
+              </Tr>
+            );
+          })}
+        </Tbody>
+      </Table>
+    </Card>
+  );
+}

--- a/apps/console/src/components/trustCenter/PublicTrustCenterDocuments.tsx
+++ b/apps/console/src/components/trustCenter/PublicTrustCenterDocuments.tsx
@@ -1,0 +1,141 @@
+import {
+  Card,
+  Tr,
+  Td,
+  Table,
+  Thead,
+  Tbody,
+  Th,
+  DocumentTypeBadge,
+  Button,
+  IconArrowDown,
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { graphql } from "relay-runtime";
+import { useMutation } from "react-relay";
+import type { PublicTrustCenterDocumentsExportPDFMutation } from "./__generated__/PublicTrustCenterDocumentsExportPDFMutation.graphql";
+
+const exportDocumentVersionPDFMutation = graphql`
+  mutation PublicTrustCenterDocumentsExportPDFMutation(
+    $input: ExportDocumentVersionPDFInput!
+  ) {
+    exportDocumentVersionPDF(input: $input) {
+      data
+    }
+  }
+`;
+
+type Document = {
+  id: string;
+  title: string;
+  documentType: string;
+  versions: {
+    edges: Array<{
+      node: {
+        id: string;
+        status: string;
+      };
+    }>;
+  };
+};
+
+type Props = {
+  documents: Document[];
+};
+
+export function PublicTrustCenterDocuments({ documents }: Props) {
+  const { __ } = useTranslate();
+  const [exportDocumentVersionPDF] = useMutation<PublicTrustCenterDocumentsExportPDFMutation>(exportDocumentVersionPDFMutation);
+
+  const handleDownload = (document: Document) => {
+    const latestVersion = document.versions.edges[0]?.node;
+    if (!latestVersion) return;
+
+    exportDocumentVersionPDF({
+      variables: {
+        input: { documentVersionId: latestVersion.id },
+      },
+      onCompleted: (data) => {
+        if (data.exportDocumentVersionPDF?.data) {
+          const link = window.document.createElement("a");
+          link.href = data.exportDocumentVersionPDF.data;
+          link.download = `${document.title}.pdf`;
+          window.document.body.appendChild(link);
+          link.click();
+          window.document.body.removeChild(link);
+        }
+      },
+    });
+  };
+
+  if (documents.length === 0) {
+    return (
+      <Card padded>
+        <div className="text-center py-8">
+          <h2 className="text-xl font-semibold text-txt-primary mb-2">
+            {__("Documents")}
+          </h2>
+          <p className="text-txt-secondary">
+            {__("No documents are currently available.")}
+          </p>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card padded className="space-y-4">
+      <div>
+        <h2 className="text-xl font-semibold text-txt-primary">
+          {__("Documents")}
+        </h2>
+        <p className="text-sm text-txt-secondary mt-1">
+          {__("Security and compliance documentation")}
+        </p>
+      </div>
+
+      <Table>
+        <Thead>
+          <Tr>
+            <Th className="w-1/2">{__("Document")}</Th>
+            <Th className="w-1/4">{__("Type")}</Th>
+            <Th className="w-1/4">{__("Download")}</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {documents.map((document) => {
+            const latestVersion = document.versions.edges[0]?.node;
+
+            return (
+              <Tr key={document.id}>
+                <Td>
+                  <div className="font-medium">
+                    {document.title}
+                  </div>
+                </Td>
+                <Td>
+                  <DocumentTypeBadge type={document.documentType} />
+                </Td>
+                <Td>
+                  {latestVersion ? (
+                    <Button
+                      variant="secondary"
+                      icon={IconArrowDown}
+                      onClick={() => handleDownload(document)}
+                    >
+                      {__("Download")}
+                    </Button>
+                  ) : (
+                    <span className="text-txt-tertiary text-sm">
+                      {__("Not available")}
+                    </span>
+                  )}
+                </Td>
+              </Tr>
+            );
+          })}
+        </Tbody>
+      </Table>
+    </Card>
+  );
+}

--- a/apps/console/src/components/trustCenter/PublicTrustCenterVendors.tsx
+++ b/apps/console/src/components/trustCenter/PublicTrustCenterVendors.tsx
@@ -1,0 +1,117 @@
+import {
+  Card,
+  Tr,
+  Td,
+  Table,
+  Thead,
+  Tbody,
+  Th,
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { faviconUrl, sprintf } from "@probo/helpers";
+
+type Vendor = {
+  id: string;
+  name: string;
+  category: string;
+  description: string | null;
+  createdAt: string;
+  privacyPolicyUrl?: string | null;
+  websiteUrl?: string | null;
+};
+
+type Props = {
+  vendors: Vendor[];
+  organizationName: string;
+};
+
+export function PublicTrustCenterVendors({ vendors, organizationName }: Props) {
+  const { __ } = useTranslate();
+
+  if (vendors.length === 0) {
+    return (
+      <Card padded>
+        <div className="text-center py-8">
+          <h2 className="text-xl font-semibold text-txt-primary mb-2">
+            {__("Vendors")}
+          </h2>
+          <p className="text-txt-secondary">
+            {__("No vendor information is currently available.")}
+          </p>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card padded className="space-y-4">
+      <div>
+        <h2 className="text-xl font-semibold text-txt-primary">
+          {__("Vendors")}
+        </h2>
+        <p className="text-sm text-txt-secondary mt-1">
+          {sprintf(__("Third-party vendors and service providers %s work with"), organizationName)}
+        </p>
+      </div>
+
+      <Table>
+        <Thead>
+          <Tr>
+            <Th>{__("Company")}</Th>
+            <Th>{__("Website")}</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {vendors.map((vendor) => {
+            const url = vendor.privacyPolicyUrl || vendor.websiteUrl;
+            const logo = faviconUrl(vendor.websiteUrl);
+
+            const getCleanUrl = (url: string) => {
+              try {
+                const parsedUrl = new URL(url);
+                return parsedUrl.hostname + parsedUrl.pathname + parsedUrl.search;
+              } catch {
+                return url.replace(/^https?:\/\//, '');
+              }
+            };
+
+            return (
+              <Tr key={vendor.id}>
+                <Td>
+                  <div className="flex items-center space-x-3">
+                    {logo && (
+                      <img
+                        src={logo}
+                        alt={`${vendor.name} logo`}
+                        className="w-8 h-8 object-contain rounded-full"
+                      />
+                    )}
+                    <div className="font-medium">
+                      {vendor.name}
+                    </div>
+                  </div>
+                </Td>
+                <Td>
+                  {url ? (
+                    <a
+                      href={url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-600 hover:text-blue-800 underline"
+                    >
+                      {getCleanUrl(url)}
+                    </a>
+                  ) : (
+                    <span className="text-txt-secondary text-sm">
+                      {__("No website available")}
+                    </span>
+                  )}
+                </Td>
+              </Tr>
+            );
+          })}
+        </Tbody>
+      </Table>
+    </Card>
+  );
+}

--- a/apps/console/src/components/trustCenter/TrustCenterAuditsCard.tsx
+++ b/apps/console/src/components/trustCenter/TrustCenterAuditsCard.tsx
@@ -1,0 +1,174 @@
+import { graphql } from "relay-runtime";
+import {
+  Card,
+  Button,
+  Tr,
+  Td,
+  Table,
+  Thead,
+  Tbody,
+  Th,
+  IconChevronDown,
+  IconCheckmark1,
+  IconCrossLargeX,
+  Badge,
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { useFragment } from "react-relay";
+import { useMemo, useState } from "react";
+import { sprintf, getAuditStateVariant, getAuditStateLabel } from "@probo/helpers";
+import { useOrganizationId } from "/hooks/useOrganizationId";
+import clsx from "clsx";
+
+const trustCenterAuditFragment = graphql`
+  fragment TrustCenterAuditsCardFragment on Audit {
+    id
+    framework {
+      name
+    }
+    validFrom
+    validUntil
+    state
+    showOnTrustCenter
+    createdAt
+  }
+`;
+
+type Mutation<Params> = (p: {
+  variables: {
+    input: {
+      id: string;
+      showOnTrustCenter: boolean;
+    } & Params;
+  };
+}) => void;
+
+type Props<Params> = {
+  audits: (any & { id: string })[];
+  params: Params;
+  disabled?: boolean;
+  onToggleVisibility: Mutation<Params>;
+  variant?: "card" | "table";
+};
+
+export function TrustCenterAuditsCard<Params>(props: Props<Params>) {
+  const { __ } = useTranslate();
+  const [limit, setLimit] = useState<number | null>(4);
+  const audits = useMemo(() => {
+    return limit ? props.audits.slice(0, limit) : props.audits;
+  }, [props.audits, limit]);
+  const showMoreButton = limit !== null && props.audits.length > limit;
+  const variant = props.variant ?? "table";
+
+  const onToggleVisibility = (auditId: string, showOnTrustCenter: boolean) => {
+    props.onToggleVisibility({
+      variables: {
+        input: {
+          id: auditId,
+          showOnTrustCenter,
+          ...props.params,
+        },
+      },
+    });
+  };
+
+  const Wrapper = variant === "card" ? Card : "div";
+
+  return (
+    <Wrapper {...(variant === "card" ? { padded: true } : {})} className="space-y-[10px]">
+      <Table className={clsx(variant === "card" && "bg-invert")}>
+        <Thead>
+          <Tr>
+            <Th>{__("Framework")}</Th>
+            <Th>{__("Valid Until")}</Th>
+            <Th>{__("State")}</Th>
+            <Th>{__("Visibility")}</Th>
+            <Th></Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {audits.length === 0 && (
+            <Tr>
+              <Td colSpan={5} className="text-center text-txt-secondary">
+                {__("No audits available")}
+              </Td>
+            </Tr>
+          )}
+          {audits.map((audit) => (
+            <AuditRow
+              key={audit.id}
+              audit={audit}
+              onToggleVisibility={onToggleVisibility}
+              disabled={props.disabled}
+            />
+          ))}
+        </Tbody>
+      </Table>
+      {showMoreButton && (
+        <Button
+          variant="tertiary"
+          onClick={() => setLimit(null)}
+          className="mt-3 mx-auto"
+          icon={IconChevronDown}
+        >
+          {sprintf(__("Show %s more"), props.audits.length - limit)}
+        </Button>
+      )}
+    </Wrapper>
+  );
+}
+
+function AuditRow(props: {
+  audit: any & { id: string };
+  onToggleVisibility: (auditId: string, showOnTrustCenter: boolean) => void;
+  disabled?: boolean;
+}) {
+  const audit = useFragment(trustCenterAuditFragment, props.audit);
+  const organizationId = useOrganizationId();
+  const { __ } = useTranslate();
+
+  const validUntilFormatted = audit.validUntil
+    ? new Date(audit.validUntil).toLocaleDateString()
+    : __("No expiry");
+
+  return (
+    <Tr to={`/organizations/${organizationId}/audits/${audit.id}`}>
+      <Td>
+        <div className="flex gap-4 items-center">
+          {audit.framework.name}
+        </div>
+      </Td>
+      <Td>{validUntilFormatted}</Td>
+      <Td>
+        <Badge variant={getAuditStateVariant(audit.state)}>
+          {getAuditStateLabel(__, audit.state)}
+        </Badge>
+      </Td>
+      <Td>
+        <div className="flex items-center gap-2">
+          {audit.showOnTrustCenter ? (
+            <>
+              <IconCheckmark1 className="w-4 h-4 text-txt-primary" />
+              <span className="text-txt-primary">{__("Visible")}</span>
+            </>
+          ) : (
+            <>
+              <IconCrossLargeX className="w-4 h-4 text-txt-tertiary" />
+              <span className="text-txt-tertiary">{__("Hidden")}</span>
+            </>
+          )}
+        </div>
+      </Td>
+      <Td noLink width={100} className="text-end">
+        <Button
+          variant="secondary"
+          onClick={() => props.onToggleVisibility(audit.id, !audit.showOnTrustCenter)}
+          icon={audit.showOnTrustCenter ? IconCrossLargeX : IconCheckmark1}
+          disabled={props.disabled}
+        >
+          {audit.showOnTrustCenter ? __("Hide") : __("Show")}
+        </Button>
+      </Td>
+    </Tr>
+  );
+}

--- a/apps/console/src/components/trustCenter/TrustCenterDocumentDialog.tsx
+++ b/apps/console/src/components/trustCenter/TrustCenterDocumentDialog.tsx
@@ -1,0 +1,99 @@
+import { useTranslate } from "@probo/i18n";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  Button,
+  useDialogRef,
+} from "@probo/ui";
+import { type ReactNode } from "react";
+import { useFragment, graphql } from "react-relay";
+import type { TrustCenterDocumentsCardFragment$key } from "./__generated__/TrustCenterDocumentsCardFragment.graphql";
+
+const trustCenterDocumentDialogFragment = graphql`
+  fragment TrustCenterDocumentDialogFragment on Document {
+    id
+    title
+    showOnTrustCenter
+  }
+`;
+
+type Props = {
+  children: ReactNode;
+  documents: (TrustCenterDocumentsCardFragment$key & { id: string })[];
+  onToggleVisibility: (documentId: string, showOnTrustCenter: boolean) => void;
+  disabled?: boolean;
+};
+
+export default function TrustCenterDocumentDialog({
+  children,
+  documents,
+  onToggleVisibility,
+  disabled,
+}: Props) {
+  const { __ } = useTranslate();
+  const dialogRef = useDialogRef();
+
+  return (
+    <>
+      <span onClick={() => !disabled && dialogRef.current?.open()}>
+        {children}
+      </span>
+      <Dialog ref={dialogRef}>
+        <DialogContent>
+          <div className="text-lg font-semibold mb-4">
+            {__("Manage Document Visibility on Trust Center")}
+          </div>
+          <div className="py-4">
+            <p className="text-txt-secondary mb-4">
+              {__("Control which documents are visible on your public trust center.")}
+            </p>
+            <div className="space-y-2 max-h-96 overflow-y-auto">
+              {documents.map((documentKey) => (
+                <DocumentDialogRow
+                  key={documentKey.id}
+                  document={documentKey}
+                  onToggleVisibility={onToggleVisibility}
+                  disabled={disabled}
+                />
+              ))}
+            </div>
+          </div>
+          <DialogFooter>
+            <Button onClick={() => dialogRef.current?.close()}>
+              {__("Close")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function DocumentDialogRow({
+  document: documentKey,
+  onToggleVisibility,
+  disabled,
+}: {
+  document: TrustCenterDocumentsCardFragment$key & { id: string };
+  onToggleVisibility: (documentId: string, showOnTrustCenter: boolean) => void;
+  disabled?: boolean;
+}) {
+  const document = useFragment(trustCenterDocumentDialogFragment, documentKey);
+  const { __ } = useTranslate();
+
+  return (
+    <div className="flex items-center justify-between p-3 border border-border-solid rounded">
+      <div className="flex-1">
+        <div className="font-medium">{document.title}</div>
+      </div>
+      <Button
+        variant="secondary"
+        onClick={() => onToggleVisibility(document.id, !document.showOnTrustCenter)}
+        disabled={disabled}
+      >
+        {document.showOnTrustCenter ? __("Hide") : __("Show")}
+      </Button>
+    </div>
+  );
+}

--- a/apps/console/src/components/trustCenter/TrustCenterDocumentsCard.tsx
+++ b/apps/console/src/components/trustCenter/TrustCenterDocumentsCard.tsx
@@ -1,0 +1,177 @@
+import { graphql } from "relay-runtime";
+import {
+  Card,
+  Button,
+  Tr,
+  Td,
+  Table,
+  Thead,
+  Tbody,
+  Th,
+  IconChevronDown,
+  IconCheckmark1,
+  IconCrossLargeX,
+  DocumentVersionBadge,
+  DocumentTypeBadge,
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import type { TrustCenterDocumentsCardFragment$key } from "./__generated__/TrustCenterDocumentsCardFragment.graphql";
+import { useFragment } from "react-relay";
+import { useMemo, useState } from "react";
+import { sprintf } from "@probo/helpers";
+import { useOrganizationId } from "/hooks/useOrganizationId";
+import clsx from "clsx";
+
+const trustCenterDocumentFragment = graphql`
+  fragment TrustCenterDocumentsCardFragment on Document {
+    id
+    title
+    createdAt
+    documentType
+    showOnTrustCenter
+    versions(first: 1) {
+      edges {
+        node {
+          id
+          status
+        }
+      }
+    }
+  }
+`;
+
+type Mutation<Params> = (p: {
+  variables: {
+    input: {
+      id: string;
+      showOnTrustCenter: boolean;
+    } & Params;
+  };
+}) => void;
+
+type Props<Params> = {
+  documents: (TrustCenterDocumentsCardFragment$key & { id: string })[];
+  params: Params;
+  disabled?: boolean;
+  onToggleVisibility: Mutation<Params>;
+  variant?: "card" | "table";
+};
+
+export function TrustCenterDocumentsCard<Params>(props: Props<Params>) {
+  const { __ } = useTranslate();
+  const [limit, setLimit] = useState<number | null>(4);
+  const documents = useMemo(() => {
+    return limit ? props.documents.slice(0, limit) : props.documents;
+  }, [props.documents, limit]);
+  const showMoreButton = limit !== null && props.documents.length > limit;
+  const variant = props.variant ?? "table";
+
+  const onToggleVisibility = (documentId: string, showOnTrustCenter: boolean) => {
+    props.onToggleVisibility({
+      variables: {
+        input: {
+          id: documentId,
+          showOnTrustCenter,
+          ...props.params,
+        },
+      },
+    });
+  };
+
+  const Wrapper = variant === "card" ? Card : "div";
+
+  return (
+    <Wrapper padded className="space-y-[10px]">
+      <Table className={clsx(variant === "card" && "bg-invert")}>
+        <Thead>
+          <Tr>
+            <Th>{__("Name")}</Th>
+            <Th>{__("Type")}</Th>
+            <Th>{__("State")}</Th>
+            <Th>{__("Visibility")}</Th>
+            <Th></Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {documents.length === 0 && (
+            <Tr>
+              <Td colSpan={5} className="text-center text-txt-secondary">
+                {__("No documents available")}
+              </Td>
+            </Tr>
+          )}
+          {documents.map((document) => (
+            <DocumentRow
+              key={document.id}
+              document={document}
+              onToggleVisibility={onToggleVisibility}
+              disabled={props.disabled}
+            />
+          ))}
+
+        </Tbody>
+      </Table>
+      {showMoreButton && (
+        <Button
+          variant="tertiary"
+          onClick={() => setLimit(null)}
+          className="mt-3 mx-auto"
+          icon={IconChevronDown}
+        >
+          {sprintf(__("Show %s more"), props.documents.length - limit)}
+        </Button>
+      )}
+    </Wrapper>
+  );
+}
+
+function DocumentRow(props: {
+  document: TrustCenterDocumentsCardFragment$key & { id: string };
+  onToggleVisibility: (documentId: string, showOnTrustCenter: boolean) => void;
+  disabled?: boolean;
+}) {
+  const document = useFragment(trustCenterDocumentFragment, props.document);
+  const organizationId = useOrganizationId();
+  const { __ } = useTranslate();
+
+  return (
+    <Tr to={`/organizations/${organizationId}/documents/${document.id}`}>
+      <Td>
+        <div className="flex gap-4 items-center">
+          {document.title}
+        </div>
+      </Td>
+      <Td>
+        <DocumentTypeBadge type={document.documentType} />
+      </Td>
+      <Td>
+        <DocumentVersionBadge state={document.versions?.edges?.[0]?.node?.status} />
+      </Td>
+      <Td>
+        <div className="flex items-center gap-2">
+          {document.showOnTrustCenter ? (
+            <>
+              <IconCheckmark1 className="w-4 h-4 text-txt-primary" />
+              <span className="text-txt-primary">{__("Visible")}</span>
+            </>
+          ) : (
+            <>
+              <IconCrossLargeX className="w-4 h-4 text-txt-tertiary" />
+              <span className="text-txt-tertiary">{__("Hidden")}</span>
+            </>
+          )}
+        </div>
+      </Td>
+      <Td noLink width={100} className="text-end">
+        <Button
+          variant="secondary"
+          onClick={() => props.onToggleVisibility(document.id, !document.showOnTrustCenter)}
+          icon={document.showOnTrustCenter ? IconCrossLargeX : IconCheckmark1}
+          disabled={props.disabled}
+        >
+          {document.showOnTrustCenter ? __("Hide") : __("Show")}
+        </Button>
+      </Td>
+    </Tr>
+  );
+}

--- a/apps/console/src/components/trustCenter/TrustCenterVendorsCard.tsx
+++ b/apps/console/src/components/trustCenter/TrustCenterVendorsCard.tsx
@@ -1,0 +1,165 @@
+import { graphql } from "relay-runtime";
+import {
+  Card,
+  Button,
+  Tr,
+  Td,
+  Table,
+  Thead,
+  Tbody,
+  Th,
+  IconChevronDown,
+  IconCheckmark1,
+  IconCrossLargeX,
+  Badge,
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { useFragment } from "react-relay";
+import { useMemo, useState } from "react";
+import { sprintf } from "@probo/helpers";
+import { useOrganizationId } from "/hooks/useOrganizationId";
+import clsx from "clsx";
+
+const trustCenterVendorFragment = graphql`
+  fragment TrustCenterVendorsCardFragment on Vendor {
+    id
+    name
+    category
+    description
+    showOnTrustCenter
+    createdAt
+  }
+`;
+
+type Mutation<Params> = (p: {
+  variables: {
+    input: {
+      id: string;
+      showOnTrustCenter: boolean;
+    } & Params;
+  };
+}) => void;
+
+type Props<Params> = {
+  vendors: (any & { id: string })[];
+  params: Params;
+  disabled?: boolean;
+  onToggleVisibility: Mutation<Params>;
+  variant?: "card" | "table";
+};
+
+export function TrustCenterVendorsCard<Params>(props: Props<Params>) {
+  const { __ } = useTranslate();
+  const [limit, setLimit] = useState<number | null>(4);
+  const vendors = useMemo(() => {
+    return limit ? props.vendors.slice(0, limit) : props.vendors;
+  }, [props.vendors, limit]);
+  const showMoreButton = limit !== null && props.vendors.length > limit;
+  const variant = props.variant ?? "table";
+
+  const onToggleVisibility = (vendorId: string, showOnTrustCenter: boolean) => {
+    props.onToggleVisibility({
+      variables: {
+        input: {
+          id: vendorId,
+          showOnTrustCenter,
+          ...props.params,
+        },
+      },
+    });
+  };
+
+  const Wrapper = variant === "card" ? Card : "div";
+
+  return (
+    <Wrapper padded className="space-y-[10px]">
+      <Table className={clsx(variant === "card" && "bg-invert")}>
+        <Thead>
+          <Tr>
+            <Th>{__("Name")}</Th>
+            <Th>{__("Category")}</Th>
+            <Th>{__("Visibility")}</Th>
+            <Th></Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {vendors.length === 0 && (
+            <Tr>
+              <Td colSpan={4} className="text-center text-txt-secondary">
+                {__("No vendors available")}
+              </Td>
+            </Tr>
+          )}
+          {vendors.map((vendor) => (
+            <VendorRow
+              key={vendor.id}
+              vendor={vendor}
+              onToggleVisibility={onToggleVisibility}
+              disabled={props.disabled}
+            />
+          ))}
+        </Tbody>
+      </Table>
+      {showMoreButton && (
+        <Button
+          variant="tertiary"
+          onClick={() => setLimit(null)}
+          className="mt-3 mx-auto"
+          icon={IconChevronDown}
+        >
+          {sprintf(__("Show %s more"), props.vendors.length - limit)}
+        </Button>
+      )}
+    </Wrapper>
+  );
+}
+
+function VendorRow(props: {
+  vendor: any & { id: string };
+  onToggleVisibility: (vendorId: string, showOnTrustCenter: boolean) => void;
+  disabled?: boolean;
+}) {
+  const vendor = useFragment(trustCenterVendorFragment, props.vendor);
+  const organizationId = useOrganizationId();
+  const { __ } = useTranslate();
+
+  return (
+    <Tr to={`/organizations/${organizationId}/vendors/${vendor.id}`}>
+      <Td>
+        <div className="flex gap-4 items-center">
+          {vendor.name}
+        </div>
+      </Td>
+      <Td>
+        <Badge variant="neutral">
+          {vendor.category}
+        </Badge>
+      </Td>
+      <Td>
+        <div className="flex items-center gap-2">
+          {vendor.showOnTrustCenter ? (
+            <>
+              <IconCheckmark1 className="w-4 h-4 text-txt-primary" />
+              <span className="text-txt-primary">{__("Visible")}</span>
+            </>
+          ) : (
+            <>
+              <IconCrossLargeX className="w-4 h-4 text-txt-tertiary" />
+              <span className="text-txt-tertiary">{__("Hidden")}</span>
+            </>
+          )}
+        </div>
+      </Td>
+      <Td noLink width={100} className="text-end">
+        <Button
+          variant="secondary"
+          onClick={() => props.onToggleVisibility(vendor.id, !vendor.showOnTrustCenter)}
+          icon={vendor.showOnTrustCenter ? IconCrossLargeX : IconCheckmark1}
+          disabled={props.disabled}
+        >
+          {vendor.showOnTrustCenter ? __("Hide") : __("Show")}
+        </Button>
+      </Td>
+    </Tr>
+  );
+}

--- a/apps/console/src/components/trustCenter/__generated__/PublicTrustCenterDocumentsExportPDFMutation.graphql.ts
+++ b/apps/console/src/components/trustCenter/__generated__/PublicTrustCenterDocumentsExportPDFMutation.graphql.ts
@@ -1,0 +1,92 @@
+/**
+ * @generated SignedSource<<24fd0dcf15c98ad3d20762e4ccc83a1b>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type ExportDocumentVersionPDFInput = {
+  documentVersionId: string;
+};
+export type PublicTrustCenterDocumentsExportPDFMutation$variables = {
+  input: ExportDocumentVersionPDFInput;
+};
+export type PublicTrustCenterDocumentsExportPDFMutation$data = {
+  readonly exportDocumentVersionPDF: {
+    readonly data: string;
+  };
+};
+export type PublicTrustCenterDocumentsExportPDFMutation = {
+  response: PublicTrustCenterDocumentsExportPDFMutation$data;
+  variables: PublicTrustCenterDocumentsExportPDFMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "ExportDocumentVersionPDFPayload",
+    "kind": "LinkedField",
+    "name": "exportDocumentVersionPDF",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "data",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "PublicTrustCenterDocumentsExportPDFMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "PublicTrustCenterDocumentsExportPDFMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "b5d33d4c301cfa811bb74d52f61f52e8",
+    "id": null,
+    "metadata": {},
+    "name": "PublicTrustCenterDocumentsExportPDFMutation",
+    "operationKind": "mutation",
+    "text": "mutation PublicTrustCenterDocumentsExportPDFMutation(\n  $input: ExportDocumentVersionPDFInput!\n) {\n  exportDocumentVersionPDF(input: $input) {\n    data\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "b6a173895aea2450ad4ac1a4ec6aeb4e";
+
+export default node;

--- a/apps/console/src/components/trustCenter/__generated__/TrustCenterAuditsCardFragment.graphql.ts
+++ b/apps/console/src/components/trustCenter/__generated__/TrustCenterAuditsCardFragment.graphql.ts
@@ -1,0 +1,104 @@
+/**
+ * @generated SignedSource<<794277d17daabd92807ccfaa5a1c2dbb>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type AuditState = "COMPLETED" | "IN_PROGRESS" | "NOT_STARTED" | "OUTDATED" | "REJECTED";
+import { FragmentRefs } from "relay-runtime";
+export type TrustCenterAuditsCardFragment$data = {
+  readonly createdAt: any;
+  readonly framework: {
+    readonly name: string;
+  };
+  readonly id: string;
+  readonly showOnTrustCenter: boolean;
+  readonly state: AuditState;
+  readonly validFrom: any | null | undefined;
+  readonly validUntil: any | null | undefined;
+  readonly " $fragmentType": "TrustCenterAuditsCardFragment";
+};
+export type TrustCenterAuditsCardFragment$key = {
+  readonly " $data"?: TrustCenterAuditsCardFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"TrustCenterAuditsCardFragment">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "TrustCenterAuditsCardFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Framework",
+      "kind": "LinkedField",
+      "name": "framework",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "validFrom",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "validUntil",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "state",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "showOnTrustCenter",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "createdAt",
+      "storageKey": null
+    }
+  ],
+  "type": "Audit",
+  "abstractKey": null
+};
+
+(node as any).hash = "9c9291dffd5c057c0e70e2567a897362";
+
+export default node;

--- a/apps/console/src/components/trustCenter/__generated__/TrustCenterDocumentDialogFragment.graphql.ts
+++ b/apps/console/src/components/trustCenter/__generated__/TrustCenterDocumentDialogFragment.graphql.ts
@@ -1,0 +1,58 @@
+/**
+ * @generated SignedSource<<3ff483dcc660e6b45d676db7fc05a30e>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type TrustCenterDocumentDialogFragment$data = {
+  readonly id: string;
+  readonly showOnTrustCenter: boolean;
+  readonly title: string;
+  readonly " $fragmentType": "TrustCenterDocumentDialogFragment";
+};
+export type TrustCenterDocumentDialogFragment$key = {
+  readonly " $data"?: TrustCenterDocumentDialogFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"TrustCenterDocumentDialogFragment">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "TrustCenterDocumentDialogFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "title",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "showOnTrustCenter",
+      "storageKey": null
+    }
+  ],
+  "type": "Document",
+  "abstractKey": null
+};
+
+(node as any).hash = "d886df25fdf197161a91bbc693c9fac8";
+
+export default node;

--- a/apps/console/src/components/trustCenter/__generated__/TrustCenterDocumentsCardFragment.graphql.ts
+++ b/apps/console/src/components/trustCenter/__generated__/TrustCenterDocumentsCardFragment.graphql.ts
@@ -1,0 +1,134 @@
+/**
+ * @generated SignedSource<<711a0b67f3e93814ae3297a2578373c6>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type DocumentStatus = "DRAFT" | "PUBLISHED";
+export type DocumentType = "ISMS" | "OTHER" | "POLICY";
+import { FragmentRefs } from "relay-runtime";
+export type TrustCenterDocumentsCardFragment$data = {
+  readonly createdAt: any;
+  readonly documentType: DocumentType;
+  readonly id: string;
+  readonly showOnTrustCenter: boolean;
+  readonly title: string;
+  readonly versions: {
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly id: string;
+        readonly status: DocumentStatus;
+      };
+    }>;
+  };
+  readonly " $fragmentType": "TrustCenterDocumentsCardFragment";
+};
+export type TrustCenterDocumentsCardFragment$key = {
+  readonly " $data"?: TrustCenterDocumentsCardFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"TrustCenterDocumentsCardFragment">;
+};
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "TrustCenterDocumentsCardFragment",
+  "selections": [
+    (v0/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "title",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "createdAt",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "documentType",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "showOnTrustCenter",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 1
+        }
+      ],
+      "concreteType": "DocumentVersionConnection",
+      "kind": "LinkedField",
+      "name": "versions",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "DocumentVersionEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "DocumentVersion",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                (v0/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "status",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "versions(first:1)"
+    }
+  ],
+  "type": "Document",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "88d5e5e3a2d9f4b730428efcea644f25";
+
+export default node;

--- a/apps/console/src/components/trustCenter/__generated__/TrustCenterVendorsCardFragment.graphql.ts
+++ b/apps/console/src/components/trustCenter/__generated__/TrustCenterVendorsCardFragment.graphql.ts
@@ -1,0 +1,83 @@
+/**
+ * @generated SignedSource<<b3d65d827fc901aa002b24df72f79ee2>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type VendorCategory = "ANALYTICS" | "CLOUD_MONITORING" | "CLOUD_PROVIDER" | "COLLABORATION" | "CUSTOMER_SUPPORT" | "DATA_STORAGE_AND_PROCESSING" | "DOCUMENT_MANAGEMENT" | "EMPLOYEE_MANAGEMENT" | "ENGINEERING" | "FINANCE" | "IDENTITY_PROVIDER" | "IT" | "MARKETING" | "OFFICE_OPERATIONS" | "OTHER" | "PASSWORD_MANAGEMENT" | "PRODUCT_AND_DESIGN" | "PROFESSIONAL_SERVICES" | "RECRUITING" | "SALES" | "SECURITY" | "VERSION_CONTROL";
+import { FragmentRefs } from "relay-runtime";
+export type TrustCenterVendorsCardFragment$data = {
+  readonly category: VendorCategory;
+  readonly createdAt: any;
+  readonly description: string | null | undefined;
+  readonly id: string;
+  readonly name: string;
+  readonly showOnTrustCenter: boolean;
+  readonly " $fragmentType": "TrustCenterVendorsCardFragment";
+};
+export type TrustCenterVendorsCardFragment$key = {
+  readonly " $data"?: TrustCenterVendorsCardFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"TrustCenterVendorsCardFragment">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "TrustCenterVendorsCardFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "category",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "description",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "showOnTrustCenter",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "createdAt",
+      "storageKey": null
+    }
+  ],
+  "type": "Vendor",
+  "abstractKey": null
+};
+
+(node as any).hash = "72b637589fd9299b5e982450fccbfd12";
+
+export default node;

--- a/apps/console/src/hooks/forms/__generated__/useVendorFormMutation.graphql.ts
+++ b/apps/console/src/hooks/forms/__generated__/useVendorFormMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<95aa70195a3e90acb366441fd037c2f2>>
+ * @generated SignedSource<<faa26838a242a98d5df14f51ff257950>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,6 +26,7 @@ export type UpdateVendorInput = {
   securityOwnerId?: string | null | undefined;
   securityPageUrl?: string | null | undefined;
   serviceLevelAgreementUrl?: string | null | undefined;
+  showOnTrustCenter?: boolean | null | undefined;
   statusPageUrl?: string | null | undefined;
   subprocessorsListUrl?: string | null | undefined;
   termsOfServiceUrl?: string | null | undefined;

--- a/apps/console/src/hooks/graph/AuditGraph.ts
+++ b/apps/console/src/hooks/graph/AuditGraph.ts
@@ -1,0 +1,279 @@
+import { graphql } from "relay-runtime";
+import { useMutation } from "react-relay";
+import { useConfirm } from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { promisifyMutation, sprintf } from "@probo/helpers";
+import { useMutationWithToasts } from "../useMutationWithToasts";
+
+export const auditsQuery = graphql`
+  query AuditGraphListQuery($organizationId: ID!) {
+    node(id: $organizationId) {
+      ... on Organization {
+        ...AuditsPageFragment
+      }
+    }
+  }
+`;
+
+export const auditNodeQuery = graphql`
+  query AuditGraphNodeQuery($auditId: ID!) {
+    node(id: $auditId) {
+      ... on Audit {
+        id
+        validFrom
+        validUntil
+        report {
+          id
+          filename
+          mimeType
+          size
+          downloadUrl
+          createdAt
+        }
+        reportUrl
+        state
+        framework {
+          id
+          name
+        }
+        organization {
+          id
+          name
+        }
+        createdAt
+        updatedAt
+      }
+    }
+  }
+`;
+
+export const createAuditMutation = graphql`
+  mutation AuditGraphCreateMutation(
+    $input: CreateAuditInput!
+    $connections: [ID!]!
+  ) {
+    createAudit(input: $input) {
+      auditEdge @prependEdge(connections: $connections) {
+        node {
+          id
+          validFrom
+          validUntil
+          report {
+            id
+            filename
+          }
+          state
+          framework {
+            id
+            name
+          }
+          createdAt
+        }
+      }
+    }
+  }
+`;
+
+export const updateAuditMutation = graphql`
+  mutation AuditGraphUpdateMutation($input: UpdateAuditInput!) {
+    updateAudit(input: $input) {
+      audit {
+        id
+        validFrom
+        validUntil
+        report {
+          id
+          filename
+        }
+        state
+        framework {
+          id
+          name
+        }
+        updatedAt
+      }
+    }
+  }
+`;
+
+export const deleteAuditMutation = graphql`
+  mutation AuditGraphDeleteMutation(
+    $input: DeleteAuditInput!
+    $connections: [ID!]!
+  ) {
+    deleteAudit(input: $input) {
+      deletedAuditId @deleteEdge(connections: $connections)
+    }
+  }
+`;
+
+export const useDeleteAudit = (
+  audit: { id: string; framework: { name: string } },
+  connectionId: string
+) => {
+  const { __ } = useTranslate();
+  const [mutate] = useMutationWithToasts(deleteAuditMutation, {
+    successMessage: __("Audit deleted successfully"),
+    errorMessage: __("Failed to delete audit"),
+  });
+  const confirm = useConfirm();
+
+  return () => {
+    confirm(
+      () =>
+        mutate({
+          variables: {
+            input: {
+              auditId: audit.id!,
+            },
+            connections: [connectionId],
+          },
+        }),
+      {
+        message: sprintf(
+          __(
+            "This will permanently delete the audit for %s. This action cannot be undone."
+          ),
+          audit.framework.name
+        ),
+      }
+    );
+  };
+};
+
+export const useCreateAudit = (connectionId: string) => {
+  const [mutate] = useMutation(createAuditMutation);
+  const { __ } = useTranslate();
+
+  return (input: {
+    organizationId: string;
+    frameworkId: string;
+    validFrom?: string;
+    validUntil?: string;
+    reportKey?: string;
+    state?: string;
+  }) => {
+    if (!input.organizationId) {
+      return alert(__("Failed to create audit: organization is required"));
+    }
+    if (!input.frameworkId) {
+      return alert(__("Failed to create audit: framework is required"));
+    }
+
+    return promisifyMutation(mutate)({
+      variables: {
+        input: {
+          organizationId: input.organizationId,
+          frameworkId: input.frameworkId,
+          validFrom: input.validFrom,
+          validUntil: input.validUntil,
+          reportKey: input.reportKey,
+          state: input.state || "NOT_STARTED",
+        },
+        connections: [connectionId],
+      },
+    });
+  };
+};
+
+export const useUpdateAudit = () => {
+  const [mutate] = useMutation(updateAuditMutation);
+  const { __ } = useTranslate();
+
+  return (input: {
+    id: string;
+    validFrom?: string;
+    validUntil?: string;
+    state?: string;
+  }) => {
+    if (!input.id) {
+      return alert(__("Failed to update audit: audit ID is required"));
+    }
+
+    return promisifyMutation(mutate)({
+      variables: {
+        input,
+      },
+    });
+  };
+};
+
+export const uploadAuditReportMutation = graphql`
+  mutation AuditGraphUploadReportMutation($input: UploadAuditReportInput!) {
+    uploadAuditReport(input: $input) {
+      audit {
+        id
+        report {
+          id
+          filename
+          downloadUrl
+          createdAt
+        }
+        updatedAt
+      }
+    }
+  }
+`;
+
+export const useUploadAuditReport = () => {
+  const { __ } = useTranslate();
+  const [mutate, isLoading] = useMutationWithToasts(uploadAuditReportMutation, {
+    successMessage: __("Audit report uploaded successfully"),
+    errorMessage: __("Failed to upload audit report"),
+  });
+
+  const uploadAuditReport = (input: { auditId: string; file: File }) => {
+    if (!input.auditId) {
+      return alert(__("Failed to upload report: audit ID is required"));
+    }
+
+    return mutate({
+      variables: {
+        input: {
+          auditId: input.auditId,
+          file: null,
+        },
+      },
+      uploadables: {
+        "input.file": input.file,
+      },
+    });
+  };
+
+  return [uploadAuditReport, isLoading] as const;
+};
+
+export const deleteAuditReportMutation = graphql`
+  mutation AuditGraphDeleteReportMutation($input: DeleteAuditReportInput!) {
+    deleteAuditReport(input: $input) {
+      audit {
+        id
+        report {
+          id
+          filename
+          downloadUrl
+          createdAt
+        }
+        updatedAt
+      }
+    }
+  }
+`;
+
+export const useDeleteAuditReport = () => {
+  const { __ } = useTranslate();
+  const [mutate] = useMutationWithToasts(deleteAuditReportMutation, {
+    successMessage: __("Audit report deleted successfully"),
+    errorMessage: __("Failed to delete audit report"),
+  });
+
+  return (input: { auditId: string }) => {
+    return mutate({
+      variables: {
+        input: {
+          auditId: input.auditId,
+        },
+      },
+    });
+  };
+};

--- a/apps/console/src/hooks/graph/PublicTrustCenterGraph.ts
+++ b/apps/console/src/hooks/graph/PublicTrustCenterGraph.ts
@@ -1,0 +1,66 @@
+import { graphql } from "relay-runtime";
+
+export const publicTrustCenterQuery = graphql`
+  query PublicTrustCenterGraphQuery($slug: String!) {
+    trustCenterBySlug(slug: $slug) {
+      id
+      active
+      slug
+      organization {
+        id
+        name
+        logoUrl
+      }
+      publicDocuments(first: 100) {
+        edges {
+          node {
+            id
+            title
+            documentType
+            versions(first: 1) {
+              edges {
+                node {
+                  id
+                  status
+                }
+              }
+            }
+          }
+        }
+      }
+      publicAudits(first: 100) {
+        edges {
+          node {
+            id
+            framework {
+              name
+            }
+            validFrom
+            validUntil
+            state
+            createdAt
+            report {
+              id
+              filename
+              downloadUrl
+            }
+            reportUrl
+          }
+        }
+      }
+      publicVendors(first: 100) {
+        edges {
+          node {
+            id
+            name
+            category
+            description
+            createdAt
+            websiteUrl
+            privacyPolicyUrl
+          }
+        }
+      }
+    }
+  }
+`;

--- a/apps/console/src/hooks/graph/TrustCenterAuditGraph.ts
+++ b/apps/console/src/hooks/graph/TrustCenterAuditGraph.ts
@@ -1,0 +1,28 @@
+import { graphql } from "relay-runtime";
+import { useMutationWithToasts } from "/hooks/useMutationWithToasts";
+import { useTranslate } from "@probo/i18n";
+import type { TrustCenterAuditGraphUpdateMutation } from "./__generated__/TrustCenterAuditGraphUpdateMutation.graphql";
+
+export const trustCenterAuditUpdateMutation = graphql`
+  mutation TrustCenterAuditGraphUpdateMutation($input: UpdateAuditInput!) {
+    updateAudit(input: $input) {
+      audit {
+        id
+        showOnTrustCenter
+        ...TrustCenterAuditsCardFragment
+      }
+    }
+  }
+`;
+
+export function useTrustCenterAuditUpdate() {
+  const { __ } = useTranslate();
+
+  return useMutationWithToasts<TrustCenterAuditGraphUpdateMutation>(
+    trustCenterAuditUpdateMutation,
+    {
+      successMessage: __("Audit visibility updated successfully."),
+      errorMessage: __("Failed to update audit visibility. Please try again."),
+    }
+  );
+}

--- a/apps/console/src/hooks/graph/TrustCenterDocumentGraph.ts
+++ b/apps/console/src/hooks/graph/TrustCenterDocumentGraph.ts
@@ -1,0 +1,46 @@
+import { graphql } from "relay-runtime";
+import { useMutationWithToasts } from "/hooks/useMutationWithToasts";
+import { useTranslate } from "@probo/i18n";
+import type { TrustCenterDocumentGraphUpdateMutation } from "./__generated__/TrustCenterDocumentGraphUpdateMutation.graphql";
+
+export const trustCenterDocumentsQuery = graphql`
+  query TrustCenterDocumentGraphQuery($organizationId: ID!) {
+    organization: node(id: $organizationId) {
+      ... on Organization {
+        id
+        documents(first: 100) {
+          edges {
+            node {
+              id
+              ...TrustCenterDocumentsCardFragment
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const updateDocumentVisibilityMutation = graphql`
+  mutation TrustCenterDocumentGraphUpdateMutation($input: UpdateDocumentInput!) {
+    updateDocument(input: $input) {
+      document {
+        id
+        showOnTrustCenter
+        ...TrustCenterDocumentsCardFragment
+      }
+    }
+  }
+`;
+
+export function useUpdateDocumentVisibilityMutation() {
+  const { __ } = useTranslate();
+
+  return useMutationWithToasts<TrustCenterDocumentGraphUpdateMutation>(
+    updateDocumentVisibilityMutation,
+    {
+      successMessage: __("Document visibility updated successfully."),
+      errorMessage: __("Failed to update document visibility. Please try again."),
+    }
+  );
+}

--- a/apps/console/src/hooks/graph/TrustCenterGraph.ts
+++ b/apps/console/src/hooks/graph/TrustCenterGraph.ts
@@ -1,0 +1,68 @@
+import { graphql } from "relay-runtime";
+import { useMutationWithToasts } from "/hooks/useMutationWithToasts";
+import type { TrustCenterGraphUpdateMutation } from "./__generated__/TrustCenterGraphUpdateMutation.graphql";
+
+export const trustCenterQuery = graphql`
+  query TrustCenterGraphQuery($organizationId: ID!) {
+    organization: node(id: $organizationId) {
+      ... on Organization {
+        id
+        name
+        trustCenter {
+          id
+          active
+          slug
+          createdAt
+          updatedAt
+        }
+        documents(first: 100) {
+          edges {
+            node {
+              id
+              ...TrustCenterDocumentsCardFragment
+            }
+          }
+        }
+        audits(first: 100) {
+          edges {
+            node {
+              id
+              ...TrustCenterAuditsCardFragment
+            }
+          }
+        }
+        vendors(first: 100) {
+          edges {
+            node {
+              id
+              ...TrustCenterVendorsCardFragment
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const updateTrustCenterMutation = graphql`
+  mutation TrustCenterGraphUpdateMutation($input: UpdateTrustCenterInput!) {
+    updateTrustCenter(input: $input) {
+      trustCenter {
+        id
+        active
+        slug
+        updatedAt
+      }
+    }
+  }
+`;
+
+export function useUpdateTrustCenterMutation() {
+  return useMutationWithToasts<TrustCenterGraphUpdateMutation>(
+    updateTrustCenterMutation,
+    {
+      successMessage: "Trust center updated successfully",
+      errorMessage: "Failed to update trust center",
+    }
+  );
+}

--- a/apps/console/src/hooks/graph/TrustCenterVendorGraph.ts
+++ b/apps/console/src/hooks/graph/TrustCenterVendorGraph.ts
@@ -1,0 +1,28 @@
+import { graphql } from "relay-runtime";
+import { useMutationWithToasts } from "/hooks/useMutationWithToasts";
+import { useTranslate } from "@probo/i18n";
+import type { TrustCenterVendorGraphUpdateMutation } from "./__generated__/TrustCenterVendorGraphUpdateMutation.graphql";
+
+export const trustCenterVendorUpdateMutation = graphql`
+  mutation TrustCenterVendorGraphUpdateMutation($input: UpdateVendorInput!) {
+    updateVendor(input: $input) {
+      vendor {
+        id
+        showOnTrustCenter
+        ...TrustCenterVendorsCardFragment
+      }
+    }
+  }
+`;
+
+export function useTrustCenterVendorUpdate() {
+  const { __ } = useTranslate();
+
+  return useMutationWithToasts<TrustCenterVendorGraphUpdateMutation>(
+    trustCenterVendorUpdateMutation,
+    {
+      successMessage: __("Vendor visibility updated successfully."),
+      errorMessage: __("Failed to update vendor visibility. Please try again."),
+    }
+  );
+}

--- a/apps/console/src/hooks/graph/__generated__/AuditGraphCreateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/AuditGraphCreateMutation.graphql.ts
@@ -1,0 +1,242 @@
+/**
+ * @generated SignedSource<<fd92d4fe2e50fc37c5ae6eda9058f650>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type AuditState = "COMPLETED" | "IN_PROGRESS" | "NOT_STARTED" | "OUTDATED" | "REJECTED";
+export type CreateAuditInput = {
+  frameworkId: string;
+  organizationId: string;
+  state?: AuditState | null | undefined;
+  validFrom?: any | null | undefined;
+  validUntil?: any | null | undefined;
+};
+export type AuditGraphCreateMutation$variables = {
+  connections: ReadonlyArray<string>;
+  input: CreateAuditInput;
+};
+export type AuditGraphCreateMutation$data = {
+  readonly createAudit: {
+    readonly auditEdge: {
+      readonly node: {
+        readonly createdAt: any;
+        readonly framework: {
+          readonly id: string;
+          readonly name: string;
+        };
+        readonly id: string;
+        readonly report: {
+          readonly filename: string;
+          readonly id: string;
+        } | null | undefined;
+        readonly state: AuditState;
+        readonly validFrom: any | null | undefined;
+        readonly validUntil: any | null | undefined;
+      };
+    };
+  };
+};
+export type AuditGraphCreateMutation = {
+  response: AuditGraphCreateMutation$data;
+  variables: AuditGraphCreateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "AuditEdge",
+  "kind": "LinkedField",
+  "name": "auditEdge",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Audit",
+      "kind": "LinkedField",
+      "name": "node",
+      "plural": false,
+      "selections": [
+        (v3/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "validFrom",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "validUntil",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Report",
+          "kind": "LinkedField",
+          "name": "report",
+          "plural": false,
+          "selections": [
+            (v3/*: any*/),
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "filename",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "state",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Framework",
+          "kind": "LinkedField",
+          "name": "framework",
+          "plural": false,
+          "selections": [
+            (v3/*: any*/),
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "name",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "createdAt",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "AuditGraphCreateMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "CreateAuditPayload",
+        "kind": "LinkedField",
+        "name": "createAudit",
+        "plural": false,
+        "selections": [
+          (v4/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "AuditGraphCreateMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "CreateAuditPayload",
+        "kind": "LinkedField",
+        "name": "createAudit",
+        "plural": false,
+        "selections": [
+          (v4/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "prependEdge",
+            "key": "",
+            "kind": "LinkedHandle",
+            "name": "auditEdge",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "5c941d42e42700b5e06a5a64c861054b",
+    "id": null,
+    "metadata": {},
+    "name": "AuditGraphCreateMutation",
+    "operationKind": "mutation",
+    "text": "mutation AuditGraphCreateMutation(\n  $input: CreateAuditInput!\n) {\n  createAudit(input: $input) {\n    auditEdge {\n      node {\n        id\n        validFrom\n        validUntil\n        report {\n          id\n          filename\n        }\n        state\n        framework {\n          id\n          name\n        }\n        createdAt\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "231fafa942acf107e2f0187bccc844da";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/AuditGraphDeleteMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/AuditGraphDeleteMutation.graphql.ts
@@ -1,0 +1,132 @@
+/**
+ * @generated SignedSource<<abf5473524b2c61dd92c4975aa4b21f1>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type DeleteAuditInput = {
+  auditId: string;
+};
+export type AuditGraphDeleteMutation$variables = {
+  connections: ReadonlyArray<string>;
+  input: DeleteAuditInput;
+};
+export type AuditGraphDeleteMutation$data = {
+  readonly deleteAudit: {
+    readonly deletedAuditId: string;
+  };
+};
+export type AuditGraphDeleteMutation = {
+  response: AuditGraphDeleteMutation$data;
+  variables: AuditGraphDeleteMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "deletedAuditId",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "AuditGraphDeleteMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteAuditPayload",
+        "kind": "LinkedField",
+        "name": "deleteAudit",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "AuditGraphDeleteMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteAuditPayload",
+        "kind": "LinkedField",
+        "name": "deleteAudit",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "deleteEdge",
+            "key": "",
+            "kind": "ScalarHandle",
+            "name": "deletedAuditId",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "48906b2f55360bea9a8fc7f0daea34be",
+    "id": null,
+    "metadata": {},
+    "name": "AuditGraphDeleteMutation",
+    "operationKind": "mutation",
+    "text": "mutation AuditGraphDeleteMutation(\n  $input: DeleteAuditInput!\n) {\n  deleteAudit(input: $input) {\n    deletedAuditId\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "e0f3771289e512982adc900199820821";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/AuditGraphDeleteReportMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/AuditGraphDeleteReportMutation.graphql.ts
@@ -1,0 +1,153 @@
+/**
+ * @generated SignedSource<<14b4821bc7eec6b85029d0aae3a3a271>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type DeleteAuditReportInput = {
+  auditId: string;
+};
+export type AuditGraphDeleteReportMutation$variables = {
+  input: DeleteAuditReportInput;
+};
+export type AuditGraphDeleteReportMutation$data = {
+  readonly deleteAuditReport: {
+    readonly audit: {
+      readonly id: string;
+      readonly report: {
+        readonly createdAt: any;
+        readonly downloadUrl: string | null | undefined;
+        readonly filename: string;
+        readonly id: string;
+      } | null | undefined;
+      readonly updatedAt: any;
+    };
+  };
+};
+export type AuditGraphDeleteReportMutation = {
+  response: AuditGraphDeleteReportMutation$data;
+  variables: AuditGraphDeleteReportMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "DeleteAuditReportPayload",
+    "kind": "LinkedField",
+    "name": "deleteAuditReport",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Audit",
+        "kind": "LinkedField",
+        "name": "audit",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Report",
+            "kind": "LinkedField",
+            "name": "report",
+            "plural": false,
+            "selections": [
+              (v1/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "filename",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "downloadUrl",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "createdAt",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "updatedAt",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "AuditGraphDeleteReportMutation",
+    "selections": (v2/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "AuditGraphDeleteReportMutation",
+    "selections": (v2/*: any*/)
+  },
+  "params": {
+    "cacheID": "ebceb2fd2a2ffae09bc1578e37dde7e0",
+    "id": null,
+    "metadata": {},
+    "name": "AuditGraphDeleteReportMutation",
+    "operationKind": "mutation",
+    "text": "mutation AuditGraphDeleteReportMutation(\n  $input: DeleteAuditReportInput!\n) {\n  deleteAuditReport(input: $input) {\n    audit {\n      id\n      report {\n        id\n        filename\n        downloadUrl\n        createdAt\n      }\n      updatedAt\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "4b5e9537b35458eb3daa313ead9ba655";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/AuditGraphListQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/AuditGraphListQuery.graphql.ts
@@ -1,0 +1,307 @@
+/**
+ * @generated SignedSource<<421ff1807db813d87849e15e60fc958e>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type AuditGraphListQuery$variables = {
+  organizationId: string;
+};
+export type AuditGraphListQuery$data = {
+  readonly node: {
+    readonly " $fragmentSpreads": FragmentRefs<"AuditsPageFragment">;
+  };
+};
+export type AuditGraphListQuery = {
+  response: AuditGraphListQuery$data;
+  variables: AuditGraphListQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "organizationId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "organizationId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "AuditGraphListQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "AuditsPageFragment"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "AuditGraphListQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": (v4/*: any*/),
+                "concreteType": "AuditConnection",
+                "kind": "LinkedField",
+                "name": "audits",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AuditEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Audit",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v3/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "validFrom",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "validUntil",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Report",
+                            "kind": "LinkedField",
+                            "name": "report",
+                            "plural": false,
+                            "selections": [
+                              (v3/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "filename",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "state",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Framework",
+                            "kind": "LinkedField",
+                            "name": "framework",
+                            "plural": false,
+                            "selections": [
+                              (v3/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "name",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "createdAt",
+                            "storageKey": null
+                          },
+                          (v2/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "cursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageInfo",
+                    "kind": "LinkedField",
+                    "name": "pageInfo",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "endCursor",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "hasNextPage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "hasPreviousPage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "startCursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ClientExtension",
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "__id",
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ],
+                "storageKey": "audits(first:10)"
+              },
+              {
+                "alias": null,
+                "args": (v4/*: any*/),
+                "filters": [
+                  "orderBy"
+                ],
+                "handle": "connection",
+                "key": "AuditsPage_audits",
+                "kind": "LinkedHandle",
+                "name": "audits"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "1c53759e5b25eb390345fee12e536896",
+    "id": null,
+    "metadata": {},
+    "name": "AuditGraphListQuery",
+    "operationKind": "query",
+    "text": "query AuditGraphListQuery(\n  $organizationId: ID!\n) {\n  node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      ...AuditsPageFragment\n    }\n    id\n  }\n}\n\nfragment AuditsPageFragment on Organization {\n  audits(first: 10) {\n    edges {\n      node {\n        id\n        validFrom\n        validUntil\n        report {\n          id\n          filename\n        }\n        state\n        framework {\n          id\n          name\n        }\n        createdAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "3a082303ae15c8982a08c3bae8312846";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/AuditGraphNodeQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/AuditGraphNodeQuery.graphql.ts
@@ -1,0 +1,278 @@
+/**
+ * @generated SignedSource<<597dc89a18faf5837517c12ab6046991>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type AuditState = "COMPLETED" | "IN_PROGRESS" | "NOT_STARTED" | "OUTDATED" | "REJECTED";
+export type AuditGraphNodeQuery$variables = {
+  auditId: string;
+};
+export type AuditGraphNodeQuery$data = {
+  readonly node: {
+    readonly createdAt?: any;
+    readonly framework?: {
+      readonly id: string;
+      readonly name: string;
+    };
+    readonly id?: string;
+    readonly organization?: {
+      readonly id: string;
+      readonly name: string;
+    };
+    readonly report?: {
+      readonly createdAt: any;
+      readonly downloadUrl: string | null | undefined;
+      readonly filename: string;
+      readonly id: string;
+      readonly mimeType: string;
+      readonly size: number;
+    } | null | undefined;
+    readonly reportUrl?: string | null | undefined;
+    readonly state?: AuditState;
+    readonly updatedAt?: any;
+    readonly validFrom?: any | null | undefined;
+    readonly validUntil?: any | null | undefined;
+  };
+};
+export type AuditGraphNodeQuery = {
+  response: AuditGraphNodeQuery$data;
+  variables: AuditGraphNodeQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "auditId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "auditId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "validFrom",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "validUntil",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Report",
+  "kind": "LinkedField",
+  "name": "report",
+  "plural": false,
+  "selections": [
+    (v2/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "filename",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "mimeType",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "size",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "downloadUrl",
+      "storageKey": null
+    },
+    (v5/*: any*/)
+  ],
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "reportUrl",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "state",
+  "storageKey": null
+},
+v9 = [
+  (v2/*: any*/),
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "name",
+    "storageKey": null
+  }
+],
+v10 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Framework",
+  "kind": "LinkedField",
+  "name": "framework",
+  "plural": false,
+  "selections": (v9/*: any*/),
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Organization",
+  "kind": "LinkedField",
+  "name": "organization",
+  "plural": false,
+  "selections": (v9/*: any*/),
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "updatedAt",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "AuditGraphNodeQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/),
+              (v10/*: any*/),
+              (v11/*: any*/),
+              (v5/*: any*/),
+              (v12/*: any*/)
+            ],
+            "type": "Audit",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "AuditGraphNodeQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/),
+              (v10/*: any*/),
+              (v11/*: any*/),
+              (v5/*: any*/),
+              (v12/*: any*/)
+            ],
+            "type": "Audit",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "8cab4d1083ea5990e42dbec0b435b7bd",
+    "id": null,
+    "metadata": {},
+    "name": "AuditGraphNodeQuery",
+    "operationKind": "query",
+    "text": "query AuditGraphNodeQuery(\n  $auditId: ID!\n) {\n  node(id: $auditId) {\n    __typename\n    ... on Audit {\n      id\n      validFrom\n      validUntil\n      report {\n        id\n        filename\n        mimeType\n        size\n        downloadUrl\n        createdAt\n      }\n      reportUrl\n      state\n      framework {\n        id\n        name\n      }\n      organization {\n        id\n        name\n      }\n      createdAt\n      updatedAt\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "3263f3b8f244acf3c982464daa078f7b";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/AuditGraphUpdateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/AuditGraphUpdateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f55547fed473a026bb7c43be28a2c6dc>>
+ * @generated SignedSource<<d2c542541d5bfda5464af2b34ccae603>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,7 @@ import { ConcreteRequest } from 'relay-runtime';
 export type AuditState = "COMPLETED" | "IN_PROGRESS" | "NOT_STARTED" | "OUTDATED" | "REJECTED";
 export type UpdateAuditInput = {
   id: string;
+  showOnTrustCenter?: boolean | null | undefined;
   state?: AuditState | null | undefined;
   validFrom?: any | null | undefined;
   validUntil?: any | null | undefined;

--- a/apps/console/src/hooks/graph/__generated__/AuditGraphUpdateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/AuditGraphUpdateMutation.graphql.ts
@@ -1,0 +1,188 @@
+/**
+ * @generated SignedSource<<f55547fed473a026bb7c43be28a2c6dc>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type AuditState = "COMPLETED" | "IN_PROGRESS" | "NOT_STARTED" | "OUTDATED" | "REJECTED";
+export type UpdateAuditInput = {
+  id: string;
+  state?: AuditState | null | undefined;
+  validFrom?: any | null | undefined;
+  validUntil?: any | null | undefined;
+};
+export type AuditGraphUpdateMutation$variables = {
+  input: UpdateAuditInput;
+};
+export type AuditGraphUpdateMutation$data = {
+  readonly updateAudit: {
+    readonly audit: {
+      readonly framework: {
+        readonly id: string;
+        readonly name: string;
+      };
+      readonly id: string;
+      readonly report: {
+        readonly filename: string;
+        readonly id: string;
+      } | null | undefined;
+      readonly state: AuditState;
+      readonly updatedAt: any;
+      readonly validFrom: any | null | undefined;
+      readonly validUntil: any | null | undefined;
+    };
+  };
+};
+export type AuditGraphUpdateMutation = {
+  response: AuditGraphUpdateMutation$data;
+  variables: AuditGraphUpdateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "UpdateAuditPayload",
+    "kind": "LinkedField",
+    "name": "updateAudit",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Audit",
+        "kind": "LinkedField",
+        "name": "audit",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "validFrom",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "validUntil",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Report",
+            "kind": "LinkedField",
+            "name": "report",
+            "plural": false,
+            "selections": [
+              (v1/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "filename",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "state",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Framework",
+            "kind": "LinkedField",
+            "name": "framework",
+            "plural": false,
+            "selections": [
+              (v1/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "updatedAt",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "AuditGraphUpdateMutation",
+    "selections": (v2/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "AuditGraphUpdateMutation",
+    "selections": (v2/*: any*/)
+  },
+  "params": {
+    "cacheID": "afd98ba771c6c437c46c275655333eb6",
+    "id": null,
+    "metadata": {},
+    "name": "AuditGraphUpdateMutation",
+    "operationKind": "mutation",
+    "text": "mutation AuditGraphUpdateMutation(\n  $input: UpdateAuditInput!\n) {\n  updateAudit(input: $input) {\n    audit {\n      id\n      validFrom\n      validUntil\n      report {\n        id\n        filename\n      }\n      state\n      framework {\n        id\n        name\n      }\n      updatedAt\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "3ddd17832768611675505d76da1839a1";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/AuditGraphUploadReportMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/AuditGraphUploadReportMutation.graphql.ts
@@ -1,0 +1,154 @@
+/**
+ * @generated SignedSource<<39001f4e110ade4633319d2e71f1377f>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type UploadAuditReportInput = {
+  auditId: string;
+  file: any;
+};
+export type AuditGraphUploadReportMutation$variables = {
+  input: UploadAuditReportInput;
+};
+export type AuditGraphUploadReportMutation$data = {
+  readonly uploadAuditReport: {
+    readonly audit: {
+      readonly id: string;
+      readonly report: {
+        readonly createdAt: any;
+        readonly downloadUrl: string | null | undefined;
+        readonly filename: string;
+        readonly id: string;
+      } | null | undefined;
+      readonly updatedAt: any;
+    };
+  };
+};
+export type AuditGraphUploadReportMutation = {
+  response: AuditGraphUploadReportMutation$data;
+  variables: AuditGraphUploadReportMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "UploadAuditReportPayload",
+    "kind": "LinkedField",
+    "name": "uploadAuditReport",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Audit",
+        "kind": "LinkedField",
+        "name": "audit",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Report",
+            "kind": "LinkedField",
+            "name": "report",
+            "plural": false,
+            "selections": [
+              (v1/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "filename",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "downloadUrl",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "createdAt",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "updatedAt",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "AuditGraphUploadReportMutation",
+    "selections": (v2/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "AuditGraphUploadReportMutation",
+    "selections": (v2/*: any*/)
+  },
+  "params": {
+    "cacheID": "05229f6e6fb7e64ceaf93c4bb8f144e6",
+    "id": null,
+    "metadata": {},
+    "name": "AuditGraphUploadReportMutation",
+    "operationKind": "mutation",
+    "text": "mutation AuditGraphUploadReportMutation(\n  $input: UploadAuditReportInput!\n) {\n  uploadAuditReport(input: $input) {\n    audit {\n      id\n      report {\n        id\n        filename\n        downloadUrl\n        createdAt\n      }\n      updatedAt\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "1acff19bbb4a2e0eeca934cc90040eda";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/PublicTrustCenterGraphQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/PublicTrustCenterGraphQuery.graphql.ts
@@ -1,0 +1,547 @@
+/**
+ * @generated SignedSource<<db6f17f33029746ad576e10564eb21f7>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type AuditState = "COMPLETED" | "IN_PROGRESS" | "NOT_STARTED" | "OUTDATED" | "REJECTED";
+export type DocumentStatus = "DRAFT" | "PUBLISHED";
+export type DocumentType = "ISMS" | "OTHER" | "POLICY";
+export type VendorCategory = "ANALYTICS" | "CLOUD_MONITORING" | "CLOUD_PROVIDER" | "COLLABORATION" | "CUSTOMER_SUPPORT" | "DATA_STORAGE_AND_PROCESSING" | "DOCUMENT_MANAGEMENT" | "EMPLOYEE_MANAGEMENT" | "ENGINEERING" | "FINANCE" | "IDENTITY_PROVIDER" | "IT" | "MARKETING" | "OFFICE_OPERATIONS" | "OTHER" | "PASSWORD_MANAGEMENT" | "PRODUCT_AND_DESIGN" | "PROFESSIONAL_SERVICES" | "RECRUITING" | "SALES" | "SECURITY" | "VERSION_CONTROL";
+export type PublicTrustCenterGraphQuery$variables = {
+  slug: string;
+};
+export type PublicTrustCenterGraphQuery$data = {
+  readonly trustCenterBySlug: {
+    readonly active: boolean;
+    readonly id: string;
+    readonly organization: {
+      readonly id: string;
+      readonly logoUrl: string | null | undefined;
+      readonly name: string;
+    };
+    readonly publicAudits: {
+      readonly edges: ReadonlyArray<{
+        readonly node: {
+          readonly createdAt: any;
+          readonly framework: {
+            readonly name: string;
+          };
+          readonly id: string;
+          readonly report: {
+            readonly downloadUrl: string | null | undefined;
+            readonly filename: string;
+            readonly id: string;
+          } | null | undefined;
+          readonly reportUrl: string | null | undefined;
+          readonly state: AuditState;
+          readonly validFrom: any | null | undefined;
+          readonly validUntil: any | null | undefined;
+        };
+      }>;
+    };
+    readonly publicDocuments: {
+      readonly edges: ReadonlyArray<{
+        readonly node: {
+          readonly documentType: DocumentType;
+          readonly id: string;
+          readonly title: string;
+          readonly versions: {
+            readonly edges: ReadonlyArray<{
+              readonly node: {
+                readonly id: string;
+                readonly status: DocumentStatus;
+              };
+            }>;
+          };
+        };
+      }>;
+    };
+    readonly publicVendors: {
+      readonly edges: ReadonlyArray<{
+        readonly node: {
+          readonly category: VendorCategory;
+          readonly createdAt: any;
+          readonly description: string | null | undefined;
+          readonly id: string;
+          readonly name: string;
+          readonly privacyPolicyUrl: string | null | undefined;
+          readonly websiteUrl: string | null | undefined;
+        };
+      }>;
+    };
+    readonly slug: string;
+  } | null | undefined;
+};
+export type PublicTrustCenterGraphQuery = {
+  response: PublicTrustCenterGraphQuery$data;
+  variables: PublicTrustCenterGraphQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "slug"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "slug",
+    "variableName": "slug"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "active",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Organization",
+  "kind": "LinkedField",
+  "name": "organization",
+  "plural": false,
+  "selections": [
+    (v2/*: any*/),
+    (v5/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "logoUrl",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v7 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 100
+  }
+],
+v8 = {
+  "alias": null,
+  "args": (v7/*: any*/),
+  "concreteType": "DocumentConnection",
+  "kind": "LinkedField",
+  "name": "publicDocuments",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "DocumentEdge",
+      "kind": "LinkedField",
+      "name": "edges",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Document",
+          "kind": "LinkedField",
+          "name": "node",
+          "plural": false,
+          "selections": [
+            (v2/*: any*/),
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "title",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "documentType",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": [
+                {
+                  "kind": "Literal",
+                  "name": "first",
+                  "value": 1
+                }
+              ],
+              "concreteType": "DocumentVersionConnection",
+              "kind": "LinkedField",
+              "name": "versions",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "DocumentVersionEdge",
+                  "kind": "LinkedField",
+                  "name": "edges",
+                  "plural": true,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "DocumentVersion",
+                      "kind": "LinkedField",
+                      "name": "node",
+                      "plural": false,
+                      "selections": [
+                        (v2/*: any*/),
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "status",
+                          "storageKey": null
+                        }
+                      ],
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                }
+              ],
+              "storageKey": "versions(first:1)"
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": "publicDocuments(first:100)"
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "validFrom",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "validUntil",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "state",
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+},
+v13 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Report",
+  "kind": "LinkedField",
+  "name": "report",
+  "plural": false,
+  "selections": [
+    (v2/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "filename",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "downloadUrl",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v14 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "reportUrl",
+  "storageKey": null
+},
+v15 = {
+  "alias": null,
+  "args": (v7/*: any*/),
+  "concreteType": "VendorConnection",
+  "kind": "LinkedField",
+  "name": "publicVendors",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "VendorEdge",
+      "kind": "LinkedField",
+      "name": "edges",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Vendor",
+          "kind": "LinkedField",
+          "name": "node",
+          "plural": false,
+          "selections": [
+            (v2/*: any*/),
+            (v5/*: any*/),
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "category",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "description",
+              "storageKey": null
+            },
+            (v12/*: any*/),
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "websiteUrl",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "privacyPolicyUrl",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": "publicVendors(first:100)"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "PublicTrustCenterGraphQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "TrustCenter",
+        "kind": "LinkedField",
+        "name": "trustCenterBySlug",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          (v4/*: any*/),
+          (v6/*: any*/),
+          (v8/*: any*/),
+          {
+            "alias": null,
+            "args": (v7/*: any*/),
+            "concreteType": "AuditConnection",
+            "kind": "LinkedField",
+            "name": "publicAudits",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "AuditEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Audit",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Framework",
+                        "kind": "LinkedField",
+                        "name": "framework",
+                        "plural": false,
+                        "selections": [
+                          (v5/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      (v9/*: any*/),
+                      (v10/*: any*/),
+                      (v11/*: any*/),
+                      (v12/*: any*/),
+                      (v13/*: any*/),
+                      (v14/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "publicAudits(first:100)"
+          },
+          (v15/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "PublicTrustCenterGraphQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "TrustCenter",
+        "kind": "LinkedField",
+        "name": "trustCenterBySlug",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          (v4/*: any*/),
+          (v6/*: any*/),
+          (v8/*: any*/),
+          {
+            "alias": null,
+            "args": (v7/*: any*/),
+            "concreteType": "AuditConnection",
+            "kind": "LinkedField",
+            "name": "publicAudits",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "AuditEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Audit",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Framework",
+                        "kind": "LinkedField",
+                        "name": "framework",
+                        "plural": false,
+                        "selections": [
+                          (v5/*: any*/),
+                          (v2/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      (v9/*: any*/),
+                      (v10/*: any*/),
+                      (v11/*: any*/),
+                      (v12/*: any*/),
+                      (v13/*: any*/),
+                      (v14/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "publicAudits(first:100)"
+          },
+          (v15/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "8b16e3d34954bc44f90d907fbc73251b",
+    "id": null,
+    "metadata": {},
+    "name": "PublicTrustCenterGraphQuery",
+    "operationKind": "query",
+    "text": "query PublicTrustCenterGraphQuery(\n  $slug: String!\n) {\n  trustCenterBySlug(slug: $slug) {\n    id\n    active\n    slug\n    organization {\n      id\n      name\n      logoUrl\n    }\n    publicDocuments(first: 100) {\n      edges {\n        node {\n          id\n          title\n          documentType\n          versions(first: 1) {\n            edges {\n              node {\n                id\n                status\n              }\n            }\n          }\n        }\n      }\n    }\n    publicAudits(first: 100) {\n      edges {\n        node {\n          id\n          framework {\n            name\n            id\n          }\n          validFrom\n          validUntil\n          state\n          createdAt\n          report {\n            id\n            filename\n            downloadUrl\n          }\n          reportUrl\n        }\n      }\n    }\n    publicVendors(first: 100) {\n      edges {\n        node {\n          id\n          name\n          category\n          description\n          createdAt\n          websiteUrl\n          privacyPolicyUrl\n        }\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "ef092098026ef8420e8b58ec02274ad2";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterAuditGraphUpdateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterAuditGraphUpdateMutation.graphql.ts
@@ -1,0 +1,118 @@
+/**
+ * @generated SignedSource<<92803a3585816e3db509c46a86d083e9>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type AuditState = "COMPLETED" | "IN_PROGRESS" | "NOT_STARTED" | "OUTDATED" | "REJECTED";
+export type UpdateAuditInput = {
+  id: string;
+  showOnTrustCenter?: boolean | null | undefined;
+  state?: AuditState | null | undefined;
+  validFrom?: any | null | undefined;
+  validUntil?: any | null | undefined;
+};
+export type TrustCenterAuditGraphUpdateMutation$variables = {
+  input: UpdateAuditInput;
+};
+export type TrustCenterAuditGraphUpdateMutation$data = {
+  readonly updateAudit: {
+    readonly audit: {
+      readonly id: string;
+      readonly showOnTrustCenter: boolean;
+    };
+  };
+};
+export type TrustCenterAuditGraphUpdateMutation = {
+  response: TrustCenterAuditGraphUpdateMutation$data;
+  variables: TrustCenterAuditGraphUpdateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "UpdateAuditPayload",
+    "kind": "LinkedField",
+    "name": "updateAudit",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Audit",
+        "kind": "LinkedField",
+        "name": "audit",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "showOnTrustCenter",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TrustCenterAuditGraphUpdateMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "TrustCenterAuditGraphUpdateMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "1ecc930abe6daebb184b1e55ccebc65c",
+    "id": null,
+    "metadata": {},
+    "name": "TrustCenterAuditGraphUpdateMutation",
+    "operationKind": "mutation",
+    "text": "mutation TrustCenterAuditGraphUpdateMutation(\n  $input: UpdateAuditInput!\n) {\n  updateAudit(input: $input) {\n    audit {\n      id\n      showOnTrustCenter\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "ebf90264b72bb993d60f48d1d3fc4fb7";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterAuditGraphUpdateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterAuditGraphUpdateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<92803a3585816e3db509c46a86d083e9>>
+ * @generated SignedSource<<2a5e6cd48ca8a8fd7fe448c3a6190ccc>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,6 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
 export type AuditState = "COMPLETED" | "IN_PROGRESS" | "NOT_STARTED" | "OUTDATED" | "REJECTED";
 export type UpdateAuditInput = {
   id: string;
@@ -25,6 +26,7 @@ export type TrustCenterAuditGraphUpdateMutation$data = {
     readonly audit: {
       readonly id: string;
       readonly showOnTrustCenter: boolean;
+      readonly " $fragmentSpreads": FragmentRefs<"TrustCenterAuditsCardFragment">;
     };
   };
 };
@@ -43,55 +45,62 @@ var v0 = [
 ],
 v1 = [
   {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "input",
-        "variableName": "input"
-      }
-    ],
-    "concreteType": "UpdateAuditPayload",
-    "kind": "LinkedField",
-    "name": "updateAudit",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "Audit",
-        "kind": "LinkedField",
-        "name": "audit",
-        "plural": false,
-        "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "showOnTrustCenter",
-            "storageKey": null
-          }
-        ],
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
   }
-];
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "showOnTrustCenter",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "TrustCenterAuditGraphUpdateMutation",
-    "selections": (v1/*: any*/),
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "UpdateAuditPayload",
+        "kind": "LinkedField",
+        "name": "updateAudit",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Audit",
+            "kind": "LinkedField",
+            "name": "audit",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "TrustCenterAuditsCardFragment"
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
     "type": "Mutation",
     "abstractKey": null
   },
@@ -100,19 +109,91 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "TrustCenterAuditGraphUpdateMutation",
-    "selections": (v1/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "UpdateAuditPayload",
+        "kind": "LinkedField",
+        "name": "updateAudit",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Audit",
+            "kind": "LinkedField",
+            "name": "audit",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Framework",
+                "kind": "LinkedField",
+                "name": "framework",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "name",
+                    "storageKey": null
+                  },
+                  (v2/*: any*/)
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "validFrom",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "validUntil",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "state",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "createdAt",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "cacheID": "1ecc930abe6daebb184b1e55ccebc65c",
+    "cacheID": "9cb78f25506e1a67b5f29d4f742f8773",
     "id": null,
     "metadata": {},
     "name": "TrustCenterAuditGraphUpdateMutation",
     "operationKind": "mutation",
-    "text": "mutation TrustCenterAuditGraphUpdateMutation(\n  $input: UpdateAuditInput!\n) {\n  updateAudit(input: $input) {\n    audit {\n      id\n      showOnTrustCenter\n    }\n  }\n}\n"
+    "text": "mutation TrustCenterAuditGraphUpdateMutation(\n  $input: UpdateAuditInput!\n) {\n  updateAudit(input: $input) {\n    audit {\n      id\n      showOnTrustCenter\n      ...TrustCenterAuditsCardFragment\n    }\n  }\n}\n\nfragment TrustCenterAuditsCardFragment on Audit {\n  id\n  framework {\n    name\n    id\n  }\n  validFrom\n  validUntil\n  state\n  showOnTrustCenter\n  createdAt\n}\n"
   }
 };
 })();
 
-(node as any).hash = "ebf90264b72bb993d60f48d1d3fc4fb7";
+(node as any).hash = "1e92374989ecf8f439d069eb003e4e4e";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterDocumentGraphQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterDocumentGraphQuery.graphql.ts
@@ -1,0 +1,288 @@
+/**
+ * @generated SignedSource<<6676a9b480eeef26f00ff97963b39b86>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type TrustCenterDocumentGraphQuery$variables = {
+  organizationId: string;
+};
+export type TrustCenterDocumentGraphQuery$data = {
+  readonly organization: {
+    readonly documents?: {
+      readonly edges: ReadonlyArray<{
+        readonly node: {
+          readonly id: string;
+          readonly " $fragmentSpreads": FragmentRefs<"TrustCenterDocumentsCardFragment">;
+        };
+      }>;
+    };
+    readonly id?: string;
+  };
+};
+export type TrustCenterDocumentGraphQuery = {
+  response: TrustCenterDocumentGraphQuery$data;
+  variables: TrustCenterDocumentGraphQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "organizationId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "organizationId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 100
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TrustCenterDocumentGraphQuery",
+    "selections": [
+      {
+        "alias": "organization",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v2/*: any*/),
+              {
+                "alias": null,
+                "args": (v3/*: any*/),
+                "concreteType": "DocumentConnection",
+                "kind": "LinkedField",
+                "name": "documents",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "DocumentEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Document",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          {
+                            "args": null,
+                            "kind": "FragmentSpread",
+                            "name": "TrustCenterDocumentsCardFragment"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "documents(first:100)"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "TrustCenterDocumentGraphQuery",
+    "selections": [
+      {
+        "alias": "organization",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": (v3/*: any*/),
+                "concreteType": "DocumentConnection",
+                "kind": "LinkedField",
+                "name": "documents",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "DocumentEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Document",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "title",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "createdAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "documentType",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "showOnTrustCenter",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "first",
+                                "value": 1
+                              }
+                            ],
+                            "concreteType": "DocumentVersionConnection",
+                            "kind": "LinkedField",
+                            "name": "versions",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "DocumentVersionEdge",
+                                "kind": "LinkedField",
+                                "name": "edges",
+                                "plural": true,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "DocumentVersion",
+                                    "kind": "LinkedField",
+                                    "name": "node",
+                                    "plural": false,
+                                    "selections": [
+                                      (v2/*: any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "status",
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": "versions(first:1)"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "documents(first:100)"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "f8e5f4d7adcf1e794bc046ef21317f89",
+    "id": null,
+    "metadata": {},
+    "name": "TrustCenterDocumentGraphQuery",
+    "operationKind": "query",
+    "text": "query TrustCenterDocumentGraphQuery(\n  $organizationId: ID!\n) {\n  organization: node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      id\n      documents(first: 100) {\n        edges {\n          node {\n            id\n            ...TrustCenterDocumentsCardFragment\n          }\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment TrustCenterDocumentsCardFragment on Document {\n  id\n  title\n  createdAt\n  documentType\n  showOnTrustCenter\n  versions(first: 1) {\n    edges {\n      node {\n        id\n        status\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "f4e34ac09a2b56c2298bc319d9701f4d";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterDocumentGraphUpdateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterDocumentGraphUpdateMutation.graphql.ts
@@ -1,0 +1,222 @@
+/**
+ * @generated SignedSource<<5b8f324da8c4dc9302cb6f821062757d>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type DocumentType = "ISMS" | "OTHER" | "POLICY";
+export type UpdateDocumentInput = {
+  content?: string | null | undefined;
+  createdBy?: string | null | undefined;
+  documentType?: DocumentType | null | undefined;
+  id: string;
+  ownerId?: string | null | undefined;
+  showOnTrustCenter?: boolean | null | undefined;
+  title?: string | null | undefined;
+};
+export type TrustCenterDocumentGraphUpdateMutation$variables = {
+  input: UpdateDocumentInput;
+};
+export type TrustCenterDocumentGraphUpdateMutation$data = {
+  readonly updateDocument: {
+    readonly document: {
+      readonly id: string;
+      readonly showOnTrustCenter: boolean;
+      readonly " $fragmentSpreads": FragmentRefs<"TrustCenterDocumentsCardFragment">;
+    };
+  };
+};
+export type TrustCenterDocumentGraphUpdateMutation = {
+  response: TrustCenterDocumentGraphUpdateMutation$data;
+  variables: TrustCenterDocumentGraphUpdateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "showOnTrustCenter",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TrustCenterDocumentGraphUpdateMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "UpdateDocumentPayload",
+        "kind": "LinkedField",
+        "name": "updateDocument",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Document",
+            "kind": "LinkedField",
+            "name": "document",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "TrustCenterDocumentsCardFragment"
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "TrustCenterDocumentGraphUpdateMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "UpdateDocumentPayload",
+        "kind": "LinkedField",
+        "name": "updateDocument",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Document",
+            "kind": "LinkedField",
+            "name": "document",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "title",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "createdAt",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "documentType",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 1
+                  }
+                ],
+                "concreteType": "DocumentVersionConnection",
+                "kind": "LinkedField",
+                "name": "versions",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "DocumentVersionEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "DocumentVersion",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "status",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "versions(first:1)"
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "b112314d6ef35feebf49bd2f8c636b33",
+    "id": null,
+    "metadata": {},
+    "name": "TrustCenterDocumentGraphUpdateMutation",
+    "operationKind": "mutation",
+    "text": "mutation TrustCenterDocumentGraphUpdateMutation(\n  $input: UpdateDocumentInput!\n) {\n  updateDocument(input: $input) {\n    document {\n      id\n      showOnTrustCenter\n      ...TrustCenterDocumentsCardFragment\n    }\n  }\n}\n\nfragment TrustCenterDocumentsCardFragment on Document {\n  id\n  title\n  createdAt\n  documentType\n  showOnTrustCenter\n  versions(first: 1) {\n    edges {\n      node {\n        id\n        status\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "46f72a664d3edb0e5665b1ecea69e31a";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterGraphQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterGraphQuery.graphql.ts
@@ -1,0 +1,558 @@
+/**
+ * @generated SignedSource<<46a922efef96e5c7d015bd0f27467bf3>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type TrustCenterGraphQuery$variables = {
+  organizationId: string;
+};
+export type TrustCenterGraphQuery$data = {
+  readonly organization: {
+    readonly audits?: {
+      readonly edges: ReadonlyArray<{
+        readonly node: {
+          readonly id: string;
+          readonly " $fragmentSpreads": FragmentRefs<"TrustCenterAuditsCardFragment">;
+        };
+      }>;
+    };
+    readonly documents?: {
+      readonly edges: ReadonlyArray<{
+        readonly node: {
+          readonly id: string;
+          readonly " $fragmentSpreads": FragmentRefs<"TrustCenterDocumentsCardFragment">;
+        };
+      }>;
+    };
+    readonly id?: string;
+    readonly name?: string;
+    readonly trustCenter?: {
+      readonly active: boolean;
+      readonly createdAt: any;
+      readonly id: string;
+      readonly slug: string;
+      readonly updatedAt: any;
+    } | null | undefined;
+    readonly vendors?: {
+      readonly edges: ReadonlyArray<{
+        readonly node: {
+          readonly id: string;
+          readonly " $fragmentSpreads": FragmentRefs<"TrustCenterVendorsCardFragment">;
+        };
+      }>;
+    };
+  };
+};
+export type TrustCenterGraphQuery = {
+  response: TrustCenterGraphQuery$data;
+  variables: TrustCenterGraphQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "organizationId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "organizationId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "TrustCenter",
+  "kind": "LinkedField",
+  "name": "trustCenter",
+  "plural": false,
+  "selections": [
+    (v2/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "active",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slug",
+      "storageKey": null
+    },
+    (v4/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "updatedAt",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v6 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 100
+  }
+],
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "showOnTrustCenter",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TrustCenterGraphQuery",
+    "selections": [
+      {
+        "alias": "organization",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v5/*: any*/),
+              {
+                "alias": null,
+                "args": (v6/*: any*/),
+                "concreteType": "DocumentConnection",
+                "kind": "LinkedField",
+                "name": "documents",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "DocumentEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Document",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          {
+                            "args": null,
+                            "kind": "FragmentSpread",
+                            "name": "TrustCenterDocumentsCardFragment"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "documents(first:100)"
+              },
+              {
+                "alias": null,
+                "args": (v6/*: any*/),
+                "concreteType": "AuditConnection",
+                "kind": "LinkedField",
+                "name": "audits",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AuditEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Audit",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          {
+                            "args": null,
+                            "kind": "FragmentSpread",
+                            "name": "TrustCenterAuditsCardFragment"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "audits(first:100)"
+              },
+              {
+                "alias": null,
+                "args": (v6/*: any*/),
+                "concreteType": "VendorConnection",
+                "kind": "LinkedField",
+                "name": "vendors",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "VendorEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Vendor",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          {
+                            "args": null,
+                            "kind": "FragmentSpread",
+                            "name": "TrustCenterVendorsCardFragment"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "vendors(first:100)"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "TrustCenterGraphQuery",
+    "selections": [
+      {
+        "alias": "organization",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v3/*: any*/),
+              (v5/*: any*/),
+              {
+                "alias": null,
+                "args": (v6/*: any*/),
+                "concreteType": "DocumentConnection",
+                "kind": "LinkedField",
+                "name": "documents",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "DocumentEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Document",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "title",
+                            "storageKey": null
+                          },
+                          (v4/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "documentType",
+                            "storageKey": null
+                          },
+                          (v7/*: any*/),
+                          {
+                            "alias": null,
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "first",
+                                "value": 1
+                              }
+                            ],
+                            "concreteType": "DocumentVersionConnection",
+                            "kind": "LinkedField",
+                            "name": "versions",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "DocumentVersionEdge",
+                                "kind": "LinkedField",
+                                "name": "edges",
+                                "plural": true,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "DocumentVersion",
+                                    "kind": "LinkedField",
+                                    "name": "node",
+                                    "plural": false,
+                                    "selections": [
+                                      (v2/*: any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "status",
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": "versions(first:1)"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "documents(first:100)"
+              },
+              {
+                "alias": null,
+                "args": (v6/*: any*/),
+                "concreteType": "AuditConnection",
+                "kind": "LinkedField",
+                "name": "audits",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AuditEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Audit",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Framework",
+                            "kind": "LinkedField",
+                            "name": "framework",
+                            "plural": false,
+                            "selections": [
+                              (v3/*: any*/),
+                              (v2/*: any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "validFrom",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "validUntil",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "state",
+                            "storageKey": null
+                          },
+                          (v7/*: any*/),
+                          (v4/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "audits(first:100)"
+              },
+              {
+                "alias": null,
+                "args": (v6/*: any*/),
+                "concreteType": "VendorConnection",
+                "kind": "LinkedField",
+                "name": "vendors",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "VendorEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Vendor",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          (v3/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "category",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "description",
+                            "storageKey": null
+                          },
+                          (v7/*: any*/),
+                          (v4/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "vendors(first:100)"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "a22d734ee326d24f3f67ffecf4653b2f",
+    "id": null,
+    "metadata": {},
+    "name": "TrustCenterGraphQuery",
+    "operationKind": "query",
+    "text": "query TrustCenterGraphQuery(\n  $organizationId: ID!\n) {\n  organization: node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      id\n      name\n      trustCenter {\n        id\n        active\n        slug\n        createdAt\n        updatedAt\n      }\n      documents(first: 100) {\n        edges {\n          node {\n            id\n            ...TrustCenterDocumentsCardFragment\n          }\n        }\n      }\n      audits(first: 100) {\n        edges {\n          node {\n            id\n            ...TrustCenterAuditsCardFragment\n          }\n        }\n      }\n      vendors(first: 100) {\n        edges {\n          node {\n            id\n            ...TrustCenterVendorsCardFragment\n          }\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment TrustCenterAuditsCardFragment on Audit {\n  id\n  framework {\n    name\n    id\n  }\n  validFrom\n  validUntil\n  state\n  showOnTrustCenter\n  createdAt\n}\n\nfragment TrustCenterDocumentsCardFragment on Document {\n  id\n  title\n  createdAt\n  documentType\n  showOnTrustCenter\n  versions(first: 1) {\n    edges {\n      node {\n        id\n        status\n      }\n    }\n  }\n}\n\nfragment TrustCenterVendorsCardFragment on Vendor {\n  id\n  name\n  category\n  description\n  showOnTrustCenter\n  createdAt\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "260529b3ca03240b07989f278bb7a539";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterGraphUpdateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterGraphUpdateMutation.graphql.ts
@@ -1,0 +1,131 @@
+/**
+ * @generated SignedSource<<c257950f58c4b876a6ff7ef6083f005b>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type UpdateTrustCenterInput = {
+  active?: boolean | null | undefined;
+  slug?: string | null | undefined;
+  trustCenterId: string;
+};
+export type TrustCenterGraphUpdateMutation$variables = {
+  input: UpdateTrustCenterInput;
+};
+export type TrustCenterGraphUpdateMutation$data = {
+  readonly updateTrustCenter: {
+    readonly trustCenter: {
+      readonly active: boolean;
+      readonly id: string;
+      readonly slug: string;
+      readonly updatedAt: any;
+    };
+  };
+};
+export type TrustCenterGraphUpdateMutation = {
+  response: TrustCenterGraphUpdateMutation$data;
+  variables: TrustCenterGraphUpdateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "UpdateTrustCenterPayload",
+    "kind": "LinkedField",
+    "name": "updateTrustCenter",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "TrustCenter",
+        "kind": "LinkedField",
+        "name": "trustCenter",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "active",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "updatedAt",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TrustCenterGraphUpdateMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "TrustCenterGraphUpdateMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "18e80937923185923d9b427819334337",
+    "id": null,
+    "metadata": {},
+    "name": "TrustCenterGraphUpdateMutation",
+    "operationKind": "mutation",
+    "text": "mutation TrustCenterGraphUpdateMutation(\n  $input: UpdateTrustCenterInput!\n) {\n  updateTrustCenter(input: $input) {\n    trustCenter {\n      id\n      active\n      slug\n      updatedAt\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "988f3baf354e729d6cc9482129040898";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterVendorGraphUpdateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterVendorGraphUpdateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<012c4e605372a38efef4780c63d40888>>
+ * @generated SignedSource<<be30aebdf9a7304cd154284fa9f6b207>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,6 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
 export type VendorCategory = "ANALYTICS" | "CLOUD_MONITORING" | "CLOUD_PROVIDER" | "COLLABORATION" | "CUSTOMER_SUPPORT" | "DATA_STORAGE_AND_PROCESSING" | "DOCUMENT_MANAGEMENT" | "EMPLOYEE_MANAGEMENT" | "ENGINEERING" | "FINANCE" | "IDENTITY_PROVIDER" | "IT" | "MARKETING" | "OFFICE_OPERATIONS" | "OTHER" | "PASSWORD_MANAGEMENT" | "PRODUCT_AND_DESIGN" | "PROFESSIONAL_SERVICES" | "RECRUITING" | "SALES" | "SECURITY" | "VERSION_CONTROL";
 export type UpdateVendorInput = {
   businessAssociateAgreementUrl?: string | null | undefined;
@@ -40,6 +41,7 @@ export type TrustCenterVendorGraphUpdateMutation$data = {
     readonly vendor: {
       readonly id: string;
       readonly showOnTrustCenter: boolean;
+      readonly " $fragmentSpreads": FragmentRefs<"TrustCenterVendorsCardFragment">;
     };
   };
 };
@@ -58,55 +60,62 @@ var v0 = [
 ],
 v1 = [
   {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "input",
-        "variableName": "input"
-      }
-    ],
-    "concreteType": "UpdateVendorPayload",
-    "kind": "LinkedField",
-    "name": "updateVendor",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "Vendor",
-        "kind": "LinkedField",
-        "name": "vendor",
-        "plural": false,
-        "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "showOnTrustCenter",
-            "storageKey": null
-          }
-        ],
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
   }
-];
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "showOnTrustCenter",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "TrustCenterVendorGraphUpdateMutation",
-    "selections": (v1/*: any*/),
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "UpdateVendorPayload",
+        "kind": "LinkedField",
+        "name": "updateVendor",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Vendor",
+            "kind": "LinkedField",
+            "name": "vendor",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "TrustCenterVendorsCardFragment"
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
     "type": "Mutation",
     "abstractKey": null
   },
@@ -115,19 +124,72 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "TrustCenterVendorGraphUpdateMutation",
-    "selections": (v1/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "UpdateVendorPayload",
+        "kind": "LinkedField",
+        "name": "updateVendor",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Vendor",
+            "kind": "LinkedField",
+            "name": "vendor",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "category",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "description",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "createdAt",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "cacheID": "44e483af96833ea9efb1567fa5983282",
+    "cacheID": "92823eef2e21ea731d8f37dbf9cd5da3",
     "id": null,
     "metadata": {},
     "name": "TrustCenterVendorGraphUpdateMutation",
     "operationKind": "mutation",
-    "text": "mutation TrustCenterVendorGraphUpdateMutation(\n  $input: UpdateVendorInput!\n) {\n  updateVendor(input: $input) {\n    vendor {\n      id\n      showOnTrustCenter\n    }\n  }\n}\n"
+    "text": "mutation TrustCenterVendorGraphUpdateMutation(\n  $input: UpdateVendorInput!\n) {\n  updateVendor(input: $input) {\n    vendor {\n      id\n      showOnTrustCenter\n      ...TrustCenterVendorsCardFragment\n    }\n  }\n}\n\nfragment TrustCenterVendorsCardFragment on Vendor {\n  id\n  name\n  category\n  description\n  showOnTrustCenter\n  createdAt\n}\n"
   }
 };
 })();
 
-(node as any).hash = "e561918e67c08f1e3fae85dfb04591d1";
+(node as any).hash = "2b4395821fcfbd30bb06448db5429289";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterVendorGraphUpdateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterVendorGraphUpdateMutation.graphql.ts
@@ -1,0 +1,133 @@
+/**
+ * @generated SignedSource<<012c4e605372a38efef4780c63d40888>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type VendorCategory = "ANALYTICS" | "CLOUD_MONITORING" | "CLOUD_PROVIDER" | "COLLABORATION" | "CUSTOMER_SUPPORT" | "DATA_STORAGE_AND_PROCESSING" | "DOCUMENT_MANAGEMENT" | "EMPLOYEE_MANAGEMENT" | "ENGINEERING" | "FINANCE" | "IDENTITY_PROVIDER" | "IT" | "MARKETING" | "OFFICE_OPERATIONS" | "OTHER" | "PASSWORD_MANAGEMENT" | "PRODUCT_AND_DESIGN" | "PROFESSIONAL_SERVICES" | "RECRUITING" | "SALES" | "SECURITY" | "VERSION_CONTROL";
+export type UpdateVendorInput = {
+  businessAssociateAgreementUrl?: string | null | undefined;
+  businessOwnerId?: string | null | undefined;
+  category?: VendorCategory | null | undefined;
+  certifications?: ReadonlyArray<string> | null | undefined;
+  dataProcessingAgreementUrl?: string | null | undefined;
+  description?: string | null | undefined;
+  headquarterAddress?: string | null | undefined;
+  id: string;
+  legalName?: string | null | undefined;
+  name?: string | null | undefined;
+  privacyPolicyUrl?: string | null | undefined;
+  securityOwnerId?: string | null | undefined;
+  securityPageUrl?: string | null | undefined;
+  serviceLevelAgreementUrl?: string | null | undefined;
+  showOnTrustCenter?: boolean | null | undefined;
+  statusPageUrl?: string | null | undefined;
+  subprocessorsListUrl?: string | null | undefined;
+  termsOfServiceUrl?: string | null | undefined;
+  trustPageUrl?: string | null | undefined;
+  websiteUrl?: string | null | undefined;
+};
+export type TrustCenterVendorGraphUpdateMutation$variables = {
+  input: UpdateVendorInput;
+};
+export type TrustCenterVendorGraphUpdateMutation$data = {
+  readonly updateVendor: {
+    readonly vendor: {
+      readonly id: string;
+      readonly showOnTrustCenter: boolean;
+    };
+  };
+};
+export type TrustCenterVendorGraphUpdateMutation = {
+  response: TrustCenterVendorGraphUpdateMutation$data;
+  variables: TrustCenterVendorGraphUpdateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "UpdateVendorPayload",
+    "kind": "LinkedField",
+    "name": "updateVendor",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Vendor",
+        "kind": "LinkedField",
+        "name": "vendor",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "showOnTrustCenter",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TrustCenterVendorGraphUpdateMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "TrustCenterVendorGraphUpdateMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "44e483af96833ea9efb1567fa5983282",
+    "id": null,
+    "metadata": {},
+    "name": "TrustCenterVendorGraphUpdateMutation",
+    "operationKind": "mutation",
+    "text": "mutation TrustCenterVendorGraphUpdateMutation(\n  $input: UpdateVendorInput!\n) {\n  updateVendor(input: $input) {\n    vendor {\n      id\n      showOnTrustCenter\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "e561918e67c08f1e3fae85dfb04591d1";
+
+export default node;

--- a/apps/console/src/layouts/MainLayout.tsx
+++ b/apps/console/src/layouts/MainLayout.tsx
@@ -14,6 +14,7 @@ import {
   IconTodo,
   IconListStack,
   IconBox,
+  IconShield,
   Layout,
   SidebarItem,
   UserDropdown as UserDropdownRoot,
@@ -136,6 +137,11 @@ export function MainLayout() {
             label={__("Audits")}
             icon={IconCheckmark1}
             to={`${prefix}/audits`}
+          />
+          <SidebarItem
+            label={__("Trust Center")}
+            icon={IconShield}
+            to={`${prefix}/trust-center`}
           />
           <SidebarItem
             label={__("Settings")}

--- a/apps/console/src/layouts/MainLayout.tsx
+++ b/apps/console/src/layouts/MainLayout.tsx
@@ -9,6 +9,7 @@ import {
   IconInboxEmpty,
   IconPageTextLine,
   IconSettingsGear2,
+  IconCheckmark1,
   IconStore,
   IconTodo,
   IconListStack,
@@ -130,6 +131,11 @@ export function MainLayout() {
             label={__("Data")}
             icon={IconListStack}
             to={`${prefix}/data`}
+          />
+          <SidebarItem
+            label={__("Audits")}
+            icon={IconCheckmark1}
+            to={`${prefix}/audits`}
           />
           <SidebarItem
             label={__("Settings")}

--- a/apps/console/src/layouts/PublicTrustCenterLayout.tsx
+++ b/apps/console/src/layouts/PublicTrustCenterLayout.tsx
@@ -1,0 +1,58 @@
+import { Outlet } from "react-router";
+import { Logo } from "@probo/ui";
+import type { ReactNode } from "react";
+
+type Props = {
+  organizationName: string;
+  organizationLogo?: string | null;
+  children?: ReactNode;
+};
+
+export function PublicTrustCenterLayout({ organizationName, organizationLogo, children }: Props) {
+  return (
+    <div className="min-h-screen bg-tertiary">
+      <header className="bg-surface border-b border-border-solid">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center justify-between h-16">
+            <div className="flex items-center space-x-4">
+              {organizationLogo ? (
+                <img
+                  src={organizationLogo}
+                  alt={organizationName}
+                  className="h-8 w-8 rounded"
+                />
+              ) : (
+                <Logo className="h-8 w-8" />
+              )}
+              <div>
+                <h1 className="text-lg font-semibold text-txt-primary">
+                  {organizationName}
+                </h1>
+                <p className="text-sm text-txt-secondary">Trust Center</p>
+              </div>
+            </div>
+            <div className="text-sm text-txt-tertiary">
+              <a
+                href="https://www.getprobo.com/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:text-txt-secondary transition-colors flex items-center space-x-1"
+              >
+                <img
+                  src="/favicons/favicon.ico"
+                  alt="Probo"
+                  className="h-4 w-4"
+                />
+                <span>Powered by Probo</span>
+              </a>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {children || <Outlet />}
+      </main>
+    </div>
+  );
+}

--- a/apps/console/src/pages/PublicTrustCenterPage.tsx
+++ b/apps/console/src/pages/PublicTrustCenterPage.tsx
@@ -1,0 +1,80 @@
+import { useParams, Navigate } from "react-router";
+import { usePreloadedQuery, useLazyLoadQuery, type PreloadedQuery } from "react-relay";
+import { usePageTitle } from "@probo/hooks";
+import { useTranslate } from "@probo/i18n";
+import { sprintf } from "@probo/helpers";
+import { publicTrustCenterQuery } from "/hooks/graph/PublicTrustCenterGraph";
+import type { PublicTrustCenterGraphQuery } from "/hooks/graph/__generated__/PublicTrustCenterGraphQuery.graphql";
+import { PublicTrustCenterLayout } from "/layouts/PublicTrustCenterLayout";
+import { PublicTrustCenterAudits } from "../components/trustCenter/PublicTrustCenterAudits";
+import { PublicTrustCenterVendors } from "../components/trustCenter/PublicTrustCenterVendors";
+import { PublicTrustCenterDocuments } from "../components/trustCenter/PublicTrustCenterDocuments";
+
+type Props = {
+  queryRef?: PreloadedQuery<PublicTrustCenterGraphQuery>;
+};
+
+export default function PublicTrustCenterPage({ queryRef }: Props) {
+  const { __ } = useTranslate();
+  const { slug } = useParams<{ slug: string }>();
+
+  if (!slug) {
+    return <Navigate to="/" replace />;
+  }
+
+  const data = queryRef
+    ? usePreloadedQuery(publicTrustCenterQuery, queryRef)
+    : useLazyLoadQuery(publicTrustCenterQuery, { slug });
+
+  const { trustCenterBySlug } = data as any;
+
+  if (!trustCenterBySlug) {
+    return <Navigate to="/auth/login" replace />;
+  }
+
+  if (!trustCenterBySlug.active) {
+    return <Navigate to="/auth/login" replace />;
+  }
+
+  const { organization } = trustCenterBySlug;
+
+  usePageTitle(`${organization.name} - Trust Center`);
+
+  const documents = trustCenterBySlug.publicDocuments.edges
+    .map((e: any) => e.node)
+
+  const audits = trustCenterBySlug.publicAudits.edges
+    .map((e: any) => e.node);
+
+  const vendors = trustCenterBySlug.publicVendors.edges
+    .map((e: any) => e.node);
+
+  return (
+    <PublicTrustCenterLayout
+      organizationName={organization.name}
+      organizationLogo={organization.logoUrl}
+    >
+      <div className="space-y-8">
+        <div className="text-center">
+          <h1 className="text-3xl font-bold text-txt-primary mb-4">
+            {sprintf(__("%s Trust Center"), organization.name)}
+          </h1>
+          <p className="text-lg text-txt-secondary max-w-2xl mx-auto">
+            {__("Explore our security practices, compliance certifications, and transparency reports.")}
+          </p>
+        </div>
+        <PublicTrustCenterAudits
+          audits={audits}
+          organizationName={organization.name}
+        />
+        <PublicTrustCenterDocuments
+          documents={documents}
+        />
+        <PublicTrustCenterVendors
+          vendors={vendors}
+          organizationName={organization.name}
+        />
+      </div>
+    </PublicTrustCenterLayout>
+  );
+}

--- a/apps/console/src/pages/organizations/TrustCenterPage.tsx
+++ b/apps/console/src/pages/organizations/TrustCenterPage.tsx
@@ -1,0 +1,240 @@
+import { useTranslate } from "@probo/i18n";
+import { usePageTitle } from "@probo/hooks";
+import {
+  Button,
+  Card,
+  Checkbox,
+  Field,
+  Input,
+  PageHeader,
+  Spinner,
+  useToast,
+  Tabs,
+  TabLink,
+  TabItem,
+} from "@probo/ui";
+import { usePreloadedQuery, type PreloadedQuery } from "react-relay";
+import { trustCenterQuery, useUpdateTrustCenterMutation } from "/hooks/graph/TrustCenterGraph";
+import type { TrustCenterGraphQuery } from "/hooks/graph/__generated__/TrustCenterGraphQuery.graphql";
+import { useState } from "react";
+import { useOrganizationId } from "/hooks/useOrganizationId";
+import { Outlet, useLocation, Link } from "react-router";
+
+type Props = {
+  queryRef: PreloadedQuery<TrustCenterGraphQuery>;
+};
+
+export default function TrustCenterPage({ queryRef }: Props) {
+  const { __ } = useTranslate();
+  const { toast } = useToast();
+  const organizationId = useOrganizationId();
+  const location = useLocation();
+  const { organization } = usePreloadedQuery(trustCenterQuery, queryRef);
+
+  const [updateTrustCenter, isUpdating] = useUpdateTrustCenterMutation();
+  const [isActive, setIsActive] = useState(organization.trustCenter?.active || false);
+  const [slug, setSlug] = useState(organization.trustCenter?.slug || "");
+  const [isUpdatingSlug, setIsUpdatingSlug] = useState(false);
+
+  usePageTitle(__("Trust Center"));
+
+  const handleToggleActive = async (active: boolean) => {
+    if (!organization.trustCenter?.id) {
+      toast({
+        title: __("Error"),
+        description: __("Trust center not found"),
+        variant: "error",
+      });
+      return;
+    }
+
+    setIsActive(active);
+
+    updateTrustCenter({
+      variables: {
+        input: {
+          trustCenterId: organization.trustCenter.id,
+          active,
+        },
+      },
+      onError: () => {
+        setIsActive(!active);
+      },
+    });
+  };
+
+  const handleSlugUpdate = async () => {
+    if (!organization.trustCenter?.id) {
+      toast({
+        title: __("Error"),
+        description: __("Trust center not found"),
+        variant: "error",
+      });
+      return;
+    }
+
+    if (!slug.trim()) {
+      toast({
+        title: __("Error"),
+        description: __("Slug cannot be empty"),
+        variant: "error",
+      });
+      return;
+    }
+
+    setIsUpdatingSlug(true);
+
+    updateTrustCenter({
+      variables: {
+        input: {
+          trustCenterId: organization.trustCenter.id,
+          slug: slug.trim(),
+        },
+      },
+      onCompleted: () => {
+        setIsUpdatingSlug(false);
+      },
+      onError: () => {
+        setIsUpdatingSlug(false);
+        setSlug(organization.trustCenter?.slug || "");
+      },
+    });
+  };
+
+  const trustCenterUrl = organization.trustCenter?.slug
+    ? `${window.location.origin}/trust/${organization.trustCenter.slug}`
+    : null;
+
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title={__("Trust Center")}
+        description={__(
+          "Configure your public trust center to showcase your security and compliance posture."
+        )}
+      />
+
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-base font-medium">{__("Trust Center Status")}</h2>
+          {isUpdating && <Spinner />}
+        </div>
+        <Card padded className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div className="space-y-1">
+              <h3 className="font-medium">{__("Activate Trust Center")}</h3>
+              <p className="text-sm text-txt-tertiary">
+                {__("Make your trust center publicly accessible to build customer confidence")}
+              </p>
+            </div>
+            <Checkbox
+              checked={isActive}
+              onChange={handleToggleActive}
+            />
+          </div>
+
+          {isActive && trustCenterUrl && (
+            <div className="mt-4 p-4 bg-accent-light rounded-lg border border-accent">
+              <div className="flex items-center justify-between">
+                <div>
+                  <h4 className="font-medium text-accent-dark">
+                    {__("Your Trust Center is Live!")}
+                  </h4>
+                  <p className="text-sm text-accent-dark mt-1">
+                    {__("Your customers can now access your trust center at:")}
+                  </p>
+                  <a
+                    href={trustCenterUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm font-mono text-accent underline hover:no-underline"
+                  >
+                    {trustCenterUrl}
+                  </a>
+                </div>
+                <Button
+                  variant="secondary"
+                  onClick={() => window.open(trustCenterUrl, '_blank', 'noopener,noreferrer')}
+                >
+                  {__("View")}
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {!isActive && (
+            <div className="mt-4 p-4 bg-tertiary rounded-lg border border-border-solid">
+              <h4 className="font-medium text-txt-secondary">
+                {__("Trust Center is Inactive")}
+              </h4>
+              <p className="text-sm text-txt-tertiary mt-1">
+                {__("Your trust center is currently not accessible to the public. Enable it to start sharing your compliance status.")}
+              </p>
+            </div>
+          )}
+        </Card>
+      </div>
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-base font-medium">{__("Configuration")}</h2>
+          {isUpdatingSlug && <Spinner />}
+        </div>
+        <Card padded className="space-y-4">
+          <div className="space-y-2">
+            <Field
+              label={__("Slug")}
+              help={__("The unique identifier for your trust center URL")}
+            >
+              <div className="flex items-center space-x-2">
+                <div className="flex items-center">
+                  <Input
+                    value={slug}
+                    onChange={(e) => setSlug(e.target.value)}
+                    placeholder={__("your-organization")}
+                    className="min-w-[200px]"
+                  />
+                </div>
+                <Button
+                  variant="secondary"
+                  onClick={handleSlugUpdate}
+                  disabled={
+                    isUpdatingSlug ||
+                    !slug.trim() ||
+                    slug === organization.trustCenter?.slug
+                  }
+                >
+                  {__("Update")}
+                </Button>
+              </div>
+            </Field>
+          </div>
+        </Card>
+      </div>
+      <div className="space-y-4">
+        <h2 className="text-base font-medium">{__("Content")}</h2>
+                <Tabs>
+          <TabItem
+            asChild
+            active={
+              location.pathname === `/organizations/${organizationId}/trust-center` ||
+              location.pathname === `/organizations/${organizationId}/trust-center/audits`
+            }
+          >
+            <Link to={`/organizations/${organizationId}/trust-center/audits`}>
+              {__("Audits")}
+            </Link>
+          </TabItem>
+          <TabLink to={`/organizations/${organizationId}/trust-center/vendors`}>
+            {__("Vendors")}
+          </TabLink>
+          <TabLink to={`/organizations/${organizationId}/trust-center/documents`}>
+            {__("Documents")}
+          </TabLink>
+        </Tabs>
+
+        <Outlet context={{ organization }} />
+      </div>
+    </div>
+  );
+}

--- a/apps/console/src/pages/organizations/audits/AuditDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/audits/AuditDetailsPage.tsx
@@ -1,0 +1,255 @@
+import {
+  ConnectionHandler,
+  usePreloadedQuery,
+  type PreloadedQuery,
+} from "react-relay";
+import {
+  auditNodeQuery,
+  useDeleteAudit,
+  useUpdateAudit,
+  useUploadAuditReport,
+  useDeleteAuditReport,
+} from "../../../hooks/graph/AuditGraph";
+import {
+  ActionDropdown,
+  Badge,
+  Breadcrumb,
+  Button,
+  DropdownItem,
+  Field,
+  IconTrashCan,
+  Option,
+  Input,
+  Dropzone,
+  Card,
+  IconArrowInbox,
+  useConfirm,
+  useToast,
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { useOrganizationId } from "/hooks/useOrganizationId";
+import { ControlledField } from "/components/form/ControlledField";
+import { useFormWithSchema } from "/hooks/useFormWithSchema";
+import z from "zod";
+import { getAuditStateLabel, getAuditStateVariant, auditStates, fileSize, sprintf } from "@probo/helpers";
+
+const updateAuditSchema = z.object({
+  validFrom: z.string().optional(),
+  validUntil: z.string().optional(),
+  state: z.enum(["NOT_STARTED", "IN_PROGRESS", "COMPLETED", "REJECTED", "OUTDATED"]),
+});
+
+type Props = {
+  queryRef: PreloadedQuery<any>;
+};
+
+export default function AuditDetailsPage(props: Props) {
+  const audit = usePreloadedQuery(auditNodeQuery, props.queryRef);
+  const auditEntry = audit.node;
+  const { __, dateFormat } = useTranslate();
+  const organizationId = useOrganizationId();
+  const deleteAudit = useDeleteAudit(
+    auditEntry,
+    ConnectionHandler.getConnectionID(organizationId, "AuditsPage_audits")
+  );
+
+  const { control, formState, handleSubmit, register, reset } = useFormWithSchema(updateAuditSchema, {
+    defaultValues: {
+      validFrom: auditEntry?.validFrom?.split('T')[0] || "",
+      validUntil: auditEntry?.validUntil?.split('T')[0] || "",
+      state: auditEntry?.state || "NOT_STARTED",
+    },
+  });
+
+  const updateAudit = useUpdateAudit();
+  const [uploadAuditReport, isUploading] = useUploadAuditReport();
+  const deleteAuditReport = useDeleteAuditReport();
+  const confirm = useConfirm();
+  const { toast } = useToast();
+
+  const onSubmit = handleSubmit(async (formData) => {
+    try {
+      const formatDatetime = (dateString?: string) => {
+        if (!dateString) return undefined;
+        return `${dateString}T00:00:00Z`;
+      };
+
+      await updateAudit({
+        id: auditEntry?.id,
+        validFrom: formatDatetime(formData.validFrom),
+        validUntil: formatDatetime(formData.validUntil),
+        state: formData.state,
+      });
+      reset(formData);
+      toast({
+        title: __("Success"),
+        description: __("Audit updated successfully"),
+        variant: "success",
+      });
+    } catch (error) {
+      toast({
+        title: __("Error"),
+        description: error instanceof Error ? error.message : __("Failed to update audit"),
+        variant: "error",
+      });
+    }
+  });
+
+  const handleDeleteReport = () => {
+    if (!auditEntry?.id || !auditEntry?.report) return;
+
+    confirm(
+      async () => {
+        await deleteAuditReport({ auditId: auditEntry.id });
+      },
+      {
+        message: sprintf(
+          __(
+            'This will permanently delete the audit report "%s". This action cannot be undone.'
+          ),
+          auditEntry.report.filename
+        ),
+      }
+    );
+  };
+
+  return (
+    <div className="space-y-6">
+      <Breadcrumb
+        items={[
+          {
+            label: __("Audits"),
+            to: `/organizations/${organizationId}/audits`,
+          },
+          {
+            label: auditEntry?.framework?.name ?? __("Unknown Audit"),
+          },
+        ]}
+      />
+
+      <div className="flex justify-between items-start">
+        <div className="flex items-center gap-4">
+          <div className="text-2xl">{auditEntry?.framework?.name}</div>
+          <Badge variant={getAuditStateVariant(auditEntry?.state)}>
+            {getAuditStateLabel(__, auditEntry?.state)}
+          </Badge>
+        </div>
+        <ActionDropdown variant="secondary">
+          <DropdownItem
+            variant="danger"
+            icon={IconTrashCan}
+            onClick={deleteAudit}
+          >
+            {__("Delete")}
+          </DropdownItem>
+        </ActionDropdown>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <form onSubmit={onSubmit} className="space-y-6">
+          <ControlledField
+            control={control}
+            name="state"
+            type="select"
+            label={__("State")}
+          >
+            {auditStates.map((state) => (
+              <Option key={state} value={state}>
+                {getAuditStateLabel(__, state)}
+              </Option>
+            ))}
+          </ControlledField>
+
+          <Field label={__("Valid From")}>
+            <Input {...register("validFrom")} type="date" />
+          </Field>
+
+          <Field label={__("Valid Until")}>
+            <Input {...register("validUntil")} type="date" />
+          </Field>
+
+          <div className="flex justify-end">
+            {formState.isDirty && (
+              <Button type="submit" disabled={formState.isSubmitting}>
+                {formState.isSubmitting ? __("Updating...") : __("Update")}
+              </Button>
+            )}
+          </div>
+        </form>
+
+        <Card padded className="mt-6">
+          <div className="space-y-4">
+            <h3 className="text-lg font-medium">{__("Audit Report")}</h3>
+
+                        {auditEntry?.report ? (
+              <div className="space-y-4">
+                <div className="flex items-center justify-between p-4 bg-success-50 border border-success-200 rounded-lg">
+                  <div className="flex items-center gap-3">
+                    <IconArrowInbox className="text-success-600" size={20} />
+                    <div className="flex-1">
+                      <p className="font-medium text-success-900">
+                        {auditEntry.report.filename}
+                      </p>
+                      <div className="flex items-center gap-4 text-sm text-success-700">
+                        <span>
+                          {fileSize(__, auditEntry.report.size)}
+                        </span>
+                        <span>
+                          {__("Uploaded")} {dateFormat(auditEntry.report.createdAt)}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <ActionDropdown>
+                    <DropdownItem
+                      onClick={() => {
+                        if (auditEntry?.report?.downloadUrl) {
+                          window.open(auditEntry.report.downloadUrl, '_blank');
+                        }
+                      }}
+                      icon={IconArrowInbox}
+                    >
+                      {__("Download")}
+                    </DropdownItem>
+                    <DropdownItem
+                      variant="danger"
+                      icon={IconTrashCan}
+                      onClick={handleDeleteReport}
+                    >
+                      {__("Delete")}
+                    </DropdownItem>
+                  </ActionDropdown>
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-4">
+                <p className="text-neutral-600">
+                  {__("Upload the final audit report document (PDF recommended)")}
+                </p>
+                <Dropzone
+                  description={__("Only PDF, DOCX files up to 25MB are allowed")}
+                  isUploading={isUploading}
+                  onDrop={async (files) => {
+                    if (files.length > 0) {
+                      await uploadAuditReport({
+                        auditId: auditEntry?.id,
+                        file: files[0],
+                      });
+                      window.location.reload();
+                    }
+                  }}
+                  accept={{
+                    "application/pdf": [".pdf"],
+                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+                      [".docx"],
+                  }}
+                  maxSize={25}
+                />
+              </div>
+            )}
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/apps/console/src/pages/organizations/audits/AuditsPage.tsx
+++ b/apps/console/src/pages/organizations/audits/AuditsPage.tsx
@@ -1,0 +1,177 @@
+import {
+  Button,
+  IconPlusLarge,
+  PageHeader,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Badge,
+  ActionDropdown,
+  DropdownItem,
+  IconTrashCan,
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { usePageTitle } from "@probo/hooks";
+import {
+  graphql,
+  usePaginationFragment,
+  usePreloadedQuery,
+  type PreloadedQuery,
+} from "react-relay";
+import { useOrganizationId } from "/hooks/useOrganizationId";
+import { CreateAuditDialog } from "./dialogs/CreateAuditDialog";
+import { useDeleteAudit, auditsQuery } from "../../../hooks/graph/AuditGraph";
+import type { AuditGraphListQuery } from "/hooks/graph/__generated__/AuditGraphListQuery.graphql";
+import type { NodeOf } from "/types";
+import { getAuditStateLabel, getAuditStateVariant } from "@probo/helpers";
+import type {
+  AuditsPageFragment$data,
+  AuditsPageFragment$key,
+} from "./__generated__/AuditsPageFragment.graphql";
+import { SortableTable } from "/components/SortableTable";
+
+const paginatedAuditsFragment = graphql`
+  fragment AuditsPageFragment on Organization
+  @refetchable(queryName: "AuditsListQuery")
+  @argumentDefinitions(
+    first: { type: "Int", defaultValue: 10 }
+    orderBy: { type: "AuditOrder", defaultValue: null }
+    after: { type: "CursorKey", defaultValue: null }
+    before: { type: "CursorKey", defaultValue: null }
+    last: { type: "Int", defaultValue: null }
+  ) {
+    audits(
+      first: $first
+      after: $after
+      last: $last
+      before: $before
+      orderBy: $orderBy
+    ) @connection(key: "AuditsPage_audits") {
+      __id
+      edges {
+        node {
+          id
+          validFrom
+          validUntil
+          report {
+            id
+            filename
+          }
+          state
+          framework {
+            id
+            name
+          }
+          createdAt
+        }
+      }
+    }
+  }
+`;
+
+type AuditEntry = NodeOf<AuditsPageFragment$data["audits"]>;
+
+type Props = {
+  queryRef: PreloadedQuery<AuditGraphListQuery>;
+};
+
+export default function AuditsPage(props: Props) {
+  const { __ } = useTranslate();
+  const organizationId = useOrganizationId();
+
+  const data = usePreloadedQuery(auditsQuery, props.queryRef);
+  const pagination = usePaginationFragment(
+    paginatedAuditsFragment,
+    data.node as AuditsPageFragment$key
+  );
+  const audits = pagination.data.audits?.edges?.map((edge) => edge.node) ?? [];
+  const connectionId = pagination.data.audits.__id;
+
+  usePageTitle(__("Audits"));
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title={__("Audits")}
+        description={__(
+          "Manage your organization's compliance audits and their progress."
+        )}
+      >
+        <CreateAuditDialog
+          connection={connectionId}
+          organizationId={organizationId}
+        >
+          <Button icon={IconPlusLarge}>{__("Add audit")}</Button>
+        </CreateAuditDialog>
+      </PageHeader>
+      <SortableTable {...pagination}>
+        <Thead>
+          <Tr>
+            <Th>{__("Framework")}</Th>
+            <Th>{__("State")}</Th>
+            <Th>{__("Valid From")}</Th>
+            <Th>{__("Valid Until")}</Th>
+            <Th>{__("Report")}</Th>
+            <Th></Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {audits.map((entry) => (
+            <AuditRow
+              key={entry.id}
+              entry={entry}
+              connectionId={connectionId}
+            />
+          ))}
+        </Tbody>
+      </SortableTable>
+    </div>
+  );
+}
+
+function AuditRow({
+  entry,
+  connectionId,
+}: {
+  entry: AuditEntry;
+  connectionId: string;
+}) {
+  const organizationId = useOrganizationId();
+  const { __, dateFormat } = useTranslate();
+  const deleteAudit = useDeleteAudit(entry, connectionId);
+
+  return (
+    <Tr to={`/organizations/${organizationId}/audits/${entry.id}`}>
+      <Td>{entry.framework?.name ?? __("Unknown Framework")}</Td>
+      <Td>
+        <Badge variant={getAuditStateVariant(entry.state)}>
+          {getAuditStateLabel(__, entry.state)}
+        </Badge>
+      </Td>
+      <Td>{dateFormat(entry.validFrom, { year: "numeric", month: "short", day: "numeric" }) || __("Not set")}</Td>
+      <Td>{dateFormat(entry.validUntil, { year: "numeric", month: "short", day: "numeric" }) || __("Not set")}</Td>
+      <Td>
+        {entry.report ? (
+          <div className="flex flex-col">
+            <Badge variant="success">{__("Uploaded")}</Badge>
+          </div>
+        ) : (
+          <Badge variant="neutral">{__("Not uploaded")}</Badge>
+        )}
+      </Td>
+      <Td noLink width={50} className="text-end">
+        <ActionDropdown>
+          <DropdownItem
+            onClick={deleteAudit}
+            variant="danger"
+            icon={IconTrashCan}
+          >
+            {__("Delete")}
+          </DropdownItem>
+        </ActionDropdown>
+      </Td>
+    </Tr>
+  );
+}

--- a/apps/console/src/pages/organizations/audits/__generated__/AuditsListQuery.graphql.ts
+++ b/apps/console/src/pages/organizations/audits/__generated__/AuditsListQuery.graphql.ts
@@ -1,0 +1,368 @@
+/**
+ * @generated SignedSource<<273ddcd519e40c3d2af76944a1f93191>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type AuditOrderField = "CREATED_AT" | "STATE" | "VALID_FROM" | "VALID_UNTIL";
+export type OrderDirection = "ASC" | "DESC";
+export type AuditOrder = {
+  direction: OrderDirection;
+  field: AuditOrderField;
+};
+export type AuditsListQuery$variables = {
+  after?: any | null | undefined;
+  before?: any | null | undefined;
+  first?: number | null | undefined;
+  id: string;
+  last?: number | null | undefined;
+  orderBy?: AuditOrder | null | undefined;
+};
+export type AuditsListQuery$data = {
+  readonly node: {
+    readonly " $fragmentSpreads": FragmentRefs<"AuditsPageFragment">;
+  };
+};
+export type AuditsListQuery = {
+  response: AuditsListQuery$data;
+  variables: AuditsListQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "after"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "before"
+},
+v2 = {
+  "defaultValue": 10,
+  "kind": "LocalArgument",
+  "name": "first"
+},
+v3 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "id"
+},
+v4 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "last"
+},
+v5 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "orderBy"
+},
+v6 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v7 = [
+  {
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "after"
+  },
+  {
+    "kind": "Variable",
+    "name": "before",
+    "variableName": "before"
+  },
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "first"
+  },
+  {
+    "kind": "Variable",
+    "name": "last",
+    "variableName": "last"
+  },
+  {
+    "kind": "Variable",
+    "name": "orderBy",
+    "variableName": "orderBy"
+  }
+],
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/),
+      (v3/*: any*/),
+      (v4/*: any*/),
+      (v5/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "AuditsListQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v6/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "args": (v7/*: any*/),
+            "kind": "FragmentSpread",
+            "name": "AuditsPageFragment"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/),
+      (v4/*: any*/),
+      (v5/*: any*/),
+      (v3/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "AuditsListQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v6/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v8/*: any*/),
+          (v9/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": (v7/*: any*/),
+                "concreteType": "AuditConnection",
+                "kind": "LinkedField",
+                "name": "audits",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AuditEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Audit",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v9/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "validFrom",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "validUntil",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Report",
+                            "kind": "LinkedField",
+                            "name": "report",
+                            "plural": false,
+                            "selections": [
+                              (v9/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "filename",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "state",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Framework",
+                            "kind": "LinkedField",
+                            "name": "framework",
+                            "plural": false,
+                            "selections": [
+                              (v9/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "name",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "createdAt",
+                            "storageKey": null
+                          },
+                          (v8/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "cursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageInfo",
+                    "kind": "LinkedField",
+                    "name": "pageInfo",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "endCursor",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "hasNextPage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "hasPreviousPage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "startCursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ClientExtension",
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "__id",
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": (v7/*: any*/),
+                "filters": [
+                  "orderBy"
+                ],
+                "handle": "connection",
+                "key": "AuditsPage_audits",
+                "kind": "LinkedHandle",
+                "name": "audits"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "120524c1493bac68d36318259531f84e",
+    "id": null,
+    "metadata": {},
+    "name": "AuditsListQuery",
+    "operationKind": "query",
+    "text": "query AuditsListQuery(\n  $after: CursorKey = null\n  $before: CursorKey = null\n  $first: Int = 10\n  $last: Int = null\n  $orderBy: AuditOrder = null\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...AuditsPageFragment_sdb03\n    id\n  }\n}\n\nfragment AuditsPageFragment_sdb03 on Organization {\n  audits(first: $first, after: $after, last: $last, before: $before, orderBy: $orderBy) {\n    edges {\n      node {\n        id\n        validFrom\n        validUntil\n        report {\n          id\n          filename\n        }\n        state\n        framework {\n          id\n          name\n        }\n        createdAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "ef15955eb51e30372c935dcc7dcd5099";
+
+export default node;

--- a/apps/console/src/pages/organizations/audits/__generated__/AuditsPageFragment.graphql.ts
+++ b/apps/console/src/pages/organizations/audits/__generated__/AuditsPageFragment.graphql.ts
@@ -1,0 +1,298 @@
+/**
+ * @generated SignedSource<<168c07116a618dbd9663e4072ec04139>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type AuditState = "COMPLETED" | "IN_PROGRESS" | "NOT_STARTED" | "OUTDATED" | "REJECTED";
+import { FragmentRefs } from "relay-runtime";
+export type AuditsPageFragment$data = {
+  readonly audits: {
+    readonly __id: string;
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly createdAt: any;
+        readonly framework: {
+          readonly id: string;
+          readonly name: string;
+        };
+        readonly id: string;
+        readonly report: {
+          readonly filename: string;
+          readonly id: string;
+        } | null | undefined;
+        readonly state: AuditState;
+        readonly validFrom: any | null | undefined;
+        readonly validUntil: any | null | undefined;
+      };
+    }>;
+  };
+  readonly id: string;
+  readonly " $fragmentType": "AuditsPageFragment";
+};
+export type AuditsPageFragment$key = {
+  readonly " $data"?: AuditsPageFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"AuditsPageFragment">;
+};
+
+import AuditsListQuery_graphql from './AuditsListQuery.graphql';
+
+const node: ReaderFragment = (function(){
+var v0 = [
+  "audits"
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "after"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "before"
+    },
+    {
+      "defaultValue": 10,
+      "kind": "LocalArgument",
+      "name": "first"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "last"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "orderBy"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": {
+    "connection": [
+      {
+        "count": null,
+        "cursor": null,
+        "direction": "bidirectional",
+        "path": (v0/*: any*/)
+      }
+    ],
+    "refetch": {
+      "connection": {
+        "forward": {
+          "count": "first",
+          "cursor": "after"
+        },
+        "backward": {
+          "count": "last",
+          "cursor": "before"
+        },
+        "path": (v0/*: any*/)
+      },
+      "fragmentPathInResult": [
+        "node"
+      ],
+      "operation": AuditsListQuery_graphql,
+      "identifierInfo": {
+        "identifierField": "id",
+        "identifierQueryVariableName": "id"
+      }
+    }
+  },
+  "name": "AuditsPageFragment",
+  "selections": [
+    {
+      "alias": "audits",
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "orderBy",
+          "variableName": "orderBy"
+        }
+      ],
+      "concreteType": "AuditConnection",
+      "kind": "LinkedField",
+      "name": "__AuditsPage_audits_connection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "AuditEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Audit",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                (v1/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "validFrom",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "validUntil",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "Report",
+                  "kind": "LinkedField",
+                  "name": "report",
+                  "plural": false,
+                  "selections": [
+                    (v1/*: any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "filename",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "state",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "Framework",
+                  "kind": "LinkedField",
+                  "name": "framework",
+                  "plural": false,
+                  "selections": [
+                    (v1/*: any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "name",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "createdAt",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "__typename",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "cursor",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "kind": "LinkedField",
+          "name": "pageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "endCursor",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasNextPage",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasPreviousPage",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "startCursor",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "kind": "ClientExtension",
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "__id",
+              "storageKey": null
+            }
+          ]
+        }
+      ],
+      "storageKey": null
+    },
+    (v1/*: any*/)
+  ],
+  "type": "Organization",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "ef15955eb51e30372c935dcc7dcd5099";
+
+export default node;

--- a/apps/console/src/pages/organizations/audits/dialogs/CreateAuditDialog.tsx
+++ b/apps/console/src/pages/organizations/audits/dialogs/CreateAuditDialog.tsx
@@ -1,0 +1,189 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  Field,
+  Option,
+  useDialogRef,
+  Breadcrumb,
+  Input,
+  Select,
+  useToast,
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import z from "zod";
+import { useFormWithSchema } from "/hooks/useFormWithSchema";
+import { ControlledField } from "/components/form/ControlledField";
+import { useCreateAudit } from "/hooks/graph/AuditGraph";
+import { auditStates, getAuditStateLabel } from "@probo/helpers";
+import { useLazyLoadQuery } from "react-relay";
+import { graphql } from "relay-runtime";
+import { Suspense } from "react";
+import { Controller } from "react-hook-form";
+
+const frameworksQuery = graphql`
+  query CreateAuditDialogFrameworksQuery($organizationId: ID!) {
+    organization: node(id: $organizationId) {
+      ... on Organization {
+        frameworks(first: 100) {
+          edges {
+            node {
+              id
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const schema = z.object({
+  frameworkId: z.string().min(1, "Framework is required"),
+  validFrom: z.string().optional(),
+  validUntil: z.string().optional(),
+  state: z.enum(["NOT_STARTED", "IN_PROGRESS", "COMPLETED", "REJECTED", "OUTDATED"]),
+});
+
+type Props = {
+  children: React.ReactNode;
+  connection: string;
+  organizationId: string;
+};
+
+export function CreateAuditDialog({
+  children,
+  connection,
+  organizationId,
+}: Props) {
+  const { __ } = useTranslate();
+  const { toast } = useToast();
+  const { control, handleSubmit, register, formState, reset } =
+    useFormWithSchema(schema, {
+      defaultValues: {
+        frameworkId: "",
+        validFrom: "",
+        validUntil: "",
+        state: "NOT_STARTED",
+      },
+    });
+  const ref = useDialogRef();
+  const createAudit = useCreateAudit(connection);
+
+  const onSubmit = handleSubmit(async (data) => {
+    try {
+      // Convert date strings to datetime format
+      const formatDatetime = (dateString?: string) => {
+        if (!dateString) return undefined;
+        return `${dateString}T00:00:00Z`;
+      };
+
+      await createAudit({
+        organizationId,
+        frameworkId: data.frameworkId,
+        validFrom: formatDatetime(data.validFrom),
+        validUntil: formatDatetime(data.validUntil),
+        state: data.state,
+      });
+      ref.current?.close();
+      reset();
+      toast({
+        title: __("Success"),
+        description: __("Audit created successfully"),
+        variant: "success",
+      });
+    } catch (error) {
+      toast({
+        title: __("Error"),
+        description: error instanceof Error ? error.message : __("Failed to create audit"),
+        variant: "error",
+      });
+    }
+  });
+
+  return (
+    <Dialog
+      ref={ref}
+      trigger={children}
+      title={<Breadcrumb items={[__("Audits"), __("New Audit")]} />}
+    >
+      <form onSubmit={onSubmit} className="space-y-4">
+        <DialogContent padded className="space-y-4">
+          <Field label={__("Framework")}>
+            <Suspense fallback={<Select variant="editor" disabled placeholder="Loading..." />}>
+              <FrameworkSelect
+                organizationId={organizationId}
+                control={control}
+                name="frameworkId"
+              />
+            </Suspense>
+          </Field>
+
+          <ControlledField
+            control={control}
+            name="state"
+            type="select"
+            label={__("State")}
+          >
+            {auditStates.map((state) => (
+              <Option key={state} value={state}>
+                {getAuditStateLabel(__, state)}
+              </Option>
+            ))}
+          </ControlledField>
+
+          <Field label={__("Valid From")}>
+            <Input {...register("validFrom")} type="date" />
+          </Field>
+          <Field label={__("Valid Until")}>
+            <Input {...register("validUntil")} type="date" />
+          </Field>
+        </DialogContent>
+        <DialogFooter>
+          <Button disabled={formState.isSubmitting} type="submit">
+            {__("Create")}
+          </Button>
+        </DialogFooter>
+      </form>
+    </Dialog>
+  );
+}
+
+function FrameworkSelect({
+  organizationId,
+  control,
+  name
+}: {
+  organizationId: string;
+  control: any;
+  name: string;
+}) {
+  const { __ } = useTranslate();
+  const data = useLazyLoadQuery(frameworksQuery, { organizationId }) as any;
+  const frameworks = data?.organization?.frameworks?.edges?.map((edge: any) => edge.node) ?? [];
+
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field }: any) => (
+        <Select
+          id={name}
+          variant="editor"
+          placeholder={__("Select a framework")}
+          onValueChange={field.onChange}
+          {...field}
+          className="w-full"
+          value={field.value ?? ""}
+        >
+          {frameworks.map((framework: any) => (
+            <Option key={framework.id} value={framework.id}>
+              {framework.name}
+            </Option>
+          ))}
+        </Select>
+      )}
+    />
+  );
+}

--- a/apps/console/src/pages/organizations/audits/dialogs/__generated__/CreateAuditDialogFrameworksQuery.graphql.ts
+++ b/apps/console/src/pages/organizations/audits/dialogs/__generated__/CreateAuditDialogFrameworksQuery.graphql.ts
@@ -1,0 +1,172 @@
+/**
+ * @generated SignedSource<<e7f7a5781f356aaba7ec0ff1a60b43b6>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type CreateAuditDialogFrameworksQuery$variables = {
+  organizationId: string;
+};
+export type CreateAuditDialogFrameworksQuery$data = {
+  readonly organization: {
+    readonly frameworks?: {
+      readonly edges: ReadonlyArray<{
+        readonly node: {
+          readonly id: string;
+          readonly name: string;
+        };
+      }>;
+    };
+  };
+};
+export type CreateAuditDialogFrameworksQuery = {
+  response: CreateAuditDialogFrameworksQuery$data;
+  variables: CreateAuditDialogFrameworksQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "organizationId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "organizationId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 100
+        }
+      ],
+      "concreteType": "FrameworkConnection",
+      "kind": "LinkedField",
+      "name": "frameworks",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "FrameworkEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Framework",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                (v2/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "name",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "frameworks(first:100)"
+    }
+  ],
+  "type": "Organization",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "CreateAuditDialogFrameworksQuery",
+    "selections": [
+      {
+        "alias": "organization",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "CreateAuditDialogFrameworksQuery",
+    "selections": [
+      {
+        "alias": "organization",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v3/*: any*/),
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "3b61e88adc92ac47ea6b5810a8d13f18",
+    "id": null,
+    "metadata": {},
+    "name": "CreateAuditDialogFrameworksQuery",
+    "operationKind": "query",
+    "text": "query CreateAuditDialogFrameworksQuery(\n  $organizationId: ID!\n) {\n  organization: node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      frameworks(first: 100) {\n        edges {\n          node {\n            id\n            name\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "ce9f84bb4e6e1e657cdf54bf8a3b4faa";
+
+export default node;

--- a/apps/console/src/pages/organizations/frameworks/dialogs/__generated__/FrameworkControlDialogCreateMutation.graphql.ts
+++ b/apps/console/src/pages/organizations/frameworks/dialogs/__generated__/FrameworkControlDialogCreateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5c976aa26b87b4f77dfcfeba71d3bbe3>>
+ * @generated SignedSource<<be64518840fd2564cffe1646a58c3762>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -17,7 +17,7 @@ export type CreateControlInput = {
   frameworkId: string;
   name: string;
   sectionTitle: string;
-  status?: ControlStatus | null | undefined;
+  status: ControlStatus;
 };
 export type FrameworkControlDialogCreateMutation$variables = {
   connections: ReadonlyArray<string>;

--- a/apps/console/src/pages/organizations/trustCenter/TrustCenterAuditsTab.tsx
+++ b/apps/console/src/pages/organizations/trustCenter/TrustCenterAuditsTab.tsx
@@ -1,0 +1,38 @@
+import { Card, Spinner } from "@probo/ui";
+import { useOutletContext } from "react-router";
+import { TrustCenterAuditsCard } from "/components/trustCenter/TrustCenterAuditsCard";
+import { useTrustCenterAuditUpdate } from "/hooks/graph/TrustCenterAuditGraph";
+
+type ContextType = {
+  organization: {
+    audits?: {
+      edges: Array<{
+        node: any;
+      }>;
+    };
+  };
+};
+
+export default function TrustCenterAuditsTab() {
+  const { organization } = useOutletContext<ContextType>();
+  const [updateAuditVisibility, isUpdatingAudits] = useTrustCenterAuditUpdate();
+
+  const audits = (organization.audits?.edges ?? []).map((edge) => edge.node);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        {isUpdatingAudits && <Spinner />}
+      </div>
+      <Card padded>
+        <TrustCenterAuditsCard
+          audits={audits}
+          params={{}}
+          disabled={isUpdatingAudits}
+          onToggleVisibility={updateAuditVisibility}
+          variant="table"
+        />
+      </Card>
+    </div>
+  );
+}

--- a/apps/console/src/pages/organizations/trustCenter/TrustCenterDocumentsTab.tsx
+++ b/apps/console/src/pages/organizations/trustCenter/TrustCenterDocumentsTab.tsx
@@ -1,0 +1,38 @@
+import { Card, Spinner } from "@probo/ui";
+import { useOutletContext } from "react-router";
+import { TrustCenterDocumentsCard } from "/components/trustCenter/TrustCenterDocumentsCard";
+import { useUpdateDocumentVisibilityMutation } from "/hooks/graph/TrustCenterDocumentGraph";
+
+type ContextType = {
+  organization: {
+    documents?: {
+      edges: Array<{
+        node: any;
+      }>;
+    };
+  };
+};
+
+export default function TrustCenterDocumentsTab() {
+  const { organization } = useOutletContext<ContextType>();
+  const [updateDocumentVisibility, isUpdatingDocuments] = useUpdateDocumentVisibilityMutation();
+
+  const documents = organization.documents?.edges?.map((edge) => edge.node) || [];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        {isUpdatingDocuments && <Spinner />}
+      </div>
+      <Card padded>
+        <TrustCenterDocumentsCard
+          documents={documents}
+          params={{}}
+          disabled={isUpdatingDocuments}
+          onToggleVisibility={updateDocumentVisibility}
+          variant="table"
+        />
+      </Card>
+    </div>
+  );
+}

--- a/apps/console/src/pages/organizations/trustCenter/TrustCenterVendorsTab.tsx
+++ b/apps/console/src/pages/organizations/trustCenter/TrustCenterVendorsTab.tsx
@@ -1,0 +1,38 @@
+import { Card, Spinner } from "@probo/ui";
+import { useOutletContext } from "react-router";
+import { TrustCenterVendorsCard } from "/components/trustCenter/TrustCenterVendorsCard";
+import { useTrustCenterVendorUpdate } from "/hooks/graph/TrustCenterVendorGraph";
+
+type ContextType = {
+  organization: {
+    vendors?: {
+      edges: Array<{
+        node: any;
+      }>;
+    };
+  };
+};
+
+export default function TrustCenterVendorsTab() {
+  const { organization } = useOutletContext<ContextType>();
+  const [updateVendorVisibility, isUpdatingVendors] = useTrustCenterVendorUpdate();
+
+  const vendors = organization.vendors?.edges?.map((edge) => edge.node) || [];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        {isUpdatingVendors && <Spinner />}
+      </div>
+      <Card padded>
+        <TrustCenterVendorsCard
+          vendors={vendors}
+          params={{}}
+          disabled={isUpdatingVendors}
+          onToggleVisibility={updateVendorVisibility}
+          variant="table"
+        />
+      </Card>
+    </div>
+  );
+}

--- a/apps/console/src/routes.tsx
+++ b/apps/console/src/routes.tsx
@@ -28,6 +28,7 @@ import { taskRoutes } from "./routes/taskRoutes.ts";
 import { dataRoutes } from "./routes/dataRoutes.ts";
 import { assetRoutes } from "./routes/assetRoutes.ts";
 import { auditRoutes } from "./routes/auditRoutes.ts";
+import { trustCenterRoutes } from "./routes/trustCenterRoutes.ts";
 import { lazy } from "@probo/react-lazy";
 
 /**
@@ -136,6 +137,7 @@ const routes = [
       ...assetRoutes,
       ...dataRoutes,
       ...auditRoutes,
+      ...trustCenterRoutes,
       {
         path: "*",
         Component: PageError,

--- a/apps/console/src/routes.tsx
+++ b/apps/console/src/routes.tsx
@@ -27,6 +27,7 @@ import { PageError } from "./components/PageError.tsx";
 import { taskRoutes } from "./routes/taskRoutes.ts";
 import { dataRoutes } from "./routes/dataRoutes.ts";
 import { assetRoutes } from "./routes/assetRoutes.ts";
+import { auditRoutes } from "./routes/auditRoutes.ts";
 import { lazy } from "@probo/react-lazy";
 
 /**
@@ -134,6 +135,7 @@ const routes = [
       ...taskRoutes,
       ...assetRoutes,
       ...dataRoutes,
+      ...auditRoutes,
       {
         path: "*",
         Component: PageError,

--- a/apps/console/src/routes.tsx
+++ b/apps/console/src/routes.tsx
@@ -29,6 +29,7 @@ import { dataRoutes } from "./routes/dataRoutes.ts";
 import { assetRoutes } from "./routes/assetRoutes.ts";
 import { auditRoutes } from "./routes/auditRoutes.ts";
 import { trustCenterRoutes } from "./routes/trustCenterRoutes.ts";
+import { publicTrustCenterQuery } from "./hooks/graph/PublicTrustCenterGraph.ts";
 import { lazy } from "@probo/react-lazy";
 
 /**
@@ -105,6 +106,14 @@ const routes = [
         ),
       },
     ],
+  },
+  {
+    path: "/trust/:slug",
+    ErrorBoundary: ErrorBoundary,
+    queryLoader: ({ slug }) =>
+      loadQuery(relayEnvironment, publicTrustCenterQuery, { slug }),
+    fallback: PageSkeleton,
+    Component: lazy(() => import("./pages/PublicTrustCenterPage")),
   },
   {
     path: "/organizations/:organizationId",

--- a/apps/console/src/routes/auditRoutes.ts
+++ b/apps/console/src/routes/auditRoutes.ts
@@ -1,0 +1,26 @@
+import { loadQuery } from "react-relay";
+import { relayEnvironment } from "/providers/RelayProviders";
+import { PageSkeleton } from "/components/skeletons/PageSkeleton";
+import { lazy } from "@probo/react-lazy";
+import { auditsQuery, auditNodeQuery } from "../hooks/graph/AuditGraph";
+
+export const auditRoutes = [
+  {
+    path: "audits",
+    fallback: PageSkeleton,
+    queryLoader: (params: Record<string, string>) =>
+      loadQuery(relayEnvironment, auditsQuery, { organizationId: params.organizationId }),
+    Component: lazy(
+      () => import("/pages/organizations/audits/AuditsPage")
+    ),
+  },
+  {
+    path: "audits/:auditId",
+    fallback: PageSkeleton,
+    queryLoader: (params: Record<string, string>) =>
+      loadQuery(relayEnvironment, auditNodeQuery, { auditId: params.auditId }),
+    Component: lazy(
+      () => import("/pages/organizations/audits/AuditDetailsPage")
+    ),
+  },
+];

--- a/apps/console/src/routes/trustCenterRoutes.ts
+++ b/apps/console/src/routes/trustCenterRoutes.ts
@@ -1,0 +1,49 @@
+import { loadQuery } from "react-relay";
+import { relayEnvironment } from "/providers/RelayProviders";
+import { PageSkeleton } from "/components/skeletons/PageSkeleton";
+import { LinkCardSkeleton } from "/components/skeletons/LinkCardSkeleton";
+import { lazy } from "@probo/react-lazy";
+import { trustCenterQuery } from "../hooks/graph/TrustCenterGraph";
+import type { AppRoute } from "/routes";
+
+export const trustCenterRoutes = [
+  {
+    path: "trust-center",
+    fallback: PageSkeleton,
+    queryLoader: ({ organizationId }) =>
+      loadQuery(relayEnvironment, trustCenterQuery, { organizationId }),
+    Component: lazy(
+      () => import("/pages/organizations/TrustCenterPage")
+    ),
+    children: [
+      {
+        index: true,
+        fallback: LinkCardSkeleton,
+        Component: lazy(
+          () => import("/pages/organizations/trustCenter/TrustCenterAuditsTab")
+        ),
+      },
+      {
+        path: "audits",
+        fallback: LinkCardSkeleton,
+        Component: lazy(
+          () => import("/pages/organizations/trustCenter/TrustCenterAuditsTab")
+        ),
+      },
+      {
+        path: "vendors",
+        fallback: LinkCardSkeleton,
+        Component: lazy(
+          () => import("/pages/organizations/trustCenter/TrustCenterVendorsTab")
+        ),
+      },
+      {
+        path: "documents",
+        fallback: LinkCardSkeleton,
+        Component: lazy(
+          () => import("/pages/organizations/trustCenter/TrustCenterDocumentsTab")
+        ),
+      },
+    ],
+  },
+] satisfies AppRoute[];

--- a/packages/helpers/src/audits.ts
+++ b/packages/helpers/src/audits.ts
@@ -1,0 +1,43 @@
+type Translator = (s: string) => string;
+
+export const auditStates = [
+  "NOT_STARTED",
+  "IN_PROGRESS",
+  "COMPLETED",
+  "REJECTED",
+  "OUTDATED",
+] as const;
+
+export function getAuditStateLabel(__: Translator, state: (typeof auditStates)[number]) {
+  switch (state) {
+    case "NOT_STARTED":
+      return __("Not Started");
+    case "IN_PROGRESS":
+      return __("In Progress");
+    case "COMPLETED":
+      return __("Completed");
+    case "REJECTED":
+      return __("Rejected");
+    case "OUTDATED":
+      return __("Outdated");
+    default:
+      return __("Unknown");
+  }
+}
+
+export function getAuditStateVariant(state: (typeof auditStates)[number]) {
+  switch (state) {
+    case "NOT_STARTED":
+      return "neutral";
+    case "IN_PROGRESS":
+      return "info";
+    case "COMPLETED":
+      return "success";
+    case "REJECTED":
+      return "danger";
+    case "OUTDATED":
+      return "warning";
+    default:
+      return "neutral";
+  }
+}

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -15,5 +15,6 @@ export { certificationCategoryLabel, certifications } from "./certifications";
 export { availableFrameworks } from "./frameworks";
 export { getDocumentTypeLabel, documentTypes } from "./documents";
 export { getAssetTypeVariant, getCriticityVariant } from "./assets";
+export { getAuditStateLabel, getAuditStateVariant, auditStates } from "./audits";
 export { promisifyMutation } from "./relay";
 export { fileType, fileSize } from "./file";

--- a/packages/ui/src/Atoms/Tabs/Tabs.tsx
+++ b/packages/ui/src/Atoms/Tabs/Tabs.tsx
@@ -1,5 +1,5 @@
 import type { HTMLAttributes, PropsWithChildren } from "react";
-import { NavLink } from "react-router";
+import { NavLink, type NavLinkProps } from "react-router";
 import { Root, List } from "@radix-ui/react-tabs";
 import { Slot, type AsChildProps } from "../Slot";
 import { tv } from "tailwind-variants";
@@ -41,7 +41,7 @@ export function TabItem({
     return <Component {...props} className={cls.item({ active })} />;
 }
 
-export function TabLink(props: PropsWithChildren<{ to: string }>) {
+export function TabLink(props: PropsWithChildren<NavLinkProps & { isActive?: () => boolean }>) {
     return (
         <NavLink
             className={(params) => cls.item({ active: params.isActive })}

--- a/pkg/coredata/audit.go
+++ b/pkg/coredata/audit.go
@@ -142,6 +142,7 @@ func (a *Audits) LoadByOrganizationID(
 	scope Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[AuditOrderField],
+	filter *AuditFilter,
 ) error {
 	q := `
 SELECT
@@ -161,12 +162,14 @@ WHERE
 	%s
 	AND organization_id = @organization_id
 	AND %s
+	AND %s
 `
 
-	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+	q = fmt.Sprintf(q, scope.SQLFragment(), filter.SQLFragment(), cursor.SQLFragment())
 
 	args := pgx.StrictNamedArgs{"organization_id": organizationID}
 	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, filter.SQLArguments())
 	maps.Copy(args, cursor.SQLArguments())
 
 	rows, err := conn.Query(ctx, q, args)

--- a/pkg/coredata/audit.go
+++ b/pkg/coredata/audit.go
@@ -1,0 +1,297 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"time"
+
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+	"github.com/jackc/pgx/v5"
+	"go.gearno.de/kit/pg"
+)
+
+type (
+	Audit struct {
+		ID             gid.GID    `db:"id"`
+		OrganizationID gid.GID    `db:"organization_id"`
+		FrameworkID    gid.GID    `db:"framework_id"`
+		ReportID       *gid.GID   `db:"report_id"`
+		ValidFrom      *time.Time `db:"valid_from"`
+		ValidUntil     *time.Time `db:"valid_until"`
+		State          AuditState `db:"state"`
+		CreatedAt      time.Time  `db:"created_at"`
+		UpdatedAt      time.Time  `db:"updated_at"`
+	}
+
+	Audits []*Audit
+)
+
+func (a *Audit) CursorKey(field AuditOrderField) page.CursorKey {
+	switch field {
+	case AuditOrderFieldCreatedAt:
+		return page.NewCursorKey(a.ID, a.CreatedAt)
+	case AuditOrderFieldValidFrom:
+		return page.NewCursorKey(a.ID, a.ValidFrom)
+	case AuditOrderFieldValidUntil:
+		return page.NewCursorKey(a.ID, a.ValidUntil)
+	case AuditOrderFieldState:
+		return page.NewCursorKey(a.ID, a.State)
+	}
+
+	panic(fmt.Sprintf("unsupported order by: %s", field))
+}
+
+func (a *Audit) LoadByID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	auditID gid.GID,
+) error {
+	q := `
+SELECT
+	id,
+	organization_id,
+	framework_id,
+	report_id,
+	valid_from,
+	valid_until,
+	state,
+	created_at,
+	updated_at
+FROM
+	audits
+WHERE
+	%s
+	AND id = @audit_id
+LIMIT 1;
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"audit_id": auditID}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query audit: %w", err)
+	}
+
+	audit, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[Audit])
+	if err != nil {
+		return fmt.Errorf("cannot collect audit: %w", err)
+	}
+
+	*a = audit
+
+	return nil
+}
+
+func (a *Audits) CountByOrganizationID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	organizationID gid.GID,
+) (int, error) {
+	q := `
+SELECT
+	COUNT(id)
+FROM
+	audits
+WHERE
+	%s
+	AND organization_id = @organization_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	row := conn.QueryRow(ctx, q, args)
+
+	var count int
+	err := row.Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("cannot count audits: %w", err)
+	}
+
+	return count, nil
+}
+
+func (a *Audits) LoadByOrganizationID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	organizationID gid.GID,
+	cursor *page.Cursor[AuditOrderField],
+) error {
+	q := `
+SELECT
+	id,
+	organization_id,
+	framework_id,
+	report_id,
+	valid_from,
+	valid_until,
+	state,
+	created_at,
+	updated_at
+FROM
+	audits
+WHERE
+	%s
+	AND organization_id = @organization_id
+	AND %s
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, cursor.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query audits: %w", err)
+	}
+
+	audits, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[Audit])
+	if err != nil {
+		return fmt.Errorf("cannot collect audits: %w", err)
+	}
+
+	*a = audits
+
+	return nil
+}
+
+func (a *Audit) Insert(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+INSERT INTO audits (
+	id,
+	tenant_id,
+	organization_id,
+	framework_id,
+	report_id,
+	valid_from,
+	valid_until,
+	state,
+	created_at,
+	updated_at
+) VALUES (
+	@id,
+	@tenant_id,
+	@organization_id,
+	@framework_id,
+	@report_id,
+	@valid_from,
+	@valid_until,
+	@state,
+	@created_at,
+	@updated_at
+)
+`
+
+	args := pgx.StrictNamedArgs{
+		"id":              a.ID,
+		"tenant_id":       scope.GetTenantID(),
+		"organization_id": a.OrganizationID,
+		"framework_id":    a.FrameworkID,
+		"report_id":       a.ReportID,
+		"valid_from":      a.ValidFrom,
+		"valid_until":     a.ValidUntil,
+		"state":           a.State,
+		"created_at":      a.CreatedAt,
+		"updated_at":      a.UpdatedAt,
+	}
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot insert audit: %w", err)
+	}
+
+	return nil
+}
+
+func (a *Audit) Update(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+UPDATE audits
+SET
+	report_id = @report_id,
+	valid_from = @valid_from,
+	valid_until = @valid_until,
+	state = @state,
+	updated_at = @updated_at
+WHERE
+	%s
+	AND id = @id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"id":          a.ID,
+		"report_id":   a.ReportID,
+		"valid_from":  a.ValidFrom,
+		"valid_until": a.ValidUntil,
+		"state":       a.State,
+		"updated_at":  a.UpdatedAt,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot update audit: %w", err)
+	}
+
+	return nil
+}
+
+func (a *Audit) Delete(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+DELETE FROM audits
+WHERE
+	%s
+	AND id = @id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"id": a.ID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete audit: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/audit.go
+++ b/pkg/coredata/audit.go
@@ -28,15 +28,16 @@ import (
 
 type (
 	Audit struct {
-		ID             gid.GID    `db:"id"`
-		OrganizationID gid.GID    `db:"organization_id"`
-		FrameworkID    gid.GID    `db:"framework_id"`
-		ReportID       *gid.GID   `db:"report_id"`
-		ValidFrom      *time.Time `db:"valid_from"`
-		ValidUntil     *time.Time `db:"valid_until"`
-		State          AuditState `db:"state"`
-		CreatedAt      time.Time  `db:"created_at"`
-		UpdatedAt      time.Time  `db:"updated_at"`
+		ID                gid.GID    `db:"id"`
+		OrganizationID    gid.GID    `db:"organization_id"`
+		FrameworkID       gid.GID    `db:"framework_id"`
+		ReportID          *gid.GID   `db:"report_id"`
+		ValidFrom         *time.Time `db:"valid_from"`
+		ValidUntil        *time.Time `db:"valid_until"`
+		State             AuditState `db:"state"`
+		ShowOnTrustCenter bool       `db:"show_on_trust_center"`
+		CreatedAt         time.Time  `db:"created_at"`
+		UpdatedAt         time.Time  `db:"updated_at"`
 	}
 
 	Audits []*Audit
@@ -72,6 +73,7 @@ SELECT
 	valid_from,
 	valid_until,
 	state,
+	show_on_trust_center,
 	created_at,
 	updated_at
 FROM
@@ -150,6 +152,7 @@ SELECT
 	valid_from,
 	valid_until,
 	state,
+	show_on_trust_center,
 	created_at,
 	updated_at
 FROM
@@ -196,6 +199,7 @@ INSERT INTO audits (
 	valid_from,
 	valid_until,
 	state,
+	show_on_trust_center,
 	created_at,
 	updated_at
 ) VALUES (
@@ -207,22 +211,24 @@ INSERT INTO audits (
 	@valid_from,
 	@valid_until,
 	@state,
+	@show_on_trust_center,
 	@created_at,
 	@updated_at
 )
 `
 
 	args := pgx.StrictNamedArgs{
-		"id":              a.ID,
-		"tenant_id":       scope.GetTenantID(),
-		"organization_id": a.OrganizationID,
-		"framework_id":    a.FrameworkID,
-		"report_id":       a.ReportID,
-		"valid_from":      a.ValidFrom,
-		"valid_until":     a.ValidUntil,
-		"state":           a.State,
-		"created_at":      a.CreatedAt,
-		"updated_at":      a.UpdatedAt,
+		"id":                   a.ID,
+		"tenant_id":            scope.GetTenantID(),
+		"organization_id":      a.OrganizationID,
+		"framework_id":         a.FrameworkID,
+		"report_id":            a.ReportID,
+		"valid_from":           a.ValidFrom,
+		"valid_until":          a.ValidUntil,
+		"state":                a.State,
+		"show_on_trust_center": a.ShowOnTrustCenter,
+		"created_at":           a.CreatedAt,
+		"updated_at":           a.UpdatedAt,
 	}
 
 	_, err := conn.Exec(ctx, q, args)
@@ -245,6 +251,7 @@ SET
 	valid_from = @valid_from,
 	valid_until = @valid_until,
 	state = @state,
+	show_on_trust_center = @show_on_trust_center,
 	updated_at = @updated_at
 WHERE
 	%s
@@ -254,12 +261,13 @@ WHERE
 	q = fmt.Sprintf(q, scope.SQLFragment())
 
 	args := pgx.StrictNamedArgs{
-		"id":          a.ID,
-		"report_id":   a.ReportID,
-		"valid_from":  a.ValidFrom,
-		"valid_until": a.ValidUntil,
-		"state":       a.State,
-		"updated_at":  a.UpdatedAt,
+		"id":                   a.ID,
+		"report_id":            a.ReportID,
+		"valid_from":           a.ValidFrom,
+		"valid_until":          a.ValidUntil,
+		"state":                a.State,
+		"show_on_trust_center": a.ShowOnTrustCenter,
+		"updated_at":           a.UpdatedAt,
 	}
 	maps.Copy(args, scope.SQLArguments())
 

--- a/pkg/coredata/audit_filter.go
+++ b/pkg/coredata/audit_filter.go
@@ -19,31 +19,25 @@ import (
 )
 
 type (
-	DocumentFilter struct {
-		query             *string
+	AuditFilter struct {
 		showOnTrustCenter *bool
 	}
 )
 
-func NewDocumentFilter(query *string) *DocumentFilter {
-	return &DocumentFilter{
-		query: query,
-	}
+func NewAuditFilter() *AuditFilter {
+	return &AuditFilter{}
 }
 
-func NewDocumentTrustCenterFilter() *DocumentFilter {
+func NewAuditTrustCenterFilter() *AuditFilter {
 	showOnTrustCenter := true
-	return &DocumentFilter{
+	return &AuditFilter{
 		showOnTrustCenter: &showOnTrustCenter,
 	}
 }
 
-func (f *DocumentFilter) SQLArguments() pgx.NamedArgs {
+func (f *AuditFilter) SQLArguments() pgx.NamedArgs {
 	args := pgx.NamedArgs{}
 
-	if f.query != nil {
-		args["query"] = *f.query
-	}
 	if f.showOnTrustCenter != nil {
 		args["show_on_trust_center"] = *f.showOnTrustCenter
 	}
@@ -51,32 +45,10 @@ func (f *DocumentFilter) SQLArguments() pgx.NamedArgs {
 	return args
 }
 
-func (f *DocumentFilter) SQLFragment() string {
-	conditions := []string{}
-
-	if f.query != nil && *f.query != "" {
-		conditions = append(conditions, `
-		search_vector @@ (
-			SELECT to_tsquery('simple', string_agg(lexeme || ':*', ' & '))
-			FROM unnest(regexp_split_to_array(trim(@query), '\s+')) AS lexeme
-		)`)
-	}
-
+func (f *AuditFilter) SQLFragment() string {
 	if f.showOnTrustCenter != nil {
-		conditions = append(conditions, "show_on_trust_center = @show_on_trust_center")
+		return "show_on_trust_center = @show_on_trust_center"
 	}
 
-	if len(conditions) == 0 {
-		return "TRUE"
-	}
-
-	result := ""
-	for i, condition := range conditions {
-		if i > 0 {
-			result += " AND "
-		}
-		result += condition
-	}
-
-	return result
+	return "TRUE"
 }

--- a/pkg/coredata/audit_order_field.go
+++ b/pkg/coredata/audit_order_field.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"fmt"
+)
+
+type AuditOrderField string
+
+const (
+	AuditOrderFieldCreatedAt  AuditOrderField = "CREATED_AT"
+	AuditOrderFieldValidFrom  AuditOrderField = "VALID_FROM"
+	AuditOrderFieldValidUntil AuditOrderField = "VALID_UNTIL"
+	AuditOrderFieldState      AuditOrderField = "STATE"
+)
+
+func (p AuditOrderField) Column() string {
+	return string(p)
+}
+
+func (p AuditOrderField) String() string {
+	return string(p)
+}
+
+func (p AuditOrderField) MarshalText() ([]byte, error) {
+	return []byte(p.String()), nil
+}
+
+func (p *AuditOrderField) UnmarshalText(text []byte) error {
+	val := string(text)
+	switch val {
+	case string(AuditOrderFieldCreatedAt),
+		string(AuditOrderFieldValidFrom),
+		string(AuditOrderFieldValidUntil),
+		string(AuditOrderFieldState):
+		*p = AuditOrderField(val)
+		return nil
+	}
+	return fmt.Errorf("invalid AuditOrderField value: %q", val)
+}

--- a/pkg/coredata/audit_state.go
+++ b/pkg/coredata/audit_state.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+type AuditState string
+
+const (
+	AuditStateNotStarted AuditState = "NOT_STARTED"
+	AuditStateInProgress AuditState = "IN_PROGRESS"
+	AuditStateCompleted  AuditState = "COMPLETED"
+	AuditStateRejected   AuditState = "REJECTED"
+	AuditStateOutdated   AuditState = "OUTDATED"
+)
+
+func (as AuditState) String() string {
+	return string(as)
+}
+
+func (as *AuditState) Scan(value any) error {
+	var s string
+	switch v := value.(type) {
+	case string:
+		s = v
+	case []byte:
+		s = string(v)
+	default:
+		return fmt.Errorf("unsupported type for AuditState: %T", value)
+	}
+
+	switch s {
+	case "NOT_STARTED":
+		*as = AuditStateNotStarted
+	case "IN_PROGRESS":
+		*as = AuditStateInProgress
+	case "COMPLETED":
+		*as = AuditStateCompleted
+	case "REJECTED":
+		*as = AuditStateRejected
+	case "OUTDATED":
+		*as = AuditStateOutdated
+	default:
+		return fmt.Errorf("invalid AuditState value: %q", s)
+	}
+	return nil
+}
+
+func (as AuditState) Value() (driver.Value, error) {
+	return as.String(), nil
+}

--- a/pkg/coredata/document.go
+++ b/pkg/coredata/document.go
@@ -34,6 +34,7 @@ type (
 		Title                   string       `db:"title"`
 		DocumentType            DocumentType `db:"document_type"`
 		CurrentPublishedVersion *int         `db:"current_published_version"`
+		ShowOnTrustCenter       bool         `db:"show_on_trust_center"`
 		CreatedAt               time.Time    `db:"created_at"`
 		UpdatedAt               time.Time    `db:"updated_at"`
 	}
@@ -68,6 +69,7 @@ SELECT
     title,
     document_type,
     current_published_version,
+    show_on_trust_center,
     created_at,
     updated_at
 FROM
@@ -147,6 +149,7 @@ SELECT
     title,
     document_type,
     current_published_version,
+    show_on_trust_center,
     created_at,
     updated_at
 FROM
@@ -195,6 +198,7 @@ INSERT INTO
 		title,
 		document_type,
 		current_published_version,
+		show_on_trust_center,
 		created_at,
 		updated_at
     )
@@ -206,6 +210,7 @@ VALUES (
     @title,
     @document_type,
     @current_published_version,
+    @show_on_trust_center,
     @created_at,
     @updated_at
 );
@@ -219,6 +224,7 @@ VALUES (
 		"title":                     p.Title,
 		"document_type":             p.DocumentType,
 		"current_published_version": p.CurrentPublishedVersion,
+		"show_on_trust_center":      p.ShowOnTrustCenter,
 		"created_at":                p.CreatedAt,
 		"updated_at":                p.UpdatedAt,
 	}
@@ -257,6 +263,7 @@ SET
 	current_published_version = @current_published_version,
 	owner_id = @owner_id,
 	document_type = @document_type,
+	show_on_trust_center = @show_on_trust_center,
 	updated_at = @updated_at
 WHERE %s
     AND id = @document_id
@@ -270,6 +277,7 @@ WHERE %s
 		"current_published_version": p.CurrentPublishedVersion,
 		"owner_id":                  p.OwnerID,
 		"document_type":             p.DocumentType,
+		"show_on_trust_center":      p.ShowOnTrustCenter,
 	}
 	maps.Copy(args, scope.SQLArguments())
 
@@ -342,6 +350,7 @@ WITH plcs AS (
 		p.title,
 		p.document_type,
 		p.current_published_version,
+		p.show_on_trust_center,
 		p.created_at,
 		p.updated_at
 	FROM
@@ -358,6 +367,7 @@ SELECT
 	title,
 	document_type,
 	current_published_version,
+	show_on_trust_center,
 	created_at,
 	updated_at
 FROM
@@ -448,6 +458,7 @@ WITH plcs AS (
 		p.title,
 		p.document_type,
 		p.current_published_version,
+		p.show_on_trust_center,
 		p.created_at,
 		p.updated_at
 	FROM
@@ -464,6 +475,7 @@ SELECT
 	title,
 	document_type,
 	current_published_version,
+	show_on_trust_center,
 	created_at,
 	updated_at
 FROM

--- a/pkg/coredata/migrations/20250722T151525Z.sql
+++ b/pkg/coredata/migrations/20250722T151525Z.sql
@@ -1,0 +1,34 @@
+-- Create audit state enum
+CREATE TYPE audit_state AS ENUM (
+    'NOT_STARTED',
+    'IN_PROGRESS',
+    'COMPLETED',
+    'REJECTED',
+    'OUTDATED'
+);
+
+-- Create reports table
+CREATE TABLE reports (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    object_key TEXT NOT NULL,
+    mime_type TEXT NOT NULL,
+    filename TEXT NOT NULL,
+    size BIGINT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+-- Create audits table
+CREATE TABLE audits (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    framework_id TEXT NOT NULL REFERENCES frameworks(id) ON DELETE CASCADE,
+    report_id TEXT REFERENCES reports(id) ON DELETE SET NULL,
+    valid_from DATE,
+    valid_until DATE,
+    state audit_state NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+);

--- a/pkg/coredata/migrations/20250724T135155Z.sql
+++ b/pkg/coredata/migrations/20250724T135155Z.sql
@@ -31,7 +31,7 @@ SELECT
                 unaccent(o.name),
                 '[^a-zA-Z0-9\s]', '', 'g'
             ),
-            '\s+', '_', 'g'
+            '\s+', '-', 'g'
         )
     ),
     NOW(),

--- a/pkg/coredata/migrations/20250724T135155Z.sql
+++ b/pkg/coredata/migrations/20250724T135155Z.sql
@@ -5,7 +5,7 @@ CREATE TABLE trust_centers (
     organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
     tenant_id TEXT NOT NULL,
     active BOOLEAN NOT NULL,
-    slug TEXT NOT NULL CHECK (slug ~ '^[a-z0-9_]+$'),
+    slug TEXT NOT NULL CHECK (slug ~ '^[a-z0-9_-]+$'),
     created_at TIMESTAMP WITH TIME ZONE NOT NULL,
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
     UNIQUE(slug)

--- a/pkg/coredata/migrations/20250724T135155Z.sql
+++ b/pkg/coredata/migrations/20250724T135155Z.sql
@@ -1,0 +1,51 @@
+CREATE EXTENSION IF NOT EXISTS unaccent;
+
+CREATE TABLE trust_centers (
+    id TEXT PRIMARY KEY,
+    organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    tenant_id TEXT NOT NULL,
+    active BOOLEAN NOT NULL,
+    slug TEXT NOT NULL CHECK (slug ~ '^[a-z0-9_]+$'),
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    UNIQUE(slug)
+);
+
+INSERT INTO trust_centers (
+    id,
+    organization_id,
+    tenant_id,
+    active,
+    slug,
+    created_at,
+    updated_at
+)
+SELECT
+    generate_gid(decode_base64_unpadded(o.tenant_id), 22),
+    o.id,
+    o.tenant_id,
+    false,
+    LOWER(
+        REGEXP_REPLACE(
+            REGEXP_REPLACE(
+                unaccent(o.name),
+                '[^a-zA-Z0-9\s]', '', 'g'
+            ),
+            '\s+', '_', 'g'
+        )
+    ),
+    NOW(),
+    NOW()
+FROM organizations o;
+
+ALTER TABLE documents ADD COLUMN show_on_trust_center BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE audits ADD COLUMN show_on_trust_center BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE vendors ADD COLUMN show_on_trust_center BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE documents ALTER COLUMN show_on_trust_center DROP DEFAULT;
+
+ALTER TABLE audits ALTER COLUMN show_on_trust_center DROP DEFAULT;
+
+ALTER TABLE vendors ALTER COLUMN show_on_trust_center DROP DEFAULT;

--- a/pkg/coredata/report.go
+++ b/pkg/coredata/report.go
@@ -144,14 +144,6 @@ SET
 WHERE
 	%s
 	AND id = @id
-RETURNING
-	id,
-	object_key,
-	mime_type,
-	filename,
-	size,
-	created_at,
-	updated_at
 `
 
 	q = fmt.Sprintf(q, scope.SQLFragment())
@@ -166,17 +158,10 @@ RETURNING
 	}
 	maps.Copy(args, scope.SQLArguments())
 
-	rows, err := conn.Query(ctx, q, args)
+	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
 		return fmt.Errorf("cannot update report: %w", err)
 	}
-
-	report, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[Report])
-	if err != nil {
-		return fmt.Errorf("cannot collect updated report: %w", err)
-	}
-
-	*r = report
 
 	return nil
 }

--- a/pkg/coredata/report.go
+++ b/pkg/coredata/report.go
@@ -1,0 +1,207 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"time"
+
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/jackc/pgx/v5"
+	"go.gearno.de/kit/pg"
+)
+
+type (
+	Report struct {
+		ID        gid.GID   `db:"id"`
+		ObjectKey string    `db:"object_key"`
+		MimeType  string    `db:"mime_type"`
+		Filename  string    `db:"filename"`
+		Size      int64     `db:"size"`
+		CreatedAt time.Time `db:"created_at"`
+		UpdatedAt time.Time `db:"updated_at"`
+	}
+
+	Reports []*Report
+)
+
+func (r *Report) LoadByID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	reportID gid.GID,
+) error {
+	q := `
+SELECT
+	id,
+	object_key,
+	mime_type,
+	filename,
+	size,
+	created_at,
+	updated_at
+FROM
+	reports
+WHERE
+	%s
+	AND id = @report_id
+LIMIT 1;
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"report_id": reportID}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query report: %w", err)
+	}
+
+	report, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[Report])
+	if err != nil {
+		return fmt.Errorf("cannot collect report: %w", err)
+	}
+
+	*r = report
+
+	return nil
+}
+
+func (r *Report) Insert(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+INSERT INTO reports (
+	id,
+	tenant_id,
+	object_key,
+	mime_type,
+	filename,
+	size,
+	created_at,
+	updated_at
+) VALUES (
+	@id,
+	@tenant_id,
+	@object_key,
+	@mime_type,
+	@filename,
+	@size,
+	@created_at,
+	@updated_at
+)
+`
+
+	args := pgx.StrictNamedArgs{
+		"id":         r.ID,
+		"tenant_id":  scope.GetTenantID(),
+		"object_key": r.ObjectKey,
+		"mime_type":  r.MimeType,
+		"filename":   r.Filename,
+		"size":       r.Size,
+		"created_at": r.CreatedAt,
+		"updated_at": r.UpdatedAt,
+	}
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot insert report: %w", err)
+	}
+
+	return nil
+}
+
+func (r *Report) Update(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+UPDATE reports
+SET
+	object_key = @object_key,
+	mime_type = @mime_type,
+	filename = @filename,
+	size = @size,
+	updated_at = @updated_at
+WHERE
+	%s
+	AND id = @id
+RETURNING
+	id,
+	object_key,
+	mime_type,
+	filename,
+	size,
+	created_at,
+	updated_at
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"id":         r.ID,
+		"object_key": r.ObjectKey,
+		"mime_type":  r.MimeType,
+		"filename":   r.Filename,
+		"size":       r.Size,
+		"updated_at": r.UpdatedAt,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot update report: %w", err)
+	}
+
+	report, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[Report])
+	if err != nil {
+		return fmt.Errorf("cannot collect updated report: %w", err)
+	}
+
+	*r = report
+
+	return nil
+}
+
+func (r *Report) Delete(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+DELETE FROM reports
+WHERE
+	%s
+	AND id = @id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"id": r.ID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete report: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/trust_center.go
+++ b/pkg/coredata/trust_center.go
@@ -223,9 +223,3 @@ const (
 func (tof TrustCenterOrderField) String() string {
 	return string(tof)
 }
-
-type (
-	UpdateTrustCenterParams struct {
-		Active *bool
-	}
-)

--- a/pkg/coredata/trust_center.go
+++ b/pkg/coredata/trust_center.go
@@ -211,15 +211,3 @@ WHERE
 
 	return nil
 }
-
-type (
-	TrustCenterOrderField string
-)
-
-const (
-	TrustCenterOrderFieldCreatedAt TrustCenterOrderField = "CREATED_AT"
-)
-
-func (tof TrustCenterOrderField) String() string {
-	return string(tof)
-}

--- a/pkg/coredata/trust_center.go
+++ b/pkg/coredata/trust_center.go
@@ -135,6 +135,45 @@ LIMIT 1;
 	return nil
 }
 
+// Public read-only methods for trust center
+func (tc *TrustCenter) LoadBySlug(
+	ctx context.Context,
+	conn pg.Conn,
+	slug string,
+) error {
+	q := `
+SELECT
+	id,
+	organization_id,
+	tenant_id,
+	active,
+	slug,
+	created_at,
+	updated_at
+FROM
+	trust_centers
+WHERE
+	slug = @slug
+LIMIT 1;
+`
+
+	args := pgx.StrictNamedArgs{"slug": slug}
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query trust center: %w", err)
+	}
+
+	trustCenter, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[TrustCenter])
+	if err != nil {
+		return fmt.Errorf("cannot collect trust center: %w", err)
+	}
+
+	*tc = trustCenter
+
+	return nil
+}
+
 func (tc *TrustCenter) Insert(
 	ctx context.Context,
 	conn pg.Conn,

--- a/pkg/coredata/trust_center.go
+++ b/pkg/coredata/trust_center.go
@@ -1,0 +1,231 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"time"
+
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+	"github.com/jackc/pgx/v5"
+	"go.gearno.de/kit/pg"
+)
+
+type (
+	TrustCenter struct {
+		ID             gid.GID      `db:"id"`
+		OrganizationID gid.GID      `db:"organization_id"`
+		TenantID       gid.TenantID `db:"tenant_id"`
+		Active         bool         `db:"active"`
+		Slug           string       `db:"slug"`
+		CreatedAt      time.Time    `db:"created_at"`
+		UpdatedAt      time.Time    `db:"updated_at"`
+	}
+
+	TrustCenters []*TrustCenter
+)
+
+func (tc *TrustCenter) CursorKey(orderBy TrustCenterOrderField) page.CursorKey {
+	switch orderBy {
+	case TrustCenterOrderFieldCreatedAt:
+		return page.NewCursorKey(tc.ID, tc.CreatedAt)
+	}
+
+	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
+}
+
+func (tc *TrustCenter) LoadByID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	trustCenterID gid.GID,
+) error {
+	q := `
+SELECT
+	id,
+	organization_id,
+	tenant_id,
+	active,
+	slug,
+	created_at,
+	updated_at
+FROM
+	trust_centers
+WHERE
+	%s
+	AND id = @trust_center_id
+LIMIT 1;
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"trust_center_id": trustCenterID}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query trust center: %w", err)
+	}
+
+	trustCenter, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[TrustCenter])
+	if err != nil {
+		return fmt.Errorf("cannot collect trust center: %w", err)
+	}
+
+	*tc = trustCenter
+
+	return nil
+}
+
+func (tc *TrustCenter) LoadByOrganizationID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	organizationID gid.GID,
+) error {
+	q := `
+SELECT
+	id,
+	organization_id,
+	tenant_id,
+	active,
+	slug,
+	created_at,
+	updated_at
+FROM
+	trust_centers
+WHERE
+	%s
+	AND organization_id = @organization_id
+LIMIT 1;
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query trust center: %w", err)
+	}
+
+	trustCenter, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[TrustCenter])
+	if err != nil {
+		return fmt.Errorf("cannot collect trust center: %w", err)
+	}
+
+	*tc = trustCenter
+
+	return nil
+}
+
+func (tc *TrustCenter) Insert(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+INSERT INTO trust_centers (
+	id,
+	organization_id,
+	tenant_id,
+	active,
+	slug,
+	created_at,
+	updated_at
+) VALUES (
+	@id,
+	@organization_id,
+	@tenant_id,
+	@active,
+	@slug,
+	@created_at,
+	@updated_at
+)
+`
+
+	args := pgx.StrictNamedArgs{
+		"id":              tc.ID,
+		"organization_id": tc.OrganizationID,
+		"tenant_id":       tc.TenantID,
+		"active":          tc.Active,
+		"slug":            tc.Slug,
+		"created_at":      tc.CreatedAt,
+		"updated_at":      tc.UpdatedAt,
+	}
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot insert trust center: %w", err)
+	}
+
+	return nil
+}
+
+func (tc *TrustCenter) Update(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+UPDATE trust_centers
+SET
+	active = @active,
+	slug = @slug,
+	updated_at = @updated_at
+WHERE
+	%s
+	AND id = @id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"id":         tc.ID,
+		"active":     tc.Active,
+		"slug":       tc.Slug,
+		"updated_at": tc.UpdatedAt,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot update trust center: %w", err)
+	}
+
+	return nil
+}
+
+type (
+	TrustCenterOrderField string
+)
+
+const (
+	TrustCenterOrderFieldCreatedAt TrustCenterOrderField = "CREATED_AT"
+)
+
+func (tof TrustCenterOrderField) String() string {
+	return string(tof)
+}
+
+type (
+	UpdateTrustCenterParams struct {
+		Active *bool
+	}
+)

--- a/pkg/coredata/trust_center_order_field.go
+++ b/pkg/coredata/trust_center_order_field.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+type TrustCenterOrderField string
+
+const (
+	TrustCenterOrderFieldCreatedAt TrustCenterOrderField = "CREATED_AT"
+)
+
+func (p TrustCenterOrderField) Column() string {
+	return string(p)
+}
+
+func (p TrustCenterOrderField) String() string {
+	return string(p)
+}
+
+func (p TrustCenterOrderField) MarshalText() ([]byte, error) {
+	return []byte(p.String()), nil
+}
+
+func (p *TrustCenterOrderField) UnmarshalText(text []byte) error {
+	*p = TrustCenterOrderField(text)
+	return nil
+}

--- a/pkg/coredata/vendor.go
+++ b/pkg/coredata/vendor.go
@@ -49,6 +49,7 @@ type (
 		TermsOfServiceURL             *string        `db:"terms_of_service_url"`
 		SecurityPageURL               *string        `db:"security_page_url"`
 		TrustPageURL                  *string        `db:"trust_page_url"`
+		ShowOnTrustCenter             bool           `db:"show_on_trust_center"`
 		CreatedAt                     time.Time      `db:"created_at"`
 		UpdatedAt                     time.Time      `db:"updated_at"`
 	}
@@ -98,6 +99,7 @@ SELECT
     terms_of_service_url,
     security_page_url,
     trust_page_url,
+    show_on_trust_center,
     created_at,
     updated_at
 FROM
@@ -158,6 +160,7 @@ INSERT INTO
         terms_of_service_url,
         security_page_url,
         trust_page_url,
+        show_on_trust_center,
         created_at,
         updated_at
     )
@@ -183,6 +186,7 @@ VALUES (
     @terms_of_service_url,
     @security_page_url,
     @trust_page_url,
+    @show_on_trust_center,
     @created_at,
     @updated_at
 )
@@ -210,6 +214,7 @@ VALUES (
 		"terms_of_service_url":             v.TermsOfServiceURL,
 		"security_page_url":                v.SecurityPageURL,
 		"trust_page_url":                   v.TrustPageURL,
+		"show_on_trust_center":             v.ShowOnTrustCenter,
 		"created_at":                       v.CreatedAt,
 		"updated_at":                       v.UpdatedAt,
 	}
@@ -297,6 +302,7 @@ SELECT
     terms_of_service_url,
     security_page_url,
     trust_page_url,
+    show_on_trust_center,
     created_at,
     updated_at
 FROM
@@ -353,6 +359,7 @@ SET
 	trust_page_url = @trust_page_url,
 	business_owner_id = @business_owner_id,
 	security_owner_id = @security_owner_id,
+	show_on_trust_center = @show_on_trust_center,
 	updated_at = @updated_at
 WHERE %s
     AND id = @vendor_id
@@ -380,6 +387,7 @@ WHERE %s
 		"trust_page_url":                   v.TrustPageURL,
 		"business_owner_id":                v.BusinessOwnerID,
 		"security_owner_id":                v.SecurityOwnerID,
+		"show_on_trust_center":             v.ShowOnTrustCenter,
 	}
 
 	maps.Copy(args, scope.SQLArguments())

--- a/pkg/coredata/vendor.go
+++ b/pkg/coredata/vendor.go
@@ -278,45 +278,48 @@ func (v *Vendors) LoadByOrganizationID(
 	scope Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[VendorOrderField],
+	filter *VendorFilter,
 ) error {
 	q := `
 SELECT
-    id,
-    tenant_id,
-    organization_id,
-    name,
-    description,
-    category,
-    headquarter_address,
-    legal_name,
-    website_url,
-    privacy_policy_url,
-    service_level_agreement_url,
-    data_processing_agreement_url,
-    business_associate_agreement_url,
-    subprocessors_list_url,
-    certifications,
-    business_owner_id,
-    security_owner_id,
-    status_page_url,
-    terms_of_service_url,
-    security_page_url,
-    trust_page_url,
-    show_on_trust_center,
-    created_at,
-    updated_at
+	id,
+	tenant_id,
+	organization_id,
+	name,
+	description,
+	category,
+	headquarter_address,
+	legal_name,
+	website_url,
+	privacy_policy_url,
+	service_level_agreement_url,
+	data_processing_agreement_url,
+	business_associate_agreement_url,
+	subprocessors_list_url,
+	certifications,
+	business_owner_id,
+	security_owner_id,
+	status_page_url,
+	terms_of_service_url,
+	security_page_url,
+	trust_page_url,
+	show_on_trust_center,
+	created_at,
+	updated_at
 FROM
-    vendors
+	vendors
 WHERE
-    %s
-    AND organization_id = @organization_id
-    AND %s
+	%s
+	AND organization_id = @organization_id
+	AND %s
+	AND %s
 `
-	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+	q = fmt.Sprintf(q, scope.SQLFragment(), filter.SQLFragment(), cursor.SQLFragment())
 
 	args := pgx.StrictNamedArgs{"organization_id": organizationID}
-	maps.Copy(args, cursor.SQLArguments())
 	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, filter.SQLArguments())
+	maps.Copy(args, cursor.SQLArguments())
 
 	rows, err := conn.Query(ctx, q, args)
 	if err != nil {

--- a/pkg/coredata/vendor_filter.go
+++ b/pkg/coredata/vendor_filter.go
@@ -19,31 +19,25 @@ import (
 )
 
 type (
-	DocumentFilter struct {
-		query             *string
+	VendorFilter struct {
 		showOnTrustCenter *bool
 	}
 )
 
-func NewDocumentFilter(query *string) *DocumentFilter {
-	return &DocumentFilter{
-		query: query,
-	}
+func NewVendorFilter() *VendorFilter {
+	return &VendorFilter{}
 }
 
-func NewDocumentTrustCenterFilter() *DocumentFilter {
+func NewVendorTrustCenterFilter() *VendorFilter {
 	showOnTrustCenter := true
-	return &DocumentFilter{
+	return &VendorFilter{
 		showOnTrustCenter: &showOnTrustCenter,
 	}
 }
 
-func (f *DocumentFilter) SQLArguments() pgx.NamedArgs {
+func (f *VendorFilter) SQLArguments() pgx.NamedArgs {
 	args := pgx.NamedArgs{}
 
-	if f.query != nil {
-		args["query"] = *f.query
-	}
 	if f.showOnTrustCenter != nil {
 		args["show_on_trust_center"] = *f.showOnTrustCenter
 	}
@@ -51,32 +45,10 @@ func (f *DocumentFilter) SQLArguments() pgx.NamedArgs {
 	return args
 }
 
-func (f *DocumentFilter) SQLFragment() string {
-	conditions := []string{}
-
-	if f.query != nil && *f.query != "" {
-		conditions = append(conditions, `
-		search_vector @@ (
-			SELECT to_tsquery('simple', string_agg(lexeme || ':*', ' & '))
-			FROM unnest(regexp_split_to_array(trim(@query), '\s+')) AS lexeme
-		)`)
-	}
-
+func (f *VendorFilter) SQLFragment() string {
 	if f.showOnTrustCenter != nil {
-		conditions = append(conditions, "show_on_trust_center = @show_on_trust_center")
+		return "show_on_trust_center = @show_on_trust_center"
 	}
 
-	if len(conditions) == 0 {
-		return "TRUE"
-	}
-
-	result := ""
-	for i, condition := range conditions {
-		if i > 0 {
-			result += " AND "
-		}
-		result += condition
-	}
-
-	return result
+	return "TRUE"
 }

--- a/pkg/probo/audit_service.go
+++ b/pkg/probo/audit_service.go
@@ -39,10 +39,11 @@ type (
 	}
 
 	UpdateAuditRequest struct {
-		ID         gid.GID
-		ValidFrom  *time.Time
-		ValidUntil *time.Time
-		State      *coredata.AuditState
+		ID                gid.GID
+		ValidFrom         *time.Time
+		ValidUntil        *time.Time
+		State             *coredata.AuditState
+		ShowOnTrustCenter *bool
 	}
 
 	UpdateAuditStateRequest struct {
@@ -87,14 +88,15 @@ func (s *AuditService) Create(
 	now := time.Now()
 
 	audit := &coredata.Audit{
-		ID:             gid.New(s.svc.scope.GetTenantID(), coredata.AuditEntityType),
-		OrganizationID: req.OrganizationID,
-		FrameworkID:    req.FrameworkID,
-		ValidFrom:      req.ValidFrom,
-		ValidUntil:     req.ValidUntil,
-		State:          coredata.AuditStateNotStarted,
-		CreatedAt:      now,
-		UpdatedAt:      now,
+		ID:                gid.New(s.svc.scope.GetTenantID(), coredata.AuditEntityType),
+		OrganizationID:    req.OrganizationID,
+		FrameworkID:       req.FrameworkID,
+		ValidFrom:         req.ValidFrom,
+		ValidUntil:        req.ValidUntil,
+		State:             coredata.AuditStateNotStarted,
+		ShowOnTrustCenter: false,
+		CreatedAt:         now,
+		UpdatedAt:         now,
 	}
 
 	if req.State != nil {
@@ -150,6 +152,9 @@ func (s *AuditService) Update(
 			}
 			if req.State != nil {
 				audit.State = *req.State
+			}
+			if req.ShowOnTrustCenter != nil {
+				audit.ShowOnTrustCenter = *req.ShowOnTrustCenter
 			}
 
 			audit.UpdatedAt = time.Now()

--- a/pkg/probo/audit_service.go
+++ b/pkg/probo/audit_service.go
@@ -201,7 +201,8 @@ func (s AuditService) ListForOrganizationID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(conn pg.Conn) error {
-			return audits.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID, cursor)
+			filter := coredata.NewAuditFilter()
+			return audits.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID, cursor, filter)
 		},
 	)
 

--- a/pkg/probo/audit_service.go
+++ b/pkg/probo/audit_service.go
@@ -1,0 +1,325 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package probo
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+	"go.gearno.de/kit/pg"
+)
+
+type AuditService struct {
+	svc *TenantService
+}
+
+type (
+	CreateAuditRequest struct {
+		OrganizationID gid.GID
+		FrameworkID    gid.GID
+		ValidFrom      *time.Time
+		ValidUntil     *time.Time
+		State          *coredata.AuditState
+	}
+
+	UpdateAuditRequest struct {
+		ID         gid.GID
+		ValidFrom  *time.Time
+		ValidUntil *time.Time
+		State      *coredata.AuditState
+	}
+
+	UpdateAuditStateRequest struct {
+		ID    gid.GID
+		State coredata.AuditState
+	}
+
+	UploadAuditReportRequest struct {
+		AuditID gid.GID
+		File    File
+	}
+
+	DeleteAuditReportRequest struct {
+		ID gid.GID
+	}
+)
+
+func (s AuditService) Get(
+	ctx context.Context,
+	auditID gid.GID,
+) (*coredata.Audit, error) {
+	audit := &coredata.Audit{}
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			return audit.LoadByID(ctx, conn, s.svc.scope, auditID)
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return audit, nil
+}
+
+func (s *AuditService) Create(
+	ctx context.Context,
+	req *CreateAuditRequest,
+) (*coredata.Audit, error) {
+	now := time.Now()
+
+	audit := &coredata.Audit{
+		ID:             gid.New(s.svc.scope.GetTenantID(), coredata.AuditEntityType),
+		OrganizationID: req.OrganizationID,
+		FrameworkID:    req.FrameworkID,
+		ValidFrom:      req.ValidFrom,
+		ValidUntil:     req.ValidUntil,
+		State:          coredata.AuditStateNotStarted,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	if req.State != nil {
+		audit.State = *req.State
+	}
+
+	err := s.svc.pg.WithTx(
+		ctx,
+		func(conn pg.Conn) error {
+			organization := &coredata.Organization{}
+			if err := organization.LoadByID(ctx, conn, s.svc.scope, req.OrganizationID); err != nil {
+				return fmt.Errorf("cannot load organization: %w", err)
+			}
+
+			framework := &coredata.Framework{}
+			if err := framework.LoadByID(ctx, conn, s.svc.scope, req.FrameworkID); err != nil {
+				return fmt.Errorf("cannot load framework: %w", err)
+			}
+
+			if err := audit.Insert(ctx, conn, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot insert audit: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return audit, nil
+}
+
+func (s *AuditService) Update(
+	ctx context.Context,
+	req *UpdateAuditRequest,
+) (*coredata.Audit, error) {
+	audit := &coredata.Audit{}
+
+	err := s.svc.pg.WithTx(
+		ctx,
+		func(conn pg.Conn) error {
+			if err := audit.LoadByID(ctx, conn, s.svc.scope, req.ID); err != nil {
+				return fmt.Errorf("cannot load audit: %w", err)
+			}
+
+			if req.ValidFrom != nil {
+				audit.ValidFrom = req.ValidFrom
+			}
+			if req.ValidUntil != nil {
+				audit.ValidUntil = req.ValidUntil
+			}
+			if req.State != nil {
+				audit.State = *req.State
+			}
+
+			audit.UpdatedAt = time.Now()
+
+			if err := audit.Update(ctx, conn, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot update audit: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return audit, nil
+}
+
+func (s AuditService) Delete(
+	ctx context.Context,
+	auditID gid.GID,
+) error {
+	audit := coredata.Audit{ID: auditID}
+	return s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			return audit.Delete(ctx, conn, s.svc.scope)
+		},
+	)
+}
+
+func (s AuditService) ListForOrganizationID(
+	ctx context.Context,
+	organizationID gid.GID,
+	cursor *page.Cursor[coredata.AuditOrderField],
+) (*page.Page[*coredata.Audit, coredata.AuditOrderField], error) {
+	var audits coredata.Audits
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			return audits.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID, cursor)
+		},
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("cannot list audits: %w", err)
+	}
+
+	return page.NewPage(audits, cursor), nil
+}
+
+func (s AuditService) CountForOrganizationID(
+	ctx context.Context,
+	organizationID gid.GID,
+) (int, error) {
+	var count int
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) (err error) {
+			audits := coredata.Audits{}
+			count, err = audits.CountByOrganizationID(ctx, conn, s.svc.scope, organizationID)
+			if err != nil {
+				return fmt.Errorf("cannot count audits: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+func (s AuditService) UploadReport(
+	ctx context.Context,
+	req UploadAuditReportRequest,
+) (*coredata.Audit, error) {
+	audit := &coredata.Audit{}
+
+	err := s.svc.pg.WithTx(
+		ctx,
+		func(conn pg.Conn) error {
+			if err := audit.LoadByID(ctx, conn, s.svc.scope, req.AuditID); err != nil {
+				return fmt.Errorf("cannot load audit: %w", err)
+			}
+
+			report, err := s.svc.Reports.Create(ctx, req.File)
+			if err != nil {
+				return fmt.Errorf("cannot create report: %w", err)
+			}
+
+			audit.ReportID = &report.ID
+			audit.UpdatedAt = time.Now()
+
+			if err := audit.Update(ctx, conn, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot update audit: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return audit, nil
+}
+
+func (s AuditService) GenerateReportURL(
+	ctx context.Context,
+	auditID gid.GID,
+	expiresIn time.Duration,
+) (*string, error) {
+	audit, err := s.Get(ctx, auditID)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get audit: %w", err)
+	}
+
+	if audit.ReportID == nil {
+		return nil, fmt.Errorf("audit has no report")
+	}
+
+	url, err := s.svc.Reports.GenerateDownloadURL(ctx, *audit.ReportID, expiresIn)
+	if err != nil {
+		return nil, fmt.Errorf("cannot generate report download URL: %w", err)
+	}
+
+	return url, nil
+}
+
+func (s AuditService) DeleteReport(
+	ctx context.Context,
+	auditID gid.GID,
+) (*coredata.Audit, error) {
+	audit := &coredata.Audit{}
+
+	err := s.svc.pg.WithTx(
+		ctx,
+		func(conn pg.Conn) error {
+			if err := audit.LoadByID(ctx, conn, s.svc.scope, auditID); err != nil {
+				return fmt.Errorf("cannot load audit: %w", err)
+			}
+
+			if audit.ReportID != nil {
+				if err := s.svc.Reports.Delete(ctx, *audit.ReportID); err != nil {
+					return fmt.Errorf("cannot delete report: %w", err)
+				}
+
+				audit.ReportID = nil
+				audit.UpdatedAt = time.Now()
+
+				if err := audit.Update(ctx, conn, s.svc.scope); err != nil {
+					return fmt.Errorf("cannot update audit: %w", err)
+				}
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return audit, nil
+}

--- a/pkg/probo/audit_service.go
+++ b/pkg/probo/audit_service.go
@@ -177,7 +177,11 @@ func (s AuditService) Delete(
 	return s.svc.pg.WithConn(
 		ctx,
 		func(conn pg.Conn) error {
-			return audit.Delete(ctx, conn, s.svc.scope)
+			err := audit.Delete(ctx, conn, s.svc.scope)
+			if err != nil {
+				return fmt.Errorf("cannot delete audit: %w", err)
+			}
+			return nil
 		},
 	)
 }

--- a/pkg/probo/document_service.go
+++ b/pkg/probo/document_service.go
@@ -297,11 +297,12 @@ func (s *DocumentService) Create(
 	people := &coredata.People{}
 
 	document := &coredata.Document{
-		ID:           documentID,
-		Title:        req.Title,
-		DocumentType: req.DocumentType,
-		CreatedAt:    now,
-		UpdatedAt:    now,
+		ID:                documentID,
+		Title:             req.Title,
+		DocumentType:      req.DocumentType,
+		ShowOnTrustCenter: false,
+		CreatedAt:         now,
+		UpdatedAt:         now,
 	}
 
 	documentVersion := &coredata.DocumentVersion{
@@ -984,6 +985,7 @@ func (s *DocumentService) Update(
 	newOwnerID *gid.GID,
 	documentType *coredata.DocumentType,
 	title *string,
+	showOnTrustCenter *bool,
 ) (*coredata.Document, error) {
 	document := &coredata.Document{}
 	people := &coredata.People{}
@@ -1009,6 +1011,10 @@ func (s *DocumentService) Update(
 
 			if title != nil {
 				document.Title = *title
+			}
+
+			if showOnTrustCenter != nil {
+				document.ShowOnTrustCenter = *showOnTrustCenter
 			}
 
 			document.UpdatedAt = now

--- a/pkg/probo/report_service.go
+++ b/pkg/probo/report_service.go
@@ -46,7 +46,7 @@ func (s ReportService) Get(
 	)
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot get report: %w", err)
 	}
 
 	return report, nil

--- a/pkg/probo/report_service.go
+++ b/pkg/probo/report_service.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package probo
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/gid"
+	"go.gearno.de/crypto/uuid"
+	"go.gearno.de/kit/pg"
+)
+
+type ReportService struct {
+	svc *TenantService
+}
+
+func (s ReportService) Get(
+	ctx context.Context,
+	reportID gid.GID,
+) (*coredata.Report, error) {
+	report := &coredata.Report{}
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			return report.LoadByID(ctx, conn, s.svc.scope, reportID)
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return report, nil
+}
+
+func (s ReportService) Create(
+	ctx context.Context,
+	file File,
+) (*coredata.Report, error) {
+	reportID := gid.New(s.svc.scope.GetTenantID(), coredata.ReportEntityType)
+	now := time.Now()
+
+	uuidVal, _ := uuid.NewV4()
+	objectKey := fmt.Sprintf("reports/%s/%s", reportID, uuidVal.String()+filepath.Ext(file.Filename))
+
+	_, err := s.svc.s3.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      aws.String(s.svc.bucket),
+		Key:         aws.String(objectKey),
+		Body:        file.Content,
+		ContentType: aws.String(file.ContentType),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot upload report to S3: %w", err)
+	}
+
+	report := &coredata.Report{
+		ID:        reportID,
+		ObjectKey: objectKey,
+		MimeType:  file.ContentType,
+		Filename:  file.Filename,
+		Size:      file.Size,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	err = s.svc.pg.WithConn(ctx, func(conn pg.Conn) error {
+		return report.Insert(ctx, conn, s.svc.scope)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot create report: %w", err)
+	}
+
+	return report, nil
+}
+
+func (s ReportService) Delete(
+	ctx context.Context,
+	reportID gid.GID,
+) error {
+	report, err := s.Get(ctx, reportID)
+	if err != nil {
+		return fmt.Errorf("cannot get report: %w", err)
+	}
+
+	_, err = s.svc.s3.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(s.svc.bucket),
+		Key:    aws.String(report.ObjectKey),
+	})
+	if err != nil {
+		return fmt.Errorf("cannot delete report from S3: %w", err)
+	}
+
+	err = s.svc.pg.WithConn(ctx, func(conn pg.Conn) error {
+		return report.Delete(ctx, conn, s.svc.scope)
+	})
+	if err != nil {
+		return fmt.Errorf("cannot delete report: %w", err)
+	}
+
+	return nil
+}
+
+func (s ReportService) GenerateDownloadURL(
+	ctx context.Context,
+	reportID gid.GID,
+	expiresIn time.Duration,
+) (*string, error) {
+	report, err := s.Get(ctx, reportID)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get report: %w", err)
+	}
+
+	presignClient := s3.NewPresignClient(s.svc.s3)
+
+	presignedReq, err := presignClient.PresignGetObject(ctx, &s3.GetObjectInput{
+		Bucket:                     aws.String(s.svc.bucket),
+		Key:                        aws.String(report.ObjectKey),
+		ResponseCacheControl:       aws.String("max-age=3600, public"),
+		ResponseContentType:        aws.String(report.MimeType),
+		ResponseContentDisposition: aws.String(fmt.Sprintf("attachment; filename=\"%s\"", report.Filename)),
+	}, func(opts *s3.PresignOptions) {
+		opts.Expires = expiresIn
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot presign GetObject request: %w", err)
+	}
+
+	return &presignedReq.URL, nil
+}

--- a/pkg/probo/service.go
+++ b/pkg/probo/service.go
@@ -63,6 +63,8 @@ type (
 		Connectors              *ConnectorService
 		Assets                  *AssetService
 		Data                    *DatumService
+		Audits                  *AuditService
+		Reports                 *ReportService
 	}
 )
 
@@ -140,5 +142,7 @@ func (s *Service) WithTenant(tenantID gid.TenantID) *TenantService {
 	tenantService.Connectors = &ConnectorService{svc: tenantService}
 	tenantService.Assets = &AssetService{svc: tenantService}
 	tenantService.Data = &DatumService{svc: tenantService}
+	tenantService.Audits = &AuditService{svc: tenantService}
+	tenantService.Reports = &ReportService{svc: tenantService}
 	return tenantService
 }

--- a/pkg/probo/service.go
+++ b/pkg/probo/service.go
@@ -65,6 +65,7 @@ type (
 		Data                    *DatumService
 		Audits                  *AuditService
 		Reports                 *ReportService
+		TrustCenters            *TrustCenterService
 	}
 )
 
@@ -144,5 +145,6 @@ func (s *Service) WithTenant(tenantID gid.TenantID) *TenantService {
 	tenantService.Data = &DatumService{svc: tenantService}
 	tenantService.Audits = &AuditService{svc: tenantService}
 	tenantService.Reports = &ReportService{svc: tenantService}
+	tenantService.TrustCenters = &TrustCenterService{svc: tenantService}
 	return tenantService
 }

--- a/pkg/probo/trust_center_service.go
+++ b/pkg/probo/trust_center_service.go
@@ -17,27 +17,13 @@ package probo
 import (
 	"context"
 	"fmt"
-	"regexp"
-	"strings"
 	"time"
 
 	"github.com/getprobo/probo/pkg/coredata"
 	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/slug"
 	"go.gearno.de/kit/pg"
 )
-
-var (
-	regSpacesTC      = regexp.MustCompile(`\s+`)
-	regNonAlphanumTC = regexp.MustCompile(`[^a-z0-9_]`)
-)
-
-func makeTrustCenterSlug(name string) string {
-	s := strings.ToLower(name)
-	s = regSpacesTC.ReplaceAllString(s, "_")
-	s = regNonAlphanumTC.ReplaceAllString(s, "")
-	s = strings.Trim(s, "_")
-	return s
-}
 
 type (
 	TrustCenterService struct {
@@ -67,7 +53,7 @@ func (s *TrustCenterService) Create(
 		OrganizationID: req.OrganizationID,
 		TenantID:       req.OrganizationID.TenantID(),
 		Active:         false,
-		Slug:           makeTrustCenterSlug(req.OrganizationName),
+		Slug:           slug.Make(req.OrganizationName),
 		CreatedAt:      now,
 		UpdatedAt:      now,
 	}
@@ -107,7 +93,7 @@ func (s *TrustCenterService) CreateWithConn(
 		OrganizationID: req.OrganizationID,
 		TenantID:       req.OrganizationID.TenantID(),
 		Active:         false,
-		Slug:           makeTrustCenterSlug(req.OrganizationName),
+		Slug:           slug.Make(req.OrganizationName),
 		CreatedAt:      now,
 		UpdatedAt:      now,
 	}

--- a/pkg/probo/trust_center_service.go
+++ b/pkg/probo/trust_center_service.go
@@ -36,26 +36,6 @@ type (
 	}
 )
 
-func (s TrustCenterService) Get(
-	ctx context.Context,
-	trustCenterID gid.GID,
-) (*coredata.TrustCenter, error) {
-	trustCenter := &coredata.TrustCenter{}
-
-	err := s.svc.pg.WithConn(
-		ctx,
-		func(conn pg.Conn) error {
-			return trustCenter.LoadByID(ctx, conn, s.svc.scope, trustCenterID)
-		},
-	)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return trustCenter, nil
-}
-
 func (s TrustCenterService) GetByOrganizationID(
 	ctx context.Context,
 	organizationID gid.GID,
@@ -76,7 +56,7 @@ func (s TrustCenterService) GetByOrganizationID(
 	return trustCenter, nil
 }
 
-func (s *TrustCenterService) Update(
+func (s TrustCenterService) Update(
 	ctx context.Context,
 	req *UpdateTrustCenterRequest,
 ) (*coredata.TrustCenter, error) {

--- a/pkg/probo/trust_center_service.go
+++ b/pkg/probo/trust_center_service.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/getprobo/probo/pkg/coredata"
 	"github.com/getprobo/probo/pkg/gid"
-	"github.com/getprobo/probo/pkg/slug"
 	"go.gearno.de/kit/pg"
 )
 
@@ -41,74 +40,6 @@ type (
 		Slug   *string
 	}
 )
-
-func (s *TrustCenterService) Create(
-	ctx context.Context,
-	req *CreateTrustCenterRequest,
-) (*coredata.TrustCenter, error) {
-	now := time.Now()
-
-	trustCenter := &coredata.TrustCenter{
-		ID:             gid.New(s.svc.scope.GetTenantID(), coredata.TrustCenterEntityType),
-		OrganizationID: req.OrganizationID,
-		TenantID:       req.OrganizationID.TenantID(),
-		Active:         false,
-		Slug:           slug.Make(req.OrganizationName),
-		CreatedAt:      now,
-		UpdatedAt:      now,
-	}
-
-	err := s.svc.pg.WithTx(
-		ctx,
-		func(conn pg.Conn) error {
-			organization := &coredata.Organization{}
-			if err := organization.LoadByID(ctx, conn, s.svc.scope, req.OrganizationID); err != nil {
-				return fmt.Errorf("cannot load organization: %w", err)
-			}
-
-			if err := trustCenter.Insert(ctx, conn, s.svc.scope); err != nil {
-				return fmt.Errorf("cannot insert trust center: %w", err)
-			}
-
-			return nil
-		},
-	)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return trustCenter, nil
-}
-
-func (s *TrustCenterService) CreateWithConn(
-	ctx context.Context,
-	conn pg.Conn,
-	req *CreateTrustCenterRequest,
-) (*coredata.TrustCenter, error) {
-	now := time.Now()
-
-	trustCenter := &coredata.TrustCenter{
-		ID:             gid.New(s.svc.scope.GetTenantID(), coredata.TrustCenterEntityType),
-		OrganizationID: req.OrganizationID,
-		TenantID:       req.OrganizationID.TenantID(),
-		Active:         false,
-		Slug:           slug.Make(req.OrganizationName),
-		CreatedAt:      now,
-		UpdatedAt:      now,
-	}
-
-	organization := &coredata.Organization{}
-	if err := organization.LoadByID(ctx, conn, s.svc.scope, req.OrganizationID); err != nil {
-		return nil, fmt.Errorf("cannot load organization: %w", err)
-	}
-
-	if err := trustCenter.Insert(ctx, conn, s.svc.scope); err != nil {
-		return nil, fmt.Errorf("cannot insert trust center: %w", err)
-	}
-
-	return trustCenter, nil
-}
 
 func (s TrustCenterService) Get(
 	ctx context.Context,

--- a/pkg/probo/trust_center_service.go
+++ b/pkg/probo/trust_center_service.go
@@ -29,11 +29,6 @@ type (
 		svc *TenantService
 	}
 
-	CreateTrustCenterRequest struct {
-		OrganizationID   gid.GID
-		OrganizationName string
-	}
-
 	UpdateTrustCenterRequest struct {
 		ID     gid.GID
 		Active *bool

--- a/pkg/probo/trust_center_service.go
+++ b/pkg/probo/trust_center_service.go
@@ -1,0 +1,202 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package probo
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/gid"
+	"go.gearno.de/kit/pg"
+)
+
+var (
+	regSpacesTC      = regexp.MustCompile(`\s+`)
+	regNonAlphanumTC = regexp.MustCompile(`[^a-z0-9_]`)
+)
+
+func makeTrustCenterSlug(name string) string {
+	s := strings.ToLower(name)
+	s = regSpacesTC.ReplaceAllString(s, "_")
+	s = regNonAlphanumTC.ReplaceAllString(s, "")
+	s = strings.Trim(s, "_")
+	return s
+}
+
+type (
+	TrustCenterService struct {
+		svc *TenantService
+	}
+
+	CreateTrustCenterRequest struct {
+		OrganizationID   gid.GID
+		OrganizationName string
+	}
+
+	UpdateTrustCenterRequest struct {
+		ID     gid.GID
+		Active *bool
+		Slug   *string
+	}
+)
+
+func (s *TrustCenterService) Create(
+	ctx context.Context,
+	req *CreateTrustCenterRequest,
+) (*coredata.TrustCenter, error) {
+	now := time.Now()
+
+	trustCenter := &coredata.TrustCenter{
+		ID:             gid.New(s.svc.scope.GetTenantID(), coredata.TrustCenterEntityType),
+		OrganizationID: req.OrganizationID,
+		TenantID:       req.OrganizationID.TenantID(),
+		Active:         false,
+		Slug:           makeTrustCenterSlug(req.OrganizationName),
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	err := s.svc.pg.WithTx(
+		ctx,
+		func(conn pg.Conn) error {
+			organization := &coredata.Organization{}
+			if err := organization.LoadByID(ctx, conn, s.svc.scope, req.OrganizationID); err != nil {
+				return fmt.Errorf("cannot load organization: %w", err)
+			}
+
+			if err := trustCenter.Insert(ctx, conn, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot insert trust center: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return trustCenter, nil
+}
+
+func (s *TrustCenterService) CreateWithConn(
+	ctx context.Context,
+	conn pg.Conn,
+	req *CreateTrustCenterRequest,
+) (*coredata.TrustCenter, error) {
+	now := time.Now()
+
+	trustCenter := &coredata.TrustCenter{
+		ID:             gid.New(s.svc.scope.GetTenantID(), coredata.TrustCenterEntityType),
+		OrganizationID: req.OrganizationID,
+		TenantID:       req.OrganizationID.TenantID(),
+		Active:         false,
+		Slug:           makeTrustCenterSlug(req.OrganizationName),
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	organization := &coredata.Organization{}
+	if err := organization.LoadByID(ctx, conn, s.svc.scope, req.OrganizationID); err != nil {
+		return nil, fmt.Errorf("cannot load organization: %w", err)
+	}
+
+	if err := trustCenter.Insert(ctx, conn, s.svc.scope); err != nil {
+		return nil, fmt.Errorf("cannot insert trust center: %w", err)
+	}
+
+	return trustCenter, nil
+}
+
+func (s TrustCenterService) Get(
+	ctx context.Context,
+	trustCenterID gid.GID,
+) (*coredata.TrustCenter, error) {
+	trustCenter := &coredata.TrustCenter{}
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			return trustCenter.LoadByID(ctx, conn, s.svc.scope, trustCenterID)
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return trustCenter, nil
+}
+
+func (s TrustCenterService) GetByOrganizationID(
+	ctx context.Context,
+	organizationID gid.GID,
+) (*coredata.TrustCenter, error) {
+	trustCenter := &coredata.TrustCenter{}
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			return trustCenter.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID)
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return trustCenter, nil
+}
+
+func (s *TrustCenterService) Update(
+	ctx context.Context,
+	req *UpdateTrustCenterRequest,
+) (*coredata.TrustCenter, error) {
+	trustCenter := &coredata.TrustCenter{}
+
+	err := s.svc.pg.WithTx(
+		ctx,
+		func(conn pg.Conn) error {
+			if err := trustCenter.LoadByID(ctx, conn, s.svc.scope, req.ID); err != nil {
+				return fmt.Errorf("cannot load trust center: %w", err)
+			}
+
+			if req.Active != nil {
+				trustCenter.Active = *req.Active
+			}
+			if req.Slug != nil {
+				trustCenter.Slug = *req.Slug
+			}
+
+			trustCenter.UpdatedAt = time.Now()
+
+			if err := trustCenter.Update(ctx, conn, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot update trust center: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return trustCenter, nil
+}

--- a/pkg/probo/vendor_service.go
+++ b/pkg/probo/vendor_service.go
@@ -72,6 +72,7 @@ type (
 		StatusPageURL                 *string
 		BusinessOwnerID               *gid.GID
 		SecurityOwnerID               *gid.GID
+		ShowOnTrustCenter             *bool
 	}
 
 	AssessVendorRequest struct {
@@ -259,6 +260,10 @@ func (s VendorService) Update(
 				vendor.SecurityPageURL = req.SecurityPageURL
 			}
 
+			if req.ShowOnTrustCenter != nil {
+				vendor.ShowOnTrustCenter = *req.ShowOnTrustCenter
+			}
+
 			if req.TrustPageURL != nil {
 				vendor.TrustPageURL = req.TrustPageURL
 			}
@@ -385,6 +390,7 @@ func (s VendorService) Create(
 		TrustPageURL:                  req.TrustPageURL,
 		StatusPageURL:                 req.StatusPageURL,
 		TermsOfServiceURL:             req.TermsOfServiceURL,
+		ShowOnTrustCenter:             false,
 	}
 
 	err := s.svc.pg.WithTx(

--- a/pkg/probo/vendor_service.go
+++ b/pkg/probo/vendor_service.go
@@ -131,12 +131,14 @@ func (s VendorService) ListForOrganizationID(
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
+			filter := coredata.NewVendorFilter()
 			return vendors.LoadByOrganizationID(
 				ctx,
 				conn,
 				s.svc.scope,
 				organization.ID,
 				cursor,
+				filter,
 			)
 		},
 	)

--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -36,6 +36,7 @@ import (
 	"github.com/getprobo/probo/pkg/saferedirect"
 	"github.com/getprobo/probo/pkg/server"
 	console_v1 "github.com/getprobo/probo/pkg/server/api/console/v1"
+	"github.com/getprobo/probo/pkg/trust"
 	"github.com/getprobo/probo/pkg/usrmgr"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.gearno.de/kit/httpclient"
@@ -231,12 +232,18 @@ func (impl *Implm) Run(
 		return fmt.Errorf("cannot create probo service: %w", err)
 	}
 
+	trustService := trust.NewService(
+		pgClient,
+		impl.cfg.AWS.Bucket,
+	)
+
 	serverHandler, err := server.NewServer(
 		server.Config{
 			AllowedOrigins:    impl.cfg.Api.Cors.AllowedOrigins,
 			ExtraHeaderFields: impl.cfg.Api.ExtraHeaderFields,
 			Probo:             proboService,
 			Usrmgr:            usrmgrService,
+			Trust:             trustService,
 			ConnectorRegistry: defaultConnectorRegistry,
 			Agent:             agent,
 			SafeRedirect:      &saferedirect.SafeRedirect{AllowedHost: impl.cfg.Hostname},

--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -22,6 +22,7 @@ import (
 	"github.com/getprobo/probo/pkg/probo"
 	"github.com/getprobo/probo/pkg/saferedirect"
 	console_v1 "github.com/getprobo/probo/pkg/server/api/console/v1"
+	"github.com/getprobo/probo/pkg/trust"
 	"github.com/getprobo/probo/pkg/usrmgr"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/cors"
@@ -34,6 +35,7 @@ type (
 		AllowedOrigins    []string
 		Probo             *probo.Service
 		Usrmgr            *usrmgr.Service
+		Trust             *trust.Service
 		Auth              console_v1.AuthConfig
 		ConnectorRegistry *connector.ConnectorRegistry
 		SafeRedirect      *saferedirect.SafeRedirect
@@ -122,6 +124,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			s.cfg.Logger.Named("console.v1"),
 			s.cfg.Probo,
 			s.cfg.Usrmgr,
+			s.cfg.Trust,
 			s.cfg.Auth,
 			s.cfg.ConnectorRegistry,
 			s.cfg.SafeRedirect,

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -703,6 +703,14 @@ input RiskFilter {
 }
 
 # Core Types
+type TrustCenter implements Node {
+  id: ID!
+  active: Boolean!
+  slug: String!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+}
+
 type Organization implements Node {
   id: ID!
   name: String!
@@ -816,6 +824,8 @@ type Organization implements Node {
     orderBy: AuditOrder
   ): AuditConnection! @goField(forceResolver: true)
 
+  trustCenter: TrustCenter @goField(forceResolver: true)
+
   createdAt: Datetime!
   updatedAt: Datetime!
 }
@@ -891,6 +901,7 @@ type Vendor implements Node {
   headquarterAddress: String
   legalName: String
   websiteUrl: String
+  showOnTrustCenter: Boolean!
   createdAt: Datetime!
   updatedAt: Datetime!
 }
@@ -1052,6 +1063,7 @@ type Document implements Node {
   description: String!
   documentType: DocumentType!
   currentPublishedVersion: Int
+  showOnTrustCenter: Boolean!
   owner: People! @goField(forceResolver: true)
   organization: Organization! @goField(forceResolver: true)
 
@@ -1134,6 +1146,7 @@ type Audit implements Node {
   report: Report @goField(forceResolver: true)
   reportUrl: String @goField(forceResolver: true)
   state: AuditState!
+  showOnTrustCenter: Boolean!
   createdAt: Datetime!
   updatedAt: Datetime!
 }
@@ -1397,6 +1410,10 @@ type Mutation {
     input: UpdateOrganizationInput!
   ): UpdateOrganizationPayload!
 
+  updateTrustCenter(
+    input: UpdateTrustCenterInput!
+  ): UpdateTrustCenterPayload!
+
   # User mutations
   confirmEmail(input: ConfirmEmailInput!): ConfirmEmailPayload!
   inviteUser(input: InviteUserInput!): InviteUserPayload!
@@ -1563,6 +1580,12 @@ input UpdateOrganizationInput {
   logo: Upload
 }
 
+input UpdateTrustCenterInput {
+  trustCenterId: ID!
+  active: Boolean
+  slug: String
+}
+
 input CreateVendorInput {
   organizationId: ID!
   name: String!
@@ -1605,6 +1628,7 @@ input UpdateVendorInput {
   trustPageUrl: String
   businessOwnerId: ID
   securityOwnerId: ID
+  showOnTrustCenter: Boolean
 }
 
 input DeleteVendorInput {
@@ -1836,6 +1860,7 @@ input UpdateDocumentInput {
   ownerId: ID
   createdBy: ID
   documentType: DocumentType
+  showOnTrustCenter: Boolean
 }
 
 input ExportDocumentVersionPDFInput {
@@ -1897,6 +1922,7 @@ input UpdateAuditInput {
   validFrom: Datetime
   validUntil: Datetime
   state: AuditState
+  showOnTrustCenter: Boolean
 }
 
 input DeleteAuditInput {
@@ -1919,6 +1945,10 @@ type CreateOrganizationPayload {
 
 type UpdateOrganizationPayload {
   organization: Organization!
+}
+
+type UpdateTrustCenterPayload {
+  trustCenter: TrustCenter!
 }
 
 type CreateControlPayload {

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -127,6 +127,30 @@ enum RiskTreatment
     )
 }
 
+enum AuditState
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.AuditState") {
+  NOT_STARTED
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.AuditStateNotStarted"
+    )
+  IN_PROGRESS
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.AuditStateInProgress"
+    )
+  COMPLETED
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.AuditStateCompleted"
+    )
+  REJECTED
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.AuditStateRejected"
+    )
+  OUTDATED
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.AuditStateOutdated"
+    )
+}
+
 # Order Field Enums
 enum UserOrderField
   @goModel(model: "github.com/getprobo/probo/pkg/coredata.UserOrderField") {
@@ -521,6 +545,27 @@ enum ControlStatus
       value: "github.com/getprobo/probo/pkg/coredata.ControlStatusExcluded"
     )
 }
+
+enum AuditOrderField
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.AuditOrderField") {
+  CREATED_AT
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.AuditOrderFieldCreatedAt"
+    )
+  VALID_FROM
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.AuditOrderFieldValidFrom"
+    )
+  VALID_UNTIL
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.AuditOrderFieldValidUntil"
+    )
+  STATE
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.AuditOrderFieldState"
+    )
+}
+
 # Input Types
 input UserOrder
   @goModel(
@@ -592,6 +637,14 @@ input RiskOrder
   ) {
   direction: OrderDirection!
   field: RiskOrderField!
+}
+
+input AuditOrder
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.AuditOrderBy"
+  ) {
+  direction: OrderDirection!
+  field: AuditOrderField!
 }
 
 input EvidenceOrder
@@ -754,6 +807,14 @@ type Organization implements Node {
     before: CursorKey
     orderBy: DatumOrder
   ): DatumConnection! @goField(forceResolver: true)
+
+  audits(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+    orderBy: AuditOrder
+  ): AuditConnection! @goField(forceResolver: true)
 
   createdAt: Datetime!
   updatedAt: Datetime!
@@ -1064,6 +1125,30 @@ type Risk implements Node {
   updatedAt: Datetime!
 }
 
+type Audit implements Node {
+  id: ID!
+  organization: Organization! @goField(forceResolver: true)
+  framework: Framework! @goField(forceResolver: true)
+  validFrom: Datetime
+  validUntil: Datetime
+  report: Report @goField(forceResolver: true)
+  reportUrl: String @goField(forceResolver: true)
+  state: AuditState!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+}
+
+type Report implements Node {
+  id: ID!
+  objectKey: String!
+  mimeType: String!
+  filename: String!
+  size: Int!
+  downloadUrl: String @goField(forceResolver: true)
+  createdAt: Datetime!
+  updatedAt: Datetime!
+}
+
 type Session {
   id: ID!
   expiresAt: Datetime!
@@ -1283,6 +1368,20 @@ type DatumEdge {
   node: Datum!
 }
 
+type AuditConnection
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.AuditConnection"
+  ) {
+  totalCount: Int! @goField(forceResolver: true)
+  edges: [AuditEdge!]!
+  pageInfo: PageInfo!
+}
+
+type AuditEdge {
+  cursor: CursorKey!
+  node: Audit!
+}
+
 # Root Types
 type Query {
   node(id: ID!): Node!
@@ -1437,6 +1536,12 @@ type Mutation {
   createDatum(input: CreateDatumInput!): CreateDatumPayload!
   updateDatum(input: UpdateDatumInput!): UpdateDatumPayload!
   deleteDatum(input: DeleteDatumInput!): DeleteDatumPayload!
+
+  createAudit(input: CreateAuditInput!): CreateAuditPayload!
+  updateAudit(input: UpdateAuditInput!): UpdateAuditPayload!
+  deleteAudit(input: DeleteAuditInput!): DeleteAuditPayload!
+  uploadAuditReport(input: UploadAuditReportInput!): UploadAuditReportPayload!
+  deleteAuditReport(input: DeleteAuditReportInput!): DeleteAuditReportPayload!
 }
 
 # Input Types
@@ -1776,6 +1881,35 @@ input UpdateControlInput {
 
 input DeleteControlInput {
   controlId: ID!
+}
+
+# Audit input types
+input CreateAuditInput {
+  organizationId: ID!
+  frameworkId: ID!
+  validFrom: Datetime
+  validUntil: Datetime
+  state: AuditState
+}
+
+input UpdateAuditInput {
+  id: ID!
+  validFrom: Datetime
+  validUntil: Datetime
+  state: AuditState
+}
+
+input DeleteAuditInput {
+  auditId: ID!
+}
+
+input UploadAuditReportInput {
+  auditId: ID!
+  file: Upload!
+}
+
+input DeleteAuditReportInput {
+  auditId: ID!
 }
 
 # Payload Types
@@ -2353,4 +2487,24 @@ type UpdateDatumPayload {
 
 type DeleteDatumPayload {
   deletedDatumId: ID!
+}
+
+type CreateAuditPayload {
+  auditEdge: AuditEdge!
+}
+
+type UpdateAuditPayload {
+  audit: Audit!
+}
+
+type DeleteAuditPayload {
+  deletedAuditId: ID!
+}
+
+type UploadAuditReportPayload {
+  audit: Audit!
+}
+
+type DeleteAuditReportPayload {
+  audit: Audit!
 }

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -702,6 +702,14 @@ input RiskFilter {
   query: String
 }
 
+input OrganizationFilter {
+  trustCenterSlug: String
+}
+
+input TrustCenterFilter {
+  slug: String
+}
+
 # Core Types
 type TrustCenter implements Node {
   id: ID!
@@ -709,6 +717,31 @@ type TrustCenter implements Node {
   slug: String!
   createdAt: Datetime!
   updatedAt: Datetime!
+  organization: Organization! @goField(forceResolver: true)
+
+  publicDocuments(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+    orderBy: DocumentOrder
+  ): DocumentConnection! @goField(forceResolver: true)
+
+  publicAudits(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+    orderBy: AuditOrder
+  ): AuditConnection! @goField(forceResolver: true)
+
+  publicVendors(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+    orderBy: VendorOrder
+  ): VendorConnection! @goField(forceResolver: true)
 }
 
 type Organization implements Node {
@@ -1177,6 +1210,7 @@ type Viewer {
     last: Int
     before: CursorKey
     orderBy: OrganizationOrder
+    filter: OrganizationFilter
   ): OrganizationConnection! @goField(forceResolver: true)
 }
 
@@ -1189,6 +1223,16 @@ type OrganizationConnection {
 type OrganizationEdge {
   cursor: CursorKey!
   node: Organization!
+}
+
+type TrustCenterConnection {
+  edges: [TrustCenterEdge!]!
+  pageInfo: PageInfo!
+}
+
+type TrustCenterEdge {
+  cursor: CursorKey!
+  node: TrustCenter!
 }
 
 type UserConnection {
@@ -1399,6 +1443,14 @@ type AuditEdge {
 type Query {
   node(id: ID!): Node!
   viewer: Viewer!
+  trustCenters(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+    filter: TrustCenterFilter
+  ): TrustCenterConnection! @goField(forceResolver: true)
+  trustCenterBySlug(slug: String!): TrustCenter @goField(forceResolver: true)
 }
 
 type Mutation {

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -44,6 +44,8 @@ type Config struct {
 type ResolverRoot interface {
 	Asset() AssetResolver
 	AssetConnection() AssetConnectionResolver
+	Audit() AuditResolver
+	AuditConnection() AuditConnectionResolver
 	Control() ControlResolver
 	ControlConnection() ControlConnectionResolver
 	Datum() DatumResolver
@@ -62,6 +64,7 @@ type ResolverRoot interface {
 	Organization() OrganizationResolver
 	PeopleConnection() PeopleConnectionResolver
 	Query() QueryResolver
+	Report() ReportResolver
 	Risk() RiskResolver
 	RiskConnection() RiskConnectionResolver
 	Task() TaskResolver
@@ -109,6 +112,30 @@ type ComplexityRoot struct {
 
 	AssignTaskPayload struct {
 		Task func(childComplexity int) int
+	}
+
+	Audit struct {
+		CreatedAt    func(childComplexity int) int
+		Framework    func(childComplexity int) int
+		ID           func(childComplexity int) int
+		Organization func(childComplexity int) int
+		Report       func(childComplexity int) int
+		ReportURL    func(childComplexity int) int
+		State        func(childComplexity int) int
+		UpdatedAt    func(childComplexity int) int
+		ValidFrom    func(childComplexity int) int
+		ValidUntil   func(childComplexity int) int
+	}
+
+	AuditConnection struct {
+		Edges      func(childComplexity int) int
+		PageInfo   func(childComplexity int) int
+		TotalCount func(childComplexity int) int
+	}
+
+	AuditEdge struct {
+		Cursor func(childComplexity int) int
+		Node   func(childComplexity int) int
 	}
 
 	BulkPublishDocumentVersionsPayload struct {
@@ -173,6 +200,10 @@ type ComplexityRoot struct {
 
 	CreateAssetPayload struct {
 		AssetEdge func(childComplexity int) int
+	}
+
+	CreateAuditPayload struct {
+		AuditEdge func(childComplexity int) int
 	}
 
 	CreateControlDocumentMappingPayload struct {
@@ -272,6 +303,14 @@ type ComplexityRoot struct {
 
 	DeleteAssetPayload struct {
 		DeletedAssetID func(childComplexity int) int
+	}
+
+	DeleteAuditPayload struct {
+		DeletedAuditID func(childComplexity int) int
+	}
+
+	DeleteAuditReportPayload struct {
+		Audit func(childComplexity int) int
 	}
 
 	DeleteControlDocumentMappingPayload struct {
@@ -520,6 +559,7 @@ type ComplexityRoot struct {
 		CancelSignatureRequest                func(childComplexity int, input types.CancelSignatureRequestInput) int
 		ConfirmEmail                          func(childComplexity int, input types.ConfirmEmailInput) int
 		CreateAsset                           func(childComplexity int, input types.CreateAssetInput) int
+		CreateAudit                           func(childComplexity int, input types.CreateAuditInput) int
 		CreateControl                         func(childComplexity int, input types.CreateControlInput) int
 		CreateControlDocumentMapping          func(childComplexity int, input types.CreateControlDocumentMappingInput) int
 		CreateControlMeasureMapping           func(childComplexity int, input types.CreateControlMeasureMappingInput) int
@@ -537,6 +577,8 @@ type ComplexityRoot struct {
 		CreateVendor                          func(childComplexity int, input types.CreateVendorInput) int
 		CreateVendorRiskAssessment            func(childComplexity int, input types.CreateVendorRiskAssessmentInput) int
 		DeleteAsset                           func(childComplexity int, input types.DeleteAssetInput) int
+		DeleteAudit                           func(childComplexity int, input types.DeleteAuditInput) int
+		DeleteAuditReport                     func(childComplexity int, input types.DeleteAuditReportInput) int
 		DeleteControl                         func(childComplexity int, input types.DeleteControlInput) int
 		DeleteControlDocumentMapping          func(childComplexity int, input types.DeleteControlDocumentMappingInput) int
 		DeleteControlMeasureMapping           func(childComplexity int, input types.DeleteControlMeasureMappingInput) int
@@ -566,6 +608,7 @@ type ComplexityRoot struct {
 		SendSigningNotifications              func(childComplexity int, input types.SendSigningNotificationsInput) int
 		UnassignTask                          func(childComplexity int, input types.UnassignTaskInput) int
 		UpdateAsset                           func(childComplexity int, input types.UpdateAssetInput) int
+		UpdateAudit                           func(childComplexity int, input types.UpdateAuditInput) int
 		UpdateControl                         func(childComplexity int, input types.UpdateControlInput) int
 		UpdateDatum                           func(childComplexity int, input types.UpdateDatumInput) int
 		UpdateDocument                        func(childComplexity int, input types.UpdateDocumentInput) int
@@ -577,6 +620,7 @@ type ComplexityRoot struct {
 		UpdateRisk                            func(childComplexity int, input types.UpdateRiskInput) int
 		UpdateTask                            func(childComplexity int, input types.UpdateTaskInput) int
 		UpdateVendor                          func(childComplexity int, input types.UpdateVendorInput) int
+		UploadAuditReport                     func(childComplexity int, input types.UploadAuditReportInput) int
 		UploadMeasureEvidence                 func(childComplexity int, input types.UploadMeasureEvidenceInput) int
 		UploadTaskEvidence                    func(childComplexity int, input types.UploadTaskEvidenceInput) int
 		UploadVendorComplianceReport          func(childComplexity int, input types.UploadVendorComplianceReportInput) int
@@ -584,6 +628,7 @@ type ComplexityRoot struct {
 
 	Organization struct {
 		Assets     func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AssetOrderBy) int
+		Audits     func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AuditOrderBy) int
 		Connectors func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ConnectorOrder) int
 		Controls   func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ControlOrderBy, filter *types.ControlFilter) int
 		CreatedAt  func(childComplexity int) int
@@ -655,6 +700,17 @@ type ComplexityRoot struct {
 
 	RemoveUserPayload struct {
 		Success func(childComplexity int) int
+	}
+
+	Report struct {
+		CreatedAt   func(childComplexity int) int
+		DownloadURL func(childComplexity int) int
+		Filename    func(childComplexity int) int
+		ID          func(childComplexity int) int
+		MimeType    func(childComplexity int) int
+		ObjectKey   func(childComplexity int) int
+		Size        func(childComplexity int) int
+		UpdatedAt   func(childComplexity int) int
 	}
 
 	RequestEvidencePayload struct {
@@ -741,6 +797,10 @@ type ComplexityRoot struct {
 		Asset func(childComplexity int) int
 	}
 
+	UpdateAuditPayload struct {
+		Audit func(childComplexity int) int
+	}
+
 	UpdateControlPayload struct {
 		Control func(childComplexity int) int
 	}
@@ -783,6 +843,10 @@ type ComplexityRoot struct {
 
 	UpdateVendorPayload struct {
 		Vendor func(childComplexity int) int
+	}
+
+	UploadAuditReportPayload struct {
+		Audit func(childComplexity int) int
 	}
 
 	UploadMeasureEvidencePayload struct {
@@ -917,6 +981,16 @@ type AssetResolver interface {
 type AssetConnectionResolver interface {
 	TotalCount(ctx context.Context, obj *types.AssetConnection) (int, error)
 }
+type AuditResolver interface {
+	Organization(ctx context.Context, obj *types.Audit) (*types.Organization, error)
+	Framework(ctx context.Context, obj *types.Audit) (*types.Framework, error)
+
+	Report(ctx context.Context, obj *types.Audit) (*types.Report, error)
+	ReportURL(ctx context.Context, obj *types.Audit) (*string, error)
+}
+type AuditConnectionResolver interface {
+	TotalCount(ctx context.Context, obj *types.AuditConnection) (int, error)
+}
 type ControlResolver interface {
 	Framework(ctx context.Context, obj *types.Control) (*types.Framework, error)
 	Measures(ctx context.Context, obj *types.Control, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy, filter *types.MeasureFilter) (*types.MeasureConnection, error)
@@ -1049,6 +1123,11 @@ type MutationResolver interface {
 	CreateDatum(ctx context.Context, input types.CreateDatumInput) (*types.CreateDatumPayload, error)
 	UpdateDatum(ctx context.Context, input types.UpdateDatumInput) (*types.UpdateDatumPayload, error)
 	DeleteDatum(ctx context.Context, input types.DeleteDatumInput) (*types.DeleteDatumPayload, error)
+	CreateAudit(ctx context.Context, input types.CreateAuditInput) (*types.CreateAuditPayload, error)
+	UpdateAudit(ctx context.Context, input types.UpdateAuditInput) (*types.UpdateAuditPayload, error)
+	DeleteAudit(ctx context.Context, input types.DeleteAuditInput) (*types.DeleteAuditPayload, error)
+	UploadAuditReport(ctx context.Context, input types.UploadAuditReportInput) (*types.UploadAuditReportPayload, error)
+	DeleteAuditReport(ctx context.Context, input types.DeleteAuditReportInput) (*types.DeleteAuditReportPayload, error)
 }
 type OrganizationResolver interface {
 	LogoURL(ctx context.Context, obj *types.Organization) (*string, error)
@@ -1064,6 +1143,7 @@ type OrganizationResolver interface {
 	Tasks(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TaskOrderBy) (*types.TaskConnection, error)
 	Assets(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AssetOrderBy) (*types.AssetConnection, error)
 	Data(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DatumOrderBy) (*types.DatumConnection, error)
+	Audits(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AuditOrderBy) (*types.AuditConnection, error)
 }
 type PeopleConnectionResolver interface {
 	TotalCount(ctx context.Context, obj *types.PeopleConnection) (int, error)
@@ -1071,6 +1151,9 @@ type PeopleConnectionResolver interface {
 type QueryResolver interface {
 	Node(ctx context.Context, id gid.GID) (types.Node, error)
 	Viewer(ctx context.Context) (*types.Viewer, error)
+}
+type ReportResolver interface {
+	DownloadURL(ctx context.Context, obj *types.Report) (*string, error)
 }
 type RiskResolver interface {
 	Owner(ctx context.Context, obj *types.Risk) (*types.People, error)
@@ -1267,6 +1350,111 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.AssignTaskPayload.Task(childComplexity), true
+
+	case "Audit.createdAt":
+		if e.complexity.Audit.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.Audit.CreatedAt(childComplexity), true
+
+	case "Audit.framework":
+		if e.complexity.Audit.Framework == nil {
+			break
+		}
+
+		return e.complexity.Audit.Framework(childComplexity), true
+
+	case "Audit.id":
+		if e.complexity.Audit.ID == nil {
+			break
+		}
+
+		return e.complexity.Audit.ID(childComplexity), true
+
+	case "Audit.organization":
+		if e.complexity.Audit.Organization == nil {
+			break
+		}
+
+		return e.complexity.Audit.Organization(childComplexity), true
+
+	case "Audit.report":
+		if e.complexity.Audit.Report == nil {
+			break
+		}
+
+		return e.complexity.Audit.Report(childComplexity), true
+
+	case "Audit.reportUrl":
+		if e.complexity.Audit.ReportURL == nil {
+			break
+		}
+
+		return e.complexity.Audit.ReportURL(childComplexity), true
+
+	case "Audit.state":
+		if e.complexity.Audit.State == nil {
+			break
+		}
+
+		return e.complexity.Audit.State(childComplexity), true
+
+	case "Audit.updatedAt":
+		if e.complexity.Audit.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.Audit.UpdatedAt(childComplexity), true
+
+	case "Audit.validFrom":
+		if e.complexity.Audit.ValidFrom == nil {
+			break
+		}
+
+		return e.complexity.Audit.ValidFrom(childComplexity), true
+
+	case "Audit.validUntil":
+		if e.complexity.Audit.ValidUntil == nil {
+			break
+		}
+
+		return e.complexity.Audit.ValidUntil(childComplexity), true
+
+	case "AuditConnection.edges":
+		if e.complexity.AuditConnection.Edges == nil {
+			break
+		}
+
+		return e.complexity.AuditConnection.Edges(childComplexity), true
+
+	case "AuditConnection.pageInfo":
+		if e.complexity.AuditConnection.PageInfo == nil {
+			break
+		}
+
+		return e.complexity.AuditConnection.PageInfo(childComplexity), true
+
+	case "AuditConnection.totalCount":
+		if e.complexity.AuditConnection.TotalCount == nil {
+			break
+		}
+
+		return e.complexity.AuditConnection.TotalCount(childComplexity), true
+
+	case "AuditEdge.cursor":
+		if e.complexity.AuditEdge.Cursor == nil {
+			break
+		}
+
+		return e.complexity.AuditEdge.Cursor(childComplexity), true
+
+	case "AuditEdge.node":
+		if e.complexity.AuditEdge.Node == nil {
+			break
+		}
+
+		return e.complexity.AuditEdge.Node(childComplexity), true
 
 	case "BulkPublishDocumentVersionsPayload.documentEdges":
 		if e.complexity.BulkPublishDocumentVersionsPayload.DocumentEdges == nil {
@@ -1494,6 +1682,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.CreateAssetPayload.AssetEdge(childComplexity), true
+
+	case "CreateAuditPayload.auditEdge":
+		if e.complexity.CreateAuditPayload.AuditEdge == nil {
+			break
+		}
+
+		return e.complexity.CreateAuditPayload.AuditEdge(childComplexity), true
 
 	case "CreateControlDocumentMappingPayload.controlEdge":
 		if e.complexity.CreateControlDocumentMappingPayload.ControlEdge == nil {
@@ -1751,6 +1946,20 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.DeleteAssetPayload.DeletedAssetID(childComplexity), true
+
+	case "DeleteAuditPayload.deletedAuditId":
+		if e.complexity.DeleteAuditPayload.DeletedAuditID == nil {
+			break
+		}
+
+		return e.complexity.DeleteAuditPayload.DeletedAuditID(childComplexity), true
+
+	case "DeleteAuditReportPayload.audit":
+		if e.complexity.DeleteAuditReportPayload.Audit == nil {
+			break
+		}
+
+		return e.complexity.DeleteAuditReportPayload.Audit(childComplexity), true
 
 	case "DeleteControlDocumentMappingPayload.deletedControlId":
 		if e.complexity.DeleteControlDocumentMappingPayload.DeletedControlID == nil {
@@ -2702,6 +2911,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.CreateAsset(childComplexity, args["input"].(types.CreateAssetInput)), true
 
+	case "Mutation.createAudit":
+		if e.complexity.Mutation.CreateAudit == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_createAudit_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreateAudit(childComplexity, args["input"].(types.CreateAuditInput)), true
+
 	case "Mutation.createControl":
 		if e.complexity.Mutation.CreateControl == nil {
 			break
@@ -2905,6 +3126,30 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.DeleteAsset(childComplexity, args["input"].(types.DeleteAssetInput)), true
+
+	case "Mutation.deleteAudit":
+		if e.complexity.Mutation.DeleteAudit == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_deleteAudit_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteAudit(childComplexity, args["input"].(types.DeleteAuditInput)), true
+
+	case "Mutation.deleteAuditReport":
+		if e.complexity.Mutation.DeleteAuditReport == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_deleteAuditReport_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteAuditReport(childComplexity, args["input"].(types.DeleteAuditReportInput)), true
 
 	case "Mutation.deleteControl":
 		if e.complexity.Mutation.DeleteControl == nil {
@@ -3254,6 +3499,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.UpdateAsset(childComplexity, args["input"].(types.UpdateAssetInput)), true
 
+	case "Mutation.updateAudit":
+		if e.complexity.Mutation.UpdateAudit == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_updateAudit_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UpdateAudit(childComplexity, args["input"].(types.UpdateAuditInput)), true
+
 	case "Mutation.updateControl":
 		if e.complexity.Mutation.UpdateControl == nil {
 			break
@@ -3386,6 +3643,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.UpdateVendor(childComplexity, args["input"].(types.UpdateVendorInput)), true
 
+	case "Mutation.uploadAuditReport":
+		if e.complexity.Mutation.UploadAuditReport == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_uploadAuditReport_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UploadAuditReport(childComplexity, args["input"].(types.UploadAuditReportInput)), true
+
 	case "Mutation.uploadMeasureEvidence":
 		if e.complexity.Mutation.UploadMeasureEvidence == nil {
 			break
@@ -3433,6 +3702,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Organization.Assets(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.AssetOrderBy)), true
+
+	case "Organization.audits":
+		if e.complexity.Organization.Audits == nil {
+			break
+		}
+
+		args, err := ec.field_Organization_audits_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.Audits(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.AuditOrderBy)), true
 
 	case "Organization.connectors":
 		if e.complexity.Organization.Connectors == nil {
@@ -3802,6 +4083,62 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.RemoveUserPayload.Success(childComplexity), true
 
+	case "Report.createdAt":
+		if e.complexity.Report.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.Report.CreatedAt(childComplexity), true
+
+	case "Report.downloadUrl":
+		if e.complexity.Report.DownloadURL == nil {
+			break
+		}
+
+		return e.complexity.Report.DownloadURL(childComplexity), true
+
+	case "Report.filename":
+		if e.complexity.Report.Filename == nil {
+			break
+		}
+
+		return e.complexity.Report.Filename(childComplexity), true
+
+	case "Report.id":
+		if e.complexity.Report.ID == nil {
+			break
+		}
+
+		return e.complexity.Report.ID(childComplexity), true
+
+	case "Report.mimeType":
+		if e.complexity.Report.MimeType == nil {
+			break
+		}
+
+		return e.complexity.Report.MimeType(childComplexity), true
+
+	case "Report.objectKey":
+		if e.complexity.Report.ObjectKey == nil {
+			break
+		}
+
+		return e.complexity.Report.ObjectKey(childComplexity), true
+
+	case "Report.size":
+		if e.complexity.Report.Size == nil {
+			break
+		}
+
+		return e.complexity.Report.Size(childComplexity), true
+
+	case "Report.updatedAt":
+		if e.complexity.Report.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.Report.UpdatedAt(childComplexity), true
+
 	case "RequestEvidencePayload.evidenceEdge":
 		if e.complexity.RequestEvidencePayload.EvidenceEdge == nil {
 			break
@@ -4158,6 +4495,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.UpdateAssetPayload.Asset(childComplexity), true
 
+	case "UpdateAuditPayload.audit":
+		if e.complexity.UpdateAuditPayload.Audit == nil {
+			break
+		}
+
+		return e.complexity.UpdateAuditPayload.Audit(childComplexity), true
+
 	case "UpdateControlPayload.control":
 		if e.complexity.UpdateControlPayload.Control == nil {
 			break
@@ -4234,6 +4578,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.UpdateVendorPayload.Vendor(childComplexity), true
+
+	case "UploadAuditReportPayload.audit":
+		if e.complexity.UploadAuditReportPayload.Audit == nil {
+			break
+		}
+
+		return e.complexity.UploadAuditReportPayload.Audit(childComplexity), true
 
 	case "UploadMeasureEvidencePayload.evidenceEdge":
 		if e.complexity.UploadMeasureEvidencePayload.EvidenceEdge == nil {
@@ -4770,6 +5121,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputAssessVendorInput,
 		ec.unmarshalInputAssetOrder,
 		ec.unmarshalInputAssignTaskInput,
+		ec.unmarshalInputAuditOrder,
 		ec.unmarshalInputBulkPublishDocumentVersionsInput,
 		ec.unmarshalInputBulkRequestSignaturesInput,
 		ec.unmarshalInputCancelSignatureRequestInput,
@@ -4778,6 +5130,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputControlFilter,
 		ec.unmarshalInputControlOrder,
 		ec.unmarshalInputCreateAssetInput,
+		ec.unmarshalInputCreateAuditInput,
 		ec.unmarshalInputCreateControlDocumentMappingInput,
 		ec.unmarshalInputCreateControlInput,
 		ec.unmarshalInputCreateControlMeasureMappingInput,
@@ -4797,6 +5150,8 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputCreateVendorRiskAssessmentInput,
 		ec.unmarshalInputDatumOrder,
 		ec.unmarshalInputDeleteAssetInput,
+		ec.unmarshalInputDeleteAuditInput,
+		ec.unmarshalInputDeleteAuditReportInput,
 		ec.unmarshalInputDeleteControlDocumentMappingInput,
 		ec.unmarshalInputDeleteControlInput,
 		ec.unmarshalInputDeleteControlMeasureMappingInput,
@@ -4840,6 +5195,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputTaskOrder,
 		ec.unmarshalInputUnassignTaskInput,
 		ec.unmarshalInputUpdateAssetInput,
+		ec.unmarshalInputUpdateAuditInput,
 		ec.unmarshalInputUpdateControlInput,
 		ec.unmarshalInputUpdateDatumInput,
 		ec.unmarshalInputUpdateDocumentInput,
@@ -4851,6 +5207,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputUpdateRiskInput,
 		ec.unmarshalInputUpdateTaskInput,
 		ec.unmarshalInputUpdateVendorInput,
+		ec.unmarshalInputUploadAuditReportInput,
 		ec.unmarshalInputUploadMeasureEvidenceInput,
 		ec.unmarshalInputUploadTaskEvidenceInput,
 		ec.unmarshalInputUploadVendorComplianceReportInput,
@@ -5081,6 +5438,30 @@ enum RiskTreatment
   TRANSFERRED
     @goEnum(
       value: "github.com/getprobo/probo/pkg/coredata.RiskTreatmentTransferred"
+    )
+}
+
+enum AuditState
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.AuditState") {
+  NOT_STARTED
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.AuditStateNotStarted"
+    )
+  IN_PROGRESS
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.AuditStateInProgress"
+    )
+  COMPLETED
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.AuditStateCompleted"
+    )
+  REJECTED
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.AuditStateRejected"
+    )
+  OUTDATED
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.AuditStateOutdated"
     )
 }
 
@@ -5478,6 +5859,27 @@ enum ControlStatus
       value: "github.com/getprobo/probo/pkg/coredata.ControlStatusExcluded"
     )
 }
+
+enum AuditOrderField
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.AuditOrderField") {
+  CREATED_AT
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.AuditOrderFieldCreatedAt"
+    )
+  VALID_FROM
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.AuditOrderFieldValidFrom"
+    )
+  VALID_UNTIL
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.AuditOrderFieldValidUntil"
+    )
+  STATE
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.AuditOrderFieldState"
+    )
+}
+
 # Input Types
 input UserOrder
   @goModel(
@@ -5549,6 +5951,14 @@ input RiskOrder
   ) {
   direction: OrderDirection!
   field: RiskOrderField!
+}
+
+input AuditOrder
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.AuditOrderBy"
+  ) {
+  direction: OrderDirection!
+  field: AuditOrderField!
 }
 
 input EvidenceOrder
@@ -5711,6 +6121,14 @@ type Organization implements Node {
     before: CursorKey
     orderBy: DatumOrder
   ): DatumConnection! @goField(forceResolver: true)
+
+  audits(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+    orderBy: AuditOrder
+  ): AuditConnection! @goField(forceResolver: true)
 
   createdAt: Datetime!
   updatedAt: Datetime!
@@ -6021,6 +6439,30 @@ type Risk implements Node {
   updatedAt: Datetime!
 }
 
+type Audit implements Node {
+  id: ID!
+  organization: Organization! @goField(forceResolver: true)
+  framework: Framework! @goField(forceResolver: true)
+  validFrom: Datetime
+  validUntil: Datetime
+  report: Report @goField(forceResolver: true)
+  reportUrl: String @goField(forceResolver: true)
+  state: AuditState!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+}
+
+type Report implements Node {
+  id: ID!
+  objectKey: String!
+  mimeType: String!
+  filename: String!
+  size: Int!
+  downloadUrl: String @goField(forceResolver: true)
+  createdAt: Datetime!
+  updatedAt: Datetime!
+}
+
 type Session {
   id: ID!
   expiresAt: Datetime!
@@ -6240,6 +6682,20 @@ type DatumEdge {
   node: Datum!
 }
 
+type AuditConnection
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.AuditConnection"
+  ) {
+  totalCount: Int! @goField(forceResolver: true)
+  edges: [AuditEdge!]!
+  pageInfo: PageInfo!
+}
+
+type AuditEdge {
+  cursor: CursorKey!
+  node: Audit!
+}
+
 # Root Types
 type Query {
   node(id: ID!): Node!
@@ -6394,6 +6850,12 @@ type Mutation {
   createDatum(input: CreateDatumInput!): CreateDatumPayload!
   updateDatum(input: UpdateDatumInput!): UpdateDatumPayload!
   deleteDatum(input: DeleteDatumInput!): DeleteDatumPayload!
+
+  createAudit(input: CreateAuditInput!): CreateAuditPayload!
+  updateAudit(input: UpdateAuditInput!): UpdateAuditPayload!
+  deleteAudit(input: DeleteAuditInput!): DeleteAuditPayload!
+  uploadAuditReport(input: UploadAuditReportInput!): UploadAuditReportPayload!
+  deleteAuditReport(input: DeleteAuditReportInput!): DeleteAuditReportPayload!
 }
 
 # Input Types
@@ -6733,6 +7195,35 @@ input UpdateControlInput {
 
 input DeleteControlInput {
   controlId: ID!
+}
+
+# Audit input types
+input CreateAuditInput {
+  organizationId: ID!
+  frameworkId: ID!
+  validFrom: Datetime
+  validUntil: Datetime
+  state: AuditState
+}
+
+input UpdateAuditInput {
+  id: ID!
+  validFrom: Datetime
+  validUntil: Datetime
+  state: AuditState
+}
+
+input DeleteAuditInput {
+  auditId: ID!
+}
+
+input UploadAuditReportInput {
+  auditId: ID!
+  file: Upload!
+}
+
+input DeleteAuditReportInput {
+  auditId: ID!
 }
 
 # Payload Types
@@ -7310,6 +7801,26 @@ type UpdateDatumPayload {
 
 type DeleteDatumPayload {
   deletedDatumId: ID!
+}
+
+type CreateAuditPayload {
+  auditEdge: AuditEdge!
+}
+
+type UpdateAuditPayload {
+  audit: Audit!
+}
+
+type DeleteAuditPayload {
+  deletedAuditId: ID!
+}
+
+type UploadAuditReportPayload {
+  audit: Audit!
+}
+
+type DeleteAuditReportPayload {
+  audit: Audit!
 }
 `, BuiltIn: false},
 }
@@ -8746,6 +9257,29 @@ func (ec *executionContext) field_Mutation_createAsset_argsInput(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation_createAudit_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_createAudit_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_createAudit_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.CreateAuditInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNCreateAuditInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateAuditInput(ctx, tmp)
+	}
+
+	var zeroVal types.CreateAuditInput
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation_createControlDocumentMapping_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -9134,6 +9668,52 @@ func (ec *executionContext) field_Mutation_deleteAsset_argsInput(
 	}
 
 	var zeroVal types.DeleteAssetInput
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_deleteAuditReport_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_deleteAuditReport_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_deleteAuditReport_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.DeleteAuditReportInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNDeleteAuditReportInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteAuditReportInput(ctx, tmp)
+	}
+
+	var zeroVal types.DeleteAuditReportInput
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_deleteAudit_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_deleteAudit_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_deleteAudit_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.DeleteAuditInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNDeleteAuditInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteAuditInput(ctx, tmp)
+	}
+
+	var zeroVal types.DeleteAuditInput
 	return zeroVal, nil
 }
 
@@ -9804,6 +10384,29 @@ func (ec *executionContext) field_Mutation_updateAsset_argsInput(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation_updateAudit_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_updateAudit_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_updateAudit_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.UpdateAuditInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNUpdateAuditInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateAuditInput(ctx, tmp)
+	}
+
+	var zeroVal types.UpdateAuditInput
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation_updateControl_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -10057,6 +10660,29 @@ func (ec *executionContext) field_Mutation_updateVendor_argsInput(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation_uploadAuditReport_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_uploadAuditReport_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_uploadAuditReport_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.UploadAuditReportInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNUploadAuditReportInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUploadAuditReportInput(ctx, tmp)
+	}
+
+	var zeroVal types.UploadAuditReportInput
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation_uploadMeasureEvidence_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -10218,6 +10844,101 @@ func (ec *executionContext) field_Organization_assets_argsOrderBy(
 	}
 
 	var zeroVal *types.AssetOrderBy
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_audits_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Organization_audits_argsFirst(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["first"] = arg0
+	arg1, err := ec.field_Organization_audits_argsAfter(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["after"] = arg1
+	arg2, err := ec.field_Organization_audits_argsLast(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["last"] = arg2
+	arg3, err := ec.field_Organization_audits_argsBefore(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["before"] = arg3
+	arg4, err := ec.field_Organization_audits_argsOrderBy(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["orderBy"] = arg4
+	return args, nil
+}
+func (ec *executionContext) field_Organization_audits_argsFirst(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*int, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("first"))
+	if tmp, ok := rawArgs["first"]; ok {
+		return ec.unmarshalOInt2ᚖint(ctx, tmp)
+	}
+
+	var zeroVal *int
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_audits_argsAfter(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*page.CursorKey, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("after"))
+	if tmp, ok := rawArgs["after"]; ok {
+		return ec.unmarshalOCursorKey2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐCursorKey(ctx, tmp)
+	}
+
+	var zeroVal *page.CursorKey
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_audits_argsLast(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*int, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("last"))
+	if tmp, ok := rawArgs["last"]; ok {
+		return ec.unmarshalOInt2ᚖint(ctx, tmp)
+	}
+
+	var zeroVal *int
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_audits_argsBefore(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*page.CursorKey, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("before"))
+	if tmp, ok := rawArgs["before"]; ok {
+		return ec.unmarshalOCursorKey2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐCursorKey(ctx, tmp)
+	}
+
+	var zeroVal *page.CursorKey
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_audits_argsOrderBy(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*types.AuditOrderBy, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("orderBy"))
+	if tmp, ok := rawArgs["orderBy"]; ok {
+		return ec.unmarshalOAuditOrder2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐAuditOrderBy(ctx, tmp)
+	}
+
+	var zeroVal *types.AuditOrderBy
 	return zeroVal, nil
 }
 
@@ -12782,6 +13503,8 @@ func (ec *executionContext) fieldContext_Asset_organization(_ context.Context, f
 				return ec.fieldContext_Organization_assets(ctx, field)
 			case "data":
 				return ec.fieldContext_Organization_data(ctx, field)
+			case "audits":
+				return ec.fieldContext_Organization_audits(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Organization_createdAt(ctx, field)
 			case "updatedAt":
@@ -13206,6 +13929,764 @@ func (ec *executionContext) fieldContext_AssignTaskPayload_task(_ context.Contex
 				return ec.fieldContext_Task_updatedAt(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Task", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Audit_id(ctx context.Context, field graphql.CollectedField, obj *types.Audit) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Audit_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(gid.GID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Audit_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Audit",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Audit_organization(ctx context.Context, field graphql.CollectedField, obj *types.Audit) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Audit_organization(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Audit().Organization(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.Organization)
+	fc.Result = res
+	return ec.marshalNOrganization2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐOrganization(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Audit_organization(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Audit",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Organization_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Organization_name(ctx, field)
+			case "logoUrl":
+				return ec.fieldContext_Organization_logoUrl(ctx, field)
+			case "users":
+				return ec.fieldContext_Organization_users(ctx, field)
+			case "connectors":
+				return ec.fieldContext_Organization_connectors(ctx, field)
+			case "frameworks":
+				return ec.fieldContext_Organization_frameworks(ctx, field)
+			case "controls":
+				return ec.fieldContext_Organization_controls(ctx, field)
+			case "vendors":
+				return ec.fieldContext_Organization_vendors(ctx, field)
+			case "peoples":
+				return ec.fieldContext_Organization_peoples(ctx, field)
+			case "documents":
+				return ec.fieldContext_Organization_documents(ctx, field)
+			case "measures":
+				return ec.fieldContext_Organization_measures(ctx, field)
+			case "risks":
+				return ec.fieldContext_Organization_risks(ctx, field)
+			case "tasks":
+				return ec.fieldContext_Organization_tasks(ctx, field)
+			case "assets":
+				return ec.fieldContext_Organization_assets(ctx, field)
+			case "data":
+				return ec.fieldContext_Organization_data(ctx, field)
+			case "audits":
+				return ec.fieldContext_Organization_audits(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Organization_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Organization_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Organization", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Audit_framework(ctx context.Context, field graphql.CollectedField, obj *types.Audit) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Audit_framework(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Audit().Framework(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.Framework)
+	fc.Result = res
+	return ec.marshalNFramework2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐFramework(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Audit_framework(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Audit",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Framework_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Framework_name(ctx, field)
+			case "description":
+				return ec.fieldContext_Framework_description(ctx, field)
+			case "organization":
+				return ec.fieldContext_Framework_organization(ctx, field)
+			case "controls":
+				return ec.fieldContext_Framework_controls(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Framework_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Framework_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Framework", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Audit_validFrom(ctx context.Context, field graphql.CollectedField, obj *types.Audit) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Audit_validFrom(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ValidFrom, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	fc.Result = res
+	return ec.marshalODatetime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Audit_validFrom(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Audit",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Audit_validUntil(ctx context.Context, field graphql.CollectedField, obj *types.Audit) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Audit_validUntil(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ValidUntil, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	fc.Result = res
+	return ec.marshalODatetime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Audit_validUntil(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Audit",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Audit_report(ctx context.Context, field graphql.CollectedField, obj *types.Audit) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Audit_report(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Audit().Report(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*types.Report)
+	fc.Result = res
+	return ec.marshalOReport2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐReport(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Audit_report(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Audit",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Report_id(ctx, field)
+			case "objectKey":
+				return ec.fieldContext_Report_objectKey(ctx, field)
+			case "mimeType":
+				return ec.fieldContext_Report_mimeType(ctx, field)
+			case "filename":
+				return ec.fieldContext_Report_filename(ctx, field)
+			case "size":
+				return ec.fieldContext_Report_size(ctx, field)
+			case "downloadUrl":
+				return ec.fieldContext_Report_downloadUrl(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Report_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Report_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Report", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Audit_reportUrl(ctx context.Context, field graphql.CollectedField, obj *types.Audit) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Audit_reportUrl(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Audit().ReportURL(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Audit_reportUrl(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Audit",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Audit_state(ctx context.Context, field graphql.CollectedField, obj *types.Audit) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Audit_state(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.State, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(coredata.AuditState)
+	fc.Result = res
+	return ec.marshalNAuditState2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐAuditState(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Audit_state(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Audit",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type AuditState does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Audit_createdAt(ctx context.Context, field graphql.CollectedField, obj *types.Audit) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Audit_createdAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNDatetime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Audit_createdAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Audit",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Audit_updatedAt(ctx context.Context, field graphql.CollectedField, obj *types.Audit) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Audit_updatedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNDatetime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Audit_updatedAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Audit",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AuditConnection_totalCount(ctx context.Context, field graphql.CollectedField, obj *types.AuditConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AuditConnection_totalCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.AuditConnection().TotalCount(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AuditConnection_totalCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AuditConnection",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AuditConnection_edges(ctx context.Context, field graphql.CollectedField, obj *types.AuditConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AuditConnection_edges(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Edges, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*types.AuditEdge)
+	fc.Result = res
+	return ec.marshalNAuditEdge2ᚕᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐAuditEdgeᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AuditConnection_edges(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AuditConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "cursor":
+				return ec.fieldContext_AuditEdge_cursor(ctx, field)
+			case "node":
+				return ec.fieldContext_AuditEdge_node(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type AuditEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AuditConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *types.AuditConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AuditConnection_pageInfo(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PageInfo, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(types.PageInfo)
+	fc.Result = res
+	return ec.marshalNPageInfo2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐPageInfo(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AuditConnection_pageInfo(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AuditConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "hasNextPage":
+				return ec.fieldContext_PageInfo_hasNextPage(ctx, field)
+			case "hasPreviousPage":
+				return ec.fieldContext_PageInfo_hasPreviousPage(ctx, field)
+			case "startCursor":
+				return ec.fieldContext_PageInfo_startCursor(ctx, field)
+			case "endCursor":
+				return ec.fieldContext_PageInfo_endCursor(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AuditEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *types.AuditEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AuditEdge_cursor(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Cursor, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(page.CursorKey)
+	fc.Result = res
+	return ec.marshalNCursorKey2githubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐCursorKey(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AuditEdge_cursor(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AuditEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type CursorKey does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AuditEdge_node(ctx context.Context, field graphql.CollectedField, obj *types.AuditEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AuditEdge_node(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Node, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.Audit)
+	fc.Result = res
+	return ec.marshalNAudit2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐAudit(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AuditEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AuditEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Audit_id(ctx, field)
+			case "organization":
+				return ec.fieldContext_Audit_organization(ctx, field)
+			case "framework":
+				return ec.fieldContext_Audit_framework(ctx, field)
+			case "validFrom":
+				return ec.fieldContext_Audit_validFrom(ctx, field)
+			case "validUntil":
+				return ec.fieldContext_Audit_validUntil(ctx, field)
+			case "report":
+				return ec.fieldContext_Audit_report(ctx, field)
+			case "reportUrl":
+				return ec.fieldContext_Audit_reportUrl(ctx, field)
+			case "state":
+				return ec.fieldContext_Audit_state(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Audit_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Audit_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Audit", field.Name)
 		},
 	}
 	return fc, nil
@@ -14718,6 +16199,56 @@ func (ec *executionContext) fieldContext_CreateAssetPayload_assetEdge(_ context.
 	return fc, nil
 }
 
+func (ec *executionContext) _CreateAuditPayload_auditEdge(ctx context.Context, field graphql.CollectedField, obj *types.CreateAuditPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CreateAuditPayload_auditEdge(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AuditEdge, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.AuditEdge)
+	fc.Result = res
+	return ec.marshalNAuditEdge2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐAuditEdge(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CreateAuditPayload_auditEdge(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CreateAuditPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "cursor":
+				return ec.fieldContext_AuditEdge_cursor(ctx, field)
+			case "node":
+				return ec.fieldContext_AuditEdge_node(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type AuditEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _CreateControlDocumentMappingPayload_controlEdge(ctx context.Context, field graphql.CollectedField, obj *types.CreateControlDocumentMappingPayload) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_CreateControlDocumentMappingPayload_controlEdge(ctx, field)
 	if err != nil {
@@ -16148,6 +17679,8 @@ func (ec *executionContext) fieldContext_Datum_organization(_ context.Context, f
 				return ec.fieldContext_Organization_assets(ctx, field)
 			case "data":
 				return ec.fieldContext_Organization_data(ctx, field)
+			case "audits":
+				return ec.fieldContext_Organization_audits(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Organization_createdAt(ctx, field)
 			case "updatedAt":
@@ -16540,6 +18073,116 @@ func (ec *executionContext) fieldContext_DeleteAssetPayload_deletedAssetId(_ con
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DeleteAuditPayload_deletedAuditId(ctx context.Context, field graphql.CollectedField, obj *types.DeleteAuditPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DeleteAuditPayload_deletedAuditId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DeletedAuditID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(gid.GID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DeleteAuditPayload_deletedAuditId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DeleteAuditPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DeleteAuditReportPayload_audit(ctx context.Context, field graphql.CollectedField, obj *types.DeleteAuditReportPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DeleteAuditReportPayload_audit(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Audit, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.Audit)
+	fc.Result = res
+	return ec.marshalNAudit2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐAudit(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DeleteAuditReportPayload_audit(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DeleteAuditReportPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Audit_id(ctx, field)
+			case "organization":
+				return ec.fieldContext_Audit_organization(ctx, field)
+			case "framework":
+				return ec.fieldContext_Audit_framework(ctx, field)
+			case "validFrom":
+				return ec.fieldContext_Audit_validFrom(ctx, field)
+			case "validUntil":
+				return ec.fieldContext_Audit_validUntil(ctx, field)
+			case "report":
+				return ec.fieldContext_Audit_report(ctx, field)
+			case "reportUrl":
+				return ec.fieldContext_Audit_reportUrl(ctx, field)
+			case "state":
+				return ec.fieldContext_Audit_state(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Audit_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Audit_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Audit", field.Name)
 		},
 	}
 	return fc, nil
@@ -17733,6 +19376,8 @@ func (ec *executionContext) fieldContext_Document_organization(_ context.Context
 				return ec.fieldContext_Organization_assets(ctx, field)
 			case "data":
 				return ec.fieldContext_Organization_data(ctx, field)
+			case "audits":
+				return ec.fieldContext_Organization_audits(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Organization_createdAt(ctx, field)
 			case "updatedAt":
@@ -20886,6 +22531,8 @@ func (ec *executionContext) fieldContext_Framework_organization(_ context.Contex
 				return ec.fieldContext_Organization_assets(ctx, field)
 			case "data":
 				return ec.fieldContext_Organization_data(ctx, field)
+			case "audits":
+				return ec.fieldContext_Organization_audits(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Organization_createdAt(ctx, field)
 			case "updatedAt":
@@ -26377,6 +28024,301 @@ func (ec *executionContext) fieldContext_Mutation_deleteDatum(ctx context.Contex
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_createAudit(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_createAudit(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateAudit(rctx, fc.Args["input"].(types.CreateAuditInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.CreateAuditPayload)
+	fc.Result = res
+	return ec.marshalNCreateAuditPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateAuditPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_createAudit(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "auditEdge":
+				return ec.fieldContext_CreateAuditPayload_auditEdge(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CreateAuditPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_createAudit_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_updateAudit(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_updateAudit(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UpdateAudit(rctx, fc.Args["input"].(types.UpdateAuditInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.UpdateAuditPayload)
+	fc.Result = res
+	return ec.marshalNUpdateAuditPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateAuditPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_updateAudit(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "audit":
+				return ec.fieldContext_UpdateAuditPayload_audit(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UpdateAuditPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_updateAudit_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_deleteAudit(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_deleteAudit(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteAudit(rctx, fc.Args["input"].(types.DeleteAuditInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.DeleteAuditPayload)
+	fc.Result = res
+	return ec.marshalNDeleteAuditPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteAuditPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_deleteAudit(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "deletedAuditId":
+				return ec.fieldContext_DeleteAuditPayload_deletedAuditId(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DeleteAuditPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_deleteAudit_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_uploadAuditReport(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_uploadAuditReport(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UploadAuditReport(rctx, fc.Args["input"].(types.UploadAuditReportInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.UploadAuditReportPayload)
+	fc.Result = res
+	return ec.marshalNUploadAuditReportPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUploadAuditReportPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_uploadAuditReport(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "audit":
+				return ec.fieldContext_UploadAuditReportPayload_audit(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UploadAuditReportPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_uploadAuditReport_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_deleteAuditReport(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_deleteAuditReport(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteAuditReport(rctx, fc.Args["input"].(types.DeleteAuditReportInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.DeleteAuditReportPayload)
+	fc.Result = res
+	return ec.marshalNDeleteAuditReportPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteAuditReportPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_deleteAuditReport(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "audit":
+				return ec.fieldContext_DeleteAuditReportPayload_audit(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DeleteAuditReportPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_deleteAuditReport_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Organization_id(ctx context.Context, field graphql.CollectedField, obj *types.Organization) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Organization_id(ctx, field)
 	if err != nil {
@@ -27258,6 +29200,69 @@ func (ec *executionContext) fieldContext_Organization_data(ctx context.Context, 
 	return fc, nil
 }
 
+func (ec *executionContext) _Organization_audits(ctx context.Context, field graphql.CollectedField, obj *types.Organization) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Organization_audits(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Organization().Audits(rctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey), fc.Args["orderBy"].(*types.AuditOrderBy))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.AuditConnection)
+	fc.Result = res
+	return ec.marshalNAuditConnection2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐAuditConnection(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Organization_audits(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Organization",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "totalCount":
+				return ec.fieldContext_AuditConnection_totalCount(ctx, field)
+			case "edges":
+				return ec.fieldContext_AuditConnection_edges(ctx, field)
+			case "pageInfo":
+				return ec.fieldContext_AuditConnection_pageInfo(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type AuditConnection", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Organization_audits_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Organization_createdAt(ctx context.Context, field graphql.CollectedField, obj *types.Organization) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Organization_createdAt(ctx, field)
 	if err != nil {
@@ -27563,6 +29568,8 @@ func (ec *executionContext) fieldContext_OrganizationEdge_node(_ context.Context
 				return ec.fieldContext_Organization_assets(ctx, field)
 			case "data":
 				return ec.fieldContext_Organization_data(ctx, field)
+			case "audits":
+				return ec.fieldContext_Organization_audits(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Organization_createdAt(ctx, field)
 			case "updatedAt":
@@ -28855,6 +30862,355 @@ func (ec *executionContext) fieldContext_RemoveUserPayload_success(_ context.Con
 	return fc, nil
 }
 
+func (ec *executionContext) _Report_id(ctx context.Context, field graphql.CollectedField, obj *types.Report) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Report_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(gid.GID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Report_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Report",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Report_objectKey(ctx context.Context, field graphql.CollectedField, obj *types.Report) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Report_objectKey(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ObjectKey, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Report_objectKey(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Report",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Report_mimeType(ctx context.Context, field graphql.CollectedField, obj *types.Report) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Report_mimeType(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.MimeType, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Report_mimeType(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Report",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Report_filename(ctx context.Context, field graphql.CollectedField, obj *types.Report) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Report_filename(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Filename, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Report_filename(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Report",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Report_size(ctx context.Context, field graphql.CollectedField, obj *types.Report) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Report_size(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Size, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Report_size(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Report",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Report_downloadUrl(ctx context.Context, field graphql.CollectedField, obj *types.Report) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Report_downloadUrl(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Report().DownloadURL(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Report_downloadUrl(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Report",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Report_createdAt(ctx context.Context, field graphql.CollectedField, obj *types.Report) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Report_createdAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNDatetime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Report_createdAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Report",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Report_updatedAt(ctx context.Context, field graphql.CollectedField, obj *types.Report) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Report_updatedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNDatetime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Report_updatedAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Report",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _RequestEvidencePayload_evidenceEdge(ctx context.Context, field graphql.CollectedField, obj *types.RequestEvidencePayload) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_RequestEvidencePayload_evidenceEdge(ctx, field)
 	if err != nil {
@@ -29615,6 +31971,8 @@ func (ec *executionContext) fieldContext_Risk_organization(_ context.Context, fi
 				return ec.fieldContext_Organization_assets(ctx, field)
 			case "data":
 				return ec.fieldContext_Organization_data(ctx, field)
+			case "audits":
+				return ec.fieldContext_Organization_audits(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Organization_createdAt(ctx, field)
 			case "updatedAt":
@@ -30701,6 +33059,8 @@ func (ec *executionContext) fieldContext_Task_organization(_ context.Context, fi
 				return ec.fieldContext_Organization_assets(ctx, field)
 			case "data":
 				return ec.fieldContext_Organization_data(ctx, field)
+			case "audits":
+				return ec.fieldContext_Organization_audits(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Organization_createdAt(ctx, field)
 			case "updatedAt":
@@ -31328,6 +33688,72 @@ func (ec *executionContext) fieldContext_UpdateAssetPayload_asset(_ context.Cont
 	return fc, nil
 }
 
+func (ec *executionContext) _UpdateAuditPayload_audit(ctx context.Context, field graphql.CollectedField, obj *types.UpdateAuditPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UpdateAuditPayload_audit(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Audit, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.Audit)
+	fc.Result = res
+	return ec.marshalNAudit2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐAudit(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UpdateAuditPayload_audit(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UpdateAuditPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Audit_id(ctx, field)
+			case "organization":
+				return ec.fieldContext_Audit_organization(ctx, field)
+			case "framework":
+				return ec.fieldContext_Audit_framework(ctx, field)
+			case "validFrom":
+				return ec.fieldContext_Audit_validFrom(ctx, field)
+			case "validUntil":
+				return ec.fieldContext_Audit_validUntil(ctx, field)
+			case "report":
+				return ec.fieldContext_Audit_report(ctx, field)
+			case "reportUrl":
+				return ec.fieldContext_Audit_reportUrl(ctx, field)
+			case "state":
+				return ec.fieldContext_Audit_state(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Audit_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Audit_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Audit", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _UpdateControlPayload_control(ctx context.Context, field graphql.CollectedField, obj *types.UpdateControlPayload) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_UpdateControlPayload_control(ctx, field)
 	if err != nil {
@@ -31795,6 +34221,8 @@ func (ec *executionContext) fieldContext_UpdateOrganizationPayload_organization(
 				return ec.fieldContext_Organization_assets(ctx, field)
 			case "data":
 				return ec.fieldContext_Organization_data(ctx, field)
+			case "audits":
+				return ec.fieldContext_Organization_audits(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Organization_createdAt(ctx, field)
 			case "updatedAt":
@@ -32115,6 +34543,72 @@ func (ec *executionContext) fieldContext_UpdateVendorPayload_vendor(_ context.Co
 				return ec.fieldContext_Vendor_updatedAt(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Vendor", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UploadAuditReportPayload_audit(ctx context.Context, field graphql.CollectedField, obj *types.UploadAuditReportPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UploadAuditReportPayload_audit(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Audit, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.Audit)
+	fc.Result = res
+	return ec.marshalNAudit2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐAudit(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UploadAuditReportPayload_audit(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UploadAuditReportPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Audit_id(ctx, field)
+			case "organization":
+				return ec.fieldContext_Audit_organization(ctx, field)
+			case "framework":
+				return ec.fieldContext_Audit_framework(ctx, field)
+			case "validFrom":
+				return ec.fieldContext_Audit_validFrom(ctx, field)
+			case "validUntil":
+				return ec.fieldContext_Audit_validUntil(ctx, field)
+			case "report":
+				return ec.fieldContext_Audit_report(ctx, field)
+			case "reportUrl":
+				return ec.fieldContext_Audit_reportUrl(ctx, field)
+			case "state":
+				return ec.fieldContext_Audit_state(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Audit_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Audit_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Audit", field.Name)
 		},
 	}
 	return fc, nil
@@ -33012,6 +35506,8 @@ func (ec *executionContext) fieldContext_Vendor_organization(_ context.Context, 
 				return ec.fieldContext_Organization_assets(ctx, field)
 			case "data":
 				return ec.fieldContext_Organization_data(ctx, field)
+			case "audits":
+				return ec.fieldContext_Organization_audits(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Organization_createdAt(ctx, field)
 			case "updatedAt":
@@ -37775,6 +40271,40 @@ func (ec *executionContext) unmarshalInputAssignTaskInput(ctx context.Context, o
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputAuditOrder(ctx context.Context, obj any) (types.AuditOrderBy, error) {
+	var it types.AuditOrderBy
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"direction", "field"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "direction":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("direction"))
+			data, err := ec.unmarshalNOrderDirection2githubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐOrderDirection(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Direction = data
+		case "field":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("field"))
+			data, err := ec.unmarshalNAuditOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐAuditOrderField(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Field = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputBulkPublishDocumentVersionsInput(ctx context.Context, obj any) (types.BulkPublishDocumentVersionsInput, error) {
 	var it types.BulkPublishDocumentVersionsInput
 	asMap := map[string]any{}
@@ -38066,6 +40596,61 @@ func (ec *executionContext) unmarshalInputCreateAssetInput(ctx context.Context, 
 				return it, err
 			}
 			it.VendorIds = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputCreateAuditInput(ctx context.Context, obj any) (types.CreateAuditInput, error) {
+	var it types.CreateAuditInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"organizationId", "frameworkId", "validFrom", "validUntil", "state"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "organizationId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("organizationId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OrganizationID = data
+		case "frameworkId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("frameworkId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.FrameworkID = data
+		case "validFrom":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("validFrom"))
+			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ValidFrom = data
+		case "validUntil":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("validUntil"))
+			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ValidUntil = data
+		case "state":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("state"))
+			data, err := ec.unmarshalOAuditState2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐAuditState(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.State = data
 		}
 	}
 
@@ -39097,6 +41682,60 @@ func (ec *executionContext) unmarshalInputDeleteAssetInput(ctx context.Context, 
 				return it, err
 			}
 			it.AssetID = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputDeleteAuditInput(ctx context.Context, obj any) (types.DeleteAuditInput, error) {
+	var it types.DeleteAuditInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"auditId"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "auditId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("auditId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AuditID = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputDeleteAuditReportInput(ctx context.Context, obj any) (types.DeleteAuditReportInput, error) {
+	var it types.DeleteAuditReportInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"auditId"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "auditId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("auditId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AuditID = data
 		}
 	}
 
@@ -40502,6 +43141,54 @@ func (ec *executionContext) unmarshalInputUpdateAssetInput(ctx context.Context, 
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputUpdateAuditInput(ctx context.Context, obj any) (types.UpdateAuditInput, error) {
+	var it types.UpdateAuditInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id", "validFrom", "validUntil", "state"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ID = data
+		case "validFrom":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("validFrom"))
+			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ValidFrom = data
+		case "validUntil":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("validUntil"))
+			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ValidUntil = data
+		case "state":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("state"))
+			data, err := ec.unmarshalOAuditState2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐAuditState(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.State = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputUpdateControlInput(ctx context.Context, obj any) (types.UpdateControlInput, error) {
 	var it types.UpdateControlInput
 	asMap := map[string]any{}
@@ -41240,6 +43927,40 @@ func (ec *executionContext) unmarshalInputUpdateVendorInput(ctx context.Context,
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputUploadAuditReportInput(ctx context.Context, obj any) (types.UploadAuditReportInput, error) {
+	var it types.UploadAuditReportInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"auditId", "file"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "auditId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("auditId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AuditID = data
+		case "file":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("file"))
+			data, err := ec.unmarshalNUpload2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚐUpload(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.File = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputUploadMeasureEvidenceInput(ctx context.Context, obj any) (types.UploadMeasureEvidenceInput, error) {
 	var it types.UploadMeasureEvidenceInput
 	asMap := map[string]any{}
@@ -41549,6 +44270,13 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._Risk(ctx, sel, obj)
+	case types.Report:
+		return ec._Report(ctx, sel, &obj)
+	case *types.Report:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Report(ctx, sel, obj)
 	case types.People:
 		return ec._People(ctx, sel, &obj)
 	case *types.People:
@@ -41626,6 +44354,13 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._Connector(ctx, sel, obj)
+	case types.Audit:
+		return ec._Audit(ctx, sel, &obj)
+	case *types.Audit:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Audit(ctx, sel, obj)
 	case types.Asset:
 		return ec._Asset(ctx, sel, &obj)
 	case *types.Asset:
@@ -42031,6 +44766,326 @@ func (ec *executionContext) _AssignTaskPayload(ctx context.Context, sel ast.Sele
 			out.Values[i] = graphql.MarshalString("AssignTaskPayload")
 		case "task":
 			out.Values[i] = ec._AssignTaskPayload_task(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var auditImplementors = []string{"Audit", "Node"}
+
+func (ec *executionContext) _Audit(ctx context.Context, sel ast.SelectionSet, obj *types.Audit) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, auditImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Audit")
+		case "id":
+			out.Values[i] = ec._Audit_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "organization":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Audit_organization(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "framework":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Audit_framework(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "validFrom":
+			out.Values[i] = ec._Audit_validFrom(ctx, field, obj)
+		case "validUntil":
+			out.Values[i] = ec._Audit_validUntil(ctx, field, obj)
+		case "report":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Audit_report(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "reportUrl":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Audit_reportUrl(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "state":
+			out.Values[i] = ec._Audit_state(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "createdAt":
+			out.Values[i] = ec._Audit_createdAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "updatedAt":
+			out.Values[i] = ec._Audit_updatedAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var auditConnectionImplementors = []string{"AuditConnection"}
+
+func (ec *executionContext) _AuditConnection(ctx context.Context, sel ast.SelectionSet, obj *types.AuditConnection) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, auditConnectionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("AuditConnection")
+		case "totalCount":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._AuditConnection_totalCount(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "edges":
+			out.Values[i] = ec._AuditConnection_edges(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "pageInfo":
+			out.Values[i] = ec._AuditConnection_pageInfo(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var auditEdgeImplementors = []string{"AuditEdge"}
+
+func (ec *executionContext) _AuditEdge(ctx context.Context, sel ast.SelectionSet, obj *types.AuditEdge) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, auditEdgeImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("AuditEdge")
+		case "cursor":
+			out.Values[i] = ec._AuditEdge_cursor(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "node":
+			out.Values[i] = ec._AuditEdge_node(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -42681,6 +45736,45 @@ func (ec *executionContext) _CreateAssetPayload(ctx context.Context, sel ast.Sel
 			out.Values[i] = graphql.MarshalString("CreateAssetPayload")
 		case "assetEdge":
 			out.Values[i] = ec._CreateAssetPayload_assetEdge(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var createAuditPayloadImplementors = []string{"CreateAuditPayload"}
+
+func (ec *executionContext) _CreateAuditPayload(ctx context.Context, sel ast.SelectionSet, obj *types.CreateAuditPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, createAuditPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CreateAuditPayload")
+		case "auditEdge":
+			out.Values[i] = ec._CreateAuditPayload_auditEdge(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -43699,6 +46793,84 @@ func (ec *executionContext) _DeleteAssetPayload(ctx context.Context, sel ast.Sel
 			out.Values[i] = graphql.MarshalString("DeleteAssetPayload")
 		case "deletedAssetId":
 			out.Values[i] = ec._DeleteAssetPayload_deletedAssetId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var deleteAuditPayloadImplementors = []string{"DeleteAuditPayload"}
+
+func (ec *executionContext) _DeleteAuditPayload(ctx context.Context, sel ast.SelectionSet, obj *types.DeleteAuditPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, deleteAuditPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("DeleteAuditPayload")
+		case "deletedAuditId":
+			out.Values[i] = ec._DeleteAuditPayload_deletedAuditId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var deleteAuditReportPayloadImplementors = []string{"DeleteAuditReportPayload"}
+
+func (ec *executionContext) _DeleteAuditReportPayload(ctx context.Context, sel ast.SelectionSet, obj *types.DeleteAuditReportPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, deleteAuditReportPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("DeleteAuditReportPayload")
+		case "audit":
+			out.Values[i] = ec._DeleteAuditReportPayload_audit(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -46886,6 +50058,41 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "createAudit":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_createAudit(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "updateAudit":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_updateAudit(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "deleteAudit":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_deleteAudit(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "uploadAuditReport":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_uploadAuditReport(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "deleteAuditReport":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_deleteAuditReport(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -47369,6 +50576,42 @@ func (ec *executionContext) _Organization(ctx context.Context, sel ast.Selection
 					}
 				}()
 				res = ec._Organization_data(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "audits":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Organization_audits(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -47916,6 +51159,108 @@ func (ec *executionContext) _RemoveUserPayload(ctx context.Context, sel ast.Sele
 			out.Values[i] = ec._RemoveUserPayload_success(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var reportImplementors = []string{"Report", "Node"}
+
+func (ec *executionContext) _Report(ctx context.Context, sel ast.SelectionSet, obj *types.Report) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, reportImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Report")
+		case "id":
+			out.Values[i] = ec._Report_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "objectKey":
+			out.Values[i] = ec._Report_objectKey(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "mimeType":
+			out.Values[i] = ec._Report_mimeType(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "filename":
+			out.Values[i] = ec._Report_filename(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "size":
+			out.Values[i] = ec._Report_size(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "downloadUrl":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Report_downloadUrl(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "createdAt":
+			out.Values[i] = ec._Report_createdAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "updatedAt":
+			out.Values[i] = ec._Report_updatedAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
@@ -48914,6 +52259,45 @@ func (ec *executionContext) _UpdateAssetPayload(ctx context.Context, sel ast.Sel
 	return out
 }
 
+var updateAuditPayloadImplementors = []string{"UpdateAuditPayload"}
+
+func (ec *executionContext) _UpdateAuditPayload(ctx context.Context, sel ast.SelectionSet, obj *types.UpdateAuditPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, updateAuditPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("UpdateAuditPayload")
+		case "audit":
+			out.Values[i] = ec._UpdateAuditPayload_audit(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var updateControlPayloadImplementors = []string{"UpdateControlPayload"}
 
 func (ec *executionContext) _UpdateControlPayload(ctx context.Context, sel ast.SelectionSet, obj *types.UpdateControlPayload) graphql.Marshaler {
@@ -49317,6 +52701,45 @@ func (ec *executionContext) _UpdateVendorPayload(ctx context.Context, sel ast.Se
 			out.Values[i] = graphql.MarshalString("UpdateVendorPayload")
 		case "vendor":
 			out.Values[i] = ec._UpdateVendorPayload_vendor(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var uploadAuditReportPayloadImplementors = []string{"UploadAuditReportPayload"}
+
+func (ec *executionContext) _UploadAuditReportPayload(ctx context.Context, sel ast.SelectionSet, obj *types.UploadAuditReportPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, uploadAuditReportPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("UploadAuditReportPayload")
+		case "audit":
+			out.Values[i] = ec._UploadAuditReportPayload_audit(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -51074,6 +54497,150 @@ func (ec *executionContext) marshalNAssignTaskPayload2ᚖgithubᚗcomᚋgetprobo
 	return ec._AssignTaskPayload(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNAudit2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐAudit(ctx context.Context, sel ast.SelectionSet, v *types.Audit) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Audit(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNAuditConnection2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐAuditConnection(ctx context.Context, sel ast.SelectionSet, v types.AuditConnection) graphql.Marshaler {
+	return ec._AuditConnection(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNAuditConnection2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐAuditConnection(ctx context.Context, sel ast.SelectionSet, v *types.AuditConnection) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._AuditConnection(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNAuditEdge2ᚕᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐAuditEdgeᚄ(ctx context.Context, sel ast.SelectionSet, v []*types.AuditEdge) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNAuditEdge2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐAuditEdge(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNAuditEdge2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐAuditEdge(ctx context.Context, sel ast.SelectionSet, v *types.AuditEdge) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._AuditEdge(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNAuditOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐAuditOrderField(ctx context.Context, v any) (coredata.AuditOrderField, error) {
+	tmp, err := graphql.UnmarshalString(v)
+	res := unmarshalNAuditOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐAuditOrderField[tmp]
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNAuditOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐAuditOrderField(ctx context.Context, sel ast.SelectionSet, v coredata.AuditOrderField) graphql.Marshaler {
+	_ = sel
+	res := graphql.MarshalString(marshalNAuditOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐAuditOrderField[v])
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+var (
+	unmarshalNAuditOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐAuditOrderField = map[string]coredata.AuditOrderField{
+		"CREATED_AT":  coredata.AuditOrderFieldCreatedAt,
+		"VALID_FROM":  coredata.AuditOrderFieldValidFrom,
+		"VALID_UNTIL": coredata.AuditOrderFieldValidUntil,
+		"STATE":       coredata.AuditOrderFieldState,
+	}
+	marshalNAuditOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐAuditOrderField = map[coredata.AuditOrderField]string{
+		coredata.AuditOrderFieldCreatedAt:  "CREATED_AT",
+		coredata.AuditOrderFieldValidFrom:  "VALID_FROM",
+		coredata.AuditOrderFieldValidUntil: "VALID_UNTIL",
+		coredata.AuditOrderFieldState:      "STATE",
+	}
+)
+
+func (ec *executionContext) unmarshalNAuditState2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐAuditState(ctx context.Context, v any) (coredata.AuditState, error) {
+	tmp, err := graphql.UnmarshalString(v)
+	res := unmarshalNAuditState2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐAuditState[tmp]
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNAuditState2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐAuditState(ctx context.Context, sel ast.SelectionSet, v coredata.AuditState) graphql.Marshaler {
+	_ = sel
+	res := graphql.MarshalString(marshalNAuditState2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐAuditState[v])
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+var (
+	unmarshalNAuditState2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐAuditState = map[string]coredata.AuditState{
+		"NOT_STARTED": coredata.AuditStateNotStarted,
+		"IN_PROGRESS": coredata.AuditStateInProgress,
+		"COMPLETED":   coredata.AuditStateCompleted,
+		"REJECTED":    coredata.AuditStateRejected,
+		"OUTDATED":    coredata.AuditStateOutdated,
+	}
+	marshalNAuditState2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐAuditState = map[coredata.AuditState]string{
+		coredata.AuditStateNotStarted: "NOT_STARTED",
+		coredata.AuditStateInProgress: "IN_PROGRESS",
+		coredata.AuditStateCompleted:  "COMPLETED",
+		coredata.AuditStateRejected:   "REJECTED",
+		coredata.AuditStateOutdated:   "OUTDATED",
+	}
+)
+
 func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v any) (bool, error) {
 	res, err := graphql.UnmarshalBoolean(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -51455,6 +55022,25 @@ func (ec *executionContext) marshalNCreateAssetPayload2ᚖgithubᚗcomᚋgetprob
 		return graphql.Null
 	}
 	return ec._CreateAssetPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNCreateAuditInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateAuditInput(ctx context.Context, v any) (types.CreateAuditInput, error) {
+	res, err := ec.unmarshalInputCreateAuditInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNCreateAuditPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateAuditPayload(ctx context.Context, sel ast.SelectionSet, v types.CreateAuditPayload) graphql.Marshaler {
+	return ec._CreateAuditPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNCreateAuditPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateAuditPayload(ctx context.Context, sel ast.SelectionSet, v *types.CreateAuditPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._CreateAuditPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNCreateControlDocumentMappingInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateControlDocumentMappingInput(ctx context.Context, v any) (types.CreateControlDocumentMappingInput, error) {
@@ -52014,6 +55600,44 @@ func (ec *executionContext) marshalNDeleteAssetPayload2ᚖgithubᚗcomᚋgetprob
 		return graphql.Null
 	}
 	return ec._DeleteAssetPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNDeleteAuditInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteAuditInput(ctx context.Context, v any) (types.DeleteAuditInput, error) {
+	res, err := ec.unmarshalInputDeleteAuditInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNDeleteAuditPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteAuditPayload(ctx context.Context, sel ast.SelectionSet, v types.DeleteAuditPayload) graphql.Marshaler {
+	return ec._DeleteAuditPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNDeleteAuditPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteAuditPayload(ctx context.Context, sel ast.SelectionSet, v *types.DeleteAuditPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._DeleteAuditPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNDeleteAuditReportInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteAuditReportInput(ctx context.Context, v any) (types.DeleteAuditReportInput, error) {
+	res, err := ec.unmarshalInputDeleteAuditReportInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNDeleteAuditReportPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteAuditReportPayload(ctx context.Context, sel ast.SelectionSet, v types.DeleteAuditReportPayload) graphql.Marshaler {
+	return ec._DeleteAuditReportPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNDeleteAuditReportPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteAuditReportPayload(ctx context.Context, sel ast.SelectionSet, v *types.DeleteAuditReportPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._DeleteAuditReportPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNDeleteControlDocumentMappingInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteControlDocumentMappingInput(ctx context.Context, v any) (types.DeleteControlDocumentMappingInput, error) {
@@ -54065,6 +57689,25 @@ func (ec *executionContext) marshalNUpdateAssetPayload2ᚖgithubᚗcomᚋgetprob
 	return ec._UpdateAssetPayload(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNUpdateAuditInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateAuditInput(ctx context.Context, v any) (types.UpdateAuditInput, error) {
+	res, err := ec.unmarshalInputUpdateAuditInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNUpdateAuditPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateAuditPayload(ctx context.Context, sel ast.SelectionSet, v types.UpdateAuditPayload) graphql.Marshaler {
+	return ec._UpdateAuditPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNUpdateAuditPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateAuditPayload(ctx context.Context, sel ast.SelectionSet, v *types.UpdateAuditPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._UpdateAuditPayload(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNUpdateControlInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateControlInput(ctx context.Context, v any) (types.UpdateControlInput, error) {
 	res, err := ec.unmarshalInputUpdateControlInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -54288,6 +57931,25 @@ func (ec *executionContext) marshalNUpload2githubᚗcomᚋ99designsᚋgqlgenᚋg
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) unmarshalNUploadAuditReportInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUploadAuditReportInput(ctx context.Context, v any) (types.UploadAuditReportInput, error) {
+	res, err := ec.unmarshalInputUploadAuditReportInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNUploadAuditReportPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUploadAuditReportPayload(ctx context.Context, sel ast.SelectionSet, v types.UploadAuditReportPayload) graphql.Marshaler {
+	return ec._UploadAuditReportPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNUploadAuditReportPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUploadAuditReportPayload(ctx context.Context, sel ast.SelectionSet, v *types.UploadAuditReportPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._UploadAuditReportPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNUploadMeasureEvidenceInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUploadMeasureEvidenceInput(ctx context.Context, v any) (types.UploadMeasureEvidenceInput, error) {
@@ -55150,6 +58812,50 @@ var (
 	}
 )
 
+func (ec *executionContext) unmarshalOAuditOrder2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐAuditOrderBy(ctx context.Context, v any) (*types.AuditOrderBy, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputAuditOrder(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOAuditState2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐAuditState(ctx context.Context, v any) (*coredata.AuditState, error) {
+	if v == nil {
+		return nil, nil
+	}
+	tmp, err := graphql.UnmarshalString(v)
+	res := unmarshalOAuditState2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐAuditState[tmp]
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOAuditState2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐAuditState(ctx context.Context, sel ast.SelectionSet, v *coredata.AuditState) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	_ = sel
+	_ = ctx
+	res := graphql.MarshalString(marshalOAuditState2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐAuditState[*v])
+	return res
+}
+
+var (
+	unmarshalOAuditState2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐAuditState = map[string]coredata.AuditState{
+		"NOT_STARTED": coredata.AuditStateNotStarted,
+		"IN_PROGRESS": coredata.AuditStateInProgress,
+		"COMPLETED":   coredata.AuditStateCompleted,
+		"REJECTED":    coredata.AuditStateRejected,
+		"OUTDATED":    coredata.AuditStateOutdated,
+	}
+	marshalOAuditState2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐAuditState = map[coredata.AuditState]string{
+		coredata.AuditStateNotStarted: "NOT_STARTED",
+		coredata.AuditStateInProgress: "IN_PROGRESS",
+		coredata.AuditStateCompleted:  "COMPLETED",
+		coredata.AuditStateRejected:   "REJECTED",
+		coredata.AuditStateOutdated:   "OUTDATED",
+	}
+)
+
 func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v any) (bool, error) {
 	res, err := graphql.UnmarshalBoolean(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -55662,6 +59368,13 @@ func (ec *executionContext) unmarshalOPeopleOrder2ᚖgithubᚗcomᚋgetproboᚋp
 	}
 	res, err := ec.unmarshalInputPeopleOrder(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOReport2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐReport(ctx context.Context, sel ast.SelectionSet, v *types.Report) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._Report(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalORiskFilter2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐRiskFilter(ctx context.Context, v any) (*types.RiskFilter, error) {

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -115,16 +115,17 @@ type ComplexityRoot struct {
 	}
 
 	Audit struct {
-		CreatedAt    func(childComplexity int) int
-		Framework    func(childComplexity int) int
-		ID           func(childComplexity int) int
-		Organization func(childComplexity int) int
-		Report       func(childComplexity int) int
-		ReportURL    func(childComplexity int) int
-		State        func(childComplexity int) int
-		UpdatedAt    func(childComplexity int) int
-		ValidFrom    func(childComplexity int) int
-		ValidUntil   func(childComplexity int) int
+		CreatedAt         func(childComplexity int) int
+		Framework         func(childComplexity int) int
+		ID                func(childComplexity int) int
+		Organization      func(childComplexity int) int
+		Report            func(childComplexity int) int
+		ReportURL         func(childComplexity int) int
+		ShowOnTrustCenter func(childComplexity int) int
+		State             func(childComplexity int) int
+		UpdatedAt         func(childComplexity int) int
+		ValidFrom         func(childComplexity int) int
+		ValidUntil        func(childComplexity int) int
 	}
 
 	AuditConnection struct {
@@ -386,6 +387,7 @@ type ComplexityRoot struct {
 		ID                      func(childComplexity int) int
 		Organization            func(childComplexity int) int
 		Owner                   func(childComplexity int) int
+		ShowOnTrustCenter       func(childComplexity int) int
 		Title                   func(childComplexity int) int
 		UpdatedAt               func(childComplexity int) int
 		Versions                func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentVersionOrderBy, filter *types.DocumentVersionFilter) int
@@ -619,6 +621,7 @@ type ComplexityRoot struct {
 		UpdatePeople                          func(childComplexity int, input types.UpdatePeopleInput) int
 		UpdateRisk                            func(childComplexity int, input types.UpdateRiskInput) int
 		UpdateTask                            func(childComplexity int, input types.UpdateTaskInput) int
+		UpdateTrustCenter                     func(childComplexity int, input types.UpdateTrustCenterInput) int
 		UpdateVendor                          func(childComplexity int, input types.UpdateVendorInput) int
 		UploadAuditReport                     func(childComplexity int, input types.UploadAuditReportInput) int
 		UploadMeasureEvidence                 func(childComplexity int, input types.UploadMeasureEvidenceInput) int
@@ -627,24 +630,25 @@ type ComplexityRoot struct {
 	}
 
 	Organization struct {
-		Assets     func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AssetOrderBy) int
-		Audits     func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AuditOrderBy) int
-		Connectors func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ConnectorOrder) int
-		Controls   func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ControlOrderBy, filter *types.ControlFilter) int
-		CreatedAt  func(childComplexity int) int
-		Data       func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DatumOrderBy) int
-		Documents  func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy, filter *types.DocumentFilter) int
-		Frameworks func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.FrameworkOrderBy) int
-		ID         func(childComplexity int) int
-		LogoURL    func(childComplexity int) int
-		Measures   func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy, filter *types.MeasureFilter) int
-		Name       func(childComplexity int) int
-		Peoples    func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.PeopleOrderBy) int
-		Risks      func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskOrderBy, filter *types.RiskFilter) int
-		Tasks      func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TaskOrderBy) int
-		UpdatedAt  func(childComplexity int) int
-		Users      func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.UserOrderBy) int
-		Vendors    func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.VendorOrderBy) int
+		Assets      func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AssetOrderBy) int
+		Audits      func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AuditOrderBy) int
+		Connectors  func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ConnectorOrder) int
+		Controls    func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ControlOrderBy, filter *types.ControlFilter) int
+		CreatedAt   func(childComplexity int) int
+		Data        func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DatumOrderBy) int
+		Documents   func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy, filter *types.DocumentFilter) int
+		Frameworks  func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.FrameworkOrderBy) int
+		ID          func(childComplexity int) int
+		LogoURL     func(childComplexity int) int
+		Measures    func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy, filter *types.MeasureFilter) int
+		Name        func(childComplexity int) int
+		Peoples     func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.PeopleOrderBy) int
+		Risks       func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskOrderBy, filter *types.RiskFilter) int
+		Tasks       func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TaskOrderBy) int
+		TrustCenter func(childComplexity int) int
+		UpdatedAt   func(childComplexity int) int
+		Users       func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.UserOrderBy) int
+		Vendors     func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.VendorOrderBy) int
 	}
 
 	OrganizationConnection struct {
@@ -789,6 +793,14 @@ type ComplexityRoot struct {
 		Node   func(childComplexity int) int
 	}
 
+	TrustCenter struct {
+		Active    func(childComplexity int) int
+		CreatedAt func(childComplexity int) int
+		ID        func(childComplexity int) int
+		Slug      func(childComplexity int) int
+		UpdatedAt func(childComplexity int) int
+	}
+
 	UnassignTaskPayload struct {
 		Task func(childComplexity int) int
 	}
@@ -839,6 +851,10 @@ type ComplexityRoot struct {
 
 	UpdateTaskPayload struct {
 		Task func(childComplexity int) int
+	}
+
+	UpdateTrustCenterPayload struct {
+		TrustCenter func(childComplexity int) int
 	}
 
 	UpdateVendorPayload struct {
@@ -899,6 +915,7 @@ type ComplexityRoot struct {
 		SecurityOwner                 func(childComplexity int) int
 		SecurityPageURL               func(childComplexity int) int
 		ServiceLevelAgreementURL      func(childComplexity int) int
+		ShowOnTrustCenter             func(childComplexity int) int
 		StatusPageURL                 func(childComplexity int) int
 		SubprocessorsListURL          func(childComplexity int) int
 		TermsOfServiceURL             func(childComplexity int) int
@@ -1058,6 +1075,7 @@ type MeasureConnectionResolver interface {
 type MutationResolver interface {
 	CreateOrganization(ctx context.Context, input types.CreateOrganizationInput) (*types.CreateOrganizationPayload, error)
 	UpdateOrganization(ctx context.Context, input types.UpdateOrganizationInput) (*types.UpdateOrganizationPayload, error)
+	UpdateTrustCenter(ctx context.Context, input types.UpdateTrustCenterInput) (*types.UpdateTrustCenterPayload, error)
 	ConfirmEmail(ctx context.Context, input types.ConfirmEmailInput) (*types.ConfirmEmailPayload, error)
 	InviteUser(ctx context.Context, input types.InviteUserInput) (*types.InviteUserPayload, error)
 	RemoveUser(ctx context.Context, input types.RemoveUserInput) (*types.RemoveUserPayload, error)
@@ -1144,6 +1162,7 @@ type OrganizationResolver interface {
 	Assets(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AssetOrderBy) (*types.AssetConnection, error)
 	Data(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DatumOrderBy) (*types.DatumConnection, error)
 	Audits(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AuditOrderBy) (*types.AuditConnection, error)
+	TrustCenter(ctx context.Context, obj *types.Organization) (*types.TrustCenter, error)
 }
 type PeopleConnectionResolver interface {
 	TotalCount(ctx context.Context, obj *types.PeopleConnection) (int, error)
@@ -1392,6 +1411,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Audit.ReportURL(childComplexity), true
+
+	case "Audit.showOnTrustCenter":
+		if e.complexity.Audit.ShowOnTrustCenter == nil {
+			break
+		}
+
+		return e.complexity.Audit.ShowOnTrustCenter(childComplexity), true
 
 	case "Audit.state":
 		if e.complexity.Audit.State == nil {
@@ -2154,6 +2180,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Document.Owner(childComplexity), true
+
+	case "Document.showOnTrustCenter":
+		if e.complexity.Document.ShowOnTrustCenter == nil {
+			break
+		}
+
+		return e.complexity.Document.ShowOnTrustCenter(childComplexity), true
 
 	case "Document.title":
 		if e.complexity.Document.Title == nil {
@@ -3631,6 +3664,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.UpdateTask(childComplexity, args["input"].(types.UpdateTaskInput)), true
 
+	case "Mutation.updateTrustCenter":
+		if e.complexity.Mutation.UpdateTrustCenter == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_updateTrustCenter_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UpdateTrustCenter(childComplexity, args["input"].(types.UpdateTrustCenterInput)), true
+
 	case "Mutation.updateVendor":
 		if e.complexity.Mutation.UpdateVendor == nil {
 			break
@@ -3850,6 +3895,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Organization.Tasks(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.TaskOrderBy)), true
+
+	case "Organization.trustCenter":
+		if e.complexity.Organization.TrustCenter == nil {
+			break
+		}
+
+		return e.complexity.Organization.TrustCenter(childComplexity), true
 
 	case "Organization.updatedAt":
 		if e.complexity.Organization.UpdatedAt == nil {
@@ -4481,6 +4533,41 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.TaskEdge.Node(childComplexity), true
 
+	case "TrustCenter.active":
+		if e.complexity.TrustCenter.Active == nil {
+			break
+		}
+
+		return e.complexity.TrustCenter.Active(childComplexity), true
+
+	case "TrustCenter.createdAt":
+		if e.complexity.TrustCenter.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.TrustCenter.CreatedAt(childComplexity), true
+
+	case "TrustCenter.id":
+		if e.complexity.TrustCenter.ID == nil {
+			break
+		}
+
+		return e.complexity.TrustCenter.ID(childComplexity), true
+
+	case "TrustCenter.slug":
+		if e.complexity.TrustCenter.Slug == nil {
+			break
+		}
+
+		return e.complexity.TrustCenter.Slug(childComplexity), true
+
+	case "TrustCenter.updatedAt":
+		if e.complexity.TrustCenter.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.TrustCenter.UpdatedAt(childComplexity), true
+
 	case "UnassignTaskPayload.task":
 		if e.complexity.UnassignTaskPayload.Task == nil {
 			break
@@ -4571,6 +4658,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.UpdateTaskPayload.Task(childComplexity), true
+
+	case "UpdateTrustCenterPayload.trustCenter":
+		if e.complexity.UpdateTrustCenterPayload.TrustCenter == nil {
+			break
+		}
+
+		return e.complexity.UpdateTrustCenterPayload.TrustCenter(childComplexity), true
 
 	case "UpdateVendorPayload.vendor":
 		if e.complexity.UpdateVendorPayload.Vendor == nil {
@@ -4817,6 +4911,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Vendor.ServiceLevelAgreementURL(childComplexity), true
+
+	case "Vendor.showOnTrustCenter":
+		if e.complexity.Vendor.ShowOnTrustCenter == nil {
+			break
+		}
+
+		return e.complexity.Vendor.ShowOnTrustCenter(childComplexity), true
 
 	case "Vendor.statusPageUrl":
 		if e.complexity.Vendor.StatusPageURL == nil {
@@ -5206,6 +5307,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputUpdatePeopleInput,
 		ec.unmarshalInputUpdateRiskInput,
 		ec.unmarshalInputUpdateTaskInput,
+		ec.unmarshalInputUpdateTrustCenterInput,
 		ec.unmarshalInputUpdateVendorInput,
 		ec.unmarshalInputUploadAuditReportInput,
 		ec.unmarshalInputUploadMeasureEvidenceInput,
@@ -6017,6 +6119,14 @@ input RiskFilter {
 }
 
 # Core Types
+type TrustCenter implements Node {
+  id: ID!
+  active: Boolean!
+  slug: String!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+}
+
 type Organization implements Node {
   id: ID!
   name: String!
@@ -6130,6 +6240,8 @@ type Organization implements Node {
     orderBy: AuditOrder
   ): AuditConnection! @goField(forceResolver: true)
 
+  trustCenter: TrustCenter @goField(forceResolver: true)
+
   createdAt: Datetime!
   updatedAt: Datetime!
 }
@@ -6205,6 +6317,7 @@ type Vendor implements Node {
   headquarterAddress: String
   legalName: String
   websiteUrl: String
+  showOnTrustCenter: Boolean!
   createdAt: Datetime!
   updatedAt: Datetime!
 }
@@ -6366,6 +6479,7 @@ type Document implements Node {
   description: String!
   documentType: DocumentType!
   currentPublishedVersion: Int
+  showOnTrustCenter: Boolean!
   owner: People! @goField(forceResolver: true)
   organization: Organization! @goField(forceResolver: true)
 
@@ -6448,6 +6562,7 @@ type Audit implements Node {
   report: Report @goField(forceResolver: true)
   reportUrl: String @goField(forceResolver: true)
   state: AuditState!
+  showOnTrustCenter: Boolean!
   createdAt: Datetime!
   updatedAt: Datetime!
 }
@@ -6711,6 +6826,10 @@ type Mutation {
     input: UpdateOrganizationInput!
   ): UpdateOrganizationPayload!
 
+  updateTrustCenter(
+    input: UpdateTrustCenterInput!
+  ): UpdateTrustCenterPayload!
+
   # User mutations
   confirmEmail(input: ConfirmEmailInput!): ConfirmEmailPayload!
   inviteUser(input: InviteUserInput!): InviteUserPayload!
@@ -6877,6 +6996,12 @@ input UpdateOrganizationInput {
   logo: Upload
 }
 
+input UpdateTrustCenterInput {
+  trustCenterId: ID!
+  active: Boolean
+  slug: String
+}
+
 input CreateVendorInput {
   organizationId: ID!
   name: String!
@@ -6919,6 +7044,7 @@ input UpdateVendorInput {
   trustPageUrl: String
   businessOwnerId: ID
   securityOwnerId: ID
+  showOnTrustCenter: Boolean
 }
 
 input DeleteVendorInput {
@@ -7150,6 +7276,7 @@ input UpdateDocumentInput {
   ownerId: ID
   createdBy: ID
   documentType: DocumentType
+  showOnTrustCenter: Boolean
 }
 
 input ExportDocumentVersionPDFInput {
@@ -7211,6 +7338,7 @@ input UpdateAuditInput {
   validFrom: Datetime
   validUntil: Datetime
   state: AuditState
+  showOnTrustCenter: Boolean
 }
 
 input DeleteAuditInput {
@@ -7233,6 +7361,10 @@ type CreateOrganizationPayload {
 
 type UpdateOrganizationPayload {
   organization: Organization!
+}
+
+type UpdateTrustCenterPayload {
+  trustCenter: TrustCenter!
 }
 
 type CreateControlPayload {
@@ -10637,6 +10769,29 @@ func (ec *executionContext) field_Mutation_updateTask_argsInput(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation_updateTrustCenter_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_updateTrustCenter_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_updateTrustCenter_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.UpdateTrustCenterInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNUpdateTrustCenterInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateTrustCenterInput(ctx, tmp)
+	}
+
+	var zeroVal types.UpdateTrustCenterInput
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation_updateVendor_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -13030,6 +13185,8 @@ func (ec *executionContext) fieldContext_AssessVendorPayload_vendor(_ context.Co
 				return ec.fieldContext_Vendor_legalName(ctx, field)
 			case "websiteUrl":
 				return ec.fieldContext_Vendor_websiteUrl(ctx, field)
+			case "showOnTrustCenter":
+				return ec.fieldContext_Vendor_showOnTrustCenter(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Vendor_createdAt(ctx, field)
 			case "updatedAt":
@@ -13505,6 +13662,8 @@ func (ec *executionContext) fieldContext_Asset_organization(_ context.Context, f
 				return ec.fieldContext_Organization_data(ctx, field)
 			case "audits":
 				return ec.fieldContext_Organization_audits(ctx, field)
+			case "trustCenter":
+				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Organization_createdAt(ctx, field)
 			case "updatedAt":
@@ -14049,6 +14208,8 @@ func (ec *executionContext) fieldContext_Audit_organization(_ context.Context, f
 				return ec.fieldContext_Organization_data(ctx, field)
 			case "audits":
 				return ec.fieldContext_Organization_audits(ctx, field)
+			case "trustCenter":
+				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Organization_createdAt(ctx, field)
 			case "updatedAt":
@@ -14341,6 +14502,50 @@ func (ec *executionContext) fieldContext_Audit_state(_ context.Context, field gr
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type AuditState does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Audit_showOnTrustCenter(ctx context.Context, field graphql.CollectedField, obj *types.Audit) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Audit_showOnTrustCenter(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ShowOnTrustCenter, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Audit_showOnTrustCenter(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Audit",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -14681,6 +14886,8 @@ func (ec *executionContext) fieldContext_AuditEdge_node(_ context.Context, field
 				return ec.fieldContext_Audit_reportUrl(ctx, field)
 			case "state":
 				return ec.fieldContext_Audit_state(ctx, field)
+			case "showOnTrustCenter":
+				return ec.fieldContext_Audit_showOnTrustCenter(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Audit_createdAt(ctx, field)
 			case "updatedAt":
@@ -17681,6 +17888,8 @@ func (ec *executionContext) fieldContext_Datum_organization(_ context.Context, f
 				return ec.fieldContext_Organization_data(ctx, field)
 			case "audits":
 				return ec.fieldContext_Organization_audits(ctx, field)
+			case "trustCenter":
+				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Organization_createdAt(ctx, field)
 			case "updatedAt":
@@ -18177,6 +18386,8 @@ func (ec *executionContext) fieldContext_DeleteAuditReportPayload_audit(_ contex
 				return ec.fieldContext_Audit_reportUrl(ctx, field)
 			case "state":
 				return ec.fieldContext_Audit_state(ctx, field)
+			case "showOnTrustCenter":
+				return ec.fieldContext_Audit_showOnTrustCenter(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Audit_createdAt(ctx, field)
 			case "updatedAt":
@@ -19241,6 +19452,50 @@ func (ec *executionContext) fieldContext_Document_currentPublishedVersion(_ cont
 	return fc, nil
 }
 
+func (ec *executionContext) _Document_showOnTrustCenter(ctx context.Context, field graphql.CollectedField, obj *types.Document) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Document_showOnTrustCenter(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ShowOnTrustCenter, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Document_showOnTrustCenter(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Document",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Document_owner(ctx context.Context, field graphql.CollectedField, obj *types.Document) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Document_owner(ctx, field)
 	if err != nil {
@@ -19378,6 +19633,8 @@ func (ec *executionContext) fieldContext_Document_organization(_ context.Context
 				return ec.fieldContext_Organization_data(ctx, field)
 			case "audits":
 				return ec.fieldContext_Organization_audits(ctx, field)
+			case "trustCenter":
+				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Organization_createdAt(ctx, field)
 			case "updatedAt":
@@ -19842,6 +20099,8 @@ func (ec *executionContext) fieldContext_DocumentEdge_node(_ context.Context, fi
 				return ec.fieldContext_Document_documentType(ctx, field)
 			case "currentPublishedVersion":
 				return ec.fieldContext_Document_currentPublishedVersion(ctx, field)
+			case "showOnTrustCenter":
+				return ec.fieldContext_Document_showOnTrustCenter(ctx, field)
 			case "owner":
 				return ec.fieldContext_Document_owner(ctx, field)
 			case "organization":
@@ -19954,6 +20213,8 @@ func (ec *executionContext) fieldContext_DocumentVersion_document(_ context.Cont
 				return ec.fieldContext_Document_documentType(ctx, field)
 			case "currentPublishedVersion":
 				return ec.fieldContext_Document_currentPublishedVersion(ctx, field)
+			case "showOnTrustCenter":
+				return ec.fieldContext_Document_showOnTrustCenter(ctx, field)
 			case "owner":
 				return ec.fieldContext_Document_owner(ctx, field)
 			case "organization":
@@ -22533,6 +22794,8 @@ func (ec *executionContext) fieldContext_Framework_organization(_ context.Contex
 				return ec.fieldContext_Organization_data(ctx, field)
 			case "audits":
 				return ec.fieldContext_Organization_audits(ctx, field)
+			case "trustCenter":
+				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Organization_createdAt(ctx, field)
 			case "updatedAt":
@@ -24161,6 +24424,65 @@ func (ec *executionContext) fieldContext_Mutation_updateOrganization(ctx context
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_updateOrganization_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_updateTrustCenter(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_updateTrustCenter(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UpdateTrustCenter(rctx, fc.Args["input"].(types.UpdateTrustCenterInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.UpdateTrustCenterPayload)
+	fc.Result = res
+	return ec.marshalNUpdateTrustCenterPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateTrustCenterPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_updateTrustCenter(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "trustCenter":
+				return ec.fieldContext_UpdateTrustCenterPayload_trustCenter(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UpdateTrustCenterPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_updateTrustCenter_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -29263,6 +29585,59 @@ func (ec *executionContext) fieldContext_Organization_audits(ctx context.Context
 	return fc, nil
 }
 
+func (ec *executionContext) _Organization_trustCenter(ctx context.Context, field graphql.CollectedField, obj *types.Organization) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Organization_trustCenter(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Organization().TrustCenter(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*types.TrustCenter)
+	fc.Result = res
+	return ec.marshalOTrustCenter2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenter(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Organization_trustCenter(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Organization",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TrustCenter_id(ctx, field)
+			case "active":
+				return ec.fieldContext_TrustCenter_active(ctx, field)
+			case "slug":
+				return ec.fieldContext_TrustCenter_slug(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_TrustCenter_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_TrustCenter_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustCenter", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Organization_createdAt(ctx context.Context, field graphql.CollectedField, obj *types.Organization) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Organization_createdAt(ctx, field)
 	if err != nil {
@@ -29570,6 +29945,8 @@ func (ec *executionContext) fieldContext_OrganizationEdge_node(_ context.Context
 				return ec.fieldContext_Organization_data(ctx, field)
 			case "audits":
 				return ec.fieldContext_Organization_audits(ctx, field)
+			case "trustCenter":
+				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Organization_createdAt(ctx, field)
 			case "updatedAt":
@@ -30561,6 +30938,8 @@ func (ec *executionContext) fieldContext_PublishDocumentVersionPayload_document(
 				return ec.fieldContext_Document_documentType(ctx, field)
 			case "currentPublishedVersion":
 				return ec.fieldContext_Document_currentPublishedVersion(ctx, field)
+			case "showOnTrustCenter":
+				return ec.fieldContext_Document_showOnTrustCenter(ctx, field)
 			case "owner":
 				return ec.fieldContext_Document_owner(ctx, field)
 			case "organization":
@@ -31973,6 +32352,8 @@ func (ec *executionContext) fieldContext_Risk_organization(_ context.Context, fi
 				return ec.fieldContext_Organization_data(ctx, field)
 			case "audits":
 				return ec.fieldContext_Organization_audits(ctx, field)
+			case "trustCenter":
+				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Organization_createdAt(ctx, field)
 			case "updatedAt":
@@ -33061,6 +33442,8 @@ func (ec *executionContext) fieldContext_Task_organization(_ context.Context, fi
 				return ec.fieldContext_Organization_data(ctx, field)
 			case "audits":
 				return ec.fieldContext_Organization_audits(ctx, field)
+			case "trustCenter":
+				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Organization_createdAt(ctx, field)
 			case "updatedAt":
@@ -33550,6 +33933,226 @@ func (ec *executionContext) fieldContext_TaskEdge_node(_ context.Context, field 
 	return fc, nil
 }
 
+func (ec *executionContext) _TrustCenter_id(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenter) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenter_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(gid.GID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenter_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenter",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenter_active(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenter) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenter_active(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Active, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenter_active(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenter",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenter_slug(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenter) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenter_slug(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Slug, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenter_slug(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenter",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenter_createdAt(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenter) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenter_createdAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNDatetime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenter_createdAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenter",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenter_updatedAt(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenter) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenter_updatedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNDatetime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenter_updatedAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenter",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _UnassignTaskPayload_task(ctx context.Context, field graphql.CollectedField, obj *types.UnassignTaskPayload) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_UnassignTaskPayload_task(ctx, field)
 	if err != nil {
@@ -33743,6 +34346,8 @@ func (ec *executionContext) fieldContext_UpdateAuditPayload_audit(_ context.Cont
 				return ec.fieldContext_Audit_reportUrl(ctx, field)
 			case "state":
 				return ec.fieldContext_Audit_state(ctx, field)
+			case "showOnTrustCenter":
+				return ec.fieldContext_Audit_showOnTrustCenter(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Audit_createdAt(ctx, field)
 			case "updatedAt":
@@ -33933,6 +34538,8 @@ func (ec *executionContext) fieldContext_UpdateDocumentPayload_document(_ contex
 				return ec.fieldContext_Document_documentType(ctx, field)
 			case "currentPublishedVersion":
 				return ec.fieldContext_Document_currentPublishedVersion(ctx, field)
+			case "showOnTrustCenter":
+				return ec.fieldContext_Document_showOnTrustCenter(ctx, field)
 			case "owner":
 				return ec.fieldContext_Document_owner(ctx, field)
 			case "organization":
@@ -34223,6 +34830,8 @@ func (ec *executionContext) fieldContext_UpdateOrganizationPayload_organization(
 				return ec.fieldContext_Organization_data(ctx, field)
 			case "audits":
 				return ec.fieldContext_Organization_audits(ctx, field)
+			case "trustCenter":
+				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Organization_createdAt(ctx, field)
 			case "updatedAt":
@@ -34454,6 +35063,62 @@ func (ec *executionContext) fieldContext_UpdateTaskPayload_task(_ context.Contex
 	return fc, nil
 }
 
+func (ec *executionContext) _UpdateTrustCenterPayload_trustCenter(ctx context.Context, field graphql.CollectedField, obj *types.UpdateTrustCenterPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UpdateTrustCenterPayload_trustCenter(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TrustCenter, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.TrustCenter)
+	fc.Result = res
+	return ec.marshalNTrustCenter2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenter(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UpdateTrustCenterPayload_trustCenter(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UpdateTrustCenterPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TrustCenter_id(ctx, field)
+			case "active":
+				return ec.fieldContext_TrustCenter_active(ctx, field)
+			case "slug":
+				return ec.fieldContext_TrustCenter_slug(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_TrustCenter_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_TrustCenter_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustCenter", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _UpdateVendorPayload_vendor(ctx context.Context, field graphql.CollectedField, obj *types.UpdateVendorPayload) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_UpdateVendorPayload_vendor(ctx, field)
 	if err != nil {
@@ -34537,6 +35202,8 @@ func (ec *executionContext) fieldContext_UpdateVendorPayload_vendor(_ context.Co
 				return ec.fieldContext_Vendor_legalName(ctx, field)
 			case "websiteUrl":
 				return ec.fieldContext_Vendor_websiteUrl(ctx, field)
+			case "showOnTrustCenter":
+				return ec.fieldContext_Vendor_showOnTrustCenter(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Vendor_createdAt(ctx, field)
 			case "updatedAt":
@@ -34603,6 +35270,8 @@ func (ec *executionContext) fieldContext_UploadAuditReportPayload_audit(_ contex
 				return ec.fieldContext_Audit_reportUrl(ctx, field)
 			case "state":
 				return ec.fieldContext_Audit_state(ctx, field)
+			case "showOnTrustCenter":
+				return ec.fieldContext_Audit_showOnTrustCenter(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Audit_createdAt(ctx, field)
 			case "updatedAt":
@@ -35508,6 +36177,8 @@ func (ec *executionContext) fieldContext_Vendor_organization(_ context.Context, 
 				return ec.fieldContext_Organization_data(ctx, field)
 			case "audits":
 				return ec.fieldContext_Organization_audits(ctx, field)
+			case "trustCenter":
+				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Organization_createdAt(ctx, field)
 			case "updatedAt":
@@ -36303,6 +36974,50 @@ func (ec *executionContext) fieldContext_Vendor_websiteUrl(_ context.Context, fi
 	return fc, nil
 }
 
+func (ec *executionContext) _Vendor_showOnTrustCenter(ctx context.Context, field graphql.CollectedField, obj *types.Vendor) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Vendor_showOnTrustCenter(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ShowOnTrustCenter, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Vendor_showOnTrustCenter(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Vendor",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Vendor_createdAt(ctx context.Context, field graphql.CollectedField, obj *types.Vendor) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Vendor_createdAt(ctx, field)
 	if err != nil {
@@ -36518,6 +37233,8 @@ func (ec *executionContext) fieldContext_VendorComplianceReport_vendor(_ context
 				return ec.fieldContext_Vendor_legalName(ctx, field)
 			case "websiteUrl":
 				return ec.fieldContext_Vendor_websiteUrl(ctx, field)
+			case "showOnTrustCenter":
+				return ec.fieldContext_Vendor_showOnTrustCenter(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Vendor_createdAt(ctx, field)
 			case "updatedAt":
@@ -37321,6 +38038,8 @@ func (ec *executionContext) fieldContext_VendorEdge_node(_ context.Context, fiel
 				return ec.fieldContext_Vendor_legalName(ctx, field)
 			case "websiteUrl":
 				return ec.fieldContext_Vendor_websiteUrl(ctx, field)
+			case "showOnTrustCenter":
+				return ec.fieldContext_Vendor_showOnTrustCenter(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Vendor_createdAt(ctx, field)
 			case "updatedAt":
@@ -37459,6 +38178,8 @@ func (ec *executionContext) fieldContext_VendorRiskAssessment_vendor(_ context.C
 				return ec.fieldContext_Vendor_legalName(ctx, field)
 			case "websiteUrl":
 				return ec.fieldContext_Vendor_websiteUrl(ctx, field)
+			case "showOnTrustCenter":
+				return ec.fieldContext_Vendor_showOnTrustCenter(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_Vendor_createdAt(ctx, field)
 			case "updatedAt":
@@ -43148,7 +43869,7 @@ func (ec *executionContext) unmarshalInputUpdateAuditInput(ctx context.Context, 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "validFrom", "validUntil", "state"}
+	fieldsInOrder := [...]string{"id", "validFrom", "validUntil", "state", "showOnTrustCenter"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -43183,6 +43904,13 @@ func (ec *executionContext) unmarshalInputUpdateAuditInput(ctx context.Context, 
 				return it, err
 			}
 			it.State = data
+		case "showOnTrustCenter":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("showOnTrustCenter"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ShowOnTrustCenter = data
 		}
 	}
 
@@ -43313,7 +44041,7 @@ func (ec *executionContext) unmarshalInputUpdateDocumentInput(ctx context.Contex
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "title", "content", "ownerId", "createdBy", "documentType"}
+	fieldsInOrder := [...]string{"id", "title", "content", "ownerId", "createdBy", "documentType", "showOnTrustCenter"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -43362,6 +44090,13 @@ func (ec *executionContext) unmarshalInputUpdateDocumentInput(ctx context.Contex
 				return it, err
 			}
 			it.DocumentType = data
+		case "showOnTrustCenter":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("showOnTrustCenter"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ShowOnTrustCenter = data
 		}
 	}
 
@@ -43774,6 +44509,47 @@ func (ec *executionContext) unmarshalInputUpdateTaskInput(ctx context.Context, o
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputUpdateTrustCenterInput(ctx context.Context, obj any) (types.UpdateTrustCenterInput, error) {
+	var it types.UpdateTrustCenterInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"trustCenterId", "active", "slug"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "trustCenterId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("trustCenterId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.TrustCenterID = data
+		case "active":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("active"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Active = data
+		case "slug":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("slug"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Slug = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputUpdateVendorInput(ctx context.Context, obj any) (types.UpdateVendorInput, error) {
 	var it types.UpdateVendorInput
 	asMap := map[string]any{}
@@ -43781,7 +44557,7 @@ func (ec *executionContext) unmarshalInputUpdateVendorInput(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "name", "description", "statusPageUrl", "termsOfServiceUrl", "privacyPolicyUrl", "serviceLevelAgreementUrl", "dataProcessingAgreementUrl", "businessAssociateAgreementUrl", "subprocessorsListUrl", "websiteUrl", "legalName", "headquarterAddress", "category", "certifications", "securityPageUrl", "trustPageUrl", "businessOwnerId", "securityOwnerId"}
+	fieldsInOrder := [...]string{"id", "name", "description", "statusPageUrl", "termsOfServiceUrl", "privacyPolicyUrl", "serviceLevelAgreementUrl", "dataProcessingAgreementUrl", "businessAssociateAgreementUrl", "subprocessorsListUrl", "websiteUrl", "legalName", "headquarterAddress", "category", "certifications", "securityPageUrl", "trustPageUrl", "businessOwnerId", "securityOwnerId", "showOnTrustCenter"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -43921,6 +44697,13 @@ func (ec *executionContext) unmarshalInputUpdateVendorInput(ctx context.Context,
 				return it, err
 			}
 			it.SecurityOwnerID = data
+		case "showOnTrustCenter":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("showOnTrustCenter"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ShowOnTrustCenter = data
 		}
 	}
 
@@ -44256,6 +45039,13 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._User(ctx, sel, obj)
+	case types.TrustCenter:
+		return ec._TrustCenter(ctx, sel, &obj)
+	case *types.TrustCenter:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._TrustCenter(ctx, sel, obj)
 	case types.Task:
 		return ec._Task(ctx, sel, &obj)
 	case *types.Task:
@@ -44952,6 +45742,11 @@ func (ec *executionContext) _Audit(ctx context.Context, sel ast.SelectionSet, ob
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "state":
 			out.Values[i] = ec._Audit_state(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "showOnTrustCenter":
+			out.Values[i] = ec._Audit_showOnTrustCenter(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
@@ -47535,6 +48330,11 @@ func (ec *executionContext) _Document(ctx context.Context, sel ast.SelectionSet,
 			}
 		case "currentPublishedVersion":
 			out.Values[i] = ec._Document_currentPublishedVersion(ctx, field, obj)
+		case "showOnTrustCenter":
+			out.Values[i] = ec._Document_showOnTrustCenter(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		case "owner":
 			field := field
 
@@ -49603,6 +50403,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "updateTrustCenter":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_updateTrustCenter(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "confirmEmail":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_confirmEmail(ctx, field)
@@ -50615,6 +51422,39 @@ func (ec *executionContext) _Organization(ctx context.Context, sel ast.Selection
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "trustCenter":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Organization_trustCenter(ctx, field, obj)
 				return res
 			}
 
@@ -52181,6 +53021,65 @@ func (ec *executionContext) _TaskEdge(ctx context.Context, sel ast.SelectionSet,
 	return out
 }
 
+var trustCenterImplementors = []string{"TrustCenter", "Node"}
+
+func (ec *executionContext) _TrustCenter(ctx context.Context, sel ast.SelectionSet, obj *types.TrustCenter) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, trustCenterImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TrustCenter")
+		case "id":
+			out.Values[i] = ec._TrustCenter_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "active":
+			out.Values[i] = ec._TrustCenter_active(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "slug":
+			out.Values[i] = ec._TrustCenter_slug(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "createdAt":
+			out.Values[i] = ec._TrustCenter_createdAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "updatedAt":
+			out.Values[i] = ec._TrustCenter_updatedAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var unassignTaskPayloadImplementors = []string{"UnassignTaskPayload"}
 
 func (ec *executionContext) _UnassignTaskPayload(ctx context.Context, sel ast.SelectionSet, obj *types.UnassignTaskPayload) graphql.Marshaler {
@@ -52662,6 +53561,45 @@ func (ec *executionContext) _UpdateTaskPayload(ctx context.Context, sel ast.Sele
 			out.Values[i] = graphql.MarshalString("UpdateTaskPayload")
 		case "task":
 			out.Values[i] = ec._UpdateTaskPayload_task(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var updateTrustCenterPayloadImplementors = []string{"UpdateTrustCenterPayload"}
+
+func (ec *executionContext) _UpdateTrustCenterPayload(ctx context.Context, sel ast.SelectionSet, obj *types.UpdateTrustCenterPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, updateTrustCenterPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("UpdateTrustCenterPayload")
+		case "trustCenter":
+			out.Values[i] = ec._UpdateTrustCenterPayload_trustCenter(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -53294,6 +54232,11 @@ func (ec *executionContext) _Vendor(ctx context.Context, sel ast.SelectionSet, o
 			out.Values[i] = ec._Vendor_legalName(ctx, field, obj)
 		case "websiteUrl":
 			out.Values[i] = ec._Vendor_websiteUrl(ctx, field, obj)
+		case "showOnTrustCenter":
+			out.Values[i] = ec._Vendor_showOnTrustCenter(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		case "createdAt":
 			out.Values[i] = ec._Vendor_createdAt(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -57651,6 +58594,16 @@ var (
 	}
 )
 
+func (ec *executionContext) marshalNTrustCenter2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenter(ctx context.Context, sel ast.SelectionSet, v *types.TrustCenter) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TrustCenter(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNUnassignTaskInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUnassignTaskInput(ctx context.Context, v any) (types.UnassignTaskInput, error) {
 	res, err := ec.unmarshalInputUnassignTaskInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -57896,6 +58849,25 @@ func (ec *executionContext) marshalNUpdateTaskPayload2ᚖgithubᚗcomᚋgetprobo
 		return graphql.Null
 	}
 	return ec._UpdateTaskPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNUpdateTrustCenterInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateTrustCenterInput(ctx context.Context, v any) (types.UpdateTrustCenterInput, error) {
+	res, err := ec.unmarshalInputUpdateTrustCenterInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNUpdateTrustCenterPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateTrustCenterPayload(ctx context.Context, sel ast.SelectionSet, v types.UpdateTrustCenterPayload) graphql.Marshaler {
+	return ec._UpdateTrustCenterPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNUpdateTrustCenterPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateTrustCenterPayload(ctx context.Context, sel ast.SelectionSet, v *types.UpdateTrustCenterPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._UpdateTrustCenterPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNUpdateVendorInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateVendorInput(ctx context.Context, v any) (types.UpdateVendorInput, error) {
@@ -59525,6 +60497,13 @@ var (
 		coredata.TaskStateDone: "DONE",
 	}
 )
+
+func (ec *executionContext) marshalOTrustCenter2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenter(ctx context.Context, sel ast.SelectionSet, v *types.TrustCenter) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._TrustCenter(ctx, sel, v)
+}
 
 func (ec *executionContext) unmarshalOUpload2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚐUpload(ctx context.Context, v any) (*graphql.Upload, error) {
 	if v == nil {

--- a/pkg/server/api/console/v1/types/audit.go
+++ b/pkg/server/api/console/v1/types/audit.go
@@ -54,14 +54,15 @@ func NewAuditConnection(
 
 func NewAudit(a *coredata.Audit) *Audit {
 	audit := &Audit{
-		ID:           a.ID,
-		ValidFrom:    a.ValidFrom,
-		ValidUntil:   a.ValidUntil,
-		State:        a.State,
-		CreatedAt:    a.CreatedAt,
-		UpdatedAt:    a.UpdatedAt,
-		Organization: &Organization{ID: a.OrganizationID},
-		Framework:    &Framework{ID: a.FrameworkID},
+		ID:                a.ID,
+		ValidFrom:         a.ValidFrom,
+		ValidUntil:        a.ValidUntil,
+		State:             a.State,
+		ShowOnTrustCenter: a.ShowOnTrustCenter,
+		CreatedAt:         a.CreatedAt,
+		UpdatedAt:         a.UpdatedAt,
+		Organization:      &Organization{ID: a.OrganizationID},
+		Framework:         &Framework{ID: a.FrameworkID},
 	}
 
 	if a.ReportID != nil {

--- a/pkg/server/api/console/v1/types/audit.go
+++ b/pkg/server/api/console/v1/types/audit.go
@@ -64,7 +64,6 @@ func NewAudit(a *coredata.Audit) *Audit {
 		Framework:    &Framework{ID: a.FrameworkID},
 	}
 
-	// Set Report field if ReportID exists
 	if a.ReportID != nil {
 		audit.Report = &Report{ID: *a.ReportID}
 	}

--- a/pkg/server/api/console/v1/types/audit.go
+++ b/pkg/server/api/console/v1/types/audit.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package types
+
+import (
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+)
+
+type (
+	AuditOrderBy OrderBy[coredata.AuditOrderField]
+
+	AuditConnection struct {
+		TotalCount int
+		Edges      []*AuditEdge
+		PageInfo   PageInfo
+
+		Resolver any
+		ParentID gid.GID
+	}
+)
+
+func NewAuditConnection(
+	p *page.Page[*coredata.Audit, coredata.AuditOrderField],
+	parentType any,
+	parentID gid.GID,
+) *AuditConnection {
+	edges := make([]*AuditEdge, len(p.Data))
+	for i, audit := range p.Data {
+		edges[i] = NewAuditEdge(audit, p.Cursor.OrderBy.Field)
+	}
+
+	return &AuditConnection{
+		Edges:    edges,
+		PageInfo: *NewPageInfo(p),
+
+		Resolver: parentType,
+		ParentID: parentID,
+	}
+}
+
+func NewAudit(a *coredata.Audit) *Audit {
+	audit := &Audit{
+		ID:           a.ID,
+		ValidFrom:    a.ValidFrom,
+		ValidUntil:   a.ValidUntil,
+		State:        a.State,
+		CreatedAt:    a.CreatedAt,
+		UpdatedAt:    a.UpdatedAt,
+		Organization: &Organization{ID: a.OrganizationID},
+		Framework:    &Framework{ID: a.FrameworkID},
+	}
+
+	// Set Report field if ReportID exists
+	if a.ReportID != nil {
+		audit.Report = &Report{ID: *a.ReportID}
+	}
+
+	return audit
+}
+
+func NewAuditEdge(a *coredata.Audit, orderField coredata.AuditOrderField) *AuditEdge {
+	return &AuditEdge{
+		Node:   NewAudit(a),
+		Cursor: a.CursorKey(orderField),
+	}
+}

--- a/pkg/server/api/console/v1/types/audit.go
+++ b/pkg/server/api/console/v1/types/audit.go
@@ -53,7 +53,7 @@ func NewAuditConnection(
 }
 
 func NewAudit(a *coredata.Audit) *Audit {
-	audit := &Audit{
+	return &Audit{
 		ID:                a.ID,
 		ValidFrom:         a.ValidFrom,
 		ValidUntil:        a.ValidUntil,
@@ -61,15 +61,7 @@ func NewAudit(a *coredata.Audit) *Audit {
 		ShowOnTrustCenter: a.ShowOnTrustCenter,
 		CreatedAt:         a.CreatedAt,
 		UpdatedAt:         a.UpdatedAt,
-		Organization:      &Organization{ID: a.OrganizationID},
-		Framework:         &Framework{ID: a.FrameworkID},
 	}
-
-	if a.ReportID != nil {
-		audit.Report = &Report{ID: *a.ReportID}
-	}
-
-	return audit
 }
 
 func NewAuditEdge(a *coredata.Audit, orderField coredata.AuditOrderField) *AuditEdge {

--- a/pkg/server/api/console/v1/types/document.go
+++ b/pkg/server/api/console/v1/types/document.go
@@ -79,6 +79,7 @@ func NewDocument(document *coredata.Document) *Document {
 		Title:                   document.Title,
 		DocumentType:            document.DocumentType,
 		CurrentPublishedVersion: document.CurrentPublishedVersion,
+		ShowOnTrustCenter:       document.ShowOnTrustCenter,
 		CreatedAt:               document.CreatedAt,
 		UpdatedAt:               document.UpdatedAt,
 	}

--- a/pkg/server/api/console/v1/types/report.go
+++ b/pkg/server/api/console/v1/types/report.go
@@ -12,29 +12,20 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-package coredata
+package types
 
-const (
-	OrganizationEntityType uint16 = iota
-	FrameworkEntityType
-	MeasureEntityType
-	TaskEntityType
-	EvidenceEntityType
-	ConnectorEntityType
-	VendorRiskAssessmentEntityType
-	VendorEntityType
-	PeopleEntityType
-	VendorComplianceReportEntityType
-	DocumentEntityType
-	UserEntityType
-	SessionEntityType
-	EmailEntityType
-	ControlEntityType
-	RiskEntityType
-	DocumentVersionEntityType
-	DocumentVersionSignatureEntityType
-	AssetEntityType
-	DatumEntityType
-	AuditEntityType
-	ReportEntityType
+import (
+	"github.com/getprobo/probo/pkg/coredata"
 )
+
+func NewReport(r *coredata.Report) *Report {
+	return &Report{
+		ID:        r.ID,
+		ObjectKey: r.ObjectKey,
+		MimeType:  r.MimeType,
+		Filename:  r.Filename,
+		Size:      int(r.Size),
+		CreatedAt: r.CreatedAt,
+		UpdatedAt: r.UpdatedAt,
+	}
+}

--- a/pkg/server/api/console/v1/types/trust_center.go
+++ b/pkg/server/api/console/v1/types/trust_center.go
@@ -12,30 +12,18 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-package coredata
+package types
 
-const (
-	OrganizationEntityType uint16 = iota
-	FrameworkEntityType
-	MeasureEntityType
-	TaskEntityType
-	EvidenceEntityType
-	ConnectorEntityType
-	VendorRiskAssessmentEntityType
-	VendorEntityType
-	PeopleEntityType
-	VendorComplianceReportEntityType
-	DocumentEntityType
-	UserEntityType
-	SessionEntityType
-	EmailEntityType
-	ControlEntityType
-	RiskEntityType
-	DocumentVersionEntityType
-	DocumentVersionSignatureEntityType
-	AssetEntityType
-	DatumEntityType
-	AuditEntityType
-	ReportEntityType
-	TrustCenterEntityType
+import (
+	"github.com/getprobo/probo/pkg/coredata"
 )
+
+func NewTrustCenter(tc *coredata.TrustCenter) *TrustCenter {
+	return &TrustCenter{
+		ID:        tc.ID,
+		Active:    tc.Active,
+		Slug:      tc.Slug,
+		CreatedAt: tc.CreatedAt,
+		UpdatedAt: tc.UpdatedAt,
+	}
+}

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -57,16 +57,17 @@ type AssignTaskPayload struct {
 }
 
 type Audit struct {
-	ID           gid.GID             `json:"id"`
-	Organization *Organization       `json:"organization"`
-	Framework    *Framework          `json:"framework"`
-	ValidFrom    *time.Time          `json:"validFrom,omitempty"`
-	ValidUntil   *time.Time          `json:"validUntil,omitempty"`
-	Report       *Report             `json:"report,omitempty"`
-	ReportURL    *string             `json:"reportUrl,omitempty"`
-	State        coredata.AuditState `json:"state"`
-	CreatedAt    time.Time           `json:"createdAt"`
-	UpdatedAt    time.Time           `json:"updatedAt"`
+	ID                gid.GID             `json:"id"`
+	Organization      *Organization       `json:"organization"`
+	Framework         *Framework          `json:"framework"`
+	ValidFrom         *time.Time          `json:"validFrom,omitempty"`
+	ValidUntil        *time.Time          `json:"validUntil,omitempty"`
+	Report            *Report             `json:"report,omitempty"`
+	ReportURL         *string             `json:"reportUrl,omitempty"`
+	State             coredata.AuditState `json:"state"`
+	ShowOnTrustCenter bool                `json:"showOnTrustCenter"`
+	CreatedAt         time.Time           `json:"createdAt"`
+	UpdatedAt         time.Time           `json:"updatedAt"`
 }
 
 func (Audit) IsNode()             {}
@@ -582,6 +583,7 @@ type Document struct {
 	Description             string                     `json:"description"`
 	DocumentType            coredata.DocumentType      `json:"documentType"`
 	CurrentPublishedVersion *int                       `json:"currentPublishedVersion,omitempty"`
+	ShowOnTrustCenter       bool                       `json:"showOnTrustCenter"`
 	Owner                   *People                    `json:"owner"`
 	Organization            *Organization              `json:"organization"`
 	Versions                *DocumentVersionConnection `json:"versions"`
@@ -800,24 +802,25 @@ type Mutation struct {
 }
 
 type Organization struct {
-	ID         gid.GID              `json:"id"`
-	Name       string               `json:"name"`
-	LogoURL    *string              `json:"logoUrl,omitempty"`
-	Users      *UserConnection      `json:"users"`
-	Connectors *ConnectorConnection `json:"connectors"`
-	Frameworks *FrameworkConnection `json:"frameworks"`
-	Controls   *ControlConnection   `json:"controls"`
-	Vendors    *VendorConnection    `json:"vendors"`
-	Peoples    *PeopleConnection    `json:"peoples"`
-	Documents  *DocumentConnection  `json:"documents"`
-	Measures   *MeasureConnection   `json:"measures"`
-	Risks      *RiskConnection      `json:"risks"`
-	Tasks      *TaskConnection      `json:"tasks"`
-	Assets     *AssetConnection     `json:"assets"`
-	Data       *DatumConnection     `json:"data"`
-	Audits     *AuditConnection     `json:"audits"`
-	CreatedAt  time.Time            `json:"createdAt"`
-	UpdatedAt  time.Time            `json:"updatedAt"`
+	ID          gid.GID              `json:"id"`
+	Name        string               `json:"name"`
+	LogoURL     *string              `json:"logoUrl,omitempty"`
+	Users       *UserConnection      `json:"users"`
+	Connectors  *ConnectorConnection `json:"connectors"`
+	Frameworks  *FrameworkConnection `json:"frameworks"`
+	Controls    *ControlConnection   `json:"controls"`
+	Vendors     *VendorConnection    `json:"vendors"`
+	Peoples     *PeopleConnection    `json:"peoples"`
+	Documents   *DocumentConnection  `json:"documents"`
+	Measures    *MeasureConnection   `json:"measures"`
+	Risks       *RiskConnection      `json:"risks"`
+	Tasks       *TaskConnection      `json:"tasks"`
+	Assets      *AssetConnection     `json:"assets"`
+	Data        *DatumConnection     `json:"data"`
+	Audits      *AuditConnection     `json:"audits"`
+	TrustCenter *TrustCenter         `json:"trustCenter,omitempty"`
+	CreatedAt   time.Time            `json:"createdAt"`
+	UpdatedAt   time.Time            `json:"updatedAt"`
 }
 
 func (Organization) IsNode()             {}
@@ -992,6 +995,17 @@ type TaskEdge struct {
 	Node   *Task          `json:"node"`
 }
 
+type TrustCenter struct {
+	ID        gid.GID   `json:"id"`
+	Active    bool      `json:"active"`
+	Slug      string    `json:"slug"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+func (TrustCenter) IsNode()             {}
+func (this TrustCenter) GetID() gid.GID { return this.ID }
+
 type UnassignTaskInput struct {
 	TaskID gid.GID `json:"taskId"`
 }
@@ -1016,10 +1030,11 @@ type UpdateAssetPayload struct {
 }
 
 type UpdateAuditInput struct {
-	ID         gid.GID              `json:"id"`
-	ValidFrom  *time.Time           `json:"validFrom,omitempty"`
-	ValidUntil *time.Time           `json:"validUntil,omitempty"`
-	State      *coredata.AuditState `json:"state,omitempty"`
+	ID                gid.GID              `json:"id"`
+	ValidFrom         *time.Time           `json:"validFrom,omitempty"`
+	ValidUntil        *time.Time           `json:"validUntil,omitempty"`
+	State             *coredata.AuditState `json:"state,omitempty"`
+	ShowOnTrustCenter *bool                `json:"showOnTrustCenter,omitempty"`
 }
 
 type UpdateAuditPayload struct {
@@ -1052,12 +1067,13 @@ type UpdateDatumPayload struct {
 }
 
 type UpdateDocumentInput struct {
-	ID           gid.GID                `json:"id"`
-	Title        *string                `json:"title,omitempty"`
-	Content      *string                `json:"content,omitempty"`
-	OwnerID      *gid.GID               `json:"ownerId,omitempty"`
-	CreatedBy    *gid.GID               `json:"createdBy,omitempty"`
-	DocumentType *coredata.DocumentType `json:"documentType,omitempty"`
+	ID                gid.GID                `json:"id"`
+	Title             *string                `json:"title,omitempty"`
+	Content           *string                `json:"content,omitempty"`
+	OwnerID           *gid.GID               `json:"ownerId,omitempty"`
+	CreatedBy         *gid.GID               `json:"createdBy,omitempty"`
+	DocumentType      *coredata.DocumentType `json:"documentType,omitempty"`
+	ShowOnTrustCenter *bool                  `json:"showOnTrustCenter,omitempty"`
 }
 
 type UpdateDocumentPayload struct {
@@ -1151,6 +1167,16 @@ type UpdateTaskPayload struct {
 	Task *Task `json:"task"`
 }
 
+type UpdateTrustCenterInput struct {
+	TrustCenterID gid.GID `json:"trustCenterId"`
+	Active        *bool   `json:"active,omitempty"`
+	Slug          *string `json:"slug,omitempty"`
+}
+
+type UpdateTrustCenterPayload struct {
+	TrustCenter *TrustCenter `json:"trustCenter"`
+}
+
 type UpdateVendorInput struct {
 	ID                            gid.GID                  `json:"id"`
 	Name                          *string                  `json:"name,omitempty"`
@@ -1171,6 +1197,7 @@ type UpdateVendorInput struct {
 	TrustPageURL                  *string                  `json:"trustPageUrl,omitempty"`
 	BusinessOwnerID               *gid.GID                 `json:"businessOwnerId,omitempty"`
 	SecurityOwnerID               *gid.GID                 `json:"securityOwnerId,omitempty"`
+	ShowOnTrustCenter             *bool                    `json:"showOnTrustCenter,omitempty"`
 }
 
 type UpdateVendorPayload struct {
@@ -1261,6 +1288,7 @@ type Vendor struct {
 	HeadquarterAddress            *string                           `json:"headquarterAddress,omitempty"`
 	LegalName                     *string                           `json:"legalName,omitempty"`
 	WebsiteURL                    *string                           `json:"websiteUrl,omitempty"`
+	ShowOnTrustCenter             bool                              `json:"showOnTrustCenter"`
 	CreatedAt                     time.Time                         `json:"createdAt"`
 	UpdatedAt                     time.Time                         `json:"updatedAt"`
 }

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -836,6 +836,10 @@ type OrganizationEdge struct {
 	Node   *Organization  `json:"node"`
 }
 
+type OrganizationFilter struct {
+	TrustCenterSlug *string `json:"trustCenterSlug,omitempty"`
+}
+
 type OrganizationOrder struct {
 	Direction page.OrderDirection             `json:"direction"`
 	Field     coredata.OrganizationOrderField `json:"field"`
@@ -996,15 +1000,33 @@ type TaskEdge struct {
 }
 
 type TrustCenter struct {
-	ID        gid.GID   `json:"id"`
-	Active    bool      `json:"active"`
-	Slug      string    `json:"slug"`
-	CreatedAt time.Time `json:"createdAt"`
-	UpdatedAt time.Time `json:"updatedAt"`
+	ID              gid.GID             `json:"id"`
+	Active          bool                `json:"active"`
+	Slug            string              `json:"slug"`
+	CreatedAt       time.Time           `json:"createdAt"`
+	UpdatedAt       time.Time           `json:"updatedAt"`
+	Organization    *Organization       `json:"organization"`
+	PublicDocuments *DocumentConnection `json:"publicDocuments"`
+	PublicAudits    *AuditConnection    `json:"publicAudits"`
+	PublicVendors   *VendorConnection   `json:"publicVendors"`
 }
 
 func (TrustCenter) IsNode()             {}
 func (this TrustCenter) GetID() gid.GID { return this.ID }
+
+type TrustCenterConnection struct {
+	Edges    []*TrustCenterEdge `json:"edges"`
+	PageInfo *PageInfo          `json:"pageInfo"`
+}
+
+type TrustCenterEdge struct {
+	Cursor page.CursorKey `json:"cursor"`
+	Node   *TrustCenter   `json:"node"`
+}
+
+type TrustCenterFilter struct {
+	Slug *string `json:"slug,omitempty"`
+}
 
 type UnassignTaskInput struct {
 	TaskID gid.GID `json:"taskId"`

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -56,6 +56,27 @@ type AssignTaskPayload struct {
 	Task *Task `json:"task"`
 }
 
+type Audit struct {
+	ID           gid.GID             `json:"id"`
+	Organization *Organization       `json:"organization"`
+	Framework    *Framework          `json:"framework"`
+	ValidFrom    *time.Time          `json:"validFrom,omitempty"`
+	ValidUntil   *time.Time          `json:"validUntil,omitempty"`
+	Report       *Report             `json:"report,omitempty"`
+	ReportURL    *string             `json:"reportUrl,omitempty"`
+	State        coredata.AuditState `json:"state"`
+	CreatedAt    time.Time           `json:"createdAt"`
+	UpdatedAt    time.Time           `json:"updatedAt"`
+}
+
+func (Audit) IsNode()             {}
+func (this Audit) GetID() gid.GID { return this.ID }
+
+type AuditEdge struct {
+	Cursor page.CursorKey `json:"cursor"`
+	Node   *Audit         `json:"node"`
+}
+
 type BulkPublishDocumentVersionsInput struct {
 	DocumentIds []gid.GID `json:"documentIds"`
 	Changelog   string    `json:"changelog"`
@@ -156,6 +177,18 @@ type CreateAssetInput struct {
 
 type CreateAssetPayload struct {
 	AssetEdge *AssetEdge `json:"assetEdge"`
+}
+
+type CreateAuditInput struct {
+	OrganizationID gid.GID              `json:"organizationId"`
+	FrameworkID    gid.GID              `json:"frameworkId"`
+	ValidFrom      *time.Time           `json:"validFrom,omitempty"`
+	ValidUntil     *time.Time           `json:"validUntil,omitempty"`
+	State          *coredata.AuditState `json:"state,omitempty"`
+}
+
+type CreateAuditPayload struct {
+	AuditEdge *AuditEdge `json:"auditEdge"`
 }
 
 type CreateControlDocumentMappingInput struct {
@@ -397,6 +430,22 @@ type DeleteAssetInput struct {
 
 type DeleteAssetPayload struct {
 	DeletedAssetID gid.GID `json:"deletedAssetId"`
+}
+
+type DeleteAuditInput struct {
+	AuditID gid.GID `json:"auditId"`
+}
+
+type DeleteAuditPayload struct {
+	DeletedAuditID gid.GID `json:"deletedAuditId"`
+}
+
+type DeleteAuditReportInput struct {
+	AuditID gid.GID `json:"auditId"`
+}
+
+type DeleteAuditReportPayload struct {
+	Audit *Audit `json:"audit"`
 }
 
 type DeleteControlDocumentMappingInput struct {
@@ -766,6 +815,7 @@ type Organization struct {
 	Tasks      *TaskConnection      `json:"tasks"`
 	Assets     *AssetConnection     `json:"assets"`
 	Data       *DatumConnection     `json:"data"`
+	Audits     *AuditConnection     `json:"audits"`
 	CreatedAt  time.Time            `json:"createdAt"`
 	UpdatedAt  time.Time            `json:"updatedAt"`
 }
@@ -837,6 +887,20 @@ type RemoveUserInput struct {
 type RemoveUserPayload struct {
 	Success bool `json:"success"`
 }
+
+type Report struct {
+	ID          gid.GID   `json:"id"`
+	ObjectKey   string    `json:"objectKey"`
+	MimeType    string    `json:"mimeType"`
+	Filename    string    `json:"filename"`
+	Size        int       `json:"size"`
+	DownloadURL *string   `json:"downloadUrl,omitempty"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+}
+
+func (Report) IsNode()             {}
+func (this Report) GetID() gid.GID { return this.ID }
 
 type RequestEvidenceInput struct {
 	TaskID      gid.GID               `json:"taskId"`
@@ -949,6 +1013,17 @@ type UpdateAssetInput struct {
 
 type UpdateAssetPayload struct {
 	Asset *Asset `json:"asset"`
+}
+
+type UpdateAuditInput struct {
+	ID         gid.GID              `json:"id"`
+	ValidFrom  *time.Time           `json:"validFrom,omitempty"`
+	ValidUntil *time.Time           `json:"validUntil,omitempty"`
+	State      *coredata.AuditState `json:"state,omitempty"`
+}
+
+type UpdateAuditPayload struct {
+	Audit *Audit `json:"audit"`
 }
 
 type UpdateControlInput struct {
@@ -1100,6 +1175,15 @@ type UpdateVendorInput struct {
 
 type UpdateVendorPayload struct {
 	Vendor *Vendor `json:"vendor"`
+}
+
+type UploadAuditReportInput struct {
+	AuditID gid.GID        `json:"auditId"`
+	File    graphql.Upload `json:"file"`
+}
+
+type UploadAuditReportPayload struct {
+	Audit *Audit `json:"audit"`
 }
 
 type UploadMeasureEvidenceInput struct {

--- a/pkg/server/api/console/v1/types/vendor.go
+++ b/pkg/server/api/console/v1/types/vendor.go
@@ -79,6 +79,7 @@ func NewVendor(v *coredata.Vendor) *Vendor {
 		LegalName:                     v.LegalName,
 		WebsiteURL:                    v.WebsiteURL,
 		Category:                      v.Category,
+		ShowOnTrustCenter:             v.ShowOnTrustCenter,
 		UpdatedAt:                     v.UpdatedAt,
 		CreatedAt:                     v.CreatedAt,
 	}

--- a/pkg/server/api/console/v1/v1_resolver.go
+++ b/pkg/server/api/console/v1/v1_resolver.go
@@ -973,6 +973,24 @@ func (r *mutationResolver) UpdateOrganization(ctx context.Context, input types.U
 	}, nil
 }
 
+// UpdateTrustCenter is the resolver for the updateTrustCenter field.
+func (r *mutationResolver) UpdateTrustCenter(ctx context.Context, input types.UpdateTrustCenterInput) (*types.UpdateTrustCenterPayload, error) {
+	prb := r.ProboService(ctx, input.TrustCenterID.TenantID())
+
+	trustCenter, err := prb.TrustCenters.Update(ctx, &probo.UpdateTrustCenterRequest{
+		ID:     input.TrustCenterID,
+		Active: input.Active,
+		Slug:   input.Slug,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot update trust center: %w", err)
+	}
+
+	return &types.UpdateTrustCenterPayload{
+		TrustCenter: types.NewTrustCenter(trustCenter),
+	}, nil
+}
+
 // ConfirmEmail is the resolver for the confirmEmail field.
 func (r *mutationResolver) ConfirmEmail(ctx context.Context, input types.ConfirmEmailInput) (*types.ConfirmEmailPayload, error) {
 	err := r.usrmgrSvc.ConfirmEmail(ctx, input.Token)
@@ -1151,6 +1169,7 @@ func (r *mutationResolver) UpdateVendor(ctx context.Context, input types.UpdateV
 		Certifications:                input.Certifications,
 		BusinessOwnerID:               input.BusinessOwnerID,
 		SecurityOwnerID:               input.SecurityOwnerID,
+		ShowOnTrustCenter:             input.ShowOnTrustCenter,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("cannot update vendor: %w", err)
@@ -1872,6 +1891,7 @@ func (r *mutationResolver) UpdateDocument(ctx context.Context, input types.Updat
 		input.OwnerID,
 		input.DocumentType,
 		input.Title,
+		input.ShowOnTrustCenter,
 	)
 
 	if err != nil {
@@ -2293,10 +2313,11 @@ func (r *mutationResolver) UpdateAudit(ctx context.Context, input types.UpdateAu
 	prb := r.ProboService(ctx, input.ID.TenantID())
 
 	req := probo.UpdateAuditRequest{
-		ID:         input.ID,
-		ValidFrom:  input.ValidFrom,
-		ValidUntil: input.ValidUntil,
-		State:      input.State,
+		ID:                input.ID,
+		ValidFrom:         input.ValidFrom,
+		ValidUntil:        input.ValidUntil,
+		State:             input.State,
+		ShowOnTrustCenter: input.ShowOnTrustCenter,
 	}
 
 	audit, err := prb.Audits.Update(ctx, &req)
@@ -2711,6 +2732,18 @@ func (r *organizationResolver) Audits(ctx context.Context, obj *types.Organizati
 	return types.NewAuditConnection(page, r, obj.ID), nil
 }
 
+// TrustCenter is the resolver for the trustCenter field.
+func (r *organizationResolver) TrustCenter(ctx context.Context, obj *types.Organization) (*types.TrustCenter, error) {
+	prb := r.ProboService(ctx, obj.ID.TenantID())
+
+	trustCenter, err := prb.TrustCenters.GetByOrganizationID(ctx, obj.ID)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get trust center: %w", err)
+	}
+
+	return types.NewTrustCenter(trustCenter), nil
+}
+
 // TotalCount is the resolver for the totalCount field.
 func (r *peopleConnectionResolver) TotalCount(ctx context.Context, obj *types.PeopleConnection) (int, error) {
 	prb := r.ProboService(ctx, obj.ParentID.TenantID())
@@ -2842,6 +2875,12 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 			panic(fmt.Errorf("cannot get report: %w", err))
 		}
 		return types.NewReport(report), nil
+	case coredata.TrustCenterEntityType:
+		trustCenter, err := prb.TrustCenters.GetByOrganizationID(ctx, id)
+		if err != nil {
+			panic(fmt.Errorf("cannot get trust center: %w", err))
+		}
+		return types.NewTrustCenter(trustCenter), nil
 	default:
 	}
 

--- a/pkg/server/api/console/v1/v1_resolver.go
+++ b/pkg/server/api/console/v1/v1_resolver.go
@@ -111,29 +111,31 @@ func (r *assetConnectionResolver) TotalCount(ctx context.Context, obj *types.Ass
 func (r *auditResolver) Organization(ctx context.Context, obj *types.Audit) (*types.Organization, error) {
 	prb := r.ProboService(ctx, obj.ID.TenantID())
 
-	if obj.Organization == nil {
-		return nil, fmt.Errorf("cannot get organization")
-	}
-
-	org, err := prb.Organizations.Get(ctx, obj.Organization.ID)
+	audit, err := prb.Audits.Get(ctx, obj.ID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get organization: %w", err)
+		return nil, fmt.Errorf("cannot load audit: %w", err)
 	}
 
-	return types.NewOrganization(org), nil
+	organization, err := prb.Organizations.Get(ctx, audit.OrganizationID)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load organization: %w", err)
+	}
+
+	return types.NewOrganization(organization), nil
 }
 
 // Framework is the resolver for the framework field.
 func (r *auditResolver) Framework(ctx context.Context, obj *types.Audit) (*types.Framework, error) {
 	prb := r.ProboService(ctx, obj.ID.TenantID())
 
-	if obj.Framework == nil {
-		return nil, fmt.Errorf("cannot get framework")
+	audit, err := prb.Audits.Get(ctx, obj.ID)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load audit: %w", err)
 	}
 
-	framework, err := prb.Frameworks.Get(ctx, obj.Framework.ID)
+	framework, err := prb.Frameworks.Get(ctx, audit.FrameworkID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get framework: %w", err)
+		return nil, fmt.Errorf("cannot load framework: %w", err)
 	}
 
 	return types.NewFramework(framework), nil
@@ -143,13 +145,18 @@ func (r *auditResolver) Framework(ctx context.Context, obj *types.Audit) (*types
 func (r *auditResolver) Report(ctx context.Context, obj *types.Audit) (*types.Report, error) {
 	prb := r.ProboService(ctx, obj.ID.TenantID())
 
-	if obj.Report == nil {
+	audit, err := prb.Audits.Get(ctx, obj.ID)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load audit: %w", err)
+	}
+
+	if audit.ReportID == nil {
 		return nil, nil
 	}
 
-	report, err := prb.Reports.Get(ctx, obj.Report.ID)
+	report, err := prb.Reports.Get(ctx, *audit.ReportID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get report: %w", err)
+		return nil, fmt.Errorf("cannot load report: %w", err)
 	}
 
 	return types.NewReport(report), nil

--- a/pkg/server/api/console/v1/v1_resolver.go
+++ b/pkg/server/api/console/v1/v1_resolver.go
@@ -107,6 +107,81 @@ func (r *assetConnectionResolver) TotalCount(ctx context.Context, obj *types.Ass
 	panic(fmt.Errorf("unsupported resolver: %T", obj.Resolver))
 }
 
+// Organization is the resolver for the organization field.
+func (r *auditResolver) Organization(ctx context.Context, obj *types.Audit) (*types.Organization, error) {
+	prb := r.ProboService(ctx, obj.ID.TenantID())
+
+	if obj.Organization == nil {
+		return nil, fmt.Errorf("cannot get organization")
+	}
+
+	org, err := prb.Organizations.Get(ctx, obj.Organization.ID)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get organization: %w", err)
+	}
+
+	return types.NewOrganization(org), nil
+}
+
+// Framework is the resolver for the framework field.
+func (r *auditResolver) Framework(ctx context.Context, obj *types.Audit) (*types.Framework, error) {
+	prb := r.ProboService(ctx, obj.ID.TenantID())
+
+	if obj.Framework == nil {
+		return nil, fmt.Errorf("cannot get framework")
+	}
+
+	framework, err := prb.Frameworks.Get(ctx, obj.Framework.ID)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get framework: %w", err)
+	}
+
+	return types.NewFramework(framework), nil
+}
+
+// Report is the resolver for the report field.
+func (r *auditResolver) Report(ctx context.Context, obj *types.Audit) (*types.Report, error) {
+	prb := r.ProboService(ctx, obj.ID.TenantID())
+
+	if obj.Report == nil {
+		return nil, nil
+	}
+
+	report, err := prb.Reports.Get(ctx, obj.Report.ID)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get report: %w", err)
+	}
+
+	return types.NewReport(report), nil
+}
+
+// ReportURL is the resolver for the reportUrl field.
+func (r *auditResolver) ReportURL(ctx context.Context, obj *types.Audit) (*string, error) {
+	prb := r.ProboService(ctx, obj.ID.TenantID())
+
+	if obj.Report == nil {
+		return nil, nil
+	}
+
+	url, err := prb.Audits.GenerateReportURL(ctx, obj.ID, 15*time.Minute)
+	if err != nil {
+		return nil, fmt.Errorf("cannot generate report URL: %w", err)
+	}
+
+	return url, nil
+}
+
+// TotalCount is the resolver for the totalCount field.
+func (r *auditConnectionResolver) TotalCount(ctx context.Context, obj *types.AuditConnection) (int, error) {
+	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+
+	count, err := prb.Audits.CountForOrganizationID(ctx, obj.ParentID)
+	if err != nil {
+		return 0, fmt.Errorf("cannot count audits: %w", err)
+	}
+	return count, nil
+}
+
 // Framework is the resolver for the framework field.
 func (r *controlResolver) Framework(ctx context.Context, obj *types.Control) (*types.Framework, error) {
 	prb := r.ProboService(ctx, obj.ID.TenantID())
@@ -2191,6 +2266,101 @@ func (r *mutationResolver) DeleteDatum(ctx context.Context, input types.DeleteDa
 	}, nil
 }
 
+// CreateAudit is the resolver for the createAudit field.
+func (r *mutationResolver) CreateAudit(ctx context.Context, input types.CreateAuditInput) (*types.CreateAuditPayload, error) {
+	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+
+	req := probo.CreateAuditRequest{
+		OrganizationID: input.OrganizationID,
+		FrameworkID:    input.FrameworkID,
+		ValidFrom:      input.ValidFrom,
+		ValidUntil:     input.ValidUntil,
+		State:          input.State,
+	}
+
+	audit, err := prb.Audits.Create(ctx, &req)
+	if err != nil {
+		panic(fmt.Errorf("cannot create audit: %w", err))
+	}
+
+	return &types.CreateAuditPayload{
+		AuditEdge: types.NewAuditEdge(audit, coredata.AuditOrderFieldCreatedAt),
+	}, nil
+}
+
+// UpdateAudit is the resolver for the updateAudit field.
+func (r *mutationResolver) UpdateAudit(ctx context.Context, input types.UpdateAuditInput) (*types.UpdateAuditPayload, error) {
+	prb := r.ProboService(ctx, input.ID.TenantID())
+
+	req := probo.UpdateAuditRequest{
+		ID:         input.ID,
+		ValidFrom:  input.ValidFrom,
+		ValidUntil: input.ValidUntil,
+		State:      input.State,
+	}
+
+	audit, err := prb.Audits.Update(ctx, &req)
+	if err != nil {
+		panic(fmt.Errorf("cannot update audit: %w", err))
+	}
+
+	return &types.UpdateAuditPayload{
+		Audit: types.NewAudit(audit),
+	}, nil
+}
+
+// DeleteAudit is the resolver for the deleteAudit field.
+func (r *mutationResolver) DeleteAudit(ctx context.Context, input types.DeleteAuditInput) (*types.DeleteAuditPayload, error) {
+	prb := r.ProboService(ctx, input.AuditID.TenantID())
+
+	err := prb.Audits.Delete(ctx, input.AuditID)
+	if err != nil {
+		panic(fmt.Errorf("cannot delete audit: %w", err))
+	}
+
+	return &types.DeleteAuditPayload{
+		DeletedAuditID: input.AuditID,
+	}, nil
+}
+
+// UploadAuditReport is the resolver for the uploadAuditReport field.
+func (r *mutationResolver) UploadAuditReport(ctx context.Context, input types.UploadAuditReportInput) (*types.UploadAuditReportPayload, error) {
+	prb := r.ProboService(ctx, input.AuditID.TenantID())
+
+	req := probo.UploadAuditReportRequest{
+		AuditID: input.AuditID,
+		File: probo.File{
+			Content:     input.File.File,
+			Filename:    input.File.Filename,
+			Size:        input.File.Size,
+			ContentType: input.File.ContentType,
+		},
+	}
+
+	audit, err := prb.Audits.UploadReport(ctx, req)
+	if err != nil {
+		panic(fmt.Errorf("cannot upload audit report: %w", err))
+	}
+
+	return &types.UploadAuditReportPayload{
+		Audit: types.NewAudit(audit),
+	}, nil
+}
+
+// DeleteAuditReport is the resolver for the deleteAuditReport field.
+func (r *mutationResolver) DeleteAuditReport(ctx context.Context, input types.DeleteAuditReportInput) (*types.DeleteAuditReportPayload, error) {
+	prb := r.ProboService(ctx, input.AuditID.TenantID())
+
+	audit, err := prb.Audits.DeleteReport(ctx, input.AuditID)
+	if err != nil {
+		return nil, fmt.Errorf("cannot delete audit report: %w", err)
+	}
+
+	return &types.DeleteAuditReportPayload{
+		Audit: types.NewAudit(audit),
+	}, nil
+}
+
 // LogoURL is the resolver for the logoUrl field.
 func (r *organizationResolver) LogoURL(ctx context.Context, obj *types.Organization) (*string, error) {
 	prb := r.ProboService(ctx, obj.ID.TenantID())
@@ -2516,6 +2686,31 @@ func (r *organizationResolver) Data(ctx context.Context, obj *types.Organization
 	return types.NewDataConnection(page, r, obj.ID), nil
 }
 
+// Audits is the resolver for the audits field.
+func (r *organizationResolver) Audits(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AuditOrderBy) (*types.AuditConnection, error) {
+	prb := r.ProboService(ctx, obj.ID.TenantID())
+
+	pageOrderBy := page.OrderBy[coredata.AuditOrderField]{
+		Field:     coredata.AuditOrderFieldCreatedAt,
+		Direction: page.OrderDirectionDesc,
+	}
+	if orderBy != nil {
+		pageOrderBy = page.OrderBy[coredata.AuditOrderField]{
+			Field:     orderBy.Field,
+			Direction: orderBy.Direction,
+		}
+	}
+
+	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
+
+	page, err := prb.Audits.ListForOrganizationID(ctx, obj.ID, cursor)
+	if err != nil {
+		panic(fmt.Errorf("cannot list organization audits: %w", err))
+	}
+
+	return types.NewAuditConnection(page, r, obj.ID), nil
+}
+
 // TotalCount is the resolver for the totalCount field.
 func (r *peopleConnectionResolver) TotalCount(ctx context.Context, obj *types.PeopleConnection) (int, error) {
 	prb := r.ProboService(ctx, obj.ParentID.TenantID())
@@ -2635,6 +2830,18 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 			panic(fmt.Errorf("cannot get data: %w", err))
 		}
 		return types.NewDatum(datum), nil
+	case coredata.AuditEntityType:
+		audit, err := prb.Audits.Get(ctx, id)
+		if err != nil {
+			panic(fmt.Errorf("cannot get audit: %w", err))
+		}
+		return types.NewAudit(audit), nil
+	case coredata.ReportEntityType:
+		report, err := prb.Reports.Get(ctx, id)
+		if err != nil {
+			panic(fmt.Errorf("cannot get report: %w", err))
+		}
+		return types.NewReport(report), nil
 	default:
 	}
 
@@ -2650,6 +2857,18 @@ func (r *queryResolver) Viewer(ctx context.Context) (*types.Viewer, error) {
 		ID:   session.ID,
 		User: types.NewUser(user),
 	}, nil
+}
+
+// DownloadURL is the resolver for the downloadUrl field.
+func (r *reportResolver) DownloadURL(ctx context.Context, obj *types.Report) (*string, error) {
+	prb := r.ProboService(ctx, obj.ID.TenantID())
+
+	url, err := prb.Reports.GenerateDownloadURL(ctx, obj.ID, 15*time.Minute)
+	if err != nil {
+		return nil, fmt.Errorf("cannot generate download URL: %w", err)
+	}
+
+	return url, nil
 }
 
 // Owner is the resolver for the owner field.
@@ -3136,6 +3355,14 @@ func (r *Resolver) AssetConnection() schema.AssetConnectionResolver {
 	return &assetConnectionResolver{r}
 }
 
+// Audit returns schema.AuditResolver implementation.
+func (r *Resolver) Audit() schema.AuditResolver { return &auditResolver{r} }
+
+// AuditConnection returns schema.AuditConnectionResolver implementation.
+func (r *Resolver) AuditConnection() schema.AuditConnectionResolver {
+	return &auditConnectionResolver{r}
+}
+
 // Control returns schema.ControlResolver implementation.
 func (r *Resolver) Control() schema.ControlResolver { return &controlResolver{r} }
 
@@ -3208,6 +3435,9 @@ func (r *Resolver) PeopleConnection() schema.PeopleConnectionResolver {
 // Query returns schema.QueryResolver implementation.
 func (r *Resolver) Query() schema.QueryResolver { return &queryResolver{r} }
 
+// Report returns schema.ReportResolver implementation.
+func (r *Resolver) Report() schema.ReportResolver { return &reportResolver{r} }
+
 // Risk returns schema.RiskResolver implementation.
 func (r *Resolver) Risk() schema.RiskResolver { return &riskResolver{r} }
 
@@ -3246,6 +3476,8 @@ func (r *Resolver) Viewer() schema.ViewerResolver { return &viewerResolver{r} }
 
 type assetResolver struct{ *Resolver }
 type assetConnectionResolver struct{ *Resolver }
+type auditResolver struct{ *Resolver }
+type auditConnectionResolver struct{ *Resolver }
 type controlResolver struct{ *Resolver }
 type controlConnectionResolver struct{ *Resolver }
 type datumResolver struct{ *Resolver }
@@ -3264,6 +3496,7 @@ type mutationResolver struct{ *Resolver }
 type organizationResolver struct{ *Resolver }
 type peopleConnectionResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
+type reportResolver struct{ *Resolver }
 type riskResolver struct{ *Resolver }
 type riskConnectionResolver struct{ *Resolver }
 type taskResolver struct{ *Resolver }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/getprobo/probo/pkg/server/api"
 	console_v1 "github.com/getprobo/probo/pkg/server/api/console/v1"
 	"github.com/getprobo/probo/pkg/server/web"
+	"github.com/getprobo/probo/pkg/trust"
 	"github.com/getprobo/probo/pkg/usrmgr"
 	"github.com/go-chi/chi/v5"
 	"go.gearno.de/kit/log"
@@ -37,6 +38,7 @@ type Config struct {
 	ExtraHeaderFields map[string]string
 	Probo             *probo.Service
 	Usrmgr            *usrmgr.Service
+	Trust             *trust.Service
 	Auth              console_v1.AuthConfig
 	ConnectorRegistry *connector.ConnectorRegistry
 	Agent             *agents.Agent
@@ -59,6 +61,7 @@ func NewServer(cfg Config) (*Server, error) {
 		AllowedOrigins:    cfg.AllowedOrigins,
 		Probo:             cfg.Probo,
 		Usrmgr:            cfg.Usrmgr,
+		Trust:             cfg.Trust,
 		Auth:              cfg.Auth,
 		ConnectorRegistry: cfg.ConnectorRegistry,
 		SafeRedirect:      cfg.SafeRedirect,

--- a/pkg/trust/service.go
+++ b/pkg/trust/service.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package trust
+
+import (
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/gid"
+	"go.gearno.de/kit/pg"
+)
+
+type (
+	Service struct {
+		pg     *pg.Client
+		bucket string
+	}
+
+	TenantService struct {
+		pg           *pg.Client
+		bucket       string
+		scope        coredata.Scoper
+		TrustCenters *TrustCenterService
+	}
+)
+
+func NewService(
+	pgClient *pg.Client,
+	bucket string,
+) *Service {
+	return &Service{
+		pg:     pgClient,
+		bucket: bucket,
+	}
+}
+
+func (s *Service) WithTenant(tenantID gid.TenantID) *TenantService {
+	tenantService := &TenantService{
+		pg:     s.pg,
+		bucket: s.bucket,
+		scope:  coredata.NewScope(tenantID),
+	}
+
+	tenantService.TrustCenters = &TrustCenterService{svc: tenantService}
+
+	return tenantService
+}

--- a/pkg/trust/trust_center_service.go
+++ b/pkg/trust/trust_center_service.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package trust
+
+import (
+	"context"
+
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+	"go.gearno.de/kit/pg"
+)
+
+type TrustCenterService struct {
+	svc *TenantService
+}
+
+// Public read-only methods for trust center
+func (s TrustCenterService) GetBySlug(
+	ctx context.Context,
+	slug string,
+) (*coredata.TrustCenter, error) {
+	trustCenter := &coredata.TrustCenter{}
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			return trustCenter.LoadBySlug(ctx, conn, slug)
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return trustCenter, nil
+}
+
+func (s TrustCenterService) ListPublicAudits(
+	ctx context.Context,
+	organizationID gid.GID,
+	cursor *page.Cursor[coredata.AuditOrderField],
+) (*page.Page[*coredata.Audit, coredata.AuditOrderField], error) {
+	var audits coredata.Audits
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			filter := coredata.NewAuditTrustCenterFilter()
+			return audits.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID, cursor, filter)
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return page.NewPage(audits, cursor), nil
+}
+
+func (s TrustCenterService) ListPublicDocuments(
+	ctx context.Context,
+	organizationID gid.GID,
+	cursor *page.Cursor[coredata.DocumentOrderField],
+) (*page.Page[*coredata.Document, coredata.DocumentOrderField], error) {
+	var documents coredata.Documents
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			filter := coredata.NewDocumentTrustCenterFilter()
+			return documents.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID, cursor, filter)
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return page.NewPage(documents, cursor), nil
+}
+
+func (s TrustCenterService) ListPublicVendors(
+	ctx context.Context,
+	organizationID gid.GID,
+	cursor *page.Cursor[coredata.VendorOrderField],
+) (*page.Page[*coredata.Vendor, coredata.VendorOrderField], error) {
+	var vendors coredata.Vendors
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			filter := coredata.NewVendorTrustCenterFilter()
+			return vendors.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID, cursor, filter)
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return page.NewPage(vendors, cursor), nil
+}


### PR DESCRIPTION
Access management will be done in another the next PR.

## UI
<img width="1007" height="774" alt="Screenshot 2025-07-28 at 20 04 11" src="https://github.com/user-attachments/assets/e507bbb9-29cb-41d3-b555-4b9ba09b69db" />
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added a public Trust Center page that displays an organization’s compliance audits, documents, and vendors. This allows anyone with the link to view key trust and security information for an organization.

- **New Features**
  - Public Trust Center route at `/trust/:slug` with organization branding.
  - Sections for public audits, documents (with PDF export), and vendors.
  - New backend GraphQL queries and filters to support public data access by slug.

<!-- End of auto-generated description by cubic. -->

