### PR TITLE
chore: Replace mailhog

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -75,14 +75,17 @@ services:
       - "./compose/tempo/tempo.yaml:/etc/tempo.yaml:ro"
       - "tempo-data:/var/tempo:rw"
 
-  mailhog:
-    image: "mailhog/mailhog:latest"
-    platform: linux/amd64 
+  mailpit:
+    image: "axllent/mailpit:latest"
     ports:
       - "1025:1025" # SMTP server
       - "8025:8025" # Web UI
     environment:
-      - MH_STORAGE=memory
+      - "MP_DISABLE_VERSION_CHECK=true"
+      - "MP_VERBOSE=false"
+      - "MP_SMTP_AUTH_ACCEPT_ANY=true"
+      - "MP_ENABLE_PROMETHEUS=true"
+      - "MP_SMTP_AUTH_ALLOW_INSECURE=true"
 
   chrome:
     image: "chromedp/headless-shell:140.0.7259.2"


### PR DESCRIPTION
Mailhog hasn’t been updated since August 2022. While the SMTP protocol remains stable, the underlying libraries and dependencies may have evolved. Using an actively maintained tool can help avoid potential security or compatibility issues in the future.

Let me know if you have any questions or need further adjustments!
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced MailHog with Mailpit in Docker Compose for local email testing. Keeps the same ports and adds metrics while using an actively maintained image.

- **Dependencies**
  - Switched image to axllent/mailpit:latest.
  - Enabled Prometheus and relaxed SMTP auth for local dev via MP_* env vars.

- **Migration**
  - Service renamed: update any SMTP host references from mailhog to mailpit (or use localhost:1025).
  - Web UI remains at http://localhost:8025; update docs mentioning MailHog if needed.

<!-- End of auto-generated description by cubic. -->

