### PR TITLE
Use more robust front end public trust center authentification check

### DIFF
--- a/apps/console/src/trust/pages/PublicTrustCenterPage.tsx
+++ b/apps/console/src/trust/pages/PublicTrustCenterPage.tsx
@@ -5,10 +5,10 @@ import { PublicTrustCenterLayout } from "/layouts/PublicTrustCenterLayout";
 import { PublicTrustCenterAudits } from "../components/PublicTrustCenterAudits";
 import { PublicTrustCenterVendors } from "../components/PublicTrustCenterVendors";
 import { PublicTrustCenterDocuments } from "../components/PublicTrustCenterDocuments";
-import { TrustRelayProvider, useTrustAuth } from "/providers/TrustRelayProvider";
-import { Suspense } from "react";
+import { TrustRelayProvider } from "/providers/TrustRelayProvider";
 import { useLazyLoadQuery } from "react-relay";
 import { graphql } from "react-relay";
+import { Suspense } from "react";
 import { Spinner } from "@probo/ui";
 import type { PublicTrustCenterPageQuery } from "./__generated__/PublicTrustCenterPageQuery.graphql";
 
@@ -44,6 +44,7 @@ const PublicTrustCenterQuery = graphql`
       id
       active
       slug
+      isUserAuthenticated
       organization {
         id
         name
@@ -91,7 +92,6 @@ const PublicTrustCenterQuery = graphql`
 function PublicTrustCenterContent() {
   const { __ } = useTranslate();
   const { slug } = useParams<{ slug: string }>();
-  const { isAuthenticated } = useTrustAuth();
 
   if (!slug) {
     return <Navigate to="/" replace />;
@@ -101,6 +101,8 @@ function PublicTrustCenterContent() {
 
   const organization = data?.trustCenterBySlug?.organization;
   const organizationName = organization?.name || "";
+
+  const isUserAuthenticated = data?.trustCenterBySlug?.isUserAuthenticated ?? false;
 
   usePageTitle(
     organizationName ? `${organizationName} - Trust Center` : "Trust Center"
@@ -131,19 +133,19 @@ function PublicTrustCenterContent() {
     <PublicTrustCenterLayout
       organizationName={organizationName}
       organizationLogo={organization?.logoUrl}
-      isAuthenticated={isAuthenticated}
+      isAuthenticated={isUserAuthenticated}
     >
       <div className="space-y-12">
         <PublicTrustCenterAudits
           audits={trustCenterAudits}
           organizationName={organizationName}
-          isAuthenticated={isAuthenticated}
+          isAuthenticated={isUserAuthenticated}
           trustCenterId={data.trustCenterBySlug.id}
         />
         <PublicTrustCenterDocuments
           documents={trustCenterDocuments}
           organizationName={organizationName}
-          isAuthenticated={isAuthenticated}
+          isAuthenticated={isUserAuthenticated}
           trustCenterId={data.trustCenterBySlug.id}
         />
         <PublicTrustCenterVendors

--- a/apps/console/src/trust/pages/__generated__/PublicTrustCenterPageQuery.graphql.ts
+++ b/apps/console/src/trust/pages/__generated__/PublicTrustCenterPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7510cf085d283274b579e0571eb503c4>>
+ * @generated SignedSource<<029dd7c4e23d3456922e9a2778d4f4db>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -42,6 +42,7 @@ export type PublicTrustCenterPageQuery$data = {
       }>;
     };
     readonly id: string;
+    readonly isUserAuthenticated: boolean;
     readonly organization: {
       readonly id: string;
       readonly logoUrl: string | null | undefined;
@@ -106,10 +107,17 @@ v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "isUserAuthenticated",
   "storageKey": null
 },
 v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v7 = {
   "alias": null,
   "args": null,
   "concreteType": "Organization",
@@ -118,7 +126,7 @@ v6 = {
   "plural": false,
   "selections": [
     (v2/*: any*/),
-    (v5/*: any*/),
+    (v6/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -129,16 +137,16 @@ v6 = {
   ],
   "storageKey": null
 },
-v7 = [
+v8 = [
   {
     "kind": "Literal",
     "name": "first",
     "value": 100
   }
 ],
-v8 = {
+v9 = {
   "alias": null,
-  "args": (v7/*: any*/),
+  "args": (v8/*: any*/),
   "concreteType": "DocumentConnection",
   "kind": "LinkedField",
   "name": "documents",
@@ -184,7 +192,7 @@ v8 = {
   ],
   "storageKey": "documents(first:100)"
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "concreteType": "Report",
@@ -210,9 +218,9 @@ v9 = {
   ],
   "storageKey": null
 },
-v10 = {
+v11 = {
   "alias": null,
-  "args": (v7/*: any*/),
+  "args": (v8/*: any*/),
   "concreteType": "VendorConnection",
   "kind": "LinkedField",
   "name": "vendors",
@@ -235,7 +243,7 @@ v10 = {
           "plural": false,
           "selections": [
             (v2/*: any*/),
-            (v5/*: any*/),
+            (v6/*: any*/),
             {
               "alias": null,
               "args": null,
@@ -284,11 +292,12 @@ return {
           (v2/*: any*/),
           (v3/*: any*/),
           (v4/*: any*/),
-          (v6/*: any*/),
-          (v8/*: any*/),
+          (v5/*: any*/),
+          (v7/*: any*/),
+          (v9/*: any*/),
           {
             "alias": null,
-            "args": (v7/*: any*/),
+            "args": (v8/*: any*/),
             "concreteType": "AuditConnection",
             "kind": "LinkedField",
             "name": "audits",
@@ -319,11 +328,11 @@ return {
                         "name": "framework",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/)
+                          (v6/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v9/*: any*/)
+                      (v10/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -333,7 +342,7 @@ return {
             ],
             "storageKey": "audits(first:100)"
           },
-          (v10/*: any*/)
+          (v11/*: any*/)
         ],
         "storageKey": null
       }
@@ -358,11 +367,12 @@ return {
           (v2/*: any*/),
           (v3/*: any*/),
           (v4/*: any*/),
-          (v6/*: any*/),
-          (v8/*: any*/),
+          (v5/*: any*/),
+          (v7/*: any*/),
+          (v9/*: any*/),
           {
             "alias": null,
-            "args": (v7/*: any*/),
+            "args": (v8/*: any*/),
             "concreteType": "AuditConnection",
             "kind": "LinkedField",
             "name": "audits",
@@ -393,12 +403,12 @@ return {
                         "name": "framework",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
+                          (v6/*: any*/),
                           (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v9/*: any*/)
+                      (v10/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -408,23 +418,23 @@ return {
             ],
             "storageKey": "audits(first:100)"
           },
-          (v10/*: any*/)
+          (v11/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "9d0437e87c7c88083619611892bcc422",
+    "cacheID": "88353d6751cb7dea9294fb6d2268745a",
     "id": null,
     "metadata": {},
     "name": "PublicTrustCenterPageQuery",
     "operationKind": "query",
-    "text": "query PublicTrustCenterPageQuery(\n  $slug: String!\n) {\n  trustCenterBySlug(slug: $slug) {\n    id\n    active\n    slug\n    organization {\n      id\n      name\n      logoUrl\n    }\n    documents(first: 100) {\n      edges {\n        node {\n          id\n          title\n          documentType\n        }\n      }\n    }\n    audits(first: 100) {\n      edges {\n        node {\n          id\n          framework {\n            name\n            id\n          }\n          report {\n            id\n            filename\n            downloadUrl\n          }\n        }\n      }\n    }\n    vendors(first: 100) {\n      edges {\n        node {\n          id\n          name\n          category\n          websiteUrl\n          privacyPolicyUrl\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query PublicTrustCenterPageQuery(\n  $slug: String!\n) {\n  trustCenterBySlug(slug: $slug) {\n    id\n    active\n    slug\n    isUserAuthenticated\n    organization {\n      id\n      name\n      logoUrl\n    }\n    documents(first: 100) {\n      edges {\n        node {\n          id\n          title\n          documentType\n        }\n      }\n    }\n    audits(first: 100) {\n      edges {\n        node {\n          id\n          framework {\n            name\n            id\n          }\n          report {\n            id\n            filename\n            downloadUrl\n          }\n        }\n      }\n    }\n    vendors(first: 100) {\n      edges {\n        node {\n          id\n          name\n          category\n          websiteUrl\n          privacyPolicyUrl\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "7fc4b49f2a965be237cf3d51baa815bd";
+(node as any).hash = "9a87db527de655882bdeb429c265a3ee";
 
 export default node;

--- a/pkg/server/api/trust/v1/schema.graphql
+++ b/pkg/server/api/trust/v1/schema.graphql
@@ -200,6 +200,7 @@ type TrustCenter implements Node {
   active: Boolean!
   slug: String!
   organization: Organization! @goField(forceResolver: true)
+  isUserAuthenticated: Boolean! @goField(forceResolver: true)
 
   documents(
     first: Int

--- a/pkg/server/api/trust/v1/types/types.go
+++ b/pkg/server/api/trust/v1/types/types.go
@@ -115,13 +115,14 @@ func (Report) IsNode()             {}
 func (this Report) GetID() gid.GID { return this.ID }
 
 type TrustCenter struct {
-	ID           gid.GID             `json:"id"`
-	Active       bool                `json:"active"`
-	Slug         string              `json:"slug"`
-	Organization *Organization       `json:"organization"`
-	Documents    *DocumentConnection `json:"documents"`
-	Audits       *AuditConnection    `json:"audits"`
-	Vendors      *VendorConnection   `json:"vendors"`
+	ID                  gid.GID             `json:"id"`
+	Active              bool                `json:"active"`
+	Slug                string              `json:"slug"`
+	Organization        *Organization       `json:"organization"`
+	IsUserAuthenticated bool                `json:"isUserAuthenticated"`
+	Documents           *DocumentConnection `json:"documents"`
+	Audits              *AuditConnection    `json:"audits"`
+	Vendors             *VendorConnection   `json:"vendors"`
 }
 
 func (TrustCenter) IsNode()             {}

--- a/pkg/server/api/trust/v1/v1_resolver.go
+++ b/pkg/server/api/trust/v1/v1_resolver.go
@@ -153,6 +153,14 @@ func (r *trustCenterResolver) Organization(ctx context.Context, obj *types.Trust
 	return obj.Organization, nil
 }
 
+// IsUserAuthenticated is the resolver for the isUserAuthenticated field.
+func (r *trustCenterResolver) IsUserAuthenticated(ctx context.Context, obj *types.TrustCenter) (bool, error) {
+	if err := auth.ValidateTenantAccess(ctx, r, userTenantContextKey, obj.Organization.ID.TenantID()); err != nil {
+		return false, nil
+	}
+	return true, nil
+}
+
 // Documents is the resolver for the documents field.
 func (r *trustCenterResolver) Documents(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.DocumentConnection, error) {
 	trust := r.trustCenterSvc.WithTenant(obj.Organization.ID.TenantID())


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add a server-validated authentication check to the Public Trust Center to correctly gate downloads and protected content. Prevents unauthenticated users from seeing download options.

- **Bug Fixes**
  - Added TrustCenter.isUserAuthenticated to GraphQL, resolved via tenant access validation.
  - PublicTrustCenterPage queries this field, sets auth state, and passes it to child components to control visibility.
  - TrustRelayProvider now initializes auth state to false to avoid flashing protected UI before the check completes.

<!-- End of auto-generated description by cubic. -->

