### PR TITLE
Add snapshots

### DIFF
--- a/apps/console/src/components/SnapshotBanner.tsx
+++ b/apps/console/src/components/SnapshotBanner.tsx
@@ -1,0 +1,45 @@
+import { IconClock } from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { useLazyLoadQuery, graphql } from "react-relay";
+import type { SnapshotBannerQuery } from "./__generated__/SnapshotBannerQuery.graphql";
+
+const snapshotQuery = graphql`
+  query SnapshotBannerQuery($snapshotId: ID!) {
+    node(id: $snapshotId) {
+      ... on Snapshot {
+        id
+        name
+        createdAt
+      }
+    }
+  }
+`;
+
+type Props = {
+  snapshotId: string;
+};
+
+export function SnapshotBanner({ snapshotId }: Props) {
+  const { __, dateFormat } = useTranslate();
+
+  const data = useLazyLoadQuery<SnapshotBannerQuery>(snapshotQuery, { snapshotId });
+  const snapshot = data.node;
+
+  if (!snapshot) {
+    return null;
+  }
+
+  return (
+    <div className="bg-warning rounded-lg p-4 flex items-center gap-3">
+      <IconClock className="text-warning-600 flex-shrink-0" size={20} />
+      <div className="flex-1">
+        <div className="flex items-center gap-2 mb-1">
+          <span className="font-medium text-warning-800">{__("Snapshot")} {snapshot.name}</span>
+        </div>
+        <p className="text-sm text-warning-700">
+          {__("You are viewing a snapshot of data from")} {dateFormat(snapshot.createdAt, { year: "numeric", month: "short", day: "numeric" })}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/console/src/components/__generated__/SnapshotBannerQuery.graphql.ts
+++ b/apps/console/src/components/__generated__/SnapshotBannerQuery.graphql.ts
@@ -1,0 +1,144 @@
+/**
+ * @generated SignedSource<<a11c48ca33ac17dd7eaf6eeca4a0c20d>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type SnapshotBannerQuery$variables = {
+  snapshotId: string;
+};
+export type SnapshotBannerQuery$data = {
+  readonly node: {
+    readonly createdAt?: any;
+    readonly id?: string;
+    readonly name?: string;
+  };
+};
+export type SnapshotBannerQuery = {
+  response: SnapshotBannerQuery$data;
+  variables: SnapshotBannerQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "snapshotId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "snapshotId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SnapshotBannerQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/)
+            ],
+            "type": "Snapshot",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SnapshotBannerQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v3/*: any*/),
+              (v4/*: any*/)
+            ],
+            "type": "Snapshot",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "8f21371ececf96444bb6b00e52783573",
+    "id": null,
+    "metadata": {},
+    "name": "SnapshotBannerQuery",
+    "operationKind": "query",
+    "text": "query SnapshotBannerQuery(\n  $snapshotId: ID!\n) {\n  node(id: $snapshotId) {\n    __typename\n    ... on Snapshot {\n      id\n      name\n      createdAt\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "1602d5b6c0ae4a3122998e4d3419af05";
+
+export default node;

--- a/apps/console/src/components/form/SnapshotTypeOptions.tsx
+++ b/apps/console/src/components/form/SnapshotTypeOptions.tsx
@@ -1,0 +1,17 @@
+import { useTranslate } from "@probo/i18n";
+import { Option } from "@probo/ui";
+import { snapshotTypes, getSnapshotTypeLabel } from "@probo/helpers";
+
+export function SnapshotTypeOptions() {
+  const { __ } = useTranslate();
+
+  return (
+    <>
+      {snapshotTypes.map((type) => (
+        <Option key={type} value={type}>
+          {getSnapshotTypeLabel(__, type)}
+        </Option>
+      ))}
+    </>
+  );
+}

--- a/apps/console/src/components/form/VendorsMultiSelectField.tsx
+++ b/apps/console/src/components/form/VendorsMultiSelectField.tsx
@@ -1,23 +1,32 @@
 import { Avatar, Field, Option, Select, Badge, Button, IconCrossLargeX } from "@probo/ui";
 import { Suspense, useState, type ComponentProps } from "react";
 import { useTranslate } from "@probo/i18n";
-import { type Control, Controller } from "react-hook-form";
+import { type Control, Controller, type FieldValues } from "react-hook-form";
 import { useVendors } from "/hooks/graph/VendorGraph.ts";
 import { faviconUrl } from "@probo/helpers";
+import type { Path } from "react-hook-form";
 
