### PR TITLE
Better handling of document versions

### DIFF
--- a/apps/console/src/hooks/graph/DocumentGraph.ts
+++ b/apps/console/src/hooks/graph/DocumentGraph.ts
@@ -3,6 +3,7 @@ import { graphql } from "relay-runtime";
 import { useMutationWithToasts } from "../useMutationWithToasts";
 import type { DocumentGraphDeleteMutation } from "./__generated__/DocumentGraphDeleteMutation.graphql";
 import type { DocumentGraphSendSigningNotificationsMutation } from "./__generated__/DocumentGraphSendSigningNotificationsMutation.graphql";
+import type { DocumentGraphDeleteDraftMutation } from "./__generated__/DocumentGraphDeleteDraftMutation.graphql";
 
 export const documentsQuery = graphql`
   query DocumentGraphListQuery($organizationId: ID!) {
@@ -13,15 +14,14 @@ export const documentsQuery = graphql`
   }
 `;
 
-export const DocumentsConnectionKey = "DocumentsPageFragment_documents";
+export const DocumentsConnectionKey = "DocumentsListQuery_documents";
 
 const deleteDocumentMutation = graphql`
   mutation DocumentGraphDeleteMutation(
     $input: DeleteDocumentInput!
-    $connections: [ID!]!
   ) {
     deleteDocument(input: $input) {
-      deletedDocumentId @deleteEdge(connections: $connections)
+      deletedDocumentId @deleteRecord
     }
   }
 `;
@@ -34,6 +34,29 @@ export function useDeleteDocumentMutation() {
     {
       successMessage: __("Document deleted successfully."),
       errorMessage: __("Failed to delete document. Please try again."),
+    }
+  );
+}
+
+const deleteDraftDocumentVersionMutation = graphql`
+  mutation DocumentGraphDeleteDraftMutation(
+    $input: DeleteDraftDocumentVersionInput!
+    $connections: [ID!]!
+  ) {
+    deleteDraftDocumentVersion(input: $input) {
+      deletedDocumentVersionId @deleteEdge(connections: $connections)
+    }
+  }
+`;
+
+export function useDeleteDraftDocumentVersionMutation() {
+  const { __ } = useTranslate();
+
+  return useMutationWithToasts<DocumentGraphDeleteDraftMutation>(
+    deleteDraftDocumentVersionMutation,
+    {
+      successMessage: __("Draft deleted successfully."),
+      errorMessage: __("Failed to delete draft. Please try again."),
     }
   );
 }

--- a/apps/console/src/hooks/graph/__generated__/DocumentGraphDeleteDraftMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/DocumentGraphDeleteDraftMutation.graphql.ts
@@ -1,0 +1,132 @@
+/**
+ * @generated SignedSource<<f114dd31b601c0097380450ab5029b01>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type DeleteDraftDocumentVersionInput = {
+  documentVersionId: string;
+};
+export type DocumentGraphDeleteDraftMutation$variables = {
+  connections: ReadonlyArray<string>;
+  input: DeleteDraftDocumentVersionInput;
+};
+export type DocumentGraphDeleteDraftMutation$data = {
+  readonly deleteDraftDocumentVersion: {
+    readonly deletedDocumentVersionId: string;
+  };
+};
+export type DocumentGraphDeleteDraftMutation = {
+  response: DocumentGraphDeleteDraftMutation$data;
+  variables: DocumentGraphDeleteDraftMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "deletedDocumentVersionId",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "DocumentGraphDeleteDraftMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteDraftDocumentVersionPayload",
+        "kind": "LinkedField",
+        "name": "deleteDraftDocumentVersion",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "DocumentGraphDeleteDraftMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteDraftDocumentVersionPayload",
+        "kind": "LinkedField",
+        "name": "deleteDraftDocumentVersion",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "deleteEdge",
+            "key": "",
+            "kind": "ScalarHandle",
+            "name": "deletedDocumentVersionId",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "cd7e8253362e1d7e719e4ae2c206756e",
+    "id": null,
+    "metadata": {},
+    "name": "DocumentGraphDeleteDraftMutation",
+    "operationKind": "mutation",
+    "text": "mutation DocumentGraphDeleteDraftMutation(\n  $input: DeleteDraftDocumentVersionInput!\n) {\n  deleteDraftDocumentVersion(input: $input) {\n    deletedDocumentVersionId\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "d43940b41e3838fd03c3341c13b4c5c5";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/DocumentGraphDeleteMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/DocumentGraphDeleteMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<64c2c92a2a0806f34243f8fc9904167c>>
+ * @generated SignedSource<<6b7916e6ff46a629bf97a7b072db2d8b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,7 +13,6 @@ export type DeleteDocumentInput = {
   documentId: string;
 };
 export type DocumentGraphDeleteMutation$variables = {
-  connections: ReadonlyArray<string>;
   input: DeleteDocumentInput;
 };
 export type DocumentGraphDeleteMutation$data = {
@@ -27,24 +26,21 @@ export type DocumentGraphDeleteMutation = {
 };
 
 const node: ConcreteRequest = (function(){
-var v0 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "connections"
-},
-v1 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "input"
-},
-v2 = [
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
   {
     "kind": "Variable",
     "name": "input",
     "variableName": "input"
   }
 ],
-v3 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -53,23 +49,20 @@ v3 = {
 };
 return {
   "fragment": {
-    "argumentDefinitions": [
-      (v0/*: any*/),
-      (v1/*: any*/)
-    ],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "DocumentGraphDeleteMutation",
     "selections": [
       {
         "alias": null,
-        "args": (v2/*: any*/),
+        "args": (v1/*: any*/),
         "concreteType": "DeleteDocumentPayload",
         "kind": "LinkedField",
         "name": "deleteDocument",
         "plural": false,
         "selections": [
-          (v3/*: any*/)
+          (v2/*: any*/)
         ],
         "storageKey": null
       }
@@ -79,37 +72,27 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": [
-      (v1/*: any*/),
-      (v0/*: any*/)
-    ],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "DocumentGraphDeleteMutation",
     "selections": [
       {
         "alias": null,
-        "args": (v2/*: any*/),
+        "args": (v1/*: any*/),
         "concreteType": "DeleteDocumentPayload",
         "kind": "LinkedField",
         "name": "deleteDocument",
         "plural": false,
         "selections": [
-          (v3/*: any*/),
+          (v2/*: any*/),
           {
             "alias": null,
             "args": null,
             "filters": null,
-            "handle": "deleteEdge",
+            "handle": "deleteRecord",
             "key": "",
             "kind": "ScalarHandle",
-            "name": "deletedDocumentId",
-            "handleArgs": [
-              {
-                "kind": "Variable",
-                "name": "connections",
-                "variableName": "connections"
-              }
-            ]
+            "name": "deletedDocumentId"
           }
         ],
         "storageKey": null
@@ -127,6 +110,6 @@ return {
 };
 })();
 
-(node as any).hash = "355f3a70caecabb2146075657665633e";
+(node as any).hash = "471020248ed9d398ab80655e04cb823d";
 
 export default node;

--- a/apps/console/src/pages/organizations/documents/DocumentsPage.tsx
+++ b/apps/console/src/pages/organizations/documents/DocumentsPage.tsx
@@ -227,7 +227,6 @@ const rowFragment = graphql`
 function DocumentRow({
   document: documentKey,
   organizationId,
-  connectionId,
   checked,
   onCheck,
 }: {
@@ -257,7 +256,6 @@ function DocumentRow({
         deleteDocument({
           variables: {
             input: { documentId: document.id },
-            connections: [connectionId],
           },
         }),
       {

--- a/pkg/coredata/document_version.go
+++ b/pkg/coredata/document_version.go
@@ -415,3 +415,29 @@ WHERE %s
 
 	return nil
 }
+
+func (p DocumentVersion) Delete(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+DELETE FROM document_versions
+WHERE %s
+	AND id = @document_version_id
+`
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.NamedArgs{
+		"document_version_id": p.ID,
+	}
+
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete document version: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -1604,6 +1604,9 @@ type Mutation {
   createDraftDocumentVersion(
     input: CreateDraftDocumentVersionInput!
   ): CreateDraftDocumentVersionPayload!
+  deleteDraftDocumentVersion(
+    input: DeleteDraftDocumentVersionInput!
+  ): DeleteDraftDocumentVersionPayload!
   updateDocumentVersion(
     input: UpdateDocumentVersionInput!
   ): UpdateDocumentVersionPayload!
@@ -2427,8 +2430,16 @@ type CreateDraftDocumentVersionPayload {
   documentVersionEdge: DocumentVersionEdge!
 }
 
+type DeleteDraftDocumentVersionPayload {
+  deletedDocumentVersionId: ID!
+}
+
 input CreateDraftDocumentVersionInput {
   documentID: ID!
+}
+
+input DeleteDraftDocumentVersionInput {
+  documentVersionId: ID!
 }
 
 input UpdateDocumentVersionInput {

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -343,6 +343,10 @@ type ComplexityRoot struct {
 		DeletedDocumentID func(childComplexity int) int
 	}
 
+	DeleteDraftDocumentVersionPayload struct {
+		DeletedDocumentVersionID func(childComplexity int) int
+	}
+
 	DeleteEvidencePayload struct {
 		DeletedEvidenceID func(childComplexity int) int
 	}
@@ -602,6 +606,7 @@ type ComplexityRoot struct {
 		DeleteControlMeasureMapping           func(childComplexity int, input types.DeleteControlMeasureMappingInput) int
 		DeleteDatum                           func(childComplexity int, input types.DeleteDatumInput) int
 		DeleteDocument                        func(childComplexity int, input types.DeleteDocumentInput) int
+		DeleteDraftDocumentVersion            func(childComplexity int, input types.DeleteDraftDocumentVersionInput) int
 		DeleteEvidence                        func(childComplexity int, input types.DeleteEvidenceInput) int
 		DeleteFramework                       func(childComplexity int, input types.DeleteFrameworkInput) int
 		DeleteMeasure                         func(childComplexity int, input types.DeleteMeasureInput) int
@@ -1179,6 +1184,7 @@ type MutationResolver interface {
 	BulkPublishDocumentVersions(ctx context.Context, input types.BulkPublishDocumentVersionsInput) (*types.BulkPublishDocumentVersionsPayload, error)
 	GenerateDocumentChangelog(ctx context.Context, input types.GenerateDocumentChangelogInput) (*types.GenerateDocumentChangelogPayload, error)
 	CreateDraftDocumentVersion(ctx context.Context, input types.CreateDraftDocumentVersionInput) (*types.CreateDraftDocumentVersionPayload, error)
+	DeleteDraftDocumentVersion(ctx context.Context, input types.DeleteDraftDocumentVersionInput) (*types.DeleteDraftDocumentVersionPayload, error)
 	UpdateDocumentVersion(ctx context.Context, input types.UpdateDocumentVersionInput) (*types.UpdateDocumentVersionPayload, error)
 	RequestSignature(ctx context.Context, input types.RequestSignatureInput) (*types.RequestSignaturePayload, error)
 	BulkRequestSignatures(ctx context.Context, input types.BulkRequestSignaturesInput) (*types.BulkRequestSignaturesPayload, error)
@@ -2099,6 +2105,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.DeleteDocumentPayload.DeletedDocumentID(childComplexity), true
+
+	case "DeleteDraftDocumentVersionPayload.deletedDocumentVersionId":
+		if e.complexity.DeleteDraftDocumentVersionPayload.DeletedDocumentVersionID == nil {
+			break
+		}
+
+		return e.complexity.DeleteDraftDocumentVersionPayload.DeletedDocumentVersionID(childComplexity), true
 
 	case "DeleteEvidencePayload.deletedEvidenceId":
 		if e.complexity.DeleteEvidencePayload.DeletedEvidenceID == nil {
@@ -3333,6 +3346,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.DeleteDocument(childComplexity, args["input"].(types.DeleteDocumentInput)), true
+
+	case "Mutation.deleteDraftDocumentVersion":
+		if e.complexity.Mutation.DeleteDraftDocumentVersion == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_deleteDraftDocumentVersion_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteDraftDocumentVersion(childComplexity, args["input"].(types.DeleteDraftDocumentVersionInput)), true
 
 	case "Mutation.deleteEvidence":
 		if e.complexity.Mutation.DeleteEvidence == nil {
@@ -5495,6 +5520,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputDeleteControlMeasureMappingInput,
 		ec.unmarshalInputDeleteDatumInput,
 		ec.unmarshalInputDeleteDocumentInput,
+		ec.unmarshalInputDeleteDraftDocumentVersionInput,
 		ec.unmarshalInputDeleteEvidenceInput,
 		ec.unmarshalInputDeleteFrameworkInput,
 		ec.unmarshalInputDeleteMeasureInput,
@@ -7262,6 +7288,9 @@ type Mutation {
   createDraftDocumentVersion(
     input: CreateDraftDocumentVersionInput!
   ): CreateDraftDocumentVersionPayload!
+  deleteDraftDocumentVersion(
+    input: DeleteDraftDocumentVersionInput!
+  ): DeleteDraftDocumentVersionPayload!
   updateDocumentVersion(
     input: UpdateDocumentVersionInput!
   ): UpdateDocumentVersionPayload!
@@ -8085,8 +8114,16 @@ type CreateDraftDocumentVersionPayload {
   documentVersionEdge: DocumentVersionEdge!
 }
 
+type DeleteDraftDocumentVersionPayload {
+  deletedDocumentVersionId: ID!
+}
+
 input CreateDraftDocumentVersionInput {
   documentID: ID!
+}
+
+input DeleteDraftDocumentVersionInput {
+  documentVersionId: ID!
 }
 
 input UpdateDocumentVersionInput {
@@ -10335,6 +10372,29 @@ func (ec *executionContext) field_Mutation_deleteDocument_argsInput(
 	}
 
 	var zeroVal types.DeleteDocumentInput
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_deleteDraftDocumentVersion_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_deleteDraftDocumentVersion_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_deleteDraftDocumentVersion_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.DeleteDraftDocumentVersionInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNDeleteDraftDocumentVersionInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteDraftDocumentVersionInput(ctx, tmp)
+	}
+
+	var zeroVal types.DeleteDraftDocumentVersionInput
 	return zeroVal, nil
 }
 
@@ -19375,6 +19435,50 @@ func (ec *executionContext) _DeleteDocumentPayload_deletedDocumentId(ctx context
 func (ec *executionContext) fieldContext_DeleteDocumentPayload_deletedDocumentId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "DeleteDocumentPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DeleteDraftDocumentVersionPayload_deletedDocumentVersionId(ctx context.Context, field graphql.CollectedField, obj *types.DeleteDraftDocumentVersionPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DeleteDraftDocumentVersionPayload_deletedDocumentVersionId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DeletedDocumentVersionID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(gid.GID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DeleteDraftDocumentVersionPayload_deletedDocumentVersionId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DeleteDraftDocumentVersionPayload",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -28457,6 +28561,65 @@ func (ec *executionContext) fieldContext_Mutation_createDraftDocumentVersion(ctx
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_createDraftDocumentVersion_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_deleteDraftDocumentVersion(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_deleteDraftDocumentVersion(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteDraftDocumentVersion(rctx, fc.Args["input"].(types.DeleteDraftDocumentVersionInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.DeleteDraftDocumentVersionPayload)
+	fc.Result = res
+	return ec.marshalNDeleteDraftDocumentVersionPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteDraftDocumentVersionPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_deleteDraftDocumentVersion(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "deletedDocumentVersionId":
+				return ec.fieldContext_DeleteDraftDocumentVersionPayload_deletedDocumentVersionId(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DeleteDraftDocumentVersionPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_deleteDraftDocumentVersion_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -44442,6 +44605,33 @@ func (ec *executionContext) unmarshalInputDeleteDocumentInput(ctx context.Contex
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputDeleteDraftDocumentVersionInput(ctx context.Context, obj any) (types.DeleteDraftDocumentVersionInput, error) {
+	var it types.DeleteDraftDocumentVersionInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"documentVersionId"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "documentVersionId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentVersionId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DocumentVersionID = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputDeleteEvidenceInput(ctx context.Context, obj any) (types.DeleteEvidenceInput, error) {
 	var it types.DeleteEvidenceInput
 	asMap := map[string]any{}
@@ -49915,6 +50105,45 @@ func (ec *executionContext) _DeleteDocumentPayload(ctx context.Context, sel ast.
 	return out
 }
 
+var deleteDraftDocumentVersionPayloadImplementors = []string{"DeleteDraftDocumentVersionPayload"}
+
+func (ec *executionContext) _DeleteDraftDocumentVersionPayload(ctx context.Context, sel ast.SelectionSet, obj *types.DeleteDraftDocumentVersionPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, deleteDraftDocumentVersionPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("DeleteDraftDocumentVersionPayload")
+		case "deletedDocumentVersionId":
+			out.Values[i] = ec._DeleteDraftDocumentVersionPayload_deletedDocumentVersionId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var deleteEvidencePayloadImplementors = []string{"DeleteEvidencePayload"}
 
 func (ec *executionContext) _DeleteEvidencePayload(ctx context.Context, sel ast.SelectionSet, obj *types.DeleteEvidencePayload) graphql.Marshaler {
@@ -52880,6 +53109,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "createDraftDocumentVersion":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_createDraftDocumentVersion(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "deleteDraftDocumentVersion":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_deleteDraftDocumentVersion(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
@@ -59141,6 +59377,25 @@ func (ec *executionContext) marshalNDeleteDocumentPayload2ᚖgithubᚗcomᚋgetp
 		return graphql.Null
 	}
 	return ec._DeleteDocumentPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNDeleteDraftDocumentVersionInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteDraftDocumentVersionInput(ctx context.Context, v any) (types.DeleteDraftDocumentVersionInput, error) {
+	res, err := ec.unmarshalInputDeleteDraftDocumentVersionInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNDeleteDraftDocumentVersionPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteDraftDocumentVersionPayload(ctx context.Context, sel ast.SelectionSet, v types.DeleteDraftDocumentVersionPayload) graphql.Marshaler {
+	return ec._DeleteDraftDocumentVersionPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNDeleteDraftDocumentVersionPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteDraftDocumentVersionPayload(ctx context.Context, sel ast.SelectionSet, v *types.DeleteDraftDocumentVersionPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._DeleteDraftDocumentVersionPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNDeleteEvidenceInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteEvidenceInput(ctx context.Context, v any) (types.DeleteEvidenceInput, error) {

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -503,6 +503,14 @@ type DeleteDocumentPayload struct {
 	DeletedDocumentID gid.GID `json:"deletedDocumentId"`
 }
 
+type DeleteDraftDocumentVersionInput struct {
+	DocumentVersionID gid.GID `json:"documentVersionId"`
+}
+
+type DeleteDraftDocumentVersionPayload struct {
+	DeletedDocumentVersionID gid.GID `json:"deletedDocumentVersionId"`
+}
+
 type DeleteEvidenceInput struct {
 	EvidenceID gid.GID `json:"evidenceId"`
 }

--- a/pkg/server/api/console/v1/v1_resolver.go
+++ b/pkg/server/api/console/v1/v1_resolver.go
@@ -2063,6 +2063,20 @@ func (r *mutationResolver) CreateDraftDocumentVersion(ctx context.Context, input
 	}, nil
 }
 
+// DeleteDraftDocumentVersion is the resolver for the deleteDraftDocumentVersion field.
+func (r *mutationResolver) DeleteDraftDocumentVersion(ctx context.Context, input types.DeleteDraftDocumentVersionInput) (*types.DeleteDraftDocumentVersionPayload, error) {
+	prb := r.ProboService(ctx, input.DocumentVersionID.TenantID())
+
+	err := prb.Documents.DeleteDraft(ctx, input.DocumentVersionID)
+	if err != nil {
+		panic(fmt.Errorf("cannot delete draft document version: %w", err))
+	}
+
+	return &types.DeleteDraftDocumentVersionPayload{
+		DeletedDocumentVersionID: input.DocumentVersionID,
+	}, nil
+}
+
 // UpdateDocumentVersion is the resolver for the updateDocumentVersion field.
 func (r *mutationResolver) UpdateDocumentVersion(ctx context.Context, input types.UpdateDocumentVersionInput) (*types.UpdateDocumentVersionPayload, error) {
 	prb := r.ProboService(ctx, input.DocumentVersionID.TenantID())


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for deleting draft document versions and improved the document editing flow to prevent unwanted draft creation.

- **New Features**
  - Users can now delete draft versions of documents from the UI.
  - Drafts are only created when editing a published document, not when opening the edit dialog.

- **Backend**
  - Added GraphQL mutation and service logic for deleting draft document versions.
  - Updated database models to support draft deletion.

<!-- End of auto-generated description by cubic. -->

