### PR TITLE
Add nonconformity registries

### DIFF
--- a/apps/console/src/components/form/AuditSelectField.tsx
+++ b/apps/console/src/components/form/AuditSelectField.tsx
@@ -1,0 +1,107 @@
+import { Field, Option, Select, Badge } from "@probo/ui";
+import { Suspense, type ComponentProps } from "react";
+import { useTranslate } from "@probo/i18n";
+import { type Control, Controller, type FieldValues, type Path } from "react-hook-form";
+import { useLazyLoadQuery, graphql } from "react-relay";
+import { getAuditStateVariant, getAuditStateLabel } from "@probo/helpers";
+import type { AuditSelectFieldQuery } from "./__generated__/AuditSelectFieldQuery.graphql";
+
+const auditsQuery = graphql`
+  query AuditSelectFieldQuery($organizationId: ID!) {
+    organization: node(id: $organizationId) {
+      ... on Organization {
+        audits(first: 100) {
+          edges {
+            node {
+              id
+              name
+              framework {
+                id
+                name
+              }
+              state
+              validFrom
+              validUntil
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+type Props<T extends FieldValues = FieldValues> = {
+  organizationId: string;
+  control: Control<T>;
+  name: Path<T>;
+  label?: string;
+  error?: string;
+} & ComponentProps<typeof Field>;
+
+export function AuditSelectField<T extends FieldValues = FieldValues>({
+  organizationId,
+  control,
+  ...props
+}: Props<T>) {
+  return (
+    <Field {...props}>
+      <Suspense
+        fallback={<Select variant="editor" loading placeholder="Loading..." />}
+      >
+        <AuditSelectWithQuery
+          organizationId={organizationId}
+          control={control}
+          name={props.name}
+          disabled={props.disabled}
+        />
+      </Suspense>
+    </Field>
+  );
+}
+
+function AuditSelectWithQuery<T extends FieldValues = FieldValues>(
+  props: Pick<Props<T>, "organizationId" | "control" | "name" | "disabled">
+) {
+  const { __ } = useTranslate();
+  const { name, organizationId, control } = props;
+  const data = useLazyLoadQuery<AuditSelectFieldQuery>(auditsQuery, { organizationId });
+  const audits = data?.organization?.audits?.edges?.map((edge) => edge.node).filter((node) => node !== null) ?? [];
+
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <Select
+          disabled={props.disabled}
+          id={name}
+          variant="editor"
+          placeholder={__("Select an audit")}
+          onValueChange={field.onChange}
+          key={audits?.length.toString() ?? "0"}
+          {...field}
+          className="w-full"
+          value={field.value ?? ""}
+        >
+          {audits?.map((audit) => (
+            <Option key={audit.id} value={audit.id}>
+              <div className="flex items-center justify-between w-full">
+                <span>
+                  {audit.name
+                    ? `${audit.framework.name} - ${audit.name}`
+                    : audit.framework.name
+                  }
+                </span>
+                <div className="ml-3">
+                  <Badge variant={getAuditStateVariant(audit.state)}>
+                    {getAuditStateLabel(__, audit.state)}
+                  </Badge>
+                </div>
+              </div>
+            </Option>
+          ))}
+        </Select>
+      )}
+    />
+  );
+}

--- a/apps/console/src/components/form/__generated__/AuditSelectFieldQuery.graphql.ts
+++ b/apps/console/src/components/form/__generated__/AuditSelectFieldQuery.graphql.ts
@@ -1,0 +1,215 @@
+/**
+ * @generated SignedSource<<21026731cd2ebaf80c8c2e251b9a57f8>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type AuditState = "COMPLETED" | "IN_PROGRESS" | "NOT_STARTED" | "OUTDATED" | "REJECTED";
+export type AuditSelectFieldQuery$variables = {
+  organizationId: string;
+};
+export type AuditSelectFieldQuery$data = {
+  readonly organization: {
+    readonly audits?: {
+      readonly edges: ReadonlyArray<{
+        readonly node: {
+          readonly framework: {
+            readonly id: string;
+            readonly name: string;
+          };
+          readonly id: string;
+          readonly name: string | null | undefined;
+          readonly state: AuditState;
+          readonly validFrom: any | null | undefined;
+          readonly validUntil: any | null | undefined;
+        };
+      }>;
+    };
+  };
+};
+export type AuditSelectFieldQuery = {
+  response: AuditSelectFieldQuery$data;
+  variables: AuditSelectFieldQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "organizationId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "organizationId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v4 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 100
+        }
+      ],
+      "concreteType": "AuditConnection",
+      "kind": "LinkedField",
+      "name": "audits",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "AuditEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Audit",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                (v2/*: any*/),
+                (v3/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "Framework",
+                  "kind": "LinkedField",
+                  "name": "framework",
+                  "plural": false,
+                  "selections": [
+                    (v2/*: any*/),
+                    (v3/*: any*/)
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "state",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "validFrom",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "validUntil",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "audits(first:100)"
+    }
+  ],
+  "type": "Organization",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "AuditSelectFieldQuery",
+    "selections": [
+      {
+        "alias": "organization",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v4/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "AuditSelectFieldQuery",
+    "selections": [
+      {
+        "alias": "organization",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v4/*: any*/),
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "339c5438bb684c44887cc9cb53fb2c6a",
+    "id": null,
+    "metadata": {},
+    "name": "AuditSelectFieldQuery",
+    "operationKind": "query",
+    "text": "query AuditSelectFieldQuery(\n  $organizationId: ID!\n) {\n  organization: node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      audits(first: 100) {\n        edges {\n          node {\n            id\n            name\n            framework {\n              id\n              name\n            }\n            state\n            validFrom\n            validUntil\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "2bde1a04326144fe1b133672870807eb";
+
+export default node;

--- a/apps/console/src/hooks/graph/NonconformityRegistryGraph.ts
+++ b/apps/console/src/hooks/graph/NonconformityRegistryGraph.ts
@@ -1,0 +1,243 @@
+import { graphql } from "relay-runtime";
+import { useMutation } from "react-relay";
+import { useConfirm } from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { promisifyMutation, sprintf } from "@probo/helpers";
+import { useMutationWithToasts } from "../useMutationWithToasts";
+
+export const RegistriesConnectionKey = "RegistriesPage_nonconformityRegistries";
+
+export const nonconformityRegistriesQuery = graphql`
+  query NonconformityRegistryGraphListQuery($organizationId: ID!) {
+    node(id: $organizationId) {
+      ... on Organization {
+        ...RegistriesPageFragment
+      }
+    }
+  }
+`;
+
+export const nonconformityRegistryNodeQuery = graphql`
+  query NonconformityRegistryGraphNodeQuery($nonconformityRegistryId: ID!) {
+    node(id: $nonconformityRegistryId) {
+      ... on NonconformityRegistry {
+        id
+        referenceId
+        description
+        dateIdentified
+        rootCause
+        correctiveAction
+        dueDate
+        status
+        effectivenessCheck
+        audit {
+          id
+          framework {
+            id
+            name
+          }
+        }
+        owner {
+          id
+          fullName
+        }
+        organization {
+          id
+          name
+        }
+        createdAt
+        updatedAt
+      }
+    }
+  }
+`;
+
+export const createNonconformityRegistryMutation = graphql`
+  mutation NonconformityRegistryGraphCreateMutation(
+    $input: CreateNonconformityRegistryInput!
+    $connections: [ID!]!
+  ) {
+    createNonconformityRegistry(input: $input) {
+      nonconformityRegistryEdge @prependEdge(connections: $connections) {
+        node {
+          id
+          referenceId
+          description
+          status
+          dateIdentified
+          dueDate
+          rootCause
+          audit {
+            id
+            framework {
+              name
+            }
+          }
+          owner {
+            id
+            fullName
+          }
+          createdAt
+        }
+      }
+    }
+  }
+`;
+
+export const updateNonconformityRegistryMutation = graphql`
+  mutation NonconformityRegistryGraphUpdateMutation($input: UpdateNonconformityRegistryInput!) {
+    updateNonconformityRegistry(input: $input) {
+      nonconformityRegistry {
+        id
+        referenceId
+        description
+        dateIdentified
+        rootCause
+        correctiveAction
+        dueDate
+        status
+        effectivenessCheck
+        owner {
+          id
+          fullName
+        }
+        audit {
+          id
+          framework {
+            id
+            name
+          }
+        }
+        updatedAt
+      }
+    }
+  }
+`;
+
+export const deleteNonconformityRegistryMutation = graphql`
+  mutation NonconformityRegistryGraphDeleteMutation(
+    $input: DeleteNonconformityRegistryInput!
+    $connections: [ID!]!
+  ) {
+    deleteNonconformityRegistry(input: $input) {
+      deletedNonconformityRegistryId @deleteEdge(connections: $connections)
+    }
+  }
+`;
+
+export const useDeleteNonconformityRegistry = (
+  registry: { id: string; referenceId: string },
+  connectionId: string
+) => {
+  const { __ } = useTranslate();
+  const [mutate] = useMutationWithToasts(deleteNonconformityRegistryMutation, {
+    successMessage: __("Non conformity registry entry deleted successfully"),
+    errorMessage: __("Failed to delete non conformity registry entry"),
+  });
+  const confirm = useConfirm();
+
+  return () => {
+    confirm(
+      () =>
+        mutate({
+          variables: {
+            input: {
+              nonconformityRegistryId: registry.id,
+            },
+            connections: [connectionId],
+          },
+        }),
+      {
+        message: sprintf(
+          __(
+            "This will permanently delete the non conformity registry entry %s. This action cannot be undone."
+          ),
+          registry.referenceId
+        ),
+      }
+    );
+  };
+};
+
+export const useCreateNonconformityRegistry = (connectionId: string) => {
+  const [mutate] = useMutation(createNonconformityRegistryMutation);
+  const { __ } = useTranslate();
+
+  return (input: {
+    organizationId: string;
+    referenceId: string;
+    description?: string;
+    auditId: string;
+    dateIdentified?: string;
+    rootCause: string;
+    correctiveAction?: string;
+    ownerId: string;
+    dueDate?: string;
+    status: string;
+    effectivenessCheck?: string;
+  }) => {
+    if (!input.organizationId) {
+      return alert(__("Failed to create non conformity registry entry: organization is required"));
+    }
+    if (!input.referenceId) {
+      return alert(__("Failed to create non conformity registry entry: reference ID is required"));
+    }
+    if (!input.auditId) {
+      return alert(__("Failed to create non conformity registry entry: audit is required"));
+    }
+    if (!input.ownerId) {
+      return alert(__("Failed to create non conformity registry entry: owner is required"));
+    }
+    if (!input.rootCause) {
+      return alert(__("Failed to create non conformity registry entry: root cause is required"));
+    }
+
+    return promisifyMutation(mutate)({
+      variables: {
+        input: {
+          organizationId: input.organizationId,
+          referenceId: input.referenceId,
+          description: input.description,
+          auditId: input.auditId,
+          dateIdentified: input.dateIdentified,
+          rootCause: input.rootCause,
+          correctiveAction: input.correctiveAction,
+          ownerId: input.ownerId,
+          dueDate: input.dueDate,
+          status: input.status || "OPEN",
+          effectivenessCheck: input.effectivenessCheck,
+        },
+        connections: [connectionId],
+      },
+    });
+  };
+};
+
+export const useUpdateNonconformityRegistry = () => {
+  const [mutate] = useMutation(updateNonconformityRegistryMutation);
+  const { __ } = useTranslate();
+
+  return (input: {
+    id: string;
+    referenceId?: string;
+    description?: string;
+    dateIdentified?: string;
+    rootCause?: string;
+    correctiveAction?: string;
+    ownerId?: string;
+    auditId?: string;
+    dueDate?: string;
+    status?: string;
+    effectivenessCheck?: string;
+  }) => {
+    if (!input.id) {
+      return alert(__("Failed to update non conformity registry entry: registry ID is required"));
+    }
+
+    return promisifyMutation(mutate)({
+      variables: {
+        input,
+      },
+    });
+  };
+};

--- a/apps/console/src/hooks/graph/__generated__/NonconformityRegistryGraphCreateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/NonconformityRegistryGraphCreateMutation.graphql.ts
@@ -1,0 +1,348 @@
+/**
+ * @generated SignedSource<<a656bb20110ce8110b251091f80f27c0>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type NonconformityRegistryStatus = "CLOSED" | "IN_PROGRESS" | "OPEN";
+export type CreateNonconformityRegistryInput = {
+  auditId: string;
+  correctiveAction?: string | null | undefined;
+  dateIdentified?: any | null | undefined;
+  description?: string | null | undefined;
+  dueDate?: any | null | undefined;
+  effectivenessCheck?: string | null | undefined;
+  organizationId: string;
+  ownerId: string;
+  referenceId: string;
+  rootCause: string;
+  status: NonconformityRegistryStatus;
+};
+export type NonconformityRegistryGraphCreateMutation$variables = {
+  connections: ReadonlyArray<string>;
+  input: CreateNonconformityRegistryInput;
+};
+export type NonconformityRegistryGraphCreateMutation$data = {
+  readonly createNonconformityRegistry: {
+    readonly nonconformityRegistryEdge: {
+      readonly node: {
+        readonly audit: {
+          readonly framework: {
+            readonly name: string;
+          };
+          readonly id: string;
+        };
+        readonly createdAt: any;
+        readonly dateIdentified: any | null | undefined;
+        readonly description: string | null | undefined;
+        readonly dueDate: any | null | undefined;
+        readonly id: string;
+        readonly owner: {
+          readonly fullName: string;
+          readonly id: string;
+        };
+        readonly referenceId: string;
+        readonly rootCause: string;
+        readonly status: NonconformityRegistryStatus;
+      };
+    };
+  };
+};
+export type NonconformityRegistryGraphCreateMutation = {
+  response: NonconformityRegistryGraphCreateMutation$data;
+  variables: NonconformityRegistryGraphCreateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "referenceId",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "description",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "status",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "dateIdentified",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "dueDate",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "rootCause",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "People",
+  "kind": "LinkedField",
+  "name": "owner",
+  "plural": false,
+  "selections": [
+    (v3/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "fullName",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "NonconformityRegistryGraphCreateMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "CreateNonconformityRegistryPayload",
+        "kind": "LinkedField",
+        "name": "createNonconformityRegistry",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "NonconformityRegistryEdge",
+            "kind": "LinkedField",
+            "name": "nonconformityRegistryEdge",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "NonconformityRegistry",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v3/*: any*/),
+                  (v4/*: any*/),
+                  (v5/*: any*/),
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Audit",
+                    "kind": "LinkedField",
+                    "name": "audit",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Framework",
+                        "kind": "LinkedField",
+                        "name": "framework",
+                        "plural": false,
+                        "selections": [
+                          (v10/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  (v11/*: any*/),
+                  (v12/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "NonconformityRegistryGraphCreateMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "CreateNonconformityRegistryPayload",
+        "kind": "LinkedField",
+        "name": "createNonconformityRegistry",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "NonconformityRegistryEdge",
+            "kind": "LinkedField",
+            "name": "nonconformityRegistryEdge",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "NonconformityRegistry",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v3/*: any*/),
+                  (v4/*: any*/),
+                  (v5/*: any*/),
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Audit",
+                    "kind": "LinkedField",
+                    "name": "audit",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Framework",
+                        "kind": "LinkedField",
+                        "name": "framework",
+                        "plural": false,
+                        "selections": [
+                          (v10/*: any*/),
+                          (v3/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  (v11/*: any*/),
+                  (v12/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "prependEdge",
+            "key": "",
+            "kind": "LinkedHandle",
+            "name": "nonconformityRegistryEdge",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "de251873fde439228e9a1db5928682d3",
+    "id": null,
+    "metadata": {},
+    "name": "NonconformityRegistryGraphCreateMutation",
+    "operationKind": "mutation",
+    "text": "mutation NonconformityRegistryGraphCreateMutation(\n  $input: CreateNonconformityRegistryInput!\n) {\n  createNonconformityRegistry(input: $input) {\n    nonconformityRegistryEdge {\n      node {\n        id\n        referenceId\n        description\n        status\n        dateIdentified\n        dueDate\n        rootCause\n        audit {\n          id\n          framework {\n            name\n            id\n          }\n        }\n        owner {\n          id\n          fullName\n        }\n        createdAt\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "249806dbd8c7c28908461d20b3a0ec52";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/NonconformityRegistryGraphDeleteMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/NonconformityRegistryGraphDeleteMutation.graphql.ts
@@ -1,0 +1,132 @@
+/**
+ * @generated SignedSource<<eb0bdb8e311cea402d1aa11b79c2c1a5>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type DeleteNonconformityRegistryInput = {
+  nonconformityRegistryId: string;
+};
+export type NonconformityRegistryGraphDeleteMutation$variables = {
+  connections: ReadonlyArray<string>;
+  input: DeleteNonconformityRegistryInput;
+};
+export type NonconformityRegistryGraphDeleteMutation$data = {
+  readonly deleteNonconformityRegistry: {
+    readonly deletedNonconformityRegistryId: string;
+  };
+};
+export type NonconformityRegistryGraphDeleteMutation = {
+  response: NonconformityRegistryGraphDeleteMutation$data;
+  variables: NonconformityRegistryGraphDeleteMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "deletedNonconformityRegistryId",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "NonconformityRegistryGraphDeleteMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteNonconformityRegistryPayload",
+        "kind": "LinkedField",
+        "name": "deleteNonconformityRegistry",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "NonconformityRegistryGraphDeleteMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteNonconformityRegistryPayload",
+        "kind": "LinkedField",
+        "name": "deleteNonconformityRegistry",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "deleteEdge",
+            "key": "",
+            "kind": "ScalarHandle",
+            "name": "deletedNonconformityRegistryId",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "733821706945a20396447b1134615a0e",
+    "id": null,
+    "metadata": {},
+    "name": "NonconformityRegistryGraphDeleteMutation",
+    "operationKind": "mutation",
+    "text": "mutation NonconformityRegistryGraphDeleteMutation(\n  $input: DeleteNonconformityRegistryInput!\n) {\n  deleteNonconformityRegistry(input: $input) {\n    deletedNonconformityRegistryId\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "99bc5c0c79ffa8de365ab541c960fc84";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/NonconformityRegistryGraphListQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/NonconformityRegistryGraphListQuery.graphql.ts
@@ -1,0 +1,354 @@
+/**
+ * @generated SignedSource<<a023a856e21a5db125c12185ae6a6009>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type NonconformityRegistryGraphListQuery$variables = {
+  organizationId: string;
+};
+export type NonconformityRegistryGraphListQuery$data = {
+  readonly node: {
+    readonly " $fragmentSpreads": FragmentRefs<"RegistriesPageFragment">;
+  };
+};
+export type NonconformityRegistryGraphListQuery = {
+  response: NonconformityRegistryGraphListQuery$data;
+  variables: NonconformityRegistryGraphListQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "organizationId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "organizationId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10
+  }
+],
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "NonconformityRegistryGraphListQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "RegistriesPageFragment"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "NonconformityRegistryGraphListQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": (v4/*: any*/),
+                "concreteType": "NonconformityRegistryConnection",
+                "kind": "LinkedField",
+                "name": "nonconformityRegistries",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "totalCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "NonconformityRegistryEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "NonconformityRegistry",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v3/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "referenceId",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "description",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "status",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "dateIdentified",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "dueDate",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "rootCause",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "correctiveAction",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "effectivenessCheck",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Audit",
+                            "kind": "LinkedField",
+                            "name": "audit",
+                            "plural": false,
+                            "selections": [
+                              (v3/*: any*/),
+                              (v5/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Framework",
+                                "kind": "LinkedField",
+                                "name": "framework",
+                                "plural": false,
+                                "selections": [
+                                  (v3/*: any*/),
+                                  (v5/*: any*/)
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "People",
+                            "kind": "LinkedField",
+                            "name": "owner",
+                            "plural": false,
+                            "selections": [
+                              (v3/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "fullName",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "createdAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "updatedAt",
+                            "storageKey": null
+                          },
+                          (v2/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "cursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageInfo",
+                    "kind": "LinkedField",
+                    "name": "pageInfo",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "hasNextPage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "endCursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ClientExtension",
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "__id",
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ],
+                "storageKey": "nonconformityRegistries(first:10)"
+              },
+              {
+                "alias": null,
+                "args": (v4/*: any*/),
+                "filters": null,
+                "handle": "connection",
+                "key": "RegistriesPage_nonconformityRegistries",
+                "kind": "LinkedHandle",
+                "name": "nonconformityRegistries"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "c46e924846c9edfbc065055ee875c979",
+    "id": null,
+    "metadata": {},
+    "name": "NonconformityRegistryGraphListQuery",
+    "operationKind": "query",
+    "text": "query NonconformityRegistryGraphListQuery(\n  $organizationId: ID!\n) {\n  node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      ...RegistriesPageFragment\n    }\n    id\n  }\n}\n\nfragment RegistriesPageFragment on Organization {\n  id\n  nonconformityRegistries(first: 10) {\n    totalCount\n    edges {\n      node {\n        id\n        referenceId\n        description\n        status\n        dateIdentified\n        dueDate\n        rootCause\n        correctiveAction\n        effectivenessCheck\n        audit {\n          id\n          name\n          framework {\n            id\n            name\n          }\n        }\n        owner {\n          id\n          fullName\n        }\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "eb05763f0b78e8a91640f863bc335378";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/NonconformityRegistryGraphNodeQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/NonconformityRegistryGraphNodeQuery.graphql.ts
@@ -1,0 +1,307 @@
+/**
+ * @generated SignedSource<<7b7982ce6c305e82103ca4422bbb7c2f>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type NonconformityRegistryStatus = "CLOSED" | "IN_PROGRESS" | "OPEN";
+export type NonconformityRegistryGraphNodeQuery$variables = {
+  nonconformityRegistryId: string;
+};
+export type NonconformityRegistryGraphNodeQuery$data = {
+  readonly node: {
+    readonly audit?: {
+      readonly framework: {
+        readonly id: string;
+        readonly name: string;
+      };
+      readonly id: string;
+    };
+    readonly correctiveAction?: string | null | undefined;
+    readonly createdAt?: any;
+    readonly dateIdentified?: any | null | undefined;
+    readonly description?: string | null | undefined;
+    readonly dueDate?: any | null | undefined;
+    readonly effectivenessCheck?: string | null | undefined;
+    readonly id?: string;
+    readonly organization?: {
+      readonly id: string;
+      readonly name: string;
+    };
+    readonly owner?: {
+      readonly fullName: string;
+      readonly id: string;
+    };
+    readonly referenceId?: string;
+    readonly rootCause?: string;
+    readonly status?: NonconformityRegistryStatus;
+    readonly updatedAt?: any;
+  };
+};
+export type NonconformityRegistryGraphNodeQuery = {
+  response: NonconformityRegistryGraphNodeQuery$data;
+  variables: NonconformityRegistryGraphNodeQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "nonconformityRegistryId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "nonconformityRegistryId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "referenceId",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "description",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "dateIdentified",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "rootCause",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "correctiveAction",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "dueDate",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "status",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "effectivenessCheck",
+  "storageKey": null
+},
+v11 = [
+  (v2/*: any*/),
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "name",
+    "storageKey": null
+  }
+],
+v12 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Audit",
+  "kind": "LinkedField",
+  "name": "audit",
+  "plural": false,
+  "selections": [
+    (v2/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Framework",
+      "kind": "LinkedField",
+      "name": "framework",
+      "plural": false,
+      "selections": (v11/*: any*/),
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v13 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "People",
+  "kind": "LinkedField",
+  "name": "owner",
+  "plural": false,
+  "selections": [
+    (v2/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "fullName",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v14 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Organization",
+  "kind": "LinkedField",
+  "name": "organization",
+  "plural": false,
+  "selections": (v11/*: any*/),
+  "storageKey": null
+},
+v15 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+},
+v16 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "updatedAt",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "NonconformityRegistryGraphNodeQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/),
+              (v9/*: any*/),
+              (v10/*: any*/),
+              (v12/*: any*/),
+              (v13/*: any*/),
+              (v14/*: any*/),
+              (v15/*: any*/),
+              (v16/*: any*/)
+            ],
+            "type": "NonconformityRegistry",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "NonconformityRegistryGraphNodeQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/),
+              (v9/*: any*/),
+              (v10/*: any*/),
+              (v12/*: any*/),
+              (v13/*: any*/),
+              (v14/*: any*/),
+              (v15/*: any*/),
+              (v16/*: any*/)
+            ],
+            "type": "NonconformityRegistry",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "fd9bf2453d001f33ed1e32ad5784b647",
+    "id": null,
+    "metadata": {},
+    "name": "NonconformityRegistryGraphNodeQuery",
+    "operationKind": "query",
+    "text": "query NonconformityRegistryGraphNodeQuery(\n  $nonconformityRegistryId: ID!\n) {\n  node(id: $nonconformityRegistryId) {\n    __typename\n    ... on NonconformityRegistry {\n      id\n      referenceId\n      description\n      dateIdentified\n      rootCause\n      correctiveAction\n      dueDate\n      status\n      effectivenessCheck\n      audit {\n        id\n        framework {\n          id\n          name\n        }\n      }\n      owner {\n        id\n        fullName\n      }\n      organization {\n        id\n        name\n      }\n      createdAt\n      updatedAt\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "3395719bf2203fba19ccc94d6f740014";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/NonconformityRegistryGraphUpdateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/NonconformityRegistryGraphUpdateMutation.graphql.ts
@@ -1,0 +1,250 @@
+/**
+ * @generated SignedSource<<19732d1bd6a2a118a8e813058693bad0>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type NonconformityRegistryStatus = "CLOSED" | "IN_PROGRESS" | "OPEN";
+export type UpdateNonconformityRegistryInput = {
+  auditId?: string | null | undefined;
+  correctiveAction?: string | null | undefined;
+  dateIdentified?: any | null | undefined;
+  description?: string | null | undefined;
+  dueDate?: any | null | undefined;
+  effectivenessCheck?: string | null | undefined;
+  id: string;
+  ownerId?: string | null | undefined;
+  referenceId?: string | null | undefined;
+  rootCause?: string | null | undefined;
+  status?: NonconformityRegistryStatus | null | undefined;
+};
+export type NonconformityRegistryGraphUpdateMutation$variables = {
+  input: UpdateNonconformityRegistryInput;
+};
+export type NonconformityRegistryGraphUpdateMutation$data = {
+  readonly updateNonconformityRegistry: {
+    readonly nonconformityRegistry: {
+      readonly audit: {
+        readonly framework: {
+          readonly id: string;
+          readonly name: string;
+        };
+        readonly id: string;
+      };
+      readonly correctiveAction: string | null | undefined;
+      readonly dateIdentified: any | null | undefined;
+      readonly description: string | null | undefined;
+      readonly dueDate: any | null | undefined;
+      readonly effectivenessCheck: string | null | undefined;
+      readonly id: string;
+      readonly owner: {
+        readonly fullName: string;
+        readonly id: string;
+      };
+      readonly referenceId: string;
+      readonly rootCause: string;
+      readonly status: NonconformityRegistryStatus;
+      readonly updatedAt: any;
+    };
+  };
+};
+export type NonconformityRegistryGraphUpdateMutation = {
+  response: NonconformityRegistryGraphUpdateMutation$data;
+  variables: NonconformityRegistryGraphUpdateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "UpdateNonconformityRegistryPayload",
+    "kind": "LinkedField",
+    "name": "updateNonconformityRegistry",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "NonconformityRegistry",
+        "kind": "LinkedField",
+        "name": "nonconformityRegistry",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "referenceId",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "description",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "dateIdentified",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "rootCause",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "correctiveAction",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "dueDate",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "status",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "effectivenessCheck",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "People",
+            "kind": "LinkedField",
+            "name": "owner",
+            "plural": false,
+            "selections": [
+              (v1/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "fullName",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Audit",
+            "kind": "LinkedField",
+            "name": "audit",
+            "plural": false,
+            "selections": [
+              (v1/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Framework",
+                "kind": "LinkedField",
+                "name": "framework",
+                "plural": false,
+                "selections": [
+                  (v1/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "name",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "updatedAt",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "NonconformityRegistryGraphUpdateMutation",
+    "selections": (v2/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "NonconformityRegistryGraphUpdateMutation",
+    "selections": (v2/*: any*/)
+  },
+  "params": {
+    "cacheID": "a76545f5642f914e8e8206160e1d8839",
+    "id": null,
+    "metadata": {},
+    "name": "NonconformityRegistryGraphUpdateMutation",
+    "operationKind": "mutation",
+    "text": "mutation NonconformityRegistryGraphUpdateMutation(\n  $input: UpdateNonconformityRegistryInput!\n) {\n  updateNonconformityRegistry(input: $input) {\n    nonconformityRegistry {\n      id\n      referenceId\n      description\n      dateIdentified\n      rootCause\n      correctiveAction\n      dueDate\n      status\n      effectivenessCheck\n      owner {\n        id\n        fullName\n      }\n      audit {\n        id\n        framework {\n          id\n          name\n        }\n      }\n      updatedAt\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "456b4f3b6f36c0b518bd3eb870e0d2c5";
+
+export default node;

--- a/apps/console/src/layouts/MainLayout.tsx
+++ b/apps/console/src/layouts/MainLayout.tsx
@@ -3,6 +3,7 @@ import {
   DropdownSeparator,
   IconArrowBoxLeft,
   IconBank,
+  IconBook,
   IconCircleQuestionmark,
   IconFire3,
   IconGroup1,
@@ -137,6 +138,11 @@ export function MainLayout() {
             label={__("Audits")}
             icon={IconCheckmark1}
             to={`${prefix}/audits`}
+          />
+          <SidebarItem
+            label={__("Nonconformity Registries")}
+            icon={IconBook}
+            to={`${prefix}/nonconformityRegistries`}
           />
           <SidebarItem
             label={__("Trust Center")}

--- a/apps/console/src/pages/organizations/documents/tabs/DocumentSignaturesTab.tsx
+++ b/apps/console/src/pages/organizations/documents/tabs/DocumentSignaturesTab.tsx
@@ -38,7 +38,7 @@ function SignatureList(props: { version: Version }) {
   const { __ } = useTranslate();
   const signatureMap = new Map(signatures.map((s) => [s.signedBy.id, s]));
   const organizationId = useOrganizationId();
-  const people = usePeople(organizationId);
+  const people = usePeople(organizationId, { excludeContractEnded: true });
   const signable = props.version.status === "PUBLISHED";
 
   if (!props.version.signatures) {

--- a/apps/console/src/pages/organizations/nonconformityRegistries/NonconformityRegistriesPage.tsx
+++ b/apps/console/src/pages/organizations/nonconformityRegistries/NonconformityRegistriesPage.tsx
@@ -1,0 +1,273 @@
+import {
+  Button,
+  IconPlusLarge,
+  PageHeader,
+  Card,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Badge,
+  ActionDropdown,
+  DropdownItem,
+  IconTrashCan,
+  Table,
+  useConfirm,
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { usePageTitle } from "@probo/hooks";
+import {
+  graphql,
+  usePaginationFragment,
+  usePreloadedQuery,
+  useMutation,
+  ConnectionHandler,
+  type PreloadedQuery,
+} from "react-relay";
+import { useOrganizationId } from "/hooks/useOrganizationId";
+import { CreateNonconformityRegistryDialog } from "./dialogs/CreateNonconformityRegistryDialog";
+import { deleteNonconformityRegistryMutation, RegistriesConnectionKey } from "../../../hooks/graph/NonconformityRegistryGraph";
+import { sprintf, promisifyMutation, getStatusVariant, getStatusLabel } from "@probo/helpers";
+import type { RegistriesPageQuery } from "./__generated__/RegistriesPageQuery.graphql";
+import type {
+  RegistriesPageFragment$key,
+  RegistriesPageFragment$data,
+} from "./__generated__/RegistriesPageFragment.graphql";
+
+type NonconformityRegistry = RegistriesPageFragment$data['nonconformityRegistries']['edges'][number]['node'];
+
+interface NonconformityRegistriesPageProps {
+  queryRef: PreloadedQuery<RegistriesPageQuery>;
+}
+
+const registriesPageFragment = graphql`
+  fragment RegistriesPageFragment on Organization
+  @refetchable(queryName: "RegistriesPageRefetchQuery")
+  @argumentDefinitions(
+    first: { type: "Int", defaultValue: 10 }
+    after: { type: "CursorKey" }
+  ) {
+    id
+    nonconformityRegistries(first: $first, after: $after)
+      @connection(key: "RegistriesPage_nonconformityRegistries") {
+      __id
+      totalCount
+      edges {
+        node {
+          id
+          referenceId
+          description
+          status
+          dateIdentified
+          dueDate
+          rootCause
+          correctiveAction
+          effectivenessCheck
+          audit {
+            id
+            name
+            framework {
+              id
+              name
+            }
+          }
+          owner {
+            id
+            fullName
+          }
+          createdAt
+          updatedAt
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+`;
+
+export default function NonconformityRegistriesPage({ queryRef }: NonconformityRegistriesPageProps) {
+  const { __ } = useTranslate();
+  const organizationId = useOrganizationId();
+
+  usePageTitle(__("Nonconformity Registries"));
+
+  const organization = usePreloadedQuery(
+    graphql`
+      query RegistriesPageQuery($organizationId: ID!) {
+        node(id: $organizationId) {
+          ... on Organization {
+            ...RegistriesPageFragment
+          }
+        }
+      }
+    `,
+    queryRef
+  );
+
+  const { data: registriesData, loadNext, hasNext } = usePaginationFragment(
+    registriesPageFragment,
+    organization.node as RegistriesPageFragment$key
+  );
+
+  const connectionId = ConnectionHandler.getConnectionID(organizationId, RegistriesConnectionKey);
+  const registries: NonconformityRegistry[] = registriesData?.nonconformityRegistries?.edges?.map((edge) => edge.node) ?? [];
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title={__("Nonconformity Registries")}
+        description={__(
+          "Manage your organization's non conformity registries."
+        )}
+      >
+        <CreateNonconformityRegistryDialog organizationId={organizationId} connection={connectionId}>
+          <Button icon={IconPlusLarge}>{__("Add nonconformity registry")}</Button>
+        </CreateNonconformityRegistryDialog>
+      </PageHeader>
+
+      {registries.length === 0 ? (
+        <Card padded>
+          <div className="text-center py-12">
+            <h3 className="text-lg font-semibold mb-2">
+              {__("No non conformity registry entries yet")}
+            </h3>
+            <p className="text-txt-tertiary mb-4">
+              {__("Create your first non conformity registry entry to get started.")}
+            </p>
+          </div>
+        </Card>
+      ) : (
+        <Card>
+          <Table>
+            <Thead>
+              <Tr>
+                <Th>{__("Reference ID")}</Th>
+                <Th>{__("Description")}</Th>
+                <Th>{__("Status")}</Th>
+                <Th>{__("Audit")}</Th>
+                <Th>{__("Owner")}</Th>
+                <Th>{__("Due Date")}</Th>
+                <Th>{__("Actions")}</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {registries.map((registry) => (
+                <RegistryRow
+                  key={registry.id}
+                  registry={registry}
+                  connectionId={connectionId}
+                />
+              ))}
+            </Tbody>
+          </Table>
+
+          {hasNext && (
+            <div className="p-4 border-t">
+              <Button
+                variant="secondary"
+                onClick={() => loadNext(10)}
+                disabled={!hasNext}
+              >
+                {__("Load more")}
+              </Button>
+            </div>
+          )}
+        </Card>
+      )}
+
+
+    </div>
+  );
+}
+
+function RegistryRow({
+  registry,
+  connectionId,
+}: {
+  registry: NonconformityRegistry;
+  connectionId: string;
+}) {
+  const organizationId = useOrganizationId();
+  const { __ } = useTranslate();
+  const confirm = useConfirm();
+  const [deleteRegistry] = useMutation(deleteNonconformityRegistryMutation);
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString();
+  };
+
+  const handleDeleteRegistry = (registry: NonconformityRegistry) => {
+    if (!connectionId) return;
+
+    confirm(
+      () => {
+        return promisifyMutation(deleteRegistry)({
+          variables: {
+            input: {
+              nonconformityRegistryId: registry.id,
+            },
+            connections: [connectionId],
+          },
+        });
+      },
+      {
+        message: sprintf(
+          __(
+            "This will permanently delete the registry entry %s. This action cannot be undone."
+          ),
+          registry.referenceId
+        ),
+      }
+    );
+  };
+
+  return (
+    <Tr to={`/organizations/${organizationId}/nonconformityRegistries/${registry.id}`}>
+      <Td>
+        <span className="font-mono text-sm">{registry.referenceId}</span>
+      </Td>
+      <Td>
+        <div className="min-w-0">
+          <p className="whitespace-pre-wrap break-words">
+            {registry.description || __("No description")}
+          </p>
+        </div>
+      </Td>
+      <Td>
+        <Badge variant={getStatusVariant(registry.status)}>
+          {getStatusLabel(registry.status)}
+        </Badge>
+      </Td>
+      <Td>
+        {registry.audit.name
+          ? `${registry.audit.framework.name} - ${registry.audit.name}`
+          : registry.audit.framework.name
+        }
+      </Td>
+      <Td>{registry.owner.fullName}</Td>
+      <Td>
+        {registry.dueDate ? (
+          <time dateTime={registry.dueDate}>
+            {formatDate(registry.dueDate)}
+          </time>
+        ) : (
+          <span className="text-txt-tertiary">{__("No due date")}</span>
+        )}
+      </Td>
+      <Td noLink width={50} className="text-end">
+        <ActionDropdown>
+          <DropdownItem
+            icon={IconTrashCan}
+            variant="danger"
+            onSelect={() => handleDeleteRegistry(registry)}
+          >
+            {__("Delete")}
+          </DropdownItem>
+        </ActionDropdown>
+      </Td>
+    </Tr>
+  );
+}

--- a/apps/console/src/pages/organizations/nonconformityRegistries/NonconformityRegistryDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/nonconformityRegistries/NonconformityRegistryDetailsPage.tsx
@@ -1,0 +1,264 @@
+import {
+  ConnectionHandler,
+  usePreloadedQuery,
+  type PreloadedQuery,
+} from "react-relay";
+import {
+  nonconformityRegistryNodeQuery,
+  useDeleteNonconformityRegistry,
+  useUpdateNonconformityRegistry,
+  RegistriesConnectionKey,
+} from "../../../hooks/graph/NonconformityRegistryGraph";
+import {
+  ActionDropdown,
+  Badge,
+  Breadcrumb,
+  Button,
+  DropdownItem,
+  Field,
+  IconTrashCan,
+  Option,
+  Input,
+  Card,
+  Textarea,
+  useToast,
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { useOrganizationId } from "/hooks/useOrganizationId";
+import { ControlledField } from "/components/form/ControlledField";
+import { PeopleSelectField } from "/components/form/PeopleSelectField";
+import { AuditSelectField } from "/components/form/AuditSelectField";
+import { useFormWithSchema } from "/hooks/useFormWithSchema";
+import z from "zod";
+import { getStatusVariant, getStatusLabel, formatDatetime, getNonconformityRegistryStatusOptions } from "@probo/helpers";
+import type { NonconformityRegistryGraphNodeQuery } from "/hooks/graph/__generated__/NonconformityRegistryGraphNodeQuery.graphql";
+
+const updateRegistrySchema = z.object({
+  referenceId: z.string().min(1, "Reference ID is required"),
+  description: z.string().optional(),
+  dateIdentified: z.string().optional(),
+  dueDate: z.string().optional(),
+  rootCause: z.string().min(1, "Root cause is required"),
+  correctiveAction: z.string().optional(),
+  effectivenessCheck: z.string().optional(),
+  status: z.enum(["OPEN", "IN_PROGRESS", "CLOSED"]),
+  ownerId: z.string().min(1, "Owner is required"),
+  auditId: z.string().min(1, "Audit is required"),
+});
+
+type Props = {
+  queryRef: PreloadedQuery<NonconformityRegistryGraphNodeQuery>;
+};
+
+export default function NonconformityRegistryDetailsPage(props: Props) {
+  const data = usePreloadedQuery<NonconformityRegistryGraphNodeQuery>(
+    nonconformityRegistryNodeQuery,
+    props.queryRef
+  );
+  const registry = data.node;
+  const { __ } = useTranslate();
+  const organizationId = useOrganizationId();
+
+  const deleteRegistry = useDeleteNonconformityRegistry(
+    { id: registry.id!, referenceId: registry.referenceId! },
+    ConnectionHandler.getConnectionID(organizationId, RegistriesConnectionKey)
+  );
+
+  const { control, formState, handleSubmit, register, reset } = useFormWithSchema(
+    updateRegistrySchema,
+    {
+      defaultValues: {
+        referenceId: registry.referenceId || "",
+        description: registry.description || "",
+        dateIdentified: registry.dateIdentified?.split('T')[0] || "",
+        dueDate: registry.dueDate?.split('T')[0] || "",
+        rootCause: registry.rootCause || "",
+        correctiveAction: registry.correctiveAction || "",
+        effectivenessCheck: registry.effectivenessCheck || "",
+        status: registry.status || "OPEN",
+        ownerId: registry.owner?.id || "",
+        auditId: registry.audit?.id || "",
+      },
+    }
+  );
+
+  const updateRegistry = useUpdateNonconformityRegistry();
+  const { toast } = useToast();
+
+  const onSubmit = handleSubmit(async (formData) => {
+    if (!registry.id) return;
+
+    try {
+      await updateRegistry({
+        id: registry.id,
+        referenceId: formData.referenceId,
+        description: formData.description,
+        dateIdentified: formatDatetime(formData.dateIdentified),
+        dueDate: formatDatetime(formData.dueDate),
+        rootCause: formData.rootCause,
+        correctiveAction: formData.correctiveAction,
+        effectivenessCheck: formData.effectivenessCheck,
+        status: formData.status,
+        ownerId: formData.ownerId,
+        auditId: formData.auditId,
+      });
+      reset(formData);
+      toast({
+        title: __("Success"),
+        description: __("Non conformity registry entry updated successfully"),
+        variant: "success",
+      });
+    } catch (error) {
+      toast({
+        title: __("Error"),
+        description: error instanceof Error ? error.message : __("Failed to update non conformity registry entry"),
+        variant: "error",
+      });
+    }
+  });
+
+  const statusOptions = getNonconformityRegistryStatusOptions(__);
+
+  return (
+    <div className="space-y-6">
+      <Breadcrumb
+        items={[
+          {
+            label: __("Nonconformity Registries"),
+            to: `/organizations/${organizationId}/nonconformityRegistries`,
+          },
+          {
+            label: registry.referenceId || __("Unknown Nonconformity Registry"),
+          },
+        ]}
+      />
+
+      <div className="flex justify-between items-start">
+        <div className="flex items-center gap-4">
+          <div className="text-2xl font-semibold">
+            {registry.referenceId}
+          </div>
+          <Badge variant={getStatusVariant(registry.status || "OPEN")}>
+            {getStatusLabel(registry.status || "OPEN")}
+          </Badge>
+        </div>
+        <ActionDropdown variant="secondary">
+          <DropdownItem
+            variant="danger"
+            icon={IconTrashCan}
+            onClick={deleteRegistry}
+          >
+            {__("Delete")}
+          </DropdownItem>
+        </ActionDropdown>
+      </div>
+
+      <div className="max-w-4xl">
+        <Card padded>
+          <form onSubmit={onSubmit} className="space-y-6">
+            <h3 className="text-lg font-medium">{__("Nonconformity Registry")}</h3>
+
+            <Field
+              label={__("Reference ID")}
+              required
+              error={formState.errors.referenceId?.message}
+            >
+              <Input
+                {...register("referenceId")}
+                placeholder={__("Enter reference ID")}
+              />
+            </Field>
+
+            <AuditSelectField
+              organizationId={organizationId}
+              control={control}
+              name="auditId"
+              label={__("Audit")}
+              error={formState.errors.auditId?.message}
+              required
+            />
+
+            <Field label={__("Description")}>
+              <Textarea
+                {...register("description")}
+                placeholder={__("Enter description")}
+                rows={3}
+              />
+            </Field>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <ControlledField
+                control={control}
+                name="status"
+                type="select"
+                label={__("Status")}
+                required
+              >
+                {statusOptions.map((option) => (
+                  <Option key={option.value} value={option.value}>
+                    {option.label}
+                  </Option>
+                ))}
+              </ControlledField>
+
+              <PeopleSelectField
+                organizationId={organizationId}
+                control={control}
+                name="ownerId"
+                label={__("Owner")}
+                error={formState.errors.ownerId?.message}
+                required
+              />
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <Field label={__("Date Identified")}>
+                <Input {...register("dateIdentified")} type="date" />
+              </Field>
+
+              <Field label={__("Due Date")}>
+                <Input {...register("dueDate")} type="date" />
+              </Field>
+            </div>
+
+            <Field
+              label={__("Root Cause")}
+              required
+              error={formState.errors.rootCause?.message}
+            >
+              <Textarea
+                {...register("rootCause")}
+                placeholder={__("Enter root cause")}
+                rows={3}
+              />
+            </Field>
+
+            <Field label={__("Corrective Action")}>
+              <Textarea
+                {...register("correctiveAction")}
+                placeholder={__("Enter corrective action")}
+                rows={3}
+              />
+            </Field>
+
+            <Field label={__("Effectiveness Check")}>
+              <Textarea
+                {...register("effectivenessCheck")}
+                placeholder={__("Enter effectiveness check details")}
+                rows={3}
+              />
+            </Field>
+
+            <div className="flex justify-end">
+              {formState.isDirty && (
+                <Button type="submit" disabled={formState.isSubmitting}>
+                  {formState.isSubmitting ? __("Updating...") : __("Update")}
+                </Button>
+              )}
+            </div>
+          </form>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/apps/console/src/pages/organizations/nonconformityRegistries/__generated__/RegistriesPageFragment.graphql.ts
+++ b/apps/console/src/pages/organizations/nonconformityRegistries/__generated__/RegistriesPageFragment.graphql.ts
@@ -1,0 +1,338 @@
+/**
+ * @generated SignedSource<<662110a9800f0ef9f952778126fdbd96>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type NonconformityRegistryStatus = "CLOSED" | "IN_PROGRESS" | "OPEN";
+import { FragmentRefs } from "relay-runtime";
+export type RegistriesPageFragment$data = {
+  readonly id: string;
+  readonly nonconformityRegistries: {
+    readonly __id: string;
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly audit: {
+          readonly framework: {
+            readonly id: string;
+            readonly name: string;
+          };
+          readonly id: string;
+          readonly name: string | null | undefined;
+        };
+        readonly correctiveAction: string | null | undefined;
+        readonly createdAt: any;
+        readonly dateIdentified: any | null | undefined;
+        readonly description: string | null | undefined;
+        readonly dueDate: any | null | undefined;
+        readonly effectivenessCheck: string | null | undefined;
+        readonly id: string;
+        readonly owner: {
+          readonly fullName: string;
+          readonly id: string;
+        };
+        readonly referenceId: string;
+        readonly rootCause: string;
+        readonly status: NonconformityRegistryStatus;
+        readonly updatedAt: any;
+      };
+    }>;
+    readonly pageInfo: {
+      readonly endCursor: any | null | undefined;
+      readonly hasNextPage: boolean;
+    };
+    readonly totalCount: number;
+  };
+  readonly " $fragmentType": "RegistriesPageFragment";
+};
+export type RegistriesPageFragment$key = {
+  readonly " $data"?: RegistriesPageFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"RegistriesPageFragment">;
+};
+
+import RegistriesPageRefetchQuery_graphql from './RegistriesPageRefetchQuery.graphql';
+
+const node: ReaderFragment = (function(){
+var v0 = [
+  "nonconformityRegistries"
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "after"
+    },
+    {
+      "defaultValue": 10,
+      "kind": "LocalArgument",
+      "name": "first"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": {
+    "connection": [
+      {
+        "count": "first",
+        "cursor": "after",
+        "direction": "forward",
+        "path": (v0/*: any*/)
+      }
+    ],
+    "refetch": {
+      "connection": {
+        "forward": {
+          "count": "first",
+          "cursor": "after"
+        },
+        "backward": null,
+        "path": (v0/*: any*/)
+      },
+      "fragmentPathInResult": [
+        "node"
+      ],
+      "operation": RegistriesPageRefetchQuery_graphql,
+      "identifierInfo": {
+        "identifierField": "id",
+        "identifierQueryVariableName": "id"
+      }
+    }
+  },
+  "name": "RegistriesPageFragment",
+  "selections": [
+    (v1/*: any*/),
+    {
+      "alias": "nonconformityRegistries",
+      "args": null,
+      "concreteType": "NonconformityRegistryConnection",
+      "kind": "LinkedField",
+      "name": "__RegistriesPage_nonconformityRegistries_connection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "totalCount",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "NonconformityRegistryEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "NonconformityRegistry",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                (v1/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "referenceId",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "description",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "status",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "dateIdentified",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "dueDate",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "rootCause",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "correctiveAction",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "effectivenessCheck",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "Audit",
+                  "kind": "LinkedField",
+                  "name": "audit",
+                  "plural": false,
+                  "selections": [
+                    (v1/*: any*/),
+                    (v2/*: any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "Framework",
+                      "kind": "LinkedField",
+                      "name": "framework",
+                      "plural": false,
+                      "selections": [
+                        (v1/*: any*/),
+                        (v2/*: any*/)
+                      ],
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "People",
+                  "kind": "LinkedField",
+                  "name": "owner",
+                  "plural": false,
+                  "selections": [
+                    (v1/*: any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "fullName",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "createdAt",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "updatedAt",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "__typename",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "cursor",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "kind": "LinkedField",
+          "name": "pageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasNextPage",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "endCursor",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "kind": "ClientExtension",
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "__id",
+              "storageKey": null
+            }
+          ]
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Organization",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "c582c6c8fa10073ddc1ad8dc33939a1f";
+
+export default node;

--- a/apps/console/src/pages/organizations/nonconformityRegistries/__generated__/RegistriesPageQuery.graphql.ts
+++ b/apps/console/src/pages/organizations/nonconformityRegistries/__generated__/RegistriesPageQuery.graphql.ts
@@ -1,0 +1,354 @@
+/**
+ * @generated SignedSource<<8c45aba43e3ecb3c9e59f9fe5bb0a630>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type RegistriesPageQuery$variables = {
+  organizationId: string;
+};
+export type RegistriesPageQuery$data = {
+  readonly node: {
+    readonly " $fragmentSpreads": FragmentRefs<"RegistriesPageFragment">;
+  };
+};
+export type RegistriesPageQuery = {
+  response: RegistriesPageQuery$data;
+  variables: RegistriesPageQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "organizationId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "organizationId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10
+  }
+],
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RegistriesPageQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "RegistriesPageFragment"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "RegistriesPageQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": (v4/*: any*/),
+                "concreteType": "NonconformityRegistryConnection",
+                "kind": "LinkedField",
+                "name": "nonconformityRegistries",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "totalCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "NonconformityRegistryEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "NonconformityRegistry",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v3/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "referenceId",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "description",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "status",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "dateIdentified",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "dueDate",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "rootCause",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "correctiveAction",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "effectivenessCheck",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Audit",
+                            "kind": "LinkedField",
+                            "name": "audit",
+                            "plural": false,
+                            "selections": [
+                              (v3/*: any*/),
+                              (v5/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Framework",
+                                "kind": "LinkedField",
+                                "name": "framework",
+                                "plural": false,
+                                "selections": [
+                                  (v3/*: any*/),
+                                  (v5/*: any*/)
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "People",
+                            "kind": "LinkedField",
+                            "name": "owner",
+                            "plural": false,
+                            "selections": [
+                              (v3/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "fullName",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "createdAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "updatedAt",
+                            "storageKey": null
+                          },
+                          (v2/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "cursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageInfo",
+                    "kind": "LinkedField",
+                    "name": "pageInfo",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "hasNextPage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "endCursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ClientExtension",
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "__id",
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ],
+                "storageKey": "nonconformityRegistries(first:10)"
+              },
+              {
+                "alias": null,
+                "args": (v4/*: any*/),
+                "filters": null,
+                "handle": "connection",
+                "key": "RegistriesPage_nonconformityRegistries",
+                "kind": "LinkedHandle",
+                "name": "nonconformityRegistries"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "738deaeb3219a79ae2ba0957d37aeb32",
+    "id": null,
+    "metadata": {},
+    "name": "RegistriesPageQuery",
+    "operationKind": "query",
+    "text": "query RegistriesPageQuery(\n  $organizationId: ID!\n) {\n  node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      ...RegistriesPageFragment\n    }\n    id\n  }\n}\n\nfragment RegistriesPageFragment on Organization {\n  id\n  nonconformityRegistries(first: 10) {\n    totalCount\n    edges {\n      node {\n        id\n        referenceId\n        description\n        status\n        dateIdentified\n        dueDate\n        rootCause\n        correctiveAction\n        effectivenessCheck\n        audit {\n          id\n          name\n          framework {\n            id\n            name\n          }\n        }\n        owner {\n          id\n          fullName\n        }\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "663123fc3652212b1b9e3fecac857d67";
+
+export default node;

--- a/apps/console/src/pages/organizations/nonconformityRegistries/__generated__/RegistriesPageRefetchQuery.graphql.ts
+++ b/apps/console/src/pages/organizations/nonconformityRegistries/__generated__/RegistriesPageRefetchQuery.graphql.ts
@@ -1,0 +1,364 @@
+/**
+ * @generated SignedSource<<539eadc93287b3c8055c4f60c2198ef3>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type RegistriesPageRefetchQuery$variables = {
+  after?: any | null | undefined;
+  first?: number | null | undefined;
+  id: string;
+};
+export type RegistriesPageRefetchQuery$data = {
+  readonly node: {
+    readonly " $fragmentSpreads": FragmentRefs<"RegistriesPageFragment">;
+  };
+};
+export type RegistriesPageRefetchQuery = {
+  response: RegistriesPageRefetchQuery$data;
+  variables: RegistriesPageRefetchQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "after"
+  },
+  {
+    "defaultValue": 10,
+    "kind": "LocalArgument",
+    "name": "first"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "after"
+  },
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "first"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RegistriesPageRefetchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "args": (v2/*: any*/),
+            "kind": "FragmentSpread",
+            "name": "RegistriesPageFragment"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "RegistriesPageRefetchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          (v4/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": (v2/*: any*/),
+                "concreteType": "NonconformityRegistryConnection",
+                "kind": "LinkedField",
+                "name": "nonconformityRegistries",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "totalCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "NonconformityRegistryEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "NonconformityRegistry",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v4/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "referenceId",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "description",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "status",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "dateIdentified",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "dueDate",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "rootCause",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "correctiveAction",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "effectivenessCheck",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Audit",
+                            "kind": "LinkedField",
+                            "name": "audit",
+                            "plural": false,
+                            "selections": [
+                              (v4/*: any*/),
+                              (v5/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Framework",
+                                "kind": "LinkedField",
+                                "name": "framework",
+                                "plural": false,
+                                "selections": [
+                                  (v4/*: any*/),
+                                  (v5/*: any*/)
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "People",
+                            "kind": "LinkedField",
+                            "name": "owner",
+                            "plural": false,
+                            "selections": [
+                              (v4/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "fullName",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "createdAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "updatedAt",
+                            "storageKey": null
+                          },
+                          (v3/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "cursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageInfo",
+                    "kind": "LinkedField",
+                    "name": "pageInfo",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "hasNextPage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "endCursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ClientExtension",
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "__id",
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": (v2/*: any*/),
+                "filters": null,
+                "handle": "connection",
+                "key": "RegistriesPage_nonconformityRegistries",
+                "kind": "LinkedHandle",
+                "name": "nonconformityRegistries"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "ada17041dda08a01108cc7fa6bc9015e",
+    "id": null,
+    "metadata": {},
+    "name": "RegistriesPageRefetchQuery",
+    "operationKind": "query",
+    "text": "query RegistriesPageRefetchQuery(\n  $after: CursorKey\n  $first: Int = 10\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...RegistriesPageFragment_2HEEH6\n    id\n  }\n}\n\nfragment RegistriesPageFragment_2HEEH6 on Organization {\n  id\n  nonconformityRegistries(first: $first, after: $after) {\n    totalCount\n    edges {\n      node {\n        id\n        referenceId\n        description\n        status\n        dateIdentified\n        dueDate\n        rootCause\n        correctiveAction\n        effectivenessCheck\n        audit {\n          id\n          name\n          framework {\n            id\n            name\n          }\n        }\n        owner {\n          id\n          fullName\n        }\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "c582c6c8fa10073ddc1ad8dc33939a1f";
+
+export default node;

--- a/apps/console/src/pages/organizations/nonconformityRegistries/dialogs/CreateNonconformityRegistryDialog.tsx
+++ b/apps/console/src/pages/organizations/nonconformityRegistries/dialogs/CreateNonconformityRegistryDialog.tsx
@@ -1,0 +1,249 @@
+import { type ReactNode } from "react";
+import {
+  Button,
+  Field,
+  useToast,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  useDialogRef,
+  Textarea,
+  Breadcrumb,
+  Label,
+  Select,
+  Option,
+  Input,
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { z } from "zod";
+import { useFormWithSchema } from "/hooks/useFormWithSchema";
+import { useCreateNonconformityRegistry } from "../../../../hooks/graph/NonconformityRegistryGraph";
+import { PeopleSelectField } from "/components/form/PeopleSelectField";
+import { AuditSelectField } from "/components/form/AuditSelectField";
+import { Controller } from "react-hook-form";
+import { formatDatetime, getNonconformityRegistryStatusOptions } from "@probo/helpers";
+
+
+
+const schema = z.object({
+  referenceId: z.string().min(1, "Reference ID is required"),
+  description: z.string().optional(),
+  auditId: z.string().min(1, "Audit is required"),
+  dateIdentified: z.string().optional(),
+  rootCause: z.string().min(1, "Root cause is required"),
+  correctiveAction: z.string().optional(),
+  ownerId: z.string().min(1, "Owner is required"),
+  dueDate: z.string().optional(),
+  status: z.enum(["OPEN", "IN_PROGRESS", "CLOSED"]),
+  effectivenessCheck: z.string().optional(),
+});
+
+type FormData = z.infer<typeof schema>;
+
+interface CreateNonconformityRegistryDialogProps {
+  children: ReactNode;
+  connection?: string;
+  organizationId: string;
+}
+
+export function CreateNonconformityRegistryDialog({
+  children,
+  organizationId,
+  connection,
+}: CreateNonconformityRegistryDialogProps) {
+  const { __ } = useTranslate();
+  const { toast } = useToast();
+  const dialogRef = useDialogRef();
+
+  const createRegistry = useCreateNonconformityRegistry(connection || "");
+  const statusOptions = getNonconformityRegistryStatusOptions(__);
+
+  const { register, handleSubmit, formState, reset, control } = useFormWithSchema(schema, {
+    defaultValues: {
+      referenceId: "",
+      description: "",
+      auditId: "",
+      dateIdentified: "",
+      rootCause: "",
+      correctiveAction: "",
+      ownerId: "",
+      dueDate: "",
+      status: "OPEN" as const,
+      effectivenessCheck: "",
+    },
+  });
+
+  const onSubmit = handleSubmit(async (formData: FormData) => {
+    try {
+      await createRegistry({
+        organizationId,
+        referenceId: formData.referenceId,
+        description: formData.description || undefined,
+        auditId: formData.auditId,
+        dateIdentified: formatDatetime(formData.dateIdentified),
+        rootCause: formData.rootCause,
+        correctiveAction: formData.correctiveAction || undefined,
+        ownerId: formData.ownerId,
+        dueDate: formatDatetime(formData.dueDate),
+        status: formData.status,
+        effectivenessCheck: formData.effectivenessCheck || undefined,
+      });
+
+      toast({
+        title: __("Success"),
+                    description: __("Non conformity registry entry created successfully"),
+        variant: "success",
+      });
+
+      reset();
+      dialogRef.current?.close();
+    } catch (error) {
+      toast({
+        title: __("Error"),
+                    description: __("Failed to create non conformity registry entry"),
+        variant: "error",
+      });
+    }
+  });
+
+  return (
+    <Dialog
+      ref={dialogRef}
+      trigger={children}
+      title={<Breadcrumb items={[__("Registries"), __("Create Entry")]} />}
+      className="max-w-2xl"
+    >
+      <form onSubmit={onSubmit}>
+        <DialogContent padded className="space-y-4">
+          <Field
+            label={__("Reference ID")}
+            {...register("referenceId")}
+            placeholder="NC-001"
+            error={formState.errors.referenceId?.message}
+            required
+          />
+
+          <AuditSelectField
+            organizationId={organizationId}
+            control={control}
+            name="auditId"
+            label={__("Audit")}
+            error={formState.errors.auditId?.message}
+            required
+          />
+
+          <div className="space-y-2">
+            <Label htmlFor="description">{__("Description")}</Label>
+            <Textarea
+              id="description"
+              {...register("description")}
+              placeholder={__("Brief description of the nonconformity...")}
+              rows={2}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <Field label={__("Status")}>
+              <Controller
+                control={control}
+                name="status"
+                render={({ field }) => (
+                  <Select
+                    variant="editor"
+                    placeholder={__("Select status")}
+                    onValueChange={field.onChange}
+                    value={field.value}
+                    className="w-full"
+                  >
+                    {statusOptions.map((option) => (
+                      <Option key={option.value} value={option.value}>
+                        {option.label}
+                      </Option>
+                    ))}
+                  </Select>
+                )}
+              />
+              {formState.errors.status && (
+                <p className="text-sm text-red-500 mt-1">{formState.errors.status.message}</p>
+              )}
+            </Field>
+
+            <PeopleSelectField
+              organizationId={organizationId}
+              control={control}
+              name="ownerId"
+              label={__("Owner")}
+              error={formState.errors.ownerId?.message}
+              required
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="dateIdentified">{__("Date Identified")}</Label>
+              <Input
+                id="dateIdentified"
+                type="date"
+                {...register("dateIdentified")}
+              />
+              {formState.errors.dateIdentified && (
+                <p className="text-sm text-red-500">{formState.errors.dateIdentified.message}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="dueDate">{__("Due Date")}</Label>
+              <Input
+                id="dueDate"
+                type="date"
+                {...register("dueDate")}
+              />
+              {formState.errors.dueDate && (
+                <p className="text-sm text-red-500">{formState.errors.dueDate.message}</p>
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="rootCause">{__("Root Cause")} *</Label>
+            <Textarea
+              id="rootCause"
+              {...register("rootCause")}
+              placeholder={__("Detailed analysis of the root cause...")}
+              rows={3}
+            />
+            {formState.errors.rootCause && (
+              <p className="text-sm text-red-500">{formState.errors.rootCause.message}</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="correctiveAction">{__("Corrective Action")}</Label>
+            <Textarea
+              id="correctiveAction"
+              {...register("correctiveAction")}
+              placeholder={__("Proposed corrective actions...")}
+              rows={3}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="effectivenessCheck">{__("Effectiveness Check")}</Label>
+            <Textarea
+              id="effectivenessCheck"
+              {...register("effectivenessCheck")}
+              placeholder={__("Assessment of corrective action effectiveness...")}
+              rows={2}
+            />
+          </div>
+        </DialogContent>
+
+        <DialogFooter>
+          <Button type="submit" disabled={formState.isSubmitting}>
+            {formState.isSubmitting ? __("Creating...") : __("Create Nonconformity Registry Entry")}
+          </Button>
+        </DialogFooter>
+      </form>
+    </Dialog>
+  );
+}

--- a/apps/console/src/routes.tsx
+++ b/apps/console/src/routes.tsx
@@ -29,6 +29,7 @@ import { dataRoutes } from "./routes/dataRoutes.ts";
 import { assetRoutes } from "./routes/assetRoutes.ts";
 import { auditRoutes } from "./routes/auditRoutes.ts";
 import { trustCenterRoutes } from "./routes/trustCenterRoutes.ts";
+import { nonconformityRegistryRoutes } from "./routes/nonconformityRegistryRoutes.ts";
 import { lazy } from "@probo/react-lazy";
 
 export type AppRoute = Omit<RouteObject, "Component" | "children"> & {
@@ -149,6 +150,7 @@ const routes = [
       ...assetRoutes,
       ...dataRoutes,
       ...auditRoutes,
+      ...nonconformityRegistryRoutes,
       ...trustCenterRoutes,
       {
         path: "*",

--- a/apps/console/src/routes/nonconformityRegistryRoutes.ts
+++ b/apps/console/src/routes/nonconformityRegistryRoutes.ts
@@ -1,0 +1,29 @@
+import { loadQuery } from "react-relay";
+import { relayEnvironment } from "/providers/RelayProviders";
+import { PageSkeleton } from "/components/skeletons/PageSkeleton";
+import { lazy } from "@probo/react-lazy";
+import { nonconformityRegistriesQuery, nonconformityRegistryNodeQuery } from "/hooks/graph/NonconformityRegistryGraph";
+import type { AppRoute } from "/routes";
+
+export const nonconformityRegistryRoutes= [
+  {
+    path: "nonconformityRegistries",
+    fallback: PageSkeleton,
+    queryLoader: ({ organizationId }: { organizationId: string }) =>
+      loadQuery(relayEnvironment, nonconformityRegistriesQuery, { organizationId }),
+    Component: lazy(
+      () => import("/pages/organizations/nonconformityRegistries/NonconformityRegistriesPage")
+    ),
+  },
+  {
+    path: "nonconformityRegistries/:registryId",
+    fallback: PageSkeleton,
+    queryLoader: (params: Record<string, string>) =>
+      loadQuery(relayEnvironment, nonconformityRegistryNodeQuery, {
+        nonconformityRegistryId: params.registryId
+      }),
+    Component: lazy(
+      () => import("/pages/organizations/nonconformityRegistries/NonconformityRegistryDetailsPage")
+    ),
+  },
+] satisfies AppRoute[];

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -16,6 +16,7 @@ export { availableFrameworks } from "./frameworks";
 export { getDocumentTypeLabel, documentTypes } from "./documents";
 export { getAssetTypeVariant, getCriticityVariant } from "./assets";
 export { getAuditStateLabel, getAuditStateVariant, auditStates } from "./audits";
+export { getStatusVariant, getStatusLabel, getNonconformityRegistryStatusOptions, registryStatuses } from "./registryStatus";
 export { promisifyMutation } from "./relay";
 export { fileType, fileSize } from "./file";
 export { formatDatetime } from "./date";

--- a/packages/helpers/src/registryStatus.ts
+++ b/packages/helpers/src/registryStatus.ts
@@ -1,0 +1,46 @@
+type Translator = (s: string) => string;
+
+export type NonconformityRegistryStatus = "CLOSED" | "IN_PROGRESS" | "OPEN";
+
+export const registryStatuses = [
+  "OPEN",
+  "IN_PROGRESS",
+  "CLOSED",
+] as const;
+
+export const getStatusVariant = (status: NonconformityRegistryStatus) => {
+  switch (status) {
+    case "OPEN":
+      return "danger" as const;
+    case "IN_PROGRESS":
+      return "warning" as const;
+    case "CLOSED":
+      return "success" as const;
+    default:
+      return "neutral" as const;
+  }
+};
+
+export const getStatusLabel = (status: NonconformityRegistryStatus) => {
+  switch (status) {
+    case "OPEN":
+      return "Open";
+    case "IN_PROGRESS":
+      return "In Progress";
+    case "CLOSED":
+      return "Closed";
+    default:
+      return status;
+  }
+};
+
+export function getNonconformityRegistryStatusOptions(__: Translator) {
+  return registryStatuses.map((status) => ({
+    value: status,
+    label: __({
+      "OPEN": "Open",
+      "IN_PROGRESS": "In Progress",
+      "CLOSED": "Closed",
+    }[status]),
+  }));
+}

--- a/pkg/coredata/entity_type_reg.go
+++ b/pkg/coredata/entity_type_reg.go
@@ -43,4 +43,5 @@ const (
 	FileEntityType
 	VendorContactEntityType
 	VendorDataPrivacyAgreementEntityType
+	NonconformityRegistryEntityType
 )

--- a/pkg/coredata/migrations/20250814T091852Z.sql
+++ b/pkg/coredata/migrations/20250814T091852Z.sql
@@ -1,0 +1,41 @@
+CREATE TYPE nonconformity_registries_status AS ENUM (
+    'OPEN',
+    'IN_PROGRESS',
+    'CLOSED'
+);
+
+CREATE TABLE nonconformity_registries (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    organization_id TEXT NOT NULL,
+    reference_id TEXT NOT NULL,
+    description TEXT,
+    audit_id TEXT NOT NULL,
+    date_identified DATE,
+    root_cause TEXT NOT NULL,
+    corrective_action TEXT,
+    owner_id TEXT NOT NULL,
+    due_date DATE,
+    status nonconformity_registries_status NOT NULL,
+    effectiveness_check TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+
+    CONSTRAINT nonconformity_registries_organization_id_fkey
+        FOREIGN KEY (organization_id)
+        REFERENCES organizations(id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+
+    CONSTRAINT nonconformity_registries_owner_id_fkey
+        FOREIGN KEY (owner_id)
+        REFERENCES peoples(id)
+        ON UPDATE CASCADE
+        ON DELETE RESTRICT,
+
+    CONSTRAINT nonconformity_registries_audit_id_fkey
+        FOREIGN KEY (audit_id)
+        REFERENCES audits(id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+);

--- a/pkg/coredata/nonconformity_registry.go
+++ b/pkg/coredata/nonconformity_registry.go
@@ -1,0 +1,341 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"time"
+
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+	"github.com/jackc/pgx/v5"
+	"go.gearno.de/kit/pg"
+)
+
+type (
+	NonconformityRegistry struct {
+		ID                 gid.GID                     `db:"id"`
+		OrganizationID     gid.GID                     `db:"organization_id"`
+		ReferenceID        string                      `db:"reference_id"`
+		Description        *string                     `db:"description"`
+		AuditID            gid.GID                     `db:"audit_id"`
+		DateIdentified     *time.Time                  `db:"date_identified"`
+		RootCause          string                      `db:"root_cause"`
+		CorrectiveAction   *string                     `db:"corrective_action"`
+		OwnerID            gid.GID                     `db:"owner_id"`
+		DueDate            *time.Time                  `db:"due_date"`
+		Status             NonconformityRegistryStatus `db:"status"`
+		EffectivenessCheck *string                     `db:"effectiveness_check"`
+		CreatedAt          time.Time                   `db:"created_at"`
+		UpdatedAt          time.Time                   `db:"updated_at"`
+	}
+
+	NonconformityRegistries []*NonconformityRegistry
+)
+
+func (nr *NonconformityRegistry) CursorKey(field NonconformityRegistryOrderField) page.CursorKey {
+	switch field {
+	case NonconformityRegistryOrderFieldCreatedAt:
+		return page.NewCursorKey(nr.ID, nr.CreatedAt)
+	case NonconformityRegistryOrderFieldDateIdentified:
+		return page.NewCursorKey(nr.ID, nr.DateIdentified)
+	case NonconformityRegistryOrderFieldDueDate:
+		return page.NewCursorKey(nr.ID, nr.DueDate)
+	case NonconformityRegistryOrderFieldStatus:
+		return page.NewCursorKey(nr.ID, nr.Status)
+	case NonconformityRegistryOrderFieldReferenceId:
+		return page.NewCursorKey(nr.ID, nr.ReferenceID)
+	}
+
+	panic(fmt.Sprintf("unsupported order by: %s", field))
+}
+
+func (nr *NonconformityRegistry) LoadByID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	nonconformityRegistryID gid.GID,
+) error {
+	q := `
+SELECT
+	id,
+	organization_id,
+	reference_id,
+	description,
+	audit_id,
+	date_identified,
+	root_cause,
+	corrective_action,
+	owner_id,
+	due_date,
+	status,
+	effectiveness_check,
+	created_at,
+	updated_at
+FROM
+	nonconformity_registries
+WHERE
+	%s
+	AND id = @nonconformity_registry_id
+LIMIT 1;
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"nonconformity_registry_id": nonconformityRegistryID}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query nonconformity registry: %w", err)
+	}
+
+	registry, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[NonconformityRegistry])
+	if err != nil {
+		return fmt.Errorf("cannot collect nonconformity registry: %w", err)
+	}
+
+	*nr = registry
+
+	return nil
+}
+
+func (nrs *NonconformityRegistries) CountByOrganizationID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	organizationID gid.GID,
+) (int, error) {
+	q := `
+SELECT
+	COUNT(id)
+FROM
+	nonconformity_registries
+WHERE
+	%s
+	AND organization_id = @organization_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	row := conn.QueryRow(ctx, q, args)
+
+	var count int
+	err := row.Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("cannot count nonconformity registries: %w", err)
+	}
+
+	return count, nil
+}
+
+func (nrs *NonconformityRegistries) LoadByOrganizationID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	organizationID gid.GID,
+	cursor *page.Cursor[NonconformityRegistryOrderField],
+) error {
+	q := `
+SELECT
+	id,
+	organization_id,
+	reference_id,
+	description,
+	audit_id,
+	date_identified,
+	root_cause,
+	corrective_action,
+	owner_id,
+	due_date,
+	status,
+	effectiveness_check,
+	created_at,
+	updated_at
+FROM
+	nonconformity_registries
+WHERE
+	%s
+	AND organization_id = @organization_id
+	AND %s
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, cursor.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query nonconformity registries: %w", err)
+	}
+
+	registries, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[NonconformityRegistry])
+	if err != nil {
+		return fmt.Errorf("cannot collect nonconformity registries: %w", err)
+	}
+
+	*nrs = registries
+
+	return nil
+}
+
+func (nr *NonconformityRegistry) Insert(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+INSERT INTO nonconformity_registries (
+	id,
+	tenant_id,
+	organization_id,
+	reference_id,
+	description,
+	audit_id,
+	date_identified,
+	root_cause,
+	corrective_action,
+	owner_id,
+	due_date,
+	status,
+	effectiveness_check,
+	created_at,
+	updated_at
+) VALUES (
+	@id,
+	@tenant_id,
+	@organization_id,
+	@reference_id,
+	@description,
+	@audit_id,
+	@date_identified,
+	@root_cause,
+	@corrective_action,
+	@owner_id,
+	@due_date,
+	@status,
+	@effectiveness_check,
+	@created_at,
+	@updated_at
+)
+`
+
+	args := pgx.StrictNamedArgs{
+		"id":                  nr.ID,
+		"tenant_id":           scope.GetTenantID(),
+		"organization_id":     nr.OrganizationID,
+		"reference_id":        nr.ReferenceID,
+		"description":         nr.Description,
+		"audit_id":            nr.AuditID,
+		"date_identified":     nr.DateIdentified,
+		"root_cause":          nr.RootCause,
+		"corrective_action":   nr.CorrectiveAction,
+		"owner_id":            nr.OwnerID,
+		"due_date":            nr.DueDate,
+		"status":              nr.Status,
+		"effectiveness_check": nr.EffectivenessCheck,
+		"created_at":          nr.CreatedAt,
+		"updated_at":          nr.UpdatedAt,
+	}
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot insert nonconformity registry: %w", err)
+	}
+
+	return nil
+}
+
+func (nr *NonconformityRegistry) Update(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+UPDATE nonconformity_registries
+SET
+	reference_id = @reference_id,
+	description = @description,
+	date_identified = @date_identified,
+	root_cause = @root_cause,
+	corrective_action = @corrective_action,
+	due_date = @due_date,
+	status = @status,
+	effectiveness_check = @effectiveness_check,
+	owner_id = @owner_id,
+	audit_id = @audit_id,
+	updated_at = @updated_at
+WHERE
+	%s
+	AND id = @id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"id":                  nr.ID,
+		"reference_id":        nr.ReferenceID,
+		"description":         nr.Description,
+		"date_identified":     nr.DateIdentified,
+		"root_cause":          nr.RootCause,
+		"corrective_action":   nr.CorrectiveAction,
+		"due_date":            nr.DueDate,
+		"status":              nr.Status,
+		"effectiveness_check": nr.EffectivenessCheck,
+		"owner_id":            nr.OwnerID,
+		"audit_id":            nr.AuditID,
+		"updated_at":          nr.UpdatedAt,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot update nonconformity registry: %w", err)
+	}
+
+	return nil
+}
+
+func (nr *NonconformityRegistry) Delete(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+DELETE FROM nonconformity_registries
+WHERE
+	%s
+	AND id = @id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"id": nr.ID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete nonconformity registry: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/nonconformity_registry_order_field.go
+++ b/pkg/coredata/nonconformity_registry_order_field.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"fmt"
+)
+
+type NonconformityRegistryOrderField string
+
+const (
+	NonconformityRegistryOrderFieldCreatedAt      NonconformityRegistryOrderField = "CREATED_AT"
+	NonconformityRegistryOrderFieldDateIdentified NonconformityRegistryOrderField = "DATE_IDENTIFIED"
+	NonconformityRegistryOrderFieldDueDate        NonconformityRegistryOrderField = "DUE_DATE"
+	NonconformityRegistryOrderFieldStatus         NonconformityRegistryOrderField = "STATUS"
+	NonconformityRegistryOrderFieldReferenceId    NonconformityRegistryOrderField = "REFERENCE_ID"
+)
+
+func (p NonconformityRegistryOrderField) Column() string {
+	return string(p)
+}
+
+func (p NonconformityRegistryOrderField) String() string {
+	return string(p)
+}
+
+func (p NonconformityRegistryOrderField) MarshalText() ([]byte, error) {
+	return []byte(p.String()), nil
+}
+
+func (p *NonconformityRegistryOrderField) UnmarshalText(text []byte) error {
+	val := string(text)
+	switch val {
+	case string(NonconformityRegistryOrderFieldCreatedAt),
+		string(NonconformityRegistryOrderFieldDateIdentified),
+		string(NonconformityRegistryOrderFieldDueDate),
+		string(NonconformityRegistryOrderFieldStatus),
+		string(NonconformityRegistryOrderFieldReferenceId):
+		*p = NonconformityRegistryOrderField(val)
+		return nil
+	}
+	return fmt.Errorf("invalid NonconformityRegistryOrderField value: %q", val)
+}

--- a/pkg/coredata/nonconformity_registry_status.go
+++ b/pkg/coredata/nonconformity_registry_status.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+type NonconformityRegistryStatus string
+
+const (
+	NonconformityRegistryStatusOpen       NonconformityRegistryStatus = "OPEN"
+	NonconformityRegistryStatusInProgress NonconformityRegistryStatus = "IN_PROGRESS"
+	NonconformityRegistryStatusClosed     NonconformityRegistryStatus = "CLOSED"
+)
+
+func (nrs NonconformityRegistryStatus) String() string {
+	return string(nrs)
+}
+
+func (nrs *NonconformityRegistryStatus) Scan(value any) error {
+	var s string
+	switch v := value.(type) {
+	case string:
+		s = v
+	case []byte:
+		s = string(v)
+	default:
+		return fmt.Errorf("unsupported type for NonconformityRegistryStatus: %T", value)
+	}
+
+	switch s {
+	case "OPEN":
+		*nrs = NonconformityRegistryStatusOpen
+	case "IN_PROGRESS":
+		*nrs = NonconformityRegistryStatusInProgress
+	case "CLOSED":
+		*nrs = NonconformityRegistryStatusClosed
+	default:
+		return fmt.Errorf("invalid NonconformityRegistryStatus value: %q", s)
+	}
+	return nil
+}
+
+func (nrs NonconformityRegistryStatus) Value() (driver.Value, error) {
+	return nrs.String(), nil
+}

--- a/pkg/probo/nonconformity_registry_service.go
+++ b/pkg/probo/nonconformity_registry_service.go
@@ -1,0 +1,270 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package probo
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+	"go.gearno.de/kit/pg"
+)
+
+type NonconformityRegistryService struct {
+	svc *TenantService
+}
+
+type (
+	CreateNonconformityRegistryRequest struct {
+		OrganizationID     gid.GID
+		ReferenceID        string
+		Description        *string
+		AuditID            gid.GID
+		DateIdentified     *time.Time
+		RootCause          string
+		CorrectiveAction   *string
+		OwnerID            gid.GID
+		DueDate            *time.Time
+		Status             *coredata.NonconformityRegistryStatus
+		EffectivenessCheck *string
+	}
+
+	UpdateNonconformityRegistryRequest struct {
+		ID                 gid.GID
+		ReferenceID        *string
+		Description        **string
+		DateIdentified     **time.Time
+		RootCause          *string
+		CorrectiveAction   **string
+		OwnerID            *gid.GID
+		AuditID            *gid.GID
+		DueDate            **time.Time
+		Status             *coredata.NonconformityRegistryStatus
+		EffectivenessCheck **string
+	}
+)
+
+func (s NonconformityRegistryService) Get(
+	ctx context.Context,
+	nonconformityRegistryID gid.GID,
+) (*coredata.NonconformityRegistry, error) {
+	registry := &coredata.NonconformityRegistry{}
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			return registry.LoadByID(ctx, conn, s.svc.scope, nonconformityRegistryID)
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return registry, nil
+}
+
+func (s *NonconformityRegistryService) Create(
+	ctx context.Context,
+	req *CreateNonconformityRegistryRequest,
+) (*coredata.NonconformityRegistry, error) {
+	now := time.Now()
+
+	registry := &coredata.NonconformityRegistry{
+		ID:                 gid.New(s.svc.scope.GetTenantID(), coredata.NonconformityRegistryEntityType),
+		OrganizationID:     req.OrganizationID,
+		ReferenceID:        req.ReferenceID,
+		Description:        req.Description,
+		AuditID:            req.AuditID,
+		DateIdentified:     req.DateIdentified,
+		RootCause:          req.RootCause,
+		CorrectiveAction:   req.CorrectiveAction,
+		OwnerID:            req.OwnerID,
+		DueDate:            req.DueDate,
+		Status:             coredata.NonconformityRegistryStatusOpen,
+		EffectivenessCheck: req.EffectivenessCheck,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+
+	if req.Status != nil {
+		registry.Status = *req.Status
+	}
+
+	err := s.svc.pg.WithTx(
+		ctx,
+		func(conn pg.Conn) error {
+			organization := &coredata.Organization{}
+			if err := organization.LoadByID(ctx, conn, s.svc.scope, req.OrganizationID); err != nil {
+				return fmt.Errorf("cannot load organization: %w", err)
+			}
+
+			audit := &coredata.Audit{}
+			if err := audit.LoadByID(ctx, conn, s.svc.scope, req.AuditID); err != nil {
+				return fmt.Errorf("cannot load audit: %w", err)
+			}
+
+			people := &coredata.People{}
+			if err := people.LoadByID(ctx, conn, s.svc.scope, req.OwnerID); err != nil {
+				return fmt.Errorf("cannot load owner: %w", err)
+			}
+
+			if err := registry.Insert(ctx, conn, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot insert nonconformity registry: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return registry, nil
+}
+
+func (s *NonconformityRegistryService) Update(
+	ctx context.Context,
+	req *UpdateNonconformityRegistryRequest,
+) (*coredata.NonconformityRegistry, error) {
+	registry := &coredata.NonconformityRegistry{}
+
+	err := s.svc.pg.WithTx(
+		ctx,
+		func(conn pg.Conn) error {
+			if err := registry.LoadByID(ctx, conn, s.svc.scope, req.ID); err != nil {
+				return fmt.Errorf("cannot load nonconformity registry: %w", err)
+			}
+
+			if req.ReferenceID != nil {
+				registry.ReferenceID = *req.ReferenceID
+			}
+			if req.Description != nil {
+				registry.Description = *req.Description
+			}
+			if req.DateIdentified != nil {
+				registry.DateIdentified = *req.DateIdentified
+			}
+			if req.RootCause != nil {
+				registry.RootCause = *req.RootCause
+			}
+			if req.CorrectiveAction != nil {
+				registry.CorrectiveAction = *req.CorrectiveAction
+			}
+			if req.OwnerID != nil {
+				registry.OwnerID = *req.OwnerID
+			}
+			if req.AuditID != nil {
+				registry.AuditID = *req.AuditID
+			}
+			if req.DueDate != nil {
+				registry.DueDate = *req.DueDate
+			}
+			if req.Status != nil {
+				registry.Status = *req.Status
+			}
+			if req.EffectivenessCheck != nil {
+				registry.EffectivenessCheck = *req.EffectivenessCheck
+			}
+
+			registry.UpdatedAt = time.Now()
+
+			if err := registry.Update(ctx, conn, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot update nonconformity registry: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return registry, nil
+}
+
+func (s NonconformityRegistryService) Delete(
+	ctx context.Context,
+	nonconformityRegistryID gid.GID,
+) error {
+	registry := coredata.NonconformityRegistry{ID: nonconformityRegistryID}
+	return s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			err := registry.Delete(ctx, conn, s.svc.scope)
+			if err != nil {
+				return fmt.Errorf("cannot delete nonconformity registry: %w", err)
+			}
+			return nil
+		},
+	)
+}
+
+func (s NonconformityRegistryService) ListForOrganizationID(
+	ctx context.Context,
+	organizationID gid.GID,
+	cursor *page.Cursor[coredata.NonconformityRegistryOrderField],
+) (*page.Page[*coredata.NonconformityRegistry, coredata.NonconformityRegistryOrderField], error) {
+	var registries coredata.NonconformityRegistries
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			err := registries.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID, cursor)
+			if err != nil {
+				return fmt.Errorf("cannot load nonconformity registries: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return page.NewPage(registries, cursor), nil
+}
+
+func (s NonconformityRegistryService) CountForOrganizationID(
+	ctx context.Context,
+	organizationID gid.GID,
+) (int, error) {
+	var count int
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) (err error) {
+			registries := coredata.NonconformityRegistries{}
+			count, err = registries.CountByOrganizationID(ctx, conn, s.svc.scope, organizationID)
+			if err != nil {
+				return fmt.Errorf("cannot count nonconformity registries: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}

--- a/pkg/probo/service.go
+++ b/pkg/probo/service.go
@@ -81,6 +81,7 @@ type (
 		Reports                           *ReportService
 		TrustCenters                      *TrustCenterService
 		TrustCenterAccesses               *TrustCenterAccessService
+		NonconformityRegistries           *NonconformityRegistryService
 	}
 )
 
@@ -173,5 +174,6 @@ func (s *Service) WithTenant(tenantID gid.TenantID) *TenantService {
 		svc:    tenantService,
 		usrmgr: s.usrmgr,
 	}
+	tenantService.NonconformityRegistries = &NonconformityRegistryService{svc: tenantService}
 	return tenantService
 }

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -151,6 +151,22 @@ enum AuditState
     )
 }
 
+enum NonconformityRegistryStatus
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.NonconformityRegistryStatus") {
+  OPEN
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.NonconformityRegistryStatusOpen"
+    )
+  IN_PROGRESS
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.NonconformityRegistryStatusInProgress"
+    )
+  CLOSED
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.NonconformityRegistryStatusClosed"
+    )
+}
+
 # Order Field Enums
 enum UserOrderField
   @goModel(model: "github.com/getprobo/probo/pkg/coredata.UserOrderField") {
@@ -584,6 +600,30 @@ enum AuditOrderField
     )
 }
 
+enum NonconformityRegistryOrderField
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.NonconformityRegistryOrderField") {
+  CREATED_AT
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.NonconformityRegistryOrderFieldCreatedAt"
+    )
+  REFERENCE_ID
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.NonconformityRegistryOrderFieldReferenceId"
+    )
+  DATE_IDENTIFIED
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.NonconformityRegistryOrderFieldDateIdentified"
+    )
+  DUE_DATE
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.NonconformityRegistryOrderFieldDueDate"
+    )
+  STATUS
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.NonconformityRegistryOrderFieldStatus"
+    )
+}
+
 enum TrustCenterAccessOrderField
   @goModel(model: "github.com/getprobo/probo/pkg/coredata.TrustCenterAccessOrderField") {
   CREATED_AT
@@ -671,6 +711,14 @@ input AuditOrder
   ) {
   direction: OrderDirection!
   field: AuditOrderField!
+}
+
+input NonconformityRegistryOrder
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.NonconformityRegistryOrderBy"
+  ) {
+  direction: OrderDirection!
+  field: NonconformityRegistryOrderField!
 }
 
 input TrustCenterAccessOrder
@@ -887,6 +935,14 @@ type Organization implements Node {
     before: CursorKey
     orderBy: AuditOrder
   ): AuditConnection! @goField(forceResolver: true)
+
+  nonconformityRegistries(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+    orderBy: NonconformityRegistryOrder
+  ): NonconformityRegistryConnection! @goField(forceResolver: true)
 
   trustCenter: TrustCenter @goField(forceResolver: true)
 
@@ -1280,6 +1336,23 @@ type Audit implements Node {
   updatedAt: Datetime!
 }
 
+type NonconformityRegistry implements Node {
+  id: ID!
+  organization: Organization! @goField(forceResolver: true)
+  referenceId: String!
+  description: String
+  audit: Audit! @goField(forceResolver: true)
+  dateIdentified: Datetime
+  rootCause: String!
+  correctiveAction: String
+  owner: People! @goField(forceResolver: true)
+  dueDate: Datetime
+  status: NonconformityRegistryStatus!
+  effectivenessCheck: String
+  createdAt: Datetime!
+  updatedAt: Datetime!
+}
+
 type Report implements Node {
   id: ID!
   objectKey: String!
@@ -1563,6 +1636,20 @@ type AuditEdge {
   node: Audit!
 }
 
+type NonconformityRegistryConnection
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.NonconformityRegistryConnection"
+  ) {
+  totalCount: Int! @goField(forceResolver: true)
+  edges: [NonconformityRegistryEdge!]!
+  pageInfo: PageInfo!
+}
+
+type NonconformityRegistryEdge {
+  cursor: CursorKey!
+  node: NonconformityRegistry!
+}
+
 # Root Types
 type Query {
   node(id: ID!): Node!
@@ -1782,6 +1869,17 @@ type Mutation {
   deleteAudit(input: DeleteAuditInput!): DeleteAuditPayload!
   uploadAuditReport(input: UploadAuditReportInput!): UploadAuditReportPayload!
   deleteAuditReport(input: DeleteAuditReportInput!): DeleteAuditReportPayload!
+
+  # Nonconformity Registry mutations
+  createNonconformityRegistry(
+    input: CreateNonconformityRegistryInput!
+  ): CreateNonconformityRegistryPayload!
+  updateNonconformityRegistry(
+    input: UpdateNonconformityRegistryInput!
+  ): UpdateNonconformityRegistryPayload!
+  deleteNonconformityRegistry(
+    input: DeleteNonconformityRegistryInput!
+  ): DeleteNonconformityRegistryPayload!
 }
 
 # Input Types
@@ -2241,6 +2339,39 @@ input UploadAuditReportInput {
 
 input DeleteAuditReportInput {
   auditId: ID!
+}
+
+# Nonconformity Registry input types
+input CreateNonconformityRegistryInput {
+  organizationId: ID!
+  referenceId: String!
+  description: String
+  auditId: ID!
+  dateIdentified: Datetime
+  rootCause: String!
+  correctiveAction: String
+  ownerId: ID!
+  dueDate: Datetime
+  status: NonconformityRegistryStatus!
+  effectivenessCheck: String
+}
+
+input UpdateNonconformityRegistryInput {
+  id: ID!
+  referenceId: String
+  description: String
+  dateIdentified: Datetime
+  rootCause: String
+  correctiveAction: String
+  ownerId: ID
+  auditId: ID
+  dueDate: Datetime
+  status: NonconformityRegistryStatus
+  effectivenessCheck: String
+}
+
+input DeleteNonconformityRegistryInput {
+  nonconformityRegistryId: ID!
 }
 
 # Payload Types
@@ -2910,4 +3041,17 @@ type UploadAuditReportPayload {
 
 type DeleteAuditReportPayload {
   audit: Audit!
+}
+
+# Nonconformity Registry payload types
+type CreateNonconformityRegistryPayload {
+  nonconformityRegistryEdge: NonconformityRegistryEdge!
+}
+
+type UpdateNonconformityRegistryPayload {
+  nonconformityRegistry: NonconformityRegistry!
+}
+
+type DeleteNonconformityRegistryPayload {
+  deletedNonconformityRegistryId: ID!
 }

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -63,6 +63,8 @@ type ResolverRoot interface {
 	Measure() MeasureResolver
 	MeasureConnection() MeasureConnectionResolver
 	Mutation() MutationResolver
+	NonconformityRegistry() NonconformityRegistryResolver
+	NonconformityRegistryConnection() NonconformityRegistryConnectionResolver
 	Organization() OrganizationResolver
 	PeopleConnection() PeopleConnectionResolver
 	Query() QueryResolver
@@ -260,6 +262,10 @@ type ComplexityRoot struct {
 		MeasureEdge func(childComplexity int) int
 	}
 
+	CreateNonconformityRegistryPayload struct {
+		NonconformityRegistryEdge func(childComplexity int) int
+	}
+
 	CreateOrganizationPayload struct {
 		OrganizationEdge func(childComplexity int) int
 	}
@@ -377,6 +383,10 @@ type ComplexityRoot struct {
 
 	DeleteMeasurePayload struct {
 		DeletedMeasureID func(childComplexity int) int
+	}
+
+	DeleteNonconformityRegistryPayload struct {
+		DeletedNonconformityRegistryID func(childComplexity int) int
 	}
 
 	DeleteOrganizationPayload struct {
@@ -622,6 +632,7 @@ type ComplexityRoot struct {
 		CreateDraftDocumentVersion             func(childComplexity int, input types.CreateDraftDocumentVersionInput) int
 		CreateFramework                        func(childComplexity int, input types.CreateFrameworkInput) int
 		CreateMeasure                          func(childComplexity int, input types.CreateMeasureInput) int
+		CreateNonconformityRegistry            func(childComplexity int, input types.CreateNonconformityRegistryInput) int
 		CreateOrganization                     func(childComplexity int, input types.CreateOrganizationInput) int
 		CreatePeople                           func(childComplexity int, input types.CreatePeopleInput) int
 		CreateRisk                             func(childComplexity int, input types.CreateRiskInput) int
@@ -645,6 +656,7 @@ type ComplexityRoot struct {
 		DeleteEvidence                         func(childComplexity int, input types.DeleteEvidenceInput) int
 		DeleteFramework                        func(childComplexity int, input types.DeleteFrameworkInput) int
 		DeleteMeasure                          func(childComplexity int, input types.DeleteMeasureInput) int
+		DeleteNonconformityRegistry            func(childComplexity int, input types.DeleteNonconformityRegistryInput) int
 		DeleteOrganization                     func(childComplexity int, input types.DeleteOrganizationInput) int
 		DeletePeople                           func(childComplexity int, input types.DeletePeopleInput) int
 		DeleteRisk                             func(childComplexity int, input types.DeleteRiskInput) int
@@ -678,6 +690,7 @@ type ComplexityRoot struct {
 		UpdateDocumentVersion                  func(childComplexity int, input types.UpdateDocumentVersionInput) int
 		UpdateFramework                        func(childComplexity int, input types.UpdateFrameworkInput) int
 		UpdateMeasure                          func(childComplexity int, input types.UpdateMeasureInput) int
+		UpdateNonconformityRegistry            func(childComplexity int, input types.UpdateNonconformityRegistryInput) int
 		UpdateOrganization                     func(childComplexity int, input types.UpdateOrganizationInput) int
 		UpdatePeople                           func(childComplexity int, input types.UpdatePeopleInput) int
 		UpdateRisk                             func(childComplexity int, input types.UpdateRiskInput) int
@@ -695,26 +708,55 @@ type ComplexityRoot struct {
 		UploadVendorDataPrivacyAgreement       func(childComplexity int, input types.UploadVendorDataPrivacyAgreementInput) int
 	}
 
+	NonconformityRegistry struct {
+		Audit              func(childComplexity int) int
+		CorrectiveAction   func(childComplexity int) int
+		CreatedAt          func(childComplexity int) int
+		DateIdentified     func(childComplexity int) int
+		Description        func(childComplexity int) int
+		DueDate            func(childComplexity int) int
+		EffectivenessCheck func(childComplexity int) int
+		ID                 func(childComplexity int) int
+		Organization       func(childComplexity int) int
+		Owner              func(childComplexity int) int
+		ReferenceID        func(childComplexity int) int
+		RootCause          func(childComplexity int) int
+		Status             func(childComplexity int) int
+		UpdatedAt          func(childComplexity int) int
+	}
+
+	NonconformityRegistryConnection struct {
+		Edges      func(childComplexity int) int
+		PageInfo   func(childComplexity int) int
+		TotalCount func(childComplexity int) int
+	}
+
+	NonconformityRegistryEdge struct {
+		Cursor func(childComplexity int) int
+		Node   func(childComplexity int) int
+	}
+
 	Organization struct {
-		Assets      func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AssetOrderBy) int
-		Audits      func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AuditOrderBy) int
-		Connectors  func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ConnectorOrder) int
-		Controls    func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ControlOrderBy, filter *types.ControlFilter) int
-		CreatedAt   func(childComplexity int) int
-		Data        func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DatumOrderBy) int
-		Documents   func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy, filter *types.DocumentFilter) int
-		Frameworks  func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.FrameworkOrderBy) int
-		ID          func(childComplexity int) int
-		LogoURL     func(childComplexity int) int
-		Measures    func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy, filter *types.MeasureFilter) int
-		Name        func(childComplexity int) int
-		Peoples     func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.PeopleOrderBy, filter *types.PeopleFilter) int
-		Risks       func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskOrderBy, filter *types.RiskFilter) int
-		Tasks       func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TaskOrderBy) int
-		TrustCenter func(childComplexity int) int
-		UpdatedAt   func(childComplexity int) int
-		Users       func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.UserOrderBy) int
-		Vendors     func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.VendorOrderBy) int
+		Assets                  func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AssetOrderBy) int
+		Audits                  func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AuditOrderBy) int
+		Connectors              func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ConnectorOrder) int
+		Controls                func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ControlOrderBy, filter *types.ControlFilter) int
+		CreatedAt               func(childComplexity int) int
+		Data                    func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DatumOrderBy) int
+		Documents               func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy, filter *types.DocumentFilter) int
+		Frameworks              func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.FrameworkOrderBy) int
+		ID                      func(childComplexity int) int
+		LogoURL                 func(childComplexity int) int
+		Measures                func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy, filter *types.MeasureFilter) int
+		Name                    func(childComplexity int) int
+		NonconformityRegistries func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.NonconformityRegistryOrderBy) int
+		Peoples                 func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.PeopleOrderBy, filter *types.PeopleFilter) int
+		Risks                   func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskOrderBy, filter *types.RiskFilter) int
+		Tasks                   func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TaskOrderBy) int
+		TrustCenter             func(childComplexity int) int
+		UpdatedAt               func(childComplexity int) int
+		Users                   func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.UserOrderBy) int
+		Vendors                 func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.VendorOrderBy) int
 	}
 
 	OrganizationConnection struct {
@@ -932,6 +974,10 @@ type ComplexityRoot struct {
 
 	UpdateMeasurePayload struct {
 		Measure func(childComplexity int) int
+	}
+
+	UpdateNonconformityRegistryPayload struct {
+		NonconformityRegistry func(childComplexity int) int
 	}
 
 	UpdateOrganizationPayload struct {
@@ -1329,6 +1375,19 @@ type MutationResolver interface {
 	DeleteAudit(ctx context.Context, input types.DeleteAuditInput) (*types.DeleteAuditPayload, error)
 	UploadAuditReport(ctx context.Context, input types.UploadAuditReportInput) (*types.UploadAuditReportPayload, error)
 	DeleteAuditReport(ctx context.Context, input types.DeleteAuditReportInput) (*types.DeleteAuditReportPayload, error)
+	CreateNonconformityRegistry(ctx context.Context, input types.CreateNonconformityRegistryInput) (*types.CreateNonconformityRegistryPayload, error)
+	UpdateNonconformityRegistry(ctx context.Context, input types.UpdateNonconformityRegistryInput) (*types.UpdateNonconformityRegistryPayload, error)
+	DeleteNonconformityRegistry(ctx context.Context, input types.DeleteNonconformityRegistryInput) (*types.DeleteNonconformityRegistryPayload, error)
+}
+type NonconformityRegistryResolver interface {
+	Organization(ctx context.Context, obj *types.NonconformityRegistry) (*types.Organization, error)
+
+	Audit(ctx context.Context, obj *types.NonconformityRegistry) (*types.Audit, error)
+
+	Owner(ctx context.Context, obj *types.NonconformityRegistry) (*types.People, error)
+}
+type NonconformityRegistryConnectionResolver interface {
+	TotalCount(ctx context.Context, obj *types.NonconformityRegistryConnection) (int, error)
 }
 type OrganizationResolver interface {
 	LogoURL(ctx context.Context, obj *types.Organization) (*string, error)
@@ -1345,6 +1404,7 @@ type OrganizationResolver interface {
 	Assets(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AssetOrderBy) (*types.AssetConnection, error)
 	Data(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DatumOrderBy) (*types.DatumConnection, error)
 	Audits(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AuditOrderBy) (*types.AuditConnection, error)
+	NonconformityRegistries(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.NonconformityRegistryOrderBy) (*types.NonconformityRegistryConnection, error)
 	TrustCenter(ctx context.Context, obj *types.Organization) (*types.TrustCenter, error)
 }
 type PeopleConnectionResolver interface {
@@ -2049,6 +2109,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.CreateMeasurePayload.MeasureEdge(childComplexity), true
 
+	case "CreateNonconformityRegistryPayload.nonconformityRegistryEdge":
+		if e.complexity.CreateNonconformityRegistryPayload.NonconformityRegistryEdge == nil {
+			break
+		}
+
+		return e.complexity.CreateNonconformityRegistryPayload.NonconformityRegistryEdge(childComplexity), true
+
 	case "CreateOrganizationPayload.organizationEdge":
 		if e.complexity.CreateOrganizationPayload.OrganizationEdge == nil {
 			break
@@ -2340,6 +2407,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.DeleteMeasurePayload.DeletedMeasureID(childComplexity), true
+
+	case "DeleteNonconformityRegistryPayload.deletedNonconformityRegistryId":
+		if e.complexity.DeleteNonconformityRegistryPayload.DeletedNonconformityRegistryID == nil {
+			break
+		}
+
+		return e.complexity.DeleteNonconformityRegistryPayload.DeletedNonconformityRegistryID(childComplexity), true
 
 	case "DeleteOrganizationPayload.deletedOrganizationId":
 		if e.complexity.DeleteOrganizationPayload.DeletedOrganizationID == nil {
@@ -3383,6 +3457,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.CreateMeasure(childComplexity, args["input"].(types.CreateMeasureInput)), true
 
+	case "Mutation.createNonconformityRegistry":
+		if e.complexity.Mutation.CreateNonconformityRegistry == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_createNonconformityRegistry_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreateNonconformityRegistry(childComplexity, args["input"].(types.CreateNonconformityRegistryInput)), true
+
 	case "Mutation.createOrganization":
 		if e.complexity.Mutation.CreateOrganization == nil {
 			break
@@ -3658,6 +3744,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.DeleteMeasure(childComplexity, args["input"].(types.DeleteMeasureInput)), true
+
+	case "Mutation.deleteNonconformityRegistry":
+		if e.complexity.Mutation.DeleteNonconformityRegistry == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_deleteNonconformityRegistry_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteNonconformityRegistry(childComplexity, args["input"].(types.DeleteNonconformityRegistryInput)), true
 
 	case "Mutation.deleteOrganization":
 		if e.complexity.Mutation.DeleteOrganization == nil {
@@ -4055,6 +4153,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.UpdateMeasure(childComplexity, args["input"].(types.UpdateMeasureInput)), true
 
+	case "Mutation.updateNonconformityRegistry":
+		if e.complexity.Mutation.UpdateNonconformityRegistry == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_updateNonconformityRegistry_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UpdateNonconformityRegistry(childComplexity, args["input"].(types.UpdateNonconformityRegistryInput)), true
+
 	case "Mutation.updateOrganization":
 		if e.complexity.Mutation.UpdateOrganization == nil {
 			break
@@ -4235,6 +4345,139 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.UploadVendorDataPrivacyAgreement(childComplexity, args["input"].(types.UploadVendorDataPrivacyAgreementInput)), true
 
+	case "NonconformityRegistry.audit":
+		if e.complexity.NonconformityRegistry.Audit == nil {
+			break
+		}
+
+		return e.complexity.NonconformityRegistry.Audit(childComplexity), true
+
+	case "NonconformityRegistry.correctiveAction":
+		if e.complexity.NonconformityRegistry.CorrectiveAction == nil {
+			break
+		}
+
+		return e.complexity.NonconformityRegistry.CorrectiveAction(childComplexity), true
+
+	case "NonconformityRegistry.createdAt":
+		if e.complexity.NonconformityRegistry.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.NonconformityRegistry.CreatedAt(childComplexity), true
+
+	case "NonconformityRegistry.dateIdentified":
+		if e.complexity.NonconformityRegistry.DateIdentified == nil {
+			break
+		}
+
+		return e.complexity.NonconformityRegistry.DateIdentified(childComplexity), true
+
+	case "NonconformityRegistry.description":
+		if e.complexity.NonconformityRegistry.Description == nil {
+			break
+		}
+
+		return e.complexity.NonconformityRegistry.Description(childComplexity), true
+
+	case "NonconformityRegistry.dueDate":
+		if e.complexity.NonconformityRegistry.DueDate == nil {
+			break
+		}
+
+		return e.complexity.NonconformityRegistry.DueDate(childComplexity), true
+
+	case "NonconformityRegistry.effectivenessCheck":
+		if e.complexity.NonconformityRegistry.EffectivenessCheck == nil {
+			break
+		}
+
+		return e.complexity.NonconformityRegistry.EffectivenessCheck(childComplexity), true
+
+	case "NonconformityRegistry.id":
+		if e.complexity.NonconformityRegistry.ID == nil {
+			break
+		}
+
+		return e.complexity.NonconformityRegistry.ID(childComplexity), true
+
+	case "NonconformityRegistry.organization":
+		if e.complexity.NonconformityRegistry.Organization == nil {
+			break
+		}
+
+		return e.complexity.NonconformityRegistry.Organization(childComplexity), true
+
+	case "NonconformityRegistry.owner":
+		if e.complexity.NonconformityRegistry.Owner == nil {
+			break
+		}
+
+		return e.complexity.NonconformityRegistry.Owner(childComplexity), true
+
+	case "NonconformityRegistry.referenceId":
+		if e.complexity.NonconformityRegistry.ReferenceID == nil {
+			break
+		}
+
+		return e.complexity.NonconformityRegistry.ReferenceID(childComplexity), true
+
+	case "NonconformityRegistry.rootCause":
+		if e.complexity.NonconformityRegistry.RootCause == nil {
+			break
+		}
+
+		return e.complexity.NonconformityRegistry.RootCause(childComplexity), true
+
+	case "NonconformityRegistry.status":
+		if e.complexity.NonconformityRegistry.Status == nil {
+			break
+		}
+
+		return e.complexity.NonconformityRegistry.Status(childComplexity), true
+
+	case "NonconformityRegistry.updatedAt":
+		if e.complexity.NonconformityRegistry.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.NonconformityRegistry.UpdatedAt(childComplexity), true
+
+	case "NonconformityRegistryConnection.edges":
+		if e.complexity.NonconformityRegistryConnection.Edges == nil {
+			break
+		}
+
+		return e.complexity.NonconformityRegistryConnection.Edges(childComplexity), true
+
+	case "NonconformityRegistryConnection.pageInfo":
+		if e.complexity.NonconformityRegistryConnection.PageInfo == nil {
+			break
+		}
+
+		return e.complexity.NonconformityRegistryConnection.PageInfo(childComplexity), true
+
+	case "NonconformityRegistryConnection.totalCount":
+		if e.complexity.NonconformityRegistryConnection.TotalCount == nil {
+			break
+		}
+
+		return e.complexity.NonconformityRegistryConnection.TotalCount(childComplexity), true
+
+	case "NonconformityRegistryEdge.cursor":
+		if e.complexity.NonconformityRegistryEdge.Cursor == nil {
+			break
+		}
+
+		return e.complexity.NonconformityRegistryEdge.Cursor(childComplexity), true
+
+	case "NonconformityRegistryEdge.node":
+		if e.complexity.NonconformityRegistryEdge.Node == nil {
+			break
+		}
+
+		return e.complexity.NonconformityRegistryEdge.Node(childComplexity), true
+
 	case "Organization.assets":
 		if e.complexity.Organization.Assets == nil {
 			break
@@ -4358,6 +4601,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Organization.Name(childComplexity), true
+
+	case "Organization.nonconformityRegistries":
+		if e.complexity.Organization.NonconformityRegistries == nil {
+			break
+		}
+
+		args, err := ec.field_Organization_nonconformityRegistries_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.NonconformityRegistries(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.NonconformityRegistryOrderBy)), true
 
 	case "Organization.peoples":
 		if e.complexity.Organization.Peoples == nil {
@@ -5252,6 +5507,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.UpdateMeasurePayload.Measure(childComplexity), true
 
+	case "UpdateNonconformityRegistryPayload.nonconformityRegistry":
+		if e.complexity.UpdateNonconformityRegistryPayload.NonconformityRegistry == nil {
+			break
+		}
+
+		return e.complexity.UpdateNonconformityRegistryPayload.NonconformityRegistry(childComplexity), true
+
 	case "UpdateOrganizationPayload.organization":
 		if e.complexity.UpdateOrganizationPayload.Organization == nil {
 			break
@@ -6134,6 +6396,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputCreateEvidenceInput,
 		ec.unmarshalInputCreateFrameworkInput,
 		ec.unmarshalInputCreateMeasureInput,
+		ec.unmarshalInputCreateNonconformityRegistryInput,
 		ec.unmarshalInputCreateOrganizationInput,
 		ec.unmarshalInputCreatePeopleInput,
 		ec.unmarshalInputCreateRiskDocumentMappingInput,
@@ -6158,6 +6421,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputDeleteEvidenceInput,
 		ec.unmarshalInputDeleteFrameworkInput,
 		ec.unmarshalInputDeleteMeasureInput,
+		ec.unmarshalInputDeleteNonconformityRegistryInput,
 		ec.unmarshalInputDeleteOrganizationInput,
 		ec.unmarshalInputDeletePeopleInput,
 		ec.unmarshalInputDeleteRiskDocumentMappingInput,
@@ -6186,6 +6450,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputInviteUserInput,
 		ec.unmarshalInputMeasureFilter,
 		ec.unmarshalInputMeasureOrder,
+		ec.unmarshalInputNonconformityRegistryOrder,
 		ec.unmarshalInputOrganizationFilter,
 		ec.unmarshalInputOrganizationOrder,
 		ec.unmarshalInputPeopleFilter,
@@ -6209,6 +6474,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputUpdateDocumentVersionInput,
 		ec.unmarshalInputUpdateFrameworkInput,
 		ec.unmarshalInputUpdateMeasureInput,
+		ec.unmarshalInputUpdateNonconformityRegistryInput,
 		ec.unmarshalInputUpdateOrganizationInput,
 		ec.unmarshalInputUpdatePeopleInput,
 		ec.unmarshalInputUpdateRiskInput,
@@ -6476,6 +6742,22 @@ enum AuditState
   OUTDATED
     @goEnum(
       value: "github.com/getprobo/probo/pkg/coredata.AuditStateOutdated"
+    )
+}
+
+enum NonconformityRegistryStatus
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.NonconformityRegistryStatus") {
+  OPEN
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.NonconformityRegistryStatusOpen"
+    )
+  IN_PROGRESS
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.NonconformityRegistryStatusInProgress"
+    )
+  CLOSED
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.NonconformityRegistryStatusClosed"
     )
 }
 
@@ -6912,6 +7194,30 @@ enum AuditOrderField
     )
 }
 
+enum NonconformityRegistryOrderField
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.NonconformityRegistryOrderField") {
+  CREATED_AT
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.NonconformityRegistryOrderFieldCreatedAt"
+    )
+  REFERENCE_ID
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.NonconformityRegistryOrderFieldReferenceId"
+    )
+  DATE_IDENTIFIED
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.NonconformityRegistryOrderFieldDateIdentified"
+    )
+  DUE_DATE
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.NonconformityRegistryOrderFieldDueDate"
+    )
+  STATUS
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.NonconformityRegistryOrderFieldStatus"
+    )
+}
+
 enum TrustCenterAccessOrderField
   @goModel(model: "github.com/getprobo/probo/pkg/coredata.TrustCenterAccessOrderField") {
   CREATED_AT
@@ -6999,6 +7305,14 @@ input AuditOrder
   ) {
   direction: OrderDirection!
   field: AuditOrderField!
+}
+
+input NonconformityRegistryOrder
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.NonconformityRegistryOrderBy"
+  ) {
+  direction: OrderDirection!
+  field: NonconformityRegistryOrderField!
 }
 
 input TrustCenterAccessOrder
@@ -7215,6 +7529,14 @@ type Organization implements Node {
     before: CursorKey
     orderBy: AuditOrder
   ): AuditConnection! @goField(forceResolver: true)
+
+  nonconformityRegistries(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+    orderBy: NonconformityRegistryOrder
+  ): NonconformityRegistryConnection! @goField(forceResolver: true)
 
   trustCenter: TrustCenter @goField(forceResolver: true)
 
@@ -7608,6 +7930,23 @@ type Audit implements Node {
   updatedAt: Datetime!
 }
 
+type NonconformityRegistry implements Node {
+  id: ID!
+  organization: Organization! @goField(forceResolver: true)
+  referenceId: String!
+  description: String
+  audit: Audit! @goField(forceResolver: true)
+  dateIdentified: Datetime
+  rootCause: String!
+  correctiveAction: String
+  owner: People! @goField(forceResolver: true)
+  dueDate: Datetime
+  status: NonconformityRegistryStatus!
+  effectivenessCheck: String
+  createdAt: Datetime!
+  updatedAt: Datetime!
+}
+
 type Report implements Node {
   id: ID!
   objectKey: String!
@@ -7891,6 +8230,20 @@ type AuditEdge {
   node: Audit!
 }
 
+type NonconformityRegistryConnection
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.NonconformityRegistryConnection"
+  ) {
+  totalCount: Int! @goField(forceResolver: true)
+  edges: [NonconformityRegistryEdge!]!
+  pageInfo: PageInfo!
+}
+
+type NonconformityRegistryEdge {
+  cursor: CursorKey!
+  node: NonconformityRegistry!
+}
+
 # Root Types
 type Query {
   node(id: ID!): Node!
@@ -8110,6 +8463,17 @@ type Mutation {
   deleteAudit(input: DeleteAuditInput!): DeleteAuditPayload!
   uploadAuditReport(input: UploadAuditReportInput!): UploadAuditReportPayload!
   deleteAuditReport(input: DeleteAuditReportInput!): DeleteAuditReportPayload!
+
+  # Nonconformity Registry mutations
+  createNonconformityRegistry(
+    input: CreateNonconformityRegistryInput!
+  ): CreateNonconformityRegistryPayload!
+  updateNonconformityRegistry(
+    input: UpdateNonconformityRegistryInput!
+  ): UpdateNonconformityRegistryPayload!
+  deleteNonconformityRegistry(
+    input: DeleteNonconformityRegistryInput!
+  ): DeleteNonconformityRegistryPayload!
 }
 
 # Input Types
@@ -8569,6 +8933,39 @@ input UploadAuditReportInput {
 
 input DeleteAuditReportInput {
   auditId: ID!
+}
+
+# Nonconformity Registry input types
+input CreateNonconformityRegistryInput {
+  organizationId: ID!
+  referenceId: String!
+  description: String
+  auditId: ID!
+  dateIdentified: Datetime
+  rootCause: String!
+  correctiveAction: String
+  ownerId: ID!
+  dueDate: Datetime
+  status: NonconformityRegistryStatus!
+  effectivenessCheck: String
+}
+
+input UpdateNonconformityRegistryInput {
+  id: ID!
+  referenceId: String
+  description: String
+  dateIdentified: Datetime
+  rootCause: String
+  correctiveAction: String
+  ownerId: ID
+  auditId: ID
+  dueDate: Datetime
+  status: NonconformityRegistryStatus
+  effectivenessCheck: String
+}
+
+input DeleteNonconformityRegistryInput {
+  nonconformityRegistryId: ID!
 }
 
 # Payload Types
@@ -9238,6 +9635,19 @@ type UploadAuditReportPayload {
 
 type DeleteAuditReportPayload {
   audit: Audit!
+}
+
+# Nonconformity Registry payload types
+type CreateNonconformityRegistryPayload {
+  nonconformityRegistryEdge: NonconformityRegistryEdge!
+}
+
+type UpdateNonconformityRegistryPayload {
+  nonconformityRegistry: NonconformityRegistry!
+}
+
+type DeleteNonconformityRegistryPayload {
+  deletedNonconformityRegistryId: ID!
 }
 `, BuiltIn: false},
 }
