### PR TITLE
Add access management to trust centers

### DIFF
--- a/apps/console/src/hooks/graph/TrustCenterAccessGraph.ts
+++ b/apps/console/src/hooks/graph/TrustCenterAccessGraph.ts
@@ -1,0 +1,95 @@
+import { graphql } from 'react-relay';
+import { useLazyLoadQuery } from 'react-relay';
+
+export const trustCenterAccessesQuery = graphql`
+  query TrustCenterAccessGraphQuery($trustCenterId: ID!) {
+    node(id: $trustCenterId) {
+      ... on TrustCenter {
+        id
+        accesses(first: 100, orderBy: { field: CREATED_AT, direction: DESC })
+          @connection(key: "TrustCenterAccessTab_accesses") {
+          __id
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
+            startCursor
+            endCursor
+          }
+          edges {
+            cursor
+            node {
+              id
+              email
+              name
+              active
+              createdAt
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const revokeTrustCenterAccessMutation = graphql`
+  mutation TrustCenterAccessGraphRevokeMutation($input: RevokeTrustCenterAccessInput!) {
+    revokeTrustCenterAccess(input: $input) {
+      trustCenterAccess {
+        id
+        email
+        name
+        active
+        createdAt
+      }
+    }
+  }
+`;
+
+export const createTrustCenterAccessMutation = graphql`
+  mutation TrustCenterAccessGraphCreateMutation(
+    $input: CreateTrustCenterAccessInput!
+    $connections: [ID!]!
+  ) {
+    createTrustCenterAccess(input: $input) {
+      trustCenterAccessEdge @prependEdge(connections: $connections) {
+        cursor
+        node {
+          id
+          email
+          name
+          active
+          createdAt
+        }
+      }
+    }
+  }
+`;
+
+export const updateTrustCenterAccessMutation = graphql`
+  mutation TrustCenterAccessGraphUpdateMutation($input: UpdateTrustCenterAccessInput!) {
+    updateTrustCenterAccess(input: $input) {
+      trustCenterAccess {
+        id
+        email
+        name
+        active
+        createdAt
+      }
+    }
+  }
+`;
+
+export const deleteTrustCenterAccessMutation = graphql`
+  mutation TrustCenterAccessGraphDeleteMutation(
+    $input: DeleteTrustCenterAccessInput!
+    $connections: [ID!]!
+  ) {
+    deleteTrustCenterAccess(input: $input) {
+      deletedTrustCenterAccessId @deleteEdge(connections: $connections)
+    }
+  }
+`;
+
+export function useTrustCenterAccesses(trustCenterId: string) {
+  return useLazyLoadQuery(trustCenterAccessesQuery, { trustCenterId });
+}

--- a/apps/console/src/hooks/graph/TrustCenterAccessTokenGraph.ts
+++ b/apps/console/src/hooks/graph/TrustCenterAccessTokenGraph.ts
@@ -1,0 +1,17 @@
+import { graphql } from 'react-relay';
+
+export const trustCenterByIdQuery = graphql`
+  query TrustCenterAccessTokenGraphQuery($trustCenterId: ID!) {
+    node(id: $trustCenterId) {
+      ... on TrustCenter {
+        id
+        slug
+        active
+        organization {
+          id
+          name
+        }
+      }
+    }
+  }
+`;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphCreateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphCreateMutation.graphql.ts
@@ -1,0 +1,201 @@
+/**
+ * @generated SignedSource<<79b53f51663ada6e9899523400d54996>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type CreateTrustCenterAccessInput = {
+  email: string;
+  name: string;
+  sendEmail?: boolean;
+  trustCenterId: string;
+};
+export type TrustCenterAccessGraphCreateMutation$variables = {
+  connections: ReadonlyArray<string>;
+  input: CreateTrustCenterAccessInput;
+};
+export type TrustCenterAccessGraphCreateMutation$data = {
+  readonly createTrustCenterAccess: {
+    readonly trustCenterAccessEdge: {
+      readonly cursor: any;
+      readonly node: {
+        readonly active: boolean;
+        readonly createdAt: any;
+        readonly email: string;
+        readonly id: string;
+        readonly name: string;
+      };
+    };
+  };
+};
+export type TrustCenterAccessGraphCreateMutation = {
+  response: TrustCenterAccessGraphCreateMutation$data;
+  variables: TrustCenterAccessGraphCreateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "TrustCenterAccessEdge",
+  "kind": "LinkedField",
+  "name": "trustCenterAccessEdge",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "cursor",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "TrustCenterAccess",
+      "kind": "LinkedField",
+      "name": "node",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "id",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "email",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "active",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "createdAt",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TrustCenterAccessGraphCreateMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "CreateTrustCenterAccessPayload",
+        "kind": "LinkedField",
+        "name": "createTrustCenterAccess",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "TrustCenterAccessGraphCreateMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "CreateTrustCenterAccessPayload",
+        "kind": "LinkedField",
+        "name": "createTrustCenterAccess",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "prependEdge",
+            "key": "",
+            "kind": "LinkedHandle",
+            "name": "trustCenterAccessEdge",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "eafddcd0263963235d3249c22eb50593",
+    "id": null,
+    "metadata": {},
+    "name": "TrustCenterAccessGraphCreateMutation",
+    "operationKind": "mutation",
+    "text": "mutation TrustCenterAccessGraphCreateMutation(\n  $input: CreateTrustCenterAccessInput!\n) {\n  createTrustCenterAccess(input: $input) {\n    trustCenterAccessEdge {\n      cursor\n      node {\n        id\n        email\n        name\n        active\n        createdAt\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "99676fee0b2de06a92cdad66c577eee7";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphDeleteMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphDeleteMutation.graphql.ts
@@ -1,0 +1,132 @@
+/**
+ * @generated SignedSource<<509cd7c9db3cbf15931c386b13a13987>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type DeleteTrustCenterAccessInput = {
+  accessId: string;
+};
+export type TrustCenterAccessGraphDeleteMutation$variables = {
+  connections: ReadonlyArray<string>;
+  input: DeleteTrustCenterAccessInput;
+};
+export type TrustCenterAccessGraphDeleteMutation$data = {
+  readonly deleteTrustCenterAccess: {
+    readonly deletedTrustCenterAccessId: string;
+  };
+};
+export type TrustCenterAccessGraphDeleteMutation = {
+  response: TrustCenterAccessGraphDeleteMutation$data;
+  variables: TrustCenterAccessGraphDeleteMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "deletedTrustCenterAccessId",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TrustCenterAccessGraphDeleteMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteTrustCenterAccessPayload",
+        "kind": "LinkedField",
+        "name": "deleteTrustCenterAccess",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "TrustCenterAccessGraphDeleteMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteTrustCenterAccessPayload",
+        "kind": "LinkedField",
+        "name": "deleteTrustCenterAccess",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "deleteEdge",
+            "key": "",
+            "kind": "ScalarHandle",
+            "name": "deletedTrustCenterAccessId",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "3f55c9ce5cac2874b769ec994977367a",
+    "id": null,
+    "metadata": {},
+    "name": "TrustCenterAccessGraphDeleteMutation",
+    "operationKind": "mutation",
+    "text": "mutation TrustCenterAccessGraphDeleteMutation(\n  $input: DeleteTrustCenterAccessInput!\n) {\n  deleteTrustCenterAccess(input: $input) {\n    deletedTrustCenterAccessId\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "0d0a44eb6db912eeb533d24718c49b35";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphQuery.graphql.ts
@@ -1,0 +1,317 @@
+/**
+ * @generated SignedSource<<2333a6a7d5415f1a08a5612dcaceee8f>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type TrustCenterAccessGraphQuery$variables = {
+  trustCenterId: string;
+};
+export type TrustCenterAccessGraphQuery$data = {
+  readonly node: {
+    readonly accesses?: {
+      readonly __id: string;
+      readonly edges: ReadonlyArray<{
+        readonly cursor: any;
+        readonly node: {
+          readonly active: boolean;
+          readonly createdAt: any;
+          readonly email: string;
+          readonly id: string;
+          readonly name: string;
+        };
+      }>;
+      readonly pageInfo: {
+        readonly endCursor: any | null | undefined;
+        readonly hasNextPage: boolean;
+        readonly hasPreviousPage: boolean;
+        readonly startCursor: any | null | undefined;
+      };
+    };
+    readonly id?: string;
+  };
+};
+export type TrustCenterAccessGraphQuery = {
+  response: TrustCenterAccessGraphQuery$data;
+  variables: TrustCenterAccessGraphQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "trustCenterId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "trustCenterId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "kind": "Literal",
+  "name": "orderBy",
+  "value": {
+    "direction": "DESC",
+    "field": "CREATED_AT"
+  }
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v5 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "PageInfo",
+    "kind": "LinkedField",
+    "name": "pageInfo",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "hasNextPage",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "hasPreviousPage",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "startCursor",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "endCursor",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "TrustCenterAccessEdge",
+    "kind": "LinkedField",
+    "name": "edges",
+    "plural": true,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "cursor",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "TrustCenterAccess",
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "email",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "active",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "createdAt",
+            "storageKey": null
+          },
+          (v4/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  },
+  {
+    "kind": "ClientExtension",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "__id",
+        "storageKey": null
+      }
+    ]
+  }
+],
+v6 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 100
+  },
+  (v3/*: any*/)
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TrustCenterAccessGraphQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v2/*: any*/),
+              {
+                "alias": "accesses",
+                "args": [
+                  (v3/*: any*/)
+                ],
+                "concreteType": "TrustCenterAccessConnection",
+                "kind": "LinkedField",
+                "name": "__TrustCenterAccessTab_accesses_connection",
+                "plural": false,
+                "selections": (v5/*: any*/),
+                "storageKey": "__TrustCenterAccessTab_accesses_connection(orderBy:{\"direction\":\"DESC\",\"field\":\"CREATED_AT\"})"
+              }
+            ],
+            "type": "TrustCenter",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "TrustCenterAccessGraphQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v4/*: any*/),
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": (v6/*: any*/),
+                "concreteType": "TrustCenterAccessConnection",
+                "kind": "LinkedField",
+                "name": "accesses",
+                "plural": false,
+                "selections": (v5/*: any*/),
+                "storageKey": "accesses(first:100,orderBy:{\"direction\":\"DESC\",\"field\":\"CREATED_AT\"})"
+              },
+              {
+                "alias": null,
+                "args": (v6/*: any*/),
+                "filters": [
+                  "orderBy"
+                ],
+                "handle": "connection",
+                "key": "TrustCenterAccessTab_accesses",
+                "kind": "LinkedHandle",
+                "name": "accesses"
+              }
+            ],
+            "type": "TrustCenter",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "5b83cd4ae2434ce2e00de7230d264432",
+    "id": null,
+    "metadata": {
+      "connection": [
+        {
+          "count": null,
+          "cursor": null,
+          "direction": "forward",
+          "path": [
+            "node",
+            "accesses"
+          ]
+        }
+      ]
+    },
+    "name": "TrustCenterAccessGraphQuery",
+    "operationKind": "query",
+    "text": "query TrustCenterAccessGraphQuery(\n  $trustCenterId: ID!\n) {\n  node(id: $trustCenterId) {\n    __typename\n    ... on TrustCenter {\n      id\n      accesses(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {\n        pageInfo {\n          hasNextPage\n          hasPreviousPage\n          startCursor\n          endCursor\n        }\n        edges {\n          cursor\n          node {\n            id\n            email\n            name\n            active\n            createdAt\n            __typename\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "af598fd2af198e63ed84fd618857a985";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphRevokeMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphRevokeMutation.graphql.ts
@@ -1,0 +1,137 @@
+/**
+ * @generated SignedSource<<a234c36ae13e75cd1b0d893c4e232fc4>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type RevokeTrustCenterAccessInput = {
+  accessId: string;
+};
+export type TrustCenterAccessGraphRevokeMutation$variables = {
+  input: RevokeTrustCenterAccessInput;
+};
+export type TrustCenterAccessGraphRevokeMutation$data = {
+  readonly revokeTrustCenterAccess: {
+    readonly trustCenterAccess: {
+      readonly active: boolean;
+      readonly createdAt: any;
+      readonly email: string;
+      readonly id: string;
+      readonly name: string;
+    };
+  };
+};
+export type TrustCenterAccessGraphRevokeMutation = {
+  response: TrustCenterAccessGraphRevokeMutation$data;
+  variables: TrustCenterAccessGraphRevokeMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "RevokeTrustCenterAccessPayload",
+    "kind": "LinkedField",
+    "name": "revokeTrustCenterAccess",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "TrustCenterAccess",
+        "kind": "LinkedField",
+        "name": "trustCenterAccess",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "email",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "active",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "createdAt",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TrustCenterAccessGraphRevokeMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "TrustCenterAccessGraphRevokeMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "b26927a2b8d02eb2e3754850b0a44d8b",
+    "id": null,
+    "metadata": {},
+    "name": "TrustCenterAccessGraphRevokeMutation",
+    "operationKind": "mutation",
+    "text": "mutation TrustCenterAccessGraphRevokeMutation(\n  $input: RevokeTrustCenterAccessInput!\n) {\n  revokeTrustCenterAccess(input: $input) {\n    trustCenterAccess {\n      id\n      email\n      name\n      active\n      createdAt\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "269cce2fe60fac04d807f1004ef0777f";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphUpdateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphUpdateMutation.graphql.ts
@@ -1,0 +1,141 @@
+/**
+ * @generated SignedSource<<54ac79c4d292eb19f73bbf2363015dd9>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type UpdateTrustCenterAccessInput = {
+  accessId: string;
+  active?: boolean | null | undefined;
+  email?: string | null | undefined;
+  name?: string | null | undefined;
+  sendEmail?: boolean;
+};
+export type TrustCenterAccessGraphUpdateMutation$variables = {
+  input: UpdateTrustCenterAccessInput;
+};
+export type TrustCenterAccessGraphUpdateMutation$data = {
+  readonly updateTrustCenterAccess: {
+    readonly trustCenterAccess: {
+      readonly active: boolean;
+      readonly createdAt: any;
+      readonly email: string;
+      readonly id: string;
+      readonly name: string;
+    };
+  };
+};
+export type TrustCenterAccessGraphUpdateMutation = {
+  response: TrustCenterAccessGraphUpdateMutation$data;
+  variables: TrustCenterAccessGraphUpdateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "UpdateTrustCenterAccessPayload",
+    "kind": "LinkedField",
+    "name": "updateTrustCenterAccess",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "TrustCenterAccess",
+        "kind": "LinkedField",
+        "name": "trustCenterAccess",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "email",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "active",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "createdAt",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TrustCenterAccessGraphUpdateMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "TrustCenterAccessGraphUpdateMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "8e284c8129de02d689385cae38cc3876",
+    "id": null,
+    "metadata": {},
+    "name": "TrustCenterAccessGraphUpdateMutation",
+    "operationKind": "mutation",
+    "text": "mutation TrustCenterAccessGraphUpdateMutation(\n  $input: UpdateTrustCenterAccessInput!\n) {\n  updateTrustCenterAccess(input: $input) {\n    trustCenterAccess {\n      id\n      email\n      name\n      active\n      createdAt\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "235754d40be56785bd0e7a36ac8c4ec2";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterAccessTokenGraphQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterAccessTokenGraphQuery.graphql.ts
@@ -1,0 +1,169 @@
+/**
+ * @generated SignedSource<<6e43a07222fde7acc3d588bac24a8077>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type TrustCenterAccessTokenGraphQuery$variables = {
+  trustCenterId: string;
+};
+export type TrustCenterAccessTokenGraphQuery$data = {
+  readonly node: {
+    readonly active?: boolean;
+    readonly id?: string;
+    readonly organization?: {
+      readonly id: string;
+      readonly name: string;
+    };
+    readonly slug?: string;
+  };
+};
+export type TrustCenterAccessTokenGraphQuery = {
+  response: TrustCenterAccessTokenGraphQuery$data;
+  variables: TrustCenterAccessTokenGraphQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "trustCenterId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "trustCenterId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "active",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Organization",
+  "kind": "LinkedField",
+  "name": "organization",
+  "plural": false,
+  "selections": [
+    (v2/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TrustCenterAccessTokenGraphQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/)
+            ],
+            "type": "TrustCenter",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "TrustCenterAccessTokenGraphQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/)
+            ],
+            "type": "TrustCenter",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "7d3d891944391d31a722364f8b1f1cbb",
+    "id": null,
+    "metadata": {},
+    "name": "TrustCenterAccessTokenGraphQuery",
+    "operationKind": "query",
+    "text": "query TrustCenterAccessTokenGraphQuery(\n  $trustCenterId: ID!\n) {\n  node(id: $trustCenterId) {\n    __typename\n    ... on TrustCenter {\n      id\n      slug\n      active\n      organization {\n        id\n        name\n      }\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "e273d4e8c8b756a5aba5271520df8602";
+
+export default node;

--- a/apps/console/src/layouts/PublicTrustCenterLayout.tsx
+++ b/apps/console/src/layouts/PublicTrustCenterLayout.tsx
@@ -1,5 +1,7 @@
 import { Outlet } from "react-router";
-import { Logo } from "@probo/ui";
+import { Logo, Button, IconArrowBoxLeft } from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { buildEndpoint } from "/providers/RelayProviders";
 import type { ReactNode } from "react";
 
 type Props = {
@@ -9,6 +11,25 @@ type Props = {
 };
 
 export function PublicTrustCenterLayout({ organizationName, organizationLogo, children }: Props) {
+  const { __ } = useTranslate();
+
+    const handleLogout = async () => {
+    try {
+      await fetch(buildEndpoint('/api/console/v1/trust-center-access/logout'), {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+      });
+    } catch (error) {
+      console.error('Logout failed:', error);
+    } finally {
+      // Redirect to home page regardless of logout success/failure
+      window.location.href = "/";
+    }
+  };
+
   return (
     <div className="min-h-screen bg-tertiary">
       <header className="bg-surface border-b border-border-solid">
@@ -31,20 +52,29 @@ export function PublicTrustCenterLayout({ organizationName, organizationLogo, ch
                 <p className="text-sm text-txt-secondary">Trust Center</p>
               </div>
             </div>
-            <div className="text-sm text-txt-tertiary">
-              <a
-                href="https://www.getprobo.com/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="hover:text-txt-secondary transition-colors flex items-center space-x-1"
-              >
-                <img
-                  src="/favicons/favicon.ico"
-                  alt="Probo"
-                  className="h-4 w-4"
-                />
-                <span>Powered by Probo</span>
-              </a>
+            <div className="flex items-center space-x-4">
+              <div className="text-sm text-txt-tertiary">
+                <a
+                  href="https://www.getprobo.com/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-txt-secondary transition-colors flex items-center space-x-1"
+                >
+                  <img
+                    src="/favicons/favicon.ico"
+                    alt="Probo"
+                    className="h-4 w-4"
+                  />
+                  <span>Powered by Probo</span>
+                </a>
+              </div>
+              <Button
+                variant="tertiary"
+                icon={IconArrowBoxLeft}
+                onClick={handleLogout}
+                title={__("Logout")}
+                className="text-sm"
+              />
             </div>
           </div>
         </div>

--- a/apps/console/src/pages/PublicTrustCenterPage.tsx
+++ b/apps/console/src/pages/PublicTrustCenterPage.tsx
@@ -9,6 +9,7 @@ import { PublicTrustCenterLayout } from "/layouts/PublicTrustCenterLayout";
 import { PublicTrustCenterAudits } from "../components/trustCenter/PublicTrustCenterAudits";
 import { PublicTrustCenterVendors } from "../components/trustCenter/PublicTrustCenterVendors";
 import { PublicTrustCenterDocuments } from "../components/trustCenter/PublicTrustCenterDocuments";
+import { PageError } from "../components/PageError";
 
 type Props = {
   queryRef?: PreloadedQuery<PublicTrustCenterGraphQuery>;
@@ -29,11 +30,11 @@ export default function PublicTrustCenterPage({ queryRef }: Props) {
   const { trustCenterBySlug } = data as any;
 
   if (!trustCenterBySlug) {
-    return <Navigate to="/auth/login" replace />;
+    return <PageError />;
   }
 
   if (!trustCenterBySlug.active) {
-    return <Navigate to="/auth/login" replace />;
+    return <PageError />;
   }
 
   const { organization } = trustCenterBySlug;

--- a/apps/console/src/pages/TrustCenterAccessPage.tsx
+++ b/apps/console/src/pages/TrustCenterAccessPage.tsx
@@ -1,0 +1,130 @@
+import { useTranslate } from "@probo/i18n";
+import { useParams, useNavigate, useSearchParams } from "react-router";
+import { useState, useEffect } from "react";
+import { PageSkeleton } from "/components/skeletons/PageSkeleton";
+import { PageError } from "/components/PageError";
+import { buildEndpoint } from "/providers/RelayProviders";
+import { IconClock, IconWarning } from "@probo/ui";
+
+function TokenErrorPage({ error }: { error: string }) {
+  const { __ } = useTranslate();
+
+  const isExpiredToken = error.toLowerCase().includes('expired');
+
+  return (
+    <div className="min-h-screen bg-level-0 flex items-center justify-center p-4">
+      <div className="max-w-md w-full text-center space-y-6">
+        <div className="space-y-4">
+          {isExpiredToken ? (
+            <div className="space-y-3">
+              <div className="inline-flex items-center justify-center w-16 h-16 bg-amber-100 rounded-full">
+                <IconClock size={32} className="text-amber-600" />
+              </div>
+              <h1 className="text-2xl font-semibold text-txt-primary">
+                {__("Access Link Expired")}
+              </h1>
+              <p className="text-txt-secondary">
+                {__("This access link has expired. Trust center access links are valid for 7 days for security reasons.")}
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              <div className="inline-flex items-center justify-center w-16 h-16 bg-red-100 rounded-full">
+                <IconWarning size={32} className="text-red-600" />
+              </div>
+              <h1 className="text-2xl font-semibold text-txt-primary">
+                {__("Invalid Access Link")}
+              </h1>
+              <p className="text-txt-secondary">
+                {__("This access link is not valid. It may have been revoked or the link might be incorrect.")}
+              </p>
+            </div>
+          )}
+        </div>
+
+        <div className="bg-level-1 border border-border-low rounded-lg p-4 space-y-3">
+          <h3 className="font-medium text-txt-primary">{__("What can you do?")}</h3>
+          <ul className="text-sm text-txt-secondary space-y-2 text-left">
+            <li className="flex items-start gap-2">
+              <span className="text-primary-600 mt-1">•</span>
+              <span>{__("Contact the person who sent you this link to request a new access invitation")}</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="text-primary-600 mt-1">•</span>
+              <span>{__("Check if you received a newer email with an updated access link")}</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="text-primary-600 mt-1">•</span>
+              <span>{__("Verify that you copied the entire link correctly from the email")}</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function TrustCenterAccessPage() {
+  const { __ } = useTranslate();
+  const { slug } = useParams<{ slug: string }>();
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get('token');
+  const navigate = useNavigate();
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!slug) {
+      setError(__("Invalid trust center"));
+      setLoading(false);
+      return;
+    }
+
+    if (!token) {
+      setError(__("Invalid or missing access token"));
+      setLoading(false);
+      return;
+    }
+
+    fetch(buildEndpoint('/api/console/v1/trust-center-access/authenticate'), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include',
+      body: JSON.stringify({ token }),
+    })
+    .then(response => response.json())
+    .then(data => {
+      if (data.success) {
+        navigate(`/trust/${slug}`);
+      } else {
+        setError(data.message || __("Authentication failed"));
+        setLoading(false);
+      }
+    })
+    .catch(() => {
+      setError(__("Authentication failed"));
+      setLoading(false);
+    });
+  }, [slug, token, __, navigate]);
+
+  if (loading) {
+    return <PageSkeleton />;
+  }
+
+  if (error) {
+    const isTokenError = error.toLowerCase().includes('token') ||
+                        error.toLowerCase().includes('expired') ||
+                        error.toLowerCase().includes('invalid');
+
+    if (isTokenError) {
+      return <TokenErrorPage error={error} />;
+    }
+
+    return <PageError error={error} />;
+  }
+
+  return <div>{__("Redirecting to trust center...")}</div>;
+}

--- a/apps/console/src/pages/organizations/TrustCenterPage.tsx
+++ b/apps/console/src/pages/organizations/TrustCenterPage.tsx
@@ -212,8 +212,7 @@ export default function TrustCenterPage({ queryRef }: Props) {
         </Card>
       </div>
       <div className="space-y-4">
-        <h2 className="text-base font-medium">{__("Content")}</h2>
-                <Tabs>
+        <Tabs>
           <TabItem
             asChild
             active={
@@ -230,6 +229,9 @@ export default function TrustCenterPage({ queryRef }: Props) {
           </TabLink>
           <TabLink to={`/organizations/${organizationId}/trust-center/documents`}>
             {__("Documents")}
+          </TabLink>
+          <TabLink to={`/organizations/${organizationId}/trust-center/access`}>
+            {__("Access")}
           </TabLink>
         </Tabs>
 

--- a/apps/console/src/pages/organizations/trustCenter/TrustCenterAccessTab.tsx
+++ b/apps/console/src/pages/organizations/trustCenter/TrustCenterAccessTab.tsx
@@ -1,0 +1,359 @@
+import { Badge, Button, Card, Dialog, DialogContent, DialogFooter, Field, Input, Spinner, Table, Tbody, Td, Th, Thead, Tr, useDialogRef, useToast, IconCheckmark1, IconCrossLargeX, IconTrashCan } from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { useOutletContext } from "react-router";
+import { useState, useCallback } from "react";
+import {
+  useTrustCenterAccesses,
+  createTrustCenterAccessMutation,
+  updateTrustCenterAccessMutation,
+  deleteTrustCenterAccessMutation
+} from "/hooks/graph/TrustCenterAccessGraph";
+import { useMutation } from "react-relay";
+
+type ContextType = {
+  organization: {
+    id: string;
+    trustCenter?: {
+      id: string;
+    };
+  };
+};
+
+export default function TrustCenterAccessTab() {
+  const { __ } = useTranslate();
+  const { toast } = useToast();
+  const { organization } = useOutletContext<ContextType>();
+
+  const [createInvitation, isCreating] = useMutation(createTrustCenterAccessMutation);
+  const [updateInvitation, isUpdating] = useMutation(updateTrustCenterAccessMutation);
+  const [deleteInvitation, isDeleting] = useMutation(deleteTrustCenterAccessMutation);
+
+  const dialogRef = useDialogRef();
+  const [email, setEmail] = useState("");
+  const [name, setName] = useState("");
+
+  type AccessType = {
+    id: string;
+    email: string;
+    name: string;
+    active: boolean;
+    createdAt: Date;
+  };
+
+  const data = useTrustCenterAccesses(organization.trustCenter?.id || "");
+
+  if (!organization.trustCenter?.id) {
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-base font-medium">{__("External Access")}</h3>
+            <p className="text-sm text-txt-tertiary">
+              {__("Manage who can access your trust center with time-limited tokens")}
+            </p>
+          </div>
+        </div>
+        <Card padded>
+          <div className="text-center text-txt-tertiary py-8">
+            <Spinner />
+          </div>
+        </Card>
+      </div>
+    );
+  }
+
+  const accesses: AccessType[] = (data as any)?.node?.accesses?.edges ?
+    (data as any).node.accesses.edges.map((edge: any) => ({
+      id: edge.node.id,
+      email: edge.node.email,
+      name: edge.node.name,
+      active: edge.node.active,
+      createdAt: new Date(edge.node.createdAt)
+    })) : [];
+
+  const handleInvite = useCallback(async () => {
+    if (!organization.trustCenter?.id) {
+      toast({
+        title: __("Error"),
+        description: __("Trust center not found"),
+        variant: "error",
+      });
+      return;
+    }
+
+    if (!email.trim() || !name.trim()) {
+      toast({
+        title: __("Error"),
+        description: __("Email and name are required"),
+        variant: "error",
+      });
+      return;
+    }
+
+    const connectionId = (data as any)?.node?.accesses?.__id;
+
+    try {
+      createInvitation({
+        variables: {
+          input: {
+            trustCenterId: organization.trustCenter.id,
+            email: email.trim(),
+            name: name.trim(),
+            sendEmail: true,
+          },
+          connections: connectionId ? [connectionId] : [],
+        },
+        onCompleted: (_, errors) => {
+          if (errors && errors.length > 0) {
+            toast({
+              title: __("Error"),
+              description: errors[0]?.message || __("Failed to send invitation"),
+              variant: "error",
+            });
+            return;
+          }
+
+          if (dialogRef.current) {
+            dialogRef.current.close();
+          }
+          setEmail("");
+          setName("");
+
+          toast({
+            title: __("Success"),
+            description: __("Access invitation sent successfully"),
+            variant: "success",
+          });
+        },
+        onError: (error) => {
+          toast({
+            title: __("Error"),
+            description: error.message || __("Failed to send invitation. Please try again."),
+            variant: "error",
+          });
+        },
+      });
+    } catch (error) {
+      toast({
+        title: __("Error"),
+        description: __("An unexpected error occurred. Please try again."),
+        variant: "error",
+      });
+    }
+  }, [organization.trustCenter?.id, email, name, data, createInvitation, toast, __, dialogRef]);
+
+  const handleRevoke = useCallback(async (accessId: string) => {
+    updateInvitation({
+      variables: {
+        input: {
+          accessId,
+          active: false,
+          sendEmail: false,
+        },
+      },
+      onCompleted: () => {
+        toast({
+          title: __("Success"),
+          description: __("Access revoked successfully"),
+          variant: "success",
+        });
+      },
+      onError: (error) => {
+        toast({
+          title: __("Error"),
+          description: error.message,
+          variant: "error",
+        });
+      },
+    });
+  }, [updateInvitation, toast, __]);
+
+  const handleReinvite = useCallback(async (access: AccessType) => {
+    if (!organization.trustCenter?.id) {
+      toast({
+        title: __("Error"),
+        description: __("Trust center not found"),
+        variant: "error",
+      });
+      return;
+    }
+
+    try {
+      updateInvitation({
+        variables: {
+          input: {
+            accessId: access.id,
+            active: true,
+            sendEmail: true,
+          },
+        },
+        onCompleted: (_, errors) => {
+          if (errors && errors.length > 0) {
+            toast({
+              title: __("Error"),
+              description: errors[0]?.message || __("Failed to send reinvitation"),
+              variant: "error",
+            });
+            return;
+          }
+
+          toast({
+            title: __("Success"),
+            description: __("Reinvitation sent successfully"),
+            variant: "success",
+          });
+        },
+        onError: (error) => {
+          toast({
+            title: __("Error"),
+            description: error.message || __("Failed to send reinvitation. Please try again."),
+            variant: "error",
+          });
+        },
+      });
+    } catch (error) {
+      toast({
+        title: __("Error"),
+        description: __("An unexpected error occurred. Please try again."),
+        variant: "error",
+      });
+    }
+  }, [organization.trustCenter?.id, updateInvitation, toast, __]);
+
+  const handleDelete = useCallback(async (accessId: string) => {
+    const connectionId = (data as any)?.node?.accesses?.__id;
+
+    deleteInvitation({
+      variables: {
+        input: {
+          accessId,
+        },
+        connections: connectionId ? [connectionId] : [],
+      },
+      onCompleted: () => {
+        toast({
+          title: __("Success"),
+          description: __("Access deleted successfully"),
+          variant: "success",
+        });
+      },
+      onError: (error) => {
+        toast({
+          title: __("Error"),
+          description: error.message,
+          variant: "error",
+        });
+      },
+    });
+  }, [deleteInvitation, toast, __, data]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-base font-medium">{__("External Access")}</h3>
+          <p className="text-sm text-txt-tertiary">
+            {__("Manage who can access your trust center with time-limited tokens")}
+          </p>
+        </div>
+        <Button onClick={() => dialogRef.current?.open()}>
+          {__("Invite")}
+        </Button>
+      </div>
+
+      <Card padded>
+        {accesses.length === 0 ? (
+          <div className="text-center text-txt-tertiary py-8">
+            {__("No external access granted yet")}
+          </div>
+        ) : (
+          <Table>
+            <Thead>
+              <Tr>
+                <Th>{__("Name")}</Th>
+                <Th>{__("Email")}</Th>
+                <Th>{__("Status")}</Th>
+                <Th>{__("Date")}</Th>
+                <Th></Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {accesses.map((access) => (
+                <Tr key={access.id}>
+                  <Td className="font-medium">{access.name}</Td>
+                  <Td>{access.email}</Td>
+                  <Td>
+                    <Badge variant={access.active ? "success" : "neutral"}>
+                      {access.active ? __("Active") : __("Revoked")}
+                    </Badge>
+                  </Td>
+                  <Td>
+                    {access.createdAt.toLocaleDateString()}
+                  </Td>
+                  <Td noLink width={120} className="text-end">
+                    <div className="flex gap-2 justify-end">
+                      <Button
+                        variant="secondary"
+                        onClick={() => access.active ? handleRevoke(access.id) : handleReinvite(access)}
+                        disabled={isUpdating}
+                        icon={access.active ? IconCrossLargeX : IconCheckmark1}
+                      />
+                      <Button
+                        variant="secondary"
+                        onClick={() => handleDelete(access.id)}
+                        disabled={isDeleting}
+                        icon={IconTrashCan}
+                      />
+                    </div>
+                  </Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </Table>
+        )}
+      </Card>
+
+      <Dialog
+        ref={dialogRef}
+        title={__("Invite External Access")}
+      >
+        <DialogContent padded className="space-y-4">
+          <p className="text-txt-secondary text-sm">
+            {__("Send a 7-day access token to an external person to view your trust center")}
+          </p>
+
+          <Field label={__("Full Name")} required>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder={__("John Doe")}
+            />
+          </Field>
+
+          <Field label={__("Email Address")} required>
+            <Input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder={__("john@example.com")}
+            />
+          </Field>
+        </DialogContent>
+
+        <DialogFooter>
+          <Button
+            variant="secondary"
+            onClick={() => dialogRef.current?.close()}
+            disabled={isCreating}
+          >
+            {__("Cancel")}
+          </Button>
+          <Button onClick={handleInvite} disabled={isCreating}>
+            {isCreating && <Spinner />}
+            {__("Send Invitation")}
+          </Button>
+        </DialogFooter>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/console/src/routes.tsx
+++ b/apps/console/src/routes.tsx
@@ -116,6 +116,12 @@ const routes = [
     Component: lazy(() => import("./pages/PublicTrustCenterPage")),
   },
   {
+    path: "/trust/:slug/access",
+    ErrorBoundary: ErrorBoundary,
+    fallback: PageSkeleton,
+    Component: lazy(() => import("./pages/TrustCenterAccessPage")),
+  },
+  {
     path: "/organizations/:organizationId",
     Component: MainLayout,
     ErrorBoundary: ErrorBoundary,

--- a/apps/console/src/routes/trustCenterRoutes.ts
+++ b/apps/console/src/routes/trustCenterRoutes.ts
@@ -44,6 +44,13 @@ export const trustCenterRoutes = [
           () => import("/pages/organizations/trustCenter/TrustCenterDocumentsTab")
         ),
       },
+      {
+        path: "access",
+        fallback: LinkCardSkeleton,
+        Component: lazy(
+          () => import("/pages/organizations/trustCenter/TrustCenterAccessTab")
+        ),
+      },
     ],
   },
 ] satisfies AppRoute[];

--- a/cfg/dev.yaml
+++ b/cfg/dev.yaml
@@ -1,4 +1,5 @@
 probod:
+  https: false
   api:
     cors:
       allowed-origins: ["http://localhost:8080", "http://localhost:5173"]

--- a/pkg/coredata/entity_type_reg.go
+++ b/pkg/coredata/entity_type_reg.go
@@ -38,4 +38,5 @@ const (
 	AuditEntityType
 	ReportEntityType
 	TrustCenterEntityType
+	TrustCenterAccessEntityType
 )

--- a/pkg/coredata/migrations/20250728T194402Z.sql
+++ b/pkg/coredata/migrations/20250728T194402Z.sql
@@ -1,0 +1,11 @@
+CREATE TABLE trust_center_accesses (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    trust_center_id TEXT NOT NULL REFERENCES trust_centers(id) ON DELETE CASCADE,
+    email CITEXT NOT NULL
+    name TEXT NOT NULL,
+    active BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    UNIQUE(trust_center_id, email)
+);

--- a/pkg/coredata/trust_center_access.go
+++ b/pkg/coredata/trust_center_access.go
@@ -1,0 +1,318 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"time"
+
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+	"github.com/jackc/pgx/v5"
+	"go.gearno.de/kit/pg"
+)
+
+type (
+	TrustCenterAccess struct {
+		ID            gid.GID      `db:"id"`
+		TenantID      gid.TenantID `db:"tenant_id"`
+		TrustCenterID gid.GID      `db:"trust_center_id"`
+		Email         string       `db:"email"`
+		Name          string       `db:"name"`
+		Active        bool         `db:"active"`
+		CreatedAt     time.Time    `db:"created_at"`
+		UpdatedAt     time.Time    `db:"updated_at"`
+	}
+
+	TrustCenterAccesses []*TrustCenterAccess
+)
+
+func (tca *TrustCenterAccess) CursorKey(orderBy TrustCenterAccessOrderField) page.CursorKey {
+	switch orderBy {
+	case TrustCenterAccessOrderFieldCreatedAt:
+		return page.NewCursorKey(tca.ID, tca.CreatedAt)
+	}
+
+	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
+}
+
+func (tca *TrustCenterAccess) LoadByID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	accessID gid.GID,
+) error {
+	q := `
+SELECT
+	id,
+	tenant_id,
+	trust_center_id,
+	email,
+	name,
+	active,
+	created_at,
+	updated_at
+FROM
+	trust_center_accesses
+WHERE
+	%s
+	AND id = @access_id
+LIMIT 1;
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"access_id": accessID}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query trust center access: %w", err)
+	}
+
+	access, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[TrustCenterAccess])
+	if err != nil {
+		return fmt.Errorf("cannot collect trust center access: %w", err)
+	}
+
+	*tca = access
+
+	return nil
+}
+
+func (tca *TrustCenterAccess) LoadByTrustCenterIDAndEmail(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	trustCenterID gid.GID,
+	email string,
+) error {
+	q := `
+SELECT
+	id,
+	tenant_id,
+	trust_center_id,
+	email,
+	name,
+	active,
+	created_at,
+	updated_at
+FROM
+	trust_center_accesses
+WHERE
+	%s
+	AND trust_center_id = @trust_center_id
+	AND email = @email
+LIMIT 1;
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"trust_center_id": trustCenterID,
+		"email":           email,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query trust center access: %w", err)
+	}
+
+	access, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[TrustCenterAccess])
+	if err != nil {
+		return fmt.Errorf("cannot collect trust center access: %w", err)
+	}
+
+	*tca = access
+
+	return nil
+}
+
+func (tca *TrustCenterAccess) Insert(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+INSERT INTO trust_center_accesses (
+	id,
+	tenant_id,
+	trust_center_id,
+	email,
+	name,
+	active,
+	created_at,
+	updated_at
+) VALUES (
+	@id,
+	@tenant_id,
+	@trust_center_id,
+	@email,
+	@name,
+	@active,
+	@created_at,
+	@updated_at
+)
+`
+
+	args := pgx.StrictNamedArgs{
+		"id":              tca.ID,
+		"tenant_id":       tca.TenantID,
+		"trust_center_id": tca.TrustCenterID,
+		"email":           tca.Email,
+		"name":            tca.Name,
+		"active":          tca.Active,
+		"created_at":      tca.CreatedAt,
+		"updated_at":      tca.UpdatedAt,
+	}
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot insert trust center access: %w", err)
+	}
+
+	return nil
+}
+
+func (tca *TrustCenterAccess) Update(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+UPDATE trust_center_accesses
+SET
+	active = @active,
+	updated_at = @updated_at
+WHERE
+	%s
+	AND id = @id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"id":         tca.ID,
+		"active":     tca.Active,
+		"updated_at": tca.UpdatedAt,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot update trust center access: %w", err)
+	}
+
+	return nil
+}
+
+func (tca *TrustCenterAccess) Delete(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+DELETE FROM trust_center_accesses
+WHERE
+	%s
+	AND id = @id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"id": tca.ID,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete trust center access: %w", err)
+	}
+
+	return nil
+}
+
+func (tcas *TrustCenterAccesses) LoadByTrustCenterID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	trustCenterID gid.GID,
+	cursor *page.Cursor[TrustCenterAccessOrderField],
+) error {
+	q := `
+SELECT
+	id,
+	tenant_id,
+	trust_center_id,
+	email,
+	name,
+	active,
+	created_at,
+	updated_at
+FROM
+	trust_center_accesses
+WHERE
+	%s
+	AND trust_center_id = @trust_center_id
+	AND %s
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"trust_center_id": trustCenterID,
+	}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, cursor.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query trust center accesses: %w", err)
+	}
+
+	accesses, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[TrustCenterAccess])
+	if err != nil {
+		return fmt.Errorf("cannot collect trust center accesses: %w", err)
+	}
+
+	*tcas = accesses
+
+	return nil
+}
+
+type (
+	TrustCenterAccessOrderField string
+)
+
+const (
+	TrustCenterAccessOrderFieldCreatedAt TrustCenterAccessOrderField = "CREATED_AT"
+)
+
+func (tcaof TrustCenterAccessOrderField) String() string {
+	return string(tcaof)
+}
+
+func (tcaof TrustCenterAccessOrderField) Column() string {
+	switch tcaof {
+	case TrustCenterAccessOrderFieldCreatedAt:
+		return "created_at"
+	}
+
+	panic(fmt.Sprintf("unsupported order by: %s", tcaof))
+}

--- a/pkg/probo/document_service.go
+++ b/pkg/probo/document_service.go
@@ -1066,6 +1066,7 @@ func (s *DocumentService) CancelSignatureRequest(
 func (s *DocumentService) ExportPDF(
 	ctx context.Context,
 	documentVersionID gid.GID,
+	onlyVisibleOnTrustCenter bool,
 ) ([]byte, error) {
 	document := &coredata.Document{}
 	version := &coredata.DocumentVersion{}
@@ -1083,6 +1084,10 @@ func (s *DocumentService) ExportPDF(
 
 			if err := document.LoadByID(ctx, conn, s.svc.scope, version.DocumentID); err != nil {
 				return fmt.Errorf("cannot load document: %w", err)
+			}
+
+			if onlyVisibleOnTrustCenter && !document.ShowOnTrustCenter {
+				return fmt.Errorf("document not visible on trust center")
 			}
 
 			if version.PublishedBy != nil {

--- a/pkg/probo/trust_center_access_service.go
+++ b/pkg/probo/trust_center_access_service.go
@@ -1,0 +1,348 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package probo
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+	"github.com/getprobo/probo/pkg/statelesstoken"
+	"github.com/getprobo/probo/pkg/usrmgr"
+	"go.gearno.de/kit/pg"
+)
+
+type (
+	TrustCenterAccessService struct {
+		svc    *TenantService
+		usrmgr *usrmgr.Service
+	}
+
+	CreateTrustCenterAccessRequest struct {
+		TrustCenterID gid.GID
+		Email         string
+		Name          string
+		SendEmail     bool
+	}
+
+	UpdateTrustCenterAccessRequest struct {
+		AccessID  gid.GID
+		Email     *string
+		Name      *string
+		Active    *bool
+		SendEmail bool
+	}
+
+	DeleteTrustCenterAccessRequest struct {
+		AccessID gid.GID
+	}
+
+	RevokeTrustCenterAccessRequest struct {
+		AccessID gid.GID
+	}
+
+	TrustCenterAccessData struct {
+		TrustCenterID gid.GID `json:"trust_center_id"`
+		Email         string  `json:"email"`
+	}
+)
+
+const (
+	TokenTypeTrustCenterAccess = "trust_center_access"
+)
+
+func (s *TenantService) getURLScheme() string {
+	if s.https {
+		return "https"
+	}
+	return "http"
+}
+
+func (s TrustCenterAccessService) RevokeAccess(
+	ctx context.Context,
+	req *RevokeTrustCenterAccessRequest,
+) (*coredata.TrustCenterAccess, error) {
+	access := &coredata.TrustCenterAccess{}
+
+	err := s.svc.pg.WithTx(ctx, func(tx pg.Conn) error {
+		if err := access.LoadByID(ctx, tx, s.svc.scope, req.AccessID); err != nil {
+			return fmt.Errorf("cannot load trust center access: %w", err)
+		}
+
+		access.Active = false
+		access.UpdatedAt = time.Now()
+
+		if err := access.Update(ctx, tx, s.svc.scope); err != nil {
+			return fmt.Errorf("cannot update trust center access: %w", err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return access, nil
+}
+
+func (s TrustCenterAccessService) ListForTrustCenterID(
+	ctx context.Context,
+	trustCenterID gid.GID,
+	cursor *page.Cursor[coredata.TrustCenterAccessOrderField],
+) (*page.Page[*coredata.TrustCenterAccess, coredata.TrustCenterAccessOrderField], error) {
+	var accesses coredata.TrustCenterAccesses
+
+	err := s.svc.pg.WithConn(ctx, func(conn pg.Conn) error {
+		return accesses.LoadByTrustCenterID(ctx, conn, s.svc.scope, trustCenterID, cursor)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return page.NewPage(accesses, cursor), nil
+}
+
+func (s TrustCenterAccessService) ValidateToken(
+	ctx context.Context,
+	tokenString string,
+) (*TrustCenterAccessData, error) {
+	token, err := statelesstoken.ValidateToken[TrustCenterAccessData](
+		s.svc.tokenSecret,
+		TokenTypeTrustCenterAccess,
+		tokenString,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot validate trust center access token: %w", err)
+	}
+
+	access := &coredata.TrustCenterAccess{}
+	err = s.svc.pg.WithConn(ctx, func(conn pg.Conn) error {
+		return access.LoadByTrustCenterIDAndEmail(ctx, conn, s.svc.scope, token.Data.TrustCenterID, token.Data.Email)
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("access not found or revoked: %w", err)
+	}
+
+	if !access.Active {
+		return nil, fmt.Errorf("access has been revoked")
+	}
+
+	return &token.Data, nil
+}
+
+func (s TrustCenterAccessService) IsAccessActive(
+	ctx context.Context,
+	trustCenterID gid.GID,
+	email string,
+) (bool, error) {
+	access := &coredata.TrustCenterAccess{}
+	err := s.svc.pg.WithConn(ctx, func(conn pg.Conn) error {
+		return access.LoadByTrustCenterIDAndEmail(ctx, conn, s.svc.scope, trustCenterID, email)
+	})
+
+	if err != nil {
+		return false, fmt.Errorf("cannot load trust center access: %w", err)
+	}
+
+	return access.Active, nil
+}
+
+func (s TrustCenterAccessService) Create(
+	ctx context.Context,
+	req *CreateTrustCenterAccessRequest,
+) (*coredata.TrustCenterAccess, error) {
+	if !strings.Contains(req.Email, "@") {
+		return nil, fmt.Errorf("invalid email address")
+	}
+
+	if req.Name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+
+	now := time.Now()
+
+	existingAccess := &coredata.TrustCenterAccess{}
+	err := s.svc.pg.WithConn(ctx, func(conn pg.Conn) error {
+		return existingAccess.LoadByTrustCenterIDAndEmail(ctx, conn, s.svc.scope, req.TrustCenterID, req.Email)
+	})
+
+	var access *coredata.TrustCenterAccess
+
+	if err == nil {
+		access = existingAccess
+		access.Name = req.Name
+		access.Active = true
+		access.UpdatedAt = now
+
+		err = s.svc.pg.WithTx(ctx, func(tx pg.Conn) error {
+			if err := access.Update(ctx, tx, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot update trust center access: %w", err)
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		access = &coredata.TrustCenterAccess{
+			ID:            gid.New(s.svc.scope.GetTenantID(), coredata.TrustCenterAccessEntityType),
+			TenantID:      s.svc.scope.GetTenantID(),
+			TrustCenterID: req.TrustCenterID,
+			Email:         req.Email,
+			Name:          req.Name,
+			Active:        true,
+			CreatedAt:     now,
+			UpdatedAt:     now,
+		}
+
+		err = s.svc.pg.WithTx(ctx, func(tx pg.Conn) error {
+			if err := access.Insert(ctx, tx, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot insert trust center access: %w", err)
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if req.SendEmail {
+		if err := s.sendAccessEmail(ctx, access); err != nil {
+			fmt.Printf("Failed to send access email\n")
+		}
+	}
+
+	return access, nil
+}
+
+func (s TrustCenterAccessService) Update(
+	ctx context.Context,
+	req *UpdateTrustCenterAccessRequest,
+) (*coredata.TrustCenterAccess, error) {
+	access := &coredata.TrustCenterAccess{}
+
+	err := s.svc.pg.WithTx(ctx, func(tx pg.Conn) error {
+		if err := access.LoadByID(ctx, tx, s.svc.scope, req.AccessID); err != nil {
+			return fmt.Errorf("cannot load trust center access: %w", err)
+		}
+
+		if req.Email != nil {
+			if !strings.Contains(*req.Email, "@") {
+				return fmt.Errorf("invalid email address")
+			}
+			access.Email = *req.Email
+		}
+
+		if req.Name != nil {
+			if *req.Name == "" {
+				return fmt.Errorf("name cannot be empty")
+			}
+			access.Name = *req.Name
+		}
+
+		if req.Active != nil {
+			access.Active = *req.Active
+		}
+
+		access.UpdatedAt = time.Now()
+
+		if err := access.Update(ctx, tx, s.svc.scope); err != nil {
+			return fmt.Errorf("cannot update trust center access: %w", err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if req.SendEmail && access.Active {
+		if err := s.sendAccessEmail(ctx, access); err != nil {
+			fmt.Printf("Failed to send access email\n")
+		}
+	}
+
+	return access, nil
+}
+
+func (s TrustCenterAccessService) Delete(
+	ctx context.Context,
+	req *DeleteTrustCenterAccessRequest,
+) error {
+	err := s.svc.pg.WithTx(ctx, func(tx pg.Conn) error {
+		access := &coredata.TrustCenterAccess{}
+
+		if err := access.LoadByID(ctx, tx, s.svc.scope, req.AccessID); err != nil {
+			return fmt.Errorf("cannot load trust center access: %w", err)
+		}
+
+		if err := access.Delete(ctx, tx, s.svc.scope); err != nil {
+			return fmt.Errorf("cannot delete trust center access: %w", err)
+		}
+
+		return nil
+	})
+
+	return err
+}
+
+func (s TrustCenterAccessService) sendAccessEmail(ctx context.Context, access *coredata.TrustCenterAccess) error {
+	accessToken, err := statelesstoken.NewToken(
+		s.svc.tokenSecret,
+		TokenTypeTrustCenterAccess,
+		7*24*time.Hour,
+		TrustCenterAccessData{
+			TrustCenterID: access.TrustCenterID,
+			Email:         access.Email,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("cannot generate access token: %w", err)
+	}
+
+	trustCenter := &coredata.TrustCenter{}
+	err = s.svc.pg.WithConn(ctx, func(conn pg.Conn) error {
+		return trustCenter.LoadByID(ctx, conn, s.svc.scope, access.TrustCenterID)
+	})
+	if err != nil {
+		return fmt.Errorf("cannot load trust center: %w", err)
+	}
+
+	organization := &coredata.Organization{}
+	err = s.svc.pg.WithConn(ctx, func(conn pg.Conn) error {
+		return organization.LoadByID(ctx, conn, s.svc.scope, trustCenter.OrganizationID)
+	})
+	if err != nil {
+		return fmt.Errorf("cannot load organization: %w", err)
+	}
+
+	accessURL := url.URL{
+		Scheme:   s.svc.getURLScheme(),
+		Host:     s.svc.hostname,
+		Path:     "/trust/" + trustCenter.Slug + "/access",
+		RawQuery: "token=" + url.QueryEscape(accessToken),
+	}
+
+	return s.usrmgr.SendTrustCenterAccessEmail(ctx, access.Name, access.Email, organization.Name, accessURL.String())
+}

--- a/pkg/probo/trust_center_service.go
+++ b/pkg/probo/trust_center_service.go
@@ -36,6 +36,26 @@ type (
 	}
 )
 
+func (s TrustCenterService) Get(
+	ctx context.Context,
+	trustCenterID gid.GID,
+) (*coredata.TrustCenter, error) {
+	trustCenter := &coredata.TrustCenter{}
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			return trustCenter.LoadByID(ctx, conn, s.svc.scope, trustCenterID)
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return trustCenter, nil
+}
+
 func (s TrustCenterService) GetByOrganizationID(
 	ctx context.Context,
 	organizationID gid.GID,

--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -55,6 +55,7 @@ type (
 
 	config struct {
 		Hostname      string               `json:"hostname"`
+		HTTPS         bool                 `json:"https"`
 		EncryptionKey cipher.EncryptionKey `json:"encryption-key"`
 		Pg            pgConfig             `json:"pg"`
 		Api           apiConfig            `json:"api"`
@@ -76,6 +77,7 @@ func New() *Implm {
 	return &Implm{
 		cfg: config{
 			Hostname: "localhost:8080",
+			HTTPS:    true,
 			Api: apiConfig{
 				Addr: "localhost:8080",
 			},
@@ -224,9 +226,11 @@ func (impl *Implm) Run(
 		s3Client,
 		impl.cfg.AWS.Bucket,
 		impl.cfg.Hostname,
+		impl.cfg.HTTPS,
 		impl.cfg.Auth.Cookie.Secret,
 		agentConfig,
 		html2pdfConverter,
+		usrmgrService,
 	)
 	if err != nil {
 		return fmt.Errorf("cannot create probo service: %w", err)

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -566,6 +566,14 @@ enum AuditOrderField
     )
 }
 
+enum TrustCenterAccessOrderField
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.TrustCenterAccessOrderField") {
+  CREATED_AT
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.TrustCenterAccessOrderFieldCreatedAt"
+    )
+}
+
 # Input Types
 input UserOrder
   @goModel(
@@ -647,6 +655,14 @@ input AuditOrder
   field: AuditOrderField!
 }
 
+input TrustCenterAccessOrder
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.TrustCenterAccessOrderBy"
+  ) {
+  direction: OrderDirection!
+  field: TrustCenterAccessOrderField!
+}
+
 input EvidenceOrder
   @goModel(
     model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.EvidenceOrderBy"
@@ -718,6 +734,14 @@ type TrustCenter implements Node {
   createdAt: Datetime!
   updatedAt: Datetime!
   organization: Organization! @goField(forceResolver: true)
+
+  accesses(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+    orderBy: TrustCenterAccessOrder
+  ): TrustCenterAccessConnection! @goField(forceResolver: true)
 
   publicDocuments(
     first: Int
@@ -1235,6 +1259,25 @@ type TrustCenterEdge {
   node: TrustCenter!
 }
 
+type TrustCenterAccess implements Node {
+  id: ID!
+  email: String!
+  name: String!
+  active: Boolean!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+}
+
+type TrustCenterAccessConnection {
+  edges: [TrustCenterAccessEdge!]!
+  pageInfo: PageInfo!
+}
+
+type TrustCenterAccessEdge {
+  cursor: CursorKey!
+  node: TrustCenterAccess!
+}
+
 type UserConnection {
   edges: [UserEdge!]!
   pageInfo: PageInfo!
@@ -1466,6 +1509,24 @@ type Mutation {
     input: UpdateTrustCenterInput!
   ): UpdateTrustCenterPayload!
 
+
+  revokeTrustCenterAccess(
+    input: RevokeTrustCenterAccessInput!
+  ): RevokeTrustCenterAccessPayload!
+
+  # Trust Center Access CRUD mutations
+  createTrustCenterAccess(
+    input: CreateTrustCenterAccessInput!
+  ): CreateTrustCenterAccessPayload!
+
+  updateTrustCenterAccess(
+    input: UpdateTrustCenterAccessInput!
+  ): UpdateTrustCenterAccessPayload!
+
+  deleteTrustCenterAccess(
+    input: DeleteTrustCenterAccessInput!
+  ): DeleteTrustCenterAccessPayload!
+
   # User mutations
   confirmEmail(input: ConfirmEmailInput!): ConfirmEmailPayload!
   inviteUser(input: InviteUserInput!): InviteUserPayload!
@@ -1636,6 +1697,31 @@ input UpdateTrustCenterInput {
   trustCenterId: ID!
   active: Boolean
   slug: String
+}
+
+
+
+input RevokeTrustCenterAccessInput {
+  accessId: ID!
+}
+
+input CreateTrustCenterAccessInput {
+  trustCenterId: ID!
+  email: String!
+  name: String!
+  sendEmail: Boolean! = true
+}
+
+input UpdateTrustCenterAccessInput {
+  accessId: ID!
+  email: String
+  name: String
+  active: Boolean
+  sendEmail: Boolean! = false
+}
+
+input DeleteTrustCenterAccessInput {
+  accessId: ID!
 }
 
 input CreateVendorInput {
@@ -2001,6 +2087,24 @@ type UpdateOrganizationPayload {
 
 type UpdateTrustCenterPayload {
   trustCenter: TrustCenter!
+}
+
+
+
+type RevokeTrustCenterAccessPayload {
+  trustCenterAccess: TrustCenterAccess!
+}
+
+type CreateTrustCenterAccessPayload {
+  trustCenterAccessEdge: TrustCenterAccessEdge!
+}
+
+type UpdateTrustCenterAccessPayload {
+  trustCenterAccess: TrustCenterAccess!
+}
+
+type DeleteTrustCenterAccessPayload {
+  deletedTrustCenterAccessId: ID!
 }
 
 type CreateControlPayload {

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -273,6 +273,10 @@ type ComplexityRoot struct {
 		TaskEdge func(childComplexity int) int
 	}
 
+	CreateTrustCenterAccessPayload struct {
+		TrustCenterAccessEdge func(childComplexity int) int
+	}
+
 	CreateVendorPayload struct {
 		VendorEdge func(childComplexity int) int
 	}
@@ -369,6 +373,10 @@ type ComplexityRoot struct {
 
 	DeleteTaskPayload struct {
 		DeletedTaskID func(childComplexity int) int
+	}
+
+	DeleteTrustCenterAccessPayload struct {
+		DeletedTrustCenterAccessID func(childComplexity int) int
 	}
 
 	DeleteVendorComplianceReportPayload struct {
@@ -577,6 +585,7 @@ type ComplexityRoot struct {
 		CreateRiskDocumentMapping             func(childComplexity int, input types.CreateRiskDocumentMappingInput) int
 		CreateRiskMeasureMapping              func(childComplexity int, input types.CreateRiskMeasureMappingInput) int
 		CreateTask                            func(childComplexity int, input types.CreateTaskInput) int
+		CreateTrustCenterAccess               func(childComplexity int, input types.CreateTrustCenterAccessInput) int
 		CreateVendor                          func(childComplexity int, input types.CreateVendorInput) int
 		CreateVendorRiskAssessment            func(childComplexity int, input types.CreateVendorRiskAssessmentInput) int
 		DeleteAsset                           func(childComplexity int, input types.DeleteAssetInput) int
@@ -595,6 +604,7 @@ type ComplexityRoot struct {
 		DeleteRiskDocumentMapping             func(childComplexity int, input types.DeleteRiskDocumentMappingInput) int
 		DeleteRiskMeasureMapping              func(childComplexity int, input types.DeleteRiskMeasureMappingInput) int
 		DeleteTask                            func(childComplexity int, input types.DeleteTaskInput) int
+		DeleteTrustCenterAccess               func(childComplexity int, input types.DeleteTrustCenterAccessInput) int
 		DeleteVendor                          func(childComplexity int, input types.DeleteVendorInput) int
 		DeleteVendorComplianceReport          func(childComplexity int, input types.DeleteVendorComplianceReportInput) int
 		ExportDocumentVersionPDF              func(childComplexity int, input types.ExportDocumentVersionPDFInput) int
@@ -608,6 +618,7 @@ type ComplexityRoot struct {
 		RemoveUser                            func(childComplexity int, input types.RemoveUserInput) int
 		RequestEvidence                       func(childComplexity int, input types.RequestEvidenceInput) int
 		RequestSignature                      func(childComplexity int, input types.RequestSignatureInput) int
+		RevokeTrustCenterAccess               func(childComplexity int, input types.RevokeTrustCenterAccessInput) int
 		SendSigningNotifications              func(childComplexity int, input types.SendSigningNotificationsInput) int
 		UnassignTask                          func(childComplexity int, input types.UnassignTaskInput) int
 		UpdateAsset                           func(childComplexity int, input types.UpdateAssetInput) int
@@ -623,6 +634,7 @@ type ComplexityRoot struct {
 		UpdateRisk                            func(childComplexity int, input types.UpdateRiskInput) int
 		UpdateTask                            func(childComplexity int, input types.UpdateTaskInput) int
 		UpdateTrustCenter                     func(childComplexity int, input types.UpdateTrustCenterInput) int
+		UpdateTrustCenterAccess               func(childComplexity int, input types.UpdateTrustCenterAccessInput) int
 		UpdateVendor                          func(childComplexity int, input types.UpdateVendorInput) int
 		UploadAuditReport                     func(childComplexity int, input types.UploadAuditReportInput) int
 		UploadMeasureEvidence                 func(childComplexity int, input types.UploadMeasureEvidenceInput) int
@@ -728,6 +740,10 @@ type ComplexityRoot struct {
 		DocumentVersionSignatureEdge func(childComplexity int) int
 	}
 
+	RevokeTrustCenterAccessPayload struct {
+		TrustCenterAccess func(childComplexity int) int
+	}
+
 	Risk struct {
 		Category           func(childComplexity int) int
 		Controls           func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ControlOrderBy, filter *types.ControlFilter) int
@@ -797,6 +813,7 @@ type ComplexityRoot struct {
 	}
 
 	TrustCenter struct {
+		Accesses        func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.OrderBy[coredata.TrustCenterAccessOrderField]) int
 		Active          func(childComplexity int) int
 		CreatedAt       func(childComplexity int) int
 		ID              func(childComplexity int) int
@@ -806,6 +823,25 @@ type ComplexityRoot struct {
 		PublicVendors   func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.VendorOrderBy) int
 		Slug            func(childComplexity int) int
 		UpdatedAt       func(childComplexity int) int
+	}
+
+	TrustCenterAccess struct {
+		Active    func(childComplexity int) int
+		CreatedAt func(childComplexity int) int
+		Email     func(childComplexity int) int
+		ID        func(childComplexity int) int
+		Name      func(childComplexity int) int
+		UpdatedAt func(childComplexity int) int
+	}
+
+	TrustCenterAccessConnection struct {
+		Edges    func(childComplexity int) int
+		PageInfo func(childComplexity int) int
+	}
+
+	TrustCenterAccessEdge struct {
+		Cursor func(childComplexity int) int
+		Node   func(childComplexity int) int
 	}
 
 	TrustCenterConnection struct {
@@ -868,6 +904,10 @@ type ComplexityRoot struct {
 
 	UpdateTaskPayload struct {
 		Task func(childComplexity int) int
+	}
+
+	UpdateTrustCenterAccessPayload struct {
+		TrustCenterAccess func(childComplexity int) int
 	}
 
 	UpdateTrustCenterPayload struct {
@@ -1093,6 +1133,10 @@ type MutationResolver interface {
 	CreateOrganization(ctx context.Context, input types.CreateOrganizationInput) (*types.CreateOrganizationPayload, error)
 	UpdateOrganization(ctx context.Context, input types.UpdateOrganizationInput) (*types.UpdateOrganizationPayload, error)
 	UpdateTrustCenter(ctx context.Context, input types.UpdateTrustCenterInput) (*types.UpdateTrustCenterPayload, error)
+	RevokeTrustCenterAccess(ctx context.Context, input types.RevokeTrustCenterAccessInput) (*types.RevokeTrustCenterAccessPayload, error)
+	CreateTrustCenterAccess(ctx context.Context, input types.CreateTrustCenterAccessInput) (*types.CreateTrustCenterAccessPayload, error)
+	UpdateTrustCenterAccess(ctx context.Context, input types.UpdateTrustCenterAccessInput) (*types.UpdateTrustCenterAccessPayload, error)
+	DeleteTrustCenterAccess(ctx context.Context, input types.DeleteTrustCenterAccessInput) (*types.DeleteTrustCenterAccessPayload, error)
 	ConfirmEmail(ctx context.Context, input types.ConfirmEmailInput) (*types.ConfirmEmailPayload, error)
 	InviteUser(ctx context.Context, input types.InviteUserInput) (*types.InviteUserPayload, error)
 	RemoveUser(ctx context.Context, input types.RemoveUserInput) (*types.RemoveUserPayload, error)
@@ -1214,6 +1258,7 @@ type TaskConnectionResolver interface {
 }
 type TrustCenterResolver interface {
 	Organization(ctx context.Context, obj *types.TrustCenter) (*types.Organization, error)
+	Accesses(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.OrderBy[coredata.TrustCenterAccessOrderField]) (*types.TrustCenterAccessConnection, error)
 	PublicDocuments(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy) (*types.DocumentConnection, error)
 	PublicAudits(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AuditOrderBy) (*types.AuditConnection, error)
 	PublicVendors(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.VendorOrderBy) (*types.VendorConnection, error)
@@ -1881,6 +1926,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.CreateTaskPayload.TaskEdge(childComplexity), true
 
+	case "CreateTrustCenterAccessPayload.trustCenterAccessEdge":
+		if e.complexity.CreateTrustCenterAccessPayload.TrustCenterAccessEdge == nil {
+			break
+		}
+
+		return e.complexity.CreateTrustCenterAccessPayload.TrustCenterAccessEdge(childComplexity), true
+
 	case "CreateVendorPayload.vendorEdge":
 		if e.complexity.CreateVendorPayload.VendorEdge == nil {
 			break
@@ -2130,6 +2182,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.DeleteTaskPayload.DeletedTaskID(childComplexity), true
+
+	case "DeleteTrustCenterAccessPayload.deletedTrustCenterAccessId":
+		if e.complexity.DeleteTrustCenterAccessPayload.DeletedTrustCenterAccessID == nil {
+			break
+		}
+
+		return e.complexity.DeleteTrustCenterAccessPayload.DeletedTrustCenterAccessID(childComplexity), true
 
 	case "DeleteVendorComplianceReportPayload.deletedVendorComplianceReportId":
 		if e.complexity.DeleteVendorComplianceReportPayload.DeletedVendorComplianceReportID == nil {
@@ -3149,6 +3208,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.CreateTask(childComplexity, args["input"].(types.CreateTaskInput)), true
 
+	case "Mutation.createTrustCenterAccess":
+		if e.complexity.Mutation.CreateTrustCenterAccess == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_createTrustCenterAccess_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreateTrustCenterAccess(childComplexity, args["input"].(types.CreateTrustCenterAccessInput)), true
+
 	case "Mutation.createVendor":
 		if e.complexity.Mutation.CreateVendor == nil {
 			break
@@ -3365,6 +3436,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.DeleteTask(childComplexity, args["input"].(types.DeleteTaskInput)), true
 
+	case "Mutation.deleteTrustCenterAccess":
+		if e.complexity.Mutation.DeleteTrustCenterAccess == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_deleteTrustCenterAccess_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteTrustCenterAccess(childComplexity, args["input"].(types.DeleteTrustCenterAccessInput)), true
+
 	case "Mutation.deleteVendor":
 		if e.complexity.Mutation.DeleteVendor == nil {
 			break
@@ -3520,6 +3603,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.RequestSignature(childComplexity, args["input"].(types.RequestSignatureInput)), true
+
+	case "Mutation.revokeTrustCenterAccess":
+		if e.complexity.Mutation.RevokeTrustCenterAccess == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_revokeTrustCenterAccess_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.RevokeTrustCenterAccess(childComplexity, args["input"].(types.RevokeTrustCenterAccessInput)), true
 
 	case "Mutation.sendSigningNotifications":
 		if e.complexity.Mutation.SendSigningNotifications == nil {
@@ -3700,6 +3795,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.UpdateTrustCenter(childComplexity, args["input"].(types.UpdateTrustCenterInput)), true
+
+	case "Mutation.updateTrustCenterAccess":
+		if e.complexity.Mutation.UpdateTrustCenterAccess == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_updateTrustCenterAccess_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UpdateTrustCenterAccess(childComplexity, args["input"].(types.UpdateTrustCenterAccessInput)), true
 
 	case "Mutation.updateVendor":
 		if e.complexity.Mutation.UpdateVendor == nil {
@@ -4254,6 +4361,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.RequestSignaturePayload.DocumentVersionSignatureEdge(childComplexity), true
 
+	case "RevokeTrustCenterAccessPayload.trustCenterAccess":
+		if e.complexity.RevokeTrustCenterAccessPayload.TrustCenterAccess == nil {
+			break
+		}
+
+		return e.complexity.RevokeTrustCenterAccessPayload.TrustCenterAccess(childComplexity), true
+
 	case "Risk.category":
 		if e.complexity.Risk.Category == nil {
 			break
@@ -4582,6 +4696,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.TaskEdge.Node(childComplexity), true
 
+	case "TrustCenter.accesses":
+		if e.complexity.TrustCenter.Accesses == nil {
+			break
+		}
+
+		args, err := ec.field_TrustCenter_accesses_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.TrustCenter.Accesses(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.OrderBy[coredata.TrustCenterAccessOrderField])), true
+
 	case "TrustCenter.active":
 		if e.complexity.TrustCenter.Active == nil {
 			break
@@ -4659,6 +4785,76 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.TrustCenter.UpdatedAt(childComplexity), true
+
+	case "TrustCenterAccess.active":
+		if e.complexity.TrustCenterAccess.Active == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterAccess.Active(childComplexity), true
+
+	case "TrustCenterAccess.createdAt":
+		if e.complexity.TrustCenterAccess.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterAccess.CreatedAt(childComplexity), true
+
+	case "TrustCenterAccess.email":
+		if e.complexity.TrustCenterAccess.Email == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterAccess.Email(childComplexity), true
+
+	case "TrustCenterAccess.id":
+		if e.complexity.TrustCenterAccess.ID == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterAccess.ID(childComplexity), true
+
+	case "TrustCenterAccess.name":
+		if e.complexity.TrustCenterAccess.Name == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterAccess.Name(childComplexity), true
+
+	case "TrustCenterAccess.updatedAt":
+		if e.complexity.TrustCenterAccess.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterAccess.UpdatedAt(childComplexity), true
+
+	case "TrustCenterAccessConnection.edges":
+		if e.complexity.TrustCenterAccessConnection.Edges == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterAccessConnection.Edges(childComplexity), true
+
+	case "TrustCenterAccessConnection.pageInfo":
+		if e.complexity.TrustCenterAccessConnection.PageInfo == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterAccessConnection.PageInfo(childComplexity), true
+
+	case "TrustCenterAccessEdge.cursor":
+		if e.complexity.TrustCenterAccessEdge.Cursor == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterAccessEdge.Cursor(childComplexity), true
+
+	case "TrustCenterAccessEdge.node":
+		if e.complexity.TrustCenterAccessEdge.Node == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterAccessEdge.Node(childComplexity), true
 
 	case "TrustCenterConnection.edges":
 		if e.complexity.TrustCenterConnection.Edges == nil {
@@ -4778,6 +4974,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.UpdateTaskPayload.Task(childComplexity), true
+
+	case "UpdateTrustCenterAccessPayload.trustCenterAccess":
+		if e.complexity.UpdateTrustCenterAccessPayload.TrustCenterAccess == nil {
+			break
+		}
+
+		return e.complexity.UpdateTrustCenterAccessPayload.TrustCenterAccess(childComplexity), true
 
 	case "UpdateTrustCenterPayload.trustCenter":
 		if e.complexity.UpdateTrustCenterPayload.TrustCenter == nil {
@@ -5367,6 +5570,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputCreateRiskInput,
 		ec.unmarshalInputCreateRiskMeasureMappingInput,
 		ec.unmarshalInputCreateTaskInput,
+		ec.unmarshalInputCreateTrustCenterAccessInput,
 		ec.unmarshalInputCreateVendorInput,
 		ec.unmarshalInputCreateVendorRiskAssessmentInput,
 		ec.unmarshalInputDatumOrder,
@@ -5386,6 +5590,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputDeleteRiskInput,
 		ec.unmarshalInputDeleteRiskMeasureMappingInput,
 		ec.unmarshalInputDeleteTaskInput,
+		ec.unmarshalInputDeleteTrustCenterAccessInput,
 		ec.unmarshalInputDeleteVendorComplianceReportInput,
 		ec.unmarshalInputDeleteVendorInput,
 		ec.unmarshalInputDocumentFilter,
@@ -5411,10 +5616,12 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputRemoveUserInput,
 		ec.unmarshalInputRequestEvidenceInput,
 		ec.unmarshalInputRequestSignatureInput,
+		ec.unmarshalInputRevokeTrustCenterAccessInput,
 		ec.unmarshalInputRiskFilter,
 		ec.unmarshalInputRiskOrder,
 		ec.unmarshalInputSendSigningNotificationsInput,
 		ec.unmarshalInputTaskOrder,
+		ec.unmarshalInputTrustCenterAccessOrder,
 		ec.unmarshalInputTrustCenterFilter,
 		ec.unmarshalInputUnassignTaskInput,
 		ec.unmarshalInputUpdateAssetInput,
@@ -5429,6 +5636,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputUpdatePeopleInput,
 		ec.unmarshalInputUpdateRiskInput,
 		ec.unmarshalInputUpdateTaskInput,
+		ec.unmarshalInputUpdateTrustCenterAccessInput,
 		ec.unmarshalInputUpdateTrustCenterInput,
 		ec.unmarshalInputUpdateVendorInput,
 		ec.unmarshalInputUploadAuditReportInput,
@@ -6104,6 +6312,14 @@ enum AuditOrderField
     )
 }
 
+enum TrustCenterAccessOrderField
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.TrustCenterAccessOrderField") {
+  CREATED_AT
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.TrustCenterAccessOrderFieldCreatedAt"
+    )
+}
+
 # Input Types
 input UserOrder
   @goModel(
@@ -6185,6 +6401,14 @@ input AuditOrder
   field: AuditOrderField!
 }
 
+input TrustCenterAccessOrder
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.TrustCenterAccessOrderBy"
+  ) {
+  direction: OrderDirection!
+  field: TrustCenterAccessOrderField!
+}
+
 input EvidenceOrder
   @goModel(
     model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.EvidenceOrderBy"
@@ -6257,7 +6481,14 @@ type TrustCenter implements Node {
   updatedAt: Datetime!
   organization: Organization! @goField(forceResolver: true)
 
-  # Public trust center fields that show only items with showOnTrustCenter=true
+  accesses(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+    orderBy: TrustCenterAccessOrder
+  ): TrustCenterAccessConnection! @goField(forceResolver: true)
+
   publicDocuments(
     first: Int
     after: CursorKey
@@ -6774,6 +7005,25 @@ type TrustCenterEdge {
   node: TrustCenter!
 }
 
+type TrustCenterAccess implements Node {
+  id: ID!
+  email: String!
+  name: String!
+  active: Boolean!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+}
+
+type TrustCenterAccessConnection {
+  edges: [TrustCenterAccessEdge!]!
+  pageInfo: PageInfo!
+}
+
+type TrustCenterAccessEdge {
+  cursor: CursorKey!
+  node: TrustCenterAccess!
+}
+
 type UserConnection {
   edges: [UserEdge!]!
   pageInfo: PageInfo!
@@ -7005,6 +7255,24 @@ type Mutation {
     input: UpdateTrustCenterInput!
   ): UpdateTrustCenterPayload!
 
+
+  revokeTrustCenterAccess(
+    input: RevokeTrustCenterAccessInput!
+  ): RevokeTrustCenterAccessPayload!
+
+  # Trust Center Access CRUD mutations
+  createTrustCenterAccess(
+    input: CreateTrustCenterAccessInput!
+  ): CreateTrustCenterAccessPayload!
+
+  updateTrustCenterAccess(
+    input: UpdateTrustCenterAccessInput!
+  ): UpdateTrustCenterAccessPayload!
+
+  deleteTrustCenterAccess(
+    input: DeleteTrustCenterAccessInput!
+  ): DeleteTrustCenterAccessPayload!
+
   # User mutations
   confirmEmail(input: ConfirmEmailInput!): ConfirmEmailPayload!
   inviteUser(input: InviteUserInput!): InviteUserPayload!
@@ -7175,6 +7443,31 @@ input UpdateTrustCenterInput {
   trustCenterId: ID!
   active: Boolean
   slug: String
+}
+
+
+
+input RevokeTrustCenterAccessInput {
+  accessId: ID!
+}
+
+input CreateTrustCenterAccessInput {
+  trustCenterId: ID!
+  email: String!
+  name: String!
+  sendEmail: Boolean! = true
+}
+
+input UpdateTrustCenterAccessInput {
+  accessId: ID!
+  email: String
+  name: String
+  active: Boolean
+  sendEmail: Boolean! = false
+}
+
+input DeleteTrustCenterAccessInput {
+  accessId: ID!
 }
 
 input CreateVendorInput {
@@ -7540,6 +7833,24 @@ type UpdateOrganizationPayload {
 
 type UpdateTrustCenterPayload {
   trustCenter: TrustCenter!
+}
+
+
+
+type RevokeTrustCenterAccessPayload {
+  trustCenterAccess: TrustCenterAccess!
+}
+
+type CreateTrustCenterAccessPayload {
+  trustCenterAccessEdge: TrustCenterAccessEdge!
+}
+
+type UpdateTrustCenterAccessPayload {
+  trustCenterAccess: TrustCenterAccess!
+}
+
+type DeleteTrustCenterAccessPayload {
+  deletedTrustCenterAccessId: ID!
 }
 
 type CreateControlPayload {
@@ -9909,6 +10220,29 @@ func (ec *executionContext) field_Mutation_createTask_argsInput(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation_createTrustCenterAccess_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_createTrustCenterAccess_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_createTrustCenterAccess_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.CreateTrustCenterAccessInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNCreateTrustCenterAccessInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateTrustCenterAccessInput(ctx, tmp)
+	}
+
+	var zeroVal types.CreateTrustCenterAccessInput
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation_createVendorRiskAssessment_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -10323,6 +10657,29 @@ func (ec *executionContext) field_Mutation_deleteTask_argsInput(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation_deleteTrustCenterAccess_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_deleteTrustCenterAccess_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_deleteTrustCenterAccess_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.DeleteTrustCenterAccessInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNDeleteTrustCenterAccessInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteTrustCenterAccessInput(ctx, tmp)
+	}
+
+	var zeroVal types.DeleteTrustCenterAccessInput
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation_deleteVendorComplianceReport_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -10619,6 +10976,29 @@ func (ec *executionContext) field_Mutation_requestSignature_argsInput(
 	}
 
 	var zeroVal types.RequestSignatureInput
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_revokeTrustCenterAccess_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_revokeTrustCenterAccess_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_revokeTrustCenterAccess_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.RevokeTrustCenterAccessInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNRevokeTrustCenterAccessInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐRevokeTrustCenterAccessInput(ctx, tmp)
+	}
+
+	var zeroVal types.RevokeTrustCenterAccessInput
 	return zeroVal, nil
 }
 
@@ -10941,6 +11321,29 @@ func (ec *executionContext) field_Mutation_updateTask_argsInput(
 	}
 
 	var zeroVal types.UpdateTaskInput
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_updateTrustCenterAccess_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_updateTrustCenterAccess_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_updateTrustCenterAccess_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.UpdateTrustCenterAccessInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNUpdateTrustCenterAccessInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateTrustCenterAccessInput(ctx, tmp)
+	}
+
+	var zeroVal types.UpdateTrustCenterAccessInput
 	return zeroVal, nil
 }
 
@@ -12984,6 +13387,101 @@ func (ec *executionContext) field_Task_evidences_argsOrderBy(
 	}
 
 	var zeroVal *types.EvidenceOrderBy
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_TrustCenter_accesses_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_TrustCenter_accesses_argsFirst(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["first"] = arg0
+	arg1, err := ec.field_TrustCenter_accesses_argsAfter(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["after"] = arg1
+	arg2, err := ec.field_TrustCenter_accesses_argsLast(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["last"] = arg2
+	arg3, err := ec.field_TrustCenter_accesses_argsBefore(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["before"] = arg3
+	arg4, err := ec.field_TrustCenter_accesses_argsOrderBy(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["orderBy"] = arg4
+	return args, nil
+}
+func (ec *executionContext) field_TrustCenter_accesses_argsFirst(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*int, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("first"))
+	if tmp, ok := rawArgs["first"]; ok {
+		return ec.unmarshalOInt2ᚖint(ctx, tmp)
+	}
+
+	var zeroVal *int
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_TrustCenter_accesses_argsAfter(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*page.CursorKey, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("after"))
+	if tmp, ok := rawArgs["after"]; ok {
+		return ec.unmarshalOCursorKey2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐCursorKey(ctx, tmp)
+	}
+
+	var zeroVal *page.CursorKey
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_TrustCenter_accesses_argsLast(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*int, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("last"))
+	if tmp, ok := rawArgs["last"]; ok {
+		return ec.unmarshalOInt2ᚖint(ctx, tmp)
+	}
+
+	var zeroVal *int
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_TrustCenter_accesses_argsBefore(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*page.CursorKey, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("before"))
+	if tmp, ok := rawArgs["before"]; ok {
+		return ec.unmarshalOCursorKey2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐCursorKey(ctx, tmp)
+	}
+
+	var zeroVal *page.CursorKey
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_TrustCenter_accesses_argsOrderBy(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*types.OrderBy[coredata.TrustCenterAccessOrderField], error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("orderBy"))
+	if tmp, ok := rawArgs["orderBy"]; ok {
+		return ec.unmarshalOTrustCenterAccessOrder2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐOrderBy(ctx, tmp)
+	}
+
+	var zeroVal *types.OrderBy[coredata.TrustCenterAccessOrderField]
 	return zeroVal, nil
 }
 
@@ -18052,6 +18550,56 @@ func (ec *executionContext) fieldContext_CreateTaskPayload_taskEdge(_ context.Co
 	return fc, nil
 }
 
+func (ec *executionContext) _CreateTrustCenterAccessPayload_trustCenterAccessEdge(ctx context.Context, field graphql.CollectedField, obj *types.CreateTrustCenterAccessPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CreateTrustCenterAccessPayload_trustCenterAccessEdge(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TrustCenterAccessEdge, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.TrustCenterAccessEdge)
+	fc.Result = res
+	return ec.marshalNTrustCenterAccessEdge2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterAccessEdge(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CreateTrustCenterAccessPayload_trustCenterAccessEdge(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CreateTrustCenterAccessPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "cursor":
+				return ec.fieldContext_TrustCenterAccessEdge_cursor(ctx, field)
+			case "node":
+				return ec.fieldContext_TrustCenterAccessEdge_node(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustCenterAccessEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _CreateVendorPayload_vendorEdge(ctx context.Context, field graphql.CollectedField, obj *types.CreateVendorPayload) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_CreateVendorPayload_vendorEdge(ctx, field)
 	if err != nil {
@@ -19733,6 +20281,50 @@ func (ec *executionContext) _DeleteTaskPayload_deletedTaskId(ctx context.Context
 func (ec *executionContext) fieldContext_DeleteTaskPayload_deletedTaskId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "DeleteTaskPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DeleteTrustCenterAccessPayload_deletedTrustCenterAccessId(ctx context.Context, field graphql.CollectedField, obj *types.DeleteTrustCenterAccessPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DeleteTrustCenterAccessPayload_deletedTrustCenterAccessId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DeletedTrustCenterAccessID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(gid.GID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DeleteTrustCenterAccessPayload_deletedTrustCenterAccessId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DeleteTrustCenterAccessPayload",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -25085,6 +25677,242 @@ func (ec *executionContext) fieldContext_Mutation_updateTrustCenter(ctx context.
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_revokeTrustCenterAccess(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_revokeTrustCenterAccess(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().RevokeTrustCenterAccess(rctx, fc.Args["input"].(types.RevokeTrustCenterAccessInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.RevokeTrustCenterAccessPayload)
+	fc.Result = res
+	return ec.marshalNRevokeTrustCenterAccessPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐRevokeTrustCenterAccessPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_revokeTrustCenterAccess(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "trustCenterAccess":
+				return ec.fieldContext_RevokeTrustCenterAccessPayload_trustCenterAccess(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type RevokeTrustCenterAccessPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_revokeTrustCenterAccess_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_createTrustCenterAccess(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_createTrustCenterAccess(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateTrustCenterAccess(rctx, fc.Args["input"].(types.CreateTrustCenterAccessInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.CreateTrustCenterAccessPayload)
+	fc.Result = res
+	return ec.marshalNCreateTrustCenterAccessPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateTrustCenterAccessPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_createTrustCenterAccess(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "trustCenterAccessEdge":
+				return ec.fieldContext_CreateTrustCenterAccessPayload_trustCenterAccessEdge(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CreateTrustCenterAccessPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_createTrustCenterAccess_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_updateTrustCenterAccess(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_updateTrustCenterAccess(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UpdateTrustCenterAccess(rctx, fc.Args["input"].(types.UpdateTrustCenterAccessInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.UpdateTrustCenterAccessPayload)
+	fc.Result = res
+	return ec.marshalNUpdateTrustCenterAccessPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateTrustCenterAccessPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_updateTrustCenterAccess(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "trustCenterAccess":
+				return ec.fieldContext_UpdateTrustCenterAccessPayload_trustCenterAccess(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UpdateTrustCenterAccessPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_updateTrustCenterAccess_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_deleteTrustCenterAccess(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_deleteTrustCenterAccess(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteTrustCenterAccess(rctx, fc.Args["input"].(types.DeleteTrustCenterAccessInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.DeleteTrustCenterAccessPayload)
+	fc.Result = res
+	return ec.marshalNDeleteTrustCenterAccessPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteTrustCenterAccessPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_deleteTrustCenterAccess(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "deletedTrustCenterAccessId":
+				return ec.fieldContext_DeleteTrustCenterAccessPayload_deletedTrustCenterAccessId(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DeleteTrustCenterAccessPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_deleteTrustCenterAccess_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation_confirmEmail(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Mutation_confirmEmail(ctx, field)
 	if err != nil {
@@ -30229,6 +31057,8 @@ func (ec *executionContext) fieldContext_Organization_trustCenter(_ context.Cont
 				return ec.fieldContext_TrustCenter_updatedAt(ctx, field)
 			case "organization":
 				return ec.fieldContext_TrustCenter_organization(ctx, field)
+			case "accesses":
+				return ec.fieldContext_TrustCenter_accesses(ctx, field)
 			case "publicDocuments":
 				return ec.fieldContext_TrustCenter_publicDocuments(ctx, field)
 			case "publicAudits":
@@ -31779,6 +32609,8 @@ func (ec *executionContext) fieldContext_Query_trustCenterBySlug(ctx context.Con
 				return ec.fieldContext_TrustCenter_updatedAt(ctx, field)
 			case "organization":
 				return ec.fieldContext_TrustCenter_organization(ctx, field)
+			case "accesses":
+				return ec.fieldContext_TrustCenter_accesses(ctx, field)
 			case "publicDocuments":
 				return ec.fieldContext_TrustCenter_publicDocuments(ctx, field)
 			case "publicAudits":
@@ -32422,6 +33254,64 @@ func (ec *executionContext) fieldContext_RequestSignaturePayload_documentVersion
 				return ec.fieldContext_DocumentVersionSignatureEdge_node(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type DocumentVersionSignatureEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RevokeTrustCenterAccessPayload_trustCenterAccess(ctx context.Context, field graphql.CollectedField, obj *types.RevokeTrustCenterAccessPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_RevokeTrustCenterAccessPayload_trustCenterAccess(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TrustCenterAccess, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.TrustCenterAccess)
+	fc.Result = res
+	return ec.marshalNTrustCenterAccess2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterAccess(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_RevokeTrustCenterAccessPayload_trustCenterAccess(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RevokeTrustCenterAccessPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TrustCenterAccess_id(ctx, field)
+			case "email":
+				return ec.fieldContext_TrustCenterAccess_email(ctx, field)
+			case "name":
+				return ec.fieldContext_TrustCenterAccess_name(ctx, field)
+			case "active":
+				return ec.fieldContext_TrustCenterAccess_active(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_TrustCenterAccess_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_TrustCenterAccess_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustCenterAccess", field.Name)
 		},
 	}
 	return fc, nil
@@ -34974,6 +35864,67 @@ func (ec *executionContext) fieldContext_TrustCenter_organization(_ context.Cont
 	return fc, nil
 }
 
+func (ec *executionContext) _TrustCenter_accesses(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenter) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenter_accesses(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TrustCenter().Accesses(rctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey), fc.Args["orderBy"].(*types.OrderBy[coredata.TrustCenterAccessOrderField]))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.TrustCenterAccessConnection)
+	fc.Result = res
+	return ec.marshalNTrustCenterAccessConnection2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterAccessConnection(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenter_accesses(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenter",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "edges":
+				return ec.fieldContext_TrustCenterAccessConnection_edges(ctx, field)
+			case "pageInfo":
+				return ec.fieldContext_TrustCenterAccessConnection_pageInfo(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustCenterAccessConnection", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_TrustCenter_accesses_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _TrustCenter_publicDocuments(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenter) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_TrustCenter_publicDocuments(ctx, field)
 	if err != nil {
@@ -35159,6 +36110,476 @@ func (ec *executionContext) fieldContext_TrustCenter_publicVendors(ctx context.C
 	if fc.Args, err = ec.field_TrustCenter_publicVendors_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterAccess_id(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterAccess) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterAccess_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(gid.GID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterAccess_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterAccess",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterAccess_email(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterAccess) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterAccess_email(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Email, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterAccess_email(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterAccess",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterAccess_name(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterAccess) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterAccess_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterAccess_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterAccess",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterAccess_active(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterAccess) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterAccess_active(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Active, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterAccess_active(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterAccess",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterAccess_createdAt(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterAccess) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterAccess_createdAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNDatetime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterAccess_createdAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterAccess",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterAccess_updatedAt(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterAccess) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterAccess_updatedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNDatetime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterAccess_updatedAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterAccess",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterAccessConnection_edges(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterAccessConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterAccessConnection_edges(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Edges, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*types.TrustCenterAccessEdge)
+	fc.Result = res
+	return ec.marshalNTrustCenterAccessEdge2ᚕᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterAccessEdgeᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterAccessConnection_edges(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterAccessConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "cursor":
+				return ec.fieldContext_TrustCenterAccessEdge_cursor(ctx, field)
+			case "node":
+				return ec.fieldContext_TrustCenterAccessEdge_node(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustCenterAccessEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterAccessConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterAccessConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterAccessConnection_pageInfo(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PageInfo, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.PageInfo)
+	fc.Result = res
+	return ec.marshalNPageInfo2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐPageInfo(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterAccessConnection_pageInfo(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterAccessConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "hasNextPage":
+				return ec.fieldContext_PageInfo_hasNextPage(ctx, field)
+			case "hasPreviousPage":
+				return ec.fieldContext_PageInfo_hasPreviousPage(ctx, field)
+			case "startCursor":
+				return ec.fieldContext_PageInfo_startCursor(ctx, field)
+			case "endCursor":
+				return ec.fieldContext_PageInfo_endCursor(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterAccessEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterAccessEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterAccessEdge_cursor(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Cursor, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(page.CursorKey)
+	fc.Result = res
+	return ec.marshalNCursorKey2githubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐCursorKey(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterAccessEdge_cursor(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterAccessEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type CursorKey does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterAccessEdge_node(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterAccessEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterAccessEdge_node(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Node, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.TrustCenterAccess)
+	fc.Result = res
+	return ec.marshalNTrustCenterAccess2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterAccess(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterAccessEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterAccessEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TrustCenterAccess_id(ctx, field)
+			case "email":
+				return ec.fieldContext_TrustCenterAccess_email(ctx, field)
+			case "name":
+				return ec.fieldContext_TrustCenterAccess_name(ctx, field)
+			case "active":
+				return ec.fieldContext_TrustCenterAccess_active(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_TrustCenterAccess_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_TrustCenterAccess_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustCenterAccess", field.Name)
+		},
 	}
 	return fc, nil
 }
@@ -35362,6 +36783,8 @@ func (ec *executionContext) fieldContext_TrustCenterEdge_node(_ context.Context,
 				return ec.fieldContext_TrustCenter_updatedAt(ctx, field)
 			case "organization":
 				return ec.fieldContext_TrustCenter_organization(ctx, field)
+			case "accesses":
+				return ec.fieldContext_TrustCenter_accesses(ctx, field)
 			case "publicDocuments":
 				return ec.fieldContext_TrustCenter_publicDocuments(ctx, field)
 			case "publicAudits":
@@ -36285,6 +37708,64 @@ func (ec *executionContext) fieldContext_UpdateTaskPayload_task(_ context.Contex
 	return fc, nil
 }
 
+func (ec *executionContext) _UpdateTrustCenterAccessPayload_trustCenterAccess(ctx context.Context, field graphql.CollectedField, obj *types.UpdateTrustCenterAccessPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UpdateTrustCenterAccessPayload_trustCenterAccess(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TrustCenterAccess, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.TrustCenterAccess)
+	fc.Result = res
+	return ec.marshalNTrustCenterAccess2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterAccess(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UpdateTrustCenterAccessPayload_trustCenterAccess(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UpdateTrustCenterAccessPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TrustCenterAccess_id(ctx, field)
+			case "email":
+				return ec.fieldContext_TrustCenterAccess_email(ctx, field)
+			case "name":
+				return ec.fieldContext_TrustCenterAccess_name(ctx, field)
+			case "active":
+				return ec.fieldContext_TrustCenterAccess_active(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_TrustCenterAccess_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_TrustCenterAccess_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustCenterAccess", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _UpdateTrustCenterPayload_trustCenter(ctx context.Context, field graphql.CollectedField, obj *types.UpdateTrustCenterPayload) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_UpdateTrustCenterPayload_trustCenter(ctx, field)
 	if err != nil {
@@ -36336,6 +37817,8 @@ func (ec *executionContext) fieldContext_UpdateTrustCenterPayload_trustCenter(_ 
 				return ec.fieldContext_TrustCenter_updatedAt(ctx, field)
 			case "organization":
 				return ec.fieldContext_TrustCenter_organization(ctx, field)
+			case "accesses":
+				return ec.fieldContext_TrustCenter_accesses(ctx, field)
 			case "publicDocuments":
 				return ec.fieldContext_TrustCenter_publicDocuments(ctx, field)
 			case "publicAudits":
@@ -43363,6 +44846,58 @@ func (ec *executionContext) unmarshalInputCreateTaskInput(ctx context.Context, o
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputCreateTrustCenterAccessInput(ctx context.Context, obj any) (types.CreateTrustCenterAccessInput, error) {
+	var it types.CreateTrustCenterAccessInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	if _, present := asMap["sendEmail"]; !present {
+		asMap["sendEmail"] = true
+	}
+
+	fieldsInOrder := [...]string{"trustCenterId", "email", "name", "sendEmail"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "trustCenterId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("trustCenterId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.TrustCenterID = data
+		case "email":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("email"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Email = data
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "sendEmail":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("sendEmail"))
+			data, err := ec.unmarshalNBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SendEmail = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputCreateVendorInput(ctx context.Context, obj any) (types.CreateVendorInput, error) {
 	var it types.CreateVendorInput
 	asMap := map[string]any{}
@@ -44066,6 +45601,33 @@ func (ec *executionContext) unmarshalInputDeleteTaskInput(ctx context.Context, o
 				return it, err
 			}
 			it.TaskID = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputDeleteTrustCenterAccessInput(ctx context.Context, obj any) (types.DeleteTrustCenterAccessInput, error) {
+	var it types.DeleteTrustCenterAccessInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"accessId"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "accessId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("accessId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AccessID = data
 		}
 	}
 
@@ -44894,6 +46456,33 @@ func (ec *executionContext) unmarshalInputRequestSignatureInput(ctx context.Cont
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputRevokeTrustCenterAccessInput(ctx context.Context, obj any) (types.RevokeTrustCenterAccessInput, error) {
+	var it types.RevokeTrustCenterAccessInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"accessId"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "accessId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("accessId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AccessID = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputRiskFilter(ctx context.Context, obj any) (types.RiskFilter, error) {
 	var it types.RiskFilter
 	asMap := map[string]any{}
@@ -45006,6 +46595,40 @@ func (ec *executionContext) unmarshalInputTaskOrder(ctx context.Context, obj any
 		case "field":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("field"))
 			data, err := ec.unmarshalNTaskOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐTaskOrderField(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Field = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputTrustCenterAccessOrder(ctx context.Context, obj any) (types.OrderBy[coredata.TrustCenterAccessOrderField], error) {
+	var it types.OrderBy[coredata.TrustCenterAccessOrderField]
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"direction", "field"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "direction":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("direction"))
+			data, err := ec.unmarshalNOrderDirection2githubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐOrderDirection(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Direction = data
+		case "field":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("field"))
+			data, err := ec.unmarshalNTrustCenterAccessOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐTrustCenterAccessOrderField(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -45793,6 +47416,65 @@ func (ec *executionContext) unmarshalInputUpdateTaskInput(ctx context.Context, o
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputUpdateTrustCenterAccessInput(ctx context.Context, obj any) (types.UpdateTrustCenterAccessInput, error) {
+	var it types.UpdateTrustCenterAccessInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	if _, present := asMap["sendEmail"]; !present {
+		asMap["sendEmail"] = false
+	}
+
+	fieldsInOrder := [...]string{"accessId", "email", "name", "active", "sendEmail"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "accessId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("accessId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AccessID = data
+		case "email":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("email"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Email = data
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "active":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("active"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Active = data
+		case "sendEmail":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("sendEmail"))
+			data, err := ec.unmarshalNBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SendEmail = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputUpdateTrustCenterInput(ctx context.Context, obj any) (types.UpdateTrustCenterInput, error) {
 	var it types.UpdateTrustCenterInput
 	asMap := map[string]any{}
@@ -46323,6 +48005,13 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._User(ctx, sel, obj)
+	case types.TrustCenterAccess:
+		return ec._TrustCenterAccess(ctx, sel, &obj)
+	case *types.TrustCenterAccess:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._TrustCenterAccess(ctx, sel, obj)
 	case types.TrustCenter:
 		return ec._TrustCenter(ctx, sel, &obj)
 	case *types.TrustCenter:
@@ -48490,6 +50179,45 @@ func (ec *executionContext) _CreateTaskPayload(ctx context.Context, sel ast.Sele
 	return out
 }
 
+var createTrustCenterAccessPayloadImplementors = []string{"CreateTrustCenterAccessPayload"}
+
+func (ec *executionContext) _CreateTrustCenterAccessPayload(ctx context.Context, sel ast.SelectionSet, obj *types.CreateTrustCenterAccessPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, createTrustCenterAccessPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CreateTrustCenterAccessPayload")
+		case "trustCenterAccessEdge":
+			out.Values[i] = ec._CreateTrustCenterAccessPayload_trustCenterAccessEdge(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var createVendorPayloadImplementors = []string{"CreateVendorPayload"}
 
 func (ec *executionContext) _CreateVendorPayload(ctx context.Context, sel ast.SelectionSet, obj *types.CreateVendorPayload) graphql.Marshaler {
@@ -49477,6 +51205,45 @@ func (ec *executionContext) _DeleteTaskPayload(ctx context.Context, sel ast.Sele
 			out.Values[i] = graphql.MarshalString("DeleteTaskPayload")
 		case "deletedTaskId":
 			out.Values[i] = ec._DeleteTaskPayload_deletedTaskId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var deleteTrustCenterAccessPayloadImplementors = []string{"DeleteTrustCenterAccessPayload"}
+
+func (ec *executionContext) _DeleteTrustCenterAccessPayload(ctx context.Context, sel ast.SelectionSet, obj *types.DeleteTrustCenterAccessPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, deleteTrustCenterAccessPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("DeleteTrustCenterAccessPayload")
+		case "deletedTrustCenterAccessId":
+			out.Values[i] = ec._DeleteTrustCenterAccessPayload_deletedTrustCenterAccessId(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -51694,6 +53461,34 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "revokeTrustCenterAccess":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_revokeTrustCenterAccess(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "createTrustCenterAccess":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_createTrustCenterAccess(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "updateTrustCenterAccess":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_updateTrustCenterAccess(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "deleteTrustCenterAccess":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_deleteTrustCenterAccess(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "confirmEmail":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_confirmEmail(ctx, field)
@@ -53528,6 +55323,45 @@ func (ec *executionContext) _RequestSignaturePayload(ctx context.Context, sel as
 	return out
 }
 
+var revokeTrustCenterAccessPayloadImplementors = []string{"RevokeTrustCenterAccessPayload"}
+
+func (ec *executionContext) _RevokeTrustCenterAccessPayload(ctx context.Context, sel ast.SelectionSet, obj *types.RevokeTrustCenterAccessPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, revokeTrustCenterAccessPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("RevokeTrustCenterAccessPayload")
+		case "trustCenterAccess":
+			out.Values[i] = ec._RevokeTrustCenterAccessPayload_trustCenterAccess(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var riskImplementors = []string{"Risk", "Node"}
 
 func (ec *executionContext) _Risk(ctx context.Context, sel ast.SelectionSet, obj *types.Risk) graphql.Marshaler {
@@ -54418,6 +56252,42 @@ func (ec *executionContext) _TrustCenter(ctx context.Context, sel ast.SelectionS
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "accesses":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TrustCenter_accesses(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "publicDocuments":
 			field := field
 
@@ -54526,6 +56396,158 @@ func (ec *executionContext) _TrustCenter(ctx context.Context, sel ast.SelectionS
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var trustCenterAccessImplementors = []string{"TrustCenterAccess", "Node"}
+
+func (ec *executionContext) _TrustCenterAccess(ctx context.Context, sel ast.SelectionSet, obj *types.TrustCenterAccess) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, trustCenterAccessImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TrustCenterAccess")
+		case "id":
+			out.Values[i] = ec._TrustCenterAccess_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "email":
+			out.Values[i] = ec._TrustCenterAccess_email(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "name":
+			out.Values[i] = ec._TrustCenterAccess_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "active":
+			out.Values[i] = ec._TrustCenterAccess_active(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "createdAt":
+			out.Values[i] = ec._TrustCenterAccess_createdAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "updatedAt":
+			out.Values[i] = ec._TrustCenterAccess_updatedAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var trustCenterAccessConnectionImplementors = []string{"TrustCenterAccessConnection"}
+
+func (ec *executionContext) _TrustCenterAccessConnection(ctx context.Context, sel ast.SelectionSet, obj *types.TrustCenterAccessConnection) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, trustCenterAccessConnectionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TrustCenterAccessConnection")
+		case "edges":
+			out.Values[i] = ec._TrustCenterAccessConnection_edges(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "pageInfo":
+			out.Values[i] = ec._TrustCenterAccessConnection_pageInfo(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var trustCenterAccessEdgeImplementors = []string{"TrustCenterAccessEdge"}
+
+func (ec *executionContext) _TrustCenterAccessEdge(ctx context.Context, sel ast.SelectionSet, obj *types.TrustCenterAccessEdge) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, trustCenterAccessEdgeImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TrustCenterAccessEdge")
+		case "cursor":
+			out.Values[i] = ec._TrustCenterAccessEdge_cursor(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "node":
+			out.Values[i] = ec._TrustCenterAccessEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -55118,6 +57140,45 @@ func (ec *executionContext) _UpdateTaskPayload(ctx context.Context, sel ast.Sele
 			out.Values[i] = graphql.MarshalString("UpdateTaskPayload")
 		case "task":
 			out.Values[i] = ec._UpdateTaskPayload_task(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var updateTrustCenterAccessPayloadImplementors = []string{"UpdateTrustCenterAccessPayload"}
+
+func (ec *executionContext) _UpdateTrustCenterAccessPayload(ctx context.Context, sel ast.SelectionSet, obj *types.UpdateTrustCenterAccessPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, updateTrustCenterAccessPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("UpdateTrustCenterAccessPayload")
+		case "trustCenterAccess":
+			out.Values[i] = ec._UpdateTrustCenterAccessPayload_trustCenterAccess(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -57809,6 +59870,25 @@ func (ec *executionContext) marshalNCreateTaskPayload2ᚖgithubᚗcomᚋgetprobo
 	return ec._CreateTaskPayload(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNCreateTrustCenterAccessInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateTrustCenterAccessInput(ctx context.Context, v any) (types.CreateTrustCenterAccessInput, error) {
+	res, err := ec.unmarshalInputCreateTrustCenterAccessInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNCreateTrustCenterAccessPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateTrustCenterAccessPayload(ctx context.Context, sel ast.SelectionSet, v types.CreateTrustCenterAccessPayload) graphql.Marshaler {
+	return ec._CreateTrustCenterAccessPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNCreateTrustCenterAccessPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateTrustCenterAccessPayload(ctx context.Context, sel ast.SelectionSet, v *types.CreateTrustCenterAccessPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._CreateTrustCenterAccessPayload(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNCreateVendorInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateVendorInput(ctx context.Context, v any) (types.CreateVendorInput, error) {
 	res, err := ec.unmarshalInputCreateVendorInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -58385,6 +60465,25 @@ func (ec *executionContext) marshalNDeleteTaskPayload2ᚖgithubᚗcomᚋgetprobo
 		return graphql.Null
 	}
 	return ec._DeleteTaskPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNDeleteTrustCenterAccessInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteTrustCenterAccessInput(ctx context.Context, v any) (types.DeleteTrustCenterAccessInput, error) {
+	res, err := ec.unmarshalInputDeleteTrustCenterAccessInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNDeleteTrustCenterAccessPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteTrustCenterAccessPayload(ctx context.Context, sel ast.SelectionSet, v types.DeleteTrustCenterAccessPayload) graphql.Marshaler {
+	return ec._DeleteTrustCenterAccessPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNDeleteTrustCenterAccessPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteTrustCenterAccessPayload(ctx context.Context, sel ast.SelectionSet, v *types.DeleteTrustCenterAccessPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._DeleteTrustCenterAccessPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNDeleteVendorComplianceReportInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteVendorComplianceReportInput(ctx context.Context, v any) (types.DeleteVendorComplianceReportInput, error) {
@@ -59815,6 +61914,25 @@ func (ec *executionContext) marshalNRequestSignaturePayload2ᚖgithubᚗcomᚋge
 	return ec._RequestSignaturePayload(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNRevokeTrustCenterAccessInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐRevokeTrustCenterAccessInput(ctx context.Context, v any) (types.RevokeTrustCenterAccessInput, error) {
+	res, err := ec.unmarshalInputRevokeTrustCenterAccessInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNRevokeTrustCenterAccessPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐRevokeTrustCenterAccessPayload(ctx context.Context, sel ast.SelectionSet, v types.RevokeTrustCenterAccessPayload) graphql.Marshaler {
+	return ec._RevokeTrustCenterAccessPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNRevokeTrustCenterAccessPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐRevokeTrustCenterAccessPayload(ctx context.Context, sel ast.SelectionSet, v *types.RevokeTrustCenterAccessPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._RevokeTrustCenterAccessPayload(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalNRisk2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐRisk(ctx context.Context, sel ast.SelectionSet, v *types.Risk) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -60161,6 +62279,110 @@ func (ec *executionContext) marshalNTrustCenter2ᚖgithubᚗcomᚋgetproboᚋpro
 	return ec._TrustCenter(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNTrustCenterAccess2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterAccess(ctx context.Context, sel ast.SelectionSet, v *types.TrustCenterAccess) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TrustCenterAccess(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNTrustCenterAccessConnection2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterAccessConnection(ctx context.Context, sel ast.SelectionSet, v types.TrustCenterAccessConnection) graphql.Marshaler {
+	return ec._TrustCenterAccessConnection(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNTrustCenterAccessConnection2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterAccessConnection(ctx context.Context, sel ast.SelectionSet, v *types.TrustCenterAccessConnection) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TrustCenterAccessConnection(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNTrustCenterAccessEdge2ᚕᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterAccessEdgeᚄ(ctx context.Context, sel ast.SelectionSet, v []*types.TrustCenterAccessEdge) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNTrustCenterAccessEdge2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterAccessEdge(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNTrustCenterAccessEdge2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterAccessEdge(ctx context.Context, sel ast.SelectionSet, v *types.TrustCenterAccessEdge) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TrustCenterAccessEdge(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNTrustCenterAccessOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐTrustCenterAccessOrderField(ctx context.Context, v any) (coredata.TrustCenterAccessOrderField, error) {
+	tmp, err := graphql.UnmarshalString(v)
+	res := unmarshalNTrustCenterAccessOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐTrustCenterAccessOrderField[tmp]
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNTrustCenterAccessOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐTrustCenterAccessOrderField(ctx context.Context, sel ast.SelectionSet, v coredata.TrustCenterAccessOrderField) graphql.Marshaler {
+	_ = sel
+	res := graphql.MarshalString(marshalNTrustCenterAccessOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐTrustCenterAccessOrderField[v])
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+var (
+	unmarshalNTrustCenterAccessOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐTrustCenterAccessOrderField = map[string]coredata.TrustCenterAccessOrderField{
+		"CREATED_AT": coredata.TrustCenterAccessOrderFieldCreatedAt,
+	}
+	marshalNTrustCenterAccessOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐTrustCenterAccessOrderField = map[coredata.TrustCenterAccessOrderField]string{
+		coredata.TrustCenterAccessOrderFieldCreatedAt: "CREATED_AT",
+	}
+)
+
 func (ec *executionContext) marshalNTrustCenterConnection2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterConnection(ctx context.Context, sel ast.SelectionSet, v types.TrustCenterConnection) graphql.Marshaler {
 	return ec._TrustCenterConnection(ctx, sel, &v)
 }
@@ -60474,6 +62696,25 @@ func (ec *executionContext) marshalNUpdateTaskPayload2ᚖgithubᚗcomᚋgetprobo
 		return graphql.Null
 	}
 	return ec._UpdateTaskPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNUpdateTrustCenterAccessInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateTrustCenterAccessInput(ctx context.Context, v any) (types.UpdateTrustCenterAccessInput, error) {
+	res, err := ec.unmarshalInputUpdateTrustCenterAccessInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNUpdateTrustCenterAccessPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateTrustCenterAccessPayload(ctx context.Context, sel ast.SelectionSet, v types.UpdateTrustCenterAccessPayload) graphql.Marshaler {
+	return ec._UpdateTrustCenterAccessPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNUpdateTrustCenterAccessPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateTrustCenterAccessPayload(ctx context.Context, sel ast.SelectionSet, v *types.UpdateTrustCenterAccessPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._UpdateTrustCenterAccessPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNUpdateTrustCenterInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateTrustCenterInput(ctx context.Context, v any) (types.UpdateTrustCenterInput, error) {
@@ -62136,6 +64377,14 @@ func (ec *executionContext) marshalOTrustCenter2ᚖgithubᚗcomᚋgetproboᚋpro
 		return graphql.Null
 	}
 	return ec._TrustCenter(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOTrustCenterAccessOrder2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐOrderBy(ctx context.Context, v any) (*types.OrderBy[coredata.TrustCenterAccessOrderField], error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputTrustCenterAccessOrder(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalOTrustCenterFilter2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterFilter(ctx context.Context, v any) (*types.TrustCenterFilter, error) {

--- a/pkg/server/api/console/v1/trust_center_access_handler.go
+++ b/pkg/server/api/console/v1/trust_center_access_handler.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package console_v1
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/getprobo/probo/pkg/crypto/cipher"
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/probo"
+	"github.com/getprobo/probo/pkg/securecookie"
+	"github.com/getprobo/probo/pkg/statelesstoken"
+	"github.com/getprobo/probo/pkg/trust"
+	"go.gearno.de/kit/httpserver"
+)
+
+type (
+	AuthTokenRequest struct {
+		Token string `json:"token"`
+	}
+
+	AuthTokenResponse struct {
+		Success       bool   `json:"success"`
+		TrustCenterID string `json:"trust_center_id,omitempty"`
+		Message       string `json:"message,omitempty"`
+	}
+
+	TrustCenterTokenData struct {
+		TrustCenterID gid.GID      `json:"trust_center_id"`
+		Email         string       `json:"email"`
+		TenantID      gid.TenantID `json:"tenant_id"`
+		Scope         string       `json:"scope"`
+		ExpiresAt     time.Time    `json:"expires_at"`
+	}
+)
+
+const (
+	TokenCookieName = "trust_center_token"
+)
+
+func authTokenHandler(proboSvc *probo.Service, trustSvc *trust.Service, authCfg AuthConfig, encryptionKey cipher.EncryptionKey) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req AuthTokenRequest
+		// Limit request body size to 1KB to prevent DoS attacks
+		limitedReader := http.MaxBytesReader(w, r.Body, 1024)
+		if err := json.NewDecoder(limitedReader).Decode(&req); err != nil {
+			httpserver.RenderError(w, http.StatusBadRequest, fmt.Errorf("cannot decode body: %w", err))
+			return
+		}
+
+		if req.Token == "" {
+			httpserver.RenderJSON(w, http.StatusBadRequest, AuthTokenResponse{
+				Success: false,
+				Message: "Token is required",
+			})
+			return
+		}
+
+		accessData, err := validateTrustCenterAccessToken(r.Context(), proboSvc, authCfg, req.Token)
+		if err != nil {
+			httpserver.RenderJSON(w, http.StatusUnauthorized, AuthTokenResponse{
+				Success: false,
+				Message: "Invalid or expired token",
+			})
+			return
+		}
+
+		tokenData := TrustCenterTokenData{
+			TrustCenterID: accessData.TrustCenterID,
+			Email:         accessData.Email,
+			TenantID:      accessData.TrustCenterID.TenantID(),
+			Scope:         TokenScopeTrustCenterReadOnly,
+			ExpiresAt:     time.Now().Add(24 * time.Hour),
+		}
+
+		tokenBytes, err := json.Marshal(tokenData)
+		if err != nil {
+			httpserver.RenderError(w, http.StatusInternalServerError, fmt.Errorf("failed to serialize token data: %w", err))
+			return
+		}
+
+		encryptedTokenData, err := cipher.Encrypt(tokenBytes, encryptionKey)
+		if err != nil {
+			httpserver.RenderError(w, http.StatusInternalServerError, fmt.Errorf("failed to encrypt token data: %w", err))
+			return
+		}
+
+		encryptedTokenString := base64.StdEncoding.EncodeToString(encryptedTokenData)
+
+		cookieConfig := securecookie.Config{
+			Name:     TokenCookieName,
+			Secret:   authCfg.CookieSecret,
+			Domain:   authCfg.CookieDomain,
+			Path:     "/",
+			MaxAge:   int(24 * time.Hour / time.Second), // 24 hours
+			Secure:   true,
+			HTTPOnly: true,
+			SameSite: http.SameSiteStrictMode,
+		}
+
+		if err := securecookie.Set(w, cookieConfig, encryptedTokenString); err != nil {
+			httpserver.RenderError(w, http.StatusInternalServerError, fmt.Errorf("failed to set cookie: %w", err))
+			return
+		}
+
+		httpserver.RenderJSON(w, http.StatusOK, AuthTokenResponse{
+			Success:       true,
+			TrustCenterID: accessData.TrustCenterID.String(),
+			Message:       "Authentication successful",
+		})
+	}
+}
+
+func validateTrustCenterAccessToken(ctx context.Context, proboSvc *probo.Service, authCfg AuthConfig, tokenString string) (*probo.TrustCenterAccessData, error) {
+	token, err := statelesstoken.ValidateToken[probo.TrustCenterAccessData](
+		authCfg.CookieSecret,
+		probo.TokenTypeTrustCenterAccess,
+		tokenString,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot validate trust center access token: %w", err)
+	}
+
+	tenantID := token.Data.TrustCenterID.TenantID()
+	tenantSvc := proboSvc.WithTenant(tenantID)
+
+	return tenantSvc.TrustCenterAccesses.ValidateToken(ctx, tokenString)
+}
+
+func trustCenterLogoutHandler(authCfg AuthConfig) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		cookieConfig := securecookie.Config{
+			Name:     TokenCookieName,
+			Secret:   authCfg.CookieSecret,
+			Domain:   authCfg.CookieDomain,
+			Path:     "/",
+			MaxAge:   -1,
+			Secure:   true,
+			HTTPOnly: true,
+			SameSite: http.SameSiteStrictMode,
+		}
+
+		securecookie.Clear(w, cookieConfig)
+
+		w.Header().Set("Clear-Site-Data", "*")
+
+		httpserver.RenderJSON(w, http.StatusOK, map[string]bool{"success": true})
+	}
+}

--- a/pkg/server/api/console/v1/types/trust_center_access.go
+++ b/pkg/server/api/console/v1/types/trust_center_access.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package types
+
+import (
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/page"
+)
+
+type TrustCenterAccessOrderBy = OrderBy[coredata.TrustCenterAccessOrderField]
+
+func NewTrustCenterAccess(tca *coredata.TrustCenterAccess) *TrustCenterAccess {
+	return &TrustCenterAccess{
+		ID:        tca.ID,
+		Email:     tca.Email,
+		Name:      tca.Name,
+		Active:    tca.Active,
+		CreatedAt: tca.CreatedAt,
+		UpdatedAt: tca.UpdatedAt,
+	}
+}
+
+func NewTrustCenterAccessConnection(
+	page *page.Page[*coredata.TrustCenterAccess, coredata.TrustCenterAccessOrderField],
+) *TrustCenterAccessConnection {
+	var edges = make([]*TrustCenterAccessEdge, len(page.Data))
+
+	for i := range edges {
+		edges[i] = NewTrustCenterAccessEdge(page.Data[i], page.Cursor.OrderBy.Field)
+	}
+
+	return &TrustCenterAccessConnection{
+		Edges:    edges,
+		PageInfo: NewPageInfo(page),
+	}
+}
+
+func NewTrustCenterAccessEdge(tca *coredata.TrustCenterAccess, orderBy coredata.TrustCenterAccessOrderField) *TrustCenterAccessEdge {
+	return &TrustCenterAccessEdge{
+		Cursor: tca.CursorKey(orderBy),
+		Node:   NewTrustCenterAccess(tca),
+	}
+}
+
+// Types are auto-generated in types.go - only helper functions remain here

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -367,6 +367,17 @@ type CreateTaskPayload struct {
 	TaskEdge *TaskEdge `json:"taskEdge"`
 }
 
+type CreateTrustCenterAccessInput struct {
+	TrustCenterID gid.GID `json:"trustCenterId"`
+	Email         string  `json:"email"`
+	Name          string  `json:"name"`
+	SendEmail     bool    `json:"sendEmail"`
+}
+
+type CreateTrustCenterAccessPayload struct {
+	TrustCenterAccessEdge *TrustCenterAccessEdge `json:"trustCenterAccessEdge"`
+}
+
 type CreateVendorInput struct {
 	OrganizationID                gid.GID                  `json:"organizationId"`
 	Name                          string                   `json:"name"`
@@ -559,6 +570,14 @@ type DeleteTaskInput struct {
 
 type DeleteTaskPayload struct {
 	DeletedTaskID gid.GID `json:"deletedTaskId"`
+}
+
+type DeleteTrustCenterAccessInput struct {
+	AccessID gid.GID `json:"accessId"`
+}
+
+type DeleteTrustCenterAccessPayload struct {
+	DeletedTrustCenterAccessID gid.GID `json:"deletedTrustCenterAccessId"`
 }
 
 type DeleteVendorComplianceReportInput struct {
@@ -929,6 +948,14 @@ type RequestSignaturePayload struct {
 	DocumentVersionSignatureEdge *DocumentVersionSignatureEdge `json:"documentVersionSignatureEdge"`
 }
 
+type RevokeTrustCenterAccessInput struct {
+	AccessID gid.GID `json:"accessId"`
+}
+
+type RevokeTrustCenterAccessPayload struct {
+	TrustCenterAccess *TrustCenterAccess `json:"trustCenterAccess"`
+}
+
 type Risk struct {
 	ID                 gid.GID                `json:"id"`
 	Name               string                 `json:"name"`
@@ -1000,19 +1027,42 @@ type TaskEdge struct {
 }
 
 type TrustCenter struct {
-	ID              gid.GID             `json:"id"`
-	Active          bool                `json:"active"`
-	Slug            string              `json:"slug"`
-	CreatedAt       time.Time           `json:"createdAt"`
-	UpdatedAt       time.Time           `json:"updatedAt"`
-	Organization    *Organization       `json:"organization"`
-	PublicDocuments *DocumentConnection `json:"publicDocuments"`
-	PublicAudits    *AuditConnection    `json:"publicAudits"`
-	PublicVendors   *VendorConnection   `json:"publicVendors"`
+	ID              gid.GID                      `json:"id"`
+	Active          bool                         `json:"active"`
+	Slug            string                       `json:"slug"`
+	CreatedAt       time.Time                    `json:"createdAt"`
+	UpdatedAt       time.Time                    `json:"updatedAt"`
+	Organization    *Organization                `json:"organization"`
+	Accesses        *TrustCenterAccessConnection `json:"accesses"`
+	PublicDocuments *DocumentConnection          `json:"publicDocuments"`
+	PublicAudits    *AuditConnection             `json:"publicAudits"`
+	PublicVendors   *VendorConnection            `json:"publicVendors"`
 }
 
 func (TrustCenter) IsNode()             {}
 func (this TrustCenter) GetID() gid.GID { return this.ID }
+
+type TrustCenterAccess struct {
+	ID        gid.GID   `json:"id"`
+	Email     string    `json:"email"`
+	Name      string    `json:"name"`
+	Active    bool      `json:"active"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+func (TrustCenterAccess) IsNode()             {}
+func (this TrustCenterAccess) GetID() gid.GID { return this.ID }
+
+type TrustCenterAccessConnection struct {
+	Edges    []*TrustCenterAccessEdge `json:"edges"`
+	PageInfo *PageInfo                `json:"pageInfo"`
+}
+
+type TrustCenterAccessEdge struct {
+	Cursor page.CursorKey     `json:"cursor"`
+	Node   *TrustCenterAccess `json:"node"`
+}
 
 type TrustCenterConnection struct {
 	Edges    []*TrustCenterEdge `json:"edges"`
@@ -1187,6 +1237,18 @@ type UpdateTaskInput struct {
 
 type UpdateTaskPayload struct {
 	Task *Task `json:"task"`
+}
+
+type UpdateTrustCenterAccessInput struct {
+	AccessID  gid.GID `json:"accessId"`
+	Email     *string `json:"email,omitempty"`
+	Name      *string `json:"name,omitempty"`
+	Active    *bool   `json:"active,omitempty"`
+	SendEmail bool    `json:"sendEmail"`
+}
+
+type UpdateTrustCenterAccessPayload struct {
+	TrustCenterAccess *TrustCenterAccess `json:"trustCenterAccess"`
 }
 
 type UpdateTrustCenterInput struct {


### PR DESCRIPTION
## UI
<img width="1164" height="538" alt="Screenshot 2025-07-30 at 12 36 56" src="https://github.com/user-attachments/assets/e4899574-259a-4420-9f1c-7c228b8e6ee4" />

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added access management to trust centers, allowing admins to invite, revoke, and manage external users' access from the UI.

- **New Features**
  - Added Trust Center Access tab for managing invitations and active users.
  - Implemented backend support for creating, updating, revoking, and deleting trust center access.
  - Added email invitations with expiring access links for external users.

<!-- End of auto-generated description by cubic. -->

