### PR TITLE
Wider sidebar

### DIFF
--- a/packages/ui/src/Atoms/Sidebar/Sidebar.tsx
+++ b/packages/ui/src/Atoms/Sidebar/Sidebar.tsx
@@ -17,7 +17,7 @@ export function Sidebar({ children }: PropsWithChildren) {
             <aside
                 className={clsx(
                     "border-r border-border-solid relative pt-16 flex-none",
-                    open ? "px-4 w-[260px]" : "px-2",
+                    open ? "px-4 w-[270px]" : "px-2",
                 )}
             >
                 {children}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Increase the open sidebar width from 260px to 270px to give content a bit more room and improve readability.

<!-- End of auto-generated description by cubic. -->