@@ -11112,6 +11522,29 @@ func (ec *executionContext) field_Mutation_createMeasure_argsInput(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation_createNonconformityRegistry_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_createNonconformityRegistry_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_createNonconformityRegistry_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.CreateNonconformityRegistryInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNCreateNonconformityRegistryInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateNonconformityRegistryInput(ctx, tmp)
+	}
+
+	var zeroVal types.CreateNonconformityRegistryInput
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation_createOrganization_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -11638,6 +12071,29 @@ func (ec *executionContext) field_Mutation_deleteMeasure_argsInput(
 	}
 
 	var zeroVal types.DeleteMeasureInput
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_deleteNonconformityRegistry_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_deleteNonconformityRegistry_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_deleteNonconformityRegistry_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.DeleteNonconformityRegistryInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNDeleteNonconformityRegistryInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteNonconformityRegistryInput(ctx, tmp)
+	}
+
+	var zeroVal types.DeleteNonconformityRegistryInput
 	return zeroVal, nil
 }
 
@@ -12397,6 +12853,29 @@ func (ec *executionContext) field_Mutation_updateMeasure_argsInput(
 	}
 
 	var zeroVal types.UpdateMeasureInput
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_updateNonconformityRegistry_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_updateNonconformityRegistry_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_updateNonconformityRegistry_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.UpdateNonconformityRegistryInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNUpdateNonconformityRegistryInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateNonconformityRegistryInput(ctx, tmp)
+	}
+
+	var zeroVal types.UpdateNonconformityRegistryInput
 	return zeroVal, nil
 }
 
