### PR TITLE
Fix empty documents checkbox

### DIFF
--- a/apps/console/src/pages/organizations/documents/DocumentsPage.tsx
+++ b/apps/console/src/pages/organizations/documents/DocumentsPage.tsx
@@ -130,7 +130,7 @@ export default function DocumentsPage(props: Props) {
             <Tr>
               <Th>
                 <Checkbox
-                  checked={selection.length === documents.length}
+                  checked={selection.length === documents.length && documents.length > 0}
                   onChange={() => reset(documents.map((d) => d.id))}
                 />
               </Th>


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed the "select all" checkbox so it no longer appears checked when there are no documents.

<!-- End of auto-generated description by cubic. -->