-type Props = {
+type Vendor = {
+  id: string;
+  name: string;
+  websiteUrl: string | null | undefined;
+};
+
+type Props<T extends FieldValues = FieldValues> = {
   organizationId: string;
-  control: Control<any>;
+  control: Control<T>;
   name: string;
   label?: string;
   error?: string;
+  selectedVendors?: Vendor[];
 } & ComponentProps<typeof Field>;
 
-export function VendorsMultiSelectField({
+export function VendorsMultiSelectField<T extends FieldValues = FieldValues>({
   organizationId,
   control,
+  selectedVendors = [],
   ...props
-}: Props) {
+}: Props<T>) {
   return (
     <Field {...props}>
       <Suspense
@@ -28,29 +37,40 @@ export function VendorsMultiSelectField({
           control={control}
           name={props.name}
           disabled={props.disabled}
+          selectedVendors={selectedVendors}
         />
       </Suspense>
     </Field>
   );
 }
 
-function VendorsMultiSelectWithQuery(
-  props: Pick<Props, "organizationId" | "control" | "name" | "disabled">
+function VendorsMultiSelectWithQuery<T extends FieldValues = FieldValues>(
+  props: Pick<Props<T>, "organizationId" | "control" | "name" | "disabled" | "selectedVendors">
 ) {
   const { __ } = useTranslate();
-  const { name, organizationId, control } = props;
+  const { name, organizationId, control, selectedVendors = [] } = props;
   const vendors = useVendors(organizationId);
   const [isOpen, setIsOpen] = useState(false);
+
+  const allVendors = [...vendors];
+  if (props.disabled) {
+    selectedVendors.forEach(selectedVendor => {
+      if (!allVendors.find(v => v.id === selectedVendor.id)) {
+        allVendors.push(selectedVendor);
+      }
+    });
+  }
 
   return (
     <>
       <Controller
         control={control}
-        name={name}
+        name={name as Path<T>}
         render={({ field }) => {
-          const selectedVendorIds = Array.isArray(field.value) ? field.value : [];
-          const selectedVendors = vendors.filter(v => selectedVendorIds.includes(v.id));
-          const availableVendors = vendors.filter(v => !selectedVendorIds.includes(v.id));
+          const selectedVendorIds = (Array.isArray(field.value) ? field.value : []) as string[];
+
+          const selectedVendors = allVendors.filter(v => selectedVendorIds.includes(v.id));
+          const availableVendors = allVendors.filter(v => !selectedVendorIds.includes(v.id));
 
           const handleAddVendor = (vendorId: string) => {
             const newValue = [...selectedVendorIds, vendorId];
@@ -65,7 +85,7 @@ function VendorsMultiSelectWithQuery(
 
           return (
             <div className="space-y-2">
-              {availableVendors.length > 0 && (
+              {availableVendors.length > 0 && !props.disabled && (
                 <Select
                   disabled={props.disabled}
                   id={name}
@@ -108,12 +128,14 @@ function VendorsMultiSelectWithQuery(
                         size="s"
                       />
                       <span>{vendor.name}</span>
-                      <Button
-                        variant="tertiary"
-                        icon={IconCrossLargeX}
-                        onClick={() => handleRemoveVendor(vendor.id)}
-                        className="h-4 w-4 p-0 hover:bg-transparent"
-                      />
+                      {!props.disabled && (
+                        <Button
+                          variant="tertiary"
+                          icon={IconCrossLargeX}
+                          onClick={() => handleRemoveVendor(vendor.id)}
+                          className="h-4 w-4 p-0 hover:bg-transparent"
+                        />
+                      )}
                     </Badge>
                   ))}
                 </div>

--- a/apps/console/src/hooks/graph/DatumGraph.ts
+++ b/apps/console/src/hooks/graph/DatumGraph.ts
@@ -5,10 +5,10 @@ import { useTranslate } from "@probo/i18n";
 import { promisifyMutation, sprintf } from "@probo/helpers";
 
 export const dataQuery = graphql`
-  query DatumGraphListQuery($organizationId: ID!) {
+  query DatumGraphListQuery($organizationId: ID!, $snapshotId: ID = null) {
     node(id: $organizationId) {
       ... on Organization {
-        ...DataPageFragment
+        ...DataPageFragment @arguments(snapshotId: $snapshotId)
       }
     }
   }
@@ -60,7 +60,7 @@ export const createDatumMutation = graphql`
             id
             fullName
           }
-          vendors(first: 10) {
+          vendors(first: 50) {
             edges {
               node {
                 id

--- a/apps/console/src/hooks/graph/SnapshotGraph.ts
+++ b/apps/console/src/hooks/graph/SnapshotGraph.ts
@@ -1,0 +1,129 @@
+import { graphql } from "relay-runtime";
+import { useMutation } from "react-relay";
+import { useConfirm } from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { promisifyMutation, sprintf } from "@probo/helpers";
+import { useMutationWithToasts } from "../useMutationWithToasts";
+
+export const SnapshotsConnectionKey = "SnapshotsPage_snapshots";
+
+export const snapshotsQuery = graphql`
+  query SnapshotGraphListQuery($organizationId: ID!) {
+    organization: node(id: $organizationId) {
+      ... on Organization {
+        ...SnapshotsPageFragment
+      }
+    }
+  }
+`;
+
+export const snapshotNodeQuery = graphql`
+  query SnapshotGraphNodeQuery($snapshotId: ID!) {
+    node(id: $snapshotId) {
+      ... on Snapshot {
+        id
+        name
+        description
+        type
+        organization {
+          id
+          name
+        }
+        createdAt
+      }
+    }
+  }
+`;
+
+export const createSnapshotMutation = graphql`
+  mutation SnapshotGraphCreateMutation(
+    $input: CreateSnapshotInput!
+    $connections: [ID!]!
+  ) {
+    createSnapshot(input: $input) {
+      snapshotEdge @prependEdge(connections: $connections) {
+        node {
+          id
+          name
+          description
+          type
+          createdAt
+        }
+      }
+    }
+  }
+`;
+
+export const deleteSnapshotMutation = graphql`
+  mutation SnapshotGraphDeleteMutation(
+    $input: DeleteSnapshotInput!
+    $connections: [ID!]!
+  ) {
+    deleteSnapshot(input: $input) {
+      deletedSnapshotId @deleteEdge(connections: $connections)
+    }
+  }
+`;
+
+export const useDeleteSnapshot = (
+  snapshot: { id: string; name: string },
+  connectionId: string
+) => {
+  const { __ } = useTranslate();
+  const [mutate] = useMutationWithToasts(deleteSnapshotMutation, {
+    successMessage: __("Snapshot deleted successfully"),
+    errorMessage: __("Failed to delete snapshot"),
+  });
+  const confirm = useConfirm();
+
+  return () => {
+    confirm(
+      () =>
+        mutate({
+          variables: {
+            input: {
+              snapshotId: snapshot.id,
+            },
+            connections: [connectionId],
+          },
+        }),
+      {
+        message: sprintf(
+          __(
+            "This will permanently delete the snapshot %s. This action cannot be undone."
+          ),
+          snapshot.name
+        ),
+      }
+    );
+  };
+};
+
+export const useCreateSnapshot = (connectionId: string) => {
+  const [mutate] = useMutation(createSnapshotMutation);
+  const { __ } = useTranslate();
+
+  return (input: {
+    organizationId: string;
+    name: string;
+    description?: string;
+  }) => {
+    if (!input.organizationId) {
+      return alert(__("Failed to create snapshot: organization is required"));
+    }
+    if (!input.name) {
+      return alert(__("Failed to create snapshot: name is required"));
+    }
+
+    return promisifyMutation(mutate)({
+      variables: {
+        input: {
+          organizationId: input.organizationId,
+          name: input.name,
+          description: input.description,
+        },
+        connections: [connectionId],
+      },
+    });
+  };
+};

--- a/apps/console/src/hooks/graph/VendorGraph.ts
+++ b/apps/console/src/hooks/graph/VendorGraph.ts
@@ -188,9 +188,13 @@ const vendorsSelectQuery = graphql`
 `;
 
 export function useVendors(organizationId: string) {
-  const data = useLazyLoadQuery<VendorGraphSelectQuery>(vendorsSelectQuery, {
-    organizationId: organizationId,
-  });
+  const data = useLazyLoadQuery<VendorGraphSelectQuery>(
+    vendorsSelectQuery,
+    {
+      organizationId: organizationId,
+    },
+    { fetchPolicy: "network-only" }
+  );
   return useMemo(() => {
     return data.organization?.vendors?.edges.map((edge) => edge.node) ?? [];
   }, [data]);

--- a/apps/console/src/hooks/graph/__generated__/DatumGraphCreateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/DatumGraphCreateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<36898ed088182687925ddd9d0b08b66a>>
+ * @generated SignedSource<<43b67fe6155860e492f2a36543727d49>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -133,7 +133,7 @@ v5 = {
             {
               "kind": "Literal",
               "name": "first",
-              "value": 10
+              "value": 50
             }
           ],
           "concreteType": "VendorConnection",
@@ -173,7 +173,7 @@ v5 = {
               "storageKey": null
             }
           ],
-          "storageKey": "vendors(first:10)"
+          "storageKey": "vendors(first:50)"
         },
         {
           "alias": null,
@@ -254,16 +254,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "31d614c716382bedf677502633969fac",
+    "cacheID": "23ff315b0cc090bcaca7739d945d8d1b",
     "id": null,
     "metadata": {},
     "name": "DatumGraphCreateMutation",
     "operationKind": "mutation",
-    "text": "mutation DatumGraphCreateMutation(\n  $input: CreateDatumInput!\n) {\n  createDatum(input: $input) {\n    datumEdge {\n      node {\n        id\n        name\n        dataClassification\n        owner {\n          id\n          fullName\n        }\n        vendors(first: 10) {\n          edges {\n            node {\n              id\n              name\n              websiteUrl\n            }\n          }\n        }\n        createdAt\n      }\n    }\n  }\n}\n"
+    "text": "mutation DatumGraphCreateMutation(\n  $input: CreateDatumInput!\n) {\n  createDatum(input: $input) {\n    datumEdge {\n      node {\n        id\n        name\n        dataClassification\n        owner {\n          id\n          fullName\n        }\n        vendors(first: 50) {\n          edges {\n            node {\n              id\n              name\n              websiteUrl\n            }\n          }\n        }\n        createdAt\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "b99929d8e7d004f77b06510051ee2e04";
+(node as any).hash = "b148ef55d18d3a45c04b5072581f2285";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/DatumGraphListQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/DatumGraphListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<157213d294566208969ddbfd7e79fd91>>
+ * @generated SignedSource<<453e3cd4a7a9fdbacd183d097ec95a05>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,7 @@ import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type DatumGraphListQuery$variables = {
   organizationId: string;
+  snapshotId?: string | null | undefined;
 };
 export type DatumGraphListQuery$data = {
   readonly node: {
@@ -29,6 +30,11 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "organizationId"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "snapshotId"
   }
 ],
 v1 = [
@@ -38,28 +44,40 @@ v1 = [
     "variableName": "organizationId"
   }
 ],
-v2 = {
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "snapshotId",
+    "variableName": "snapshotId"
+  }
+],
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v3 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v4 = [
+v5 = [
+  {
+    "fields": (v2/*: any*/),
+    "kind": "ObjectValue",
+    "name": "filter"
+  },
   {
     "kind": "Literal",
     "name": "first",
     "value": 10
   }
 ],
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -85,7 +103,7 @@ return {
             "kind": "InlineFragment",
             "selections": [
               {
-                "args": null,
+                "args": (v2/*: any*/),
                 "kind": "FragmentSpread",
                 "name": "DataPageFragment"
               }
@@ -114,14 +132,14 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v2/*: any*/),
           (v3/*: any*/),
+          (v4/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
               {
                 "alias": null,
-                "args": (v4/*: any*/),
+                "args": (v5/*: any*/),
                 "concreteType": "DatumConnection",
                 "kind": "LinkedField",
                 "name": "data",
@@ -143,8 +161,8 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v3/*: any*/),
-                          (v5/*: any*/),
+                          (v4/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -167,7 +185,7 @@ return {
                                 "name": "fullName",
                                 "storageKey": null
                               },
-                              (v3/*: any*/)
+                              (v4/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -201,8 +219,8 @@ return {
                                     "name": "node",
                                     "plural": false,
                                     "selections": [
-                                      (v3/*: any*/),
-                                      (v5/*: any*/),
+                                      (v4/*: any*/),
+                                      (v6/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -226,7 +244,7 @@ return {
                             "name": "createdAt",
                             "storageKey": null
                           },
-                          (v2/*: any*/)
+                          (v3/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -292,13 +310,14 @@ return {
                     ]
                   }
                 ],
-                "storageKey": "data(first:10)"
+                "storageKey": null
               },
               {
                 "alias": null,
-                "args": (v4/*: any*/),
+                "args": (v5/*: any*/),
                 "filters": [
-                  "orderBy"
+                  "orderBy",
+                  "filter"
                 ],
                 "handle": "connection",
                 "key": "DataPage_data",
@@ -315,16 +334,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "93f16f8bcd6ae56a947a18b90146fac4",
+    "cacheID": "7200b7cf37859346d740de3f96f1d443",
     "id": null,
     "metadata": {},
     "name": "DatumGraphListQuery",
     "operationKind": "query",
-    "text": "query DatumGraphListQuery(\n  $organizationId: ID!\n) {\n  node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      ...DataPageFragment\n    }\n    id\n  }\n}\n\nfragment DataPageFragment on Organization {\n  data(first: 10) {\n    edges {\n      node {\n        id\n        name\n        dataClassification\n        owner {\n          fullName\n          id\n        }\n        vendors(first: 50) {\n          edges {\n            node {\n              id\n              name\n              websiteUrl\n            }\n          }\n        }\n        createdAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n"
+    "text": "query DatumGraphListQuery(\n  $organizationId: ID!\n  $snapshotId: ID = null\n) {\n  node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      ...DataPageFragment_3iomuz\n    }\n    id\n  }\n}\n\nfragment DataPageFragment_3iomuz on Organization {\n  data(first: 10, filter: {snapshotId: $snapshotId}) {\n    edges {\n      node {\n        id\n        name\n        dataClassification\n        owner {\n          fullName\n          id\n        }\n        vendors(first: 50) {\n          edges {\n            node {\n              id\n              name\n              websiteUrl\n            }\n          }\n        }\n        createdAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "ebacc146f9ff0dc7fac8dcfcb8e6f74a";
+(node as any).hash = "e0782332e7e82bd1a5e7f5e40ada2dae";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/SnapshotGraphCreateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/SnapshotGraphCreateMutation.graphql.ts
@@ -1,0 +1,194 @@
+/**
+ * @generated SignedSource<<459d0a122659971be9b24c79f47691e7>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type SnapshotsType = "ASSETS" | "COMPLIANCE_REGISTRIES" | "DATA" | "NON_CONFORMITY_REGISTRIES" | "RISKS" | "VENDORS";
+export type CreateSnapshotInput = {
+  description?: string | null | undefined;
+  name: string;
+  organizationId: string;
+  type: SnapshotsType;
+};
+export type SnapshotGraphCreateMutation$variables = {
+  connections: ReadonlyArray<string>;
+  input: CreateSnapshotInput;
+};
+export type SnapshotGraphCreateMutation$data = {
+  readonly createSnapshot: {
+    readonly snapshotEdge: {
+      readonly node: {
+        readonly createdAt: any;
+        readonly description: string | null | undefined;
+        readonly id: string;
+        readonly name: string;
+        readonly type: SnapshotsType;
+      };
+    };
+  };
+};
+export type SnapshotGraphCreateMutation = {
+  response: SnapshotGraphCreateMutation$data;
+  variables: SnapshotGraphCreateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "SnapshotEdge",
+  "kind": "LinkedField",
+  "name": "snapshotEdge",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Snapshot",
+      "kind": "LinkedField",
+      "name": "node",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "id",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "description",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "type",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "createdAt",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SnapshotGraphCreateMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "CreateSnapshotPayload",
+        "kind": "LinkedField",
+        "name": "createSnapshot",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "SnapshotGraphCreateMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "CreateSnapshotPayload",
+        "kind": "LinkedField",
+        "name": "createSnapshot",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "prependEdge",
+            "key": "",
+            "kind": "LinkedHandle",
+            "name": "snapshotEdge",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "aa2e8ace42f6154271b5d035ae18cad2",
+    "id": null,
+    "metadata": {},
+    "name": "SnapshotGraphCreateMutation",
+    "operationKind": "mutation",
+    "text": "mutation SnapshotGraphCreateMutation(\n  $input: CreateSnapshotInput!\n) {\n  createSnapshot(input: $input) {\n    snapshotEdge {\n      node {\n        id\n        name\n        description\n        type\n        createdAt\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "97d681687efde567b46938fc0541635f";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/SnapshotGraphDeleteMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/SnapshotGraphDeleteMutation.graphql.ts
@@ -1,0 +1,132 @@
+/**
+ * @generated SignedSource<<6a696f2d1ebd4a2e733bd9d1b3c42017>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type DeleteSnapshotInput = {
+  snapshotId: string;
+};
+export type SnapshotGraphDeleteMutation$variables = {
+  connections: ReadonlyArray<string>;
+  input: DeleteSnapshotInput;
+};
+export type SnapshotGraphDeleteMutation$data = {
+  readonly deleteSnapshot: {
+    readonly deletedSnapshotId: string;
+  };
+};
+export type SnapshotGraphDeleteMutation = {
+  response: SnapshotGraphDeleteMutation$data;
+  variables: SnapshotGraphDeleteMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "deletedSnapshotId",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SnapshotGraphDeleteMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteSnapshotPayload",
+        "kind": "LinkedField",
+        "name": "deleteSnapshot",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "SnapshotGraphDeleteMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteSnapshotPayload",
+        "kind": "LinkedField",
+        "name": "deleteSnapshot",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "deleteEdge",
+            "key": "",
+            "kind": "ScalarHandle",
+            "name": "deletedSnapshotId",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "f5f81e50b61dbc8d5668e421cf88223f",
+    "id": null,
+    "metadata": {},
+    "name": "SnapshotGraphDeleteMutation",
+    "operationKind": "mutation",
+    "text": "mutation SnapshotGraphDeleteMutation(\n  $input: DeleteSnapshotInput!\n) {\n  deleteSnapshot(input: $input) {\n    deletedSnapshotId\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "cc7cb0955bf74c611136392354ff8dcf";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/SnapshotGraphListQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/SnapshotGraphListQuery.graphql.ts
@@ -1,0 +1,253 @@
+/**
+ * @generated SignedSource<<f4a719bca36d682b094afe419b9129e8>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type SnapshotGraphListQuery$variables = {
+  organizationId: string;
+};
+export type SnapshotGraphListQuery$data = {
+  readonly organization: {
+    readonly " $fragmentSpreads": FragmentRefs<"SnapshotsPageFragment">;
+  };
+};
+export type SnapshotGraphListQuery = {
+  response: SnapshotGraphListQuery$data;
+  variables: SnapshotGraphListQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "organizationId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "organizationId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 100
+  }
+],
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SnapshotGraphListQuery",
+    "selections": [
+      {
+        "alias": "organization",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "SnapshotsPageFragment"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SnapshotGraphListQuery",
+    "selections": [
+      {
+        "alias": "organization",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": (v3/*: any*/),
+                "concreteType": "SnapshotConnection",
+                "kind": "LinkedField",
+                "name": "snapshots",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "SnapshotEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Snapshot",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v4/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "name",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "description",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "type",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "createdAt",
+                            "storageKey": null
+                          },
+                          (v2/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "cursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageInfo",
+                    "kind": "LinkedField",
+                    "name": "pageInfo",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "endCursor",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "hasNextPage",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ClientExtension",
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "__id",
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ],
+                "storageKey": "snapshots(first:100)"
+              },
+              {
+                "alias": null,
+                "args": (v3/*: any*/),
+                "filters": null,
+                "handle": "connection",
+                "key": "SnapshotsGraphListQuery__snapshots",
+                "kind": "LinkedHandle",
+                "name": "snapshots"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          },
+          (v4/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "eda538d8a5e4e94551012bbb6b8da92f",
+    "id": null,
+    "metadata": {},
+    "name": "SnapshotGraphListQuery",
+    "operationKind": "query",
+    "text": "query SnapshotGraphListQuery(\n  $organizationId: ID!\n) {\n  organization: node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      ...SnapshotsPageFragment\n    }\n    id\n  }\n}\n\nfragment SnapshotsPageFragment on Organization {\n  snapshots(first: 100) {\n    edges {\n      node {\n        id\n        name\n        description\n        type\n        createdAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "0f264bca502a59b7f8b8ec729d0ce1ff";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/SnapshotGraphNodeQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/SnapshotGraphNodeQuery.graphql.ts
@@ -1,0 +1,184 @@
+/**
+ * @generated SignedSource<<5bcc9f9b743d01fc99fd749b970dccd3>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type SnapshotsType = "ASSETS" | "COMPLIANCE_REGISTRIES" | "DATA" | "NON_CONFORMITY_REGISTRIES" | "RISKS" | "VENDORS";
+export type SnapshotGraphNodeQuery$variables = {
+  snapshotId: string;
+};
+export type SnapshotGraphNodeQuery$data = {
+  readonly node: {
+    readonly createdAt?: any;
+    readonly description?: string | null | undefined;
+    readonly id?: string;
+    readonly name?: string;
+    readonly organization?: {
+      readonly id: string;
+      readonly name: string;
+    };
+    readonly type?: SnapshotsType;
+  };
+};
+export type SnapshotGraphNodeQuery = {
+  response: SnapshotGraphNodeQuery$data;
+  variables: SnapshotGraphNodeQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "snapshotId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "snapshotId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "description",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "type",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Organization",
+  "kind": "LinkedField",
+  "name": "organization",
+  "plural": false,
+  "selections": [
+    (v2/*: any*/),
+    (v3/*: any*/)
+  ],
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SnapshotGraphNodeQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/)
+            ],
+            "type": "Snapshot",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SnapshotGraphNodeQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/)
+            ],
+            "type": "Snapshot",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "8dafbbd8ecc8442fa065d19bba932ce2",
+    "id": null,
+    "metadata": {},
+    "name": "SnapshotGraphNodeQuery",
+    "operationKind": "query",
+    "text": "query SnapshotGraphNodeQuery(\n  $snapshotId: ID!\n) {\n  node(id: $snapshotId) {\n    __typename\n    ... on Snapshot {\n      id\n      name\n      description\n      type\n      organization {\n        id\n        name\n      }\n      createdAt\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "b687d3da56dbfa333e66f4f2c9c0c824";
+
+export default node;

--- a/apps/console/src/layouts/MainLayout.tsx
+++ b/apps/console/src/layouts/MainLayout.tsx
@@ -5,6 +5,7 @@ import {
   IconBank,
   IconBook,
   IconCircleQuestionmark,
+  IconClock,
   IconCrossLargeX,
   IconFire3,
   IconGroup1,
@@ -149,6 +150,11 @@ export function MainLayout() {
             label={__("Compliance Registries")}
             icon={IconBook}
             to={`${prefix}/complianceRegistries`}
+          />
+          <SidebarItem
+            label={__("Snapshots")}
+            icon={IconClock}
+            to={`${prefix}/snapshots`}
           />
           <SidebarItem
             label={__("Trust Center")}

--- a/apps/console/src/pages/organizations/data/__generated__/DataListQuery.graphql.ts
+++ b/apps/console/src/pages/organizations/data/__generated__/DataListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4894c4387072fb7ac2f379ab04b4168a>>
+ * @generated SignedSource<<8364d9457b59a3ef50b508ab55991638>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -22,7 +22,8 @@ export type DataListQuery$variables = {
   first?: number | null | undefined;
   id: string;
   last?: number | null | undefined;
-  orderBy?: DatumOrder | null | undefined;
+  order?: DatumOrder | null | undefined;
+  snapshotId?: string | null | undefined;
 };
 export type DataListQuery$data = {
   readonly node: {
@@ -63,57 +64,78 @@ v4 = {
 v5 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "orderBy"
+  "name": "order"
 },
-v6 = [
+v6 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "snapshotId"
+},
+v7 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
   }
 ],
-v7 = [
-  {
-    "kind": "Variable",
-    "name": "after",
-    "variableName": "after"
-  },
-  {
-    "kind": "Variable",
-    "name": "before",
-    "variableName": "before"
-  },
-  {
-    "kind": "Variable",
-    "name": "first",
-    "variableName": "first"
-  },
-  {
-    "kind": "Variable",
-    "name": "last",
-    "variableName": "last"
-  },
-  {
-    "kind": "Variable",
-    "name": "orderBy",
-    "variableName": "orderBy"
-  }
-],
 v8 = {
+  "kind": "Variable",
+  "name": "after",
+  "variableName": "after"
+},
+v9 = {
+  "kind": "Variable",
+  "name": "before",
+  "variableName": "before"
+},
+v10 = {
+  "kind": "Variable",
+  "name": "first",
+  "variableName": "first"
+},
+v11 = {
+  "kind": "Variable",
+  "name": "last",
+  "variableName": "last"
+},
+v12 = {
+  "kind": "Variable",
+  "name": "snapshotId",
+  "variableName": "snapshotId"
+},
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v9 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v10 = {
+v15 = [
+  (v8/*: any*/),
+  (v9/*: any*/),
+  {
+    "fields": [
+      (v12/*: any*/)
+    ],
+    "kind": "ObjectValue",
+    "name": "filter"
+  },
+  (v10/*: any*/),
+  (v11/*: any*/),
+  {
+    "kind": "Variable",
+    "name": "orderBy",
+    "variableName": "order"
+  }
+],
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -128,7 +150,8 @@ return {
       (v2/*: any*/),
       (v3/*: any*/),
       (v4/*: any*/),
-      (v5/*: any*/)
+      (v5/*: any*/),
+      (v6/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -136,14 +159,25 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v6/*: any*/),
+        "args": (v7/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
           {
-            "args": (v7/*: any*/),
+            "args": [
+              (v8/*: any*/),
+              (v9/*: any*/),
+              (v10/*: any*/),
+              (v11/*: any*/),
+              {
+                "kind": "Variable",
+                "name": "order",
+                "variableName": "order"
+              },
+              (v12/*: any*/)
+            ],
             "kind": "FragmentSpread",
             "name": "DataPageFragment"
           }
@@ -162,6 +196,7 @@ return {
       (v2/*: any*/),
       (v4/*: any*/),
       (v5/*: any*/),
+      (v6/*: any*/),
       (v3/*: any*/)
     ],
     "kind": "Operation",
@@ -169,20 +204,20 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v6/*: any*/),
+        "args": (v7/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v8/*: any*/),
-          (v9/*: any*/),
+          (v13/*: any*/),
+          (v14/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
               {
                 "alias": null,
-                "args": (v7/*: any*/),
+                "args": (v15/*: any*/),
                 "concreteType": "DatumConnection",
                 "kind": "LinkedField",
                 "name": "data",
@@ -204,8 +239,8 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v9/*: any*/),
-                          (v10/*: any*/),
+                          (v14/*: any*/),
+                          (v16/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -228,7 +263,7 @@ return {
                                 "name": "fullName",
                                 "storageKey": null
                               },
-                              (v9/*: any*/)
+                              (v14/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -262,8 +297,8 @@ return {
                                     "name": "node",
                                     "plural": false,
                                     "selections": [
-                                      (v9/*: any*/),
-                                      (v10/*: any*/),
+                                      (v14/*: any*/),
+                                      (v16/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -287,7 +322,7 @@ return {
                             "name": "createdAt",
                             "storageKey": null
                           },
-                          (v8/*: any*/)
+                          (v13/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -357,9 +392,10 @@ return {
               },
               {
                 "alias": null,
-                "args": (v7/*: any*/),
+                "args": (v15/*: any*/),
                 "filters": [
-                  "orderBy"
+                  "orderBy",
+                  "filter"
                 ],
                 "handle": "connection",
                 "key": "DataPage_data",
@@ -376,16 +412,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d6742fb1de534407018aeb39ca1438d5",
+    "cacheID": "dbca2ff147e8b1e367a266fcf016b184",
     "id": null,
     "metadata": {},
     "name": "DataListQuery",
     "operationKind": "query",
-    "text": "query DataListQuery(\n  $after: CursorKey = null\n  $before: CursorKey = null\n  $first: Int = 10\n  $last: Int = null\n  $orderBy: DatumOrder = null\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...DataPageFragment_sdb03\n    id\n  }\n}\n\nfragment DataPageFragment_sdb03 on Organization {\n  data(first: $first, after: $after, last: $last, before: $before, orderBy: $orderBy) {\n    edges {\n      node {\n        id\n        name\n        dataClassification\n        owner {\n          fullName\n          id\n        }\n        vendors(first: 50) {\n          edges {\n            node {\n              id\n              name\n              websiteUrl\n            }\n          }\n        }\n        createdAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n"
+    "text": "query DataListQuery(\n  $after: CursorKey = null\n  $before: CursorKey = null\n  $first: Int = 10\n  $last: Int = null\n  $order: DatumOrder = null\n  $snapshotId: ID = null\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...DataPageFragment_25MC8O\n    id\n  }\n}\n\nfragment DataPageFragment_25MC8O on Organization {\n  data(first: $first, after: $after, last: $last, before: $before, orderBy: $order, filter: {snapshotId: $snapshotId}) {\n    edges {\n      node {\n        id\n        name\n        dataClassification\n        owner {\n          fullName\n          id\n        }\n        vendors(first: 50) {\n          edges {\n            node {\n              id\n              name\n              websiteUrl\n            }\n          }\n        }\n        createdAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "a797d00b7f2cac2876322b23aa781efa";
+(node as any).hash = "a60d9b34a83df89eb59ffcd359903ce8";
 
 export default node;

--- a/apps/console/src/pages/organizations/data/__generated__/DataPageFragment.graphql.ts
+++ b/apps/console/src/pages/organizations/data/__generated__/DataPageFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0eb94f0da29f50445248a3d133714be2>>
+ * @generated SignedSource<<17f6d8607b6d2a1b575e1251019b8375>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -88,7 +88,12 @@ return {
     {
       "defaultValue": null,
       "kind": "LocalArgument",
-      "name": "orderBy"
+      "name": "order"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "snapshotId"
     }
   ],
   "kind": "Fragment",
@@ -129,9 +134,20 @@ return {
       "alias": "data",
       "args": [
         {
+          "fields": [
+            {
+              "kind": "Variable",
+              "name": "snapshotId",
+              "variableName": "snapshotId"
+            }
+          ],
+          "kind": "ObjectValue",
+          "name": "filter"
+        },
+        {
           "kind": "Variable",
           "name": "orderBy",
-          "variableName": "orderBy"
+          "variableName": "order"
         }
       ],
       "concreteType": "DatumConnection",
@@ -318,6 +334,6 @@ return {
 };
 })();
 
-(node as any).hash = "a797d00b7f2cac2876322b23aa781efa";
+(node as any).hash = "a60d9b34a83df89eb59ffcd359903ce8";
 
 export default node;

--- a/apps/console/src/pages/organizations/data/dialogs/CreateDatumDialog.tsx
+++ b/apps/console/src/pages/organizations/data/dialogs/CreateDatumDialog.tsx
@@ -27,12 +27,14 @@ type Props = {
   children: React.ReactNode;
   connection: string;
   organizationId: string;
+  onCreated?: () => void;
 };
 
 export function CreateDatumDialog({
   children,
   connection,
   organizationId,
+  onCreated,
 }: Props) {
   const { __ } = useTranslate();
   const { control, handleSubmit, register, formState, reset } =
@@ -55,6 +57,7 @@ export function CreateDatumDialog({
       });
       ref.current?.close();
       reset();
+      onCreated?.();
     } catch (error) {
       console.error("Failed to create datum:", error);
     }

--- a/apps/console/src/pages/organizations/snapshots/SnapshotsPage.tsx
+++ b/apps/console/src/pages/organizations/snapshots/SnapshotsPage.tsx
@@ -1,0 +1,176 @@
+import type { SnapshotGraphListQuery } from "/hooks/graph/__generated__/SnapshotGraphListQuery.graphql";
+import {
+  useFragment,
+  usePreloadedQuery,
+  type PreloadedQuery,
+} from "react-relay";
+import { useTranslate } from "@probo/i18n";
+import { getSnapshotTypeLabel } from "@probo/helpers";
+import {
+  ActionDropdown,
+  Button,
+  DropdownItem,
+  IconPlusLarge,
+  IconTrashCan,
+  PageHeader,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from "@probo/ui";
+import {
+  snapshotsQuery,
+  useDeleteSnapshot,
+} from "/hooks/graph/SnapshotGraph";
+import { graphql } from "relay-runtime";
+import type {
+  SnapshotsPageFragment$data,
+  SnapshotsPageFragment$key,
+} from "./__generated__/SnapshotsPageFragment.graphql";
+import type { NodeOf } from "/types";
+import SnapshotFormDialog from "./dialog/SnapshotFormDialog";
+import { usePageTitle } from "@probo/hooks";
+import { useOrganizationId } from "/hooks/useOrganizationId";
+
+type Props = {
+  queryRef: PreloadedQuery<SnapshotGraphListQuery>;
+};
+
+const snapshotsFragment = graphql`
+  fragment SnapshotsPageFragment on Organization {
+    snapshots(first: 100) @connection(key: "SnapshotsGraphListQuery__snapshots") {
+      __id
+      edges {
+        node {
+          id
+          name
+          description
+          type
+          createdAt
+        }
+      }
+    }
+  }
+`;
+
+export default function SnapshotsPage(props: Props) {
+  const { __ } = useTranslate();
+  const organizationId = useOrganizationId();
+  const organization = usePreloadedQuery(
+    snapshotsQuery,
+    props.queryRef
+  ).organization;
+  const data = useFragment<SnapshotsPageFragment$key>(
+    snapshotsFragment,
+    organization
+  );
+  const connectionId = data.snapshots.__id;
+  const snapshots = data.snapshots.edges.map((edge) => edge.node);
+  usePageTitle(__("Snapshots"));
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title={__("Snapshots")}
+        description={__(
+          "Snapshots capture point-in-time views of your organization's compliance state. Create snapshots to track progress over time."
+        )}
+      >
+        <SnapshotFormDialog connection={connectionId}>
+          <Button variant="primary" icon={IconPlusLarge}>
+            {__("New snapshot")}
+          </Button>
+        </SnapshotFormDialog>
+      </PageHeader>
+
+      {snapshots.length > 0 ? (
+        <Table>
+          <Thead>
+            <Tr>
+              <Th>{__("Name")}</Th>
+              <Th>{__("Type")}</Th>
+              <Th>{__("Description")}</Th>
+              <Th>{__("Created")}</Th>
+              <Th></Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {snapshots.map((snapshot) => (
+              <SnapshotRow
+                key={snapshot.id}
+                snapshot={snapshot}
+                connectionId={connectionId}
+                organizationId={organizationId}
+              />
+            ))}
+          </Tbody>
+        </Table>
+      ) : (
+        <div className="text-center py-12">
+          <h3 className="text-lg font-medium text-txt-secondary mb-2">
+            {__("No snapshots yet")}
+          </h3>
+          <p className="text-txt-tertiary mb-6">
+            {__("Create your first snapshot to get started")}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+type SnapshotRowProps = {
+  snapshot: NodeOf<SnapshotsPageFragment$data["snapshots"]>;
+  connectionId: string;
+  organizationId: string;
+};
+
+function SnapshotRow(props: SnapshotRowProps) {
+  const { __, dateFormat } = useTranslate();
+  const deleteSnapshot = useDeleteSnapshot(props.snapshot, props.connectionId);
+
+  const getSnapshotUrl = (snapshot: SnapshotRowProps["snapshot"]) => {
+    const baseUrl = `/organizations/${props.organizationId}/snapshots/${snapshot.id}`;
+
+    switch (snapshot.type) {
+      case "DATA":
+        return `${baseUrl}/data`;
+      case "VENDORS":
+        return `${baseUrl}/vendors`;
+      case "RISKS":
+        return `${baseUrl}/risks`;
+      case "ASSETS":
+        return `${baseUrl}/assets`;
+      default:
+        return baseUrl;
+    }
+  };
+
+  return (
+    <Tr to={getSnapshotUrl(props.snapshot)}>
+      <Td className="font-medium">{props.snapshot.name}</Td>
+      <Td className="text-txt-secondary">
+        {getSnapshotTypeLabel(__, props.snapshot.type)}
+      </Td>
+      <Td className="text-txt-secondary">
+        {props.snapshot.description || __("No description")}
+      </Td>
+      <Td className="text-txt-tertiary">
+        {dateFormat(props.snapshot.createdAt, { year: "numeric", month: "short", day: "numeric" })}
+      </Td>
+      <Td noLink width={50} className="text-end">
+        <ActionDropdown>
+          <DropdownItem
+            onClick={deleteSnapshot}
+            variant="danger"
+            icon={IconTrashCan}
+          >
+            {__("Delete")}
+          </DropdownItem>
+        </ActionDropdown>
+      </Td>
+    </Tr>
+  );
+}

--- a/apps/console/src/pages/organizations/snapshots/__generated__/SnapshotsPageFragment.graphql.ts
+++ b/apps/console/src/pages/organizations/snapshots/__generated__/SnapshotsPageFragment.graphql.ts
@@ -1,0 +1,177 @@
+/**
+ * @generated SignedSource<<05658205222e432a115cecc9c8f34d05>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type SnapshotsType = "ASSETS" | "COMPLIANCE_REGISTRIES" | "DATA" | "NON_CONFORMITY_REGISTRIES" | "RISKS" | "VENDORS";
+import { FragmentRefs } from "relay-runtime";
+export type SnapshotsPageFragment$data = {
+  readonly snapshots: {
+    readonly __id: string;
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly createdAt: any;
+        readonly description: string | null | undefined;
+        readonly id: string;
+        readonly name: string;
+        readonly type: SnapshotsType;
+      };
+    }>;
+  };
+  readonly " $fragmentType": "SnapshotsPageFragment";
+};
+export type SnapshotsPageFragment$key = {
+  readonly " $data"?: SnapshotsPageFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"SnapshotsPageFragment">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "connection": [
+      {
+        "count": null,
+        "cursor": null,
+        "direction": "forward",
+        "path": [
+          "snapshots"
+        ]
+      }
+    ]
+  },
+  "name": "SnapshotsPageFragment",
+  "selections": [
+    {
+      "alias": "snapshots",
+      "args": null,
+      "concreteType": "SnapshotConnection",
+      "kind": "LinkedField",
+      "name": "__SnapshotsGraphListQuery__snapshots_connection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "SnapshotEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Snapshot",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "id",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "name",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "description",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "type",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "createdAt",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "__typename",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "cursor",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "kind": "LinkedField",
+          "name": "pageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "endCursor",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasNextPage",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "kind": "ClientExtension",
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "__id",
+              "storageKey": null
+            }
+          ]
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Organization",
+  "abstractKey": null
+};
+
+(node as any).hash = "700dede55fd00f2b57dbbb6ed2e2613d";
+
+export default node;

--- a/apps/console/src/pages/organizations/snapshots/dialog/SnapshotFormDialog.tsx
+++ b/apps/console/src/pages/organizations/snapshots/dialog/SnapshotFormDialog.tsx
@@ -1,0 +1,145 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  Input,
+  Label,
+  PropertyRow,
+  Textarea,
+  useDialogRef,
+} from "@probo/ui";
+import type { ReactNode } from "react";
+import { useTranslate } from "@probo/i18n";
+import { Breadcrumb } from "@probo/ui";
+import { graphql } from "relay-runtime";
+import { z } from "zod";
+import { useFormWithSchema } from "/hooks/useFormWithSchema";
+import { useMutationWithToasts } from "/hooks/useMutationWithToasts";
+import { useOrganizationId } from "/hooks/useOrganizationId";
+import { ControlledField } from "/components/form/ControlledField";
+import { SnapshotTypeOptions } from "/components/form/SnapshotTypeOptions";
+
+const snapshotCreateMutation = graphql`
+  mutation SnapshotFormDialogCreateMutation(
+    $input: CreateSnapshotInput!
+    $connections: [ID!]!
+  ) {
+    createSnapshot(input: $input) {
+      snapshotEdge @prependEdge(connections: $connections) {
+        node {
+          id
+          name
+          description
+          type
+          createdAt
+        }
+      }
+    }
+  }
+`;
+
+const snapshotSchema = z.object({
+  name: z.string().min(2, { message: "Name is required" }),
+  description: z.string().optional(),
+  type: z.enum(["RISKS", "VENDORS", "ASSETS", "DATA", "NON_CONFORMITY_REGISTRIES", "COMPLIANCE_REGISTRIES"]),
+});
+
+type Props = {
+  children?: ReactNode;
+  connection?: string;
+};
+
+export default function SnapshotFormDialog(props: Props) {
+  const { __ } = useTranslate();
+  const dialogRef = useDialogRef();
+  const organizationId = useOrganizationId();
+  const [mutate] = useMutationWithToasts(snapshotCreateMutation, {
+    successMessage: __("Snapshot created successfully."),
+    errorMessage: __("Failed to create snapshot. Please try again."),
+  });
+
+  const { handleSubmit, register, reset, control, formState: { errors } } =
+    useFormWithSchema(snapshotSchema, {
+      defaultValues: {
+        name: "",
+        description: "",
+        type: "RISKS",
+      },
+    });
+
+  const onSubmit = handleSubmit(async (data) => {
+    await mutate({
+      variables: {
+        input: {
+          organizationId,
+          name: data.name,
+          description: data.description || undefined,
+          type: data.type,
+        },
+        connections: props.connection ? [props.connection] : [],
+      },
+    });
+    reset();
+    dialogRef.current?.close();
+  });
+
+  return (
+    <Dialog
+      ref={dialogRef}
+      trigger={props.children}
+      title={
+        <Breadcrumb
+          items={[
+            __("Snapshots"),
+            __("New Snapshot"),
+          ]}
+        />
+      }
+    >
+      <form onSubmit={onSubmit}>
+        <DialogContent className="grid grid-cols-[1fr_420px]">
+          <div className="py-8 px-10 space-y-4">
+            <Input
+              id="name"
+              required
+              variant="title"
+              placeholder={__("Snapshot name")}
+              {...register("name")}
+            />
+            <Textarea
+              id="description"
+              variant="ghost"
+              autogrow
+              placeholder={__("Add description (optional)")}
+              {...register("description")}
+            />
+          </div>
+          {/* Properties form */}
+          <div className="py-5 px-6 bg-subtle">
+            <Label>{__("Properties")}</Label>
+
+            <PropertyRow
+              id="type"
+              label={__("Type")}
+              error={errors.type?.message}
+            >
+              <ControlledField
+                control={control}
+                name="type"
+                type="select"
+              >
+                <SnapshotTypeOptions />
+              </ControlledField>
+            </PropertyRow>
+          </div>
+        </DialogContent>
+        <DialogFooter>
+          <Button type="submit">
+            {__("Create snapshot")}
+          </Button>
+        </DialogFooter>
+      </form>
+    </Dialog>
+  );
+}

--- a/apps/console/src/pages/organizations/snapshots/dialog/__generated__/SnapshotFormDialogCreateMutation.graphql.ts
+++ b/apps/console/src/pages/organizations/snapshots/dialog/__generated__/SnapshotFormDialogCreateMutation.graphql.ts
@@ -1,0 +1,194 @@
+/**
+ * @generated SignedSource<<22c84eaaec91c3555b99f0e067bea54f>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type SnapshotsType = "ASSETS" | "COMPLIANCE_REGISTRIES" | "DATA" | "NON_CONFORMITY_REGISTRIES" | "RISKS" | "VENDORS";
+export type CreateSnapshotInput = {
+  description?: string | null | undefined;
+  name: string;
+  organizationId: string;
+  type: SnapshotsType;
+};
+export type SnapshotFormDialogCreateMutation$variables = {
+  connections: ReadonlyArray<string>;
+  input: CreateSnapshotInput;
+};
+export type SnapshotFormDialogCreateMutation$data = {
+  readonly createSnapshot: {
+    readonly snapshotEdge: {
+      readonly node: {
+        readonly createdAt: any;
+        readonly description: string | null | undefined;
+        readonly id: string;
+        readonly name: string;
+        readonly type: SnapshotsType;
+      };
+    };
+  };
+};
+export type SnapshotFormDialogCreateMutation = {
+  response: SnapshotFormDialogCreateMutation$data;
+  variables: SnapshotFormDialogCreateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "SnapshotEdge",
+  "kind": "LinkedField",
+  "name": "snapshotEdge",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Snapshot",
+      "kind": "LinkedField",
+      "name": "node",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "id",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "description",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "type",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "createdAt",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SnapshotFormDialogCreateMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "CreateSnapshotPayload",
+        "kind": "LinkedField",
+        "name": "createSnapshot",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "SnapshotFormDialogCreateMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "CreateSnapshotPayload",
+        "kind": "LinkedField",
+        "name": "createSnapshot",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "prependEdge",
+            "key": "",
+            "kind": "LinkedHandle",
+            "name": "snapshotEdge",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "e60d598bc7f5c4958168405725664334",
+    "id": null,
+    "metadata": {},
+    "name": "SnapshotFormDialogCreateMutation",
+    "operationKind": "mutation",
+    "text": "mutation SnapshotFormDialogCreateMutation(\n  $input: CreateSnapshotInput!\n) {\n  createSnapshot(input: $input) {\n    snapshotEdge {\n      node {\n        id\n        name\n        description\n        type\n        createdAt\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "b03087e1699a90953aad7cdedaeee1a4";
+
+export default node;

--- a/apps/console/src/routes.tsx
+++ b/apps/console/src/routes.tsx
@@ -31,6 +31,7 @@ import { auditRoutes } from "./routes/auditRoutes.ts";
 import { trustCenterRoutes } from "./routes/trustCenterRoutes.ts";
 import { nonconformityRegistryRoutes } from "./routes/nonconformityRegistryRoutes.ts";
 import { complianceRegistryRoutes } from "./routes/complianceRegistryRoutes.ts";
+import { snapshotsRoutes } from "./routes/snapshotsRoutes.ts";
 import { lazy } from "@probo/react-lazy";
 
 export type AppRoute = Omit<RouteObject, "Component" | "children"> & {
@@ -153,6 +154,7 @@ const routes = [
       ...auditRoutes,
       ...nonconformityRegistryRoutes,
       ...complianceRegistryRoutes,
+      ...snapshotsRoutes,
       ...trustCenterRoutes,
       {
         path: "*",

--- a/apps/console/src/routes/dataRoutes.ts
+++ b/apps/console/src/routes/dataRoutes.ts
@@ -9,13 +9,37 @@ export const dataRoutes = [
     path: "data",
     fallback: PageSkeleton,
     queryLoader: (params: Record<string, string>) =>
-      loadQuery(relayEnvironment, dataQuery, { organizationId: params.organizationId }),
+      loadQuery(relayEnvironment, dataQuery, {
+        organizationId: params.organizationId,
+        snapshotId: null
+      }),
+    Component: lazy(
+      () => import("/pages/organizations/data/DataPage")
+    ),
+  },
+  {
+    path: "snapshots/:snapshotId/data",
+    fallback: PageSkeleton,
+    queryLoader: (params: Record<string, string>) =>
+      loadQuery(relayEnvironment, dataQuery, {
+        organizationId: params.organizationId,
+        snapshotId: params.snapshotId
+      }),
     Component: lazy(
       () => import("/pages/organizations/data/DataPage")
     ),
   },
   {
     path: "data/:dataId",
+    fallback: PageSkeleton,
+    queryLoader: (params: Record<string, string>) =>
+      loadQuery(relayEnvironment, datumNodeQuery, { dataId: params.dataId }),
+    Component: lazy(
+      () => import("../pages/organizations/data/DatumDetailsPage")
+    ),
+  },
+  {
+    path: "snapshots/:snapshotId/data/:dataId",
     fallback: PageSkeleton,
     queryLoader: (params: Record<string, string>) =>
       loadQuery(relayEnvironment, datumNodeQuery, { dataId: params.dataId }),

--- a/apps/console/src/routes/snapshotsRoutes.ts
+++ b/apps/console/src/routes/snapshotsRoutes.ts
@@ -1,0 +1,18 @@
+import { loadQuery } from "react-relay";
+import { PageSkeleton } from "/components/skeletons/PageSkeleton";
+import { relayEnvironment } from "/providers/RelayProviders";
+import { snapshotsQuery } from "/hooks/graph/SnapshotGraph";
+import type { AppRoute } from "/routes";
+import { lazy } from "@probo/react-lazy";
+
+export const snapshotsRoutes = [
+  {
+    path: "snapshots",
+    fallback: PageSkeleton,
+    queryLoader: ({ organizationId }) =>
+      loadQuery(relayEnvironment, snapshotsQuery, { organizationId }),
+    Component: lazy(
+      () => import("/pages/organizations/snapshots/SnapshotsPage")
+    ),
+  },
+] satisfies AppRoute[];

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -15,6 +15,7 @@ export { certificationCategoryLabel, certifications } from "./certifications";
 export { availableFrameworks } from "./frameworks";
 export { getDocumentTypeLabel, documentTypes } from "./documents";
 export { getAssetTypeVariant, getCriticityVariant } from "./assets";
+export { getSnapshotTypeLabel, snapshotTypes } from "./snapshots";
 export { getAuditStateLabel, getAuditStateVariant, auditStates } from "./audits";
 export { getStatusVariant, getStatusLabel, getNonconformityRegistryStatusOptions, getComplianceRegistryStatusOptions, registryStatuses } from "./registryStatus";
 export { promisifyMutation } from "./relay";

--- a/packages/helpers/src/snapshots.ts
+++ b/packages/helpers/src/snapshots.ts
@@ -1,0 +1,33 @@
+type Translator = (s: string) => string;
+
+export const snapshotTypes = [
+  "RISKS",
+  "VENDORS",
+  "ASSETS",
+  "DATA",
+  "NON_CONFORMITY_REGISTRIES",
+  "COMPLIANCE_REGISTRIES"
+] as const;
+
+export function getSnapshotTypeLabel(__: Translator, type: string | null | undefined) {
+  if (!type) {
+    return __("Unknown");
+  }
+
+  switch (type) {
+    case "RISKS":
+      return __("Risks");
+    case "VENDORS":
+      return __("Vendors");
+    case "ASSETS":
+      return __("Assets");
+    case "DATA":
+      return __("Data");
+    case "NON_CONFORMITY_REGISTRIES":
+      return __("Non Conformity Registries");
+    case "COMPLIANCE_REGISTRIES":
+      return __("Compliance Registries");
+    default:
+      return __("Unknown");
+  }
+}

--- a/pkg/coredata/datum_filter.go
+++ b/pkg/coredata/datum_filter.go
@@ -14,37 +14,47 @@
 
 package coredata
 
-const (
-	OrganizationEntityType uint16 = iota
-	FrameworkEntityType
-	MeasureEntityType
-	TaskEntityType
-	EvidenceEntityType
-	ConnectorEntityType
-	VendorRiskAssessmentEntityType
-	VendorEntityType
-	PeopleEntityType
-	VendorComplianceReportEntityType
-	DocumentEntityType
-	UserEntityType
-	SessionEntityType
-	EmailEntityType
-	ControlEntityType
-	RiskEntityType
-	DocumentVersionEntityType
-	DocumentVersionSignatureEntityType
-	AssetEntityType
-	DatumEntityType
-	AuditEntityType
-	ReportEntityType
-	TrustCenterEntityType
-	TrustCenterAccessEntityType
-	VendorBusinessAssociateAgreementEntityType
-	FileEntityType
-	VendorContactEntityType
-	VendorDataPrivacyAgreementEntityType
-	NonconformityRegistryEntityType
-	ComplianceRegistryEntityType
-	VendorServiceEntityType
-	SnapshotEntityType
+import (
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/jackc/pgx/v5"
 )
+
+type (
+	DatumFilter struct {
+		snapshotID **gid.GID
+	}
+)
+
+func NewDatumFilter() *DatumFilter {
+	return &DatumFilter{
+		snapshotID: nil,
+	}
+}
+
+func NewDatumFilterBySnapshotID(snapshotID **gid.GID) *DatumFilter {
+	return &DatumFilter{
+		snapshotID: snapshotID,
+	}
+}
+
+func (f *DatumFilter) SQLArguments() pgx.NamedArgs {
+	args := pgx.NamedArgs{}
+
+	if f.snapshotID != nil && *f.snapshotID != nil {
+		args["filter_snapshot_id"] = **f.snapshotID
+	}
+
+	return args
+}
+
+func (f *DatumFilter) SQLFragment() string {
+	if f.snapshotID == nil {
+		return "TRUE"
+	}
+
+	if *f.snapshotID == nil {
+		return "snapshot_id IS NULL"
+	} else {
+		return "snapshot_id = @filter_snapshot_id"
+	}
+}

--- a/pkg/coredata/migrations/20250819T102905Z.sql
+++ b/pkg/coredata/migrations/20250819T102905Z.sql
@@ -1,0 +1,24 @@
+CREATE TYPE snapshots_type AS ENUM (
+    'RISKS',
+    'VENDORS',
+    'ASSETS',
+    'DATA',
+    'NON_CONFORMITY_REGISTRIES',
+    'COMPLIANCE_REGISTRIES'
+);
+
+CREATE TABLE snapshots (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    organization_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    type snapshots_type NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+
+    CONSTRAINT snapshots_organization_id_fkey
+        FOREIGN KEY (organization_id)
+        REFERENCES organizations(id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+);

--- a/pkg/coredata/migrations/20250822T123225Z.sql
+++ b/pkg/coredata/migrations/20250822T123225Z.sql
@@ -1,0 +1,31 @@
+ALTER TABLE data ADD COLUMN snapshot_id TEXT;
+ALTER TABLE data ADD COLUMN source_id TEXT;
+
+ALTER TABLE data ADD CONSTRAINT data_snapshot_id_fkey
+    FOREIGN KEY (snapshot_id)
+    REFERENCES snapshots(id)
+    ON UPDATE CASCADE
+    ON DELETE CASCADE;
+
+ALTER TABLE data ADD CONSTRAINT data_source_id_snapshot_id_key
+    UNIQUE (source_id, snapshot_id);
+
+ALTER TABLE vendors ADD COLUMN snapshot_id TEXT;
+ALTER TABLE vendors ADD COLUMN source_id TEXT;
+
+ALTER TABLE vendors ADD CONSTRAINT vendors_snapshot_id_fkey
+    FOREIGN KEY (snapshot_id)
+    REFERENCES snapshots(id)
+    ON UPDATE CASCADE
+    ON DELETE CASCADE;
+
+ALTER TABLE vendors ADD CONSTRAINT vendors_source_id_snapshot_id_key
+    UNIQUE (source_id, snapshot_id);
+
+ALTER TABLE data_vendors ADD COLUMN snapshot_id TEXT;
+
+ALTER TABLE data_vendors ADD CONSTRAINT data_vendors_snapshot_id_fkey
+    FOREIGN KEY (snapshot_id)
+    REFERENCES snapshots(id)
+    ON UPDATE CASCADE
+    ON DELETE CASCADE;

--- a/pkg/coredata/snapshot.go
+++ b/pkg/coredata/snapshot.go
@@ -1,0 +1,239 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"time"
+
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+	"github.com/jackc/pgx/v5"
+	"go.gearno.de/kit/pg"
+)
+
+type (
+	Snapshot struct {
+		ID             gid.GID       `db:"id"`
+		OrganizationID gid.GID       `db:"organization_id"`
+		Name           string        `db:"name"`
+		Description    *string       `db:"description"`
+		Type           SnapshotsType `db:"type"`
+		CreatedAt      time.Time     `db:"created_at"`
+	}
+
+	Snapshots []*Snapshot
+)
+
+func (s *Snapshot) CursorKey(field SnapshotOrderField) page.CursorKey {
+	switch field {
+	case SnapshotOrderFieldCreatedAt:
+		return page.NewCursorKey(s.ID, s.CreatedAt)
+	case SnapshotOrderFieldName:
+		return page.NewCursorKey(s.ID, s.Name)
+	case SnapshotOrderFieldType:
+		return page.NewCursorKey(s.ID, s.Type)
+	}
+
+	panic(fmt.Sprintf("unsupported order by: %s", field))
+}
+
+func (s *Snapshot) LoadByID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	snapshotID gid.GID,
+) error {
+	q := `
+SELECT
+	id,
+	organization_id,
+	name,
+	description,
+	type,
+	created_at
+FROM
+	snapshots
+WHERE
+	%s
+	AND id = @snapshot_id
+LIMIT 1;
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"snapshot_id": snapshotID}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query snapshots: %w", err)
+	}
+
+	snapshot, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[Snapshot])
+	if err != nil {
+		return fmt.Errorf("cannot collect snapshot: %w", err)
+	}
+
+	*s = snapshot
+
+	return nil
+}
+
+func (s *Snapshots) CountByOrganizationID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	organizationID gid.GID,
+) (int, error) {
+	q := `
+SELECT
+	COUNT(id)
+FROM
+	snapshots
+WHERE
+	%s
+	AND organization_id = @organization_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	row := conn.QueryRow(ctx, q, args)
+
+	var count int
+	if err := row.Scan(&count); err != nil {
+		return 0, fmt.Errorf("cannot scan count: %w", err)
+	}
+
+	return count, nil
+}
+
+func (s *Snapshots) LoadByOrganizationID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	organizationID gid.GID,
+	cursor *page.Cursor[SnapshotOrderField],
+) error {
+	q := `
+SELECT
+	id,
+	organization_id,
+	name,
+	description,
+	type,
+	created_at
+FROM
+	snapshots
+WHERE
+	%s
+	AND organization_id = @organization_id
+	AND %s
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, cursor.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query snapshots: %w", err)
+	}
+
+	snapshots, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[Snapshot])
+	if err != nil {
+		return fmt.Errorf("cannot collect snapshots: %w", err)
+	}
+
+	*s = snapshots
+
+	return nil
+}
+
+func (s *Snapshot) Insert(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+INSERT INTO snapshots (
+	id,
+	tenant_id,
+	organization_id,
+	name,
+	description,
+	type,
+	created_at
+) VALUES (
+	@id,
+	@tenant_id,
+	@organization_id,
+	@name,
+	@description,
+	@type,
+	@created_at
+)
+`
+
+	args := pgx.StrictNamedArgs{
+		"id":              s.ID,
+		"tenant_id":       scope.GetTenantID(),
+		"organization_id": s.OrganizationID,
+		"name":            s.Name,
+		"description":     s.Description,
+		"type":            s.Type,
+		"created_at":      s.CreatedAt,
+	}
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot insert snapshot: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Snapshot) Delete(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+DELETE FROM snapshots
+WHERE
+	%s
+	AND organization_id = @organization_id
+	AND id = @id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"id": s.ID, "organization_id": s.OrganizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete snapshot: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/snapshot_order_field.go
+++ b/pkg/coredata/snapshot_order_field.go
@@ -14,37 +14,38 @@
 
 package coredata
 
-const (
-	OrganizationEntityType uint16 = iota
-	FrameworkEntityType
-	MeasureEntityType
-	TaskEntityType
-	EvidenceEntityType
-	ConnectorEntityType
-	VendorRiskAssessmentEntityType
-	VendorEntityType
-	PeopleEntityType
-	VendorComplianceReportEntityType
-	DocumentEntityType
-	UserEntityType
-	SessionEntityType
-	EmailEntityType
-	ControlEntityType
-	RiskEntityType
-	DocumentVersionEntityType
-	DocumentVersionSignatureEntityType
-	AssetEntityType
-	DatumEntityType
-	AuditEntityType
-	ReportEntityType
-	TrustCenterEntityType
-	TrustCenterAccessEntityType
-	VendorBusinessAssociateAgreementEntityType
-	FileEntityType
-	VendorContactEntityType
-	VendorDataPrivacyAgreementEntityType
-	NonconformityRegistryEntityType
-	ComplianceRegistryEntityType
-	VendorServiceEntityType
-	SnapshotEntityType
+import (
+	"fmt"
 )
+
+type SnapshotOrderField string
+
+const (
+	SnapshotOrderFieldCreatedAt SnapshotOrderField = "CREATED_AT"
+	SnapshotOrderFieldName      SnapshotOrderField = "NAME"
+	SnapshotOrderFieldType      SnapshotOrderField = "TYPE"
+)
+
+func (p SnapshotOrderField) Column() string {
+	return string(p)
+}
+
+func (p SnapshotOrderField) String() string {
+	return string(p)
+}
+
+func (p SnapshotOrderField) MarshalText() ([]byte, error) {
+	return []byte(p.String()), nil
+}
+
+func (p *SnapshotOrderField) UnmarshalText(text []byte) error {
+	val := string(text)
+	switch val {
+	case string(SnapshotOrderFieldCreatedAt),
+		string(SnapshotOrderFieldName),
+		string(SnapshotOrderFieldType):
+		*p = SnapshotOrderField(val)
+		return nil
+	}
+	return fmt.Errorf("invalid SnapshotOrderField value: %q", val)
+}

--- a/pkg/coredata/snapshots_type.go
+++ b/pkg/coredata/snapshots_type.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+type (
+	SnapshotsType string
+)
+
+const (
+	SnapshotsTypeRisks                   SnapshotsType = "RISKS"
+	SnapshotsTypeVendors                 SnapshotsType = "VENDORS"
+	SnapshotsTypeAssets                  SnapshotsType = "ASSETS"
+	SnapshotsTypeData                    SnapshotsType = "DATA"
+	SnapshotsTypeNonConformityRegistries SnapshotsType = "NON_CONFORMITY_REGISTRIES"
+	SnapshotsTypeComplianceRegistries    SnapshotsType = "COMPLIANCE_REGISTRIES"
+)
+
+func (st SnapshotsType) String() string {
+	return string(st)
+}
+
+func (st *SnapshotsType) Scan(value any) error {
+	var s string
+	switch v := value.(type) {
+	case string:
+		s = v
+	case []byte:
+		s = string(v)
+	default:
+		return fmt.Errorf("unsupported type for SnapshotsType: %T", value)
+	}
+
+	switch s {
+	case SnapshotsTypeRisks.String():
+		*st = SnapshotsTypeRisks
+	case SnapshotsTypeVendors.String():
+		*st = SnapshotsTypeVendors
+	case SnapshotsTypeAssets.String():
+		*st = SnapshotsTypeAssets
+	case SnapshotsTypeData.String():
+		*st = SnapshotsTypeData
+	case SnapshotsTypeNonConformityRegistries.String():
+		*st = SnapshotsTypeNonConformityRegistries
+	case SnapshotsTypeComplianceRegistries.String():
+		*st = SnapshotsTypeComplianceRegistries
+	default:
+		return fmt.Errorf("invalid SnapshotsType value: %q", s)
+	}
+	return nil
+}
+
+func (st SnapshotsType) Value() (driver.Value, error) {
+	return st.String(), nil
+}

--- a/pkg/coredata/snapshottable.go
+++ b/pkg/coredata/snapshottable.go
@@ -14,37 +14,23 @@
 
 package coredata
 
-const (
-	OrganizationEntityType uint16 = iota
-	FrameworkEntityType
-	MeasureEntityType
-	TaskEntityType
-	EvidenceEntityType
-	ConnectorEntityType
-	VendorRiskAssessmentEntityType
-	VendorEntityType
-	PeopleEntityType
-	VendorComplianceReportEntityType
-	DocumentEntityType
-	UserEntityType
-	SessionEntityType
-	EmailEntityType
-	ControlEntityType
-	RiskEntityType
-	DocumentVersionEntityType
-	DocumentVersionSignatureEntityType
-	AssetEntityType
-	DatumEntityType
-	AuditEntityType
-	ReportEntityType
-	TrustCenterEntityType
-	TrustCenterAccessEntityType
-	VendorBusinessAssociateAgreementEntityType
-	FileEntityType
-	VendorContactEntityType
-	VendorDataPrivacyAgreementEntityType
-	NonconformityRegistryEntityType
-	ComplianceRegistryEntityType
-	VendorServiceEntityType
-	SnapshotEntityType
+import (
+	"context"
+	"fmt"
+
+	"github.com/getprobo/probo/pkg/gid"
+	"go.gearno.de/kit/pg"
 )
+
+type Snapshottable interface {
+	Snapshot(ctx context.Context, conn pg.Conn, scope Scoper, organizationID, snapshotID gid.GID) error
+}
+
+func GetSnapshottable(snapshotType SnapshotsType) (Snapshottable, error) {
+	switch snapshotType {
+	case SnapshotsTypeData:
+		return Data{}, nil
+	default:
+		return nil, fmt.Errorf("unsupported snapshot type: %s", snapshotType)
+	}
+}

--- a/pkg/probo/datum_service.go
+++ b/pkg/probo/datum_service.go
@@ -115,6 +115,7 @@ func (s DatumService) ListForOrganizationID(
 	ctx context.Context,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.DatumOrderField],
+	filter *coredata.DatumFilter,
 ) (*page.Page[*coredata.Datum, coredata.DatumOrderField], error) {
 	var data coredata.Data
 
@@ -127,6 +128,7 @@ func (s DatumService) ListForOrganizationID(
 				s.svc.scope,
 				organizationID,
 				cursor,
+				filter,
 			)
 		},
 	)

--- a/pkg/probo/service.go
+++ b/pkg/probo/service.go
@@ -84,6 +84,7 @@ type (
 		TrustCenterAccesses               *TrustCenterAccessService
 		NonconformityRegistries           *NonconformityRegistryService
 		ComplianceRegistries              *ComplianceRegistryService
+		Snapshots                         *SnapshotService
 	}
 )
 
@@ -179,5 +180,6 @@ func (s *Service) WithTenant(tenantID gid.TenantID) *TenantService {
 	}
 	tenantService.NonconformityRegistries = &NonconformityRegistryService{svc: tenantService}
 	tenantService.ComplianceRegistries = &ComplianceRegistryService{svc: tenantService}
+	tenantService.Snapshots = &SnapshotService{svc: tenantService}
 	return tenantService
 }

--- a/pkg/probo/snapshot_service.go
+++ b/pkg/probo/snapshot_service.go
@@ -1,0 +1,186 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package probo
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+	"go.gearno.de/kit/pg"
+)
+
+type SnapshotService struct {
+	svc *TenantService
+}
+
+type (
+	CreateSnapshotRequest struct {
+		OrganizationID gid.GID
+		Name           string
+		Description    *string
+		Type           coredata.SnapshotsType
+	}
+
+	UpdateSnapshotRequest struct {
+		ID          gid.GID
+		Name        *string
+		Description **string
+		Type        *coredata.SnapshotsType
+	}
+)
+
+func (s *SnapshotService) Get(
+	ctx context.Context,
+	snapshotID gid.GID,
+) (*coredata.Snapshot, error) {
+	snapshot := &coredata.Snapshot{}
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			return snapshot.LoadByID(ctx, conn, s.svc.scope, snapshotID)
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return snapshot, nil
+}
+
+func (s *SnapshotService) Create(
+	ctx context.Context,
+	req *CreateSnapshotRequest,
+) (*coredata.Snapshot, error) {
+	now := time.Now()
+
+	snapshot := &coredata.Snapshot{
+		ID:             gid.New(s.svc.scope.GetTenantID(), coredata.SnapshotEntityType),
+		OrganizationID: req.OrganizationID,
+		Name:           req.Name,
+		Description:    req.Description,
+		Type:           req.Type,
+		CreatedAt:      now,
+	}
+
+	err := s.svc.pg.WithTx(
+		ctx,
+		func(conn pg.Conn) error {
+			organization := &coredata.Organization{}
+			if err := organization.LoadByID(ctx, conn, s.svc.scope, req.OrganizationID); err != nil {
+				return fmt.Errorf("cannot load organization: %w", err)
+			}
+
+			if err := snapshot.Insert(ctx, conn, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot insert snapshot: %w", err)
+			}
+
+			snapshottable, err := coredata.GetSnapshottable(req.Type)
+			if err != nil {
+				return err
+			}
+
+			if err := snapshottable.Snapshot(ctx, conn, s.svc.scope, req.OrganizationID, snapshot.ID); err != nil {
+				return fmt.Errorf("cannot create snapshot: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return snapshot, nil
+}
+
+func (s *SnapshotService) Delete(
+	ctx context.Context,
+	snapshotID gid.GID,
+) error {
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			snapshot := &coredata.Snapshot{}
+			if err := snapshot.LoadByID(ctx, conn, s.svc.scope, snapshotID); err != nil {
+				return fmt.Errorf("cannot load snapshot: %w", err)
+			}
+
+			if err := snapshot.Delete(ctx, conn, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot delete snapshot: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	return err
+}
+
+func (s *SnapshotService) ListForOrganizationID(
+	ctx context.Context,
+	organizationID gid.GID,
+	cursor *page.Cursor[coredata.SnapshotOrderField],
+) (*page.Page[*coredata.Snapshot, coredata.SnapshotOrderField], error) {
+	snapshots := coredata.Snapshots{}
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			if err := snapshots.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID, cursor); err != nil {
+				return fmt.Errorf("cannot load snapshots: %w", err)
+			}
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return page.NewPage(snapshots, cursor), nil
+}
+
+func (s *SnapshotService) CountForOrganizationID(
+	ctx context.Context,
+	organizationID gid.GID,
+) (int, error) {
+	var count int
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) (err error) {
+			snapshots := coredata.Snapshots{}
+			count, err = snapshots.CountByOrganizationID(ctx, conn, s.svc.scope, organizationID)
+			if err != nil {
+				return fmt.Errorf("cannot count snapshots: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}

--- a/pkg/probo/vendor_service.go
+++ b/pkg/probo/vendor_service.go
@@ -120,6 +120,7 @@ func (s VendorService) ListForOrganizationID(
 	ctx context.Context,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.VendorOrderField],
+	filter *coredata.VendorFilter,
 ) (*page.Page[*coredata.Vendor, coredata.VendorOrderField], error) {
 	var vendors coredata.Vendors
 	organization := &coredata.Organization{}
@@ -131,7 +132,6 @@ func (s VendorService) ListForOrganizationID(
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
-			filter := coredata.NewVendorFilter()
 			return vendors.LoadByOrganizationID(
 				ctx,
 				conn,

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -686,6 +686,50 @@ enum TrustCenterAccessOrderField
     )
 }
 
+enum SnapshotsType
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.SnapshotsType") {
+  RISKS
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.SnapshotsTypeRisks"
+    )
+  VENDORS
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.SnapshotsTypeVendors"
+    )
+  ASSETS
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.SnapshotsTypeAssets"
+    )
+  DATA
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.SnapshotsTypeData"
+    )
+  NON_CONFORMITY_REGISTRIES
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.SnapshotsTypeNonConformityRegistries"
+    )
+  COMPLIANCE_REGISTRIES
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.SnapshotsTypeComplianceRegistries"
+    )
+}
+
+enum SnapshotOrderField
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.SnapshotOrderField") {
+  CREATED_AT
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.SnapshotOrderFieldCreatedAt"
+    )
+  NAME
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.SnapshotOrderFieldName"
+    )
+  TYPE
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.SnapshotOrderFieldType"
+    )
+}
+
 # Input Types
 input UserOrder
   @goModel(
@@ -841,6 +885,14 @@ input DocumentVersionOrder
   field: DocumentVersionOrderField!
 }
 
+input SnapshotOrder
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.SnapshotOrderBy"
+  ) {
+  direction: OrderDirection!
+  field: SnapshotOrderField!
+}
+
 input DocumentVersionFilter {
   status: DocumentStatus
 }
@@ -872,6 +924,10 @@ input OrganizationFilter {
 
 input TrustCenterFilter {
   slug: String
+}
+
+input DatumFilter {
+  snapshotId: ID
 }
 
 # Core Types
@@ -996,6 +1052,7 @@ type Organization implements Node {
     last: Int
     before: CursorKey
     orderBy: DatumOrder
+    filter: DatumFilter
   ): DatumConnection! @goField(forceResolver: true)
 
   audits(
@@ -1021,6 +1078,14 @@ type Organization implements Node {
     before: CursorKey
     orderBy: ComplianceRegistryOrder
   ): ComplianceRegistryConnection! @goField(forceResolver: true)
+
+  snapshots(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+    orderBy: SnapshotOrder
+  ): SnapshotConnection! @goField(forceResolver: true)
 
   trustCenter: TrustCenter @goField(forceResolver: true)
 
@@ -1466,6 +1531,15 @@ type ComplianceRegistry implements Node {
   updatedAt: Datetime!
 }
 
+type Snapshot implements Node {
+  id: ID!
+  organization: Organization! @goField(forceResolver: true)
+  name: String!
+  description: String
+  type: SnapshotsType!
+  createdAt: Datetime!
+}
+
 type Report implements Node {
   id: ID!
   objectKey: String!
@@ -1788,6 +1862,20 @@ type ComplianceRegistryEdge {
   node: ComplianceRegistry!
 }
 
+type SnapshotConnection
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.SnapshotConnection"
+  ) {
+  totalCount: Int! @goField(forceResolver: true)
+  edges: [SnapshotEdge!]!
+  pageInfo: PageInfo!
+}
+
+type SnapshotEdge {
+  cursor: CursorKey!
+  node: Snapshot!
+}
+
 # Root Types
 type Query {
   node(id: ID!): Node!
@@ -2038,6 +2126,10 @@ type Mutation {
   deleteComplianceRegistry(
     input: DeleteComplianceRegistryInput!
   ): DeleteComplianceRegistryPayload!
+
+  # Snapshot mutations
+  createSnapshot(input: CreateSnapshotInput!): CreateSnapshotPayload!
+  deleteSnapshot(input: DeleteSnapshotInput!): DeleteSnapshotPayload!
 }
 
 # Input Types
@@ -2591,6 +2683,17 @@ input UpdateComplianceRegistryInput {
 
 input DeleteComplianceRegistryInput {
   complianceRegistryId: ID!
+}
+
+input CreateSnapshotInput {
+  organizationId: ID!
+  name: String!
+  description: String
+  type: SnapshotsType!
+}
+
+input DeleteSnapshotInput {
+  snapshotId: ID!
 }
 
 # Payload Types
@@ -3301,4 +3404,12 @@ type UpdateComplianceRegistryPayload {
 
 type DeleteComplianceRegistryPayload {
   deletedComplianceRegistryId: ID!
+}
+
+type CreateSnapshotPayload {
+  snapshotEdge: SnapshotEdge!
+}
+
+type DeleteSnapshotPayload {
+  deletedSnapshotId: ID!
 }

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -73,6 +73,8 @@ type ResolverRoot interface {
 	Report() ReportResolver
 	Risk() RiskResolver
 	RiskConnection() RiskConnectionResolver
+	Snapshot() SnapshotResolver
+	SnapshotConnection() SnapshotConnectionResolver
 	Task() TaskResolver
 	TaskConnection() TaskConnectionResolver
 	TrustCenter() TrustCenterResolver
@@ -324,6 +326,10 @@ type ComplexityRoot struct {
 		RiskEdge func(childComplexity int) int
 	}
 
+	CreateSnapshotPayload struct {
+		SnapshotEdge func(childComplexity int) int
+	}
+
 	CreateTaskPayload struct {
 		TaskEdge func(childComplexity int) int
 	}
@@ -453,6 +459,10 @@ type ComplexityRoot struct {
 
 	DeleteRiskPayload struct {
 		DeletedRiskID func(childComplexity int) int
+	}
+
+	DeleteSnapshotPayload struct {
+		DeletedSnapshotID func(childComplexity int) int
 	}
 
 	DeleteTaskPayload struct {
@@ -687,6 +697,7 @@ type ComplexityRoot struct {
 		CreateRisk                             func(childComplexity int, input types.CreateRiskInput) int
 		CreateRiskDocumentMapping              func(childComplexity int, input types.CreateRiskDocumentMappingInput) int
 		CreateRiskMeasureMapping               func(childComplexity int, input types.CreateRiskMeasureMappingInput) int
+		CreateSnapshot                         func(childComplexity int, input types.CreateSnapshotInput) int
 		CreateTask                             func(childComplexity int, input types.CreateTaskInput) int
 		CreateTrustCenterAccess                func(childComplexity int, input types.CreateTrustCenterAccessInput) int
 		CreateVendor                           func(childComplexity int, input types.CreateVendorInput) int
@@ -713,6 +724,7 @@ type ComplexityRoot struct {
 		DeleteRisk                             func(childComplexity int, input types.DeleteRiskInput) int
 		DeleteRiskDocumentMapping              func(childComplexity int, input types.DeleteRiskDocumentMappingInput) int
 		DeleteRiskMeasureMapping               func(childComplexity int, input types.DeleteRiskMeasureMappingInput) int
+		DeleteSnapshot                         func(childComplexity int, input types.DeleteSnapshotInput) int
 		DeleteTask                             func(childComplexity int, input types.DeleteTaskInput) int
 		DeleteTrustCenterAccess                func(childComplexity int, input types.DeleteTrustCenterAccessInput) int
 		DeleteVendor                           func(childComplexity int, input types.DeleteVendorInput) int
@@ -798,7 +810,7 @@ type ComplexityRoot struct {
 		Connectors              func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ConnectorOrder) int
 		Controls                func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ControlOrderBy, filter *types.ControlFilter) int
 		CreatedAt               func(childComplexity int) int
-		Data                    func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DatumOrderBy) int
+		Data                    func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DatumOrderBy, filter *types.DatumFilter) int
 		Documents               func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy, filter *types.DocumentFilter) int
 		Frameworks              func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.FrameworkOrderBy) int
 		ID                      func(childComplexity int) int
@@ -808,6 +820,7 @@ type ComplexityRoot struct {
 		NonconformityRegistries func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.NonconformityRegistryOrderBy) int
 		Peoples                 func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.PeopleOrderBy, filter *types.PeopleFilter) int
 		Risks                   func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskOrderBy, filter *types.RiskFilter) int
+		Snapshots               func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.SnapshotOrderBy) int
 		Tasks                   func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TaskOrderBy) int
 		TrustCenter             func(childComplexity int) int
 		UpdatedAt               func(childComplexity int) int
@@ -930,6 +943,26 @@ type ComplexityRoot struct {
 	Session struct {
 		ExpiresAt func(childComplexity int) int
 		ID        func(childComplexity int) int
+	}
+
+	Snapshot struct {
+		CreatedAt    func(childComplexity int) int
+		Description  func(childComplexity int) int
+		ID           func(childComplexity int) int
+		Name         func(childComplexity int) int
+		Organization func(childComplexity int) int
+		Type         func(childComplexity int) int
+	}
+
+	SnapshotConnection struct {
+		Edges      func(childComplexity int) int
+		PageInfo   func(childComplexity int) int
+		TotalCount func(childComplexity int) int
+	}
+
+	SnapshotEdge struct {
+		Cursor func(childComplexity int) int
+		Node   func(childComplexity int) int
 	}
 
 	Task struct {
@@ -1484,6 +1517,8 @@ type MutationResolver interface {
 	CreateComplianceRegistry(ctx context.Context, input types.CreateComplianceRegistryInput) (*types.CreateComplianceRegistryPayload, error)
 	UpdateComplianceRegistry(ctx context.Context, input types.UpdateComplianceRegistryInput) (*types.UpdateComplianceRegistryPayload, error)
 	DeleteComplianceRegistry(ctx context.Context, input types.DeleteComplianceRegistryInput) (*types.DeleteComplianceRegistryPayload, error)
+	CreateSnapshot(ctx context.Context, input types.CreateSnapshotInput) (*types.CreateSnapshotPayload, error)
+	DeleteSnapshot(ctx context.Context, input types.DeleteSnapshotInput) (*types.DeleteSnapshotPayload, error)
 }
 type NonconformityRegistryResolver interface {
 	Organization(ctx context.Context, obj *types.NonconformityRegistry) (*types.Organization, error)
@@ -1508,10 +1543,11 @@ type OrganizationResolver interface {
 	Risks(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskOrderBy, filter *types.RiskFilter) (*types.RiskConnection, error)
 	Tasks(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TaskOrderBy) (*types.TaskConnection, error)
 	Assets(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AssetOrderBy) (*types.AssetConnection, error)
-	Data(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DatumOrderBy) (*types.DatumConnection, error)
+	Data(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DatumOrderBy, filter *types.DatumFilter) (*types.DatumConnection, error)
 	Audits(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AuditOrderBy) (*types.AuditConnection, error)
 	NonconformityRegistries(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.NonconformityRegistryOrderBy) (*types.NonconformityRegistryConnection, error)
 	ComplianceRegistries(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ComplianceRegistryOrderBy) (*types.ComplianceRegistryConnection, error)
+	Snapshots(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.SnapshotOrderBy) (*types.SnapshotConnection, error)
 	TrustCenter(ctx context.Context, obj *types.Organization) (*types.TrustCenter, error)
 }
 type PeopleConnectionResolver interface {
@@ -1534,6 +1570,12 @@ type RiskResolver interface {
 }
 type RiskConnectionResolver interface {
 	TotalCount(ctx context.Context, obj *types.RiskConnection) (int, error)
+}
+type SnapshotResolver interface {
+	Organization(ctx context.Context, obj *types.Snapshot) (*types.Organization, error)
+}
+type SnapshotConnectionResolver interface {
+	TotalCount(ctx context.Context, obj *types.SnapshotConnection) (int, error)
 }
 type TaskResolver interface {
 	AssignedTo(ctx context.Context, obj *types.Task) (*types.People, error)
@@ -2423,6 +2465,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.CreateRiskPayload.RiskEdge(childComplexity), true
 
+	case "CreateSnapshotPayload.snapshotEdge":
+		if e.complexity.CreateSnapshotPayload.SnapshotEdge == nil {
+			break
+		}
+
+		return e.complexity.CreateSnapshotPayload.SnapshotEdge(childComplexity), true
+
 	case "CreateTaskPayload.taskEdge":
 		if e.complexity.CreateTaskPayload.TaskEdge == nil {
 			break
@@ -2735,6 +2784,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.DeleteRiskPayload.DeletedRiskID(childComplexity), true
+
+	case "DeleteSnapshotPayload.deletedSnapshotId":
+		if e.complexity.DeleteSnapshotPayload.DeletedSnapshotID == nil {
+			break
+		}
+
+		return e.complexity.DeleteSnapshotPayload.DeletedSnapshotID(childComplexity), true
 
 	case "DeleteTaskPayload.deletedTaskId":
 		if e.complexity.DeleteTaskPayload.DeletedTaskID == nil {
@@ -3820,6 +3876,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.CreateRiskMeasureMapping(childComplexity, args["input"].(types.CreateRiskMeasureMappingInput)), true
 
+	case "Mutation.createSnapshot":
+		if e.complexity.Mutation.CreateSnapshot == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_createSnapshot_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreateSnapshot(childComplexity, args["input"].(types.CreateSnapshotInput)), true
+
 	case "Mutation.createTask":
 		if e.complexity.Mutation.CreateTask == nil {
 			break
@@ -4131,6 +4199,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.DeleteRiskMeasureMapping(childComplexity, args["input"].(types.DeleteRiskMeasureMappingInput)), true
+
+	case "Mutation.deleteSnapshot":
+		if e.complexity.Mutation.DeleteSnapshot == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_deleteSnapshot_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteSnapshot(childComplexity, args["input"].(types.DeleteSnapshotInput)), true
 
 	case "Mutation.deleteTask":
 		if e.complexity.Mutation.DeleteTask == nil {
@@ -4918,7 +4998,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Organization.Data(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.DatumOrderBy)), true
+		return e.complexity.Organization.Data(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.DatumOrderBy), args["filter"].(*types.DatumFilter)), true
 
 	case "Organization.documents":
 		if e.complexity.Organization.Documents == nil {
@@ -5012,6 +5092,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Organization.Risks(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.RiskOrderBy), args["filter"].(*types.RiskFilter)), true
+
+	case "Organization.snapshots":
+		if e.complexity.Organization.Snapshots == nil {
+			break
+		}
+
+		args, err := ec.field_Organization_snapshots_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.Snapshots(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.SnapshotOrderBy)), true
 
 	case "Organization.tasks":
 		if e.complexity.Organization.Tasks == nil {
@@ -5549,6 +5641,83 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Session.ID(childComplexity), true
+
+	case "Snapshot.createdAt":
+		if e.complexity.Snapshot.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.Snapshot.CreatedAt(childComplexity), true
+
+	case "Snapshot.description":
+		if e.complexity.Snapshot.Description == nil {
+			break
+		}
+
+		return e.complexity.Snapshot.Description(childComplexity), true
+
+	case "Snapshot.id":
+		if e.complexity.Snapshot.ID == nil {
+			break
+		}
+
+		return e.complexity.Snapshot.ID(childComplexity), true
+
+	case "Snapshot.name":
+		if e.complexity.Snapshot.Name == nil {
+			break
+		}
+
+		return e.complexity.Snapshot.Name(childComplexity), true
+
+	case "Snapshot.organization":
+		if e.complexity.Snapshot.Organization == nil {
+			break
+		}
+
+		return e.complexity.Snapshot.Organization(childComplexity), true
+
+	case "Snapshot.type":
+		if e.complexity.Snapshot.Type == nil {
+			break
+		}
+
+		return e.complexity.Snapshot.Type(childComplexity), true
+
+	case "SnapshotConnection.edges":
+		if e.complexity.SnapshotConnection.Edges == nil {
+			break
+		}
+
+		return e.complexity.SnapshotConnection.Edges(childComplexity), true
+
+	case "SnapshotConnection.pageInfo":
+		if e.complexity.SnapshotConnection.PageInfo == nil {
+			break
+		}
+
+		return e.complexity.SnapshotConnection.PageInfo(childComplexity), true
+
+	case "SnapshotConnection.totalCount":
+		if e.complexity.SnapshotConnection.TotalCount == nil {
+			break
+		}
+
+		return e.complexity.SnapshotConnection.TotalCount(childComplexity), true
+
+	case "SnapshotEdge.cursor":
+		if e.complexity.SnapshotEdge.Cursor == nil {
+			break
+		}
+
+		return e.complexity.SnapshotEdge.Cursor(childComplexity), true
+
+	case "SnapshotEdge.node":
+		if e.complexity.SnapshotEdge.Node == nil {
+			break
+		}
+
+		return e.complexity.SnapshotEdge.Node(childComplexity), true
 
 	case "Task.assignedTo":
 		if e.complexity.Task.AssignedTo == nil {
@@ -6889,12 +7058,14 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputCreateRiskDocumentMappingInput,
 		ec.unmarshalInputCreateRiskInput,
 		ec.unmarshalInputCreateRiskMeasureMappingInput,
+		ec.unmarshalInputCreateSnapshotInput,
 		ec.unmarshalInputCreateTaskInput,
 		ec.unmarshalInputCreateTrustCenterAccessInput,
 		ec.unmarshalInputCreateVendorContactInput,
 		ec.unmarshalInputCreateVendorInput,
 		ec.unmarshalInputCreateVendorRiskAssessmentInput,
 		ec.unmarshalInputCreateVendorServiceInput,
+		ec.unmarshalInputDatumFilter,
 		ec.unmarshalInputDatumOrder,
 		ec.unmarshalInputDeleteAssetInput,
 		ec.unmarshalInputDeleteAuditInput,
@@ -6916,6 +7087,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputDeleteRiskDocumentMappingInput,
 		ec.unmarshalInputDeleteRiskInput,
 		ec.unmarshalInputDeleteRiskMeasureMappingInput,
+		ec.unmarshalInputDeleteSnapshotInput,
 		ec.unmarshalInputDeleteTaskInput,
 		ec.unmarshalInputDeleteTrustCenterAccessInput,
 		ec.unmarshalInputDeleteVendorBusinessAssociateAgreementInput,
@@ -6952,6 +7124,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputRiskFilter,
 		ec.unmarshalInputRiskOrder,
 		ec.unmarshalInputSendSigningNotificationsInput,
+		ec.unmarshalInputSnapshotOrder,
 		ec.unmarshalInputTaskOrder,
 		ec.unmarshalInputTrustCenterAccessOrder,
 		ec.unmarshalInputTrustCenterFilter,
@@ -7774,6 +7947,50 @@ enum TrustCenterAccessOrderField
     )
 }
 
+enum SnapshotsType
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.SnapshotsType") {
+  RISKS
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.SnapshotsTypeRisks"
+    )
+  VENDORS
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.SnapshotsTypeVendors"
+    )
+  ASSETS
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.SnapshotsTypeAssets"
+    )
+  DATA
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.SnapshotsTypeData"
+    )
+  NON_CONFORMITY_REGISTRIES
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.SnapshotsTypeNonConformityRegistries"
+    )
+  COMPLIANCE_REGISTRIES
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.SnapshotsTypeComplianceRegistries"
+    )
+}
+
+enum SnapshotOrderField
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.SnapshotOrderField") {
+  CREATED_AT
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.SnapshotOrderFieldCreatedAt"
+    )
+  NAME
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.SnapshotOrderFieldName"
+    )
+  TYPE
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.SnapshotOrderFieldType"
+    )
+}
+
 # Input Types
 input UserOrder
   @goModel(
@@ -7929,6 +8146,14 @@ input DocumentVersionOrder
   field: DocumentVersionOrderField!
 }
 
+input SnapshotOrder
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.SnapshotOrderBy"
+  ) {
+  direction: OrderDirection!
+  field: SnapshotOrderField!
+}
+
 input DocumentVersionFilter {
   status: DocumentStatus
 }
@@ -7960,6 +8185,10 @@ input OrganizationFilter {
 
 input TrustCenterFilter {
   slug: String
+}
+
+input DatumFilter {
+  snapshotId: ID
 }
 
 # Core Types
@@ -8084,6 +8313,7 @@ type Organization implements Node {
     last: Int
     before: CursorKey
     orderBy: DatumOrder
+    filter: DatumFilter
   ): DatumConnection! @goField(forceResolver: true)
 
   audits(
@@ -8109,6 +8339,14 @@ type Organization implements Node {
     before: CursorKey
     orderBy: ComplianceRegistryOrder
   ): ComplianceRegistryConnection! @goField(forceResolver: true)
+
+  snapshots(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+    orderBy: SnapshotOrder
+  ): SnapshotConnection! @goField(forceResolver: true)
 
   trustCenter: TrustCenter @goField(forceResolver: true)
 
@@ -8554,6 +8792,15 @@ type ComplianceRegistry implements Node {
   updatedAt: Datetime!
 }
 
+type Snapshot implements Node {
+  id: ID!
+  organization: Organization! @goField(forceResolver: true)
+  name: String!
+  description: String
+  type: SnapshotsType!
+  createdAt: Datetime!
+}
+
 type Report implements Node {
   id: ID!
   objectKey: String!
@@ -8876,6 +9123,20 @@ type ComplianceRegistryEdge {
   node: ComplianceRegistry!
 }
 
+type SnapshotConnection
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.SnapshotConnection"
+  ) {
+  totalCount: Int! @goField(forceResolver: true)
+  edges: [SnapshotEdge!]!
+  pageInfo: PageInfo!
+}
+
+type SnapshotEdge {
+  cursor: CursorKey!
+  node: Snapshot!
+}
+
 # Root Types
 type Query {
   node(id: ID!): Node!
@@ -9126,6 +9387,10 @@ type Mutation {
   deleteComplianceRegistry(
     input: DeleteComplianceRegistryInput!
   ): DeleteComplianceRegistryPayload!
+
+  # Snapshot mutations
+  createSnapshot(input: CreateSnapshotInput!): CreateSnapshotPayload!
+  deleteSnapshot(input: DeleteSnapshotInput!): DeleteSnapshotPayload!
 }
 
 # Input Types
@@ -9679,6 +9944,17 @@ input UpdateComplianceRegistryInput {
 
 input DeleteComplianceRegistryInput {
   complianceRegistryId: ID!
+}
+
+input CreateSnapshotInput {
+  organizationId: ID!
+  name: String!
+  description: String
+  type: SnapshotsType!
+}
+
+input DeleteSnapshotInput {
+  snapshotId: ID!
 }
 
 # Payload Types
@@ -10389,6 +10665,14 @@ type UpdateComplianceRegistryPayload {
 
 type DeleteComplianceRegistryPayload {
   deletedComplianceRegistryId: ID!
+}
+
+type CreateSnapshotPayload {
+  snapshotEdge: SnapshotEdge!
+}
+
+type DeleteSnapshotPayload {
+  deletedSnapshotId: ID!
 }
 `, BuiltIn: false},
 }
@@ -12424,6 +12708,29 @@ func (ec *executionContext) field_Mutation_createRisk_argsInput(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation_createSnapshot_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_createSnapshot_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_createSnapshot_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.CreateSnapshotInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNCreateSnapshotInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateSnapshotInput(ctx, tmp)
+	}
+
+	var zeroVal types.CreateSnapshotInput
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation_createTask_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -13019,6 +13326,29 @@ func (ec *executionContext) field_Mutation_deleteRisk_argsInput(
 	}
 
 	var zeroVal types.DeleteRiskInput
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_deleteSnapshot_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_deleteSnapshot_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_deleteSnapshot_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.DeleteSnapshotInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNDeleteSnapshotInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteSnapshotInput(ctx, tmp)
+	}
+
+	var zeroVal types.DeleteSnapshotInput
 	return zeroVal, nil
 }
 
@@ -14647,6 +14977,11 @@ func (ec *executionContext) field_Organization_data_args(ctx context.Context, ra
 		return nil, err
 	}
 	args["orderBy"] = arg4
+	arg5, err := ec.field_Organization_data_argsFilter(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["filter"] = arg5
 	return args, nil
 }
 func (ec *executionContext) field_Organization_data_argsFirst(
@@ -14711,6 +15046,19 @@ func (ec *executionContext) field_Organization_data_argsOrderBy(
 	}
 
 	var zeroVal *types.DatumOrderBy
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_data_argsFilter(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*types.DatumFilter, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("filter"))
+	if tmp, ok := rawArgs["filter"]; ok {
+		return ec.unmarshalODatumFilter2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDatumFilter(ctx, tmp)
+	}
+
+	var zeroVal *types.DatumFilter
 	return zeroVal, nil
 }
 
@@ -15353,6 +15701,101 @@ func (ec *executionContext) field_Organization_risks_argsFilter(
 	}
 
 	var zeroVal *types.RiskFilter
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_snapshots_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Organization_snapshots_argsFirst(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["first"] = arg0
+	arg1, err := ec.field_Organization_snapshots_argsAfter(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["after"] = arg1
+	arg2, err := ec.field_Organization_snapshots_argsLast(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["last"] = arg2
+	arg3, err := ec.field_Organization_snapshots_argsBefore(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["before"] = arg3
+	arg4, err := ec.field_Organization_snapshots_argsOrderBy(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["orderBy"] = arg4
+	return args, nil
+}
+func (ec *executionContext) field_Organization_snapshots_argsFirst(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*int, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("first"))
+	if tmp, ok := rawArgs["first"]; ok {
+		return ec.unmarshalOInt2ᚖint(ctx, tmp)
+	}
+
+	var zeroVal *int
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_snapshots_argsAfter(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*page.CursorKey, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("after"))
+	if tmp, ok := rawArgs["after"]; ok {
+		return ec.unmarshalOCursorKey2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐCursorKey(ctx, tmp)
+	}
+
+	var zeroVal *page.CursorKey
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_snapshots_argsLast(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*int, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("last"))
+	if tmp, ok := rawArgs["last"]; ok {
+		return ec.unmarshalOInt2ᚖint(ctx, tmp)
+	}
+
+	var zeroVal *int
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_snapshots_argsBefore(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*page.CursorKey, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("before"))
+	if tmp, ok := rawArgs["before"]; ok {
+		return ec.unmarshalOCursorKey2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐCursorKey(ctx, tmp)
+	}
+
+	var zeroVal *page.CursorKey
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_snapshots_argsOrderBy(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*types.SnapshotOrderBy, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("orderBy"))
+	if tmp, ok := rawArgs["orderBy"]; ok {
+		return ec.unmarshalOSnapshotOrder2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐSnapshotOrderBy(ctx, tmp)
+	}
+
+	var zeroVal *types.SnapshotOrderBy
 	return zeroVal, nil
 }
 
@@ -17499,6 +17942,8 @@ func (ec *executionContext) fieldContext_Asset_organization(_ context.Context, f
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "complianceRegistries":
 				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "snapshots":
+				return ec.fieldContext_Organization_snapshots(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -18090,6 +18535,8 @@ func (ec *executionContext) fieldContext_Audit_organization(_ context.Context, f
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "complianceRegistries":
 				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "snapshots":
+				return ec.fieldContext_Organization_snapshots(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -19161,6 +19608,8 @@ func (ec *executionContext) fieldContext_ComplianceRegistry_organization(_ conte
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "complianceRegistries":
 				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "snapshots":
+				return ec.fieldContext_Organization_snapshots(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -22621,6 +23070,56 @@ func (ec *executionContext) fieldContext_CreateRiskPayload_riskEdge(_ context.Co
 	return fc, nil
 }
 
+func (ec *executionContext) _CreateSnapshotPayload_snapshotEdge(ctx context.Context, field graphql.CollectedField, obj *types.CreateSnapshotPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CreateSnapshotPayload_snapshotEdge(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SnapshotEdge, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.SnapshotEdge)
+	fc.Result = res
+	return ec.marshalNSnapshotEdge2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐSnapshotEdge(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CreateSnapshotPayload_snapshotEdge(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CreateSnapshotPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "cursor":
+				return ec.fieldContext_SnapshotEdge_cursor(ctx, field)
+			case "node":
+				return ec.fieldContext_SnapshotEdge_node(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SnapshotEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _CreateTaskPayload_taskEdge(ctx context.Context, field graphql.CollectedField, obj *types.CreateTaskPayload) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_CreateTaskPayload_taskEdge(ctx, field)
 	if err != nil {
@@ -23257,6 +23756,8 @@ func (ec *executionContext) fieldContext_Datum_organization(_ context.Context, f
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "complianceRegistries":
 				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "snapshots":
+				return ec.fieldContext_Organization_snapshots(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -24740,6 +25241,50 @@ func (ec *executionContext) fieldContext_DeleteRiskPayload_deletedRiskId(_ conte
 	return fc, nil
 }
 
+func (ec *executionContext) _DeleteSnapshotPayload_deletedSnapshotId(ctx context.Context, field graphql.CollectedField, obj *types.DeleteSnapshotPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DeleteSnapshotPayload_deletedSnapshotId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DeletedSnapshotID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(gid.GID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DeleteSnapshotPayload_deletedSnapshotId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DeleteSnapshotPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _DeleteTaskPayload_deletedTaskId(ctx context.Context, field graphql.CollectedField, obj *types.DeleteTaskPayload) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_DeleteTaskPayload_deletedTaskId(ctx, field)
 	if err != nil {
@@ -25494,6 +26039,8 @@ func (ec *executionContext) fieldContext_Document_organization(_ context.Context
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "complianceRegistries":
 				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "snapshots":
+				return ec.fieldContext_Organization_snapshots(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -28659,6 +29206,8 @@ func (ec *executionContext) fieldContext_Framework_organization(_ context.Contex
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "complianceRegistries":
 				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "snapshots":
+				return ec.fieldContext_Organization_snapshots(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -35985,6 +36534,124 @@ func (ec *executionContext) fieldContext_Mutation_deleteComplianceRegistry(ctx c
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_createSnapshot(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_createSnapshot(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateSnapshot(rctx, fc.Args["input"].(types.CreateSnapshotInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.CreateSnapshotPayload)
+	fc.Result = res
+	return ec.marshalNCreateSnapshotPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateSnapshotPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_createSnapshot(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "snapshotEdge":
+				return ec.fieldContext_CreateSnapshotPayload_snapshotEdge(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CreateSnapshotPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_createSnapshot_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_deleteSnapshot(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_deleteSnapshot(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteSnapshot(rctx, fc.Args["input"].(types.DeleteSnapshotInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.DeleteSnapshotPayload)
+	fc.Result = res
+	return ec.marshalNDeleteSnapshotPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteSnapshotPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_deleteSnapshot(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "deletedSnapshotId":
+				return ec.fieldContext_DeleteSnapshotPayload_deletedSnapshotId(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DeleteSnapshotPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_deleteSnapshot_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _NonconformityRegistry_id(ctx context.Context, field graphql.CollectedField, obj *types.NonconformityRegistry) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_NonconformityRegistry_id(ctx, field)
 	if err != nil {
@@ -36104,6 +36771,8 @@ func (ec *executionContext) fieldContext_NonconformityRegistry_organization(_ co
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "complianceRegistries":
 				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "snapshots":
+				return ec.fieldContext_Organization_snapshots(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -37778,7 +38447,7 @@ func (ec *executionContext) _Organization_data(ctx context.Context, field graphq
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Organization().Data(rctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey), fc.Args["orderBy"].(*types.DatumOrderBy))
+		return ec.resolvers.Organization().Data(rctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey), fc.Args["orderBy"].(*types.DatumOrderBy), fc.Args["filter"].(*types.DatumFilter))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -38010,6 +38679,69 @@ func (ec *executionContext) fieldContext_Organization_complianceRegistries(ctx c
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Organization_complianceRegistries_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Organization_snapshots(ctx context.Context, field graphql.CollectedField, obj *types.Organization) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Organization_snapshots(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Organization().Snapshots(rctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey), fc.Args["orderBy"].(*types.SnapshotOrderBy))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.SnapshotConnection)
+	fc.Result = res
+	return ec.marshalNSnapshotConnection2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐSnapshotConnection(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Organization_snapshots(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Organization",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "totalCount":
+				return ec.fieldContext_SnapshotConnection_totalCount(ctx, field)
+			case "edges":
+				return ec.fieldContext_SnapshotConnection_edges(ctx, field)
+			case "pageInfo":
+				return ec.fieldContext_SnapshotConnection_pageInfo(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SnapshotConnection", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Organization_snapshots_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -38384,6 +39116,8 @@ func (ec *executionContext) fieldContext_OrganizationEdge_node(_ context.Context
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "complianceRegistries":
 				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "snapshots":
+				return ec.fieldContext_Organization_snapshots(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -40856,6 +41590,8 @@ func (ec *executionContext) fieldContext_Risk_organization(_ context.Context, fi
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "complianceRegistries":
 				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "snapshots":
+				return ec.fieldContext_Organization_snapshots(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -41554,6 +42290,563 @@ func (ec *executionContext) fieldContext_Session_expiresAt(_ context.Context, fi
 	return fc, nil
 }
 
+func (ec *executionContext) _Snapshot_id(ctx context.Context, field graphql.CollectedField, obj *types.Snapshot) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Snapshot_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(gid.GID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Snapshot_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Snapshot",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Snapshot_organization(ctx context.Context, field graphql.CollectedField, obj *types.Snapshot) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Snapshot_organization(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Snapshot().Organization(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.Organization)
+	fc.Result = res
+	return ec.marshalNOrganization2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐOrganization(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Snapshot_organization(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Snapshot",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Organization_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Organization_name(ctx, field)
+			case "logoUrl":
+				return ec.fieldContext_Organization_logoUrl(ctx, field)
+			case "users":
+				return ec.fieldContext_Organization_users(ctx, field)
+			case "connectors":
+				return ec.fieldContext_Organization_connectors(ctx, field)
+			case "frameworks":
+				return ec.fieldContext_Organization_frameworks(ctx, field)
+			case "controls":
+				return ec.fieldContext_Organization_controls(ctx, field)
+			case "vendors":
+				return ec.fieldContext_Organization_vendors(ctx, field)
+			case "peoples":
+				return ec.fieldContext_Organization_peoples(ctx, field)
+			case "documents":
+				return ec.fieldContext_Organization_documents(ctx, field)
+			case "measures":
+				return ec.fieldContext_Organization_measures(ctx, field)
+			case "risks":
+				return ec.fieldContext_Organization_risks(ctx, field)
+			case "tasks":
+				return ec.fieldContext_Organization_tasks(ctx, field)
+			case "assets":
+				return ec.fieldContext_Organization_assets(ctx, field)
+			case "data":
+				return ec.fieldContext_Organization_data(ctx, field)
+			case "audits":
+				return ec.fieldContext_Organization_audits(ctx, field)
+			case "nonconformityRegistries":
+				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
+			case "complianceRegistries":
+				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "snapshots":
+				return ec.fieldContext_Organization_snapshots(ctx, field)
+			case "trustCenter":
+				return ec.fieldContext_Organization_trustCenter(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Organization_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Organization_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Organization", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Snapshot_name(ctx context.Context, field graphql.CollectedField, obj *types.Snapshot) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Snapshot_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Snapshot_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Snapshot",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Snapshot_description(ctx context.Context, field graphql.CollectedField, obj *types.Snapshot) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Snapshot_description(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Description, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Snapshot_description(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Snapshot",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Snapshot_type(ctx context.Context, field graphql.CollectedField, obj *types.Snapshot) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Snapshot_type(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Type, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(coredata.SnapshotsType)
+	fc.Result = res
+	return ec.marshalNSnapshotsType2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐSnapshotsType(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Snapshot_type(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Snapshot",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type SnapshotsType does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Snapshot_createdAt(ctx context.Context, field graphql.CollectedField, obj *types.Snapshot) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Snapshot_createdAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNDatetime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Snapshot_createdAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Snapshot",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SnapshotConnection_totalCount(ctx context.Context, field graphql.CollectedField, obj *types.SnapshotConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SnapshotConnection_totalCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.SnapshotConnection().TotalCount(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SnapshotConnection_totalCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SnapshotConnection",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SnapshotConnection_edges(ctx context.Context, field graphql.CollectedField, obj *types.SnapshotConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SnapshotConnection_edges(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Edges, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*types.SnapshotEdge)
+	fc.Result = res
+	return ec.marshalNSnapshotEdge2ᚕᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐSnapshotEdgeᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SnapshotConnection_edges(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SnapshotConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "cursor":
+				return ec.fieldContext_SnapshotEdge_cursor(ctx, field)
+			case "node":
+				return ec.fieldContext_SnapshotEdge_node(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SnapshotEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SnapshotConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *types.SnapshotConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SnapshotConnection_pageInfo(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PageInfo, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(types.PageInfo)
+	fc.Result = res
+	return ec.marshalNPageInfo2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐPageInfo(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SnapshotConnection_pageInfo(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SnapshotConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "hasNextPage":
+				return ec.fieldContext_PageInfo_hasNextPage(ctx, field)
+			case "hasPreviousPage":
+				return ec.fieldContext_PageInfo_hasPreviousPage(ctx, field)
+			case "startCursor":
+				return ec.fieldContext_PageInfo_startCursor(ctx, field)
+			case "endCursor":
+				return ec.fieldContext_PageInfo_endCursor(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SnapshotEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *types.SnapshotEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SnapshotEdge_cursor(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Cursor, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(page.CursorKey)
+	fc.Result = res
+	return ec.marshalNCursorKey2githubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐCursorKey(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SnapshotEdge_cursor(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SnapshotEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type CursorKey does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SnapshotEdge_node(ctx context.Context, field graphql.CollectedField, obj *types.SnapshotEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SnapshotEdge_node(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Node, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.Snapshot)
+	fc.Result = res
+	return ec.marshalNSnapshot2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐSnapshot(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SnapshotEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SnapshotEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Snapshot_id(ctx, field)
+			case "organization":
+				return ec.fieldContext_Snapshot_organization(ctx, field)
+			case "name":
+				return ec.fieldContext_Snapshot_name(ctx, field)
+			case "description":
+				return ec.fieldContext_Snapshot_description(ctx, field)
+			case "type":
+				return ec.fieldContext_Snapshot_type(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Snapshot_createdAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Snapshot", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Task_id(ctx context.Context, field graphql.CollectedField, obj *types.Task) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Task_id(ctx, field)
 	if err != nil {
@@ -41950,6 +43243,8 @@ func (ec *executionContext) fieldContext_Task_organization(_ context.Context, fi
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "complianceRegistries":
 				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "snapshots":
+				return ec.fieldContext_Organization_snapshots(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -42736,6 +44031,8 @@ func (ec *executionContext) fieldContext_TrustCenter_organization(_ context.Cont
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "complianceRegistries":
 				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "snapshots":
+				return ec.fieldContext_Organization_snapshots(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -44325,6 +45622,8 @@ func (ec *executionContext) fieldContext_UpdateOrganizationPayload_organization(
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "complianceRegistries":
 				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "snapshots":
+				return ec.fieldContext_Organization_snapshots(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -46126,6 +47425,8 @@ func (ec *executionContext) fieldContext_Vendor_organization(_ context.Context, 
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "complianceRegistries":
 				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "snapshots":
+				return ec.fieldContext_Organization_snapshots(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "createdAt":
@@ -54594,6 +55895,54 @@ func (ec *executionContext) unmarshalInputCreateRiskMeasureMappingInput(ctx cont
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputCreateSnapshotInput(ctx context.Context, obj any) (types.CreateSnapshotInput, error) {
+	var it types.CreateSnapshotInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"organizationId", "name", "description", "type"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "organizationId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("organizationId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OrganizationID = data
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "description":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Description = data
+		case "type":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("type"))
+			data, err := ec.unmarshalNSnapshotsType2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐSnapshotsType(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Type = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputCreateTaskInput(ctx context.Context, obj any) (types.CreateTaskInput, error) {
 	var it types.CreateTaskInput
 	asMap := map[string]any{}
@@ -55030,6 +56379,33 @@ func (ec *executionContext) unmarshalInputCreateVendorServiceInput(ctx context.C
 				return it, err
 			}
 			it.Type = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputDatumFilter(ctx context.Context, obj any) (types.DatumFilter, error) {
+	var it types.DatumFilter
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"snapshotId"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "snapshotId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("snapshotId"))
+			data, err := ec.unmarshalOID2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SnapshotID = data
 		}
 	}
 
@@ -55639,6 +57015,33 @@ func (ec *executionContext) unmarshalInputDeleteRiskMeasureMappingInput(ctx cont
 				return it, err
 			}
 			it.MeasureID = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputDeleteSnapshotInput(ctx context.Context, obj any) (types.DeleteSnapshotInput, error) {
+	var it types.DeleteSnapshotInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"snapshotId"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "snapshotId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("snapshotId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SnapshotID = data
 		}
 	}
 
@@ -56772,6 +58175,40 @@ func (ec *executionContext) unmarshalInputSendSigningNotificationsInput(ctx cont
 				return it, err
 			}
 			it.OrganizationID = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputSnapshotOrder(ctx context.Context, obj any) (types.SnapshotOrderBy, error) {
+	var it types.SnapshotOrderBy
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"direction", "field"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "direction":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("direction"))
+			data, err := ec.unmarshalNOrderDirection2githubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐOrderDirection(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Direction = data
+		case "field":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("field"))
+			data, err := ec.unmarshalNSnapshotOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐSnapshotOrderField(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Field = data
 		}
 	}
 
@@ -58821,6 +60258,13 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._Task(ctx, sel, obj)
+	case types.Snapshot:
+		return ec._Snapshot(ctx, sel, &obj)
+	case *types.Snapshot:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Snapshot(ctx, sel, obj)
 	case types.Risk:
 		return ec._Risk(ctx, sel, &obj)
 	case *types.Risk:
@@ -61450,6 +62894,45 @@ func (ec *executionContext) _CreateRiskPayload(ctx context.Context, sel ast.Sele
 	return out
 }
 
+var createSnapshotPayloadImplementors = []string{"CreateSnapshotPayload"}
+
+func (ec *executionContext) _CreateSnapshotPayload(ctx context.Context, sel ast.SelectionSet, obj *types.CreateSnapshotPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, createSnapshotPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CreateSnapshotPayload")
+		case "snapshotEdge":
+			out.Values[i] = ec._CreateSnapshotPayload_snapshotEdge(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var createTaskPayloadImplementors = []string{"CreateTaskPayload"}
 
 func (ec *executionContext) _CreateTaskPayload(ctx context.Context, sel ast.SelectionSet, obj *types.CreateTaskPayload) graphql.Marshaler {
@@ -62754,6 +64237,45 @@ func (ec *executionContext) _DeleteRiskPayload(ctx context.Context, sel ast.Sele
 			out.Values[i] = graphql.MarshalString("DeleteRiskPayload")
 		case "deletedRiskId":
 			out.Values[i] = ec._DeleteRiskPayload_deletedRiskId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var deleteSnapshotPayloadImplementors = []string{"DeleteSnapshotPayload"}
+
+func (ec *executionContext) _DeleteSnapshotPayload(ctx context.Context, sel ast.SelectionSet, obj *types.DeleteSnapshotPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, deleteSnapshotPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("DeleteSnapshotPayload")
+		case "deletedSnapshotId":
+			out.Values[i] = ec._DeleteSnapshotPayload_deletedSnapshotId(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -65870,6 +67392,20 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "createSnapshot":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_createSnapshot(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "deleteSnapshot":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_deleteSnapshot(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -66767,6 +68303,42 @@ func (ec *executionContext) _Organization(ctx context.Context, sel ast.Selection
 					}
 				}()
 				res = ec._Organization_complianceRegistries(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "snapshots":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Organization_snapshots(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -68035,6 +69607,222 @@ func (ec *executionContext) _Session(ctx context.Context, sel ast.SelectionSet, 
 			}
 		case "expiresAt":
 			out.Values[i] = ec._Session_expiresAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var snapshotImplementors = []string{"Snapshot", "Node"}
+
+func (ec *executionContext) _Snapshot(ctx context.Context, sel ast.SelectionSet, obj *types.Snapshot) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, snapshotImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Snapshot")
+		case "id":
+			out.Values[i] = ec._Snapshot_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "organization":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Snapshot_organization(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "name":
+			out.Values[i] = ec._Snapshot_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "description":
+			out.Values[i] = ec._Snapshot_description(ctx, field, obj)
+		case "type":
+			out.Values[i] = ec._Snapshot_type(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "createdAt":
+			out.Values[i] = ec._Snapshot_createdAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var snapshotConnectionImplementors = []string{"SnapshotConnection"}
+
+func (ec *executionContext) _SnapshotConnection(ctx context.Context, sel ast.SelectionSet, obj *types.SnapshotConnection) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, snapshotConnectionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("SnapshotConnection")
+		case "totalCount":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._SnapshotConnection_totalCount(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "edges":
+			out.Values[i] = ec._SnapshotConnection_edges(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "pageInfo":
+			out.Values[i] = ec._SnapshotConnection_pageInfo(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var snapshotEdgeImplementors = []string{"SnapshotEdge"}
+
+func (ec *executionContext) _SnapshotEdge(ctx context.Context, sel ast.SelectionSet, obj *types.SnapshotEdge) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, snapshotEdgeImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("SnapshotEdge")
+		case "cursor":
+			out.Values[i] = ec._SnapshotEdge_cursor(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "node":
+			out.Values[i] = ec._SnapshotEdge_node(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -73238,6 +75026,25 @@ func (ec *executionContext) marshalNCreateRiskPayload2ᚖgithubᚗcomᚋgetprobo
 	return ec._CreateRiskPayload(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNCreateSnapshotInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateSnapshotInput(ctx context.Context, v any) (types.CreateSnapshotInput, error) {
+	res, err := ec.unmarshalInputCreateSnapshotInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNCreateSnapshotPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateSnapshotPayload(ctx context.Context, sel ast.SelectionSet, v types.CreateSnapshotPayload) graphql.Marshaler {
+	return ec._CreateSnapshotPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNCreateSnapshotPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateSnapshotPayload(ctx context.Context, sel ast.SelectionSet, v *types.CreateSnapshotPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._CreateSnapshotPayload(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNCreateTaskInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateTaskInput(ctx context.Context, v any) (types.CreateTaskInput, error) {
 	res, err := ec.unmarshalInputCreateTaskInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -73966,6 +75773,25 @@ func (ec *executionContext) marshalNDeleteRiskPayload2ᚖgithubᚗcomᚋgetprobo
 		return graphql.Null
 	}
 	return ec._DeleteRiskPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNDeleteSnapshotInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteSnapshotInput(ctx context.Context, v any) (types.DeleteSnapshotInput, error) {
+	res, err := ec.unmarshalInputDeleteSnapshotInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNDeleteSnapshotPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteSnapshotPayload(ctx context.Context, sel ast.SelectionSet, v types.DeleteSnapshotPayload) graphql.Marshaler {
+	return ec._DeleteSnapshotPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNDeleteSnapshotPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteSnapshotPayload(ctx context.Context, sel ast.SelectionSet, v *types.DeleteSnapshotPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._DeleteSnapshotPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNDeleteTaskInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteTaskInput(ctx context.Context, v any) (types.DeleteTaskInput, error) {
@@ -75818,6 +77644,150 @@ func (ec *executionContext) marshalNSendSigningNotificationsPayload2ᚖgithubᚗ
 	}
 	return ec._SendSigningNotificationsPayload(ctx, sel, v)
 }
+
+func (ec *executionContext) marshalNSnapshot2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐSnapshot(ctx context.Context, sel ast.SelectionSet, v *types.Snapshot) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Snapshot(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNSnapshotConnection2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐSnapshotConnection(ctx context.Context, sel ast.SelectionSet, v types.SnapshotConnection) graphql.Marshaler {
+	return ec._SnapshotConnection(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNSnapshotConnection2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐSnapshotConnection(ctx context.Context, sel ast.SelectionSet, v *types.SnapshotConnection) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._SnapshotConnection(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNSnapshotEdge2ᚕᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐSnapshotEdgeᚄ(ctx context.Context, sel ast.SelectionSet, v []*types.SnapshotEdge) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNSnapshotEdge2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐSnapshotEdge(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNSnapshotEdge2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐSnapshotEdge(ctx context.Context, sel ast.SelectionSet, v *types.SnapshotEdge) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._SnapshotEdge(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNSnapshotOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐSnapshotOrderField(ctx context.Context, v any) (coredata.SnapshotOrderField, error) {
+	tmp, err := graphql.UnmarshalString(v)
+	res := unmarshalNSnapshotOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐSnapshotOrderField[tmp]
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNSnapshotOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐSnapshotOrderField(ctx context.Context, sel ast.SelectionSet, v coredata.SnapshotOrderField) graphql.Marshaler {
+	_ = sel
+	res := graphql.MarshalString(marshalNSnapshotOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐSnapshotOrderField[v])
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+var (
+	unmarshalNSnapshotOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐSnapshotOrderField = map[string]coredata.SnapshotOrderField{
+		"CREATED_AT": coredata.SnapshotOrderFieldCreatedAt,
+		"NAME":       coredata.SnapshotOrderFieldName,
+		"TYPE":       coredata.SnapshotOrderFieldType,
+	}
+	marshalNSnapshotOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐSnapshotOrderField = map[coredata.SnapshotOrderField]string{
+		coredata.SnapshotOrderFieldCreatedAt: "CREATED_AT",
+		coredata.SnapshotOrderFieldName:      "NAME",
+		coredata.SnapshotOrderFieldType:      "TYPE",
+	}
+)
+
+func (ec *executionContext) unmarshalNSnapshotsType2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐSnapshotsType(ctx context.Context, v any) (coredata.SnapshotsType, error) {
+	tmp, err := graphql.UnmarshalString(v)
+	res := unmarshalNSnapshotsType2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐSnapshotsType[tmp]
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNSnapshotsType2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐSnapshotsType(ctx context.Context, sel ast.SelectionSet, v coredata.SnapshotsType) graphql.Marshaler {
+	_ = sel
+	res := graphql.MarshalString(marshalNSnapshotsType2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐSnapshotsType[v])
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+var (
+	unmarshalNSnapshotsType2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐSnapshotsType = map[string]coredata.SnapshotsType{
+		"RISKS":                     coredata.SnapshotsTypeRisks,
+		"VENDORS":                   coredata.SnapshotsTypeVendors,
+		"ASSETS":                    coredata.SnapshotsTypeAssets,
+		"DATA":                      coredata.SnapshotsTypeData,
+		"NON_CONFORMITY_REGISTRIES": coredata.SnapshotsTypeNonConformityRegistries,
+		"COMPLIANCE_REGISTRIES":     coredata.SnapshotsTypeComplianceRegistries,
+	}
+	marshalNSnapshotsType2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐSnapshotsType = map[coredata.SnapshotsType]string{
+		coredata.SnapshotsTypeRisks:                   "RISKS",
+		coredata.SnapshotsTypeVendors:                 "VENDORS",
+		coredata.SnapshotsTypeAssets:                  "ASSETS",
+		coredata.SnapshotsTypeData:                    "DATA",
+		coredata.SnapshotsTypeNonConformityRegistries: "NON_CONFORMITY_REGISTRIES",
+		coredata.SnapshotsTypeComplianceRegistries:    "COMPLIANCE_REGISTRIES",
+	}
+)
 
 func (ec *executionContext) unmarshalNString2string(ctx context.Context, v any) (string, error) {
 	res, err := graphql.UnmarshalString(v)
@@ -78025,6 +79995,14 @@ func (ec *executionContext) marshalODatetime2ᚖtimeᚐTime(ctx context.Context,
 	return res
 }
 
+func (ec *executionContext) unmarshalODatumFilter2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDatumFilter(ctx context.Context, v any) (*types.DatumFilter, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputDatumFilter(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalODatumOrder2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDatumOrderBy(ctx context.Context, v any) (*types.DatumOrderBy, error) {
 	if v == nil {
 		return nil, nil
@@ -78465,6 +80443,14 @@ var (
 		coredata.RiskTreatmentTransferred: "TRANSFERRED",
 	}
 )
+
+func (ec *executionContext) unmarshalOSnapshotOrder2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐSnapshotOrderBy(ctx context.Context, v any) (*types.SnapshotOrderBy, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputSnapshotOrder(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
 
 func (ec *executionContext) unmarshalOString2ᚕstringᚄ(ctx context.Context, v any) ([]string, error) {
 	if v == nil {

--- a/pkg/server/api/console/v1/types/snapshot.go
+++ b/pkg/server/api/console/v1/types/snapshot.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package types
+
+import (
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+)
+
+type (
+	SnapshotOrderBy OrderBy[coredata.SnapshotOrderField]
+
+	SnapshotConnection struct {
+		TotalCount int
+		Edges      []*SnapshotEdge
+		PageInfo   PageInfo
+
+		Resolver any
+		ParentID gid.GID
+	}
+)
+
+func NewSnapshotConnection(
+	p *page.Page[*coredata.Snapshot, coredata.SnapshotOrderField],
+	parentType any,
+	parentID gid.GID,
+) *SnapshotConnection {
+	edges := make([]*SnapshotEdge, len(p.Data))
+	for i, snapshot := range p.Data {
+		edges[i] = NewSnapshotEdge(snapshot, p.Cursor.OrderBy.Field)
+	}
+
+	return &SnapshotConnection{
+		Edges:    edges,
+		PageInfo: *NewPageInfo(p),
+
+		Resolver: parentType,
+		ParentID: parentID,
+	}
+}
+
+func NewSnapshot(s *coredata.Snapshot) *Snapshot {
+	return &Snapshot{
+		ID:          s.ID,
+		Name:        s.Name,
+		Type:        s.Type,
+		Description: s.Description,
+		CreatedAt:   s.CreatedAt,
+	}
+}
+
+func NewSnapshotEdge(s *coredata.Snapshot, orderField coredata.SnapshotOrderField) *SnapshotEdge {
+	return &SnapshotEdge{
+		Node:   NewSnapshot(s),
+		Cursor: s.CursorKey(orderField),
+	}
+}

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -430,6 +430,17 @@ type CreateRiskPayload struct {
 	RiskEdge *RiskEdge `json:"riskEdge"`
 }
 
+type CreateSnapshotInput struct {
+	OrganizationID gid.GID                `json:"organizationId"`
+	Name           string                 `json:"name"`
+	Description    *string                `json:"description,omitempty"`
+	Type           coredata.SnapshotsType `json:"type"`
+}
+
+type CreateSnapshotPayload struct {
+	SnapshotEdge *SnapshotEdge `json:"snapshotEdge"`
+}
+
 type CreateTaskInput struct {
 	OrganizationID gid.GID        `json:"organizationId"`
 	MeasureID      *gid.GID       `json:"measureId,omitempty"`
@@ -535,6 +546,10 @@ func (this Datum) GetID() gid.GID { return this.ID }
 type DatumEdge struct {
 	Cursor page.CursorKey `json:"cursor"`
 	Node   *Datum         `json:"node"`
+}
+
+type DatumFilter struct {
+	SnapshotID *gid.GID `json:"snapshotId,omitempty"`
 }
 
 type DeleteAssetInput struct {
@@ -705,6 +720,14 @@ type DeleteRiskMeasureMappingPayload struct {
 
 type DeleteRiskPayload struct {
 	DeletedRiskID gid.GID `json:"deletedRiskId"`
+}
+
+type DeleteSnapshotInput struct {
+	SnapshotID gid.GID `json:"snapshotId"`
+}
+
+type DeleteSnapshotPayload struct {
+	DeletedSnapshotID gid.GID `json:"deletedSnapshotId"`
 }
 
 type DeleteTaskInput struct {
@@ -1039,6 +1062,7 @@ type Organization struct {
 	Audits                  *AuditConnection                 `json:"audits"`
 	NonconformityRegistries *NonconformityRegistryConnection `json:"nonconformityRegistries"`
 	ComplianceRegistries    *ComplianceRegistryConnection    `json:"complianceRegistries"`
+	Snapshots               *SnapshotConnection              `json:"snapshots"`
 	TrustCenter             *TrustCenter                     `json:"trustCenter,omitempty"`
 	CreatedAt               time.Time                        `json:"createdAt"`
 	UpdatedAt               time.Time                        `json:"updatedAt"`
@@ -1199,6 +1223,23 @@ type SendSigningNotificationsPayload struct {
 type Session struct {
 	ID        gid.GID   `json:"id"`
 	ExpiresAt time.Time `json:"expiresAt"`
+}
+
+type Snapshot struct {
+	ID           gid.GID                `json:"id"`
+	Organization *Organization          `json:"organization"`
+	Name         string                 `json:"name"`
+	Description  *string                `json:"description,omitempty"`
+	Type         coredata.SnapshotsType `json:"type"`
+	CreatedAt    time.Time              `json:"createdAt"`
+}
+
+func (Snapshot) IsNode()             {}
+func (this Snapshot) GetID() gid.GID { return this.ID }
+
+type SnapshotEdge struct {
+	Cursor page.CursorKey `json:"cursor"`
+	Node   *Snapshot      `json:"node"`
 }
 
 type Task struct {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds Snapshots to capture and view point‑in‑time states of organization data. Includes a Snapshots page, create/delete flows, snapshot‑aware data views, and backend GraphQL/services with DB migrations.

- **New Features**
  - Snapshot entity with types (risks, vendors, assets, data, non‑conformity, compliance), GraphQL queries/mutations, and service layer.
  - Snapshots page (list, create via dialog, delete) and a new sidebar entry.
  - Snapshot‑aware Data pages: new route /snapshots/:snapshotId/data, optional snapshotId filter in queries, and a SnapshotBanner on list/detail pages.
  - Helpers for snapshot labels; Vendors multi‑select now respects disabled state for removing items.

- **Migration**
  - Run DB migrations to create snapshots table and add data.snapshot_id (FK).
  - No breaking changes: snapshotId is optional in data queries. Use the new Snapshots page and routes to work with snapshots.

<!-- End of auto-generated description by cubic. -->

