### PR TITLE
Add compliance registries

### DIFF
--- a/apps/console/src/hooks/graph/ComplianceRegistryGraph.ts
+++ b/apps/console/src/hooks/graph/ComplianceRegistryGraph.ts
@@ -1,0 +1,251 @@
+import { graphql } from "relay-runtime";
+import { useMutation } from "react-relay";
+import { useConfirm } from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { promisifyMutation, sprintf } from "@probo/helpers";
+import { useMutationWithToasts } from "../useMutationWithToasts";
+
+export const ComplianceRegistriesConnectionKey = "ComplianceRegistriesPage_complianceRegistries";
+
+export const complianceRegistriesQuery = graphql`
+  query ComplianceRegistryGraphListQuery($organizationId: ID!) {
+    node(id: $organizationId) {
+      ... on Organization {
+        ...ComplianceRegistriesPageFragment
+      }
+    }
+  }
+`;
+
+export const complianceRegistryNodeQuery = graphql`
+  query ComplianceRegistryGraphNodeQuery($complianceRegistryId: ID!) {
+    node(id: $complianceRegistryId) {
+      ... on ComplianceRegistry {
+        id
+        referenceId
+        area
+        source
+        requirement
+        actionsToBeImplemented
+        regulator
+        lastReviewDate
+        dueDate
+        status
+        audit {
+          id
+          name
+          framework {
+            id
+            name
+          }
+        }
+        owner {
+          id
+          fullName
+        }
+        organization {
+          id
+          name
+        }
+        createdAt
+        updatedAt
+      }
+    }
+  }
+`;
+
+export const createComplianceRegistryMutation = graphql`
+  mutation ComplianceRegistryGraphCreateMutation(
+    $input: CreateComplianceRegistryInput!
+    $connections: [ID!]!
+  ) {
+    createComplianceRegistry(input: $input) {
+      complianceRegistryEdge @prependEdge(connections: $connections) {
+        node {
+          id
+          referenceId
+          area
+          source
+          requirement
+          actionsToBeImplemented
+          regulator
+          lastReviewDate
+          dueDate
+          status
+          audit {
+            id
+            name
+            framework {
+              name
+            }
+          }
+          owner {
+            id
+            fullName
+          }
+          createdAt
+        }
+      }
+    }
+  }
+`;
+
+export const updateComplianceRegistryMutation = graphql`
+  mutation ComplianceRegistryGraphUpdateMutation($input: UpdateComplianceRegistryInput!) {
+    updateComplianceRegistry(input: $input) {
+      complianceRegistry {
+        id
+        referenceId
+        area
+        source
+        requirement
+        actionsToBeImplemented
+        regulator
+        lastReviewDate
+        dueDate
+        status
+        owner {
+          id
+          fullName
+        }
+        audit {
+          id
+          name
+          framework {
+            id
+            name
+          }
+        }
+        updatedAt
+      }
+    }
+  }
+`;
+
+export const deleteComplianceRegistryMutation = graphql`
+  mutation ComplianceRegistryGraphDeleteMutation(
+    $input: DeleteComplianceRegistryInput!
+    $connections: [ID!]!
+  ) {
+    deleteComplianceRegistry(input: $input) {
+      deletedComplianceRegistryId @deleteEdge(connections: $connections)
+    }
+  }
+`;
+
+export const useDeleteComplianceRegistry = (
+  registry: { id: string; referenceId: string },
+  connectionId: string
+) => {
+  const { __ } = useTranslate();
+  const [mutate] = useMutationWithToasts(deleteComplianceRegistryMutation, {
+    successMessage: __("Compliance registry entry deleted successfully"),
+    errorMessage: __("Failed to delete compliance registry entry"),
+  });
+  const confirm = useConfirm();
+
+  return () => {
+    confirm(
+      () =>
+        mutate({
+          variables: {
+            input: {
+              complianceRegistryId: registry.id,
+            },
+            connections: [connectionId],
+          },
+        }),
+      {
+        message: sprintf(
+          __(
+            "This will permanently delete the compliance registry entry %s. This action cannot be undone."
+          ),
+          registry.referenceId
+        ),
+      }
+    );
+  };
+};
+
+export const useCreateComplianceRegistry = (connectionId: string) => {
+  const [mutate] = useMutation(createComplianceRegistryMutation);
+  const { __ } = useTranslate();
+
+  return (input: {
+    organizationId: string;
+    referenceId: string;
+    area?: string;
+    source?: string;
+    auditId: string;
+    requirement?: string;
+    actionsToBeImplemented?: string;
+    regulator?: string;
+    ownerId: string;
+    lastReviewDate?: string;
+    dueDate?: string;
+    status: string;
+  }) => {
+    if (!input.organizationId) {
+      return alert(__("Failed to create compliance registry entry: organization is required"));
+    }
+    if (!input.referenceId) {
+      return alert(__("Failed to create compliance registry entry: reference ID is required"));
+    }
+    if (!input.auditId) {
+      return alert(__("Failed to create compliance registry entry: audit is required"));
+    }
+    if (!input.ownerId) {
+      return alert(__("Failed to create compliance registry entry: owner is required"));
+    }
+
+    return promisifyMutation(mutate)({
+      variables: {
+        input: {
+          organizationId: input.organizationId,
+          referenceId: input.referenceId,
+          area: input.area,
+          source: input.source,
+          auditId: input.auditId,
+          requirement: input.requirement,
+          actionsToBeImplemented: input.actionsToBeImplemented,
+          regulator: input.regulator,
+          ownerId: input.ownerId,
+          lastReviewDate: input.lastReviewDate,
+          dueDate: input.dueDate,
+          status: input.status || "OPEN",
+        },
+        connections: [connectionId],
+      },
+    });
+  };
+};
+
+export const useUpdateComplianceRegistry = () => {
+  const [mutate] = useMutation(updateComplianceRegistryMutation);
+  const { __ } = useTranslate();
+
+  return (input: {
+    id: string;
+    referenceId?: string;
+    area?: string;
+    source?: string;
+    auditId?: string;
+    requirement?: string;
+    actionsToBeImplemented?: string;
+    regulator?: string;
+    ownerId?: string;
+    lastReviewDate?: string;
+    dueDate?: string;
+    status?: string;
+  }) => {
+    if (!input.id) {
+      return alert(__("Failed to update compliance registry entry: registry ID is required"));
+    }
+
+    return promisifyMutation(mutate)({
+      variables: {
+        input,
+      },
+    });
+  };
+};

