### PR TITLE
Redirect user to login page after password reset

### DIFF
--- a/apps/console/src/pages/auth/ResetPasswordPage.tsx
+++ b/apps/console/src/pages/auth/ResetPasswordPage.tsx
@@ -74,7 +74,7 @@ export default function ResetPasswordPage() {
       description: __("Password reset successfully"),
       variant: "success",
     });
-    navigate("/auth/login", { replace: true });
+    navigate("/auth/LoginPage.tsx", { replace: true });
   });
 
   usePageTitle(__("Reset password"));


### PR DESCRIPTION
This PR implements a fix for the password reset flow. Now, after a user successfully resets their password, they are automatically redirected to the login page. 

Previously, the user remained on the password reset page, which could cause confusion. This change improves the user experience by guiding them directly to the login page to access their account with the new password.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Automatically redirect users to the login page after a successful password reset so they can sign in with the new password. This fixes the previous behavior where users stayed on the reset page.

<!-- End of auto-generated description by cubic. -->

