### PR TITLE
Reset vendor form on assessment

### DIFF
--- a/apps/console/src/hooks/forms/useVendorForm.tsx
+++ b/apps/console/src/hooks/forms/useVendorForm.tsx
@@ -5,6 +5,7 @@ import { useFragment } from "react-relay";
 import type { useVendorFormFragment$key } from "./__generated__/useVendorFormFragment.graphql";
 import { useMutationWithToasts } from "../useMutationWithToasts";
 import { useTranslate } from "@probo/i18n";
+import { useEffect, useMemo } from "react";
 
 const schema = z.object({
   name: z.string(),
@@ -68,8 +69,8 @@ export function useVendorForm(vendorKey: useVendorFormFragment$key) {
     errorMessage: __("Failed to update vendor. Please try again."),
   });
 
-  const form = useFormWithSchema(schema, {
-    defaultValues: {
+  const defaultValues = useMemo(
+    () => ({
       name: vendor.name,
       description: vendor.description ?? "",
       statusPageUrl: vendor.statusPageUrl ?? "",
@@ -85,7 +86,12 @@ export function useVendorForm(vendorKey: useVendorFormFragment$key) {
       trustPageUrl: vendor.trustPageUrl ?? "",
       businessOwnerId: vendor.businessOwner?.id,
       securityOwnerId: vendor.securityOwner?.id,
-    },
+    }),
+    [vendor],
+  );
+
+  const form = useFormWithSchema(schema, {
+    defaultValues,
   });
 
   const handleSubmit = form.handleSubmit((data) => {
@@ -100,6 +106,10 @@ export function useVendorForm(vendorKey: useVendorFormFragment$key) {
       form.reset(data);
     });
   });
+
+  useEffect(() => {
+    form.reset(defaultValues, { keepDirty: true });
+  }, [defaultValues, form]);
 
   return {
     ...form,

--- a/apps/console/src/pages/organizations/vendors/tabs/VendorOverviewTab.tsx
+++ b/apps/console/src/pages/organizations/vendors/tabs/VendorOverviewTab.tsx
@@ -18,7 +18,7 @@ export default function VendorOverviewTab() {
     control,
     register,
     handleSubmit,
-    formState: { errors, isDirty, isSubmitting },
+    formState: { errors, isSubmitting },
   } = useVendorForm(vendor);
 
   const urls = useMemo(
@@ -38,7 +38,7 @@ export default function VendorOverviewTab() {
         { name: "securityPageUrl", label: __("Security page URL") },
         { name: "trustPageUrl", label: __("Trust page URL") },
       ] as const,
-    []
+    [],
   );
 
   usePageTitle(vendor.name + " - " + __("Overview"));
@@ -84,7 +84,7 @@ export default function VendorOverviewTab() {
 
       {/* Ownership */}
       <div className="space-y-4">
-        <h2 className="text-base font-medium">{__("Ownership details`")}</h2>
+        <h2 className="text-base font-medium">{__("Ownership details")}</h2>
         <Card className="space-y-4" padded>
           <PeopleSelectField
             organizationId={organizationId}
@@ -134,11 +134,9 @@ export default function VendorOverviewTab() {
 
       {/* Submit */}
       <div className="flex justify-end">
-        {isDirty && (
-          <Button type="submit" disabled={isSubmitting}>
-            {__("Update vendor")}
-          </Button>
-        )}
+        <Button type="submit" disabled={isSubmitting}>
+          {__("Update vendor")}
+        </Button>
       </div>
     </form>
   );


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
The vendor form now resets its fields when the vendor data changes, ensuring the form always shows the latest information.

- **Bug Fixes**
  - The form resets on assessment, preventing outdated or stale values from appearing after vendor updates.
  - The submit button is always visible, even if no changes have been made.

<!-- End of auto-generated description by cubic. -->