--- a/apps/console/src/hooks/graph/__generated__/ComplianceRegistryGraphCreateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/ComplianceRegistryGraphCreateMutation.graphql.ts
@@ -1,0 +1,382 @@
+/**
+ * @generated SignedSource<<a3f34af85b45563725a110a4e6b6cbfb>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type ComplianceRegistryStatus = "CLOSED" | "IN_PROGRESS" | "OPEN";
+export type CreateComplianceRegistryInput = {
+  actionsToBeImplemented?: string | null | undefined;
+  area?: string | null | undefined;
+  auditId: string;
+  dueDate?: any | null | undefined;
+  lastReviewDate?: any | null | undefined;
+  organizationId: string;
+  ownerId: string;
+  referenceId: string;
+  regulator?: string | null | undefined;
+  requirement?: string | null | undefined;
+  source?: string | null | undefined;
+  status: ComplianceRegistryStatus;
+};
+export type ComplianceRegistryGraphCreateMutation$variables = {
+  connections: ReadonlyArray<string>;
+  input: CreateComplianceRegistryInput;
+};
+export type ComplianceRegistryGraphCreateMutation$data = {
+  readonly createComplianceRegistry: {
+    readonly complianceRegistryEdge: {
+      readonly node: {
+        readonly actionsToBeImplemented: string | null | undefined;
+        readonly area: string | null | undefined;
+        readonly audit: {
+          readonly framework: {
+            readonly name: string;
+          };
+          readonly id: string;
+          readonly name: string | null | undefined;
+        };
+        readonly createdAt: any;
+        readonly dueDate: any | null | undefined;
+        readonly id: string;
+        readonly lastReviewDate: any | null | undefined;
+        readonly owner: {
+          readonly fullName: string;
+          readonly id: string;
+        };
+        readonly referenceId: string;
+        readonly regulator: string | null | undefined;
+        readonly requirement: string | null | undefined;
+        readonly source: string | null | undefined;
+        readonly status: ComplianceRegistryStatus;
+      };
+    };
+  };
+};
+export type ComplianceRegistryGraphCreateMutation = {
+  response: ComplianceRegistryGraphCreateMutation$data;
+  variables: ComplianceRegistryGraphCreateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "referenceId",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "area",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "source",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "requirement",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "actionsToBeImplemented",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "regulator",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "lastReviewDate",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "dueDate",
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "status",
+  "storageKey": null
+},
+v13 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v14 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "People",
+  "kind": "LinkedField",
+  "name": "owner",
+  "plural": false,
+  "selections": [
+    (v3/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "fullName",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v15 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ComplianceRegistryGraphCreateMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "CreateComplianceRegistryPayload",
+        "kind": "LinkedField",
+        "name": "createComplianceRegistry",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ComplianceRegistryEdge",
+            "kind": "LinkedField",
+            "name": "complianceRegistryEdge",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ComplianceRegistry",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v3/*: any*/),
+                  (v4/*: any*/),
+                  (v5/*: any*/),
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/),
+                  (v10/*: any*/),
+                  (v11/*: any*/),
+                  (v12/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Audit",
+                    "kind": "LinkedField",
+                    "name": "audit",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      (v13/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Framework",
+                        "kind": "LinkedField",
+                        "name": "framework",
+                        "plural": false,
+                        "selections": [
+                          (v13/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  (v14/*: any*/),
+                  (v15/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "ComplianceRegistryGraphCreateMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "CreateComplianceRegistryPayload",
+        "kind": "LinkedField",
+        "name": "createComplianceRegistry",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ComplianceRegistryEdge",
+            "kind": "LinkedField",
+            "name": "complianceRegistryEdge",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ComplianceRegistry",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v3/*: any*/),
+                  (v4/*: any*/),
+                  (v5/*: any*/),
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/),
+                  (v10/*: any*/),
+                  (v11/*: any*/),
+                  (v12/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Audit",
+                    "kind": "LinkedField",
+                    "name": "audit",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      (v13/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Framework",
+                        "kind": "LinkedField",
+                        "name": "framework",
+                        "plural": false,
+                        "selections": [
+                          (v13/*: any*/),
+                          (v3/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  (v14/*: any*/),
+                  (v15/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "prependEdge",
+            "key": "",
+            "kind": "LinkedHandle",
+            "name": "complianceRegistryEdge",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "68c793eb099ce3e917992b3f8c22d551",
+    "id": null,
+    "metadata": {},
+    "name": "ComplianceRegistryGraphCreateMutation",
+    "operationKind": "mutation",
+    "text": "mutation ComplianceRegistryGraphCreateMutation(\n  $input: CreateComplianceRegistryInput!\n) {\n  createComplianceRegistry(input: $input) {\n    complianceRegistryEdge {\n      node {\n        id\n        referenceId\n        area\n        source\n        requirement\n        actionsToBeImplemented\n        regulator\n        lastReviewDate\n        dueDate\n        status\n        audit {\n          id\n          name\n          framework {\n            name\n            id\n          }\n        }\n        owner {\n          id\n          fullName\n        }\n        createdAt\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "50e1966d2f9cc1ed347a77f8f024125c";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/ComplianceRegistryGraphDeleteMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/ComplianceRegistryGraphDeleteMutation.graphql.ts
@@ -1,0 +1,132 @@
+/**
+ * @generated SignedSource<<0d815d748a76df90cc5305fa28913125>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type DeleteComplianceRegistryInput = {
+  complianceRegistryId: string;
+};
+export type ComplianceRegistryGraphDeleteMutation$variables = {
+  connections: ReadonlyArray<string>;
+  input: DeleteComplianceRegistryInput;
+};
+export type ComplianceRegistryGraphDeleteMutation$data = {
+  readonly deleteComplianceRegistry: {
+    readonly deletedComplianceRegistryId: string;
+  };
+};
+export type ComplianceRegistryGraphDeleteMutation = {
+  response: ComplianceRegistryGraphDeleteMutation$data;
+  variables: ComplianceRegistryGraphDeleteMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "deletedComplianceRegistryId",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ComplianceRegistryGraphDeleteMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteComplianceRegistryPayload",
+        "kind": "LinkedField",
+        "name": "deleteComplianceRegistry",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "ComplianceRegistryGraphDeleteMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteComplianceRegistryPayload",
+        "kind": "LinkedField",
+        "name": "deleteComplianceRegistry",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "deleteEdge",
+            "key": "",
+            "kind": "ScalarHandle",
+            "name": "deletedComplianceRegistryId",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "4ee4b9ffa6ea477c93a0ba80b8295a44",
+    "id": null,
+    "metadata": {},
+    "name": "ComplianceRegistryGraphDeleteMutation",
+    "operationKind": "mutation",
+    "text": "mutation ComplianceRegistryGraphDeleteMutation(\n  $input: DeleteComplianceRegistryInput!\n) {\n  deleteComplianceRegistry(input: $input) {\n    deletedComplianceRegistryId\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "c979ce19185e3d4c20c8a952b5245993";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/ComplianceRegistryGraphListQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/ComplianceRegistryGraphListQuery.graphql.ts
@@ -1,0 +1,361 @@
+/**
+ * @generated SignedSource<<8e9c859e7b87a623664e1bd16c620ef1>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ComplianceRegistryGraphListQuery$variables = {
+  organizationId: string;
+};
+export type ComplianceRegistryGraphListQuery$data = {
+  readonly node: {
+    readonly " $fragmentSpreads": FragmentRefs<"ComplianceRegistriesPageFragment">;
+  };
+};
+export type ComplianceRegistryGraphListQuery = {
+  response: ComplianceRegistryGraphListQuery$data;
+  variables: ComplianceRegistryGraphListQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "organizationId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "organizationId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10
+  }
+],
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ComplianceRegistryGraphListQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "ComplianceRegistriesPageFragment"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ComplianceRegistryGraphListQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": (v4/*: any*/),
+                "concreteType": "ComplianceRegistryConnection",
+                "kind": "LinkedField",
+                "name": "complianceRegistries",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "totalCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "ComplianceRegistryEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ComplianceRegistry",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v3/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "referenceId",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "area",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "source",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "requirement",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "status",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "lastReviewDate",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "dueDate",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "actionsToBeImplemented",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "regulator",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Audit",
+                            "kind": "LinkedField",
+                            "name": "audit",
+                            "plural": false,
+                            "selections": [
+                              (v3/*: any*/),
+                              (v5/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Framework",
+                                "kind": "LinkedField",
+                                "name": "framework",
+                                "plural": false,
+                                "selections": [
+                                  (v3/*: any*/),
+                                  (v5/*: any*/)
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "People",
+                            "kind": "LinkedField",
+                            "name": "owner",
+                            "plural": false,
+                            "selections": [
+                              (v3/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "fullName",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "createdAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "updatedAt",
+                            "storageKey": null
+                          },
+                          (v2/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "cursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageInfo",
+                    "kind": "LinkedField",
+                    "name": "pageInfo",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "hasNextPage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "endCursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ClientExtension",
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "__id",
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ],
+                "storageKey": "complianceRegistries(first:10)"
+              },
+              {
+                "alias": null,
+                "args": (v4/*: any*/),
+                "filters": null,
+                "handle": "connection",
+                "key": "ComplianceRegistriesPage_complianceRegistries",
+                "kind": "LinkedHandle",
+                "name": "complianceRegistries"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "bec30edcb0f8d7c4147e827c422d524f",
+    "id": null,
+    "metadata": {},
+    "name": "ComplianceRegistryGraphListQuery",
+    "operationKind": "query",
+    "text": "query ComplianceRegistryGraphListQuery(\n  $organizationId: ID!\n) {\n  node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      ...ComplianceRegistriesPageFragment\n    }\n    id\n  }\n}\n\nfragment ComplianceRegistriesPageFragment on Organization {\n  id\n  complianceRegistries(first: 10) {\n    totalCount\n    edges {\n      node {\n        id\n        referenceId\n        area\n        source\n        requirement\n        status\n        lastReviewDate\n        dueDate\n        actionsToBeImplemented\n        regulator\n        audit {\n          id\n          name\n          framework {\n            id\n            name\n          }\n        }\n        owner {\n          id\n          fullName\n        }\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "363434c78eb3e27ac52b6da13c7432a1";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/ComplianceRegistryGraphNodeQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/ComplianceRegistryGraphNodeQuery.graphql.ts
@@ -1,0 +1,320 @@
+/**
+ * @generated SignedSource<<14a59a4b5703ae1fb885b70ff8c8d479>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type ComplianceRegistryStatus = "CLOSED" | "IN_PROGRESS" | "OPEN";
+export type ComplianceRegistryGraphNodeQuery$variables = {
+  complianceRegistryId: string;
+};
+export type ComplianceRegistryGraphNodeQuery$data = {
+  readonly node: {
+    readonly actionsToBeImplemented?: string | null | undefined;
+    readonly area?: string | null | undefined;
+    readonly audit?: {
+      readonly framework: {
+        readonly id: string;
+        readonly name: string;
+      };
+      readonly id: string;
+      readonly name: string | null | undefined;
+    };
+    readonly createdAt?: any;
+    readonly dueDate?: any | null | undefined;
+    readonly id?: string;
+    readonly lastReviewDate?: any | null | undefined;
+    readonly organization?: {
+      readonly id: string;
+      readonly name: string;
+    };
+    readonly owner?: {
+      readonly fullName: string;
+      readonly id: string;
+    };
+    readonly referenceId?: string;
+    readonly regulator?: string | null | undefined;
+    readonly requirement?: string | null | undefined;
+    readonly source?: string | null | undefined;
+    readonly status?: ComplianceRegistryStatus;
+    readonly updatedAt?: any;
+  };
+};
+export type ComplianceRegistryGraphNodeQuery = {
+  response: ComplianceRegistryGraphNodeQuery$data;
+  variables: ComplianceRegistryGraphNodeQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "complianceRegistryId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "complianceRegistryId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "referenceId",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "area",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "source",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "requirement",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "actionsToBeImplemented",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "regulator",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "lastReviewDate",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "dueDate",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "status",
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v13 = [
+  (v2/*: any*/),
+  (v12/*: any*/)
+],
+v14 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Audit",
+  "kind": "LinkedField",
+  "name": "audit",
+  "plural": false,
+  "selections": [
+    (v2/*: any*/),
+    (v12/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Framework",
+      "kind": "LinkedField",
+      "name": "framework",
+      "plural": false,
+      "selections": (v13/*: any*/),
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v15 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "People",
+  "kind": "LinkedField",
+  "name": "owner",
+  "plural": false,
+  "selections": [
+    (v2/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "fullName",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v16 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Organization",
+  "kind": "LinkedField",
+  "name": "organization",
+  "plural": false,
+  "selections": (v13/*: any*/),
+  "storageKey": null
+},
+v17 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+},
+v18 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "updatedAt",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ComplianceRegistryGraphNodeQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/),
+              (v9/*: any*/),
+              (v10/*: any*/),
+              (v11/*: any*/),
+              (v14/*: any*/),
+              (v15/*: any*/),
+              (v16/*: any*/),
+              (v17/*: any*/),
+              (v18/*: any*/)
+            ],
+            "type": "ComplianceRegistry",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ComplianceRegistryGraphNodeQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/),
+              (v9/*: any*/),
+              (v10/*: any*/),
+              (v11/*: any*/),
+              (v14/*: any*/),
+              (v15/*: any*/),
+              (v16/*: any*/),
+              (v17/*: any*/),
+              (v18/*: any*/)
+            ],
+            "type": "ComplianceRegistry",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "bb1bf89e0916abe7f9807404aa2cf9eb",
+    "id": null,
+    "metadata": {},
+    "name": "ComplianceRegistryGraphNodeQuery",
+    "operationKind": "query",
+    "text": "query ComplianceRegistryGraphNodeQuery(\n  $complianceRegistryId: ID!\n) {\n  node(id: $complianceRegistryId) {\n    __typename\n    ... on ComplianceRegistry {\n      id\n      referenceId\n      area\n      source\n      requirement\n      actionsToBeImplemented\n      regulator\n      lastReviewDate\n      dueDate\n      status\n      audit {\n        id\n        name\n        framework {\n          id\n          name\n        }\n      }\n      owner {\n        id\n        fullName\n      }\n      organization {\n        id\n        name\n      }\n      createdAt\n      updatedAt\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "292fb8d0ee375d8c5e34cbf2633b7f77";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/ComplianceRegistryGraphUpdateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/ComplianceRegistryGraphUpdateMutation.graphql.ts
@@ -1,0 +1,262 @@
+/**
+ * @generated SignedSource<<e0af427b5ec1a1056bee3859d5c06a8a>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type ComplianceRegistryStatus = "CLOSED" | "IN_PROGRESS" | "OPEN";
+export type UpdateComplianceRegistryInput = {
+  actionsToBeImplemented?: string | null | undefined;
+  area?: string | null | undefined;
+  auditId?: string | null | undefined;
+  dueDate?: any | null | undefined;
+  id: string;
+  lastReviewDate?: any | null | undefined;
+  ownerId?: string | null | undefined;
+  referenceId?: string | null | undefined;
+  regulator?: string | null | undefined;
+  requirement?: string | null | undefined;
+  source?: string | null | undefined;
+  status?: ComplianceRegistryStatus | null | undefined;
+};
+export type ComplianceRegistryGraphUpdateMutation$variables = {
+  input: UpdateComplianceRegistryInput;
+};
+export type ComplianceRegistryGraphUpdateMutation$data = {
+  readonly updateComplianceRegistry: {
+    readonly complianceRegistry: {
+      readonly actionsToBeImplemented: string | null | undefined;
+      readonly area: string | null | undefined;
+      readonly audit: {
+        readonly framework: {
+          readonly id: string;
+          readonly name: string;
+        };
+        readonly id: string;
+        readonly name: string | null | undefined;
+      };
+      readonly dueDate: any | null | undefined;
+      readonly id: string;
+      readonly lastReviewDate: any | null | undefined;
+      readonly owner: {
+        readonly fullName: string;
+        readonly id: string;
+      };
+      readonly referenceId: string;
+      readonly regulator: string | null | undefined;
+      readonly requirement: string | null | undefined;
+      readonly source: string | null | undefined;
+      readonly status: ComplianceRegistryStatus;
+      readonly updatedAt: any;
+    };
+  };
+};
+export type ComplianceRegistryGraphUpdateMutation = {
+  response: ComplianceRegistryGraphUpdateMutation$data;
+  variables: ComplianceRegistryGraphUpdateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v3 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "UpdateComplianceRegistryPayload",
+    "kind": "LinkedField",
+    "name": "updateComplianceRegistry",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "ComplianceRegistry",
+        "kind": "LinkedField",
+        "name": "complianceRegistry",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "referenceId",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "area",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "source",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "requirement",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "actionsToBeImplemented",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "regulator",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "lastReviewDate",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "dueDate",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "status",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "People",
+            "kind": "LinkedField",
+            "name": "owner",
+            "plural": false,
+            "selections": [
+              (v1/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "fullName",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Audit",
+            "kind": "LinkedField",
+            "name": "audit",
+            "plural": false,
+            "selections": [
+              (v1/*: any*/),
+              (v2/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Framework",
+                "kind": "LinkedField",
+                "name": "framework",
+                "plural": false,
+                "selections": [
+                  (v1/*: any*/),
+                  (v2/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "updatedAt",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ComplianceRegistryGraphUpdateMutation",
+    "selections": (v3/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ComplianceRegistryGraphUpdateMutation",
+    "selections": (v3/*: any*/)
+  },
+  "params": {
+    "cacheID": "4a4f7e9273f36c87a7e48b5373f69bc2",
+    "id": null,
+    "metadata": {},
+    "name": "ComplianceRegistryGraphUpdateMutation",
+    "operationKind": "mutation",
+    "text": "mutation ComplianceRegistryGraphUpdateMutation(\n  $input: UpdateComplianceRegistryInput!\n) {\n  updateComplianceRegistry(input: $input) {\n    complianceRegistry {\n      id\n      referenceId\n      area\n      source\n      requirement\n      actionsToBeImplemented\n      regulator\n      lastReviewDate\n      dueDate\n      status\n      owner {\n        id\n        fullName\n      }\n      audit {\n        id\n        name\n        framework {\n          id\n          name\n        }\n      }\n      updatedAt\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "c4d17f11888dd8a4769b471797c25b95";
+
+export default node;

--- a/apps/console/src/layouts/MainLayout.tsx
+++ b/apps/console/src/layouts/MainLayout.tsx
@@ -5,6 +5,7 @@ import {
   IconBank,
   IconBook,
   IconCircleQuestionmark,
+  IconCrossLargeX,
   IconFire3,
   IconGroup1,
   IconInboxEmpty,
@@ -141,8 +142,13 @@ export function MainLayout() {
           />
           <SidebarItem
             label={__("Nonconformity Registries")}
-            icon={IconBook}
+            icon={IconCrossLargeX}
             to={`${prefix}/nonconformityRegistries`}
+          />
+          <SidebarItem
+            label={__("Compliance Registries")}
+            icon={IconBook}
+            to={`${prefix}/complianceRegistries`}
           />
           <SidebarItem
             label={__("Trust Center")}

--- a/apps/console/src/pages/organizations/complianceRegistries/ComplianceRegistriesPage.tsx
+++ b/apps/console/src/pages/organizations/complianceRegistries/ComplianceRegistriesPage.tsx
@@ -1,0 +1,264 @@
+import {
+  Button,
+  IconPlusLarge,
+  PageHeader,
+  Card,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Badge,
+  ActionDropdown,
+  DropdownItem,
+  IconTrashCan,
+  Table,
+  useConfirm,
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { usePageTitle } from "@probo/hooks";
+import {
+  graphql,
+  usePaginationFragment,
+  usePreloadedQuery,
+  useMutation,
+  type PreloadedQuery,
+} from "react-relay";
+import { useOrganizationId } from "/hooks/useOrganizationId";
+import { CreateComplianceRegistryDialog } from "./dialogs/CreateComplianceRegistryDialog";
+import { deleteComplianceRegistryMutation } from "../../../hooks/graph/ComplianceRegistryGraph";
+import { sprintf, promisifyMutation, getStatusVariant, getStatusLabel } from "@probo/helpers";
+import type { ComplianceRegistriesPageQuery } from "./__generated__/ComplianceRegistriesPageQuery.graphql";
+import type {
+  ComplianceRegistriesPageFragment$key,
+  ComplianceRegistriesPageFragment$data,
+} from "./__generated__/ComplianceRegistriesPageFragment.graphql";
+
+type ComplianceRegistry = ComplianceRegistriesPageFragment$data['complianceRegistries']['edges'][number]['node'];
+
+interface ComplianceRegistriesPageProps {
+  queryRef: PreloadedQuery<ComplianceRegistriesPageQuery>;
+}
+
+const complianceRegistriesPageFragment = graphql`
+  fragment ComplianceRegistriesPageFragment on Organization
+  @refetchable(queryName: "ComplianceRegistriesPageRefetchQuery")
+  @argumentDefinitions(
+    first: { type: "Int", defaultValue: 10 }
+    after: { type: "CursorKey" }
+  ) {
+    id
+    complianceRegistries(first: $first, after: $after)
+      @connection(key: "ComplianceRegistriesPage_complianceRegistries") {
+      __id
+      totalCount
+      edges {
+        node {
+          id
+          referenceId
+          area
+          source
+          requirement
+          status
+          lastReviewDate
+          dueDate
+          actionsToBeImplemented
+          regulator
+          audit {
+            id
+            name
+            framework {
+              id
+              name
+            }
+          }
+          owner {
+            id
+            fullName
+          }
+          createdAt
+          updatedAt
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+`;
+
+export default function ComplianceRegistriesPage({ queryRef }: ComplianceRegistriesPageProps) {
+  const { __ } = useTranslate();
+  const organizationId = useOrganizationId();
+
+  usePageTitle(__("Compliance Registries"));
+
+  const organization = usePreloadedQuery(
+    graphql`
+      query ComplianceRegistriesPageQuery($organizationId: ID!) {
+        node(id: $organizationId) {
+          ... on Organization {
+            ...ComplianceRegistriesPageFragment
+          }
+        }
+      }
+    `,
+    queryRef
+  );
+
+  const { data: registriesData, loadNext, hasNext } = usePaginationFragment(
+    complianceRegistriesPageFragment,
+    organization.node as ComplianceRegistriesPageFragment$key
+  );
+
+  const connectionId = registriesData?.complianceRegistries?.__id || "";
+  const registries: ComplianceRegistry[] = registriesData?.complianceRegistries?.edges?.map((edge) => edge.node) ?? [];
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title={__("Compliance Registries")}
+        description={__(
+          "Manage your organization's compliance registry entries."
+        )}
+      >
+        <CreateComplianceRegistryDialog organizationId={organizationId} connection={connectionId}>
+          <Button icon={IconPlusLarge}>{__("Add compliance registry")}</Button>
+        </CreateComplianceRegistryDialog>
+      </PageHeader>
+
+      {registries.length === 0 ? (
+        <Card padded>
+          <div className="text-center py-12">
+            <h3 className="text-lg font-semibold mb-2">
+              {__("No compliance registry entries yet")}
+            </h3>
+            <p className="text-txt-tertiary mb-4">
+              {__("Create your first compliance registry entry to get started.")}
+            </p>
+          </div>
+        </Card>
+      ) : (
+        <Card>
+          <Table>
+            <Thead>
+              <Tr>
+                <Th>{__("Reference ID")}</Th>
+                <Th>{__("Area")}</Th>
+                <Th>{__("Source")}</Th>
+                <Th>{__("Status")}</Th>
+                <Th>{__("Audit")}</Th>
+                <Th>{__("Owner")}</Th>
+                <Th>{__("Due Date")}</Th>
+                <Th>{__("Actions")}</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {registries.map((registry) => (
+                <RegistryRow
+                  key={registry.id}
+                  registry={registry}
+                  connectionId={connectionId}
+                />
+              ))}
+            </Tbody>
+          </Table>
+
+          {hasNext && (
+            <div className="p-4 border-t">
+              <Button
+                variant="secondary"
+                onClick={() => loadNext(10)}
+                disabled={!hasNext}
+              >
+                {__("Load more")}
+              </Button>
+            </div>
+          )}
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function RegistryRow({
+  registry,
+  connectionId,
+}: {
+  registry: ComplianceRegistry;
+  connectionId: string;
+}) {
+  const organizationId = useOrganizationId();
+  const { __ } = useTranslate();
+  const [deleteRegistry] = useMutation(deleteComplianceRegistryMutation);
+  const confirm = useConfirm();
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString();
+  };
+
+  const handleDelete = () => {
+    confirm(
+      () =>
+        promisifyMutation(deleteRegistry)({
+          variables: {
+            input: {
+              complianceRegistryId: registry.id,
+            },
+            connections: [connectionId],
+          },
+        }),
+      {
+        message: sprintf(
+          __(
+            "This will permanently delete the compliance registry entry %s. This action cannot be undone."
+          ),
+          registry.referenceId
+        ),
+      }
+    );
+  };
+
+  return (
+    <Tr to={`/organizations/${organizationId}/complianceRegistries/${registry.id}`}>
+      <Td>
+        <span className="font-mono text-sm">{registry.referenceId}</span>
+      </Td>
+      <Td>{registry.area || "-"}</Td>
+      <Td>{registry.source || "-"}</Td>
+      <Td>
+        <Badge variant={getStatusVariant(registry.status || "OPEN")}>
+          {getStatusLabel(registry.status || "OPEN")}
+        </Badge>
+      </Td>
+      <Td>
+          {registry.audit?.name
+            ? `${registry.audit.framework.name} - ${registry.audit.name}`
+            : registry.audit?.framework.name || "-"
+          }
+        </Td>
+      <Td>{registry.owner?.fullName || "-"}</Td>
+      <Td>
+        {registry.dueDate ? (
+          <time dateTime={registry.dueDate}>
+            {formatDate(registry.dueDate)}
+          </time>
+        ) : (
+          <span className="text-txt-tertiary">{__("No due date")}</span>
+        )}
+      </Td>
+      <Td noLink width={50} className="text-end">
+        <ActionDropdown>
+          <DropdownItem
+            icon={IconTrashCan}
+            variant="danger"
+            onSelect={handleDelete}
+          >
+            {__("Delete")}
+          </DropdownItem>
+        </ActionDropdown>
+      </Td>
+    </Tr>
+  );
+}

--- a/apps/console/src/pages/organizations/complianceRegistries/ComplianceRegistryDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/complianceRegistries/ComplianceRegistryDetailsPage.tsx
@@ -1,0 +1,315 @@
+import {
+  ConnectionHandler,
+  usePreloadedQuery,
+  type PreloadedQuery,
+} from "react-relay";
+import {
+  complianceRegistryNodeQuery,
+  useDeleteComplianceRegistry,
+  useUpdateComplianceRegistry,
+  ComplianceRegistriesConnectionKey,
+} from "../../../hooks/graph/ComplianceRegistryGraph";
+import {
+  ActionDropdown,
+  Badge,
+  Breadcrumb,
+  Button,
+  DropdownItem,
+  Field,
+  IconTrashCan,
+  Option,
+  Input,
+  Card,
+  Textarea,
+  useToast,
+  Select,
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { useOrganizationId } from "/hooks/useOrganizationId";
+import { PeopleSelectField } from "/components/form/PeopleSelectField";
+import { AuditSelectField } from "/components/form/AuditSelectField";
+import { useFormWithSchema } from "/hooks/useFormWithSchema";
+import { Controller } from "react-hook-form";
+import z from "zod";
+import { getStatusVariant, getStatusLabel, formatDatetime, getComplianceRegistryStatusOptions } from "@probo/helpers";
+import type { ComplianceRegistryGraphNodeQuery } from "/hooks/graph/__generated__/ComplianceRegistryGraphNodeQuery.graphql";
+
+const updateRegistrySchema = z.object({
+  referenceId: z.string().min(1, "Reference ID is required"),
+  area: z.string().optional(),
+  source: z.string().optional(),
+  requirement: z.string().optional(),
+  actionsToBeImplemented: z.string().optional(),
+  regulator: z.string().optional(),
+  lastReviewDate: z.string().optional(),
+  dueDate: z.string().optional(),
+  status: z.enum(["OPEN", "IN_PROGRESS", "CLOSED"]),
+  ownerId: z.string().min(1, "Owner is required"),
+  auditId: z.string().min(1, "Audit is required"),
+});
+
+type Props = {
+  queryRef: PreloadedQuery<ComplianceRegistryGraphNodeQuery>;
+};
+
+export default function ComplianceRegistryDetailsPage(props: Props) {
+  const data = usePreloadedQuery<ComplianceRegistryGraphNodeQuery>(complianceRegistryNodeQuery, props.queryRef);
+  const registry = data.node;
+  const { __ } = useTranslate();
+  const { toast } = useToast();
+  const organizationId = useOrganizationId();
+
+  if (!registry) {
+    return <div>{__("Compliance registry entry not found")}</div>;
+  }
+
+  const updateRegistry = useUpdateComplianceRegistry();
+  const statusOptions = getComplianceRegistryStatusOptions(__);
+
+  const connectionId = ConnectionHandler.getConnectionID(
+    organizationId,
+    ComplianceRegistriesConnectionKey
+  );
+
+  const deleteRegistry = useDeleteComplianceRegistry({ id: registry.id!, referenceId: registry.referenceId! }, connectionId);
+
+  const { register, handleSubmit, formState, control } = useFormWithSchema(
+    updateRegistrySchema,
+    {
+      defaultValues: {
+        referenceId: registry.referenceId || "",
+        area: registry.area || "",
+        source: registry.source || "",
+        requirement: registry.requirement || "",
+        actionsToBeImplemented: registry.actionsToBeImplemented || "",
+        regulator: registry.regulator || "",
+        lastReviewDate: registry.lastReviewDate
+          ? new Date(registry.lastReviewDate).toISOString().split("T")[0]
+          : "",
+        dueDate: registry.dueDate
+          ? new Date(registry.dueDate).toISOString().split("T")[0]
+          : "",
+        status: registry.status || "OPEN",
+        ownerId: registry.owner?.id || "",
+        auditId: registry.audit?.id || "",
+      },
+    }
+  );
+
+  const onSubmit = handleSubmit(async (formData) => {
+    try {
+      await updateRegistry({
+        id: registry.id!,
+        referenceId: formData.referenceId,
+        area: formData.area || undefined,
+        source: formData.source || undefined,
+        requirement: formData.requirement || undefined,
+        actionsToBeImplemented: formData.actionsToBeImplemented || undefined,
+        regulator: formData.regulator || undefined,
+        lastReviewDate: formatDatetime(formData.lastReviewDate),
+        dueDate: formatDatetime(formData.dueDate),
+        status: formData.status,
+        ownerId: formData.ownerId,
+        auditId: formData.auditId,
+      });
+
+      toast({
+        title: __("Success"),
+        description: __("Compliance registry entry updated successfully"),
+        variant: "success",
+      });
+    } catch (error) {
+      toast({
+        title: __("Error"),
+        description: __("Failed to update compliance registry entry"),
+        variant: "error",
+      });
+    }
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-start">
+        <div>
+                     <Breadcrumb
+             items={[
+               { label: __("Compliance Registries"), to: "../complianceRegistries" },
+               { label: registry.referenceId! },
+             ]}
+           />
+          <div className="flex items-center gap-3 mt-2">
+            <h1 className="text-2xl font-bold">{registry.referenceId}</h1>
+            <Badge variant={getStatusVariant(registry.status || "OPEN")}>
+              {getStatusLabel(registry.status || "OPEN")}
+            </Badge>
+          </div>
+        </div>
+
+        <ActionDropdown>
+          <DropdownItem icon={IconTrashCan} onClick={deleteRegistry}>
+            {__("Delete")}
+          </DropdownItem>
+        </ActionDropdown>
+      </div>
+
+      <Card padded>
+        <form onSubmit={onSubmit} className="space-y-6">
+          <Field
+            label={__("Reference ID")}
+            error={formState.errors.referenceId?.message}
+            required
+          >
+            <Input
+              {...register("referenceId")}
+              placeholder={__("Enter reference ID")}
+            />
+          </Field>
+
+          <Controller
+            name="auditId"
+            control={control}
+            render={() => (
+              <AuditSelectField
+                organizationId={organizationId}
+                control={control}
+                name="auditId"
+                label={__("Audit")}
+                error={formState.errors.auditId?.message}
+                required
+              />
+            )}
+          />
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <Field
+              label={__("Area")}
+              error={formState.errors.area?.message}
+            >
+              <Input
+                {...register("area")}
+                placeholder={__("Enter area")}
+              />
+            </Field>
+
+            <Field
+              label={__("Source")}
+              error={formState.errors.source?.message}
+            >
+              <Input
+                {...register("source")}
+                placeholder={__("Enter source")}
+              />
+            </Field>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <Field label={__("Status")}>
+              <Controller
+                control={control}
+                name="status"
+                render={({ field }) => (
+                  <Select
+                    variant="editor"
+                    placeholder={__("Select status")}
+                    onValueChange={field.onChange}
+                    value={field.value}
+                    className="w-full"
+                  >
+                    {statusOptions.map((option) => (
+                      <Option key={option.value} value={option.value}>
+                        {option.label}
+                      </Option>
+                    ))}
+                  </Select>
+                )}
+              />
+              {formState.errors.status && (
+                <p className="text-sm text-red-500 mt-1">{formState.errors.status.message}</p>
+              )}
+            </Field>
+
+            <Controller
+              name="ownerId"
+              control={control}
+              render={() => (
+                <PeopleSelectField
+                  organizationId={organizationId}
+                  control={control}
+                  name="ownerId"
+                  label={__("Owner")}
+                  error={formState.errors.ownerId?.message}
+                  required
+                />
+              )}
+            />
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <Field
+              label={__("Regulator")}
+              error={formState.errors.regulator?.message}
+            >
+              <Input
+                {...register("regulator")}
+                placeholder={__("Enter regulator")}
+              />
+            </Field>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <Field
+              label={__("Last Review Date")}
+              error={formState.errors.lastReviewDate?.message}
+            >
+              <Input
+                {...register("lastReviewDate")}
+                type="date"
+              />
+            </Field>
+
+            <Field
+              label={__("Due Date")}
+              error={formState.errors.dueDate?.message}
+            >
+              <Input
+                {...register("dueDate")}
+                type="date"
+              />
+            </Field>
+          </div>
+
+          <Field
+            label={__("Requirement")}
+            error={formState.errors.requirement?.message}
+          >
+            <Textarea
+              {...register("requirement")}
+              placeholder={__("Enter requirement")}
+              rows={4}
+            />
+          </Field>
+
+          <Field
+            label={__("Actions to be Implemented")}
+            error={formState.errors.actionsToBeImplemented?.message}
+          >
+            <Textarea
+              {...register("actionsToBeImplemented")}
+              placeholder={__("Enter actions to be implemented")}
+              rows={4}
+            />
+          </Field>
+
+          <div className="flex justify-end">
+            <Button
+              type="submit"
+              disabled={formState.isSubmitting}
+            >
+              {formState.isSubmitting ? __("Saving...") : __("Save Changes")}
+            </Button>
+          </div>
+        </form>
+      </Card>
+    </div>
+  );
+}

--- a/apps/console/src/pages/organizations/complianceRegistries/__generated__/ComplianceRegistriesPageFragment.graphql.ts
+++ b/apps/console/src/pages/organizations/complianceRegistries/__generated__/ComplianceRegistriesPageFragment.graphql.ts
@@ -1,0 +1,346 @@
+/**
+ * @generated SignedSource<<388195a5e7e9e9a1a167ad7cb298c935>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type ComplianceRegistryStatus = "CLOSED" | "IN_PROGRESS" | "OPEN";
+import { FragmentRefs } from "relay-runtime";
+export type ComplianceRegistriesPageFragment$data = {
+  readonly complianceRegistries: {
+    readonly __id: string;
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly actionsToBeImplemented: string | null | undefined;
+        readonly area: string | null | undefined;
+        readonly audit: {
+          readonly framework: {
+            readonly id: string;
+            readonly name: string;
+          };
+          readonly id: string;
+          readonly name: string | null | undefined;
+        };
+        readonly createdAt: any;
+        readonly dueDate: any | null | undefined;
+        readonly id: string;
+        readonly lastReviewDate: any | null | undefined;
+        readonly owner: {
+          readonly fullName: string;
+          readonly id: string;
+        };
+        readonly referenceId: string;
+        readonly regulator: string | null | undefined;
+        readonly requirement: string | null | undefined;
+        readonly source: string | null | undefined;
+        readonly status: ComplianceRegistryStatus;
+        readonly updatedAt: any;
+      };
+    }>;
+    readonly pageInfo: {
+      readonly endCursor: any | null | undefined;
+      readonly hasNextPage: boolean;
+    };
+    readonly totalCount: number;
+  };
+  readonly id: string;
+  readonly " $fragmentType": "ComplianceRegistriesPageFragment";
+};
+export type ComplianceRegistriesPageFragment$key = {
+  readonly " $data"?: ComplianceRegistriesPageFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"ComplianceRegistriesPageFragment">;
+};
+
+import ComplianceRegistriesPageRefetchQuery_graphql from './ComplianceRegistriesPageRefetchQuery.graphql';
+
+const node: ReaderFragment = (function(){
+var v0 = [
+  "complianceRegistries"
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "after"
+    },
+    {
+      "defaultValue": 10,
+      "kind": "LocalArgument",
+      "name": "first"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": {
+    "connection": [
+      {
+        "count": "first",
+        "cursor": "after",
+        "direction": "forward",
+        "path": (v0/*: any*/)
+      }
+    ],
+    "refetch": {
+      "connection": {
+        "forward": {
+          "count": "first",
+          "cursor": "after"
+        },
+        "backward": null,
+        "path": (v0/*: any*/)
+      },
+      "fragmentPathInResult": [
+        "node"
+      ],
+      "operation": ComplianceRegistriesPageRefetchQuery_graphql,
+      "identifierInfo": {
+        "identifierField": "id",
+        "identifierQueryVariableName": "id"
+      }
+    }
+  },
+  "name": "ComplianceRegistriesPageFragment",
+  "selections": [
+    (v1/*: any*/),
+    {
+      "alias": "complianceRegistries",
+      "args": null,
+      "concreteType": "ComplianceRegistryConnection",
+      "kind": "LinkedField",
+      "name": "__ComplianceRegistriesPage_complianceRegistries_connection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "totalCount",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ComplianceRegistryEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "ComplianceRegistry",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                (v1/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "referenceId",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "area",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "source",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "requirement",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "status",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "lastReviewDate",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "dueDate",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "actionsToBeImplemented",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "regulator",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "Audit",
+                  "kind": "LinkedField",
+                  "name": "audit",
+                  "plural": false,
+                  "selections": [
+                    (v1/*: any*/),
+                    (v2/*: any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "Framework",
+                      "kind": "LinkedField",
+                      "name": "framework",
+                      "plural": false,
+                      "selections": [
+                        (v1/*: any*/),
+                        (v2/*: any*/)
+                      ],
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "People",
+                  "kind": "LinkedField",
+                  "name": "owner",
+                  "plural": false,
+                  "selections": [
+                    (v1/*: any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "fullName",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "createdAt",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "updatedAt",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "__typename",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "cursor",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "kind": "LinkedField",
+          "name": "pageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasNextPage",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "endCursor",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "kind": "ClientExtension",
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "__id",
+              "storageKey": null
+            }
+          ]
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Organization",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "c85f1b770b00186cc074726ee8766698";
+
+export default node;

--- a/apps/console/src/pages/organizations/complianceRegistries/__generated__/ComplianceRegistriesPageQuery.graphql.ts
+++ b/apps/console/src/pages/organizations/complianceRegistries/__generated__/ComplianceRegistriesPageQuery.graphql.ts
@@ -1,0 +1,361 @@
+/**
+ * @generated SignedSource<<45ac04d64bae14926f41dccda7ec5a25>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ComplianceRegistriesPageQuery$variables = {
+  organizationId: string;
+};
+export type ComplianceRegistriesPageQuery$data = {
+  readonly node: {
+    readonly " $fragmentSpreads": FragmentRefs<"ComplianceRegistriesPageFragment">;
+  };
+};
+export type ComplianceRegistriesPageQuery = {
+  response: ComplianceRegistriesPageQuery$data;
+  variables: ComplianceRegistriesPageQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "organizationId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "organizationId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10
+  }
+],
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ComplianceRegistriesPageQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "ComplianceRegistriesPageFragment"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ComplianceRegistriesPageQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": (v4/*: any*/),
+                "concreteType": "ComplianceRegistryConnection",
+                "kind": "LinkedField",
+                "name": "complianceRegistries",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "totalCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "ComplianceRegistryEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ComplianceRegistry",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v3/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "referenceId",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "area",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "source",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "requirement",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "status",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "lastReviewDate",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "dueDate",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "actionsToBeImplemented",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "regulator",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Audit",
+                            "kind": "LinkedField",
+                            "name": "audit",
+                            "plural": false,
+                            "selections": [
+                              (v3/*: any*/),
+                              (v5/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Framework",
+                                "kind": "LinkedField",
+                                "name": "framework",
+                                "plural": false,
+                                "selections": [
+                                  (v3/*: any*/),
+                                  (v5/*: any*/)
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "People",
+                            "kind": "LinkedField",
+                            "name": "owner",
+                            "plural": false,
+                            "selections": [
+                              (v3/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "fullName",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "createdAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "updatedAt",
+                            "storageKey": null
+                          },
+                          (v2/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "cursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageInfo",
+                    "kind": "LinkedField",
+                    "name": "pageInfo",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "hasNextPage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "endCursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ClientExtension",
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "__id",
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ],
+                "storageKey": "complianceRegistries(first:10)"
+              },
+              {
+                "alias": null,
+                "args": (v4/*: any*/),
+                "filters": null,
+                "handle": "connection",
+                "key": "ComplianceRegistriesPage_complianceRegistries",
+                "kind": "LinkedHandle",
+                "name": "complianceRegistries"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "fcc5d4d2cc4ca376314b334d7f36316f",
+    "id": null,
+    "metadata": {},
+    "name": "ComplianceRegistriesPageQuery",
+    "operationKind": "query",
+    "text": "query ComplianceRegistriesPageQuery(\n  $organizationId: ID!\n) {\n  node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      ...ComplianceRegistriesPageFragment\n    }\n    id\n  }\n}\n\nfragment ComplianceRegistriesPageFragment on Organization {\n  id\n  complianceRegistries(first: 10) {\n    totalCount\n    edges {\n      node {\n        id\n        referenceId\n        area\n        source\n        requirement\n        status\n        lastReviewDate\n        dueDate\n        actionsToBeImplemented\n        regulator\n        audit {\n          id\n          name\n          framework {\n            id\n            name\n          }\n        }\n        owner {\n          id\n          fullName\n        }\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "3e8551eebdf52ee84fb3910ee77cfe15";
+
+export default node;

--- a/apps/console/src/pages/organizations/complianceRegistries/__generated__/ComplianceRegistriesPageRefetchQuery.graphql.ts
+++ b/apps/console/src/pages/organizations/complianceRegistries/__generated__/ComplianceRegistriesPageRefetchQuery.graphql.ts
@@ -1,0 +1,371 @@
+/**
+ * @generated SignedSource<<2f421894f05c26b8fbca3d5e76ebdf0d>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ComplianceRegistriesPageRefetchQuery$variables = {
+  after?: any | null | undefined;
+  first?: number | null | undefined;
+  id: string;
+};
+export type ComplianceRegistriesPageRefetchQuery$data = {
+  readonly node: {
+    readonly " $fragmentSpreads": FragmentRefs<"ComplianceRegistriesPageFragment">;
+  };
+};
+export type ComplianceRegistriesPageRefetchQuery = {
+  response: ComplianceRegistriesPageRefetchQuery$data;
+  variables: ComplianceRegistriesPageRefetchQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "after"
+  },
+  {
+    "defaultValue": 10,
+    "kind": "LocalArgument",
+    "name": "first"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "after"
+  },
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "first"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ComplianceRegistriesPageRefetchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "args": (v2/*: any*/),
+            "kind": "FragmentSpread",
+            "name": "ComplianceRegistriesPageFragment"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ComplianceRegistriesPageRefetchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          (v4/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": (v2/*: any*/),
+                "concreteType": "ComplianceRegistryConnection",
+                "kind": "LinkedField",
+                "name": "complianceRegistries",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "totalCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "ComplianceRegistryEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ComplianceRegistry",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v4/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "referenceId",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "area",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "source",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "requirement",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "status",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "lastReviewDate",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "dueDate",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "actionsToBeImplemented",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "regulator",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Audit",
+                            "kind": "LinkedField",
+                            "name": "audit",
+                            "plural": false,
+                            "selections": [
+                              (v4/*: any*/),
+                              (v5/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Framework",
+                                "kind": "LinkedField",
+                                "name": "framework",
+                                "plural": false,
+                                "selections": [
+                                  (v4/*: any*/),
+                                  (v5/*: any*/)
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "People",
+                            "kind": "LinkedField",
+                            "name": "owner",
+                            "plural": false,
+                            "selections": [
+                              (v4/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "fullName",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "createdAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "updatedAt",
+                            "storageKey": null
+                          },
+                          (v3/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "cursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageInfo",
+                    "kind": "LinkedField",
+                    "name": "pageInfo",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "hasNextPage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "endCursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ClientExtension",
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "__id",
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": (v2/*: any*/),
+                "filters": null,
+                "handle": "connection",
+                "key": "ComplianceRegistriesPage_complianceRegistries",
+                "kind": "LinkedHandle",
+                "name": "complianceRegistries"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "aaec01ab09a3becc49afe167cc55acb6",
+    "id": null,
+    "metadata": {},
+    "name": "ComplianceRegistriesPageRefetchQuery",
+    "operationKind": "query",
+    "text": "query ComplianceRegistriesPageRefetchQuery(\n  $after: CursorKey\n  $first: Int = 10\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...ComplianceRegistriesPageFragment_2HEEH6\n    id\n  }\n}\n\nfragment ComplianceRegistriesPageFragment_2HEEH6 on Organization {\n  id\n  complianceRegistries(first: $first, after: $after) {\n    totalCount\n    edges {\n      node {\n        id\n        referenceId\n        area\n        source\n        requirement\n        status\n        lastReviewDate\n        dueDate\n        actionsToBeImplemented\n        regulator\n        audit {\n          id\n          name\n          framework {\n            id\n            name\n          }\n        }\n        owner {\n          id\n          fullName\n        }\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "c85f1b770b00186cc074726ee8766698";
+
+export default node;

--- a/apps/console/src/pages/organizations/complianceRegistries/dialogs/CreateComplianceRegistryDialog.tsx
+++ b/apps/console/src/pages/organizations/complianceRegistries/dialogs/CreateComplianceRegistryDialog.tsx
@@ -1,0 +1,252 @@
+import { type ReactNode } from "react";
+import {
+  Button,
+  Field,
+  useToast,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  useDialogRef,
+  Textarea,
+  Breadcrumb,
+  Label,
+  Select,
+  Option,
+  Input,
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { z } from "zod";
+import { useFormWithSchema } from "/hooks/useFormWithSchema";
+import { useCreateComplianceRegistry } from "../../../../hooks/graph/ComplianceRegistryGraph";
+import { PeopleSelectField } from "/components/form/PeopleSelectField";
+import { AuditSelectField } from "/components/form/AuditSelectField";
+import { Controller } from "react-hook-form";
+import { formatDatetime, getComplianceRegistryStatusOptions } from "@probo/helpers";
+
+const schema = z.object({
+  referenceId: z.string().min(1, "Reference ID is required"),
+  area: z.string().optional(),
+  source: z.string().optional(),
+  auditId: z.string().min(1, "Audit is required"),
+  requirement: z.string().optional(),
+  actionsToBeImplemented: z.string().optional(),
+  regulator: z.string().optional(),
+  ownerId: z.string().min(1, "Owner is required"),
+  lastReviewDate: z.string().optional(),
+  dueDate: z.string().optional(),
+  status: z.enum(["OPEN", "IN_PROGRESS", "CLOSED"]),
+});
+
+type FormData = z.infer<typeof schema>;
+
+interface CreateComplianceRegistryDialogProps {
+  children: ReactNode;
+  organizationId: string;
+  connection?: string;
+}
+
+export function CreateComplianceRegistryDialog({
+  children,
+  organizationId,
+  connection,
+}: CreateComplianceRegistryDialogProps) {
+  const { __ } = useTranslate();
+  const { toast } = useToast();
+  const dialogRef = useDialogRef();
+
+  const createRegistry = useCreateComplianceRegistry(connection || "");
+  const statusOptions = getComplianceRegistryStatusOptions(__);
+
+  const { register, handleSubmit, formState, reset, control } = useFormWithSchema(schema, {
+    defaultValues: {
+      referenceId: "",
+      area: "",
+      source: "",
+      auditId: "",
+      requirement: "",
+      actionsToBeImplemented: "",
+      regulator: "",
+      ownerId: "",
+      lastReviewDate: "",
+      dueDate: "",
+      status: "OPEN" as const,
+    },
+  });
+
+  const onSubmit = handleSubmit(async (formData: FormData) => {
+    try {
+      await createRegistry({
+        organizationId,
+        referenceId: formData.referenceId,
+        area: formData.area || undefined,
+        source: formData.source || undefined,
+        auditId: formData.auditId,
+        requirement: formData.requirement || undefined,
+        actionsToBeImplemented: formData.actionsToBeImplemented || undefined,
+        regulator: formData.regulator || undefined,
+        ownerId: formData.ownerId,
+        lastReviewDate: formatDatetime(formData.lastReviewDate),
+        dueDate: formatDatetime(formData.dueDate),
+        status: formData.status,
+      });
+
+      toast({
+        title: __("Success"),
+        description: __("Compliance registry entry created successfully"),
+        variant: "success",
+      });
+
+      reset();
+      dialogRef.current?.close();
+    } catch (error) {
+      toast({
+        title: __("Error"),
+        description: __("Failed to create compliance registry entry"),
+        variant: "error",
+      });
+    }
+  });
+
+  return (
+    <Dialog
+      ref={dialogRef}
+      trigger={children}
+      title={<Breadcrumb items={[__("Registries"), __("Create Compliance Entry")]} />}
+      className="max-w-2xl"
+    >
+      <form onSubmit={onSubmit}>
+        <DialogContent padded className="space-y-4">
+          <Field
+            label={__("Reference ID")}
+            {...register("referenceId")}
+            placeholder="CR-001"
+            error={formState.errors.referenceId?.message}
+            required
+          />
+
+          <AuditSelectField
+            organizationId={organizationId}
+            control={control}
+            name="auditId"
+            label={__("Audit")}
+            error={formState.errors.auditId?.message}
+            required
+          />
+
+          <div className="grid grid-cols-2 gap-4">
+            <Field
+              label={__("Area")}
+              {...register("area")}
+              placeholder={__("Enter area")}
+              error={formState.errors.area?.message}
+            />
+
+            <Field
+              label={__("Source")}
+              {...register("source")}
+              placeholder={__("Enter source")}
+              error={formState.errors.source?.message}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <Field label={__("Status")}>
+              <Controller
+                control={control}
+                name="status"
+                render={({ field }) => (
+                  <Select
+                    variant="editor"
+                    placeholder={__("Select status")}
+                    onValueChange={field.onChange}
+                    value={field.value}
+                    className="w-full"
+                  >
+                    {statusOptions.map((option) => (
+                      <Option key={option.value} value={option.value}>
+                        {option.label}
+                      </Option>
+                    ))}
+                  </Select>
+                )}
+              />
+              {formState.errors.status && (
+                <p className="text-sm text-red-500 mt-1">{formState.errors.status.message}</p>
+              )}
+            </Field>
+
+            <PeopleSelectField
+              organizationId={organizationId}
+              control={control}
+              name="ownerId"
+              label={__("Owner")}
+              error={formState.errors.ownerId?.message}
+              required
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <Field
+              label={__("Regulator")}
+              {...register("regulator")}
+              placeholder={__("Enter regulator")}
+              error={formState.errors.regulator?.message}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="lastReviewDate">{__("Last Review Date")}</Label>
+              <Input
+                id="lastReviewDate"
+                type="date"
+                {...register("lastReviewDate")}
+              />
+              {formState.errors.lastReviewDate && (
+                <p className="text-sm text-red-500">{formState.errors.lastReviewDate.message}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="dueDate">{__("Due Date")}</Label>
+              <Input
+                id="dueDate"
+                type="date"
+                {...register("dueDate")}
+              />
+              {formState.errors.dueDate && (
+                <p className="text-sm text-red-500">{formState.errors.dueDate.message}</p>
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="requirement">{__("Requirement")}</Label>
+            <Textarea
+              id="requirement"
+              {...register("requirement")}
+              placeholder={__("Enter requirement details...")}
+              rows={3}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="actionsToBeImplemented">{__("Actions to be Implemented")}</Label>
+            <Textarea
+              id="actionsToBeImplemented"
+              {...register("actionsToBeImplemented")}
+              placeholder={__("Enter actions to be implemented...")}
+              rows={3}
+            />
+          </div>
+        </DialogContent>
+
+        <DialogFooter>
+          <Button type="submit" disabled={formState.isSubmitting}>
+            {formState.isSubmitting ? __("Creating...") : __("Create Compliance Registry Entry")}
+          </Button>
+        </DialogFooter>
+      </form>
+    </Dialog>
+  );
+}

--- a/apps/console/src/pages/organizations/nonconformityRegistries/NonconformityRegistryDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/nonconformityRegistries/NonconformityRegistryDetailsPage.tsx
@@ -156,8 +156,6 @@ export default function NonconformityRegistryDetailsPage(props: Props) {
       <div className="max-w-4xl">
         <Card padded>
           <form onSubmit={onSubmit} className="space-y-6">
-            <h3 className="text-lg font-medium">{__("Nonconformity Registry")}</h3>
-
             <Field
               label={__("Reference ID")}
               required

--- a/apps/console/src/routes.tsx
+++ b/apps/console/src/routes.tsx
@@ -30,6 +30,7 @@ import { assetRoutes } from "./routes/assetRoutes.ts";
 import { auditRoutes } from "./routes/auditRoutes.ts";
 import { trustCenterRoutes } from "./routes/trustCenterRoutes.ts";
 import { nonconformityRegistryRoutes } from "./routes/nonconformityRegistryRoutes.ts";
+import { complianceRegistryRoutes } from "./routes/complianceRegistryRoutes.ts";
 import { lazy } from "@probo/react-lazy";
 
 export type AppRoute = Omit<RouteObject, "Component" | "children"> & {
@@ -151,6 +152,7 @@ const routes = [
       ...dataRoutes,
       ...auditRoutes,
       ...nonconformityRegistryRoutes,
+      ...complianceRegistryRoutes,
       ...trustCenterRoutes,
       {
         path: "*",

--- a/apps/console/src/routes/complianceRegistryRoutes.ts
+++ b/apps/console/src/routes/complianceRegistryRoutes.ts
@@ -1,0 +1,29 @@
+import { loadQuery } from "react-relay";
+import { relayEnvironment } from "/providers/RelayProviders";
+import { PageSkeleton } from "/components/skeletons/PageSkeleton";
+import { lazy } from "@probo/react-lazy";
+import { complianceRegistriesQuery, complianceRegistryNodeQuery } from "/hooks/graph/ComplianceRegistryGraph";
+import type { AppRoute } from "/routes";
+
+export const complianceRegistryRoutes = [
+  {
+    path: "complianceRegistries",
+    fallback: PageSkeleton,
+    queryLoader: ({ organizationId }: { organizationId: string }) =>
+      loadQuery(relayEnvironment, complianceRegistriesQuery, { organizationId }),
+    Component: lazy(
+      () => import("/pages/organizations/complianceRegistries/ComplianceRegistriesPage")
+    ),
+  },
+  {
+    path: "complianceRegistries/:registryId",
+    fallback: PageSkeleton,
+    queryLoader: (params: Record<string, string>) =>
+      loadQuery(relayEnvironment, complianceRegistryNodeQuery, {
+        complianceRegistryId: params.registryId
+      }),
+    Component: lazy(
+      () => import("/pages/organizations/complianceRegistries/ComplianceRegistryDetailsPage")
+    ),
+  },
+] satisfies AppRoute[];

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -16,7 +16,7 @@ export { availableFrameworks } from "./frameworks";
 export { getDocumentTypeLabel, documentTypes } from "./documents";
 export { getAssetTypeVariant, getCriticityVariant } from "./assets";
 export { getAuditStateLabel, getAuditStateVariant, auditStates } from "./audits";
-export { getStatusVariant, getStatusLabel, getNonconformityRegistryStatusOptions, registryStatuses } from "./registryStatus";
+export { getStatusVariant, getStatusLabel, getNonconformityRegistryStatusOptions, getComplianceRegistryStatusOptions, registryStatuses } from "./registryStatus";
 export { promisifyMutation } from "./relay";
 export { fileType, fileSize } from "./file";
 export { formatDatetime } from "./date";

--- a/packages/helpers/src/registryStatus.ts
+++ b/packages/helpers/src/registryStatus.ts
@@ -1,6 +1,7 @@
 type Translator = (s: string) => string;
 
 export type NonconformityRegistryStatus = "CLOSED" | "IN_PROGRESS" | "OPEN";
+export type ComplianceRegistryStatus = "CLOSED" | "IN_PROGRESS" | "OPEN";
 
 export const registryStatuses = [
   "OPEN",
@@ -8,7 +9,7 @@ export const registryStatuses = [
   "CLOSED",
 ] as const;
 
-export const getStatusVariant = (status: NonconformityRegistryStatus) => {
+export const getStatusVariant = (status: NonconformityRegistryStatus | ComplianceRegistryStatus) => {
   switch (status) {
     case "OPEN":
       return "danger" as const;
@@ -21,7 +22,7 @@ export const getStatusVariant = (status: NonconformityRegistryStatus) => {
   }
 };
 
-export const getStatusLabel = (status: NonconformityRegistryStatus) => {
+export const getStatusLabel = (status: NonconformityRegistryStatus | ComplianceRegistryStatus) => {
   switch (status) {
     case "OPEN":
       return "Open";
@@ -35,6 +36,17 @@ export const getStatusLabel = (status: NonconformityRegistryStatus) => {
 };
 
 export function getNonconformityRegistryStatusOptions(__: Translator) {
+  return registryStatuses.map((status) => ({
+    value: status,
+    label: __({
+      "OPEN": "Open",
+      "IN_PROGRESS": "In Progress",
+      "CLOSED": "Closed",
+    }[status]),
+  }));
+}
+
+export function getComplianceRegistryStatusOptions(__: Translator) {
   return registryStatuses.map((status) => ({
     value: status,
     label: __({

--- a/pkg/coredata/compliance_registry.go
+++ b/pkg/coredata/compliance_registry.go
@@ -1,0 +1,348 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"time"
+
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+	"github.com/jackc/pgx/v5"
+	"go.gearno.de/kit/pg"
+)
+
+type (
+	ComplianceRegistry struct {
+		ID                     gid.GID                  `db:"id"`
+		OrganizationID         gid.GID                  `db:"organization_id"`
+		ReferenceID            string                   `db:"reference_id"`
+		Area                   *string                  `db:"area"`
+		Source                 *string                  `db:"source"`
+		AuditID                gid.GID                  `db:"audit_id"`
+		Requirement            *string                  `db:"requirement"`
+		ActionsToBeImplemented *string                  `db:"actions_to_be_implemented"`
+		Regulator              *string                  `db:"regulator"`
+		OwnerID                gid.GID                  `db:"owner_id"`
+		LastReviewDate         *time.Time               `db:"last_review_date"`
+		DueDate                *time.Time               `db:"due_date"`
+		Status                 ComplianceRegistryStatus `db:"status"`
+		CreatedAt              time.Time                `db:"created_at"`
+		UpdatedAt              time.Time                `db:"updated_at"`
+	}
+
+	ComplianceRegistries []*ComplianceRegistry
+)
+
+func (cr *ComplianceRegistry) CursorKey(field ComplianceRegistryOrderField) page.CursorKey {
+	switch field {
+	case ComplianceRegistryOrderFieldCreatedAt:
+		return page.NewCursorKey(cr.ID, cr.CreatedAt)
+	case ComplianceRegistryOrderFieldLastReviewDate:
+		return page.NewCursorKey(cr.ID, cr.LastReviewDate)
+	case ComplianceRegistryOrderFieldDueDate:
+		return page.NewCursorKey(cr.ID, cr.DueDate)
+	case ComplianceRegistryOrderFieldStatus:
+		return page.NewCursorKey(cr.ID, cr.Status)
+	case ComplianceRegistryOrderFieldReferenceId:
+		return page.NewCursorKey(cr.ID, cr.ReferenceID)
+	}
+
+	panic(fmt.Sprintf("unsupported order by: %s", field))
+}
+
+func (cr *ComplianceRegistry) LoadByID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	complianceRegistryID gid.GID,
+) error {
+	q := `
+SELECT
+	id,
+	organization_id,
+	reference_id,
+	area,
+	source,
+	audit_id,
+	requirement,
+	actions_to_be_implemented,
+	regulator,
+	owner_id,
+	last_review_date,
+	due_date,
+	status,
+	created_at,
+	updated_at
+FROM
+	compliance_registries
+WHERE
+	%s
+	AND id = @compliance_registry_id
+LIMIT 1;
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"compliance_registry_id": complianceRegistryID}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query compliance registry: %w", err)
+	}
+
+	registry, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[ComplianceRegistry])
+	if err != nil {
+		return fmt.Errorf("cannot collect compliance registry: %w", err)
+	}
+
+	*cr = registry
+
+	return nil
+}
+
+func (crs *ComplianceRegistries) CountByOrganizationID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	organizationID gid.GID,
+) (int, error) {
+	q := `
+SELECT
+	COUNT(id)
+FROM
+	compliance_registries
+WHERE
+	%s
+	AND organization_id = @organization_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	row := conn.QueryRow(ctx, q, args)
+
+	var count int
+	err := row.Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("cannot count compliance registries: %w", err)
+	}
+
+	return count, nil
+}
+
+func (crs *ComplianceRegistries) LoadByOrganizationID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	organizationID gid.GID,
+	cursor *page.Cursor[ComplianceRegistryOrderField],
+) error {
+	q := `
+SELECT
+	id,
+	organization_id,
+	reference_id,
+	area,
+	source,
+	audit_id,
+	requirement,
+	actions_to_be_implemented,
+	regulator,
+	owner_id,
+	last_review_date,
+	due_date,
+	status,
+	created_at,
+	updated_at
+FROM
+	compliance_registries
+WHERE
+	%s
+	AND organization_id = @organization_id
+	AND %s
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, cursor.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query compliance registries: %w", err)
+	}
+
+	registries, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[ComplianceRegistry])
+	if err != nil {
+		return fmt.Errorf("cannot collect compliance registries: %w", err)
+	}
+
+	*crs = registries
+
+	return nil
+}
+
+func (cr *ComplianceRegistry) Insert(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+INSERT INTO compliance_registries (
+	id,
+	tenant_id,
+	organization_id,
+	reference_id,
+	area,
+	source,
+	audit_id,
+	requirement,
+	actions_to_be_implemented,
+	regulator,
+	owner_id,
+	last_review_date,
+	due_date,
+	status,
+	created_at,
+	updated_at
+) VALUES (
+	@id,
+	@tenant_id,
+	@organization_id,
+	@reference_id,
+	@area,
+	@source,
+	@audit_id,
+	@requirement,
+	@actions_to_be_implemented,
+	@regulator,
+	@owner_id,
+	@last_review_date,
+	@due_date,
+	@status,
+	@created_at,
+	@updated_at
+)
+`
+
+	args := pgx.StrictNamedArgs{
+		"id":                        cr.ID,
+		"tenant_id":                 scope.GetTenantID(),
+		"organization_id":           cr.OrganizationID,
+		"reference_id":              cr.ReferenceID,
+		"area":                      cr.Area,
+		"source":                    cr.Source,
+		"audit_id":                  cr.AuditID,
+		"requirement":               cr.Requirement,
+		"actions_to_be_implemented": cr.ActionsToBeImplemented,
+		"regulator":                 cr.Regulator,
+		"owner_id":                  cr.OwnerID,
+		"last_review_date":          cr.LastReviewDate,
+		"due_date":                  cr.DueDate,
+		"status":                    cr.Status,
+		"created_at":                cr.CreatedAt,
+		"updated_at":                cr.UpdatedAt,
+	}
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot insert compliance registry: %w", err)
+	}
+
+	return nil
+}
+
+func (cr *ComplianceRegistry) Update(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+UPDATE compliance_registries SET
+	reference_id = @reference_id,
+	area = @area,
+	source = @source,
+	audit_id = @audit_id,
+	requirement = @requirement,
+	actions_to_be_implemented = @actions_to_be_implemented,
+	regulator = @regulator,
+	owner_id = @owner_id,
+	last_review_date = @last_review_date,
+	due_date = @due_date,
+	status = @status,
+	updated_at = @updated_at
+WHERE
+	%s
+	AND id = @id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"id":                        cr.ID,
+		"reference_id":              cr.ReferenceID,
+		"area":                      cr.Area,
+		"source":                    cr.Source,
+		"audit_id":                  cr.AuditID,
+		"requirement":               cr.Requirement,
+		"actions_to_be_implemented": cr.ActionsToBeImplemented,
+		"regulator":                 cr.Regulator,
+		"owner_id":                  cr.OwnerID,
+		"last_review_date":          cr.LastReviewDate,
+		"due_date":                  cr.DueDate,
+		"status":                    cr.Status,
+		"updated_at":                cr.UpdatedAt,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot update compliance registry: %w", err)
+	}
+
+	return nil
+}
+
+func (cr *ComplianceRegistry) Delete(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+DELETE FROM compliance_registries
+WHERE
+	%s
+	AND id = @id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"id": cr.ID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete compliance registry: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/compliance_registry_order_field.go
+++ b/pkg/coredata/compliance_registry_order_field.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"fmt"
+)
+
+type ComplianceRegistryOrderField string
+
+const (
+	ComplianceRegistryOrderFieldCreatedAt      ComplianceRegistryOrderField = "CREATED_AT"
+	ComplianceRegistryOrderFieldLastReviewDate ComplianceRegistryOrderField = "LAST_REVIEW_DATE"
+	ComplianceRegistryOrderFieldDueDate        ComplianceRegistryOrderField = "DUE_DATE"
+	ComplianceRegistryOrderFieldStatus         ComplianceRegistryOrderField = "STATUS"
+	ComplianceRegistryOrderFieldReferenceId    ComplianceRegistryOrderField = "REFERENCE_ID"
+)
+
+func (p ComplianceRegistryOrderField) Column() string {
+	return string(p)
+}
+
+func (p ComplianceRegistryOrderField) String() string {
+	return string(p)
+}
+
+func (p ComplianceRegistryOrderField) MarshalText() ([]byte, error) {
+	return []byte(p.String()), nil
+}
+
+func (p *ComplianceRegistryOrderField) UnmarshalText(text []byte) error {
+	val := string(text)
+	switch val {
+	case string(ComplianceRegistryOrderFieldCreatedAt),
+		string(ComplianceRegistryOrderFieldLastReviewDate),
+		string(ComplianceRegistryOrderFieldDueDate),
+		string(ComplianceRegistryOrderFieldStatus),
+		string(ComplianceRegistryOrderFieldReferenceId):
+		*p = ComplianceRegistryOrderField(val)
+		return nil
+	}
+	return fmt.Errorf("invalid ComplianceRegistryOrderField value: %q", val)
+}

--- a/pkg/coredata/compliance_registry_status.go
+++ b/pkg/coredata/compliance_registry_status.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+type ComplianceRegistryStatus string
+
+const (
+	ComplianceRegistryStatusOpen       ComplianceRegistryStatus = "OPEN"
+	ComplianceRegistryStatusInProgress ComplianceRegistryStatus = "IN_PROGRESS"
+	ComplianceRegistryStatusClosed     ComplianceRegistryStatus = "CLOSED"
+)
+
+func (crs ComplianceRegistryStatus) String() string {
+	return string(crs)
+}
+
+func (crs *ComplianceRegistryStatus) Scan(value any) error {
+	var s string
+	switch v := value.(type) {
+	case string:
+		s = v
+	case []byte:
+		s = string(v)
+	default:
+		return fmt.Errorf("unsupported type for ComplianceRegistryStatus: %T", value)
+	}
+
+	switch s {
+	case "OPEN":
+		*crs = ComplianceRegistryStatusOpen
+	case "IN_PROGRESS":
+		*crs = ComplianceRegistryStatusInProgress
+	case "CLOSED":
+		*crs = ComplianceRegistryStatusClosed
+	default:
+		return fmt.Errorf("invalid ComplianceRegistryStatus value: %q", s)
+	}
+	return nil
+}
+
+func (crs ComplianceRegistryStatus) Value() (driver.Value, error) {
+	return crs.String(), nil
+}

--- a/pkg/coredata/entity_type_reg.go
+++ b/pkg/coredata/entity_type_reg.go
@@ -44,4 +44,5 @@ const (
 	VendorContactEntityType
 	VendorDataPrivacyAgreementEntityType
 	NonconformityRegistryEntityType
+	ComplianceRegistryEntityType
 )

--- a/pkg/coredata/migrations/20250818T094916Z.sql
+++ b/pkg/coredata/migrations/20250818T094916Z.sql
@@ -1,0 +1,42 @@
+CREATE TYPE compliance_registries_status AS ENUM (
+    'OPEN',
+    'IN_PROGRESS',
+    'CLOSED'
+);
+
+CREATE TABLE compliance_registries (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    organization_id TEXT NOT NULL,
+    reference_id TEXT NOT NULL,
+    area TEXT,
+    source TEXT,
+    audit_id TEXT NOT NULL,
+    requirement TEXT,
+    actions_to_be_implemented TEXT,
+    regulator TEXT,
+    owner_id TEXT NOT NULL,
+    last_review_date DATE,
+    due_date DATE,
+    status compliance_registries_status NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+
+    CONSTRAINT compliance_registries_organization_id_fkey
+        FOREIGN KEY (organization_id)
+        REFERENCES organizations(id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+
+    CONSTRAINT compliance_registries_owner_id_fkey
+        FOREIGN KEY (owner_id)
+        REFERENCES peoples(id)
+        ON UPDATE CASCADE
+        ON DELETE RESTRICT,
+
+    CONSTRAINT compliance_registries_audit_id_fkey
+        FOREIGN KEY (audit_id)
+        REFERENCES audits(id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+);

--- a/pkg/probo/compliance_registry_service.go
+++ b/pkg/probo/compliance_registry_service.go
@@ -1,0 +1,300 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package probo
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+	"go.gearno.de/kit/pg"
+)
+
+type ComplianceRegistryService struct {
+	svc *TenantService
+}
+
+type (
+	CreateComplianceRegistryRequest struct {
+		OrganizationID         gid.GID
+		ReferenceID            string
+		Area                   *string
+		Source                 *string
+		AuditID                gid.GID
+		Requirement            *string
+		ActionsToBeImplemented *string
+		Regulator              *string
+		OwnerID                gid.GID
+		LastReviewDate         *time.Time
+		DueDate                *time.Time
+		Status                 *coredata.ComplianceRegistryStatus
+	}
+
+	UpdateComplianceRegistryRequest struct {
+		ID                     gid.GID
+		ReferenceID            *string
+		Area                   **string
+		Source                 **string
+		AuditID                *gid.GID
+		Requirement            **string
+		ActionsToBeImplemented **string
+		Regulator              **string
+		OwnerID                *gid.GID
+		LastReviewDate         **time.Time
+		DueDate                **time.Time
+		Status                 *coredata.ComplianceRegistryStatus
+	}
+)
+
+func (s ComplianceRegistryService) Get(
+	ctx context.Context,
+	complianceRegistryID gid.GID,
+) (*coredata.ComplianceRegistry, error) {
+	registry := &coredata.ComplianceRegistry{}
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			if err := registry.LoadByID(ctx, conn, s.svc.scope, complianceRegistryID); err != nil {
+				return fmt.Errorf("cannot load compliance registry: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return registry, nil
+}
+
+func (s *ComplianceRegistryService) Create(
+	ctx context.Context,
+	req *CreateComplianceRegistryRequest,
+) (*coredata.ComplianceRegistry, error) {
+	now := time.Now()
+
+	registry := &coredata.ComplianceRegistry{
+		ID:                     gid.New(s.svc.scope.GetTenantID(), coredata.ComplianceRegistryEntityType),
+		OrganizationID:         req.OrganizationID,
+		ReferenceID:            req.ReferenceID,
+		Area:                   req.Area,
+		Source:                 req.Source,
+		AuditID:                req.AuditID,
+		Requirement:            req.Requirement,
+		ActionsToBeImplemented: req.ActionsToBeImplemented,
+		Regulator:              req.Regulator,
+		OwnerID:                req.OwnerID,
+		LastReviewDate:         req.LastReviewDate,
+		DueDate:                req.DueDate,
+		Status:                 *req.Status,
+		CreatedAt:              now,
+		UpdatedAt:              now,
+	}
+
+	err := s.svc.pg.WithTx(
+		ctx,
+		func(conn pg.Conn) error {
+			organization := &coredata.Organization{}
+			if err := organization.LoadByID(ctx, conn, s.svc.scope, req.OrganizationID); err != nil {
+				return fmt.Errorf("cannot load organization: %w", err)
+			}
+
+			audit := &coredata.Audit{}
+			if err := audit.LoadByID(ctx, conn, s.svc.scope, req.AuditID); err != nil {
+				return fmt.Errorf("cannot load audit: %w", err)
+			}
+
+			owner := &coredata.People{}
+			if err := owner.LoadByID(ctx, conn, s.svc.scope, req.OwnerID); err != nil {
+				return fmt.Errorf("cannot load owner: %w", err)
+			}
+
+			if err := registry.Insert(ctx, conn, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot insert compliance registry: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return registry, nil
+}
+
+func (s *ComplianceRegistryService) Update(
+	ctx context.Context,
+	req *UpdateComplianceRegistryRequest,
+) (*coredata.ComplianceRegistry, error) {
+	registry := &coredata.ComplianceRegistry{}
+
+	err := s.svc.pg.WithTx(
+		ctx,
+		func(conn pg.Conn) error {
+			if err := registry.LoadByID(ctx, conn, s.svc.scope, req.ID); err != nil {
+				return fmt.Errorf("cannot load compliance registry: %w", err)
+			}
+
+			if req.ReferenceID != nil {
+				registry.ReferenceID = *req.ReferenceID
+			}
+
+			if req.Area != nil {
+				registry.Area = *req.Area
+			}
+
+			if req.Source != nil {
+				registry.Source = *req.Source
+			}
+
+			if req.AuditID != nil {
+				audit := &coredata.Audit{}
+				if err := audit.LoadByID(ctx, conn, s.svc.scope, *req.AuditID); err != nil {
+					return fmt.Errorf("cannot load audit: %w", err)
+				}
+				registry.AuditID = *req.AuditID
+			}
+
+			if req.Requirement != nil {
+				registry.Requirement = *req.Requirement
+			}
+
+			if req.ActionsToBeImplemented != nil {
+				registry.ActionsToBeImplemented = *req.ActionsToBeImplemented
+			}
+
+			if req.Regulator != nil {
+				registry.Regulator = *req.Regulator
+			}
+
+			if req.OwnerID != nil {
+				owner := &coredata.People{}
+				if err := owner.LoadByID(ctx, conn, s.svc.scope, *req.OwnerID); err != nil {
+					return fmt.Errorf("cannot load owner: %w", err)
+				}
+				registry.OwnerID = *req.OwnerID
+			}
+
+			if req.LastReviewDate != nil {
+				registry.LastReviewDate = *req.LastReviewDate
+			}
+
+			if req.DueDate != nil {
+				registry.DueDate = *req.DueDate
+			}
+
+			if req.Status != nil {
+				registry.Status = *req.Status
+			}
+
+			registry.UpdatedAt = time.Now()
+
+			if err := registry.Update(ctx, conn, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot update compliance registry: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return registry, nil
+}
+
+func (s *ComplianceRegistryService) Delete(
+	ctx context.Context,
+	complianceRegistryID gid.GID,
+) error {
+	err := s.svc.pg.WithTx(
+		ctx,
+		func(conn pg.Conn) error {
+			registry := &coredata.ComplianceRegistry{}
+			if err := registry.LoadByID(ctx, conn, s.svc.scope, complianceRegistryID); err != nil {
+				return fmt.Errorf("cannot load compliance registry: %w", err)
+			}
+
+			if err := registry.Delete(ctx, conn, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot delete compliance registry: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	return err
+}
+
+func (s ComplianceRegistryService) CountByOrganizationID(
+	ctx context.Context,
+	organizationID gid.GID,
+) (int, error) {
+	var count int
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) (err error) {
+			registries := coredata.ComplianceRegistries{}
+			count, err = registries.CountByOrganizationID(ctx, conn, s.svc.scope, organizationID)
+			if err != nil {
+				return fmt.Errorf("cannot count compliance registries: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+func (s ComplianceRegistryService) ListForOrganizationID(
+	ctx context.Context,
+	organizationID gid.GID,
+	cursor *page.Cursor[coredata.ComplianceRegistryOrderField],
+) (*page.Page[*coredata.ComplianceRegistry, coredata.ComplianceRegistryOrderField], error) {
+	var registries coredata.ComplianceRegistries
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			err := registries.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID, cursor)
+			if err != nil {
+				return fmt.Errorf("cannot load compliance registries: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return page.NewPage(registries, cursor), nil
+}

--- a/pkg/probo/service.go
+++ b/pkg/probo/service.go
@@ -82,6 +82,7 @@ type (
 		TrustCenters                      *TrustCenterService
 		TrustCenterAccesses               *TrustCenterAccessService
 		NonconformityRegistries           *NonconformityRegistryService
+		ComplianceRegistries              *ComplianceRegistryService
 	}
 )
 
@@ -175,5 +176,6 @@ func (s *Service) WithTenant(tenantID gid.TenantID) *TenantService {
 		usrmgr: s.usrmgr,
 	}
 	tenantService.NonconformityRegistries = &NonconformityRegistryService{svc: tenantService}
+	tenantService.ComplianceRegistries = &ComplianceRegistryService{svc: tenantService}
 	return tenantService
 }

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -167,6 +167,22 @@ enum NonconformityRegistryStatus
     )
 }
 
+enum ComplianceRegistryStatus
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.ComplianceRegistryStatus") {
+  OPEN
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ComplianceRegistryStatusOpen"
+    )
+  IN_PROGRESS
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ComplianceRegistryStatusInProgress"
+    )
+  CLOSED
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ComplianceRegistryStatusClosed"
+    )
+}
+
 # Order Field Enums
 enum UserOrderField
   @goModel(model: "github.com/getprobo/probo/pkg/coredata.UserOrderField") {
@@ -624,6 +640,30 @@ enum NonconformityRegistryOrderField
     )
 }
 
+enum ComplianceRegistryOrderField
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.ComplianceRegistryOrderField") {
+  CREATED_AT
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ComplianceRegistryOrderFieldCreatedAt"
+    )
+  REFERENCE_ID
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ComplianceRegistryOrderFieldReferenceId"
+    )
+  LAST_REVIEW_DATE
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ComplianceRegistryOrderFieldLastReviewDate"
+    )
+  DUE_DATE
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ComplianceRegistryOrderFieldDueDate"
+    )
+  STATUS
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ComplianceRegistryOrderFieldStatus"
+    )
+}
+
 enum TrustCenterAccessOrderField
   @goModel(model: "github.com/getprobo/probo/pkg/coredata.TrustCenterAccessOrderField") {
   CREATED_AT
@@ -719,6 +759,14 @@ input NonconformityRegistryOrder
   ) {
   direction: OrderDirection!
   field: NonconformityRegistryOrderField!
+}
+
+input ComplianceRegistryOrder
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.ComplianceRegistryOrderBy"
+  ) {
+  direction: OrderDirection!
+  field: ComplianceRegistryOrderField!
 }
 
 input TrustCenterAccessOrder
@@ -943,6 +991,14 @@ type Organization implements Node {
     before: CursorKey
     orderBy: NonconformityRegistryOrder
   ): NonconformityRegistryConnection! @goField(forceResolver: true)
+
+  complianceRegistries(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+    orderBy: ComplianceRegistryOrder
+  ): ComplianceRegistryConnection! @goField(forceResolver: true)
 
   trustCenter: TrustCenter @goField(forceResolver: true)
 
@@ -1353,6 +1409,24 @@ type NonconformityRegistry implements Node {
   updatedAt: Datetime!
 }
 
+type ComplianceRegistry implements Node {
+  id: ID!
+  organization: Organization! @goField(forceResolver: true)
+  referenceId: String!
+  area: String
+  source: String
+  audit: Audit! @goField(forceResolver: true)
+  requirement: String
+  actionsToBeImplemented: String
+  regulator: String
+  owner: People! @goField(forceResolver: true)
+  lastReviewDate: Datetime
+  dueDate: Datetime
+  status: ComplianceRegistryStatus!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+}
+
 type Report implements Node {
   id: ID!
   objectKey: String!
@@ -1650,6 +1724,20 @@ type NonconformityRegistryEdge {
   node: NonconformityRegistry!
 }
 
+type ComplianceRegistryConnection
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.ComplianceRegistryConnection"
+  ) {
+  totalCount: Int! @goField(forceResolver: true)
+  edges: [ComplianceRegistryEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ComplianceRegistryEdge {
+  cursor: CursorKey!
+  node: ComplianceRegistry!
+}
+
 # Root Types
 type Query {
   node(id: ID!): Node!
@@ -1880,6 +1968,17 @@ type Mutation {
   deleteNonconformityRegistry(
     input: DeleteNonconformityRegistryInput!
   ): DeleteNonconformityRegistryPayload!
+
+  # Compliance Registry mutations
+  createComplianceRegistry(
+    input: CreateComplianceRegistryInput!
+  ): CreateComplianceRegistryPayload!
+  updateComplianceRegistry(
+    input: UpdateComplianceRegistryInput!
+  ): UpdateComplianceRegistryPayload!
+  deleteComplianceRegistry(
+    input: DeleteComplianceRegistryInput!
+  ): DeleteComplianceRegistryPayload!
 }
 
 # Input Types
@@ -2372,6 +2471,40 @@ input UpdateNonconformityRegistryInput {
 
 input DeleteNonconformityRegistryInput {
   nonconformityRegistryId: ID!
+}
+
+input CreateComplianceRegistryInput {
+  organizationId: ID!
+  referenceId: String!
+  area: String
+  source: String
+  auditId: ID!
+  requirement: String
+  actionsToBeImplemented: String
+  regulator: String
+  ownerId: ID!
+  lastReviewDate: Datetime
+  dueDate: Datetime
+  status: ComplianceRegistryStatus!
+}
+
+input UpdateComplianceRegistryInput {
+  id: ID!
+  referenceId: String
+  area: String
+  source: String
+  auditId: ID
+  requirement: String
+  actionsToBeImplemented: String
+  regulator: String
+  ownerId: ID
+  lastReviewDate: Datetime
+  dueDate: Datetime
+  status: ComplianceRegistryStatus
+}
+
+input DeleteComplianceRegistryInput {
+  complianceRegistryId: ID!
 }
 
 # Payload Types
@@ -3054,4 +3187,16 @@ type UpdateNonconformityRegistryPayload {
 
 type DeleteNonconformityRegistryPayload {
   deletedNonconformityRegistryId: ID!
+}
+
+type CreateComplianceRegistryPayload {
+  complianceRegistryEdge: ComplianceRegistryEdge!
+}
+
+type UpdateComplianceRegistryPayload {
+  complianceRegistry: ComplianceRegistry!
+}
+
+type DeleteComplianceRegistryPayload {
+  deletedComplianceRegistryId: ID!
 }

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -48,6 +48,8 @@ type ResolverRoot interface {
 	AssetConnection() AssetConnectionResolver
 	Audit() AuditResolver
 	AuditConnection() AuditConnectionResolver
+	ComplianceRegistry() ComplianceRegistryResolver
+	ComplianceRegistryConnection() ComplianceRegistryConnectionResolver
 	Control() ControlResolver
 	ControlConnection() ControlConnectionResolver
 	Datum() DatumResolver
@@ -162,6 +164,35 @@ type ComplexityRoot struct {
 		DeletedDocumentVersionSignatureID func(childComplexity int) int
 	}
 
+	ComplianceRegistry struct {
+		ActionsToBeImplemented func(childComplexity int) int
+		Area                   func(childComplexity int) int
+		Audit                  func(childComplexity int) int
+		CreatedAt              func(childComplexity int) int
+		DueDate                func(childComplexity int) int
+		ID                     func(childComplexity int) int
+		LastReviewDate         func(childComplexity int) int
+		Organization           func(childComplexity int) int
+		Owner                  func(childComplexity int) int
+		ReferenceID            func(childComplexity int) int
+		Regulator              func(childComplexity int) int
+		Requirement            func(childComplexity int) int
+		Source                 func(childComplexity int) int
+		Status                 func(childComplexity int) int
+		UpdatedAt              func(childComplexity int) int
+	}
+
+	ComplianceRegistryConnection struct {
+		Edges      func(childComplexity int) int
+		PageInfo   func(childComplexity int) int
+		TotalCount func(childComplexity int) int
+	}
+
+	ComplianceRegistryEdge struct {
+		Cursor func(childComplexity int) int
+		Node   func(childComplexity int) int
+	}
+
 	ConfirmEmailPayload struct {
 		Success func(childComplexity int) int
 	}
@@ -216,6 +247,10 @@ type ComplexityRoot struct {
 
 	CreateAuditPayload struct {
 		AuditEdge func(childComplexity int) int
+	}
+
+	CreateComplianceRegistryPayload struct {
+		ComplianceRegistryEdge func(childComplexity int) int
 	}
 
 	CreateControlAuditMappingPayload struct {
@@ -340,6 +375,10 @@ type ComplexityRoot struct {
 
 	DeleteAuditReportPayload struct {
 		Audit func(childComplexity int) int
+	}
+
+	DeleteComplianceRegistryPayload struct {
+		DeletedComplianceRegistryID func(childComplexity int) int
 	}
 
 	DeleteControlAuditMappingPayload struct {
@@ -623,6 +662,7 @@ type ComplexityRoot struct {
 		ConfirmEmail                           func(childComplexity int, input types.ConfirmEmailInput) int
 		CreateAsset                            func(childComplexity int, input types.CreateAssetInput) int
 		CreateAudit                            func(childComplexity int, input types.CreateAuditInput) int
+		CreateComplianceRegistry               func(childComplexity int, input types.CreateComplianceRegistryInput) int
 		CreateControl                          func(childComplexity int, input types.CreateControlInput) int
 		CreateControlAuditMapping              func(childComplexity int, input types.CreateControlAuditMappingInput) int
 		CreateControlDocumentMapping           func(childComplexity int, input types.CreateControlDocumentMappingInput) int
@@ -646,6 +686,7 @@ type ComplexityRoot struct {
 		DeleteAsset                            func(childComplexity int, input types.DeleteAssetInput) int
 		DeleteAudit                            func(childComplexity int, input types.DeleteAuditInput) int
 		DeleteAuditReport                      func(childComplexity int, input types.DeleteAuditReportInput) int
+		DeleteComplianceRegistry               func(childComplexity int, input types.DeleteComplianceRegistryInput) int
 		DeleteControl                          func(childComplexity int, input types.DeleteControlInput) int
 		DeleteControlAuditMapping              func(childComplexity int, input types.DeleteControlAuditMappingInput) int
 		DeleteControlDocumentMapping           func(childComplexity int, input types.DeleteControlDocumentMappingInput) int
@@ -684,6 +725,7 @@ type ComplexityRoot struct {
 		UnassignTask                           func(childComplexity int, input types.UnassignTaskInput) int
 		UpdateAsset                            func(childComplexity int, input types.UpdateAssetInput) int
 		UpdateAudit                            func(childComplexity int, input types.UpdateAuditInput) int
+		UpdateComplianceRegistry               func(childComplexity int, input types.UpdateComplianceRegistryInput) int
 		UpdateControl                          func(childComplexity int, input types.UpdateControlInput) int
 		UpdateDatum                            func(childComplexity int, input types.UpdateDatumInput) int
 		UpdateDocument                         func(childComplexity int, input types.UpdateDocumentInput) int
@@ -739,6 +781,7 @@ type ComplexityRoot struct {
 	Organization struct {
 		Assets                  func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AssetOrderBy) int
 		Audits                  func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AuditOrderBy) int
+		ComplianceRegistries    func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ComplianceRegistryOrderBy) int
 		Connectors              func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ConnectorOrder) int
 		Controls                func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ControlOrderBy, filter *types.ControlFilter) int
 		CreatedAt               func(childComplexity int) int
@@ -950,6 +993,10 @@ type ComplexityRoot struct {
 
 	UpdateAuditPayload struct {
 		Audit func(childComplexity int) int
+	}
+
+	UpdateComplianceRegistryPayload struct {
+		ComplianceRegistry func(childComplexity int) int
 	}
 
 	UpdateControlPayload struct {
@@ -1221,6 +1268,16 @@ type AuditResolver interface {
 type AuditConnectionResolver interface {
 	TotalCount(ctx context.Context, obj *types.AuditConnection) (int, error)
 }
+type ComplianceRegistryResolver interface {
+	Organization(ctx context.Context, obj *types.ComplianceRegistry) (*types.Organization, error)
+
+	Audit(ctx context.Context, obj *types.ComplianceRegistry) (*types.Audit, error)
+
+	Owner(ctx context.Context, obj *types.ComplianceRegistry) (*types.People, error)
+}
+type ComplianceRegistryConnectionResolver interface {
+	TotalCount(ctx context.Context, obj *types.ComplianceRegistryConnection) (int, error)
+}
 type ControlResolver interface {
 	Framework(ctx context.Context, obj *types.Control) (*types.Framework, error)
 	Measures(ctx context.Context, obj *types.Control, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy, filter *types.MeasureFilter) (*types.MeasureConnection, error)
@@ -1378,6 +1435,9 @@ type MutationResolver interface {
 	CreateNonconformityRegistry(ctx context.Context, input types.CreateNonconformityRegistryInput) (*types.CreateNonconformityRegistryPayload, error)
 	UpdateNonconformityRegistry(ctx context.Context, input types.UpdateNonconformityRegistryInput) (*types.UpdateNonconformityRegistryPayload, error)
 	DeleteNonconformityRegistry(ctx context.Context, input types.DeleteNonconformityRegistryInput) (*types.DeleteNonconformityRegistryPayload, error)
+	CreateComplianceRegistry(ctx context.Context, input types.CreateComplianceRegistryInput) (*types.CreateComplianceRegistryPayload, error)
+	UpdateComplianceRegistry(ctx context.Context, input types.UpdateComplianceRegistryInput) (*types.UpdateComplianceRegistryPayload, error)
+	DeleteComplianceRegistry(ctx context.Context, input types.DeleteComplianceRegistryInput) (*types.DeleteComplianceRegistryPayload, error)
 }
 type NonconformityRegistryResolver interface {
 	Organization(ctx context.Context, obj *types.NonconformityRegistry) (*types.Organization, error)
@@ -1405,6 +1465,7 @@ type OrganizationResolver interface {
 	Data(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DatumOrderBy) (*types.DatumConnection, error)
 	Audits(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AuditOrderBy) (*types.AuditConnection, error)
 	NonconformityRegistries(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.NonconformityRegistryOrderBy) (*types.NonconformityRegistryConnection, error)
+	ComplianceRegistries(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ComplianceRegistryOrderBy) (*types.ComplianceRegistryConnection, error)
 	TrustCenter(ctx context.Context, obj *types.Organization) (*types.TrustCenter, error)
 }
 type PeopleConnectionResolver interface {
@@ -1793,6 +1854,146 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.CancelSignatureRequestPayload.DeletedDocumentVersionSignatureID(childComplexity), true
 
+	case "ComplianceRegistry.actionsToBeImplemented":
+		if e.complexity.ComplianceRegistry.ActionsToBeImplemented == nil {
+			break
+		}
+
+		return e.complexity.ComplianceRegistry.ActionsToBeImplemented(childComplexity), true
+
+	case "ComplianceRegistry.area":
+		if e.complexity.ComplianceRegistry.Area == nil {
+			break
+		}
+
+		return e.complexity.ComplianceRegistry.Area(childComplexity), true
+
+	case "ComplianceRegistry.audit":
+		if e.complexity.ComplianceRegistry.Audit == nil {
+			break
+		}
+
+		return e.complexity.ComplianceRegistry.Audit(childComplexity), true
+
+	case "ComplianceRegistry.createdAt":
+		if e.complexity.ComplianceRegistry.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.ComplianceRegistry.CreatedAt(childComplexity), true
+
+	case "ComplianceRegistry.dueDate":
+		if e.complexity.ComplianceRegistry.DueDate == nil {
+			break
+		}
+
+		return e.complexity.ComplianceRegistry.DueDate(childComplexity), true
+
+	case "ComplianceRegistry.id":
+		if e.complexity.ComplianceRegistry.ID == nil {
+			break
+		}
+
+		return e.complexity.ComplianceRegistry.ID(childComplexity), true
+
+	case "ComplianceRegistry.lastReviewDate":
+		if e.complexity.ComplianceRegistry.LastReviewDate == nil {
+			break
+		}
+
+		return e.complexity.ComplianceRegistry.LastReviewDate(childComplexity), true
+
+	case "ComplianceRegistry.organization":
+		if e.complexity.ComplianceRegistry.Organization == nil {
+			break
+		}
+
+		return e.complexity.ComplianceRegistry.Organization(childComplexity), true
+
+	case "ComplianceRegistry.owner":
+		if e.complexity.ComplianceRegistry.Owner == nil {
+			break
+		}
+
+		return e.complexity.ComplianceRegistry.Owner(childComplexity), true
+
+	case "ComplianceRegistry.referenceId":
+		if e.complexity.ComplianceRegistry.ReferenceID == nil {
+			break
+		}
+
+		return e.complexity.ComplianceRegistry.ReferenceID(childComplexity), true
+
+	case "ComplianceRegistry.regulator":
+		if e.complexity.ComplianceRegistry.Regulator == nil {
+			break
+		}
+
+		return e.complexity.ComplianceRegistry.Regulator(childComplexity), true
+
+	case "ComplianceRegistry.requirement":
+		if e.complexity.ComplianceRegistry.Requirement == nil {
+			break
+		}
+
+		return e.complexity.ComplianceRegistry.Requirement(childComplexity), true
+
+	case "ComplianceRegistry.source":
+		if e.complexity.ComplianceRegistry.Source == nil {
+			break
+		}
+
+		return e.complexity.ComplianceRegistry.Source(childComplexity), true
+
+	case "ComplianceRegistry.status":
+		if e.complexity.ComplianceRegistry.Status == nil {
+			break
+		}
+
+		return e.complexity.ComplianceRegistry.Status(childComplexity), true
+
+	case "ComplianceRegistry.updatedAt":
+		if e.complexity.ComplianceRegistry.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.ComplianceRegistry.UpdatedAt(childComplexity), true
+
+	case "ComplianceRegistryConnection.edges":
+		if e.complexity.ComplianceRegistryConnection.Edges == nil {
+			break
+		}
+
+		return e.complexity.ComplianceRegistryConnection.Edges(childComplexity), true
+
+	case "ComplianceRegistryConnection.pageInfo":
+		if e.complexity.ComplianceRegistryConnection.PageInfo == nil {
+			break
+		}
+
+		return e.complexity.ComplianceRegistryConnection.PageInfo(childComplexity), true
+
+	case "ComplianceRegistryConnection.totalCount":
+		if e.complexity.ComplianceRegistryConnection.TotalCount == nil {
+			break
+		}
+
+		return e.complexity.ComplianceRegistryConnection.TotalCount(childComplexity), true
+
+	case "ComplianceRegistryEdge.cursor":
+		if e.complexity.ComplianceRegistryEdge.Cursor == nil {
+			break
+		}
+
+		return e.complexity.ComplianceRegistryEdge.Cursor(childComplexity), true
+
+	case "ComplianceRegistryEdge.node":
+		if e.complexity.ComplianceRegistryEdge.Node == nil {
+			break
+		}
+
+		return e.complexity.ComplianceRegistryEdge.Node(childComplexity), true
+
 	case "ConfirmEmailPayload.success":
 		if e.complexity.ConfirmEmailPayload.Success == nil {
 			break
@@ -2010,6 +2211,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.CreateAuditPayload.AuditEdge(childComplexity), true
+
+	case "CreateComplianceRegistryPayload.complianceRegistryEdge":
+		if e.complexity.CreateComplianceRegistryPayload.ComplianceRegistryEdge == nil {
+			break
+		}
+
+		return e.complexity.CreateComplianceRegistryPayload.ComplianceRegistryEdge(childComplexity), true
 
 	case "CreateControlAuditMappingPayload.auditEdge":
 		if e.complexity.CreateControlAuditMappingPayload.AuditEdge == nil {
@@ -2316,6 +2524,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.DeleteAuditReportPayload.Audit(childComplexity), true
+
+	case "DeleteComplianceRegistryPayload.deletedComplianceRegistryId":
+		if e.complexity.DeleteComplianceRegistryPayload.DeletedComplianceRegistryID == nil {
+			break
+		}
+
+		return e.complexity.DeleteComplianceRegistryPayload.DeletedComplianceRegistryID(childComplexity), true
 
 	case "DeleteControlAuditMappingPayload.deletedAuditId":
 		if e.complexity.DeleteControlAuditMappingPayload.DeletedAuditID == nil {
@@ -3349,6 +3564,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.CreateAudit(childComplexity, args["input"].(types.CreateAuditInput)), true
 
+	case "Mutation.createComplianceRegistry":
+		if e.complexity.Mutation.CreateComplianceRegistry == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_createComplianceRegistry_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreateComplianceRegistry(childComplexity, args["input"].(types.CreateComplianceRegistryInput)), true
+
 	case "Mutation.createControl":
 		if e.complexity.Mutation.CreateControl == nil {
 			break
@@ -3624,6 +3851,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.DeleteAuditReport(childComplexity, args["input"].(types.DeleteAuditReportInput)), true
+
+	case "Mutation.deleteComplianceRegistry":
+		if e.complexity.Mutation.DeleteComplianceRegistry == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_deleteComplianceRegistry_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteComplianceRegistry(childComplexity, args["input"].(types.DeleteComplianceRegistryInput)), true
 
 	case "Mutation.deleteControl":
 		if e.complexity.Mutation.DeleteControl == nil {
@@ -4081,6 +4320,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.UpdateAudit(childComplexity, args["input"].(types.UpdateAuditInput)), true
 
+	case "Mutation.updateComplianceRegistry":
+		if e.complexity.Mutation.UpdateComplianceRegistry == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_updateComplianceRegistry_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UpdateComplianceRegistry(childComplexity, args["input"].(types.UpdateComplianceRegistryInput)), true
+
 	case "Mutation.updateControl":
 		if e.complexity.Mutation.UpdateControl == nil {
 			break
@@ -4501,6 +4752,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Organization.Audits(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.AuditOrderBy)), true
+
+	case "Organization.complianceRegistries":
+		if e.complexity.Organization.ComplianceRegistries == nil {
+			break
+		}
+
+		args, err := ec.field_Organization_complianceRegistries_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.ComplianceRegistries(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.ComplianceRegistryOrderBy)), true
 
 	case "Organization.connectors":
 		if e.complexity.Organization.Connectors == nil {
@@ -5465,6 +5728,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.UpdateAuditPayload.Audit(childComplexity), true
 
+	case "UpdateComplianceRegistryPayload.complianceRegistry":
+		if e.complexity.UpdateComplianceRegistryPayload.ComplianceRegistry == nil {
+			break
+		}
+
+		return e.complexity.UpdateComplianceRegistryPayload.ComplianceRegistry(childComplexity), true
+
 	case "UpdateControlPayload.control":
 		if e.complexity.UpdateControlPayload.Control == nil {
 			break
@@ -6380,12 +6650,14 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputBulkPublishDocumentVersionsInput,
 		ec.unmarshalInputBulkRequestSignaturesInput,
 		ec.unmarshalInputCancelSignatureRequestInput,
+		ec.unmarshalInputComplianceRegistryOrder,
 		ec.unmarshalInputConfirmEmailInput,
 		ec.unmarshalInputConnectorOrder,
 		ec.unmarshalInputControlFilter,
 		ec.unmarshalInputControlOrder,
 		ec.unmarshalInputCreateAssetInput,
 		ec.unmarshalInputCreateAuditInput,
+		ec.unmarshalInputCreateComplianceRegistryInput,
 		ec.unmarshalInputCreateControlAuditMappingInput,
 		ec.unmarshalInputCreateControlDocumentMappingInput,
 		ec.unmarshalInputCreateControlInput,
@@ -6411,6 +6683,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputDeleteAssetInput,
 		ec.unmarshalInputDeleteAuditInput,
 		ec.unmarshalInputDeleteAuditReportInput,
+		ec.unmarshalInputDeleteComplianceRegistryInput,
 		ec.unmarshalInputDeleteControlAuditMappingInput,
 		ec.unmarshalInputDeleteControlDocumentMappingInput,
 		ec.unmarshalInputDeleteControlInput,
@@ -6468,6 +6741,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputUnassignTaskInput,
 		ec.unmarshalInputUpdateAssetInput,
 		ec.unmarshalInputUpdateAuditInput,
+		ec.unmarshalInputUpdateComplianceRegistryInput,
 		ec.unmarshalInputUpdateControlInput,
 		ec.unmarshalInputUpdateDatumInput,
 		ec.unmarshalInputUpdateDocumentInput,
@@ -6758,6 +7032,22 @@ enum NonconformityRegistryStatus
   CLOSED
     @goEnum(
       value: "github.com/getprobo/probo/pkg/coredata.NonconformityRegistryStatusClosed"
+    )
+}
+
+enum ComplianceRegistryStatus
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.ComplianceRegistryStatus") {
+  OPEN
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ComplianceRegistryStatusOpen"
+    )
+  IN_PROGRESS
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ComplianceRegistryStatusInProgress"
+    )
+  CLOSED
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ComplianceRegistryStatusClosed"
     )
 }
 
@@ -7218,6 +7508,30 @@ enum NonconformityRegistryOrderField
     )
 }
 
+enum ComplianceRegistryOrderField
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.ComplianceRegistryOrderField") {
+  CREATED_AT
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ComplianceRegistryOrderFieldCreatedAt"
+    )
+  REFERENCE_ID
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ComplianceRegistryOrderFieldReferenceId"
+    )
+  LAST_REVIEW_DATE
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ComplianceRegistryOrderFieldLastReviewDate"
+    )
+  DUE_DATE
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ComplianceRegistryOrderFieldDueDate"
+    )
+  STATUS
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ComplianceRegistryOrderFieldStatus"
+    )
+}
+
 enum TrustCenterAccessOrderField
   @goModel(model: "github.com/getprobo/probo/pkg/coredata.TrustCenterAccessOrderField") {
   CREATED_AT
@@ -7313,6 +7627,14 @@ input NonconformityRegistryOrder
   ) {
   direction: OrderDirection!
   field: NonconformityRegistryOrderField!
+}
+
+input ComplianceRegistryOrder
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.ComplianceRegistryOrderBy"
+  ) {
+  direction: OrderDirection!
+  field: ComplianceRegistryOrderField!
 }
 
 input TrustCenterAccessOrder
@@ -7537,6 +7859,14 @@ type Organization implements Node {
     before: CursorKey
     orderBy: NonconformityRegistryOrder
   ): NonconformityRegistryConnection! @goField(forceResolver: true)
+
+  complianceRegistries(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+    orderBy: ComplianceRegistryOrder
+  ): ComplianceRegistryConnection! @goField(forceResolver: true)
 
   trustCenter: TrustCenter @goField(forceResolver: true)
 
@@ -7947,6 +8277,24 @@ type NonconformityRegistry implements Node {
   updatedAt: Datetime!
 }
 
+type ComplianceRegistry implements Node {
+  id: ID!
+  organization: Organization! @goField(forceResolver: true)
+  referenceId: String!
+  area: String
+  source: String
+  audit: Audit! @goField(forceResolver: true)
+  requirement: String
+  actionsToBeImplemented: String
+  regulator: String
+  owner: People! @goField(forceResolver: true)
+  lastReviewDate: Datetime
+  dueDate: Datetime
+  status: ComplianceRegistryStatus!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+}
+
 type Report implements Node {
   id: ID!
   objectKey: String!
@@ -8244,6 +8592,20 @@ type NonconformityRegistryEdge {
   node: NonconformityRegistry!
 }
 
+type ComplianceRegistryConnection
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.ComplianceRegistryConnection"
+  ) {
+  totalCount: Int! @goField(forceResolver: true)
+  edges: [ComplianceRegistryEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ComplianceRegistryEdge {
+  cursor: CursorKey!
+  node: ComplianceRegistry!
+}
+
 # Root Types
 type Query {
   node(id: ID!): Node!
@@ -8474,6 +8836,17 @@ type Mutation {
   deleteNonconformityRegistry(
     input: DeleteNonconformityRegistryInput!
   ): DeleteNonconformityRegistryPayload!
+
+  # Compliance Registry mutations
+  createComplianceRegistry(
+    input: CreateComplianceRegistryInput!
+  ): CreateComplianceRegistryPayload!
+  updateComplianceRegistry(
+    input: UpdateComplianceRegistryInput!
+  ): UpdateComplianceRegistryPayload!
+  deleteComplianceRegistry(
+    input: DeleteComplianceRegistryInput!
+  ): DeleteComplianceRegistryPayload!
 }
 
 # Input Types
@@ -8966,6 +9339,40 @@ input UpdateNonconformityRegistryInput {
 
 input DeleteNonconformityRegistryInput {
   nonconformityRegistryId: ID!
+}
+
+input CreateComplianceRegistryInput {
+  organizationId: ID!
+  referenceId: String!
+  area: String
+  source: String
+  auditId: ID!
+  requirement: String
+  actionsToBeImplemented: String
+  regulator: String
+  ownerId: ID!
+  lastReviewDate: Datetime
+  dueDate: Datetime
+  status: ComplianceRegistryStatus!
+}
+
+input UpdateComplianceRegistryInput {
+  id: ID!
+  referenceId: String
+  area: String
+  source: String
+  auditId: ID
+  requirement: String
+  actionsToBeImplemented: String
+  regulator: String
+  ownerId: ID
+  lastReviewDate: Datetime
+  dueDate: Datetime
+  status: ComplianceRegistryStatus
+}
+
+input DeleteComplianceRegistryInput {
+  complianceRegistryId: ID!
 }
 
 # Payload Types
@@ -9648,6 +10055,18 @@ type UpdateNonconformityRegistryPayload {
 
 type DeleteNonconformityRegistryPayload {
   deletedNonconformityRegistryId: ID!
+}
+
+type CreateComplianceRegistryPayload {
+  complianceRegistryEdge: ComplianceRegistryEdge!
+}
+
+type UpdateComplianceRegistryPayload {
+  complianceRegistry: ComplianceRegistry!
+}
+
+type DeleteComplianceRegistryPayload {
+  deletedComplianceRegistryId: ID!
 }
 `, BuiltIn: false},
 }
@@ -11315,6 +11734,29 @@ func (ec *executionContext) field_Mutation_createAudit_argsInput(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation_createComplianceRegistry_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_createComplianceRegistry_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_createComplianceRegistry_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.CreateComplianceRegistryInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNCreateComplianceRegistryInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateComplianceRegistryInput(ctx, tmp)
+	}
+
+	var zeroVal types.CreateComplianceRegistryInput
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation_createControlAuditMapping_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -11841,6 +12283,29 @@ func (ec *executionContext) field_Mutation_deleteAudit_argsInput(
 	}
 
 	var zeroVal types.DeleteAuditInput
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_deleteComplianceRegistry_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_deleteComplianceRegistry_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_deleteComplianceRegistry_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.DeleteComplianceRegistryInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNDeleteComplianceRegistryInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteComplianceRegistryInput(ctx, tmp)
+	}
+
+	var zeroVal types.DeleteComplianceRegistryInput
 	return zeroVal, nil
 }
 
@@ -12718,6 +13183,29 @@ func (ec *executionContext) field_Mutation_updateAudit_argsInput(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation_updateComplianceRegistry_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_updateComplianceRegistry_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_updateComplianceRegistry_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.UpdateComplianceRegistryInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNUpdateComplianceRegistryInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateComplianceRegistryInput(ctx, tmp)
+	}
+
+	var zeroVal types.UpdateComplianceRegistryInput
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation_updateControl_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -13411,6 +13899,101 @@ func (ec *executionContext) field_Organization_audits_argsOrderBy(
 	}
 
 	var zeroVal *types.AuditOrderBy
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_complianceRegistries_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Organization_complianceRegistries_argsFirst(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["first"] = arg0
+	arg1, err := ec.field_Organization_complianceRegistries_argsAfter(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["after"] = arg1
+	arg2, err := ec.field_Organization_complianceRegistries_argsLast(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["last"] = arg2
+	arg3, err := ec.field_Organization_complianceRegistries_argsBefore(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["before"] = arg3
+	arg4, err := ec.field_Organization_complianceRegistries_argsOrderBy(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["orderBy"] = arg4
+	return args, nil
+}
+func (ec *executionContext) field_Organization_complianceRegistries_argsFirst(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*int, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("first"))
+	if tmp, ok := rawArgs["first"]; ok {
+		return ec.unmarshalOInt2ᚖint(ctx, tmp)
+	}
+
+	var zeroVal *int
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_complianceRegistries_argsAfter(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*page.CursorKey, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("after"))
+	if tmp, ok := rawArgs["after"]; ok {
+		return ec.unmarshalOCursorKey2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐCursorKey(ctx, tmp)
+	}
+
+	var zeroVal *page.CursorKey
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_complianceRegistries_argsLast(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*int, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("last"))
+	if tmp, ok := rawArgs["last"]; ok {
+		return ec.unmarshalOInt2ᚖint(ctx, tmp)
+	}
+
+	var zeroVal *int
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_complianceRegistries_argsBefore(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*page.CursorKey, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("before"))
+	if tmp, ok := rawArgs["before"]; ok {
+		return ec.unmarshalOCursorKey2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐCursorKey(ctx, tmp)
+	}
+
+	var zeroVal *page.CursorKey
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_complianceRegistries_argsOrderBy(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*types.ComplianceRegistryOrderBy, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("orderBy"))
+	if tmp, ok := rawArgs["orderBy"]; ok {
+		return ec.unmarshalOComplianceRegistryOrder2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐComplianceRegistryOrderBy(ctx, tmp)
+	}
+
+	var zeroVal *types.ComplianceRegistryOrderBy
 	return zeroVal, nil
 }
 
@@ -16403,6 +16986,8 @@ func (ec *executionContext) fieldContext_Asset_organization(_ context.Context, f
 				return ec.fieldContext_Organization_audits(ctx, field)
 			case "nonconformityRegistries":
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
+			case "complianceRegistries":
+				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -16992,6 +17577,8 @@ func (ec *executionContext) fieldContext_Audit_organization(_ context.Context, f
 				return ec.fieldContext_Organization_audits(ctx, field)
 			case "nonconformityRegistries":
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
+			case "complianceRegistries":
+				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -17939,6 +18526,1007 @@ func (ec *executionContext) fieldContext_CancelSignatureRequestPayload_deletedDo
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceRegistry_id(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ComplianceRegistry_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(gid.GID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ComplianceRegistry_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceRegistry_organization(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ComplianceRegistry_organization(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.ComplianceRegistry().Organization(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.Organization)
+	fc.Result = res
+	return ec.marshalNOrganization2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐOrganization(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ComplianceRegistry_organization(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceRegistry",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Organization_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Organization_name(ctx, field)
+			case "logoUrl":
+				return ec.fieldContext_Organization_logoUrl(ctx, field)
+			case "users":
+				return ec.fieldContext_Organization_users(ctx, field)
+			case "connectors":
+				return ec.fieldContext_Organization_connectors(ctx, field)
+			case "frameworks":
+				return ec.fieldContext_Organization_frameworks(ctx, field)
+			case "controls":
+				return ec.fieldContext_Organization_controls(ctx, field)
+			case "vendors":
+				return ec.fieldContext_Organization_vendors(ctx, field)
+			case "peoples":
+				return ec.fieldContext_Organization_peoples(ctx, field)
+			case "documents":
+				return ec.fieldContext_Organization_documents(ctx, field)
+			case "measures":
+				return ec.fieldContext_Organization_measures(ctx, field)
+			case "risks":
+				return ec.fieldContext_Organization_risks(ctx, field)
+			case "tasks":
+				return ec.fieldContext_Organization_tasks(ctx, field)
+			case "assets":
+				return ec.fieldContext_Organization_assets(ctx, field)
+			case "data":
+				return ec.fieldContext_Organization_data(ctx, field)
+			case "audits":
+				return ec.fieldContext_Organization_audits(ctx, field)
+			case "nonconformityRegistries":
+				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
+			case "complianceRegistries":
+				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "trustCenter":
+				return ec.fieldContext_Organization_trustCenter(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Organization_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Organization_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Organization", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceRegistry_referenceId(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ComplianceRegistry_referenceId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ReferenceID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ComplianceRegistry_referenceId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceRegistry_area(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ComplianceRegistry_area(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Area, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ComplianceRegistry_area(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceRegistry_source(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ComplianceRegistry_source(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Source, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ComplianceRegistry_source(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceRegistry_audit(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ComplianceRegistry_audit(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.ComplianceRegistry().Audit(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.Audit)
+	fc.Result = res
+	return ec.marshalNAudit2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐAudit(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ComplianceRegistry_audit(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceRegistry",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Audit_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Audit_name(ctx, field)
+			case "organization":
+				return ec.fieldContext_Audit_organization(ctx, field)
+			case "framework":
+				return ec.fieldContext_Audit_framework(ctx, field)
+			case "validFrom":
+				return ec.fieldContext_Audit_validFrom(ctx, field)
+			case "validUntil":
+				return ec.fieldContext_Audit_validUntil(ctx, field)
+			case "report":
+				return ec.fieldContext_Audit_report(ctx, field)
+			case "reportUrl":
+				return ec.fieldContext_Audit_reportUrl(ctx, field)
+			case "state":
+				return ec.fieldContext_Audit_state(ctx, field)
+			case "controls":
+				return ec.fieldContext_Audit_controls(ctx, field)
+			case "showOnTrustCenter":
+				return ec.fieldContext_Audit_showOnTrustCenter(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Audit_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Audit_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Audit", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceRegistry_requirement(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ComplianceRegistry_requirement(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Requirement, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ComplianceRegistry_requirement(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceRegistry_actionsToBeImplemented(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ComplianceRegistry_actionsToBeImplemented(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ActionsToBeImplemented, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ComplianceRegistry_actionsToBeImplemented(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceRegistry_regulator(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ComplianceRegistry_regulator(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Regulator, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ComplianceRegistry_regulator(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceRegistry_owner(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ComplianceRegistry_owner(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.ComplianceRegistry().Owner(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.People)
+	fc.Result = res
+	return ec.marshalNPeople2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐPeople(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ComplianceRegistry_owner(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceRegistry",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_People_id(ctx, field)
+			case "fullName":
+				return ec.fieldContext_People_fullName(ctx, field)
+			case "primaryEmailAddress":
+				return ec.fieldContext_People_primaryEmailAddress(ctx, field)
+			case "additionalEmailAddresses":
+				return ec.fieldContext_People_additionalEmailAddresses(ctx, field)
+			case "kind":
+				return ec.fieldContext_People_kind(ctx, field)
+			case "position":
+				return ec.fieldContext_People_position(ctx, field)
+			case "contractStartDate":
+				return ec.fieldContext_People_contractStartDate(ctx, field)
+			case "contractEndDate":
+				return ec.fieldContext_People_contractEndDate(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_People_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_People_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type People", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceRegistry_lastReviewDate(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ComplianceRegistry_lastReviewDate(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.LastReviewDate, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	fc.Result = res
+	return ec.marshalODatetime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ComplianceRegistry_lastReviewDate(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceRegistry_dueDate(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ComplianceRegistry_dueDate(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DueDate, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	fc.Result = res
+	return ec.marshalODatetime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ComplianceRegistry_dueDate(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceRegistry_status(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ComplianceRegistry_status(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Status, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(coredata.ComplianceRegistryStatus)
+	fc.Result = res
+	return ec.marshalNComplianceRegistryStatus2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐComplianceRegistryStatus(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ComplianceRegistry_status(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ComplianceRegistryStatus does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceRegistry_createdAt(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ComplianceRegistry_createdAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNDatetime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ComplianceRegistry_createdAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceRegistry_updatedAt(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ComplianceRegistry_updatedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNDatetime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ComplianceRegistry_updatedAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceRegistryConnection_totalCount(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceRegistryConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ComplianceRegistryConnection_totalCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.ComplianceRegistryConnection().TotalCount(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ComplianceRegistryConnection_totalCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceRegistryConnection",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceRegistryConnection_edges(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceRegistryConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ComplianceRegistryConnection_edges(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Edges, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*types.ComplianceRegistryEdge)
+	fc.Result = res
+	return ec.marshalNComplianceRegistryEdge2ᚕᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐComplianceRegistryEdgeᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ComplianceRegistryConnection_edges(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceRegistryConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "cursor":
+				return ec.fieldContext_ComplianceRegistryEdge_cursor(ctx, field)
+			case "node":
+				return ec.fieldContext_ComplianceRegistryEdge_node(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ComplianceRegistryEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceRegistryConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceRegistryConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ComplianceRegistryConnection_pageInfo(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PageInfo, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(types.PageInfo)
+	fc.Result = res
+	return ec.marshalNPageInfo2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐPageInfo(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ComplianceRegistryConnection_pageInfo(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceRegistryConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "hasNextPage":
+				return ec.fieldContext_PageInfo_hasNextPage(ctx, field)
+			case "hasPreviousPage":
+				return ec.fieldContext_PageInfo_hasPreviousPage(ctx, field)
+			case "startCursor":
+				return ec.fieldContext_PageInfo_startCursor(ctx, field)
+			case "endCursor":
+				return ec.fieldContext_PageInfo_endCursor(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceRegistryEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceRegistryEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ComplianceRegistryEdge_cursor(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Cursor, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(page.CursorKey)
+	fc.Result = res
+	return ec.marshalNCursorKey2githubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐCursorKey(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ComplianceRegistryEdge_cursor(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceRegistryEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type CursorKey does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceRegistryEdge_node(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceRegistryEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ComplianceRegistryEdge_node(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Node, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.ComplianceRegistry)
+	fc.Result = res
+	return ec.marshalNComplianceRegistry2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐComplianceRegistry(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ComplianceRegistryEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceRegistryEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_ComplianceRegistry_id(ctx, field)
+			case "organization":
+				return ec.fieldContext_ComplianceRegistry_organization(ctx, field)
+			case "referenceId":
+				return ec.fieldContext_ComplianceRegistry_referenceId(ctx, field)
+			case "area":
+				return ec.fieldContext_ComplianceRegistry_area(ctx, field)
+			case "source":
+				return ec.fieldContext_ComplianceRegistry_source(ctx, field)
+			case "audit":
+				return ec.fieldContext_ComplianceRegistry_audit(ctx, field)
+			case "requirement":
+				return ec.fieldContext_ComplianceRegistry_requirement(ctx, field)
+			case "actionsToBeImplemented":
+				return ec.fieldContext_ComplianceRegistry_actionsToBeImplemented(ctx, field)
+			case "regulator":
+				return ec.fieldContext_ComplianceRegistry_regulator(ctx, field)
+			case "owner":
+				return ec.fieldContext_ComplianceRegistry_owner(ctx, field)
+			case "lastReviewDate":
+				return ec.fieldContext_ComplianceRegistry_lastReviewDate(ctx, field)
+			case "dueDate":
+				return ec.fieldContext_ComplianceRegistry_dueDate(ctx, field)
+			case "status":
+				return ec.fieldContext_ComplianceRegistry_status(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_ComplianceRegistry_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_ComplianceRegistry_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ComplianceRegistry", field.Name)
 		},
 	}
 	return fc, nil
@@ -19367,6 +20955,56 @@ func (ec *executionContext) fieldContext_CreateAuditPayload_auditEdge(_ context.
 				return ec.fieldContext_AuditEdge_node(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type AuditEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CreateComplianceRegistryPayload_complianceRegistryEdge(ctx context.Context, field graphql.CollectedField, obj *types.CreateComplianceRegistryPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CreateComplianceRegistryPayload_complianceRegistryEdge(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ComplianceRegistryEdge, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.ComplianceRegistryEdge)
+	fc.Result = res
+	return ec.marshalNComplianceRegistryEdge2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐComplianceRegistryEdge(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CreateComplianceRegistryPayload_complianceRegistryEdge(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CreateComplianceRegistryPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "cursor":
+				return ec.fieldContext_ComplianceRegistryEdge_cursor(ctx, field)
+			case "node":
+				return ec.fieldContext_ComplianceRegistryEdge_node(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ComplianceRegistryEdge", field.Name)
 		},
 	}
 	return fc, nil
@@ -21056,6 +22694,8 @@ func (ec *executionContext) fieldContext_Datum_organization(_ context.Context, f
 				return ec.fieldContext_Organization_audits(ctx, field)
 			case "nonconformityRegistries":
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
+			case "complianceRegistries":
+				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -21566,6 +23206,50 @@ func (ec *executionContext) fieldContext_DeleteAuditReportPayload_audit(_ contex
 				return ec.fieldContext_Audit_updatedAt(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Audit", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DeleteComplianceRegistryPayload_deletedComplianceRegistryId(ctx context.Context, field graphql.CollectedField, obj *types.DeleteComplianceRegistryPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DeleteComplianceRegistryPayload_deletedComplianceRegistryId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DeletedComplianceRegistryID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(gid.GID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DeleteComplianceRegistryPayload_deletedComplianceRegistryId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DeleteComplianceRegistryPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	return fc, nil
@@ -23203,6 +24887,8 @@ func (ec *executionContext) fieldContext_Document_organization(_ context.Context
 				return ec.fieldContext_Organization_audits(ctx, field)
 			case "nonconformityRegistries":
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
+			case "complianceRegistries":
+				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -26366,6 +28052,8 @@ func (ec *executionContext) fieldContext_Framework_organization(_ context.Contex
 				return ec.fieldContext_Organization_audits(ctx, field)
 			case "nonconformityRegistries":
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
+			case "complianceRegistries":
+				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -33279,6 +34967,183 @@ func (ec *executionContext) fieldContext_Mutation_deleteNonconformityRegistry(ct
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_createComplianceRegistry(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_createComplianceRegistry(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateComplianceRegistry(rctx, fc.Args["input"].(types.CreateComplianceRegistryInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.CreateComplianceRegistryPayload)
+	fc.Result = res
+	return ec.marshalNCreateComplianceRegistryPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateComplianceRegistryPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_createComplianceRegistry(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "complianceRegistryEdge":
+				return ec.fieldContext_CreateComplianceRegistryPayload_complianceRegistryEdge(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CreateComplianceRegistryPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_createComplianceRegistry_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_updateComplianceRegistry(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_updateComplianceRegistry(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UpdateComplianceRegistry(rctx, fc.Args["input"].(types.UpdateComplianceRegistryInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.UpdateComplianceRegistryPayload)
+	fc.Result = res
+	return ec.marshalNUpdateComplianceRegistryPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateComplianceRegistryPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_updateComplianceRegistry(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "complianceRegistry":
+				return ec.fieldContext_UpdateComplianceRegistryPayload_complianceRegistry(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UpdateComplianceRegistryPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_updateComplianceRegistry_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_deleteComplianceRegistry(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_deleteComplianceRegistry(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteComplianceRegistry(rctx, fc.Args["input"].(types.DeleteComplianceRegistryInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.DeleteComplianceRegistryPayload)
+	fc.Result = res
+	return ec.marshalNDeleteComplianceRegistryPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteComplianceRegistryPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_deleteComplianceRegistry(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "deletedComplianceRegistryId":
+				return ec.fieldContext_DeleteComplianceRegistryPayload_deletedComplianceRegistryId(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DeleteComplianceRegistryPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_deleteComplianceRegistry_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _NonconformityRegistry_id(ctx context.Context, field graphql.CollectedField, obj *types.NonconformityRegistry) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_NonconformityRegistry_id(ctx, field)
 	if err != nil {
@@ -33396,6 +35261,8 @@ func (ec *executionContext) fieldContext_NonconformityRegistry_organization(_ co
 				return ec.fieldContext_Organization_audits(ctx, field)
 			case "nonconformityRegistries":
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
+			case "complianceRegistries":
+				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -35245,6 +37112,69 @@ func (ec *executionContext) fieldContext_Organization_nonconformityRegistries(ct
 	return fc, nil
 }
 
+func (ec *executionContext) _Organization_complianceRegistries(ctx context.Context, field graphql.CollectedField, obj *types.Organization) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Organization_complianceRegistries(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Organization().ComplianceRegistries(rctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey), fc.Args["orderBy"].(*types.ComplianceRegistryOrderBy))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.ComplianceRegistryConnection)
+	fc.Result = res
+	return ec.marshalNComplianceRegistryConnection2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐComplianceRegistryConnection(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Organization_complianceRegistries(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Organization",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "totalCount":
+				return ec.fieldContext_ComplianceRegistryConnection_totalCount(ctx, field)
+			case "edges":
+				return ec.fieldContext_ComplianceRegistryConnection_edges(ctx, field)
+			case "pageInfo":
+				return ec.fieldContext_ComplianceRegistryConnection_pageInfo(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ComplianceRegistryConnection", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Organization_complianceRegistries_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Organization_trustCenter(ctx context.Context, field graphql.CollectedField, obj *types.Organization) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Organization_trustCenter(ctx, field)
 	if err != nil {
@@ -35611,6 +37541,8 @@ func (ec *executionContext) fieldContext_OrganizationEdge_node(_ context.Context
 				return ec.fieldContext_Organization_audits(ctx, field)
 			case "nonconformityRegistries":
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
+			case "complianceRegistries":
+				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -38081,6 +40013,8 @@ func (ec *executionContext) fieldContext_Risk_organization(_ context.Context, fi
 				return ec.fieldContext_Organization_audits(ctx, field)
 			case "nonconformityRegistries":
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
+			case "complianceRegistries":
+				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -39173,6 +41107,8 @@ func (ec *executionContext) fieldContext_Task_organization(_ context.Context, fi
 				return ec.fieldContext_Organization_audits(ctx, field)
 			case "nonconformityRegistries":
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
+			case "complianceRegistries":
+				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -39957,6 +41893,8 @@ func (ec *executionContext) fieldContext_TrustCenter_organization(_ context.Cont
 				return ec.fieldContext_Organization_audits(ctx, field)
 			case "nonconformityRegistries":
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
+			case "complianceRegistries":
+				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -40873,6 +42811,82 @@ func (ec *executionContext) fieldContext_UpdateAuditPayload_audit(_ context.Cont
 	return fc, nil
 }
 
+func (ec *executionContext) _UpdateComplianceRegistryPayload_complianceRegistry(ctx context.Context, field graphql.CollectedField, obj *types.UpdateComplianceRegistryPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UpdateComplianceRegistryPayload_complianceRegistry(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ComplianceRegistry, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.ComplianceRegistry)
+	fc.Result = res
+	return ec.marshalNComplianceRegistry2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐComplianceRegistry(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UpdateComplianceRegistryPayload_complianceRegistry(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UpdateComplianceRegistryPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_ComplianceRegistry_id(ctx, field)
+			case "organization":
+				return ec.fieldContext_ComplianceRegistry_organization(ctx, field)
+			case "referenceId":
+				return ec.fieldContext_ComplianceRegistry_referenceId(ctx, field)
+			case "area":
+				return ec.fieldContext_ComplianceRegistry_area(ctx, field)
+			case "source":
+				return ec.fieldContext_ComplianceRegistry_source(ctx, field)
+			case "audit":
+				return ec.fieldContext_ComplianceRegistry_audit(ctx, field)
+			case "requirement":
+				return ec.fieldContext_ComplianceRegistry_requirement(ctx, field)
+			case "actionsToBeImplemented":
+				return ec.fieldContext_ComplianceRegistry_actionsToBeImplemented(ctx, field)
+			case "regulator":
+				return ec.fieldContext_ComplianceRegistry_regulator(ctx, field)
+			case "owner":
+				return ec.fieldContext_ComplianceRegistry_owner(ctx, field)
+			case "lastReviewDate":
+				return ec.fieldContext_ComplianceRegistry_lastReviewDate(ctx, field)
+			case "dueDate":
+				return ec.fieldContext_ComplianceRegistry_dueDate(ctx, field)
+			case "status":
+				return ec.fieldContext_ComplianceRegistry_status(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_ComplianceRegistry_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_ComplianceRegistry_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ComplianceRegistry", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _UpdateControlPayload_control(ctx context.Context, field graphql.CollectedField, obj *types.UpdateControlPayload) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_UpdateControlPayload_control(ctx, field)
 	if err != nil {
@@ -41422,6 +43436,8 @@ func (ec *executionContext) fieldContext_UpdateOrganizationPayload_organization(
 				return ec.fieldContext_Organization_audits(ctx, field)
 			case "nonconformityRegistries":
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
+			case "complianceRegistries":
+				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -43103,6 +45119,8 @@ func (ec *executionContext) fieldContext_Vendor_organization(_ context.Context, 
 				return ec.fieldContext_Organization_audits(ctx, field)
 			case "nonconformityRegistries":
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
+			case "complianceRegistries":
+				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -49752,6 +51770,40 @@ func (ec *executionContext) unmarshalInputCancelSignatureRequestInput(ctx contex
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputComplianceRegistryOrder(ctx context.Context, obj any) (types.ComplianceRegistryOrderBy, error) {
+	var it types.ComplianceRegistryOrderBy
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"direction", "field"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "direction":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("direction"))
+			data, err := ec.unmarshalNOrderDirection2githubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐOrderDirection(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Direction = data
+		case "field":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("field"))
+			data, err := ec.unmarshalNComplianceRegistryOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐComplianceRegistryOrderField(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Field = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputConfirmEmailInput(ctx context.Context, obj any) (types.ConfirmEmailInput, error) {
 	var it types.ConfirmEmailInput
 	asMap := map[string]any{}
@@ -50010,6 +52062,110 @@ func (ec *executionContext) unmarshalInputCreateAuditInput(ctx context.Context, 
 				return it, err
 			}
 			it.State = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputCreateComplianceRegistryInput(ctx context.Context, obj any) (types.CreateComplianceRegistryInput, error) {
+	var it types.CreateComplianceRegistryInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"organizationId", "referenceId", "area", "source", "auditId", "requirement", "actionsToBeImplemented", "regulator", "ownerId", "lastReviewDate", "dueDate", "status"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "organizationId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("organizationId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OrganizationID = data
+		case "referenceId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("referenceId"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ReferenceID = data
+		case "area":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("area"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Area = data
+		case "source":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("source"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Source = data
+		case "auditId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("auditId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AuditID = data
+		case "requirement":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("requirement"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Requirement = data
+		case "actionsToBeImplemented":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("actionsToBeImplemented"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ActionsToBeImplemented = data
+		case "regulator":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("regulator"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Regulator = data
+		case "ownerId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("ownerId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OwnerID = data
+		case "lastReviewDate":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("lastReviewDate"))
+			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.LastReviewDate = data
+		case "dueDate":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("dueDate"))
+			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DueDate = data
+		case "status":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("status"))
+			data, err := ec.unmarshalNComplianceRegistryStatus2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐComplianceRegistryStatus(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Status = data
 		}
 	}
 
@@ -51322,6 +53478,33 @@ func (ec *executionContext) unmarshalInputDeleteAuditReportInput(ctx context.Con
 				return it, err
 			}
 			it.AuditID = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputDeleteComplianceRegistryInput(ctx context.Context, obj any) (types.DeleteComplianceRegistryInput, error) {
+	var it types.DeleteComplianceRegistryInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"complianceRegistryId"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "complianceRegistryId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("complianceRegistryId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ComplianceRegistryID = data
 		}
 	}
 
@@ -53161,6 +55344,110 @@ func (ec *executionContext) unmarshalInputUpdateAuditInput(ctx context.Context, 
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputUpdateComplianceRegistryInput(ctx context.Context, obj any) (types.UpdateComplianceRegistryInput, error) {
+	var it types.UpdateComplianceRegistryInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id", "referenceId", "area", "source", "auditId", "requirement", "actionsToBeImplemented", "regulator", "ownerId", "lastReviewDate", "dueDate", "status"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ID = data
+		case "referenceId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("referenceId"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ReferenceID = data
+		case "area":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("area"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Area = data
+		case "source":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("source"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Source = data
+		case "auditId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("auditId"))
+			data, err := ec.unmarshalOID2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AuditID = data
+		case "requirement":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("requirement"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Requirement = data
+		case "actionsToBeImplemented":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("actionsToBeImplemented"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ActionsToBeImplemented = data
+		case "regulator":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("regulator"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Regulator = data
+		case "ownerId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("ownerId"))
+			data, err := ec.unmarshalOID2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OwnerID = data
+		case "lastReviewDate":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("lastReviewDate"))
+			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.LastReviewDate = data
+		case "dueDate":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("dueDate"))
+			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DueDate = data
+		case "status":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("status"))
+			data, err := ec.unmarshalOComplianceRegistryStatus2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐComplianceRegistryStatus(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Status = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputUpdateControlInput(ctx context.Context, obj any) (types.UpdateControlInput, error) {
 	var it types.UpdateControlInput
 	asMap := map[string]any{}
@@ -54801,6 +57088,13 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._Connector(ctx, sel, obj)
+	case types.ComplianceRegistry:
+		return ec._ComplianceRegistry(ctx, sel, &obj)
+	case *types.ComplianceRegistry:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._ComplianceRegistry(ctx, sel, obj)
 	case types.Audit:
 		return ec._Audit(ctx, sel, &obj)
 	case *types.Audit:
@@ -55724,6 +58018,311 @@ func (ec *executionContext) _CancelSignatureRequestPayload(ctx context.Context, 
 	return out
 }
 
+var complianceRegistryImplementors = []string{"ComplianceRegistry", "Node"}
+
+func (ec *executionContext) _ComplianceRegistry(ctx context.Context, sel ast.SelectionSet, obj *types.ComplianceRegistry) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, complianceRegistryImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ComplianceRegistry")
+		case "id":
+			out.Values[i] = ec._ComplianceRegistry_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "organization":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._ComplianceRegistry_organization(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "referenceId":
+			out.Values[i] = ec._ComplianceRegistry_referenceId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "area":
+			out.Values[i] = ec._ComplianceRegistry_area(ctx, field, obj)
+		case "source":
+			out.Values[i] = ec._ComplianceRegistry_source(ctx, field, obj)
+		case "audit":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._ComplianceRegistry_audit(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "requirement":
+			out.Values[i] = ec._ComplianceRegistry_requirement(ctx, field, obj)
+		case "actionsToBeImplemented":
+			out.Values[i] = ec._ComplianceRegistry_actionsToBeImplemented(ctx, field, obj)
+		case "regulator":
+			out.Values[i] = ec._ComplianceRegistry_regulator(ctx, field, obj)
+		case "owner":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._ComplianceRegistry_owner(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "lastReviewDate":
+			out.Values[i] = ec._ComplianceRegistry_lastReviewDate(ctx, field, obj)
+		case "dueDate":
+			out.Values[i] = ec._ComplianceRegistry_dueDate(ctx, field, obj)
+		case "status":
+			out.Values[i] = ec._ComplianceRegistry_status(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "createdAt":
+			out.Values[i] = ec._ComplianceRegistry_createdAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "updatedAt":
+			out.Values[i] = ec._ComplianceRegistry_updatedAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var complianceRegistryConnectionImplementors = []string{"ComplianceRegistryConnection"}
+
+func (ec *executionContext) _ComplianceRegistryConnection(ctx context.Context, sel ast.SelectionSet, obj *types.ComplianceRegistryConnection) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, complianceRegistryConnectionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ComplianceRegistryConnection")
+		case "totalCount":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._ComplianceRegistryConnection_totalCount(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "edges":
+			out.Values[i] = ec._ComplianceRegistryConnection_edges(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "pageInfo":
+			out.Values[i] = ec._ComplianceRegistryConnection_pageInfo(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var complianceRegistryEdgeImplementors = []string{"ComplianceRegistryEdge"}
+
+func (ec *executionContext) _ComplianceRegistryEdge(ctx context.Context, sel ast.SelectionSet, obj *types.ComplianceRegistryEdge) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, complianceRegistryEdgeImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ComplianceRegistryEdge")
+		case "cursor":
+			out.Values[i] = ec._ComplianceRegistryEdge_cursor(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "node":
+			out.Values[i] = ec._ComplianceRegistryEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var confirmEmailPayloadImplementors = []string{"ConfirmEmailPayload"}
 
 func (ec *executionContext) _ConfirmEmailPayload(ctx context.Context, sel ast.SelectionSet, obj *types.ConfirmEmailPayload) graphql.Marshaler {
@@ -56301,6 +58900,45 @@ func (ec *executionContext) _CreateAuditPayload(ctx context.Context, sel ast.Sel
 			out.Values[i] = graphql.MarshalString("CreateAuditPayload")
 		case "auditEdge":
 			out.Values[i] = ec._CreateAuditPayload_auditEdge(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var createComplianceRegistryPayloadImplementors = []string{"CreateComplianceRegistryPayload"}
+
+func (ec *executionContext) _CreateComplianceRegistryPayload(ctx context.Context, sel ast.SelectionSet, obj *types.CreateComplianceRegistryPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, createComplianceRegistryPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CreateComplianceRegistryPayload")
+		case "complianceRegistryEdge":
+			out.Values[i] = ec._CreateComplianceRegistryPayload_complianceRegistryEdge(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -57558,6 +60196,45 @@ func (ec *executionContext) _DeleteAuditReportPayload(ctx context.Context, sel a
 			out.Values[i] = graphql.MarshalString("DeleteAuditReportPayload")
 		case "audit":
 			out.Values[i] = ec._DeleteAuditReportPayload_audit(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var deleteComplianceRegistryPayloadImplementors = []string{"DeleteComplianceRegistryPayload"}
+
+func (ec *executionContext) _DeleteComplianceRegistryPayload(ctx context.Context, sel ast.SelectionSet, obj *types.DeleteComplianceRegistryPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, deleteComplianceRegistryPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("DeleteComplianceRegistryPayload")
+		case "deletedComplianceRegistryId":
+			out.Values[i] = ec._DeleteComplianceRegistryPayload_deletedComplianceRegistryId(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -61235,6 +63912,27 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "createComplianceRegistry":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_createComplianceRegistry(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "updateComplianceRegistry":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_updateComplianceRegistry(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "deleteComplianceRegistry":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_deleteComplianceRegistry(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -62096,6 +64794,42 @@ func (ec *executionContext) _Organization(ctx context.Context, sel ast.Selection
 					}
 				}()
 				res = ec._Organization_nonconformityRegistries(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "complianceRegistries":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Organization_complianceRegistries(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -64177,6 +66911,45 @@ func (ec *executionContext) _UpdateAuditPayload(ctx context.Context, sel ast.Sel
 			out.Values[i] = graphql.MarshalString("UpdateAuditPayload")
 		case "audit":
 			out.Values[i] = ec._UpdateAuditPayload_audit(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var updateComplianceRegistryPayloadImplementors = []string{"UpdateComplianceRegistryPayload"}
+
+func (ec *executionContext) _UpdateComplianceRegistryPayload(ctx context.Context, sel ast.SelectionSet, obj *types.UpdateComplianceRegistryPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, updateComplianceRegistryPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("UpdateComplianceRegistryPayload")
+		case "complianceRegistry":
+			out.Values[i] = ec._UpdateComplianceRegistryPayload_complianceRegistry(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -67486,6 +70259,148 @@ func (ec *executionContext) marshalNCancelSignatureRequestPayload2ᚖgithubᚗco
 	return ec._CancelSignatureRequestPayload(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNComplianceRegistry2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐComplianceRegistry(ctx context.Context, sel ast.SelectionSet, v *types.ComplianceRegistry) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ComplianceRegistry(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNComplianceRegistryConnection2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐComplianceRegistryConnection(ctx context.Context, sel ast.SelectionSet, v types.ComplianceRegistryConnection) graphql.Marshaler {
+	return ec._ComplianceRegistryConnection(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNComplianceRegistryConnection2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐComplianceRegistryConnection(ctx context.Context, sel ast.SelectionSet, v *types.ComplianceRegistryConnection) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ComplianceRegistryConnection(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNComplianceRegistryEdge2ᚕᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐComplianceRegistryEdgeᚄ(ctx context.Context, sel ast.SelectionSet, v []*types.ComplianceRegistryEdge) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNComplianceRegistryEdge2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐComplianceRegistryEdge(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNComplianceRegistryEdge2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐComplianceRegistryEdge(ctx context.Context, sel ast.SelectionSet, v *types.ComplianceRegistryEdge) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ComplianceRegistryEdge(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNComplianceRegistryOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐComplianceRegistryOrderField(ctx context.Context, v any) (coredata.ComplianceRegistryOrderField, error) {
+	tmp, err := graphql.UnmarshalString(v)
+	res := unmarshalNComplianceRegistryOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐComplianceRegistryOrderField[tmp]
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNComplianceRegistryOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐComplianceRegistryOrderField(ctx context.Context, sel ast.SelectionSet, v coredata.ComplianceRegistryOrderField) graphql.Marshaler {
+	_ = sel
+	res := graphql.MarshalString(marshalNComplianceRegistryOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐComplianceRegistryOrderField[v])
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+var (
+	unmarshalNComplianceRegistryOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐComplianceRegistryOrderField = map[string]coredata.ComplianceRegistryOrderField{
+		"CREATED_AT":       coredata.ComplianceRegistryOrderFieldCreatedAt,
+		"REFERENCE_ID":     coredata.ComplianceRegistryOrderFieldReferenceId,
+		"LAST_REVIEW_DATE": coredata.ComplianceRegistryOrderFieldLastReviewDate,
+		"DUE_DATE":         coredata.ComplianceRegistryOrderFieldDueDate,
+		"STATUS":           coredata.ComplianceRegistryOrderFieldStatus,
+	}
+	marshalNComplianceRegistryOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐComplianceRegistryOrderField = map[coredata.ComplianceRegistryOrderField]string{
+		coredata.ComplianceRegistryOrderFieldCreatedAt:      "CREATED_AT",
+		coredata.ComplianceRegistryOrderFieldReferenceId:    "REFERENCE_ID",
+		coredata.ComplianceRegistryOrderFieldLastReviewDate: "LAST_REVIEW_DATE",
+		coredata.ComplianceRegistryOrderFieldDueDate:        "DUE_DATE",
+		coredata.ComplianceRegistryOrderFieldStatus:         "STATUS",
+	}
+)
+
+func (ec *executionContext) unmarshalNComplianceRegistryStatus2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐComplianceRegistryStatus(ctx context.Context, v any) (coredata.ComplianceRegistryStatus, error) {
+	tmp, err := graphql.UnmarshalString(v)
+	res := unmarshalNComplianceRegistryStatus2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐComplianceRegistryStatus[tmp]
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNComplianceRegistryStatus2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐComplianceRegistryStatus(ctx context.Context, sel ast.SelectionSet, v coredata.ComplianceRegistryStatus) graphql.Marshaler {
+	_ = sel
+	res := graphql.MarshalString(marshalNComplianceRegistryStatus2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐComplianceRegistryStatus[v])
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+var (
+	unmarshalNComplianceRegistryStatus2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐComplianceRegistryStatus = map[string]coredata.ComplianceRegistryStatus{
+		"OPEN":        coredata.ComplianceRegistryStatusOpen,
+		"IN_PROGRESS": coredata.ComplianceRegistryStatusInProgress,
+		"CLOSED":      coredata.ComplianceRegistryStatusClosed,
+	}
+	marshalNComplianceRegistryStatus2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐComplianceRegistryStatus = map[coredata.ComplianceRegistryStatus]string{
+		coredata.ComplianceRegistryStatusOpen:       "OPEN",
+		coredata.ComplianceRegistryStatusInProgress: "IN_PROGRESS",
+		coredata.ComplianceRegistryStatusClosed:     "CLOSED",
+	}
+)
+
 func (ec *executionContext) unmarshalNConfirmEmailInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐConfirmEmailInput(ctx context.Context, v any) (types.ConfirmEmailInput, error) {
 	res, err := ec.unmarshalInputConfirmEmailInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -67781,6 +70696,25 @@ func (ec *executionContext) marshalNCreateAuditPayload2ᚖgithubᚗcomᚋgetprob
 		return graphql.Null
 	}
 	return ec._CreateAuditPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNCreateComplianceRegistryInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateComplianceRegistryInput(ctx context.Context, v any) (types.CreateComplianceRegistryInput, error) {
+	res, err := ec.unmarshalInputCreateComplianceRegistryInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNCreateComplianceRegistryPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateComplianceRegistryPayload(ctx context.Context, sel ast.SelectionSet, v types.CreateComplianceRegistryPayload) graphql.Marshaler {
+	return ec._CreateComplianceRegistryPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNCreateComplianceRegistryPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateComplianceRegistryPayload(ctx context.Context, sel ast.SelectionSet, v *types.CreateComplianceRegistryPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._CreateComplianceRegistryPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNCreateControlAuditMappingInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateControlAuditMappingInput(ctx context.Context, v any) (types.CreateControlAuditMappingInput, error) {
@@ -68454,6 +71388,25 @@ func (ec *executionContext) marshalNDeleteAuditReportPayload2ᚖgithubᚗcomᚋg
 		return graphql.Null
 	}
 	return ec._DeleteAuditReportPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNDeleteComplianceRegistryInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteComplianceRegistryInput(ctx context.Context, v any) (types.DeleteComplianceRegistryInput, error) {
+	res, err := ec.unmarshalInputDeleteComplianceRegistryInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNDeleteComplianceRegistryPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteComplianceRegistryPayload(ctx context.Context, sel ast.SelectionSet, v types.DeleteComplianceRegistryPayload) graphql.Marshaler {
+	return ec._DeleteComplianceRegistryPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNDeleteComplianceRegistryPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteComplianceRegistryPayload(ctx context.Context, sel ast.SelectionSet, v *types.DeleteComplianceRegistryPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._DeleteComplianceRegistryPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNDeleteControlAuditMappingInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteControlAuditMappingInput(ctx context.Context, v any) (types.DeleteControlAuditMappingInput, error) {
@@ -71000,6 +73953,25 @@ func (ec *executionContext) marshalNUpdateAuditPayload2ᚖgithubᚗcomᚋgetprob
 	return ec._UpdateAuditPayload(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNUpdateComplianceRegistryInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateComplianceRegistryInput(ctx context.Context, v any) (types.UpdateComplianceRegistryInput, error) {
+	res, err := ec.unmarshalInputUpdateComplianceRegistryInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNUpdateComplianceRegistryPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateComplianceRegistryPayload(ctx context.Context, sel ast.SelectionSet, v types.UpdateComplianceRegistryPayload) graphql.Marshaler {
+	return ec._UpdateComplianceRegistryPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNUpdateComplianceRegistryPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateComplianceRegistryPayload(ctx context.Context, sel ast.SelectionSet, v *types.UpdateComplianceRegistryPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._UpdateComplianceRegistryPayload(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNUpdateControlInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateControlInput(ctx context.Context, v any) (types.UpdateControlInput, error) {
 	res, err := ec.unmarshalInputUpdateControlInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -72438,6 +75410,46 @@ func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast
 	res := graphql.MarshalBoolean(*v)
 	return res
 }
+
+func (ec *executionContext) unmarshalOComplianceRegistryOrder2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐComplianceRegistryOrderBy(ctx context.Context, v any) (*types.ComplianceRegistryOrderBy, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputComplianceRegistryOrder(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOComplianceRegistryStatus2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐComplianceRegistryStatus(ctx context.Context, v any) (*coredata.ComplianceRegistryStatus, error) {
+	if v == nil {
+		return nil, nil
+	}
+	tmp, err := graphql.UnmarshalString(v)
+	res := unmarshalOComplianceRegistryStatus2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐComplianceRegistryStatus[tmp]
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOComplianceRegistryStatus2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐComplianceRegistryStatus(ctx context.Context, sel ast.SelectionSet, v *coredata.ComplianceRegistryStatus) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	_ = sel
+	_ = ctx
+	res := graphql.MarshalString(marshalOComplianceRegistryStatus2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐComplianceRegistryStatus[*v])
+	return res
+}
+
+var (
+	unmarshalOComplianceRegistryStatus2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐComplianceRegistryStatus = map[string]coredata.ComplianceRegistryStatus{
+		"OPEN":        coredata.ComplianceRegistryStatusOpen,
+		"IN_PROGRESS": coredata.ComplianceRegistryStatusInProgress,
+		"CLOSED":      coredata.ComplianceRegistryStatusClosed,
+	}
+	marshalOComplianceRegistryStatus2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐComplianceRegistryStatus = map[coredata.ComplianceRegistryStatus]string{
+		coredata.ComplianceRegistryStatusOpen:       "OPEN",
+		coredata.ComplianceRegistryStatusInProgress: "IN_PROGRESS",
+		coredata.ComplianceRegistryStatusClosed:     "CLOSED",
+	}
+)
 
 func (ec *executionContext) unmarshalOConnectorOrder2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐConnectorOrder(ctx context.Context, v any) (*types.ConnectorOrder, error) {
 	if v == nil {

--- a/pkg/server/api/console/v1/types/compliance_registry.go
+++ b/pkg/server/api/console/v1/types/compliance_registry.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package types
+
+import (
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+)
+
+type (
+	ComplianceRegistryOrderBy OrderBy[coredata.ComplianceRegistryOrderField]
+
+	ComplianceRegistryConnection struct {
+		TotalCount int
+		Edges      []*ComplianceRegistryEdge
+		PageInfo   PageInfo
+
+		Resolver any
+		ParentID gid.GID
+	}
+)
+
+func NewComplianceRegistryConnection(
+	p *page.Page[*coredata.ComplianceRegistry, coredata.ComplianceRegistryOrderField],
+	parentType any,
+	parentID gid.GID,
+) *ComplianceRegistryConnection {
+	edges := make([]*ComplianceRegistryEdge, len(p.Data))
+	for i, registry := range p.Data {
+		edges[i] = NewComplianceRegistryEdge(registry, p.Cursor.OrderBy.Field)
+	}
+
+	return &ComplianceRegistryConnection{
+		Edges:    edges,
+		PageInfo: *NewPageInfo(p),
+
+		Resolver: parentType,
+		ParentID: parentID,
+	}
+}
+
+func NewComplianceRegistry(cr *coredata.ComplianceRegistry) *ComplianceRegistry {
+	return &ComplianceRegistry{
+		ID:                     cr.ID,
+		ReferenceID:            cr.ReferenceID,
+		Area:                   cr.Area,
+		Source:                 cr.Source,
+		Requirement:            cr.Requirement,
+		ActionsToBeImplemented: cr.ActionsToBeImplemented,
+		Regulator:              cr.Regulator,
+		LastReviewDate:         cr.LastReviewDate,
+		DueDate:                cr.DueDate,
+		Status:                 cr.Status,
+		CreatedAt:              cr.CreatedAt,
+		UpdatedAt:              cr.UpdatedAt,
+	}
+}
+
+func NewComplianceRegistryEdge(cr *coredata.ComplianceRegistry, orderField coredata.ComplianceRegistryOrderField) *ComplianceRegistryEdge {
+	return &ComplianceRegistryEdge{
+		Node:   NewComplianceRegistry(cr),
+		Cursor: cr.CursorKey(orderField),
+	}
+}

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -107,6 +107,32 @@ type CancelSignatureRequestPayload struct {
 	DeletedDocumentVersionSignatureID gid.GID `json:"deletedDocumentVersionSignatureId"`
 }
 
+type ComplianceRegistry struct {
+	ID                     gid.GID                           `json:"id"`
+	Organization           *Organization                     `json:"organization"`
+	ReferenceID            string                            `json:"referenceId"`
+	Area                   *string                           `json:"area,omitempty"`
+	Source                 *string                           `json:"source,omitempty"`
+	Audit                  *Audit                            `json:"audit"`
+	Requirement            *string                           `json:"requirement,omitempty"`
+	ActionsToBeImplemented *string                           `json:"actionsToBeImplemented,omitempty"`
+	Regulator              *string                           `json:"regulator,omitempty"`
+	Owner                  *People                           `json:"owner"`
+	LastReviewDate         *time.Time                        `json:"lastReviewDate,omitempty"`
+	DueDate                *time.Time                        `json:"dueDate,omitempty"`
+	Status                 coredata.ComplianceRegistryStatus `json:"status"`
+	CreatedAt              time.Time                         `json:"createdAt"`
+	UpdatedAt              time.Time                         `json:"updatedAt"`
+}
+
+func (ComplianceRegistry) IsNode()             {}
+func (this ComplianceRegistry) GetID() gid.GID { return this.ID }
+
+type ComplianceRegistryEdge struct {
+	Cursor page.CursorKey      `json:"cursor"`
+	Node   *ComplianceRegistry `json:"node"`
+}
+
 type ConfirmEmailInput struct {
 	Token string `json:"token"`
 }
@@ -194,6 +220,25 @@ type CreateAuditInput struct {
 
 type CreateAuditPayload struct {
 	AuditEdge *AuditEdge `json:"auditEdge"`
+}
+
+type CreateComplianceRegistryInput struct {
+	OrganizationID         gid.GID                           `json:"organizationId"`
+	ReferenceID            string                            `json:"referenceId"`
+	Area                   *string                           `json:"area,omitempty"`
+	Source                 *string                           `json:"source,omitempty"`
+	AuditID                gid.GID                           `json:"auditId"`
+	Requirement            *string                           `json:"requirement,omitempty"`
+	ActionsToBeImplemented *string                           `json:"actionsToBeImplemented,omitempty"`
+	Regulator              *string                           `json:"regulator,omitempty"`
+	OwnerID                gid.GID                           `json:"ownerId"`
+	LastReviewDate         *time.Time                        `json:"lastReviewDate,omitempty"`
+	DueDate                *time.Time                        `json:"dueDate,omitempty"`
+	Status                 coredata.ComplianceRegistryStatus `json:"status"`
+}
+
+type CreateComplianceRegistryPayload struct {
+	ComplianceRegistryEdge *ComplianceRegistryEdge `json:"complianceRegistryEdge"`
 }
 
 type CreateControlAuditMappingInput struct {
@@ -501,6 +546,14 @@ type DeleteAuditReportInput struct {
 
 type DeleteAuditReportPayload struct {
 	Audit *Audit `json:"audit"`
+}
+
+type DeleteComplianceRegistryInput struct {
+	ComplianceRegistryID gid.GID `json:"complianceRegistryId"`
+}
+
+type DeleteComplianceRegistryPayload struct {
+	DeletedComplianceRegistryID gid.GID `json:"deletedComplianceRegistryId"`
 }
 
 type DeleteControlAuditMappingInput struct {
@@ -964,6 +1017,7 @@ type Organization struct {
 	Data                    *DatumConnection                 `json:"data"`
 	Audits                  *AuditConnection                 `json:"audits"`
 	NonconformityRegistries *NonconformityRegistryConnection `json:"nonconformityRegistries"`
+	ComplianceRegistries    *ComplianceRegistryConnection    `json:"complianceRegistries"`
 	TrustCenter             *TrustCenter                     `json:"trustCenter,omitempty"`
 	CreatedAt               time.Time                        `json:"createdAt"`
 	UpdatedAt               time.Time                        `json:"updatedAt"`
@@ -1231,6 +1285,25 @@ type UpdateAuditInput struct {
 
 type UpdateAuditPayload struct {
 	Audit *Audit `json:"audit"`
+}
+
+type UpdateComplianceRegistryInput struct {
+	ID                     gid.GID                            `json:"id"`
+	ReferenceID            *string                            `json:"referenceId,omitempty"`
+	Area                   *string                            `json:"area,omitempty"`
+	Source                 *string                            `json:"source,omitempty"`
+	AuditID                *gid.GID                           `json:"auditId,omitempty"`
+	Requirement            *string                            `json:"requirement,omitempty"`
+	ActionsToBeImplemented *string                            `json:"actionsToBeImplemented,omitempty"`
+	Regulator              *string                            `json:"regulator,omitempty"`
+	OwnerID                *gid.GID                           `json:"ownerId,omitempty"`
+	LastReviewDate         *time.Time                         `json:"lastReviewDate,omitempty"`
+	DueDate                *time.Time                         `json:"dueDate,omitempty"`
+	Status                 *coredata.ComplianceRegistryStatus `json:"status,omitempty"`
+}
+
+type UpdateComplianceRegistryPayload struct {
+	ComplianceRegistry *ComplianceRegistry `json:"complianceRegistry"`
 }
 
 type UpdateControlInput struct {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add Compliance Registries with full CRUD across Console and GraphQL to track regulatory requirements per organization, including status, owner, audit link, and key dates. This introduces new UI pages, backend models/services, and a DB schema for storing compliance registries.

- New Features
  - Console: list page with pagination, details page with edit/delete, and a create dialog; status badges and toasts; delete confirmation.
  - Navigation: added “Compliance Registries” to the sidebar.
  - Relay: queries and mutations for list, node, create, update, delete; connection key for correct cache updates.
  - Helpers: added getComplianceRegistryStatusOptions; shared status label/variant now support compliance registries.
  - API: GraphQL types, enums, order fields, connections, queries, and mutations; resolvers for related entities.
  - Backend: coredata model, status and order enums, service wired into TenantService.

- Migration
  - Run migration 20250818T094916Z.sql to add the compliance_registries table and enum.
  - Ensure related audits and owners exist before creating registries.

<!-- End of auto-generated description by cubic. -->