@@ -13556,6 +14035,101 @@ func (ec *executionContext) field_Organization_measures_argsFilter(
 	}
 
 	var zeroVal *types.MeasureFilter
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_nonconformityRegistries_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Organization_nonconformityRegistries_argsFirst(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["first"] = arg0
+	arg1, err := ec.field_Organization_nonconformityRegistries_argsAfter(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["after"] = arg1
+	arg2, err := ec.field_Organization_nonconformityRegistries_argsLast(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["last"] = arg2
+	arg3, err := ec.field_Organization_nonconformityRegistries_argsBefore(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["before"] = arg3
+	arg4, err := ec.field_Organization_nonconformityRegistries_argsOrderBy(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["orderBy"] = arg4
+	return args, nil
+}
+func (ec *executionContext) field_Organization_nonconformityRegistries_argsFirst(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*int, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("first"))
+	if tmp, ok := rawArgs["first"]; ok {
+		return ec.unmarshalOInt2ᚖint(ctx, tmp)
+	}
+
+	var zeroVal *int
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_nonconformityRegistries_argsAfter(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*page.CursorKey, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("after"))
+	if tmp, ok := rawArgs["after"]; ok {
+		return ec.unmarshalOCursorKey2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐCursorKey(ctx, tmp)
+	}
+
+	var zeroVal *page.CursorKey
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_nonconformityRegistries_argsLast(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*int, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("last"))
+	if tmp, ok := rawArgs["last"]; ok {
+		return ec.unmarshalOInt2ᚖint(ctx, tmp)
+	}
+
+	var zeroVal *int
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_nonconformityRegistries_argsBefore(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*page.CursorKey, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("before"))
+	if tmp, ok := rawArgs["before"]; ok {
+		return ec.unmarshalOCursorKey2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐCursorKey(ctx, tmp)
+	}
+
+	var zeroVal *page.CursorKey
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_nonconformityRegistries_argsOrderBy(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*types.NonconformityRegistryOrderBy, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("orderBy"))
+	if tmp, ok := rawArgs["orderBy"]; ok {
+		return ec.unmarshalONonconformityRegistryOrder2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐNonconformityRegistryOrderBy(ctx, tmp)
+	}
+
+	var zeroVal *types.NonconformityRegistryOrderBy
 	return zeroVal, nil
 }
 
@@ -15827,6 +16401,8 @@ func (ec *executionContext) fieldContext_Asset_organization(_ context.Context, f
 				return ec.fieldContext_Organization_data(ctx, field)
 			case "audits":
 				return ec.fieldContext_Organization_audits(ctx, field)
+			case "nonconformityRegistries":
+				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -16414,6 +16990,8 @@ func (ec *executionContext) fieldContext_Audit_organization(_ context.Context, f
 				return ec.fieldContext_Organization_data(ctx, field)
 			case "audits":
 				return ec.fieldContext_Organization_audits(ctx, field)
+			case "nonconformityRegistries":
+				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -19494,6 +20072,56 @@ func (ec *executionContext) fieldContext_CreateMeasurePayload_measureEdge(_ cont
 	return fc, nil
 }
 
+func (ec *executionContext) _CreateNonconformityRegistryPayload_nonconformityRegistryEdge(ctx context.Context, field graphql.CollectedField, obj *types.CreateNonconformityRegistryPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CreateNonconformityRegistryPayload_nonconformityRegistryEdge(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NonconformityRegistryEdge, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.NonconformityRegistryEdge)
+	fc.Result = res
+	return ec.marshalNNonconformityRegistryEdge2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐNonconformityRegistryEdge(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CreateNonconformityRegistryPayload_nonconformityRegistryEdge(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CreateNonconformityRegistryPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "cursor":
+				return ec.fieldContext_NonconformityRegistryEdge_cursor(ctx, field)
+			case "node":
+				return ec.fieldContext_NonconformityRegistryEdge_node(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type NonconformityRegistryEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _CreateOrganizationPayload_organizationEdge(ctx context.Context, field graphql.CollectedField, obj *types.CreateOrganizationPayload) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_CreateOrganizationPayload_organizationEdge(ctx, field)
 	if err != nil {
@@ -20426,6 +21054,8 @@ func (ec *executionContext) fieldContext_Datum_organization(_ context.Context, f
 				return ec.fieldContext_Organization_data(ctx, field)
 			case "audits":
 				return ec.fieldContext_Organization_audits(ctx, field)
+			case "nonconformityRegistries":
+				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -21513,6 +22143,50 @@ func (ec *executionContext) fieldContext_DeleteMeasurePayload_deletedMeasureId(_
 	return fc, nil
 }
 
+func (ec *executionContext) _DeleteNonconformityRegistryPayload_deletedNonconformityRegistryId(ctx context.Context, field graphql.CollectedField, obj *types.DeleteNonconformityRegistryPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DeleteNonconformityRegistryPayload_deletedNonconformityRegistryId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DeletedNonconformityRegistryID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(gid.GID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DeleteNonconformityRegistryPayload_deletedNonconformityRegistryId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DeleteNonconformityRegistryPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _DeleteOrganizationPayload_deletedOrganizationId(ctx context.Context, field graphql.CollectedField, obj *types.DeleteOrganizationPayload) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_DeleteOrganizationPayload_deletedOrganizationId(ctx, field)
 	if err != nil {
@@ -22527,6 +23201,8 @@ func (ec *executionContext) fieldContext_Document_organization(_ context.Context
 				return ec.fieldContext_Organization_data(ctx, field)
 			case "audits":
 				return ec.fieldContext_Organization_audits(ctx, field)
+			case "nonconformityRegistries":
+				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -25688,6 +26364,8 @@ func (ec *executionContext) fieldContext_Framework_organization(_ context.Contex
 				return ec.fieldContext_Organization_data(ctx, field)
 			case "audits":
 				return ec.fieldContext_Organization_audits(ctx, field)
+			case "nonconformityRegistries":
+				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -32424,6 +33102,1142 @@ func (ec *executionContext) fieldContext_Mutation_deleteAuditReport(ctx context.
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_createNonconformityRegistry(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_createNonconformityRegistry(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateNonconformityRegistry(rctx, fc.Args["input"].(types.CreateNonconformityRegistryInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.CreateNonconformityRegistryPayload)
+	fc.Result = res
+	return ec.marshalNCreateNonconformityRegistryPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateNonconformityRegistryPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_createNonconformityRegistry(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "nonconformityRegistryEdge":
+				return ec.fieldContext_CreateNonconformityRegistryPayload_nonconformityRegistryEdge(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CreateNonconformityRegistryPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_createNonconformityRegistry_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_updateNonconformityRegistry(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_updateNonconformityRegistry(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UpdateNonconformityRegistry(rctx, fc.Args["input"].(types.UpdateNonconformityRegistryInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.UpdateNonconformityRegistryPayload)
+	fc.Result = res
+	return ec.marshalNUpdateNonconformityRegistryPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateNonconformityRegistryPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_updateNonconformityRegistry(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "nonconformityRegistry":
+				return ec.fieldContext_UpdateNonconformityRegistryPayload_nonconformityRegistry(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UpdateNonconformityRegistryPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_updateNonconformityRegistry_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_deleteNonconformityRegistry(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_deleteNonconformityRegistry(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteNonconformityRegistry(rctx, fc.Args["input"].(types.DeleteNonconformityRegistryInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.DeleteNonconformityRegistryPayload)
+	fc.Result = res
+	return ec.marshalNDeleteNonconformityRegistryPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteNonconformityRegistryPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_deleteNonconformityRegistry(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "deletedNonconformityRegistryId":
+				return ec.fieldContext_DeleteNonconformityRegistryPayload_deletedNonconformityRegistryId(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DeleteNonconformityRegistryPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_deleteNonconformityRegistry_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _NonconformityRegistry_id(ctx context.Context, field graphql.CollectedField, obj *types.NonconformityRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NonconformityRegistry_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(gid.GID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NonconformityRegistry_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NonconformityRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _NonconformityRegistry_organization(ctx context.Context, field graphql.CollectedField, obj *types.NonconformityRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NonconformityRegistry_organization(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.NonconformityRegistry().Organization(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.Organization)
+	fc.Result = res
+	return ec.marshalNOrganization2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐOrganization(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NonconformityRegistry_organization(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NonconformityRegistry",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Organization_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Organization_name(ctx, field)
+			case "logoUrl":
+				return ec.fieldContext_Organization_logoUrl(ctx, field)
+			case "users":
+				return ec.fieldContext_Organization_users(ctx, field)
+			case "connectors":
+				return ec.fieldContext_Organization_connectors(ctx, field)
+			case "frameworks":
+				return ec.fieldContext_Organization_frameworks(ctx, field)
+			case "controls":
+				return ec.fieldContext_Organization_controls(ctx, field)
+			case "vendors":
+				return ec.fieldContext_Organization_vendors(ctx, field)
+			case "peoples":
+				return ec.fieldContext_Organization_peoples(ctx, field)
+			case "documents":
+				return ec.fieldContext_Organization_documents(ctx, field)
+			case "measures":
+				return ec.fieldContext_Organization_measures(ctx, field)
+			case "risks":
+				return ec.fieldContext_Organization_risks(ctx, field)
+			case "tasks":
+				return ec.fieldContext_Organization_tasks(ctx, field)
+			case "assets":
+				return ec.fieldContext_Organization_assets(ctx, field)
+			case "data":
+				return ec.fieldContext_Organization_data(ctx, field)
+			case "audits":
+				return ec.fieldContext_Organization_audits(ctx, field)
+			case "nonconformityRegistries":
+				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
+			case "trustCenter":
+				return ec.fieldContext_Organization_trustCenter(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Organization_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Organization_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Organization", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _NonconformityRegistry_referenceId(ctx context.Context, field graphql.CollectedField, obj *types.NonconformityRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NonconformityRegistry_referenceId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ReferenceID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NonconformityRegistry_referenceId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NonconformityRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _NonconformityRegistry_description(ctx context.Context, field graphql.CollectedField, obj *types.NonconformityRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NonconformityRegistry_description(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Description, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NonconformityRegistry_description(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NonconformityRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _NonconformityRegistry_audit(ctx context.Context, field graphql.CollectedField, obj *types.NonconformityRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NonconformityRegistry_audit(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.NonconformityRegistry().Audit(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.Audit)
+	fc.Result = res
+	return ec.marshalNAudit2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐAudit(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NonconformityRegistry_audit(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NonconformityRegistry",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Audit_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Audit_name(ctx, field)
+			case "organization":
+				return ec.fieldContext_Audit_organization(ctx, field)
+			case "framework":
+				return ec.fieldContext_Audit_framework(ctx, field)
+			case "validFrom":
+				return ec.fieldContext_Audit_validFrom(ctx, field)
+			case "validUntil":
+				return ec.fieldContext_Audit_validUntil(ctx, field)
+			case "report":
+				return ec.fieldContext_Audit_report(ctx, field)
+			case "reportUrl":
+				return ec.fieldContext_Audit_reportUrl(ctx, field)
+			case "state":
+				return ec.fieldContext_Audit_state(ctx, field)
+			case "controls":
+				return ec.fieldContext_Audit_controls(ctx, field)
+			case "showOnTrustCenter":
+				return ec.fieldContext_Audit_showOnTrustCenter(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Audit_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Audit_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Audit", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _NonconformityRegistry_dateIdentified(ctx context.Context, field graphql.CollectedField, obj *types.NonconformityRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NonconformityRegistry_dateIdentified(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DateIdentified, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	fc.Result = res
+	return ec.marshalODatetime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NonconformityRegistry_dateIdentified(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NonconformityRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _NonconformityRegistry_rootCause(ctx context.Context, field graphql.CollectedField, obj *types.NonconformityRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NonconformityRegistry_rootCause(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RootCause, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NonconformityRegistry_rootCause(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NonconformityRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _NonconformityRegistry_correctiveAction(ctx context.Context, field graphql.CollectedField, obj *types.NonconformityRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NonconformityRegistry_correctiveAction(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CorrectiveAction, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NonconformityRegistry_correctiveAction(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NonconformityRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _NonconformityRegistry_owner(ctx context.Context, field graphql.CollectedField, obj *types.NonconformityRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NonconformityRegistry_owner(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.NonconformityRegistry().Owner(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.People)
+	fc.Result = res
+	return ec.marshalNPeople2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐPeople(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NonconformityRegistry_owner(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NonconformityRegistry",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_People_id(ctx, field)
+			case "fullName":
+				return ec.fieldContext_People_fullName(ctx, field)
+			case "primaryEmailAddress":
+				return ec.fieldContext_People_primaryEmailAddress(ctx, field)
+			case "additionalEmailAddresses":
+				return ec.fieldContext_People_additionalEmailAddresses(ctx, field)
+			case "kind":
+				return ec.fieldContext_People_kind(ctx, field)
+			case "position":
+				return ec.fieldContext_People_position(ctx, field)
+			case "contractStartDate":
+				return ec.fieldContext_People_contractStartDate(ctx, field)
+			case "contractEndDate":
+				return ec.fieldContext_People_contractEndDate(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_People_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_People_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type People", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _NonconformityRegistry_dueDate(ctx context.Context, field graphql.CollectedField, obj *types.NonconformityRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NonconformityRegistry_dueDate(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DueDate, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	fc.Result = res
+	return ec.marshalODatetime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NonconformityRegistry_dueDate(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NonconformityRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _NonconformityRegistry_status(ctx context.Context, field graphql.CollectedField, obj *types.NonconformityRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NonconformityRegistry_status(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Status, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(coredata.NonconformityRegistryStatus)
+	fc.Result = res
+	return ec.marshalNNonconformityRegistryStatus2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐNonconformityRegistryStatus(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NonconformityRegistry_status(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NonconformityRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type NonconformityRegistryStatus does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _NonconformityRegistry_effectivenessCheck(ctx context.Context, field graphql.CollectedField, obj *types.NonconformityRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NonconformityRegistry_effectivenessCheck(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.EffectivenessCheck, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NonconformityRegistry_effectivenessCheck(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NonconformityRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _NonconformityRegistry_createdAt(ctx context.Context, field graphql.CollectedField, obj *types.NonconformityRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NonconformityRegistry_createdAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNDatetime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NonconformityRegistry_createdAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NonconformityRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _NonconformityRegistry_updatedAt(ctx context.Context, field graphql.CollectedField, obj *types.NonconformityRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NonconformityRegistry_updatedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNDatetime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NonconformityRegistry_updatedAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NonconformityRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _NonconformityRegistryConnection_totalCount(ctx context.Context, field graphql.CollectedField, obj *types.NonconformityRegistryConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NonconformityRegistryConnection_totalCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.NonconformityRegistryConnection().TotalCount(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NonconformityRegistryConnection_totalCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NonconformityRegistryConnection",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _NonconformityRegistryConnection_edges(ctx context.Context, field graphql.CollectedField, obj *types.NonconformityRegistryConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NonconformityRegistryConnection_edges(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Edges, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*types.NonconformityRegistryEdge)
+	fc.Result = res
+	return ec.marshalNNonconformityRegistryEdge2ᚕᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐNonconformityRegistryEdgeᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NonconformityRegistryConnection_edges(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NonconformityRegistryConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "cursor":
+				return ec.fieldContext_NonconformityRegistryEdge_cursor(ctx, field)
+			case "node":
+				return ec.fieldContext_NonconformityRegistryEdge_node(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type NonconformityRegistryEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _NonconformityRegistryConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *types.NonconformityRegistryConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NonconformityRegistryConnection_pageInfo(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PageInfo, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(types.PageInfo)
+	fc.Result = res
+	return ec.marshalNPageInfo2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐPageInfo(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NonconformityRegistryConnection_pageInfo(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NonconformityRegistryConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "hasNextPage":
+				return ec.fieldContext_PageInfo_hasNextPage(ctx, field)
+			case "hasPreviousPage":
+				return ec.fieldContext_PageInfo_hasPreviousPage(ctx, field)
+			case "startCursor":
+				return ec.fieldContext_PageInfo_startCursor(ctx, field)
+			case "endCursor":
+				return ec.fieldContext_PageInfo_endCursor(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _NonconformityRegistryEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *types.NonconformityRegistryEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NonconformityRegistryEdge_cursor(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Cursor, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(page.CursorKey)
+	fc.Result = res
+	return ec.marshalNCursorKey2githubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐCursorKey(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NonconformityRegistryEdge_cursor(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NonconformityRegistryEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type CursorKey does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _NonconformityRegistryEdge_node(ctx context.Context, field graphql.CollectedField, obj *types.NonconformityRegistryEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_NonconformityRegistryEdge_node(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Node, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.NonconformityRegistry)
+	fc.Result = res
+	return ec.marshalNNonconformityRegistry2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐNonconformityRegistry(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_NonconformityRegistryEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "NonconformityRegistryEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_NonconformityRegistry_id(ctx, field)
+			case "organization":
+				return ec.fieldContext_NonconformityRegistry_organization(ctx, field)
+			case "referenceId":
+				return ec.fieldContext_NonconformityRegistry_referenceId(ctx, field)
+			case "description":
+				return ec.fieldContext_NonconformityRegistry_description(ctx, field)
+			case "audit":
+				return ec.fieldContext_NonconformityRegistry_audit(ctx, field)
+			case "dateIdentified":
+				return ec.fieldContext_NonconformityRegistry_dateIdentified(ctx, field)
+			case "rootCause":
+				return ec.fieldContext_NonconformityRegistry_rootCause(ctx, field)
+			case "correctiveAction":
+				return ec.fieldContext_NonconformityRegistry_correctiveAction(ctx, field)
+			case "owner":
+				return ec.fieldContext_NonconformityRegistry_owner(ctx, field)
+			case "dueDate":
+				return ec.fieldContext_NonconformityRegistry_dueDate(ctx, field)
+			case "status":
+				return ec.fieldContext_NonconformityRegistry_status(ctx, field)
+			case "effectivenessCheck":
+				return ec.fieldContext_NonconformityRegistry_effectivenessCheck(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_NonconformityRegistry_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_NonconformityRegistry_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type NonconformityRegistry", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Organization_id(ctx context.Context, field graphql.CollectedField, obj *types.Organization) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Organization_id(ctx, field)
 	if err != nil {
@@ -33368,6 +35182,69 @@ func (ec *executionContext) fieldContext_Organization_audits(ctx context.Context
 	return fc, nil
 }
 
+func (ec *executionContext) _Organization_nonconformityRegistries(ctx context.Context, field graphql.CollectedField, obj *types.Organization) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Organization().NonconformityRegistries(rctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey), fc.Args["orderBy"].(*types.NonconformityRegistryOrderBy))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.NonconformityRegistryConnection)
+	fc.Result = res
+	return ec.marshalNNonconformityRegistryConnection2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐNonconformityRegistryConnection(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Organization_nonconformityRegistries(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Organization",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "totalCount":
+				return ec.fieldContext_NonconformityRegistryConnection_totalCount(ctx, field)
+			case "edges":
+				return ec.fieldContext_NonconformityRegistryConnection_edges(ctx, field)
+			case "pageInfo":
+				return ec.fieldContext_NonconformityRegistryConnection_pageInfo(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type NonconformityRegistryConnection", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Organization_nonconformityRegistries_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Organization_trustCenter(ctx context.Context, field graphql.CollectedField, obj *types.Organization) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Organization_trustCenter(ctx, field)
 	if err != nil {
@@ -33732,6 +35609,8 @@ func (ec *executionContext) fieldContext_OrganizationEdge_node(_ context.Context
 				return ec.fieldContext_Organization_data(ctx, field)
 			case "audits":
 				return ec.fieldContext_Organization_audits(ctx, field)
+			case "nonconformityRegistries":
+				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -36200,6 +38079,8 @@ func (ec *executionContext) fieldContext_Risk_organization(_ context.Context, fi
 				return ec.fieldContext_Organization_data(ctx, field)
 			case "audits":
 				return ec.fieldContext_Organization_audits(ctx, field)
+			case "nonconformityRegistries":
+				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -37290,6 +39171,8 @@ func (ec *executionContext) fieldContext_Task_organization(_ context.Context, fi
 				return ec.fieldContext_Organization_data(ctx, field)
 			case "audits":
 				return ec.fieldContext_Organization_audits(ctx, field)
+			case "nonconformityRegistries":
+				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -38072,6 +39955,8 @@ func (ec *executionContext) fieldContext_TrustCenter_organization(_ context.Cont
 				return ec.fieldContext_Organization_data(ctx, field)
 			case "audits":
 				return ec.fieldContext_Organization_audits(ctx, field)
+			case "nonconformityRegistries":
+				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -39390,6 +41275,80 @@ func (ec *executionContext) fieldContext_UpdateMeasurePayload_measure(_ context.
 	return fc, nil
 }
 
+func (ec *executionContext) _UpdateNonconformityRegistryPayload_nonconformityRegistry(ctx context.Context, field graphql.CollectedField, obj *types.UpdateNonconformityRegistryPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UpdateNonconformityRegistryPayload_nonconformityRegistry(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NonconformityRegistry, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.NonconformityRegistry)
+	fc.Result = res
+	return ec.marshalNNonconformityRegistry2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐNonconformityRegistry(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UpdateNonconformityRegistryPayload_nonconformityRegistry(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UpdateNonconformityRegistryPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_NonconformityRegistry_id(ctx, field)
+			case "organization":
+				return ec.fieldContext_NonconformityRegistry_organization(ctx, field)
+			case "referenceId":
+				return ec.fieldContext_NonconformityRegistry_referenceId(ctx, field)
+			case "description":
+				return ec.fieldContext_NonconformityRegistry_description(ctx, field)
+			case "audit":
+				return ec.fieldContext_NonconformityRegistry_audit(ctx, field)
+			case "dateIdentified":
+				return ec.fieldContext_NonconformityRegistry_dateIdentified(ctx, field)
+			case "rootCause":
+				return ec.fieldContext_NonconformityRegistry_rootCause(ctx, field)
+			case "correctiveAction":
+				return ec.fieldContext_NonconformityRegistry_correctiveAction(ctx, field)
+			case "owner":
+				return ec.fieldContext_NonconformityRegistry_owner(ctx, field)
+			case "dueDate":
+				return ec.fieldContext_NonconformityRegistry_dueDate(ctx, field)
+			case "status":
+				return ec.fieldContext_NonconformityRegistry_status(ctx, field)
+			case "effectivenessCheck":
+				return ec.fieldContext_NonconformityRegistry_effectivenessCheck(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_NonconformityRegistry_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_NonconformityRegistry_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type NonconformityRegistry", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _UpdateOrganizationPayload_organization(ctx context.Context, field graphql.CollectedField, obj *types.UpdateOrganizationPayload) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_UpdateOrganizationPayload_organization(ctx, field)
 	if err != nil {
@@ -39461,6 +41420,8 @@ func (ec *executionContext) fieldContext_UpdateOrganizationPayload_organization(
 				return ec.fieldContext_Organization_data(ctx, field)
 			case "audits":
 				return ec.fieldContext_Organization_audits(ctx, field)
+			case "nonconformityRegistries":
+				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -41140,6 +43101,8 @@ func (ec *executionContext) fieldContext_Vendor_organization(_ context.Context, 
 				return ec.fieldContext_Organization_data(ctx, field)
 			case "audits":
 				return ec.fieldContext_Organization_audits(ctx, field)
+			case "nonconformityRegistries":
+				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -48505,6 +50468,103 @@ func (ec *executionContext) unmarshalInputCreateMeasureInput(ctx context.Context
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputCreateNonconformityRegistryInput(ctx context.Context, obj any) (types.CreateNonconformityRegistryInput, error) {
+	var it types.CreateNonconformityRegistryInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"organizationId", "referenceId", "description", "auditId", "dateIdentified", "rootCause", "correctiveAction", "ownerId", "dueDate", "status", "effectivenessCheck"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "organizationId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("organizationId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OrganizationID = data
+		case "referenceId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("referenceId"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ReferenceID = data
+		case "description":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Description = data
+		case "auditId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("auditId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AuditID = data
+		case "dateIdentified":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("dateIdentified"))
+			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DateIdentified = data
+		case "rootCause":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rootCause"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.RootCause = data
+		case "correctiveAction":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("correctiveAction"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.CorrectiveAction = data
+		case "ownerId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("ownerId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OwnerID = data
+		case "dueDate":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("dueDate"))
+			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DueDate = data
+		case "status":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("status"))
+			data, err := ec.unmarshalNNonconformityRegistryStatus2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐNonconformityRegistryStatus(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Status = data
+		case "effectivenessCheck":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("effectivenessCheck"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.EffectivenessCheck = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputCreateOrganizationInput(ctx context.Context, obj any) (types.CreateOrganizationInput, error) {
 	var it types.CreateOrganizationInput
 	asMap := map[string]any{}
@@ -49559,6 +51619,33 @@ func (ec *executionContext) unmarshalInputDeleteMeasureInput(ctx context.Context
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputDeleteNonconformityRegistryInput(ctx context.Context, obj any) (types.DeleteNonconformityRegistryInput, error) {
+	var it types.DeleteNonconformityRegistryInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"nonconformityRegistryId"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "nonconformityRegistryId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("nonconformityRegistryId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.NonconformityRegistryID = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputDeleteOrganizationInput(ctx context.Context, obj any) (types.DeleteOrganizationInput, error) {
 	var it types.DeleteOrganizationInput
 	asMap := map[string]any{}
@@ -50410,6 +52497,40 @@ func (ec *executionContext) unmarshalInputMeasureOrder(ctx context.Context, obj 
 		case "field":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("field"))
 			data, err := ec.unmarshalNMeasureOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐMeasureOrderField(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Field = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputNonconformityRegistryOrder(ctx context.Context, obj any) (types.NonconformityRegistryOrderBy, error) {
+	var it types.NonconformityRegistryOrderBy
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"direction", "field"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "direction":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("direction"))
+			data, err := ec.unmarshalNOrderDirection2githubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐOrderDirection(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Direction = data
+		case "field":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("field"))
+			data, err := ec.unmarshalNNonconformityRegistryOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐNonconformityRegistryOrderField(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -51350,6 +53471,103 @@ func (ec *executionContext) unmarshalInputUpdateMeasureInput(ctx context.Context
 				return it, err
 			}
 			it.State = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputUpdateNonconformityRegistryInput(ctx context.Context, obj any) (types.UpdateNonconformityRegistryInput, error) {
+	var it types.UpdateNonconformityRegistryInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id", "referenceId", "description", "dateIdentified", "rootCause", "correctiveAction", "ownerId", "auditId", "dueDate", "status", "effectivenessCheck"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ID = data
+		case "referenceId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("referenceId"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ReferenceID = data
+		case "description":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Description = data
+		case "dateIdentified":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("dateIdentified"))
+			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DateIdentified = data
+		case "rootCause":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rootCause"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.RootCause = data
+		case "correctiveAction":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("correctiveAction"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.CorrectiveAction = data
+		case "ownerId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("ownerId"))
+			data, err := ec.unmarshalOID2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OwnerID = data
+		case "auditId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("auditId"))
+			data, err := ec.unmarshalOID2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AuditID = data
+		case "dueDate":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("dueDate"))
+			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DueDate = data
+		case "status":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("status"))
+			data, err := ec.unmarshalONonconformityRegistryStatus2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐNonconformityRegistryStatus(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Status = data
+		case "effectivenessCheck":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("effectivenessCheck"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.EffectivenessCheck = data
 		}
 	}
 
@@ -52513,6 +54731,13 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._Organization(ctx, sel, obj)
+	case types.NonconformityRegistry:
+		return ec._NonconformityRegistry(ctx, sel, &obj)
+	case *types.NonconformityRegistry:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._NonconformityRegistry(ctx, sel, obj)
 	case types.Measure:
 		return ec._Measure(ctx, sel, &obj)
 	case *types.Measure:
@@ -54512,6 +56737,45 @@ func (ec *executionContext) _CreateMeasurePayload(ctx context.Context, sel ast.S
 	return out
 }
 
+var createNonconformityRegistryPayloadImplementors = []string{"CreateNonconformityRegistryPayload"}
+
+func (ec *executionContext) _CreateNonconformityRegistryPayload(ctx context.Context, sel ast.SelectionSet, obj *types.CreateNonconformityRegistryPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, createNonconformityRegistryPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CreateNonconformityRegistryPayload")
+		case "nonconformityRegistryEdge":
+			out.Values[i] = ec._CreateNonconformityRegistryPayload_nonconformityRegistryEdge(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var createOrganizationPayloadImplementors = []string{"CreateOrganizationPayload"}
 
 func (ec *executionContext) _CreateOrganizationPayload(ctx context.Context, sel ast.SelectionSet, obj *types.CreateOrganizationPayload) graphql.Marshaler {
@@ -55699,6 +57963,45 @@ func (ec *executionContext) _DeleteMeasurePayload(ctx context.Context, sel ast.S
 			out.Values[i] = graphql.MarshalString("DeleteMeasurePayload")
 		case "deletedMeasureId":
 			out.Values[i] = ec._DeleteMeasurePayload_deletedMeasureId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var deleteNonconformityRegistryPayloadImplementors = []string{"DeleteNonconformityRegistryPayload"}
+
+func (ec *executionContext) _DeleteNonconformityRegistryPayload(ctx context.Context, sel ast.SelectionSet, obj *types.DeleteNonconformityRegistryPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, deleteNonconformityRegistryPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("DeleteNonconformityRegistryPayload")
+		case "deletedNonconformityRegistryId":
+			out.Values[i] = ec._DeleteNonconformityRegistryPayload_deletedNonconformityRegistryId(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -58911,6 +61214,333 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "createNonconformityRegistry":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_createNonconformityRegistry(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "updateNonconformityRegistry":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_updateNonconformityRegistry(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "deleteNonconformityRegistry":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_deleteNonconformityRegistry(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var nonconformityRegistryImplementors = []string{"NonconformityRegistry", "Node"}
+
+func (ec *executionContext) _NonconformityRegistry(ctx context.Context, sel ast.SelectionSet, obj *types.NonconformityRegistry) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, nonconformityRegistryImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("NonconformityRegistry")
+		case "id":
+			out.Values[i] = ec._NonconformityRegistry_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "organization":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._NonconformityRegistry_organization(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "referenceId":
+			out.Values[i] = ec._NonconformityRegistry_referenceId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "description":
+			out.Values[i] = ec._NonconformityRegistry_description(ctx, field, obj)
+		case "audit":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._NonconformityRegistry_audit(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "dateIdentified":
+			out.Values[i] = ec._NonconformityRegistry_dateIdentified(ctx, field, obj)
+		case "rootCause":
+			out.Values[i] = ec._NonconformityRegistry_rootCause(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "correctiveAction":
+			out.Values[i] = ec._NonconformityRegistry_correctiveAction(ctx, field, obj)
+		case "owner":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._NonconformityRegistry_owner(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "dueDate":
+			out.Values[i] = ec._NonconformityRegistry_dueDate(ctx, field, obj)
+		case "status":
+			out.Values[i] = ec._NonconformityRegistry_status(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "effectivenessCheck":
+			out.Values[i] = ec._NonconformityRegistry_effectivenessCheck(ctx, field, obj)
+		case "createdAt":
+			out.Values[i] = ec._NonconformityRegistry_createdAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "updatedAt":
+			out.Values[i] = ec._NonconformityRegistry_updatedAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var nonconformityRegistryConnectionImplementors = []string{"NonconformityRegistryConnection"}
+
+func (ec *executionContext) _NonconformityRegistryConnection(ctx context.Context, sel ast.SelectionSet, obj *types.NonconformityRegistryConnection) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, nonconformityRegistryConnectionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("NonconformityRegistryConnection")
+		case "totalCount":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._NonconformityRegistryConnection_totalCount(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "edges":
+			out.Values[i] = ec._NonconformityRegistryConnection_edges(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "pageInfo":
+			out.Values[i] = ec._NonconformityRegistryConnection_pageInfo(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var nonconformityRegistryEdgeImplementors = []string{"NonconformityRegistryEdge"}
+
+func (ec *executionContext) _NonconformityRegistryEdge(ctx context.Context, sel ast.SelectionSet, obj *types.NonconformityRegistryEdge) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, nonconformityRegistryEdgeImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("NonconformityRegistryEdge")
+		case "cursor":
+			out.Values[i] = ec._NonconformityRegistryEdge_cursor(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "node":
+			out.Values[i] = ec._NonconformityRegistryEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -59430,6 +62060,42 @@ func (ec *executionContext) _Organization(ctx context.Context, sel ast.Selection
 					}
 				}()
 				res = ec._Organization_audits(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "nonconformityRegistries":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Organization_nonconformityRegistries(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -61745,6 +64411,45 @@ func (ec *executionContext) _UpdateMeasurePayload(ctx context.Context, sel ast.S
 			out.Values[i] = graphql.MarshalString("UpdateMeasurePayload")
 		case "measure":
 			out.Values[i] = ec._UpdateMeasurePayload_measure(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var updateNonconformityRegistryPayloadImplementors = []string{"UpdateNonconformityRegistryPayload"}
+
+func (ec *executionContext) _UpdateNonconformityRegistryPayload(ctx context.Context, sel ast.SelectionSet, obj *types.UpdateNonconformityRegistryPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, updateNonconformityRegistryPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("UpdateNonconformityRegistryPayload")
+		case "nonconformityRegistry":
+			out.Values[i] = ec._UpdateNonconformityRegistryPayload_nonconformityRegistry(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -64528,6 +67233,10 @@ func (ec *executionContext) marshalNAssignTaskPayload2ᚖgithubᚗcomᚋgetprobo
 	return ec._AssignTaskPayload(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNAudit2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐAudit(ctx context.Context, sel ast.SelectionSet, v types.Audit) graphql.Marshaler {
+	return ec._Audit(ctx, sel, &v)
+}
+
 func (ec *executionContext) marshalNAudit2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐAudit(ctx context.Context, sel ast.SelectionSet, v *types.Audit) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -65245,6 +67954,25 @@ func (ec *executionContext) marshalNCreateMeasurePayload2ᚖgithubᚗcomᚋgetpr
 	return ec._CreateMeasurePayload(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNCreateNonconformityRegistryInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateNonconformityRegistryInput(ctx context.Context, v any) (types.CreateNonconformityRegistryInput, error) {
+	res, err := ec.unmarshalInputCreateNonconformityRegistryInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNCreateNonconformityRegistryPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateNonconformityRegistryPayload(ctx context.Context, sel ast.SelectionSet, v types.CreateNonconformityRegistryPayload) graphql.Marshaler {
+	return ec._CreateNonconformityRegistryPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNCreateNonconformityRegistryPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateNonconformityRegistryPayload(ctx context.Context, sel ast.SelectionSet, v *types.CreateNonconformityRegistryPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._CreateNonconformityRegistryPayload(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNCreateOrganizationInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateOrganizationInput(ctx context.Context, v any) (types.CreateOrganizationInput, error) {
 	res, err := ec.unmarshalInputCreateOrganizationInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -65916,6 +68644,25 @@ func (ec *executionContext) marshalNDeleteMeasurePayload2ᚖgithubᚗcomᚋgetpr
 		return graphql.Null
 	}
 	return ec._DeleteMeasurePayload(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNDeleteNonconformityRegistryInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteNonconformityRegistryInput(ctx context.Context, v any) (types.DeleteNonconformityRegistryInput, error) {
+	res, err := ec.unmarshalInputDeleteNonconformityRegistryInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNDeleteNonconformityRegistryPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteNonconformityRegistryPayload(ctx context.Context, sel ast.SelectionSet, v types.DeleteNonconformityRegistryPayload) graphql.Marshaler {
+	return ec._DeleteNonconformityRegistryPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNDeleteNonconformityRegistryPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteNonconformityRegistryPayload(ctx context.Context, sel ast.SelectionSet, v *types.DeleteNonconformityRegistryPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._DeleteNonconformityRegistryPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNDeleteOrganizationInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteOrganizationInput(ctx context.Context, v any) (types.DeleteOrganizationInput, error) {
@@ -67164,6 +69911,148 @@ func (ec *executionContext) marshalNNode2githubᚗcomᚋgetproboᚋproboᚋpkg�
 	return ec._Node(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNNonconformityRegistry2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐNonconformityRegistry(ctx context.Context, sel ast.SelectionSet, v *types.NonconformityRegistry) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._NonconformityRegistry(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNNonconformityRegistryConnection2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐNonconformityRegistryConnection(ctx context.Context, sel ast.SelectionSet, v types.NonconformityRegistryConnection) graphql.Marshaler {
+	return ec._NonconformityRegistryConnection(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNNonconformityRegistryConnection2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐNonconformityRegistryConnection(ctx context.Context, sel ast.SelectionSet, v *types.NonconformityRegistryConnection) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._NonconformityRegistryConnection(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNNonconformityRegistryEdge2ᚕᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐNonconformityRegistryEdgeᚄ(ctx context.Context, sel ast.SelectionSet, v []*types.NonconformityRegistryEdge) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNNonconformityRegistryEdge2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐNonconformityRegistryEdge(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNNonconformityRegistryEdge2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐNonconformityRegistryEdge(ctx context.Context, sel ast.SelectionSet, v *types.NonconformityRegistryEdge) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._NonconformityRegistryEdge(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNNonconformityRegistryOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐNonconformityRegistryOrderField(ctx context.Context, v any) (coredata.NonconformityRegistryOrderField, error) {
+	tmp, err := graphql.UnmarshalString(v)
+	res := unmarshalNNonconformityRegistryOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐNonconformityRegistryOrderField[tmp]
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNNonconformityRegistryOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐNonconformityRegistryOrderField(ctx context.Context, sel ast.SelectionSet, v coredata.NonconformityRegistryOrderField) graphql.Marshaler {
+	_ = sel
+	res := graphql.MarshalString(marshalNNonconformityRegistryOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐNonconformityRegistryOrderField[v])
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+var (
+	unmarshalNNonconformityRegistryOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐNonconformityRegistryOrderField = map[string]coredata.NonconformityRegistryOrderField{
+		"CREATED_AT":      coredata.NonconformityRegistryOrderFieldCreatedAt,
+		"REFERENCE_ID":    coredata.NonconformityRegistryOrderFieldReferenceId,
+		"DATE_IDENTIFIED": coredata.NonconformityRegistryOrderFieldDateIdentified,
+		"DUE_DATE":        coredata.NonconformityRegistryOrderFieldDueDate,
+		"STATUS":          coredata.NonconformityRegistryOrderFieldStatus,
+	}
+	marshalNNonconformityRegistryOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐNonconformityRegistryOrderField = map[coredata.NonconformityRegistryOrderField]string{
+		coredata.NonconformityRegistryOrderFieldCreatedAt:      "CREATED_AT",
+		coredata.NonconformityRegistryOrderFieldReferenceId:    "REFERENCE_ID",
+		coredata.NonconformityRegistryOrderFieldDateIdentified: "DATE_IDENTIFIED",
+		coredata.NonconformityRegistryOrderFieldDueDate:        "DUE_DATE",
+		coredata.NonconformityRegistryOrderFieldStatus:         "STATUS",
+	}
+)
+
+func (ec *executionContext) unmarshalNNonconformityRegistryStatus2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐNonconformityRegistryStatus(ctx context.Context, v any) (coredata.NonconformityRegistryStatus, error) {
+	tmp, err := graphql.UnmarshalString(v)
+	res := unmarshalNNonconformityRegistryStatus2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐNonconformityRegistryStatus[tmp]
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNNonconformityRegistryStatus2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐNonconformityRegistryStatus(ctx context.Context, sel ast.SelectionSet, v coredata.NonconformityRegistryStatus) graphql.Marshaler {
+	_ = sel
+	res := graphql.MarshalString(marshalNNonconformityRegistryStatus2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐNonconformityRegistryStatus[v])
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+var (
+	unmarshalNNonconformityRegistryStatus2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐNonconformityRegistryStatus = map[string]coredata.NonconformityRegistryStatus{
+		"OPEN":        coredata.NonconformityRegistryStatusOpen,
+		"IN_PROGRESS": coredata.NonconformityRegistryStatusInProgress,
+		"CLOSED":      coredata.NonconformityRegistryStatusClosed,
+	}
+	marshalNNonconformityRegistryStatus2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐNonconformityRegistryStatus = map[coredata.NonconformityRegistryStatus]string{
+		coredata.NonconformityRegistryStatusOpen:       "OPEN",
+		coredata.NonconformityRegistryStatusInProgress: "IN_PROGRESS",
+		coredata.NonconformityRegistryStatusClosed:     "CLOSED",
+	}
+)
+
 func (ec *executionContext) unmarshalNOrderDirection2githubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐOrderDirection(ctx context.Context, v any) (page.OrderDirection, error) {
 	tmp, err := graphql.UnmarshalString(v)
 	res := unmarshalNOrderDirection2githubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐOrderDirection[tmp]
@@ -68223,6 +71112,25 @@ func (ec *executionContext) marshalNUpdateMeasurePayload2ᚖgithubᚗcomᚋgetpr
 		return graphql.Null
 	}
 	return ec._UpdateMeasurePayload(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNUpdateNonconformityRegistryInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateNonconformityRegistryInput(ctx context.Context, v any) (types.UpdateNonconformityRegistryInput, error) {
+	res, err := ec.unmarshalInputUpdateNonconformityRegistryInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNUpdateNonconformityRegistryPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateNonconformityRegistryPayload(ctx context.Context, sel ast.SelectionSet, v types.UpdateNonconformityRegistryPayload) graphql.Marshaler {
+	return ec._UpdateNonconformityRegistryPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNUpdateNonconformityRegistryPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateNonconformityRegistryPayload(ctx context.Context, sel ast.SelectionSet, v *types.UpdateNonconformityRegistryPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._UpdateNonconformityRegistryPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNUpdateOrganizationInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateOrganizationInput(ctx context.Context, v any) (types.UpdateOrganizationInput, error) {
@@ -69957,6 +72865,46 @@ var (
 		coredata.MeasureStateInProgress:    "IN_PROGRESS",
 		coredata.MeasureStateNotApplicable: "NOT_APPLICABLE",
 		coredata.MeasureStateImplemented:   "IMPLEMENTED",
+	}
+)
+
+func (ec *executionContext) unmarshalONonconformityRegistryOrder2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐNonconformityRegistryOrderBy(ctx context.Context, v any) (*types.NonconformityRegistryOrderBy, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputNonconformityRegistryOrder(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalONonconformityRegistryStatus2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐNonconformityRegistryStatus(ctx context.Context, v any) (*coredata.NonconformityRegistryStatus, error) {
+	if v == nil {
+		return nil, nil
+	}
+	tmp, err := graphql.UnmarshalString(v)
+	res := unmarshalONonconformityRegistryStatus2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐNonconformityRegistryStatus[tmp]
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalONonconformityRegistryStatus2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐNonconformityRegistryStatus(ctx context.Context, sel ast.SelectionSet, v *coredata.NonconformityRegistryStatus) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	_ = sel
+	_ = ctx
+	res := graphql.MarshalString(marshalONonconformityRegistryStatus2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐNonconformityRegistryStatus[*v])
+	return res
+}
+
+var (
+	unmarshalONonconformityRegistryStatus2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐNonconformityRegistryStatus = map[string]coredata.NonconformityRegistryStatus{
+		"OPEN":        coredata.NonconformityRegistryStatusOpen,
+		"IN_PROGRESS": coredata.NonconformityRegistryStatusInProgress,
+		"CLOSED":      coredata.NonconformityRegistryStatusClosed,
+	}
+	marshalONonconformityRegistryStatus2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐNonconformityRegistryStatus = map[coredata.NonconformityRegistryStatus]string{
+		coredata.NonconformityRegistryStatusOpen:       "OPEN",
+		coredata.NonconformityRegistryStatusInProgress: "IN_PROGRESS",
+		coredata.NonconformityRegistryStatusClosed:     "CLOSED",
 	}
 )
 

--- a/pkg/server/api/console/v1/types/nonconformity_registry.go
+++ b/pkg/server/api/console/v1/types/nonconformity_registry.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package types
+
+import (
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+)
+
+type (
+	NonconformityRegistryOrderBy OrderBy[coredata.NonconformityRegistryOrderField]
+
+	NonconformityRegistryConnection struct {
+		TotalCount int
+		Edges      []*NonconformityRegistryEdge
+		PageInfo   PageInfo
+
+		Resolver any
+		ParentID gid.GID
+	}
+)
+
+func NewNonconformityRegistryConnection(
+	p *page.Page[*coredata.NonconformityRegistry, coredata.NonconformityRegistryOrderField],
+	parentType any,
+	parentID gid.GID,
+) *NonconformityRegistryConnection {
+	edges := make([]*NonconformityRegistryEdge, len(p.Data))
+	for i, registry := range p.Data {
+		edges[i] = NewNonconformityRegistryEdge(registry, p.Cursor.OrderBy.Field)
+	}
+
+	return &NonconformityRegistryConnection{
+		Edges:    edges,
+		PageInfo: *NewPageInfo(p),
+
+		Resolver: parentType,
+		ParentID: parentID,
+	}
+}
+
+func NewNonconformityRegistry(nr *coredata.NonconformityRegistry) *NonconformityRegistry {
+	return &NonconformityRegistry{
+		ID:                 nr.ID,
+		ReferenceID:        nr.ReferenceID,
+		Description:        nr.Description,
+		DateIdentified:     nr.DateIdentified,
+		RootCause:          nr.RootCause,
+		CorrectiveAction:   nr.CorrectiveAction,
+		DueDate:            nr.DueDate,
+		Status:             nr.Status,
+		EffectivenessCheck: nr.EffectivenessCheck,
+		CreatedAt:          nr.CreatedAt,
+		UpdatedAt:          nr.UpdatedAt,
+	}
+}
+
+func NewNonconformityRegistryEdge(nr *coredata.NonconformityRegistry, orderField coredata.NonconformityRegistryOrderField) *NonconformityRegistryEdge {
+	return &NonconformityRegistryEdge{
+		Node:   NewNonconformityRegistry(nr),
+		Cursor: nr.CursorKey(orderField),
+	}
+}

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -306,6 +306,24 @@ type CreateMeasurePayload struct {
 	MeasureEdge *MeasureEdge `json:"measureEdge"`
 }
 
+type CreateNonconformityRegistryInput struct {
+	OrganizationID     gid.GID                              `json:"organizationId"`
+	ReferenceID        string                               `json:"referenceId"`
+	Description        *string                              `json:"description,omitempty"`
+	AuditID            gid.GID                              `json:"auditId"`
+	DateIdentified     *time.Time                           `json:"dateIdentified,omitempty"`
+	RootCause          string                               `json:"rootCause"`
+	CorrectiveAction   *string                              `json:"correctiveAction,omitempty"`
+	OwnerID            gid.GID                              `json:"ownerId"`
+	DueDate            *time.Time                           `json:"dueDate,omitempty"`
+	Status             coredata.NonconformityRegistryStatus `json:"status"`
+	EffectivenessCheck *string                              `json:"effectivenessCheck,omitempty"`
+}
+
+type CreateNonconformityRegistryPayload struct {
+	NonconformityRegistryEdge *NonconformityRegistryEdge `json:"nonconformityRegistryEdge"`
+}
+
 type CreateOrganizationInput struct {
 	Name string `json:"name"`
 }
@@ -569,6 +587,14 @@ type DeleteMeasureInput struct {
 
 type DeleteMeasurePayload struct {
 	DeletedMeasureID gid.GID `json:"deletedMeasureId"`
+}
+
+type DeleteNonconformityRegistryInput struct {
+	NonconformityRegistryID gid.GID `json:"nonconformityRegistryId"`
+}
+
+type DeleteNonconformityRegistryPayload struct {
+	DeletedNonconformityRegistryID gid.GID `json:"deletedNonconformityRegistryId"`
 }
 
 type DeleteOrganizationInput struct {
@@ -895,26 +921,52 @@ type MeasureFilter struct {
 type Mutation struct {
 }
 
+type NonconformityRegistry struct {
+	ID                 gid.GID                              `json:"id"`
+	Organization       *Organization                        `json:"organization"`
+	ReferenceID        string                               `json:"referenceId"`
+	Description        *string                              `json:"description,omitempty"`
+	Audit              *Audit                               `json:"audit"`
+	DateIdentified     *time.Time                           `json:"dateIdentified,omitempty"`
+	RootCause          string                               `json:"rootCause"`
+	CorrectiveAction   *string                              `json:"correctiveAction,omitempty"`
+	Owner              *People                              `json:"owner"`
+	DueDate            *time.Time                           `json:"dueDate,omitempty"`
+	Status             coredata.NonconformityRegistryStatus `json:"status"`
+	EffectivenessCheck *string                              `json:"effectivenessCheck,omitempty"`
+	CreatedAt          time.Time                            `json:"createdAt"`
+	UpdatedAt          time.Time                            `json:"updatedAt"`
+}
+
+func (NonconformityRegistry) IsNode()             {}
+func (this NonconformityRegistry) GetID() gid.GID { return this.ID }
+
+type NonconformityRegistryEdge struct {
+	Cursor page.CursorKey         `json:"cursor"`
+	Node   *NonconformityRegistry `json:"node"`
+}
+
 type Organization struct {
-	ID          gid.GID              `json:"id"`
-	Name        string               `json:"name"`
-	LogoURL     *string              `json:"logoUrl,omitempty"`
-	Users       *UserConnection      `json:"users"`
-	Connectors  *ConnectorConnection `json:"connectors"`
-	Frameworks  *FrameworkConnection `json:"frameworks"`
-	Controls    *ControlConnection   `json:"controls"`
-	Vendors     *VendorConnection    `json:"vendors"`
-	Peoples     *PeopleConnection    `json:"peoples"`
-	Documents   *DocumentConnection  `json:"documents"`
-	Measures    *MeasureConnection   `json:"measures"`
-	Risks       *RiskConnection      `json:"risks"`
-	Tasks       *TaskConnection      `json:"tasks"`
-	Assets      *AssetConnection     `json:"assets"`
-	Data        *DatumConnection     `json:"data"`
-	Audits      *AuditConnection     `json:"audits"`
-	TrustCenter *TrustCenter         `json:"trustCenter,omitempty"`
-	CreatedAt   time.Time            `json:"createdAt"`
-	UpdatedAt   time.Time            `json:"updatedAt"`
+	ID                      gid.GID                          `json:"id"`
+	Name                    string                           `json:"name"`
+	LogoURL                 *string                          `json:"logoUrl,omitempty"`
+	Users                   *UserConnection                  `json:"users"`
+	Connectors              *ConnectorConnection             `json:"connectors"`
+	Frameworks              *FrameworkConnection             `json:"frameworks"`
+	Controls                *ControlConnection               `json:"controls"`
+	Vendors                 *VendorConnection                `json:"vendors"`
+	Peoples                 *PeopleConnection                `json:"peoples"`
+	Documents               *DocumentConnection              `json:"documents"`
+	Measures                *MeasureConnection               `json:"measures"`
+	Risks                   *RiskConnection                  `json:"risks"`
+	Tasks                   *TaskConnection                  `json:"tasks"`
+	Assets                  *AssetConnection                 `json:"assets"`
+	Data                    *DatumConnection                 `json:"data"`
+	Audits                  *AuditConnection                 `json:"audits"`
+	NonconformityRegistries *NonconformityRegistryConnection `json:"nonconformityRegistries"`
+	TrustCenter             *TrustCenter                     `json:"trustCenter,omitempty"`
+	CreatedAt               time.Time                        `json:"createdAt"`
+	UpdatedAt               time.Time                        `json:"updatedAt"`
 }
 
 func (Organization) IsNode()             {}
@@ -1249,6 +1301,24 @@ type UpdateMeasureInput struct {
 
 type UpdateMeasurePayload struct {
 	Measure *Measure `json:"measure"`
+}
+
+type UpdateNonconformityRegistryInput struct {
+	ID                 gid.GID                               `json:"id"`
+	ReferenceID        *string                               `json:"referenceId,omitempty"`
+	Description        *string                               `json:"description,omitempty"`
+	DateIdentified     *time.Time                            `json:"dateIdentified,omitempty"`
+	RootCause          *string                               `json:"rootCause,omitempty"`
+	CorrectiveAction   *string                               `json:"correctiveAction,omitempty"`
+	OwnerID            *gid.GID                              `json:"ownerId,omitempty"`
+	AuditID            *gid.GID                              `json:"auditId,omitempty"`
+	DueDate            *time.Time                            `json:"dueDate,omitempty"`
+	Status             *coredata.NonconformityRegistryStatus `json:"status,omitempty"`
+	EffectivenessCheck *string                               `json:"effectivenessCheck,omitempty"`
+}
+
+type UpdateNonconformityRegistryPayload struct {
+	NonconformityRegistry *NonconformityRegistry `json:"nonconformityRegistry"`
 }
 
 type UpdateOrganizationInput struct {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added nonconformity registries to the platform, allowing organizations to create, view, update, and manage corrective actions related to audits.

- **New Features**
 - Created registry pages for listing and viewing nonconformity details.
 - Added dialogs for creating and updating registries.
 - Implemented backend support, GraphQL types, mutations, and queries.
 - Updated navigation to include a Registries section in the sidebar.

<!-- End of auto-generated description by cubic. -->

