### PR TITLE
Add continual improvement registries

### DIFF
--- a/apps/console/src/hooks/graph/ContinualImprovementRegistryGraph.ts
+++ b/apps/console/src/hooks/graph/ContinualImprovementRegistryGraph.ts
@@ -1,0 +1,233 @@
+import { graphql } from "relay-runtime";
+import { useMutation } from "react-relay";
+import { useConfirm } from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { promisifyMutation, sprintf } from "@probo/helpers";
+import { useMutationWithToasts } from "../useMutationWithToasts";
+
+export const ContinualImprovementRegistriesConnectionKey = "ContinualImprovementRegistriesPage_continualImprovementRegistries";
+
+export const continualImprovementRegistriesQuery = graphql`
+  query ContinualImprovementRegistryGraphListQuery($organizationId: ID!) {
+    node(id: $organizationId) {
+      ... on Organization {
+        ...ContinualImprovementRegistriesPageFragment
+      }
+    }
+  }
+`;
+
+export const continualImprovementRegistryNodeQuery = graphql`
+  query ContinualImprovementRegistryGraphNodeQuery($continualImprovementRegistryId: ID!) {
+    node(id: $continualImprovementRegistryId) {
+      ... on ContinualImprovementRegistry {
+        id
+        referenceId
+        description
+        source
+        targetDate
+        status
+        priority
+        audit {
+          id
+          name
+          framework {
+            id
+            name
+          }
+        }
+        owner {
+          id
+          fullName
+        }
+        organization {
+          id
+          name
+        }
+        createdAt
+        updatedAt
+      }
+    }
+  }
+`;
+
+export const createContinualImprovementRegistryMutation = graphql`
+  mutation ContinualImprovementRegistryGraphCreateMutation(
+    $input: CreateContinualImprovementRegistryInput!
+    $connections: [ID!]!
+  ) {
+    createContinualImprovementRegistry(input: $input) {
+      continualImprovementRegistryEdge @prependEdge(connections: $connections) {
+        node {
+          id
+          referenceId
+          description
+          source
+          targetDate
+          status
+          priority
+          audit {
+            id
+            name
+            framework {
+              name
+            }
+          }
+          owner {
+            id
+            fullName
+          }
+          createdAt
+        }
+      }
+    }
+  }
+`;
+
+export const updateContinualImprovementRegistryMutation = graphql`
+  mutation ContinualImprovementRegistryGraphUpdateMutation($input: UpdateContinualImprovementRegistryInput!) {
+    updateContinualImprovementRegistry(input: $input) {
+      continualImprovementRegistry {
+        id
+        referenceId
+        description
+        source
+        targetDate
+        status
+        priority
+        owner {
+          id
+          fullName
+        }
+        audit {
+          id
+          name
+          framework {
+            id
+            name
+          }
+        }
+        updatedAt
+      }
+    }
+  }
+`;
+
+export const deleteContinualImprovementRegistryMutation = graphql`
+  mutation ContinualImprovementRegistryGraphDeleteMutation(
+    $input: DeleteContinualImprovementRegistryInput!
+    $connections: [ID!]!
+  ) {
+    deleteContinualImprovementRegistry(input: $input) {
+      deletedContinualImprovementRegistryId @deleteEdge(connections: $connections)
+    }
+  }
+`;
+
+export const useDeleteContinualImprovementRegistry = (
+  registry: { id: string; referenceId: string },
+  connectionId: string
+) => {
+  const { __ } = useTranslate();
+  const [mutate] = useMutationWithToasts(deleteContinualImprovementRegistryMutation, {
+    successMessage: __("Continual improvement registry entry deleted successfully"),
+    errorMessage: __("Failed to delete continual improvement registry entry"),
+  });
+  const confirm = useConfirm();
+
+  return () => {
+    confirm(
+      () =>
+        mutate({
+          variables: {
+            input: {
+              continualImprovementRegistryId: registry.id,
+            },
+            connections: [connectionId],
+          },
+        }),
+      {
+        message: sprintf(
+          __(
+            "This will permanently delete the continual improvement registry entry %s. This action cannot be undone."
+          ),
+          registry.referenceId
+        ),
+      }
+    );
+  };
+};
+
+export const useCreateContinualImprovementRegistry = (connectionId: string) => {
+  const [mutate] = useMutation(createContinualImprovementRegistryMutation);
+  const { __ } = useTranslate();
+
+  return (input: {
+    organizationId: string;
+    referenceId: string;
+    description?: string;
+    source?: string;
+    auditId: string;
+    ownerId: string;
+    targetDate?: string;
+    status: string;
+    priority: string;
+  }) => {
+    if (!input.organizationId) {
+      return alert(__("Failed to create continual improvement registry entry: organization is required"));
+    }
+    if (!input.referenceId) {
+      return alert(__("Failed to create continual improvement registry entry: reference ID is required"));
+    }
+    if (!input.auditId) {
+      return alert(__("Failed to create continual improvement registry entry: audit is required"));
+    }
+    if (!input.ownerId) {
+      return alert(__("Failed to create continual improvement registry entry: owner is required"));
+    }
+
+    return promisifyMutation(mutate)({
+      variables: {
+        input: {
+          organizationId: input.organizationId,
+          referenceId: input.referenceId,
+          description: input.description,
+          source: input.source,
+          auditId: input.auditId,
+          ownerId: input.ownerId,
+          targetDate: input.targetDate,
+          status: input.status || "OPEN",
+          priority: input.priority || "MEDIUM",
+        },
+        connections: [connectionId],
+      },
+    });
+  };
+};
+
+export const useUpdateContinualImprovementRegistry = () => {
+  const [mutate] = useMutation(updateContinualImprovementRegistryMutation);
+  const { __ } = useTranslate();
+
+  return (input: {
+    id: string;
+    referenceId?: string;
+    description?: string;
+    source?: string;
+    auditId?: string;
+    ownerId?: string;
+    targetDate?: string;
+    status?: string;
+    priority?: string;
+  }) => {
+    if (!input.id) {
+      return alert(__("Failed to update continual improvement registry entry: registry ID is required"));
+    }
+
+    return promisifyMutation(mutate)({
+      variables: {
+        input,
+      },
+    });
+  };
+};

--- a/apps/console/src/hooks/graph/__generated__/ContinualImprovementRegistryGraphCreateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/ContinualImprovementRegistryGraphCreateMutation.graphql.ts
@@ -1,0 +1,350 @@
+/**
+ * @generated SignedSource<<b4f30f53809f3ed05e6830c0afade59b>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type ContinualImprovementRegistriesPriority = "HIGH" | "LOW" | "MEDIUM";
+export type ContinualImprovementRegistriesStatus = "CLOSED" | "IN_PROGRESS" | "OPEN";
+export type CreateContinualImprovementRegistryInput = {
+  auditId: string;
+  description?: string | null | undefined;
+  organizationId: string;
+  ownerId: string;
+  priority: ContinualImprovementRegistriesPriority;
+  referenceId: string;
+  source?: string | null | undefined;
+  status: ContinualImprovementRegistriesStatus;
+  targetDate?: any | null | undefined;
+};
+export type ContinualImprovementRegistryGraphCreateMutation$variables = {
+  connections: ReadonlyArray<string>;
+  input: CreateContinualImprovementRegistryInput;
+};
+export type ContinualImprovementRegistryGraphCreateMutation$data = {
+  readonly createContinualImprovementRegistry: {
+    readonly continualImprovementRegistryEdge: {
+      readonly node: {
+        readonly audit: {
+          readonly framework: {
+            readonly name: string;
+          };
+          readonly id: string;
+          readonly name: string | null | undefined;
+        };
+        readonly createdAt: any;
+        readonly description: string | null | undefined;
+        readonly id: string;
+        readonly owner: {
+          readonly fullName: string;
+          readonly id: string;
+        };
+        readonly priority: ContinualImprovementRegistriesPriority;
+        readonly referenceId: string;
+        readonly source: string | null | undefined;
+        readonly status: ContinualImprovementRegistriesStatus;
+        readonly targetDate: any | null | undefined;
+      };
+    };
+  };
+};
+export type ContinualImprovementRegistryGraphCreateMutation = {
+  response: ContinualImprovementRegistryGraphCreateMutation$data;
+  variables: ContinualImprovementRegistryGraphCreateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "referenceId",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "description",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "source",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "targetDate",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "status",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "priority",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "People",
+  "kind": "LinkedField",
+  "name": "owner",
+  "plural": false,
+  "selections": [
+    (v3/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "fullName",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ContinualImprovementRegistryGraphCreateMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "CreateContinualImprovementRegistryPayload",
+        "kind": "LinkedField",
+        "name": "createContinualImprovementRegistry",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ContinualImprovementRegistryEdge",
+            "kind": "LinkedField",
+            "name": "continualImprovementRegistryEdge",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ContinualImprovementRegistry",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v3/*: any*/),
+                  (v4/*: any*/),
+                  (v5/*: any*/),
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Audit",
+                    "kind": "LinkedField",
+                    "name": "audit",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      (v10/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Framework",
+                        "kind": "LinkedField",
+                        "name": "framework",
+                        "plural": false,
+                        "selections": [
+                          (v10/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  (v11/*: any*/),
+                  (v12/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "ContinualImprovementRegistryGraphCreateMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "CreateContinualImprovementRegistryPayload",
+        "kind": "LinkedField",
+        "name": "createContinualImprovementRegistry",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ContinualImprovementRegistryEdge",
+            "kind": "LinkedField",
+            "name": "continualImprovementRegistryEdge",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ContinualImprovementRegistry",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v3/*: any*/),
+                  (v4/*: any*/),
+                  (v5/*: any*/),
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Audit",
+                    "kind": "LinkedField",
+                    "name": "audit",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      (v10/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Framework",
+                        "kind": "LinkedField",
+                        "name": "framework",
+                        "plural": false,
+                        "selections": [
+                          (v10/*: any*/),
+                          (v3/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  (v11/*: any*/),
+                  (v12/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "prependEdge",
+            "key": "",
+            "kind": "LinkedHandle",
+            "name": "continualImprovementRegistryEdge",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "a3ddc3c5ac1f55ef2db276ae41ae213b",
+    "id": null,
+    "metadata": {},
+    "name": "ContinualImprovementRegistryGraphCreateMutation",
+    "operationKind": "mutation",
+    "text": "mutation ContinualImprovementRegistryGraphCreateMutation(\n  $input: CreateContinualImprovementRegistryInput!\n) {\n  createContinualImprovementRegistry(input: $input) {\n    continualImprovementRegistryEdge {\n      node {\n        id\n        referenceId\n        description\n        source\n        targetDate\n        status\n        priority\n        audit {\n          id\n          name\n          framework {\n            name\n            id\n          }\n        }\n        owner {\n          id\n          fullName\n        }\n        createdAt\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "5d9e0771c839c6c220dabdb00267a7ee";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/ContinualImprovementRegistryGraphDeleteMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/ContinualImprovementRegistryGraphDeleteMutation.graphql.ts
@@ -1,0 +1,132 @@
+/**
+ * @generated SignedSource<<55e8b0de5cb20c0a479bb4862aab4677>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type DeleteContinualImprovementRegistryInput = {
+  continualImprovementRegistryId: string;
+};
+export type ContinualImprovementRegistryGraphDeleteMutation$variables = {
+  connections: ReadonlyArray<string>;
+  input: DeleteContinualImprovementRegistryInput;
+};
+export type ContinualImprovementRegistryGraphDeleteMutation$data = {
+  readonly deleteContinualImprovementRegistry: {
+    readonly deletedContinualImprovementRegistryId: string;
+  };
+};
+export type ContinualImprovementRegistryGraphDeleteMutation = {
+  response: ContinualImprovementRegistryGraphDeleteMutation$data;
+  variables: ContinualImprovementRegistryGraphDeleteMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "deletedContinualImprovementRegistryId",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ContinualImprovementRegistryGraphDeleteMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteContinualImprovementRegistryPayload",
+        "kind": "LinkedField",
+        "name": "deleteContinualImprovementRegistry",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "ContinualImprovementRegistryGraphDeleteMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteContinualImprovementRegistryPayload",
+        "kind": "LinkedField",
+        "name": "deleteContinualImprovementRegistry",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "deleteEdge",
+            "key": "",
+            "kind": "ScalarHandle",
+            "name": "deletedContinualImprovementRegistryId",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "1f973509e72c6a1a729e98a8b4240b25",
+    "id": null,
+    "metadata": {},
+    "name": "ContinualImprovementRegistryGraphDeleteMutation",
+    "operationKind": "mutation",
+    "text": "mutation ContinualImprovementRegistryGraphDeleteMutation(\n  $input: DeleteContinualImprovementRegistryInput!\n) {\n  deleteContinualImprovementRegistry(input: $input) {\n    deletedContinualImprovementRegistryId\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "7c7512a398e2391d5f7f083395cc6395";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/ContinualImprovementRegistryGraphListQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/ContinualImprovementRegistryGraphListQuery.graphql.ts
@@ -1,0 +1,340 @@
+/**
+ * @generated SignedSource<<7d5f12e454c99687263a264f59618ebe>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ContinualImprovementRegistryGraphListQuery$variables = {
+  organizationId: string;
+};
+export type ContinualImprovementRegistryGraphListQuery$data = {
+  readonly node: {
+    readonly " $fragmentSpreads": FragmentRefs<"ContinualImprovementRegistriesPageFragment">;
+  };
+};
+export type ContinualImprovementRegistryGraphListQuery = {
+  response: ContinualImprovementRegistryGraphListQuery$data;
+  variables: ContinualImprovementRegistryGraphListQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "organizationId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "organizationId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10
+  }
+],
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ContinualImprovementRegistryGraphListQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "ContinualImprovementRegistriesPageFragment"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ContinualImprovementRegistryGraphListQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": (v4/*: any*/),
+                "concreteType": "ContinualImprovementRegistryConnection",
+                "kind": "LinkedField",
+                "name": "continualImprovementRegistries",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "totalCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "ContinualImprovementRegistryEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ContinualImprovementRegistry",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v3/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "referenceId",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "description",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "source",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "targetDate",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "status",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "priority",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Audit",
+                            "kind": "LinkedField",
+                            "name": "audit",
+                            "plural": false,
+                            "selections": [
+                              (v3/*: any*/),
+                              (v5/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Framework",
+                                "kind": "LinkedField",
+                                "name": "framework",
+                                "plural": false,
+                                "selections": [
+                                  (v3/*: any*/),
+                                  (v5/*: any*/)
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "People",
+                            "kind": "LinkedField",
+                            "name": "owner",
+                            "plural": false,
+                            "selections": [
+                              (v3/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "fullName",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "createdAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "updatedAt",
+                            "storageKey": null
+                          },
+                          (v2/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "cursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageInfo",
+                    "kind": "LinkedField",
+                    "name": "pageInfo",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "hasNextPage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "endCursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ClientExtension",
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "__id",
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ],
+                "storageKey": "continualImprovementRegistries(first:10)"
+              },
+              {
+                "alias": null,
+                "args": (v4/*: any*/),
+                "filters": null,
+                "handle": "connection",
+                "key": "ContinualImprovementRegistriesPage_continualImprovementRegistries",
+                "kind": "LinkedHandle",
+                "name": "continualImprovementRegistries"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "875ae8e8faf73c6c1672d6c033e8dcf0",
+    "id": null,
+    "metadata": {},
+    "name": "ContinualImprovementRegistryGraphListQuery",
+    "operationKind": "query",
+    "text": "query ContinualImprovementRegistryGraphListQuery(\n  $organizationId: ID!\n) {\n  node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      ...ContinualImprovementRegistriesPageFragment\n    }\n    id\n  }\n}\n\nfragment ContinualImprovementRegistriesPageFragment on Organization {\n  id\n  continualImprovementRegistries(first: 10) {\n    totalCount\n    edges {\n      node {\n        id\n        referenceId\n        description\n        source\n        targetDate\n        status\n        priority\n        audit {\n          id\n          name\n          framework {\n            id\n            name\n          }\n        }\n        owner {\n          id\n          fullName\n        }\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "1098fc11629892073fbe6d7561b229e3";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/ContinualImprovementRegistryGraphNodeQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/ContinualImprovementRegistryGraphNodeQuery.graphql.ts
@@ -1,0 +1,291 @@
+/**
+ * @generated SignedSource<<6ac0e2eaa895ed1c2409e524e0333ab6>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type ContinualImprovementRegistriesPriority = "HIGH" | "LOW" | "MEDIUM";
+export type ContinualImprovementRegistriesStatus = "CLOSED" | "IN_PROGRESS" | "OPEN";
+export type ContinualImprovementRegistryGraphNodeQuery$variables = {
+  continualImprovementRegistryId: string;
+};
+export type ContinualImprovementRegistryGraphNodeQuery$data = {
+  readonly node: {
+    readonly audit?: {
+      readonly framework: {
+        readonly id: string;
+        readonly name: string;
+      };
+      readonly id: string;
+      readonly name: string | null | undefined;
+    };
+    readonly createdAt?: any;
+    readonly description?: string | null | undefined;
+    readonly id?: string;
+    readonly organization?: {
+      readonly id: string;
+      readonly name: string;
+    };
+    readonly owner?: {
+      readonly fullName: string;
+      readonly id: string;
+    };
+    readonly priority?: ContinualImprovementRegistriesPriority;
+    readonly referenceId?: string;
+    readonly source?: string | null | undefined;
+    readonly status?: ContinualImprovementRegistriesStatus;
+    readonly targetDate?: any | null | undefined;
+    readonly updatedAt?: any;
+  };
+};
+export type ContinualImprovementRegistryGraphNodeQuery = {
+  response: ContinualImprovementRegistryGraphNodeQuery$data;
+  variables: ContinualImprovementRegistryGraphNodeQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "continualImprovementRegistryId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "continualImprovementRegistryId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "referenceId",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "description",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "source",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "targetDate",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "status",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "priority",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v10 = [
+  (v2/*: any*/),
+  (v9/*: any*/)
+],
+v11 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Audit",
+  "kind": "LinkedField",
+  "name": "audit",
+  "plural": false,
+  "selections": [
+    (v2/*: any*/),
+    (v9/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Framework",
+      "kind": "LinkedField",
+      "name": "framework",
+      "plural": false,
+      "selections": (v10/*: any*/),
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "People",
+  "kind": "LinkedField",
+  "name": "owner",
+  "plural": false,
+  "selections": [
+    (v2/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "fullName",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v13 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Organization",
+  "kind": "LinkedField",
+  "name": "organization",
+  "plural": false,
+  "selections": (v10/*: any*/),
+  "storageKey": null
+},
+v14 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+},
+v15 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "updatedAt",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ContinualImprovementRegistryGraphNodeQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/),
+              (v11/*: any*/),
+              (v12/*: any*/),
+              (v13/*: any*/),
+              (v14/*: any*/),
+              (v15/*: any*/)
+            ],
+            "type": "ContinualImprovementRegistry",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ContinualImprovementRegistryGraphNodeQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/),
+              (v11/*: any*/),
+              (v12/*: any*/),
+              (v13/*: any*/),
+              (v14/*: any*/),
+              (v15/*: any*/)
+            ],
+            "type": "ContinualImprovementRegistry",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "c3195d70369df1a1ca2a73fdfef37039",
+    "id": null,
+    "metadata": {},
+    "name": "ContinualImprovementRegistryGraphNodeQuery",
+    "operationKind": "query",
+    "text": "query ContinualImprovementRegistryGraphNodeQuery(\n  $continualImprovementRegistryId: ID!\n) {\n  node(id: $continualImprovementRegistryId) {\n    __typename\n    ... on ContinualImprovementRegistry {\n      id\n      referenceId\n      description\n      source\n      targetDate\n      status\n      priority\n      audit {\n        id\n        name\n        framework {\n          id\n          name\n        }\n      }\n      owner {\n        id\n        fullName\n      }\n      organization {\n        id\n        name\n      }\n      createdAt\n      updatedAt\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "fe3c3ff44245eb13ea465ae5809ef5bd";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/ContinualImprovementRegistryGraphUpdateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/ContinualImprovementRegistryGraphUpdateMutation.graphql.ts
@@ -1,0 +1,236 @@
+/**
+ * @generated SignedSource<<befa49d6faa4e4c918a2ff8a85c7fe7d>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type ContinualImprovementRegistriesPriority = "HIGH" | "LOW" | "MEDIUM";
+export type ContinualImprovementRegistriesStatus = "CLOSED" | "IN_PROGRESS" | "OPEN";
+export type UpdateContinualImprovementRegistryInput = {
+  auditId?: string | null | undefined;
+  description?: string | null | undefined;
+  id: string;
+  ownerId?: string | null | undefined;
+  priority?: ContinualImprovementRegistriesPriority | null | undefined;
+  referenceId?: string | null | undefined;
+  source?: string | null | undefined;
+  status?: ContinualImprovementRegistriesStatus | null | undefined;
+  targetDate?: any | null | undefined;
+};
+export type ContinualImprovementRegistryGraphUpdateMutation$variables = {
+  input: UpdateContinualImprovementRegistryInput;
+};
+export type ContinualImprovementRegistryGraphUpdateMutation$data = {
+  readonly updateContinualImprovementRegistry: {
+    readonly continualImprovementRegistry: {
+      readonly audit: {
+        readonly framework: {
+          readonly id: string;
+          readonly name: string;
+        };
+        readonly id: string;
+        readonly name: string | null | undefined;
+      };
+      readonly description: string | null | undefined;
+      readonly id: string;
+      readonly owner: {
+        readonly fullName: string;
+        readonly id: string;
+      };
+      readonly priority: ContinualImprovementRegistriesPriority;
+      readonly referenceId: string;
+      readonly source: string | null | undefined;
+      readonly status: ContinualImprovementRegistriesStatus;
+      readonly targetDate: any | null | undefined;
+      readonly updatedAt: any;
+    };
+  };
+};
+export type ContinualImprovementRegistryGraphUpdateMutation = {
+  response: ContinualImprovementRegistryGraphUpdateMutation$data;
+  variables: ContinualImprovementRegistryGraphUpdateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v3 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "UpdateContinualImprovementRegistryPayload",
+    "kind": "LinkedField",
+    "name": "updateContinualImprovementRegistry",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "ContinualImprovementRegistry",
+        "kind": "LinkedField",
+        "name": "continualImprovementRegistry",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "referenceId",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "description",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "source",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "targetDate",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "status",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "priority",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "People",
+            "kind": "LinkedField",
+            "name": "owner",
+            "plural": false,
+            "selections": [
+              (v1/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "fullName",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Audit",
+            "kind": "LinkedField",
+            "name": "audit",
+            "plural": false,
+            "selections": [
+              (v1/*: any*/),
+              (v2/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Framework",
+                "kind": "LinkedField",
+                "name": "framework",
+                "plural": false,
+                "selections": [
+                  (v1/*: any*/),
+                  (v2/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "updatedAt",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ContinualImprovementRegistryGraphUpdateMutation",
+    "selections": (v3/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ContinualImprovementRegistryGraphUpdateMutation",
+    "selections": (v3/*: any*/)
+  },
+  "params": {
+    "cacheID": "b3b3931c06838e6e60f33738be340d6c",
+    "id": null,
+    "metadata": {},
+    "name": "ContinualImprovementRegistryGraphUpdateMutation",
+    "operationKind": "mutation",
+    "text": "mutation ContinualImprovementRegistryGraphUpdateMutation(\n  $input: UpdateContinualImprovementRegistryInput!\n) {\n  updateContinualImprovementRegistry(input: $input) {\n    continualImprovementRegistry {\n      id\n      referenceId\n      description\n      source\n      targetDate\n      status\n      priority\n      owner {\n        id\n        fullName\n      }\n      audit {\n        id\n        name\n        framework {\n          id\n          name\n        }\n      }\n      updatedAt\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "e59f20342fd5532b1815034334cd5560";
+
+export default node;

--- a/apps/console/src/layouts/MainLayout.tsx
+++ b/apps/console/src/layouts/MainLayout.tsx
@@ -18,6 +18,7 @@ import {
   IconListStack,
   IconBox,
   IconShield,
+  IconRotateCw,
   Layout,
   SidebarItem,
   UserDropdown as UserDropdownRoot,
@@ -144,12 +145,17 @@ export function MainLayout() {
           <SidebarItem
             label={__("Nonconformity Registries")}
             icon={IconCrossLargeX}
-            to={`${prefix}/nonconformityRegistries`}
+            to={`${prefix}/nonconformity-registries`}
           />
           <SidebarItem
             label={__("Compliance Registries")}
             icon={IconBook}
-            to={`${prefix}/complianceRegistries`}
+            to={`${prefix}/compliance-registries`}
+          />
+           <SidebarItem
+            label={__("Continual Improvement Registries")}
+            icon={IconRotateCw}
+            to={`${prefix}/continual-improvement-registries`}
           />
           <SidebarItem
             label={__("Snapshots")}

--- a/apps/console/src/pages/organizations/complianceRegistries/ComplianceRegistriesPage.tsx
+++ b/apps/console/src/pages/organizations/complianceRegistries/ComplianceRegistriesPage.tsx
@@ -221,7 +221,7 @@ function RegistryRow({
   };
 
   return (
-    <Tr to={`/organizations/${organizationId}/complianceRegistries/${registry.id}`}>
+    <Tr to={`/organizations/${organizationId}/compliance-registries/${registry.id}`}>
       <Td>
         <span className="font-mono text-sm">{registry.referenceId}</span>
       </Td>
@@ -233,11 +233,11 @@ function RegistryRow({
         </Badge>
       </Td>
       <Td>
-          {registry.audit?.name
-            ? `${registry.audit.framework.name} - ${registry.audit.name}`
-            : registry.audit?.framework.name || "-"
-          }
-        </Td>
+        {registry.audit.name
+          ? `${registry.audit.framework.name} - ${registry.audit.name}`
+          : registry.audit.framework.name
+        }
+      </Td>
       <Td>{registry.owner?.fullName || "-"}</Td>
       <Td>
         {registry.dueDate ? (

--- a/apps/console/src/pages/organizations/complianceRegistries/ComplianceRegistryDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/complianceRegistries/ComplianceRegistryDetailsPage.tsx
@@ -133,7 +133,7 @@ export default function ComplianceRegistryDetailsPage(props: Props) {
         <div>
                      <Breadcrumb
              items={[
-               { label: __("Compliance Registries"), to: "../complianceRegistries" },
+               { label: __("Compliance Registries"), to: "../compliance-registries" },
                { label: registry.referenceId! },
              ]}
            />

--- a/apps/console/src/pages/organizations/continualImprovementRegistries/ContinualImprovementRegistriesPage.tsx
+++ b/apps/console/src/pages/organizations/continualImprovementRegistries/ContinualImprovementRegistriesPage.tsx
@@ -1,0 +1,276 @@
+import {
+  Button,
+  IconPlusLarge,
+  PageHeader,
+  Card,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Badge,
+  ActionDropdown,
+  DropdownItem,
+  IconTrashCan,
+  Table,
+  useConfirm,
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { usePageTitle } from "@probo/hooks";
+import {
+  ConnectionHandler,
+  graphql,
+  usePaginationFragment,
+  usePreloadedQuery,
+  useMutation,
+  type PreloadedQuery,
+} from "react-relay";
+import { useOrganizationId } from "/hooks/useOrganizationId";
+import { CreateContinualImprovementRegistryDialog } from "./dialogs/CreateContinualImprovementRegistryDialog";
+import { deleteContinualImprovementRegistryMutation, ContinualImprovementRegistriesConnectionKey } from "../../../hooks/graph/ContinualImprovementRegistryGraph";
+import { sprintf, promisifyMutation, getStatusVariant, getStatusLabel } from "@probo/helpers";
+import type { NodeOf } from "/types";
+import type { ContinualImprovementRegistriesPageQuery } from "./__generated__/ContinualImprovementRegistriesPageQuery.graphql";
+import type {
+  ContinualImprovementRegistriesPageFragment$key,
+  ContinualImprovementRegistriesPageFragment$data,
+} from "./__generated__/ContinualImprovementRegistriesPageFragment.graphql";
+
+interface ContinualImprovementRegistriesPageProps {
+  queryRef: PreloadedQuery<ContinualImprovementRegistriesPageQuery>;
+}
+
+const continualImprovementRegistriesPageFragment = graphql`
+  fragment ContinualImprovementRegistriesPageFragment on Organization
+  @refetchable(queryName: "ContinualImprovementRegistriesPageRefetchQuery")
+  @argumentDefinitions(
+    first: { type: "Int", defaultValue: 10 }
+    after: { type: "CursorKey" }
+  ) {
+    id
+    continualImprovementRegistries(first: $first, after: $after)
+      @connection(key: "ContinualImprovementRegistriesPage_continualImprovementRegistries") {
+      __id
+      totalCount
+      edges {
+        node {
+          id
+          referenceId
+          description
+          source
+          targetDate
+          status
+          priority
+          audit {
+            id
+            name
+            framework {
+              id
+              name
+            }
+          }
+          owner {
+            id
+            fullName
+          }
+          createdAt
+          updatedAt
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+`;
+
+export default function ContinualImprovementRegistriesPage({ queryRef }: ContinualImprovementRegistriesPageProps) {
+  const { __ } = useTranslate();
+  const organizationId = useOrganizationId();
+
+  usePageTitle(__("Continual Improvement Registries"));
+
+  const organization = usePreloadedQuery(
+    graphql`
+      query ContinualImprovementRegistriesPageQuery($organizationId: ID!) {
+        node(id: $organizationId) {
+          ... on Organization {
+            ...ContinualImprovementRegistriesPageFragment
+          }
+        }
+      }
+    `,
+    queryRef
+  );
+
+  const {
+    data,
+    loadNext,
+    hasNext,
+    isLoadingNext,
+  } = usePaginationFragment<
+    ContinualImprovementRegistriesPageQuery,
+    ContinualImprovementRegistriesPageFragment$key
+  >(continualImprovementRegistriesPageFragment, organization.node);
+  if (!data) {
+    return <div>{__("Organization not found")}</div>;
+  }
+
+  const connectionId = ConnectionHandler.getConnectionID(
+    organizationId,
+    ContinualImprovementRegistriesConnectionKey
+  );
+  const registries = data?.continualImprovementRegistries?.edges?.map((edge) => edge.node) ?? [];
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title={__("Continual Improvement Registries")} description={__("Manage your continual improvement registry entries")}>
+        <CreateContinualImprovementRegistryDialog
+          organizationId={organizationId}
+          connectionId={connectionId}
+        >
+          <Button icon={IconPlusLarge}>
+            {__("Add continual improvement registry")}
+          </Button>
+        </CreateContinualImprovementRegistryDialog>
+      </PageHeader>
+
+      {registries.length > 0 ? (
+        <Card>
+          <Table>
+            <Thead>
+              <Tr>
+                <Th>{__("Reference ID")}</Th>
+                <Th>{__("Description")}</Th>
+                <Th>{__("Status")}</Th>
+                <Th>{__("Priority")}</Th>
+                <Th>{__("Audit")}</Th>
+                <Th>{__("Owner")}</Th>
+                <Th>{__("Target Date")}</Th>
+                <Th>{__("Actions")}</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {registries.map((registry) => (
+                <RegistryRow
+                  key={registry.id}
+                  registry={registry}
+                  connectionId={connectionId}
+                />
+              ))}
+            </Tbody>
+          </Table>
+
+          {hasNext && (
+            <div className="p-4 border-t">
+              <Button
+                variant="secondary"
+                onClick={() => loadNext(10)}
+                disabled={isLoadingNext}
+              >
+                {isLoadingNext ? __("Loading...") : __("Load more")}
+              </Button>
+            </div>
+          )}
+        </Card>
+      ) : (
+        <Card padded>
+          <div className="text-center py-12">
+            <h3 className="text-lg font-semibold mb-2">
+              {__("No continual improvement registry entries yet")}
+            </h3>
+            <p className="text-txt-tertiary mb-4">
+              {__("Create your first continual improvement registry entry to get started.")}
+            </p>
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function RegistryRow({
+  registry,
+  connectionId,
+}: {
+  registry: NodeOf<NonNullable<ContinualImprovementRegistriesPageFragment$data['continualImprovementRegistries']>>;
+  connectionId: string;
+}) {
+  const organizationId = useOrganizationId();
+  const { __ } = useTranslate();
+  const [deleteRegistry] = useMutation(deleteContinualImprovementRegistryMutation);
+  const confirm = useConfirm();
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString();
+  };
+
+  const handleDelete = () => {
+    confirm(
+      () =>
+        promisifyMutation(deleteRegistry)({
+          variables: {
+            input: {
+              continualImprovementRegistryId: registry.id,
+            },
+            connections: [connectionId],
+          },
+        }),
+      {
+        message: sprintf(
+          __(
+            "This will permanently delete the continual improvement registry entry %s. This action cannot be undone."
+          ),
+          registry.referenceId
+        ),
+      }
+    );
+  };
+
+  return (
+    <Tr to={`/organizations/${organizationId}/continual-improvement-registries/${registry.id}`}>
+      <Td>
+        <span className="font-mono text-sm">{registry.referenceId}</span>
+      </Td>
+      <Td>{registry.description || "-"}</Td>
+      <Td>
+        <Badge variant={getStatusVariant(registry.status)}>
+          {getStatusLabel(registry.status)}
+        </Badge>
+      </Td>
+      <Td>
+        <Badge variant={registry.priority === "HIGH" ? "danger" : registry.priority === "MEDIUM" ? "warning" : "success"}>
+          {registry.priority === "HIGH" ? __("High") : registry.priority === "MEDIUM" ? __("Medium") : __("Low")}
+        </Badge>
+      </Td>
+      <Td>
+        {registry.audit.name
+          ? `${registry.audit.framework.name} - ${registry.audit.name}`
+          : registry.audit.framework.name
+        }
+      </Td>
+      <Td>{registry.owner?.fullName || "-"}</Td>
+      <Td>
+        {registry.targetDate ? (
+          <time dateTime={registry.targetDate}>
+            {formatDate(registry.targetDate)}
+          </time>
+        ) : (
+          <span className="text-txt-tertiary">{__("No target date")}</span>
+        )}
+      </Td>
+      <Td noLink width={50} className="text-end">
+        <ActionDropdown>
+          <DropdownItem
+            icon={IconTrashCan}
+            variant="danger"
+            onSelect={handleDelete}
+          >
+            {__("Delete")}
+          </DropdownItem>
+        </ActionDropdown>
+      </Td>
+    </Tr>
+  );
+}

--- a/apps/console/src/pages/organizations/continualImprovementRegistries/ContinualImprovementRegistryDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/continualImprovementRegistries/ContinualImprovementRegistryDetailsPage.tsx
@@ -1,0 +1,287 @@
+import {
+  ConnectionHandler,
+  usePreloadedQuery,
+  type PreloadedQuery,
+} from "react-relay";
+import {
+  continualImprovementRegistryNodeQuery,
+  useDeleteContinualImprovementRegistry,
+  useUpdateContinualImprovementRegistry,
+  ContinualImprovementRegistriesConnectionKey,
+} from "../../../hooks/graph/ContinualImprovementRegistryGraph";
+import {
+  ActionDropdown,
+  Badge,
+  Breadcrumb,
+  Button,
+  DropdownItem,
+  Field,
+  Option,
+  Input,
+  Card,
+  Textarea,
+  useToast,
+  Select,
+  Label,
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { useOrganizationId } from "/hooks/useOrganizationId";
+import { PeopleSelectField } from "/components/form/PeopleSelectField";
+import { AuditSelectField } from "/components/form/AuditSelectField";
+import { useFormWithSchema } from "/hooks/useFormWithSchema";
+import { Controller } from "react-hook-form";
+import z from "zod";
+import { getStatusVariant, getStatusLabel, formatDatetime } from "@probo/helpers";
+import type { ContinualImprovementRegistryGraphNodeQuery } from "/hooks/graph/__generated__/ContinualImprovementRegistryGraphNodeQuery.graphql";
+
+const updateRegistrySchema = z.object({
+  referenceId: z.string().min(1, "Reference ID is required"),
+  description: z.string().optional(),
+  source: z.string().optional(),
+  targetDate: z.string().optional(),
+  status: z.enum(["OPEN", "IN_PROGRESS", "CLOSED"]),
+  priority: z.enum(["LOW", "MEDIUM", "HIGH"]),
+  ownerId: z.string().min(1, "Owner is required"),
+  auditId: z.string().min(1, "Audit is required"),
+});
+
+type Props = {
+  queryRef: PreloadedQuery<ContinualImprovementRegistryGraphNodeQuery>;
+};
+
+export default function ContinualImprovementRegistryDetailsPage(props: Props) {
+  const data = usePreloadedQuery<ContinualImprovementRegistryGraphNodeQuery>(continualImprovementRegistryNodeQuery, props.queryRef);
+  const registry = data.node;
+  const { __ } = useTranslate();
+  const { toast } = useToast();
+  const organizationId = useOrganizationId();
+
+  if (!registry) {
+    return <div>{__("Continual improvement registry entry not found")}</div>;
+  }
+
+  const updateRegistry = useUpdateContinualImprovementRegistry();
+
+  const connectionId = ConnectionHandler.getConnectionID(
+    organizationId,
+    ContinualImprovementRegistriesConnectionKey
+  );
+
+  const deleteRegistry = useDeleteContinualImprovementRegistry({ id: registry.id!, referenceId: registry.referenceId! }, connectionId);
+
+  const { register, handleSubmit, formState, control } = useFormWithSchema(
+    updateRegistrySchema,
+    {
+      defaultValues: {
+        referenceId: registry.referenceId || "",
+        description: registry.description || "",
+        source: registry.source || "",
+        targetDate: registry.targetDate
+          ? new Date(registry.targetDate).toISOString().split("T")[0]
+          : "",
+        status: registry.status || "OPEN",
+        priority: registry.priority || "MEDIUM",
+        ownerId: registry.owner?.id || "",
+        auditId: registry.audit?.id || "",
+      },
+    }
+  );
+
+  const onSubmit = handleSubmit(async (formData) => {
+    try {
+      await updateRegistry({
+        id: registry.id!,
+        referenceId: formData.referenceId,
+        description: formData.description || undefined,
+        source: formData.source || undefined,
+        targetDate: formatDatetime(formData.targetDate),
+        status: formData.status,
+        priority: formData.priority,
+        ownerId: formData.ownerId,
+        auditId: formData.auditId,
+      });
+
+      toast({
+        title: __("Success"),
+        description: __("Continual improvement registry entry updated successfully"),
+        variant: "success",
+      });
+    } catch (error) {
+      toast({
+        title: __("Error"),
+        description: __("Failed to update continual improvement registry entry"),
+        variant: "error",
+      });
+    }
+  });
+
+  const statusOptions = [
+    { value: "OPEN", label: __("Open") },
+    { value: "IN_PROGRESS", label: __("In Progress") },
+    { value: "CLOSED", label: __("Closed") },
+  ];
+
+  const priorityOptions = [
+    { value: "LOW", label: __("Low") },
+    { value: "MEDIUM", label: __("Medium") },
+    { value: "HIGH", label: __("High") },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <Breadcrumb
+          items={[
+            { label: __("Continual Improvement Registries"), to: "../continual-improvement-registries" },
+            { label: registry.referenceId! },
+          ]}
+        />
+        <ActionDropdown>
+          <DropdownItem onClick={deleteRegistry} variant="danger">
+            {__("Delete")}
+          </DropdownItem>
+        </ActionDropdown>
+      </div>
+
+      <Card>
+        <div className="p-6">
+          <div className="mb-6">
+            <div className="flex items-center gap-4">
+              <h1 className="text-2xl font-bold">{registry.referenceId}</h1>
+              <Badge variant={getStatusVariant(registry.status || "OPEN")}>
+                {getStatusLabel(registry.status || "OPEN")}
+              </Badge>
+              <Badge variant={registry.priority === "HIGH" ? "danger" : registry.priority === "MEDIUM" ? "warning" : "success"}>
+                {registry.priority === "HIGH" ? __("High") : registry.priority === "MEDIUM" ? __("Medium") : __("Low")}
+              </Badge>
+            </div>
+          </div>
+
+          <form onSubmit={onSubmit} className="space-y-4">
+            <Field
+              label={__("Reference ID")}
+              {...register("referenceId")}
+              error={formState.errors.referenceId?.message}
+              required
+            />
+
+            <AuditSelectField
+              organizationId={organizationId}
+              control={control}
+              name="auditId"
+              label={__("Audit")}
+              error={formState.errors.auditId?.message}
+              required
+            />
+
+            <div>
+              <Label>{__("Description")}</Label>
+              <Textarea
+                {...register("description")}
+                placeholder={__("Enter description")}
+                rows={3}
+              />
+              {formState.errors.description?.message && (
+                <div className="text-red-500 text-sm mt-1">
+                  {formState.errors.description.message}
+                </div>
+              )}
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <Field
+                label={__("Source")}
+                {...register("source")}
+                error={formState.errors.source?.message}
+              />
+
+              <div>
+                <Label>{__("Target Date")}</Label>
+                <Input
+                  type="date"
+                  {...register("targetDate")}
+                />
+                {formState.errors.targetDate?.message && (
+                  <div className="text-red-500 text-sm mt-1">
+                    {formState.errors.targetDate.message}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <PeopleSelectField
+              organizationId={organizationId}
+              control={control}
+              name="ownerId"
+              label={__("Owner")}
+              error={formState.errors.ownerId?.message}
+              required
+            />
+
+            <div className="grid grid-cols-2 gap-4">
+              <Controller
+                control={control}
+                name="status"
+                render={({ field }) => (
+                  <div>
+                    <Label>{__("Status")} *</Label>
+                    <Select
+                      value={field.value}
+                      onValueChange={field.onChange}
+                    >
+                      {statusOptions.map((option) => (
+                        <Option key={option.value} value={option.value}>
+                          {option.label}
+                        </Option>
+                      ))}
+                    </Select>
+                    {formState.errors.status?.message && (
+                      <div className="text-red-500 text-sm mt-1">
+                        {formState.errors.status.message}
+                      </div>
+                    )}
+                  </div>
+                )}
+              />
+
+              <Controller
+                control={control}
+                name="priority"
+                render={({ field }) => (
+                  <div>
+                    <Label>{__("Priority")} *</Label>
+                    <Select
+                      value={field.value}
+                      onValueChange={field.onChange}
+                    >
+                      {priorityOptions.map((option) => (
+                        <Option key={option.value} value={option.value}>
+                          {option.label}
+                        </Option>
+                      ))}
+                    </Select>
+                    {formState.errors.priority?.message && (
+                      <div className="text-red-500 text-sm mt-1">
+                        {formState.errors.priority.message}
+                      </div>
+                    )}
+                  </div>
+                )}
+              />
+            </div>
+
+            <div className="flex justify-end pt-4">
+              <Button
+                type="submit"
+                variant="primary"
+                disabled={formState.isSubmitting}
+              >
+                {formState.isSubmitting ? __("Saving...") : __("Save Changes")}
+              </Button>
+            </div>
+          </form>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/apps/console/src/pages/organizations/continualImprovementRegistries/__generated__/ContinualImprovementRegistriesPageFragment.graphql.ts
+++ b/apps/console/src/pages/organizations/continualImprovementRegistries/__generated__/ContinualImprovementRegistriesPageFragment.graphql.ts
@@ -1,0 +1,323 @@
+/**
+ * @generated SignedSource<<9fd7671cda5fa074c27aebb356782846>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type ContinualImprovementRegistriesPriority = "HIGH" | "LOW" | "MEDIUM";
+export type ContinualImprovementRegistriesStatus = "CLOSED" | "IN_PROGRESS" | "OPEN";
+import { FragmentRefs } from "relay-runtime";
+export type ContinualImprovementRegistriesPageFragment$data = {
+  readonly continualImprovementRegistries: {
+    readonly __id: string;
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly audit: {
+          readonly framework: {
+            readonly id: string;
+            readonly name: string;
+          };
+          readonly id: string;
+          readonly name: string | null | undefined;
+        };
+        readonly createdAt: any;
+        readonly description: string | null | undefined;
+        readonly id: string;
+        readonly owner: {
+          readonly fullName: string;
+          readonly id: string;
+        };
+        readonly priority: ContinualImprovementRegistriesPriority;
+        readonly referenceId: string;
+        readonly source: string | null | undefined;
+        readonly status: ContinualImprovementRegistriesStatus;
+        readonly targetDate: any | null | undefined;
+        readonly updatedAt: any;
+      };
+    }>;
+    readonly pageInfo: {
+      readonly endCursor: any | null | undefined;
+      readonly hasNextPage: boolean;
+    };
+    readonly totalCount: number;
+  };
+  readonly id: string;
+  readonly " $fragmentType": "ContinualImprovementRegistriesPageFragment";
+};
+export type ContinualImprovementRegistriesPageFragment$key = {
+  readonly " $data"?: ContinualImprovementRegistriesPageFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"ContinualImprovementRegistriesPageFragment">;
+};
+
+import ContinualImprovementRegistriesPageRefetchQuery_graphql from './ContinualImprovementRegistriesPageRefetchQuery.graphql';
+
+const node: ReaderFragment = (function(){
+var v0 = [
+  "continualImprovementRegistries"
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "after"
+    },
+    {
+      "defaultValue": 10,
+      "kind": "LocalArgument",
+      "name": "first"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": {
+    "connection": [
+      {
+        "count": "first",
+        "cursor": "after",
+        "direction": "forward",
+        "path": (v0/*: any*/)
+      }
+    ],
+    "refetch": {
+      "connection": {
+        "forward": {
+          "count": "first",
+          "cursor": "after"
+        },
+        "backward": null,
+        "path": (v0/*: any*/)
+      },
+      "fragmentPathInResult": [
+        "node"
+      ],
+      "operation": ContinualImprovementRegistriesPageRefetchQuery_graphql,
+      "identifierInfo": {
+        "identifierField": "id",
+        "identifierQueryVariableName": "id"
+      }
+    }
+  },
+  "name": "ContinualImprovementRegistriesPageFragment",
+  "selections": [
+    (v1/*: any*/),
+    {
+      "alias": "continualImprovementRegistries",
+      "args": null,
+      "concreteType": "ContinualImprovementRegistryConnection",
+      "kind": "LinkedField",
+      "name": "__ContinualImprovementRegistriesPage_continualImprovementRegistries_connection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "totalCount",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ContinualImprovementRegistryEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "ContinualImprovementRegistry",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                (v1/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "referenceId",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "description",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "source",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "targetDate",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "status",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "priority",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "Audit",
+                  "kind": "LinkedField",
+                  "name": "audit",
+                  "plural": false,
+                  "selections": [
+                    (v1/*: any*/),
+                    (v2/*: any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "Framework",
+                      "kind": "LinkedField",
+                      "name": "framework",
+                      "plural": false,
+                      "selections": [
+                        (v1/*: any*/),
+                        (v2/*: any*/)
+                      ],
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "People",
+                  "kind": "LinkedField",
+                  "name": "owner",
+                  "plural": false,
+                  "selections": [
+                    (v1/*: any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "fullName",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "createdAt",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "updatedAt",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "__typename",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "cursor",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "kind": "LinkedField",
+          "name": "pageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasNextPage",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "endCursor",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "kind": "ClientExtension",
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "__id",
+              "storageKey": null
+            }
+          ]
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Organization",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "838609d0047346d2031f045e5227c9f0";
+
+export default node;

--- a/apps/console/src/pages/organizations/continualImprovementRegistries/__generated__/ContinualImprovementRegistriesPageQuery.graphql.ts
+++ b/apps/console/src/pages/organizations/continualImprovementRegistries/__generated__/ContinualImprovementRegistriesPageQuery.graphql.ts
@@ -1,0 +1,340 @@
+/**
+ * @generated SignedSource<<a226745b4849f8d82a412528166f860f>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ContinualImprovementRegistriesPageQuery$variables = {
+  organizationId: string;
+};
+export type ContinualImprovementRegistriesPageQuery$data = {
+  readonly node: {
+    readonly " $fragmentSpreads": FragmentRefs<"ContinualImprovementRegistriesPageFragment">;
+  };
+};
+export type ContinualImprovementRegistriesPageQuery = {
+  response: ContinualImprovementRegistriesPageQuery$data;
+  variables: ContinualImprovementRegistriesPageQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "organizationId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "organizationId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10
+  }
+],
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ContinualImprovementRegistriesPageQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "ContinualImprovementRegistriesPageFragment"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ContinualImprovementRegistriesPageQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": (v4/*: any*/),
+                "concreteType": "ContinualImprovementRegistryConnection",
+                "kind": "LinkedField",
+                "name": "continualImprovementRegistries",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "totalCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "ContinualImprovementRegistryEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ContinualImprovementRegistry",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v3/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "referenceId",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "description",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "source",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "targetDate",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "status",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "priority",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Audit",
+                            "kind": "LinkedField",
+                            "name": "audit",
+                            "plural": false,
+                            "selections": [
+                              (v3/*: any*/),
+                              (v5/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Framework",
+                                "kind": "LinkedField",
+                                "name": "framework",
+                                "plural": false,
+                                "selections": [
+                                  (v3/*: any*/),
+                                  (v5/*: any*/)
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "People",
+                            "kind": "LinkedField",
+                            "name": "owner",
+                            "plural": false,
+                            "selections": [
+                              (v3/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "fullName",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "createdAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "updatedAt",
+                            "storageKey": null
+                          },
+                          (v2/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "cursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageInfo",
+                    "kind": "LinkedField",
+                    "name": "pageInfo",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "hasNextPage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "endCursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ClientExtension",
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "__id",
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ],
+                "storageKey": "continualImprovementRegistries(first:10)"
+              },
+              {
+                "alias": null,
+                "args": (v4/*: any*/),
+                "filters": null,
+                "handle": "connection",
+                "key": "ContinualImprovementRegistriesPage_continualImprovementRegistries",
+                "kind": "LinkedHandle",
+                "name": "continualImprovementRegistries"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "734faf62cb9f84c554159d0cc35a9eda",
+    "id": null,
+    "metadata": {},
+    "name": "ContinualImprovementRegistriesPageQuery",
+    "operationKind": "query",
+    "text": "query ContinualImprovementRegistriesPageQuery(\n  $organizationId: ID!\n) {\n  node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      ...ContinualImprovementRegistriesPageFragment\n    }\n    id\n  }\n}\n\nfragment ContinualImprovementRegistriesPageFragment on Organization {\n  id\n  continualImprovementRegistries(first: 10) {\n    totalCount\n    edges {\n      node {\n        id\n        referenceId\n        description\n        source\n        targetDate\n        status\n        priority\n        audit {\n          id\n          name\n          framework {\n            id\n            name\n          }\n        }\n        owner {\n          id\n          fullName\n        }\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "fcece87ab1695d20b6b5f31379e67f1d";
+
+export default node;

--- a/apps/console/src/pages/organizations/continualImprovementRegistries/__generated__/ContinualImprovementRegistriesPageRefetchQuery.graphql.ts
+++ b/apps/console/src/pages/organizations/continualImprovementRegistries/__generated__/ContinualImprovementRegistriesPageRefetchQuery.graphql.ts
@@ -1,0 +1,350 @@
+/**
+ * @generated SignedSource<<4ae1cc52a5065a1ee1c8edf344307b6c>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ContinualImprovementRegistriesPageRefetchQuery$variables = {
+  after?: any | null | undefined;
+  first?: number | null | undefined;
+  id: string;
+};
+export type ContinualImprovementRegistriesPageRefetchQuery$data = {
+  readonly node: {
+    readonly " $fragmentSpreads": FragmentRefs<"ContinualImprovementRegistriesPageFragment">;
+  };
+};
+export type ContinualImprovementRegistriesPageRefetchQuery = {
+  response: ContinualImprovementRegistriesPageRefetchQuery$data;
+  variables: ContinualImprovementRegistriesPageRefetchQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "after"
+  },
+  {
+    "defaultValue": 10,
+    "kind": "LocalArgument",
+    "name": "first"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "after"
+  },
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "first"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ContinualImprovementRegistriesPageRefetchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "args": (v2/*: any*/),
+            "kind": "FragmentSpread",
+            "name": "ContinualImprovementRegistriesPageFragment"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ContinualImprovementRegistriesPageRefetchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          (v4/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": (v2/*: any*/),
+                "concreteType": "ContinualImprovementRegistryConnection",
+                "kind": "LinkedField",
+                "name": "continualImprovementRegistries",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "totalCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "ContinualImprovementRegistryEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ContinualImprovementRegistry",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v4/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "referenceId",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "description",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "source",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "targetDate",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "status",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "priority",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Audit",
+                            "kind": "LinkedField",
+                            "name": "audit",
+                            "plural": false,
+                            "selections": [
+                              (v4/*: any*/),
+                              (v5/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Framework",
+                                "kind": "LinkedField",
+                                "name": "framework",
+                                "plural": false,
+                                "selections": [
+                                  (v4/*: any*/),
+                                  (v5/*: any*/)
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "People",
+                            "kind": "LinkedField",
+                            "name": "owner",
+                            "plural": false,
+                            "selections": [
+                              (v4/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "fullName",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "createdAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "updatedAt",
+                            "storageKey": null
+                          },
+                          (v3/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "cursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageInfo",
+                    "kind": "LinkedField",
+                    "name": "pageInfo",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "hasNextPage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "endCursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ClientExtension",
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "__id",
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": (v2/*: any*/),
+                "filters": null,
+                "handle": "connection",
+                "key": "ContinualImprovementRegistriesPage_continualImprovementRegistries",
+                "kind": "LinkedHandle",
+                "name": "continualImprovementRegistries"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "2b886a4652dbea93012ef2306451ea4e",
+    "id": null,
+    "metadata": {},
+    "name": "ContinualImprovementRegistriesPageRefetchQuery",
+    "operationKind": "query",
+    "text": "query ContinualImprovementRegistriesPageRefetchQuery(\n  $after: CursorKey\n  $first: Int = 10\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...ContinualImprovementRegistriesPageFragment_2HEEH6\n    id\n  }\n}\n\nfragment ContinualImprovementRegistriesPageFragment_2HEEH6 on Organization {\n  id\n  continualImprovementRegistries(first: $first, after: $after) {\n    totalCount\n    edges {\n      node {\n        id\n        referenceId\n        description\n        source\n        targetDate\n        status\n        priority\n        audit {\n          id\n          name\n          framework {\n            id\n            name\n          }\n        }\n        owner {\n          id\n          fullName\n        }\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "838609d0047346d2031f045e5227c9f0";
+
+export default node;

--- a/apps/console/src/pages/organizations/continualImprovementRegistries/dialogs/CreateContinualImprovementRegistryDialog.tsx
+++ b/apps/console/src/pages/organizations/continualImprovementRegistries/dialogs/CreateContinualImprovementRegistryDialog.tsx
@@ -1,0 +1,248 @@
+import { type ReactNode } from "react";
+import {
+  Button,
+  Field,
+  useToast,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  useDialogRef,
+  Textarea,
+  Breadcrumb,
+  Label,
+  Select,
+  Option,
+  Input,
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { z } from "zod";
+import { useFormWithSchema } from "/hooks/useFormWithSchema";
+import { useCreateContinualImprovementRegistry } from "../../../../hooks/graph/ContinualImprovementRegistryGraph";
+import { PeopleSelectField } from "/components/form/PeopleSelectField";
+import { AuditSelectField } from "/components/form/AuditSelectField";
+import { Controller } from "react-hook-form";
+import { formatDatetime } from "@probo/helpers";
+
+const schema = z.object({
+  referenceId: z.string().min(1, "Reference ID is required"),
+  description: z.string().optional(),
+  source: z.string().optional(),
+  auditId: z.string().min(1, "Audit is required"),
+  ownerId: z.string().min(1, "Owner is required"),
+  targetDate: z.string().optional(),
+  status: z.enum(["OPEN", "IN_PROGRESS", "CLOSED"]),
+  priority: z.enum(["LOW", "MEDIUM", "HIGH"]),
+});
+
+type FormData = z.infer<typeof schema>;
+
+interface CreateContinualImprovementRegistryDialogProps {
+  children: ReactNode;
+  organizationId: string;
+  connectionId?: string;
+}
+
+export function CreateContinualImprovementRegistryDialog({
+  children,
+  organizationId,
+  connectionId,
+}: CreateContinualImprovementRegistryDialogProps) {
+  const { __ } = useTranslate();
+  const { toast } = useToast();
+  const dialogRef = useDialogRef();
+
+  const createRegistry = useCreateContinualImprovementRegistry(connectionId || "");
+
+  const { register, handleSubmit, formState, reset, control } = useFormWithSchema(schema, {
+    defaultValues: {
+      referenceId: "",
+      description: "",
+      source: "",
+      auditId: "",
+      ownerId: "",
+      targetDate: "",
+      status: "OPEN" as const,
+      priority: "MEDIUM" as const,
+    },
+  });
+
+  const onSubmit = handleSubmit(async (formData: FormData) => {
+    try {
+      await createRegistry({
+        organizationId,
+        referenceId: formData.referenceId,
+        description: formData.description || undefined,
+        source: formData.source || undefined,
+        auditId: formData.auditId,
+        ownerId: formData.ownerId,
+        targetDate: formatDatetime(formData.targetDate),
+        status: formData.status,
+        priority: formData.priority,
+      });
+
+      toast({
+        title: __("Success"),
+        description: __("Continual improvement registry entry created successfully"),
+        variant: "success",
+      });
+
+      reset();
+      dialogRef.current?.close();
+    } catch (error) {
+      toast({
+        title: __("Error"),
+        description: __("Failed to create continual improvement registry entry"),
+        variant: "error",
+      });
+    }
+  });
+
+  const statusOptions = [
+    { value: "OPEN", label: __("Open") },
+    { value: "IN_PROGRESS", label: __("In Progress") },
+    { value: "CLOSED", label: __("Closed") },
+  ];
+
+  const priorityOptions = [
+    { value: "LOW", label: __("Low") },
+    { value: "MEDIUM", label: __("Medium") },
+    { value: "HIGH", label: __("High") },
+  ];
+
+  return (
+    <Dialog
+      ref={dialogRef}
+      trigger={children}
+      title={<Breadcrumb items={[__("Registries"), __("Create Continual Improvement Entry")]} />}
+      className="max-w-2xl"
+    >
+      <form onSubmit={onSubmit}>
+        <DialogContent padded className="space-y-4">
+          <Field
+            label={__("Reference ID")}
+            {...register("referenceId")}
+            placeholder="CI-001"
+            error={formState.errors.referenceId?.message}
+            required
+          />
+
+          <AuditSelectField
+            organizationId={organizationId}
+            control={control}
+            name="auditId"
+            label={__("Audit")}
+            error={formState.errors.auditId?.message}
+            required
+          />
+
+          <div>
+            <Label>{__("Description")}</Label>
+            <Textarea
+              {...register("description")}
+              placeholder={__("Enter description of the continual improvement item")}
+              rows={3}
+            />
+            {formState.errors.description?.message && (
+              <div className="text-red-500 text-sm mt-1">
+                {formState.errors.description.message}
+              </div>
+            )}
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <Field
+              label={__("Source")}
+              {...register("source")}
+              placeholder={__("Enter source")}
+              error={formState.errors.source?.message}
+            />
+
+            <div>
+              <Label>{__("Target Date")}</Label>
+              <Input
+                type="date"
+                {...register("targetDate")}
+              />
+              {formState.errors.targetDate?.message && (
+                <div className="text-red-500 text-sm mt-1">
+                  {formState.errors.targetDate.message}
+                </div>
+              )}
+            </div>
+          </div>
+
+          <PeopleSelectField
+            organizationId={organizationId}
+            control={control}
+            name="ownerId"
+            label={__("Owner")}
+            error={formState.errors.ownerId?.message}
+            required
+          />
+
+          <div className="grid grid-cols-2 gap-4">
+            <Controller
+              control={control}
+              name="status"
+              render={({ field }) => (
+                <div>
+                  <Label>{__("Status")} *</Label>
+                  <Select
+                    value={field.value}
+                    onValueChange={field.onChange}
+                  >
+                    {statusOptions.map((option) => (
+                      <Option key={option.value} value={option.value}>
+                        {option.label}
+                      </Option>
+                    ))}
+                  </Select>
+                  {formState.errors.status?.message && (
+                    <div className="text-red-500 text-sm mt-1">
+                      {formState.errors.status.message}
+                    </div>
+                  )}
+                </div>
+              )}
+            />
+
+            <Controller
+              control={control}
+              name="priority"
+              render={({ field }) => (
+                <div>
+                  <Label>{__("Priority")} *</Label>
+                  <Select
+                    value={field.value}
+                    onValueChange={field.onChange}
+                  >
+                    {priorityOptions.map((option) => (
+                      <Option key={option.value} value={option.value}>
+                        {option.label}
+                      </Option>
+                    ))}
+                  </Select>
+                  {formState.errors.priority?.message && (
+                    <div className="text-red-500 text-sm mt-1">
+                      {formState.errors.priority.message}
+                    </div>
+                  )}
+                </div>
+              )}
+            />
+          </div>
+        </DialogContent>
+
+        <DialogFooter>
+          <Button
+            type="submit"
+            variant="primary"
+            disabled={formState.isSubmitting}
+          >
+            {formState.isSubmitting ? __("Creating...") : __("Create Entry")}
+          </Button>
+        </DialogFooter>
+      </form>
+    </Dialog>
+  );
+}

--- a/apps/console/src/pages/organizations/nonconformityRegistries/NonconformityRegistriesPage.tsx
+++ b/apps/console/src/pages/organizations/nonconformityRegistries/NonconformityRegistriesPage.tsx
@@ -225,7 +225,7 @@ function RegistryRow({
   };
 
   return (
-    <Tr to={`/organizations/${organizationId}/nonconformityRegistries/${registry.id}`}>
+    <Tr to={`/organizations/${organizationId}/nonconformity-registries/${registry.id}`}>
       <Td>
         <span className="font-mono text-sm">{registry.referenceId}</span>
       </Td>

--- a/apps/console/src/pages/organizations/nonconformityRegistries/NonconformityRegistryDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/nonconformityRegistries/NonconformityRegistryDetailsPage.tsx
@@ -125,7 +125,7 @@ export default function NonconformityRegistryDetailsPage(props: Props) {
         items={[
           {
             label: __("Nonconformity Registries"),
-            to: `/organizations/${organizationId}/nonconformityRegistries`,
+            to: `/organizations/${organizationId}/nonconformity-registries`,
           },
           {
             label: registry.referenceId || __("Unknown Nonconformity Registry"),

--- a/apps/console/src/routes.tsx
+++ b/apps/console/src/routes.tsx
@@ -32,6 +32,7 @@ import { trustCenterRoutes } from "./routes/trustCenterRoutes.ts";
 import { nonconformityRegistryRoutes } from "./routes/nonconformityRegistryRoutes.ts";
 import { complianceRegistryRoutes } from "./routes/complianceRegistryRoutes.ts";
 import { snapshotsRoutes } from "./routes/snapshotsRoutes.ts";
+import { continualImprovementRegistryRoutes } from "./routes/continualImprovementRegistryRoutes.ts";
 import { lazy } from "@probo/react-lazy";
 
 export type AppRoute = Omit<RouteObject, "Component" | "children"> & {
@@ -155,6 +156,7 @@ const routes = [
       ...nonconformityRegistryRoutes,
       ...complianceRegistryRoutes,
       ...snapshotsRoutes,
+      ...continualImprovementRegistryRoutes,
       ...trustCenterRoutes,
       {
         path: "*",

--- a/apps/console/src/routes/complianceRegistryRoutes.ts
+++ b/apps/console/src/routes/complianceRegistryRoutes.ts
@@ -7,7 +7,7 @@ import type { AppRoute } from "/routes";
 
 export const complianceRegistryRoutes = [
   {
-    path: "complianceRegistries",
+    path: "compliance-registries",
     fallback: PageSkeleton,
     queryLoader: ({ organizationId }: { organizationId: string }) =>
       loadQuery(relayEnvironment, complianceRegistriesQuery, { organizationId }),
@@ -16,7 +16,7 @@ export const complianceRegistryRoutes = [
     ),
   },
   {
-    path: "complianceRegistries/:registryId",
+    path: "compliance-registries/:registryId",
     fallback: PageSkeleton,
     queryLoader: (params: Record<string, string>) =>
       loadQuery(relayEnvironment, complianceRegistryNodeQuery, {

--- a/apps/console/src/routes/continualImprovementRegistryRoutes.ts
+++ b/apps/console/src/routes/continualImprovementRegistryRoutes.ts
@@ -1,0 +1,29 @@
+import { loadQuery } from "react-relay";
+import { relayEnvironment } from "/providers/RelayProviders";
+import { PageSkeleton } from "/components/skeletons/PageSkeleton";
+import { lazy } from "@probo/react-lazy";
+import { continualImprovementRegistriesQuery, continualImprovementRegistryNodeQuery } from "/hooks/graph/ContinualImprovementRegistryGraph";
+import type { AppRoute } from "/routes";
+
+export const continualImprovementRegistryRoutes = [
+  {
+    path: "continual-improvement-registries",
+    fallback: PageSkeleton,
+    queryLoader: ({ organizationId }: { organizationId: string }) =>
+      loadQuery(relayEnvironment, continualImprovementRegistriesQuery, { organizationId }),
+    Component: lazy(
+      () => import("/pages/organizations/continualImprovementRegistries/ContinualImprovementRegistriesPage")
+    ),
+  },
+  {
+    path: "continual-improvement-registries/:registryId",
+    fallback: PageSkeleton,
+    queryLoader: (params: Record<string, string>) =>
+      loadQuery(relayEnvironment, continualImprovementRegistryNodeQuery, {
+        continualImprovementRegistryId: params.registryId
+      }),
+    Component: lazy(
+      () => import("/pages/organizations/continualImprovementRegistries/ContinualImprovementRegistryDetailsPage")
+    ),
+  },
+] satisfies AppRoute[];

--- a/apps/console/src/routes/nonconformityRegistryRoutes.ts
+++ b/apps/console/src/routes/nonconformityRegistryRoutes.ts
@@ -7,7 +7,7 @@ import type { AppRoute } from "/routes";
 
 export const nonconformityRegistryRoutes= [
   {
-    path: "nonconformityRegistries",
+    path: "nonconformity-registries",
     fallback: PageSkeleton,
     queryLoader: ({ organizationId }: { organizationId: string }) =>
       loadQuery(relayEnvironment, nonconformityRegistriesQuery, { organizationId }),
@@ -16,7 +16,7 @@ export const nonconformityRegistryRoutes= [
     ),
   },
   {
-    path: "nonconformityRegistries/:registryId",
+    path: "nonconformity-registries/:registryId",
     fallback: PageSkeleton,
     queryLoader: (params: Record<string, string>) =>
       loadQuery(relayEnvironment, nonconformityRegistryNodeQuery, {

--- a/packages/ui/src/Atoms/Icons/IconRotateCw.tsx
+++ b/packages/ui/src/Atoms/Icons/IconRotateCw.tsx
@@ -1,0 +1,10 @@
+import type {IconProps} from "./type.ts";
+
+// Source: Lucide Icons "rotate-cw" - https://lucide.dev/icons/rotate-cw
+// Licensed under ISC License
+export function IconRotateCw({size = 24, className}: IconProps) {
+  return <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className} xmlns="http://www.w3.org/2000/svg">
+    <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"/>
+    <path d="M21 3v5h-5"/>
+  </svg>
+}

--- a/packages/ui/src/Atoms/Icons/index.tsx
+++ b/packages/ui/src/Atoms/Icons/index.tsx
@@ -78,3 +78,4 @@ export { IconChevronUp } from "./IconChevronUp.tsx";
 export { IconBlock } from "./IconBlock.tsx";
 export { IconChevronDown } from "./IconChevronDown.tsx";
 export { IconPageCross } from "./IconPageCross.tsx";
+export { IconRotateCw } from "./IconRotateCw.tsx";

--- a/packages/ui/src/Atoms/Sidebar/Sidebar.tsx
+++ b/packages/ui/src/Atoms/Sidebar/Sidebar.tsx
@@ -17,7 +17,7 @@ export function Sidebar({ children }: PropsWithChildren) {
             <aside
                 className={clsx(
                     "border-r border-border-solid relative pt-16 flex-none",
-                    open ? "px-4 w-[270px]" : "px-2",
+                    open ? "px-4 w-[330px]" : "px-2",
                 )}
             >
                 {children}

--- a/pkg/coredata/continual_improvement_registries.go
+++ b/pkg/coredata/continual_improvement_registries.go
@@ -1,0 +1,324 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"time"
+
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+	"github.com/jackc/pgx/v5"
+	"go.gearno.de/kit/pg"
+)
+
+type (
+	ContinualImprovementRegistry struct {
+		ID             gid.GID                                `db:"id"`
+		OrganizationID gid.GID                                `db:"organization_id"`
+		ReferenceID    string                                 `db:"reference_id"`
+		Description    *string                                `db:"description"`
+		AuditID        gid.GID                                `db:"audit_id"`
+		Source         *string                                `db:"source"`
+		OwnerID        gid.GID                                `db:"owner_id"`
+		TargetDate     *time.Time                             `db:"target_date"`
+		Status         ContinualImprovementRegistriesStatus   `db:"status"`
+		Priority       ContinualImprovementRegistriesPriority `db:"priority"`
+		CreatedAt      time.Time                              `db:"created_at"`
+		UpdatedAt      time.Time                              `db:"updated_at"`
+	}
+
+	ContinualImprovementRegistries []*ContinualImprovementRegistry
+)
+
+func (cir *ContinualImprovementRegistry) CursorKey(field ContinualImprovementRegistriesOrderField) page.CursorKey {
+	switch field {
+	case ContinualImprovementRegistriesOrderFieldCreatedAt:
+		return page.NewCursorKey(cir.ID, cir.CreatedAt)
+	case ContinualImprovementRegistriesOrderFieldTargetDate:
+		return page.NewCursorKey(cir.ID, cir.TargetDate)
+	case ContinualImprovementRegistriesOrderFieldStatus:
+		return page.NewCursorKey(cir.ID, cir.Status)
+	case ContinualImprovementRegistriesOrderFieldPriority:
+		return page.NewCursorKey(cir.ID, cir.Priority)
+	case ContinualImprovementRegistriesOrderFieldReferenceId:
+		return page.NewCursorKey(cir.ID, cir.ReferenceID)
+	}
+
+	panic(fmt.Sprintf("unsupported order by: %s", field))
+}
+
+func (cir *ContinualImprovementRegistry) LoadByID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	continualImprovementRegistryID gid.GID,
+) error {
+	q := `
+SELECT
+	id,
+	organization_id,
+	reference_id,
+	description,
+	audit_id,
+	source,
+	owner_id,
+	target_date,
+	status,
+	priority,
+	created_at,
+	updated_at
+FROM
+	continual_improvement_registries
+WHERE
+	%s
+	AND id = @continual_improvement_registry_id
+LIMIT 1;
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"continual_improvement_registry_id": continualImprovementRegistryID}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query continual improvement registry: %w", err)
+	}
+
+	registry, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[ContinualImprovementRegistry])
+	if err != nil {
+		return fmt.Errorf("cannot collect continual improvement registry: %w", err)
+	}
+
+	*cir = registry
+
+	return nil
+}
+
+func (cirs *ContinualImprovementRegistries) CountByOrganizationID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	organizationID gid.GID,
+) (int, error) {
+	q := `
+SELECT
+	COUNT(id)
+FROM
+	continual_improvement_registries
+WHERE
+	%s
+	AND organization_id = @organization_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	row := conn.QueryRow(ctx, q, args)
+
+	var count int
+	err := row.Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("cannot count continual improvement registries: %w", err)
+	}
+
+	return count, nil
+}
+
+func (cirs *ContinualImprovementRegistries) LoadByOrganizationID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	organizationID gid.GID,
+	cursor *page.Cursor[ContinualImprovementRegistriesOrderField],
+) error {
+	q := `
+SELECT
+	id,
+	organization_id,
+	reference_id,
+	description,
+	audit_id,
+	source,
+	owner_id,
+	target_date,
+	status,
+	priority,
+	created_at,
+	updated_at
+FROM
+	continual_improvement_registries
+WHERE
+	%s
+	AND organization_id = @organization_id
+	AND %s
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, cursor.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query continual improvement registries: %w", err)
+	}
+
+	registries, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[ContinualImprovementRegistry])
+	if err != nil {
+		return fmt.Errorf("cannot collect continual improvement registries: %w", err)
+	}
+
+	*cirs = registries
+
+	return nil
+}
+
+func (cir *ContinualImprovementRegistry) Insert(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+INSERT INTO continual_improvement_registries (
+	id,
+	tenant_id,
+	organization_id,
+	reference_id,
+	description,
+	audit_id,
+	source,
+	owner_id,
+	target_date,
+	status,
+	priority,
+	created_at,
+	updated_at
+) VALUES (
+	@id,
+	@tenant_id,
+	@organization_id,
+	@reference_id,
+	@description,
+	@audit_id,
+	@source,
+	@owner_id,
+	@target_date,
+	@status,
+	@priority,
+	@created_at,
+	@updated_at
+)
+`
+
+	args := pgx.StrictNamedArgs{
+		"id":              cir.ID,
+		"tenant_id":       scope.GetTenantID(),
+		"organization_id": cir.OrganizationID,
+		"reference_id":    cir.ReferenceID,
+		"description":     cir.Description,
+		"audit_id":        cir.AuditID,
+		"source":          cir.Source,
+		"owner_id":        cir.OwnerID,
+		"target_date":     cir.TargetDate,
+		"status":          cir.Status,
+		"priority":        cir.Priority,
+		"created_at":      cir.CreatedAt,
+		"updated_at":      cir.UpdatedAt,
+	}
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot insert continual improvement registry: %w", err)
+	}
+
+	return nil
+}
+
+func (cir *ContinualImprovementRegistry) Update(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+UPDATE continual_improvement_registries SET
+	reference_id = @reference_id,
+	description = @description,
+	audit_id = @audit_id,
+	source = @source,
+	owner_id = @owner_id,
+	target_date = @target_date,
+	status = @status,
+	priority = @priority,
+	updated_at = @updated_at
+WHERE
+	%s
+	AND id = @id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"id":           cir.ID,
+		"reference_id": cir.ReferenceID,
+		"description":  cir.Description,
+		"audit_id":     cir.AuditID,
+		"source":       cir.Source,
+		"owner_id":     cir.OwnerID,
+		"target_date":  cir.TargetDate,
+		"status":       cir.Status,
+		"priority":     cir.Priority,
+		"updated_at":   cir.UpdatedAt,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot update continual improvement registry: %w", err)
+	}
+
+	return nil
+}
+
+func (cir *ContinualImprovementRegistry) Delete(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+DELETE FROM continual_improvement_registries
+WHERE
+	%s
+	AND id = @id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"id": cir.ID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete continual improvement registry: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/continual_improvement_registries_order_field.go
+++ b/pkg/coredata/continual_improvement_registries_order_field.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"fmt"
+)
+
+type ContinualImprovementRegistriesOrderField string
+
+const (
+	ContinualImprovementRegistriesOrderFieldCreatedAt   ContinualImprovementRegistriesOrderField = "CREATED_AT"
+	ContinualImprovementRegistriesOrderFieldTargetDate  ContinualImprovementRegistriesOrderField = "TARGET_DATE"
+	ContinualImprovementRegistriesOrderFieldStatus      ContinualImprovementRegistriesOrderField = "STATUS"
+	ContinualImprovementRegistriesOrderFieldPriority    ContinualImprovementRegistriesOrderField = "PRIORITY"
+	ContinualImprovementRegistriesOrderFieldReferenceId ContinualImprovementRegistriesOrderField = "REFERENCE_ID"
+)
+
+func (p ContinualImprovementRegistriesOrderField) Column() string {
+	return string(p)
+}
+
+func (p ContinualImprovementRegistriesOrderField) String() string {
+	return string(p)
+}
+
+func (p ContinualImprovementRegistriesOrderField) MarshalText() ([]byte, error) {
+	return []byte(p.String()), nil
+}
+
+func (p *ContinualImprovementRegistriesOrderField) UnmarshalText(text []byte) error {
+	val := string(text)
+	switch val {
+	case string(ContinualImprovementRegistriesOrderFieldCreatedAt),
+		string(ContinualImprovementRegistriesOrderFieldTargetDate),
+		string(ContinualImprovementRegistriesOrderFieldStatus),
+		string(ContinualImprovementRegistriesOrderFieldPriority),
+		string(ContinualImprovementRegistriesOrderFieldReferenceId):
+		*p = ContinualImprovementRegistriesOrderField(val)
+		return nil
+	}
+	return fmt.Errorf("invalid ContinualImprovementRegistriesOrderField value: %q", val)
+}

--- a/pkg/coredata/continual_improvement_registries_priority.go
+++ b/pkg/coredata/continual_improvement_registries_priority.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+type ContinualImprovementRegistriesPriority string
+
+const (
+	ContinualImprovementRegistriesPriorityLow    ContinualImprovementRegistriesPriority = "LOW"
+	ContinualImprovementRegistriesPriorityMedium ContinualImprovementRegistriesPriority = "MEDIUM"
+	ContinualImprovementRegistriesPriorityHigh   ContinualImprovementRegistriesPriority = "HIGH"
+)
+
+func (cirp ContinualImprovementRegistriesPriority) String() string {
+	return string(cirp)
+}
+
+func (cirp *ContinualImprovementRegistriesPriority) Scan(value any) error {
+	var s string
+	switch v := value.(type) {
+	case string:
+		s = v
+	case []byte:
+		s = string(v)
+	default:
+		return fmt.Errorf("unsupported type for ContinualImprovementRegistriesPriority: %T", value)
+	}
+
+	switch s {
+	case "LOW":
+		*cirp = ContinualImprovementRegistriesPriorityLow
+	case "MEDIUM":
+		*cirp = ContinualImprovementRegistriesPriorityMedium
+	case "HIGH":
+		*cirp = ContinualImprovementRegistriesPriorityHigh
+	default:
+		return fmt.Errorf("invalid ContinualImprovementRegistriesPriority value: %q", s)
+	}
+	return nil
+}
+
+func (cirp ContinualImprovementRegistriesPriority) Value() (driver.Value, error) {
+	return cirp.String(), nil
+}

--- a/pkg/coredata/continual_improvement_registries_status.go
+++ b/pkg/coredata/continual_improvement_registries_status.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+type ContinualImprovementRegistriesStatus string
+
+const (
+	ContinualImprovementRegistriesStatusOpen       ContinualImprovementRegistriesStatus = "OPEN"
+	ContinualImprovementRegistriesStatusInProgress ContinualImprovementRegistriesStatus = "IN_PROGRESS"
+	ContinualImprovementRegistriesStatusClosed     ContinualImprovementRegistriesStatus = "CLOSED"
+)
+
+func (cirs ContinualImprovementRegistriesStatus) String() string {
+	return string(cirs)
+}
+
+func (cirs *ContinualImprovementRegistriesStatus) Scan(value any) error {
+	var s string
+	switch v := value.(type) {
+	case string:
+		s = v
+	case []byte:
+		s = string(v)
+	default:
+		return fmt.Errorf("unsupported type for ContinualImprovementRegistriesStatus: %T", value)
+	}
+
+	switch s {
+	case "OPEN":
+		*cirs = ContinualImprovementRegistriesStatusOpen
+	case "IN_PROGRESS":
+		*cirs = ContinualImprovementRegistriesStatusInProgress
+	case "CLOSED":
+		*cirs = ContinualImprovementRegistriesStatusClosed
+	default:
+		return fmt.Errorf("invalid ContinualImprovementRegistriesStatus value: %q", s)
+	}
+	return nil
+}
+
+func (cirs ContinualImprovementRegistriesStatus) Value() (driver.Value, error) {
+	return cirs.String(), nil
+}

--- a/pkg/coredata/entity_type_reg.go
+++ b/pkg/coredata/entity_type_reg.go
@@ -47,4 +47,5 @@ const (
 	ComplianceRegistryEntityType
 	VendorServiceEntityType
 	SnapshotEntityType
+	ContinualImprovementRegistryEntityType
 )

--- a/pkg/coredata/migrations/20250826T121441Z.sql
+++ b/pkg/coredata/migrations/20250826T121441Z.sql
@@ -1,0 +1,45 @@
+CREATE TYPE continual_improvement_registries_status AS ENUM (
+    'OPEN',
+    'IN_PROGRESS',
+    'CLOSED'
+);
+
+CREATE TYPE continual_improvement_registries_priority AS ENUM (
+    'LOW',
+    'MEDIUM',
+    'HIGH'
+);
+
+CREATE TABLE continual_improvement_registries (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    organization_id TEXT NOT NULL,
+    reference_id TEXT NOT NULL,
+    description TEXT,
+    audit_id TEXT NOT NULL,
+    source TEXT,
+    owner_id TEXT NOT NULL,
+    target_date DATE,
+    status continual_improvement_registries_status NOT NULL,
+    priority continual_improvement_registries_priority NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+
+    CONSTRAINT continual_improvement_registries_organization_id_fkey
+        FOREIGN KEY (organization_id)
+        REFERENCES organizations(id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+
+    CONSTRAINT continual_improvement_registries_owner_id_fkey
+        FOREIGN KEY (owner_id)
+        REFERENCES peoples(id)
+        ON UPDATE CASCADE
+        ON DELETE RESTRICT,
+
+    CONSTRAINT continual_improvement_registries_audit_id_fkey
+        FOREIGN KEY (audit_id)
+        REFERENCES audits(id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+);

--- a/pkg/probo/continual_improvement_registries_service.go
+++ b/pkg/probo/continual_improvement_registries_service.go
@@ -1,0 +1,279 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package probo
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+	"go.gearno.de/kit/pg"
+)
+
+type ContinualImprovementRegistriesService struct {
+	svc *TenantService
+}
+
+type (
+	CreateContinualImprovementRegistryRequest struct {
+		OrganizationID gid.GID
+		ReferenceID    string
+		Description    *string
+		AuditID        gid.GID
+		Source         *string
+		OwnerID        gid.GID
+		TargetDate     *time.Time
+		Status         *coredata.ContinualImprovementRegistriesStatus
+		Priority       *coredata.ContinualImprovementRegistriesPriority
+	}
+
+	UpdateContinualImprovementRegistryRequest struct {
+		ID          gid.GID
+		ReferenceID *string
+		Description **string
+		AuditID     *gid.GID
+		Source      **string
+		OwnerID     *gid.GID
+		TargetDate  **time.Time
+		Status      *coredata.ContinualImprovementRegistriesStatus
+		Priority    *coredata.ContinualImprovementRegistriesPriority
+	}
+)
+
+func (s ContinualImprovementRegistriesService) Get(
+	ctx context.Context,
+	continualImprovementRegistryID gid.GID,
+) (*coredata.ContinualImprovementRegistry, error) {
+	registry := &coredata.ContinualImprovementRegistry{}
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			if err := registry.LoadByID(ctx, conn, s.svc.scope, continualImprovementRegistryID); err != nil {
+				return fmt.Errorf("cannot load continual improvement registry: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return registry, nil
+}
+
+func (s *ContinualImprovementRegistriesService) Create(
+	ctx context.Context,
+	req *CreateContinualImprovementRegistryRequest,
+) (*coredata.ContinualImprovementRegistry, error) {
+	now := time.Now()
+
+	registry := &coredata.ContinualImprovementRegistry{
+		ID:             gid.New(s.svc.scope.GetTenantID(), coredata.ContinualImprovementRegistryEntityType),
+		OrganizationID: req.OrganizationID,
+		ReferenceID:    req.ReferenceID,
+		Description:    req.Description,
+		AuditID:        req.AuditID,
+		Source:         req.Source,
+		OwnerID:        req.OwnerID,
+		TargetDate:     req.TargetDate,
+		Status:         *req.Status,
+		Priority:       *req.Priority,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	err := s.svc.pg.WithTx(
+		ctx,
+		func(conn pg.Conn) error {
+			organization := &coredata.Organization{}
+			if err := organization.LoadByID(ctx, conn, s.svc.scope, req.OrganizationID); err != nil {
+				return fmt.Errorf("cannot load organization: %w", err)
+			}
+
+			audit := &coredata.Audit{}
+			if err := audit.LoadByID(ctx, conn, s.svc.scope, req.AuditID); err != nil {
+				return fmt.Errorf("cannot load audit: %w", err)
+			}
+
+			owner := &coredata.People{}
+			if err := owner.LoadByID(ctx, conn, s.svc.scope, req.OwnerID); err != nil {
+				return fmt.Errorf("cannot load owner: %w", err)
+			}
+
+			if err := registry.Insert(ctx, conn, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot insert continual improvement registry: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return registry, nil
+}
+
+func (s *ContinualImprovementRegistriesService) Update(
+	ctx context.Context,
+	req *UpdateContinualImprovementRegistryRequest,
+) (*coredata.ContinualImprovementRegistry, error) {
+	registry := &coredata.ContinualImprovementRegistry{}
+
+	err := s.svc.pg.WithTx(
+		ctx,
+		func(conn pg.Conn) error {
+			if err := registry.LoadByID(ctx, conn, s.svc.scope, req.ID); err != nil {
+				return fmt.Errorf("cannot load continual improvement registry: %w", err)
+			}
+
+			if req.ReferenceID != nil {
+				registry.ReferenceID = *req.ReferenceID
+			}
+
+			if req.Description != nil {
+				registry.Description = *req.Description
+			}
+
+			if req.AuditID != nil {
+				audit := &coredata.Audit{}
+				if err := audit.LoadByID(ctx, conn, s.svc.scope, *req.AuditID); err != nil {
+					return fmt.Errorf("cannot load audit: %w", err)
+				}
+				registry.AuditID = *req.AuditID
+			}
+
+			if req.Source != nil {
+				registry.Source = *req.Source
+			}
+
+			if req.OwnerID != nil {
+				owner := &coredata.People{}
+				if err := owner.LoadByID(ctx, conn, s.svc.scope, *req.OwnerID); err != nil {
+					return fmt.Errorf("cannot load owner: %w", err)
+				}
+				registry.OwnerID = *req.OwnerID
+			}
+
+			if req.TargetDate != nil {
+				registry.TargetDate = *req.TargetDate
+			}
+
+			if req.Status != nil {
+				registry.Status = *req.Status
+			}
+
+			if req.Priority != nil {
+				registry.Priority = *req.Priority
+			}
+
+			registry.UpdatedAt = time.Now()
+
+			if err := registry.Update(ctx, conn, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot update continual improvement registry: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return registry, nil
+}
+
+func (s *ContinualImprovementRegistriesService) Delete(
+	ctx context.Context,
+	continualImprovementRegistryID gid.GID,
+) error {
+	err := s.svc.pg.WithTx(
+		ctx,
+		func(conn pg.Conn) error {
+			registry := &coredata.ContinualImprovementRegistry{}
+			if err := registry.LoadByID(ctx, conn, s.svc.scope, continualImprovementRegistryID); err != nil {
+				return fmt.Errorf("cannot load continual improvement registry: %w", err)
+			}
+
+			if err := registry.Delete(ctx, conn, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot delete continual improvement registry: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	return err
+}
+
+func (s ContinualImprovementRegistriesService) CountByOrganizationID(
+	ctx context.Context,
+	organizationID gid.GID,
+) (int, error) {
+	var count int
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) (err error) {
+			registries := coredata.ContinualImprovementRegistries{}
+			count, err = registries.CountByOrganizationID(ctx, conn, s.svc.scope, organizationID)
+			if err != nil {
+				return fmt.Errorf("cannot count continual improvement registries: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+func (s ContinualImprovementRegistriesService) ListForOrganizationID(
+	ctx context.Context,
+	organizationID gid.GID,
+	cursor *page.Cursor[coredata.ContinualImprovementRegistriesOrderField],
+) (*page.Page[*coredata.ContinualImprovementRegistry, coredata.ContinualImprovementRegistriesOrderField], error) {
+	var registries coredata.ContinualImprovementRegistries
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			err := registries.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID, cursor)
+			if err != nil {
+				return fmt.Errorf("cannot load continual improvement registries: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return page.NewPage(registries, cursor), nil
+}

--- a/pkg/probo/service.go
+++ b/pkg/probo/service.go
@@ -85,6 +85,7 @@ type (
 		NonconformityRegistries           *NonconformityRegistryService
 		ComplianceRegistries              *ComplianceRegistryService
 		Snapshots                         *SnapshotService
+		ContinualImprovementRegistries    *ContinualImprovementRegistriesService
 	}
 )
 
@@ -174,12 +175,10 @@ func (s *Service) WithTenant(tenantID gid.TenantID) *TenantService {
 	tenantService.Audits = &AuditService{svc: tenantService}
 	tenantService.Reports = &ReportService{svc: tenantService}
 	tenantService.TrustCenters = &TrustCenterService{svc: tenantService}
-	tenantService.TrustCenterAccesses = &TrustCenterAccessService{
-		svc:    tenantService,
-		usrmgr: s.usrmgr,
-	}
+	tenantService.TrustCenterAccesses = &TrustCenterAccessService{svc: tenantService, usrmgr: s.usrmgr}
 	tenantService.NonconformityRegistries = &NonconformityRegistryService{svc: tenantService}
 	tenantService.ComplianceRegistries = &ComplianceRegistryService{svc: tenantService}
 	tenantService.Snapshots = &SnapshotService{svc: tenantService}
+	tenantService.ContinualImprovementRegistries = &ContinualImprovementRegistriesService{svc: tenantService}
 	return tenantService
 }

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -183,6 +183,38 @@ enum ComplianceRegistryStatus
     )
 }
 
+enum ContinualImprovementRegistriesStatus
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesStatus") {
+  OPEN
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesStatusOpen"
+    )
+  IN_PROGRESS
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesStatusInProgress"
+    )
+  CLOSED
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesStatusClosed"
+    )
+}
+
+enum ContinualImprovementRegistriesPriority
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesPriority") {
+  LOW
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesPriorityLow"
+    )
+  MEDIUM
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesPriorityMedium"
+    )
+  HIGH
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesPriorityHigh"
+    )
+}
+
 # Order Field Enums
 enum UserOrderField
   @goModel(model: "github.com/getprobo/probo/pkg/coredata.UserOrderField") {
@@ -678,6 +710,30 @@ enum ComplianceRegistryOrderField
     )
 }
 
+enum ContinualImprovementRegistriesOrderField
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesOrderField") {
+  CREATED_AT
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesOrderFieldCreatedAt"
+    )
+  REFERENCE_ID
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesOrderFieldReferenceId"
+    )
+  TARGET_DATE
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesOrderFieldTargetDate"
+    )
+  STATUS
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesOrderFieldStatus"
+    )
+  PRIORITY
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesOrderFieldPriority"
+    )
+}
+
 enum TrustCenterAccessOrderField
   @goModel(model: "github.com/getprobo/probo/pkg/coredata.TrustCenterAccessOrderField") {
   CREATED_AT
@@ -825,6 +881,14 @@ input ComplianceRegistryOrder
   ) {
   direction: OrderDirection!
   field: ComplianceRegistryOrderField!
+}
+
+input ContinualImprovementRegistriesOrder
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.ContinualImprovementRegistriesOrderBy"
+  ) {
+  direction: OrderDirection!
+  field: ContinualImprovementRegistriesOrderField!
 }
 
 input TrustCenterAccessOrder
@@ -1078,6 +1142,14 @@ type Organization implements Node {
     before: CursorKey
     orderBy: ComplianceRegistryOrder
   ): ComplianceRegistryConnection! @goField(forceResolver: true)
+
+  continualImprovementRegistries(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+    orderBy: ContinualImprovementRegistriesOrder
+  ): ContinualImprovementRegistryConnection! @goField(forceResolver: true)
 
   snapshots(
     first: Int
@@ -1539,6 +1611,21 @@ type ComplianceRegistry implements Node {
   updatedAt: Datetime!
 }
 
+type ContinualImprovementRegistry implements Node {
+  id: ID!
+  organization: Organization! @goField(forceResolver: true)
+  referenceId: String!
+  description: String
+  audit: Audit! @goField(forceResolver: true)
+  source: String
+  owner: People! @goField(forceResolver: true)
+  targetDate: Datetime
+  status: ContinualImprovementRegistriesStatus!
+  priority: ContinualImprovementRegistriesPriority!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+}
+
 type Snapshot implements Node {
   id: ID!
   organization: Organization! @goField(forceResolver: true)
@@ -1880,6 +1967,20 @@ type ComplianceRegistryEdge {
   node: ComplianceRegistry!
 }
 
+type ContinualImprovementRegistryConnection
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.ContinualImprovementRegistryConnection"
+  ) {
+  totalCount: Int! @goField(forceResolver: true)
+  edges: [ContinualImprovementRegistryEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ContinualImprovementRegistryEdge {
+  cursor: CursorKey!
+  node: ContinualImprovementRegistry!
+}
+
 type SnapshotConnection
   @goModel(
     model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.SnapshotConnection"
@@ -2150,6 +2251,17 @@ type Mutation {
   deleteComplianceRegistry(
     input: DeleteComplianceRegistryInput!
   ): DeleteComplianceRegistryPayload!
+
+  # Continual Improvement Registry mutations
+  createContinualImprovementRegistry(
+    input: CreateContinualImprovementRegistryInput!
+  ): CreateContinualImprovementRegistryPayload!
+  updateContinualImprovementRegistry(
+    input: UpdateContinualImprovementRegistryInput!
+  ): UpdateContinualImprovementRegistryPayload!
+  deleteContinualImprovementRegistry(
+    input: DeleteContinualImprovementRegistryInput!
+  ): DeleteContinualImprovementRegistryPayload!
 
   # Snapshot mutations
   createSnapshot(input: CreateSnapshotInput!): CreateSnapshotPayload!
@@ -2717,6 +2829,34 @@ input UpdateComplianceRegistryInput {
 
 input DeleteComplianceRegistryInput {
   complianceRegistryId: ID!
+}
+
+input CreateContinualImprovementRegistryInput {
+  organizationId: ID!
+  referenceId: String!
+  description: String
+  auditId: ID!
+  source: String
+  ownerId: ID!
+  targetDate: Datetime
+  status: ContinualImprovementRegistriesStatus!
+  priority: ContinualImprovementRegistriesPriority!
+}
+
+input UpdateContinualImprovementRegistryInput {
+  id: ID!
+  referenceId: String
+  description: String
+  auditId: ID
+  source: String
+  ownerId: ID
+  targetDate: Datetime
+  status: ContinualImprovementRegistriesStatus
+  priority: ContinualImprovementRegistriesPriority
+}
+
+input DeleteContinualImprovementRegistryInput {
+  continualImprovementRegistryId: ID!
 }
 
 input CreateSnapshotInput {
@@ -3448,6 +3588,18 @@ type UpdateComplianceRegistryPayload {
 
 type DeleteComplianceRegistryPayload {
   deletedComplianceRegistryId: ID!
+}
+
+type CreateContinualImprovementRegistryPayload {
+  continualImprovementRegistryEdge: ContinualImprovementRegistryEdge!
+}
+
+type UpdateContinualImprovementRegistryPayload {
+  continualImprovementRegistry: ContinualImprovementRegistry!
+}
+
+type DeleteContinualImprovementRegistryPayload {
+  deletedContinualImprovementRegistryId: ID!
 }
 
 type CreateSnapshotPayload {

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -50,6 +50,8 @@ type ResolverRoot interface {
 	AuditConnection() AuditConnectionResolver
 	ComplianceRegistry() ComplianceRegistryResolver
 	ComplianceRegistryConnection() ComplianceRegistryConnectionResolver
+	ContinualImprovementRegistry() ContinualImprovementRegistryResolver
+	ContinualImprovementRegistryConnection() ContinualImprovementRegistryConnectionResolver
 	Control() ControlResolver
 	ControlConnection() ControlConnectionResolver
 	Datum() DatumResolver
@@ -218,6 +220,32 @@ type ComplexityRoot struct {
 		Node   func(childComplexity int) int
 	}
 
+	ContinualImprovementRegistry struct {
+		Audit        func(childComplexity int) int
+		CreatedAt    func(childComplexity int) int
+		Description  func(childComplexity int) int
+		ID           func(childComplexity int) int
+		Organization func(childComplexity int) int
+		Owner        func(childComplexity int) int
+		Priority     func(childComplexity int) int
+		ReferenceID  func(childComplexity int) int
+		Source       func(childComplexity int) int
+		Status       func(childComplexity int) int
+		TargetDate   func(childComplexity int) int
+		UpdatedAt    func(childComplexity int) int
+	}
+
+	ContinualImprovementRegistryConnection struct {
+		Edges      func(childComplexity int) int
+		PageInfo   func(childComplexity int) int
+		TotalCount func(childComplexity int) int
+	}
+
+	ContinualImprovementRegistryEdge struct {
+		Cursor func(childComplexity int) int
+		Node   func(childComplexity int) int
+	}
+
 	Control struct {
 		Audits                 func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AuditOrderBy) int
 		CreatedAt              func(childComplexity int) int
@@ -255,6 +283,10 @@ type ComplexityRoot struct {
 
 	CreateComplianceRegistryPayload struct {
 		ComplianceRegistryEdge func(childComplexity int) int
+	}
+
+	CreateContinualImprovementRegistryPayload struct {
+		ContinualImprovementRegistryEdge func(childComplexity int) int
 	}
 
 	CreateControlAuditMappingPayload struct {
@@ -396,6 +428,10 @@ type ComplexityRoot struct {
 
 	DeleteComplianceRegistryPayload struct {
 		DeletedComplianceRegistryID func(childComplexity int) int
+	}
+
+	DeleteContinualImprovementRegistryPayload struct {
+		DeletedContinualImprovementRegistryID func(childComplexity int) int
 	}
 
 	DeleteControlAuditMappingPayload struct {
@@ -693,6 +729,7 @@ type ComplexityRoot struct {
 		CreateAsset                            func(childComplexity int, input types.CreateAssetInput) int
 		CreateAudit                            func(childComplexity int, input types.CreateAuditInput) int
 		CreateComplianceRegistry               func(childComplexity int, input types.CreateComplianceRegistryInput) int
+		CreateContinualImprovementRegistry     func(childComplexity int, input types.CreateContinualImprovementRegistryInput) int
 		CreateControl                          func(childComplexity int, input types.CreateControlInput) int
 		CreateControlAuditMapping              func(childComplexity int, input types.CreateControlAuditMappingInput) int
 		CreateControlDocumentMapping           func(childComplexity int, input types.CreateControlDocumentMappingInput) int
@@ -720,6 +757,7 @@ type ComplexityRoot struct {
 		DeleteAudit                            func(childComplexity int, input types.DeleteAuditInput) int
 		DeleteAuditReport                      func(childComplexity int, input types.DeleteAuditReportInput) int
 		DeleteComplianceRegistry               func(childComplexity int, input types.DeleteComplianceRegistryInput) int
+		DeleteContinualImprovementRegistry     func(childComplexity int, input types.DeleteContinualImprovementRegistryInput) int
 		DeleteControl                          func(childComplexity int, input types.DeleteControlInput) int
 		DeleteControlAuditMapping              func(childComplexity int, input types.DeleteControlAuditMappingInput) int
 		DeleteControlDocumentMapping           func(childComplexity int, input types.DeleteControlDocumentMappingInput) int
@@ -762,6 +800,7 @@ type ComplexityRoot struct {
 		UpdateAsset                            func(childComplexity int, input types.UpdateAssetInput) int
 		UpdateAudit                            func(childComplexity int, input types.UpdateAuditInput) int
 		UpdateComplianceRegistry               func(childComplexity int, input types.UpdateComplianceRegistryInput) int
+		UpdateContinualImprovementRegistry     func(childComplexity int, input types.UpdateContinualImprovementRegistryInput) int
 		UpdateControl                          func(childComplexity int, input types.UpdateControlInput) int
 		UpdateDatum                            func(childComplexity int, input types.UpdateDatumInput) int
 		UpdateDocument                         func(childComplexity int, input types.UpdateDocumentInput) int
@@ -817,28 +856,29 @@ type ComplexityRoot struct {
 	}
 
 	Organization struct {
-		Assets                  func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AssetOrderBy) int
-		Audits                  func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AuditOrderBy) int
-		ComplianceRegistries    func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ComplianceRegistryOrderBy) int
-		Connectors              func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ConnectorOrder) int
-		Controls                func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ControlOrderBy, filter *types.ControlFilter) int
-		CreatedAt               func(childComplexity int) int
-		Data                    func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DatumOrderBy, filter *types.DatumFilter) int
-		Documents               func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy, filter *types.DocumentFilter) int
-		Frameworks              func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.FrameworkOrderBy) int
-		ID                      func(childComplexity int) int
-		LogoURL                 func(childComplexity int) int
-		Measures                func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy, filter *types.MeasureFilter) int
-		Name                    func(childComplexity int) int
-		NonconformityRegistries func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.NonconformityRegistryOrderBy) int
-		Peoples                 func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.PeopleOrderBy, filter *types.PeopleFilter) int
-		Risks                   func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskOrderBy, filter *types.RiskFilter) int
-		Snapshots               func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.SnapshotOrderBy) int
-		Tasks                   func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TaskOrderBy) int
-		TrustCenter             func(childComplexity int) int
-		UpdatedAt               func(childComplexity int) int
-		Users                   func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.UserOrderBy) int
-		Vendors                 func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.VendorOrderBy) int
+		Assets                         func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AssetOrderBy) int
+		Audits                         func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AuditOrderBy) int
+		ComplianceRegistries           func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ComplianceRegistryOrderBy) int
+		Connectors                     func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ConnectorOrder) int
+		ContinualImprovementRegistries func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ContinualImprovementRegistriesOrderBy) int
+		Controls                       func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ControlOrderBy, filter *types.ControlFilter) int
+		CreatedAt                      func(childComplexity int) int
+		Data                           func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DatumOrderBy, filter *types.DatumFilter) int
+		Documents                      func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy, filter *types.DocumentFilter) int
+		Frameworks                     func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.FrameworkOrderBy) int
+		ID                             func(childComplexity int) int
+		LogoURL                        func(childComplexity int) int
+		Measures                       func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy, filter *types.MeasureFilter) int
+		Name                           func(childComplexity int) int
+		NonconformityRegistries        func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.NonconformityRegistryOrderBy) int
+		Peoples                        func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.PeopleOrderBy, filter *types.PeopleFilter) int
+		Risks                          func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskOrderBy, filter *types.RiskFilter) int
+		Snapshots                      func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.SnapshotOrderBy) int
+		Tasks                          func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TaskOrderBy) int
+		TrustCenter                    func(childComplexity int) int
+		UpdatedAt                      func(childComplexity int) int
+		Users                          func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.UserOrderBy) int
+		Vendors                        func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.VendorOrderBy) int
 	}
 
 	OrganizationConnection struct {
@@ -1058,6 +1098,10 @@ type ComplexityRoot struct {
 
 	UpdateComplianceRegistryPayload struct {
 		ComplianceRegistry func(childComplexity int) int
+	}
+
+	UpdateContinualImprovementRegistryPayload struct {
+		ContinualImprovementRegistry func(childComplexity int) int
 	}
 
 	UpdateControlPayload struct {
@@ -1367,6 +1411,16 @@ type ComplianceRegistryResolver interface {
 type ComplianceRegistryConnectionResolver interface {
 	TotalCount(ctx context.Context, obj *types.ComplianceRegistryConnection) (int, error)
 }
+type ContinualImprovementRegistryResolver interface {
+	Organization(ctx context.Context, obj *types.ContinualImprovementRegistry) (*types.Organization, error)
+
+	Audit(ctx context.Context, obj *types.ContinualImprovementRegistry) (*types.Audit, error)
+
+	Owner(ctx context.Context, obj *types.ContinualImprovementRegistry) (*types.People, error)
+}
+type ContinualImprovementRegistryConnectionResolver interface {
+	TotalCount(ctx context.Context, obj *types.ContinualImprovementRegistryConnection) (int, error)
+}
 type ControlResolver interface {
 	Framework(ctx context.Context, obj *types.Control) (*types.Framework, error)
 	Measures(ctx context.Context, obj *types.Control, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy, filter *types.MeasureFilter) (*types.MeasureConnection, error)
@@ -1534,6 +1588,9 @@ type MutationResolver interface {
 	CreateComplianceRegistry(ctx context.Context, input types.CreateComplianceRegistryInput) (*types.CreateComplianceRegistryPayload, error)
 	UpdateComplianceRegistry(ctx context.Context, input types.UpdateComplianceRegistryInput) (*types.UpdateComplianceRegistryPayload, error)
 	DeleteComplianceRegistry(ctx context.Context, input types.DeleteComplianceRegistryInput) (*types.DeleteComplianceRegistryPayload, error)
+	CreateContinualImprovementRegistry(ctx context.Context, input types.CreateContinualImprovementRegistryInput) (*types.CreateContinualImprovementRegistryPayload, error)
+	UpdateContinualImprovementRegistry(ctx context.Context, input types.UpdateContinualImprovementRegistryInput) (*types.UpdateContinualImprovementRegistryPayload, error)
+	DeleteContinualImprovementRegistry(ctx context.Context, input types.DeleteContinualImprovementRegistryInput) (*types.DeleteContinualImprovementRegistryPayload, error)
 	CreateSnapshot(ctx context.Context, input types.CreateSnapshotInput) (*types.CreateSnapshotPayload, error)
 	DeleteSnapshot(ctx context.Context, input types.DeleteSnapshotInput) (*types.DeleteSnapshotPayload, error)
 }
@@ -1564,6 +1621,7 @@ type OrganizationResolver interface {
 	Audits(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AuditOrderBy) (*types.AuditConnection, error)
 	NonconformityRegistries(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.NonconformityRegistryOrderBy) (*types.NonconformityRegistryConnection, error)
 	ComplianceRegistries(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ComplianceRegistryOrderBy) (*types.ComplianceRegistryConnection, error)
+	ContinualImprovementRegistries(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ContinualImprovementRegistriesOrderBy) (*types.ContinualImprovementRegistryConnection, error)
 	Snapshots(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.SnapshotOrderBy) (*types.SnapshotConnection, error)
 	TrustCenter(ctx context.Context, obj *types.Organization) (*types.TrustCenter, error)
 }
@@ -2175,6 +2233,125 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.ConnectorEdge.Node(childComplexity), true
 
+	case "ContinualImprovementRegistry.audit":
+		if e.complexity.ContinualImprovementRegistry.Audit == nil {
+			break
+		}
+
+		return e.complexity.ContinualImprovementRegistry.Audit(childComplexity), true
+
+	case "ContinualImprovementRegistry.createdAt":
+		if e.complexity.ContinualImprovementRegistry.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.ContinualImprovementRegistry.CreatedAt(childComplexity), true
+
+	case "ContinualImprovementRegistry.description":
+		if e.complexity.ContinualImprovementRegistry.Description == nil {
+			break
+		}
+
+		return e.complexity.ContinualImprovementRegistry.Description(childComplexity), true
+
+	case "ContinualImprovementRegistry.id":
+		if e.complexity.ContinualImprovementRegistry.ID == nil {
+			break
+		}
+
+		return e.complexity.ContinualImprovementRegistry.ID(childComplexity), true
+
+	case "ContinualImprovementRegistry.organization":
+		if e.complexity.ContinualImprovementRegistry.Organization == nil {
+			break
+		}
+
+		return e.complexity.ContinualImprovementRegistry.Organization(childComplexity), true
+
+	case "ContinualImprovementRegistry.owner":
+		if e.complexity.ContinualImprovementRegistry.Owner == nil {
+			break
+		}
+
+		return e.complexity.ContinualImprovementRegistry.Owner(childComplexity), true
+
+	case "ContinualImprovementRegistry.priority":
+		if e.complexity.ContinualImprovementRegistry.Priority == nil {
+			break
+		}
+
+		return e.complexity.ContinualImprovementRegistry.Priority(childComplexity), true
+
+	case "ContinualImprovementRegistry.referenceId":
+		if e.complexity.ContinualImprovementRegistry.ReferenceID == nil {
+			break
+		}
+
+		return e.complexity.ContinualImprovementRegistry.ReferenceID(childComplexity), true
+
+	case "ContinualImprovementRegistry.source":
+		if e.complexity.ContinualImprovementRegistry.Source == nil {
+			break
+		}
+
+		return e.complexity.ContinualImprovementRegistry.Source(childComplexity), true
+
+	case "ContinualImprovementRegistry.status":
+		if e.complexity.ContinualImprovementRegistry.Status == nil {
+			break
+		}
+
+		return e.complexity.ContinualImprovementRegistry.Status(childComplexity), true
+
+	case "ContinualImprovementRegistry.targetDate":
+		if e.complexity.ContinualImprovementRegistry.TargetDate == nil {
+			break
+		}
+
+		return e.complexity.ContinualImprovementRegistry.TargetDate(childComplexity), true
+
+	case "ContinualImprovementRegistry.updatedAt":
+		if e.complexity.ContinualImprovementRegistry.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.ContinualImprovementRegistry.UpdatedAt(childComplexity), true
+
+	case "ContinualImprovementRegistryConnection.edges":
+		if e.complexity.ContinualImprovementRegistryConnection.Edges == nil {
+			break
+		}
+
+		return e.complexity.ContinualImprovementRegistryConnection.Edges(childComplexity), true
+
+	case "ContinualImprovementRegistryConnection.pageInfo":
+		if e.complexity.ContinualImprovementRegistryConnection.PageInfo == nil {
+			break
+		}
+
+		return e.complexity.ContinualImprovementRegistryConnection.PageInfo(childComplexity), true
+
+	case "ContinualImprovementRegistryConnection.totalCount":
+		if e.complexity.ContinualImprovementRegistryConnection.TotalCount == nil {
+			break
+		}
+
+		return e.complexity.ContinualImprovementRegistryConnection.TotalCount(childComplexity), true
+
+	case "ContinualImprovementRegistryEdge.cursor":
+		if e.complexity.ContinualImprovementRegistryEdge.Cursor == nil {
+			break
+		}
+
+		return e.complexity.ContinualImprovementRegistryEdge.Cursor(childComplexity), true
+
+	case "ContinualImprovementRegistryEdge.node":
+		if e.complexity.ContinualImprovementRegistryEdge.Node == nil {
+			break
+		}
+
+		return e.complexity.ContinualImprovementRegistryEdge.Node(childComplexity), true
+
 	case "Control.audits":
 		if e.complexity.Control.Audits == nil {
 			break
@@ -2341,6 +2518,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.CreateComplianceRegistryPayload.ComplianceRegistryEdge(childComplexity), true
+
+	case "CreateContinualImprovementRegistryPayload.continualImprovementRegistryEdge":
+		if e.complexity.CreateContinualImprovementRegistryPayload.ContinualImprovementRegistryEdge == nil {
+			break
+		}
+
+		return e.complexity.CreateContinualImprovementRegistryPayload.ContinualImprovementRegistryEdge(childComplexity), true
 
 	case "CreateControlAuditMappingPayload.auditEdge":
 		if e.complexity.CreateControlAuditMappingPayload.AuditEdge == nil {
@@ -2682,6 +2866,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.DeleteComplianceRegistryPayload.DeletedComplianceRegistryID(childComplexity), true
+
+	case "DeleteContinualImprovementRegistryPayload.deletedContinualImprovementRegistryId":
+		if e.complexity.DeleteContinualImprovementRegistryPayload.DeletedContinualImprovementRegistryID == nil {
+			break
+		}
+
+		return e.complexity.DeleteContinualImprovementRegistryPayload.DeletedContinualImprovementRegistryID(childComplexity), true
 
 	case "DeleteControlAuditMappingPayload.deletedAuditId":
 		if e.complexity.DeleteControlAuditMappingPayload.DeletedAuditID == nil {
@@ -3755,6 +3946,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.CreateComplianceRegistry(childComplexity, args["input"].(types.CreateComplianceRegistryInput)), true
 
+	case "Mutation.createContinualImprovementRegistry":
+		if e.complexity.Mutation.CreateContinualImprovementRegistry == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_createContinualImprovementRegistry_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreateContinualImprovementRegistry(childComplexity, args["input"].(types.CreateContinualImprovementRegistryInput)), true
+
 	case "Mutation.createControl":
 		if e.complexity.Mutation.CreateControl == nil {
 			break
@@ -4078,6 +4281,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.DeleteComplianceRegistry(childComplexity, args["input"].(types.DeleteComplianceRegistryInput)), true
+
+	case "Mutation.deleteContinualImprovementRegistry":
+		if e.complexity.Mutation.DeleteContinualImprovementRegistry == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_deleteContinualImprovementRegistry_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteContinualImprovementRegistry(childComplexity, args["input"].(types.DeleteContinualImprovementRegistryInput)), true
 
 	case "Mutation.deleteControl":
 		if e.complexity.Mutation.DeleteControl == nil {
@@ -4583,6 +4798,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.UpdateComplianceRegistry(childComplexity, args["input"].(types.UpdateComplianceRegistryInput)), true
 
+	case "Mutation.updateContinualImprovementRegistry":
+		if e.complexity.Mutation.UpdateContinualImprovementRegistry == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_updateContinualImprovementRegistry_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UpdateContinualImprovementRegistry(childComplexity, args["input"].(types.UpdateContinualImprovementRegistryInput)), true
+
 	case "Mutation.updateControl":
 		if e.complexity.Mutation.UpdateControl == nil {
 			break
@@ -5051,6 +5278,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Organization.Connectors(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.ConnectorOrder)), true
+
+	case "Organization.continualImprovementRegistries":
+		if e.complexity.Organization.ContinualImprovementRegistries == nil {
+			break
+		}
+
+		args, err := ec.field_Organization_continualImprovementRegistries_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.ContinualImprovementRegistries(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.ContinualImprovementRegistriesOrderBy)), true
 
 	case "Organization.controls":
 		if e.complexity.Organization.Controls == nil {
@@ -6118,6 +6357,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.UpdateComplianceRegistryPayload.ComplianceRegistry(childComplexity), true
 
+	case "UpdateContinualImprovementRegistryPayload.continualImprovementRegistry":
+		if e.complexity.UpdateContinualImprovementRegistryPayload.ContinualImprovementRegistry == nil {
+			break
+		}
+
+		return e.complexity.UpdateContinualImprovementRegistryPayload.ContinualImprovementRegistry(childComplexity), true
+
 	case "UpdateControlPayload.control":
 		if e.complexity.UpdateControlPayload.Control == nil {
 			break
@@ -7132,11 +7378,13 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputComplianceRegistryOrder,
 		ec.unmarshalInputConfirmEmailInput,
 		ec.unmarshalInputConnectorOrder,
+		ec.unmarshalInputContinualImprovementRegistriesOrder,
 		ec.unmarshalInputControlFilter,
 		ec.unmarshalInputControlOrder,
 		ec.unmarshalInputCreateAssetInput,
 		ec.unmarshalInputCreateAuditInput,
 		ec.unmarshalInputCreateComplianceRegistryInput,
+		ec.unmarshalInputCreateContinualImprovementRegistryInput,
 		ec.unmarshalInputCreateControlAuditMappingInput,
 		ec.unmarshalInputCreateControlDocumentMappingInput,
 		ec.unmarshalInputCreateControlInput,
@@ -7167,6 +7415,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputDeleteAuditInput,
 		ec.unmarshalInputDeleteAuditReportInput,
 		ec.unmarshalInputDeleteComplianceRegistryInput,
+		ec.unmarshalInputDeleteContinualImprovementRegistryInput,
 		ec.unmarshalInputDeleteControlAuditMappingInput,
 		ec.unmarshalInputDeleteControlDocumentMappingInput,
 		ec.unmarshalInputDeleteControlInput,
@@ -7229,6 +7478,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputUpdateAssetInput,
 		ec.unmarshalInputUpdateAuditInput,
 		ec.unmarshalInputUpdateComplianceRegistryInput,
+		ec.unmarshalInputUpdateContinualImprovementRegistryInput,
 		ec.unmarshalInputUpdateControlInput,
 		ec.unmarshalInputUpdateDatumInput,
 		ec.unmarshalInputUpdateDocumentInput,
@@ -7538,6 +7788,38 @@ enum ComplianceRegistryStatus
   CLOSED
     @goEnum(
       value: "github.com/getprobo/probo/pkg/coredata.ComplianceRegistryStatusClosed"
+    )
+}
+
+enum ContinualImprovementRegistriesStatus
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesStatus") {
+  OPEN
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesStatusOpen"
+    )
+  IN_PROGRESS
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesStatusInProgress"
+    )
+  CLOSED
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesStatusClosed"
+    )
+}
+
+enum ContinualImprovementRegistriesPriority
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesPriority") {
+  LOW
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesPriorityLow"
+    )
+  MEDIUM
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesPriorityMedium"
+    )
+  HIGH
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesPriorityHigh"
     )
 }
 
@@ -8036,6 +8318,30 @@ enum ComplianceRegistryOrderField
     )
 }
 
+enum ContinualImprovementRegistriesOrderField
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesOrderField") {
+  CREATED_AT
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesOrderFieldCreatedAt"
+    )
+  REFERENCE_ID
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesOrderFieldReferenceId"
+    )
+  TARGET_DATE
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesOrderFieldTargetDate"
+    )
+  STATUS
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesOrderFieldStatus"
+    )
+  PRIORITY
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.ContinualImprovementRegistriesOrderFieldPriority"
+    )
+}
+
 enum TrustCenterAccessOrderField
   @goModel(model: "github.com/getprobo/probo/pkg/coredata.TrustCenterAccessOrderField") {
   CREATED_AT
@@ -8183,6 +8489,14 @@ input ComplianceRegistryOrder
   ) {
   direction: OrderDirection!
   field: ComplianceRegistryOrderField!
+}
+
+input ContinualImprovementRegistriesOrder
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.ContinualImprovementRegistriesOrderBy"
+  ) {
+  direction: OrderDirection!
+  field: ContinualImprovementRegistriesOrderField!
 }
 
 input TrustCenterAccessOrder
@@ -8436,6 +8750,14 @@ type Organization implements Node {
     before: CursorKey
     orderBy: ComplianceRegistryOrder
   ): ComplianceRegistryConnection! @goField(forceResolver: true)
+
+  continualImprovementRegistries(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+    orderBy: ContinualImprovementRegistriesOrder
+  ): ContinualImprovementRegistryConnection! @goField(forceResolver: true)
 
   snapshots(
     first: Int
@@ -8897,6 +9219,21 @@ type ComplianceRegistry implements Node {
   updatedAt: Datetime!
 }
 
+type ContinualImprovementRegistry implements Node {
+  id: ID!
+  organization: Organization! @goField(forceResolver: true)
+  referenceId: String!
+  description: String
+  audit: Audit! @goField(forceResolver: true)
+  source: String
+  owner: People! @goField(forceResolver: true)
+  targetDate: Datetime
+  status: ContinualImprovementRegistriesStatus!
+  priority: ContinualImprovementRegistriesPriority!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+}
+
 type Snapshot implements Node {
   id: ID!
   organization: Organization! @goField(forceResolver: true)
@@ -9238,6 +9575,20 @@ type ComplianceRegistryEdge {
   node: ComplianceRegistry!
 }
 
+type ContinualImprovementRegistryConnection
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.ContinualImprovementRegistryConnection"
+  ) {
+  totalCount: Int! @goField(forceResolver: true)
+  edges: [ContinualImprovementRegistryEdge!]!
+  pageInfo: PageInfo!
+}
+
+type ContinualImprovementRegistryEdge {
+  cursor: CursorKey!
+  node: ContinualImprovementRegistry!
+}
+
 type SnapshotConnection
   @goModel(
     model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.SnapshotConnection"
@@ -9508,6 +9859,17 @@ type Mutation {
   deleteComplianceRegistry(
     input: DeleteComplianceRegistryInput!
   ): DeleteComplianceRegistryPayload!
+
+  # Continual Improvement Registry mutations
+  createContinualImprovementRegistry(
+    input: CreateContinualImprovementRegistryInput!
+  ): CreateContinualImprovementRegistryPayload!
+  updateContinualImprovementRegistry(
+    input: UpdateContinualImprovementRegistryInput!
+  ): UpdateContinualImprovementRegistryPayload!
+  deleteContinualImprovementRegistry(
+    input: DeleteContinualImprovementRegistryInput!
+  ): DeleteContinualImprovementRegistryPayload!
 
   # Snapshot mutations
   createSnapshot(input: CreateSnapshotInput!): CreateSnapshotPayload!
@@ -10075,6 +10437,34 @@ input UpdateComplianceRegistryInput {
 
 input DeleteComplianceRegistryInput {
   complianceRegistryId: ID!
+}
+
+input CreateContinualImprovementRegistryInput {
+  organizationId: ID!
+  referenceId: String!
+  description: String
+  auditId: ID!
+  source: String
+  ownerId: ID!
+  targetDate: Datetime
+  status: ContinualImprovementRegistriesStatus!
+  priority: ContinualImprovementRegistriesPriority!
+}
+
+input UpdateContinualImprovementRegistryInput {
+  id: ID!
+  referenceId: String
+  description: String
+  auditId: ID
+  source: String
+  ownerId: ID
+  targetDate: Datetime
+  status: ContinualImprovementRegistriesStatus
+  priority: ContinualImprovementRegistriesPriority
+}
+
+input DeleteContinualImprovementRegistryInput {
+  continualImprovementRegistryId: ID!
 }
 
 input CreateSnapshotInput {
@@ -10806,6 +11196,18 @@ type UpdateComplianceRegistryPayload {
 
 type DeleteComplianceRegistryPayload {
   deletedComplianceRegistryId: ID!
+}
+
+type CreateContinualImprovementRegistryPayload {
+  continualImprovementRegistryEdge: ContinualImprovementRegistryEdge!
+}
+
+type UpdateContinualImprovementRegistryPayload {
+  continualImprovementRegistry: ContinualImprovementRegistry!
+}
+
+type DeleteContinualImprovementRegistryPayload {
+  deletedContinualImprovementRegistryId: ID!
 }
 
 type CreateSnapshotPayload {
@@ -12599,6 +13001,29 @@ func (ec *executionContext) field_Mutation_createComplianceRegistry_argsInput(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation_createContinualImprovementRegistry_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_createContinualImprovementRegistry_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_createContinualImprovementRegistry_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.CreateContinualImprovementRegistryInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNCreateContinualImprovementRegistryInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateContinualImprovementRegistryInput(ctx, tmp)
+	}
+
+	var zeroVal types.CreateContinualImprovementRegistryInput
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation_createControlAuditMapping_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -13217,6 +13642,29 @@ func (ec *executionContext) field_Mutation_deleteComplianceRegistry_argsInput(
 	}
 
 	var zeroVal types.DeleteComplianceRegistryInput
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_deleteContinualImprovementRegistry_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_deleteContinualImprovementRegistry_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_deleteContinualImprovementRegistry_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.DeleteContinualImprovementRegistryInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNDeleteContinualImprovementRegistryInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteContinualImprovementRegistryInput(ctx, tmp)
+	}
+
+	var zeroVal types.DeleteContinualImprovementRegistryInput
 	return zeroVal, nil
 }
 
@@ -14186,6 +14634,29 @@ func (ec *executionContext) field_Mutation_updateComplianceRegistry_argsInput(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation_updateContinualImprovementRegistry_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_updateContinualImprovementRegistry_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_updateContinualImprovementRegistry_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.UpdateContinualImprovementRegistryInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNUpdateContinualImprovementRegistryInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateContinualImprovementRegistryInput(ctx, tmp)
+	}
+
+	var zeroVal types.UpdateContinualImprovementRegistryInput
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation_updateControl_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -15115,6 +15586,101 @@ func (ec *executionContext) field_Organization_connectors_argsOrderBy(
 	}
 
 	var zeroVal *types.ConnectorOrder
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_continualImprovementRegistries_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Organization_continualImprovementRegistries_argsFirst(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["first"] = arg0
+	arg1, err := ec.field_Organization_continualImprovementRegistries_argsAfter(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["after"] = arg1
+	arg2, err := ec.field_Organization_continualImprovementRegistries_argsLast(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["last"] = arg2
+	arg3, err := ec.field_Organization_continualImprovementRegistries_argsBefore(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["before"] = arg3
+	arg4, err := ec.field_Organization_continualImprovementRegistries_argsOrderBy(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["orderBy"] = arg4
+	return args, nil
+}
+func (ec *executionContext) field_Organization_continualImprovementRegistries_argsFirst(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*int, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("first"))
+	if tmp, ok := rawArgs["first"]; ok {
+		return ec.unmarshalOInt2ᚖint(ctx, tmp)
+	}
+
+	var zeroVal *int
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_continualImprovementRegistries_argsAfter(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*page.CursorKey, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("after"))
+	if tmp, ok := rawArgs["after"]; ok {
+		return ec.unmarshalOCursorKey2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐCursorKey(ctx, tmp)
+	}
+
+	var zeroVal *page.CursorKey
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_continualImprovementRegistries_argsLast(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*int, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("last"))
+	if tmp, ok := rawArgs["last"]; ok {
+		return ec.unmarshalOInt2ᚖint(ctx, tmp)
+	}
+
+	var zeroVal *int
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_continualImprovementRegistries_argsBefore(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*page.CursorKey, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("before"))
+	if tmp, ok := rawArgs["before"]; ok {
+		return ec.unmarshalOCursorKey2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐCursorKey(ctx, tmp)
+	}
+
+	var zeroVal *page.CursorKey
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_continualImprovementRegistries_argsOrderBy(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*types.ContinualImprovementRegistriesOrderBy, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("orderBy"))
+	if tmp, ok := rawArgs["orderBy"]; ok {
+		return ec.unmarshalOContinualImprovementRegistriesOrder2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐContinualImprovementRegistriesOrderBy(ctx, tmp)
+	}
+
+	var zeroVal *types.ContinualImprovementRegistriesOrderBy
 	return zeroVal, nil
 }
 
@@ -18337,6 +18903,8 @@ func (ec *executionContext) fieldContext_Asset_organization(_ context.Context, f
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "complianceRegistries":
 				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "continualImprovementRegistries":
+				return ec.fieldContext_Organization_continualImprovementRegistries(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
 			case "trustCenter":
@@ -18930,6 +19498,8 @@ func (ec *executionContext) fieldContext_Audit_organization(_ context.Context, f
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "complianceRegistries":
 				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "continualImprovementRegistries":
+				return ec.fieldContext_Organization_continualImprovementRegistries(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
 			case "trustCenter":
@@ -20003,6 +20573,8 @@ func (ec *executionContext) fieldContext_ComplianceRegistry_organization(_ conte
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "complianceRegistries":
 				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "continualImprovementRegistries":
+				return ec.fieldContext_Organization_continualImprovementRegistries(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
 			case "trustCenter":
@@ -21355,6 +21927,885 @@ func (ec *executionContext) fieldContext_ConnectorEdge_node(_ context.Context, f
 	return fc, nil
 }
 
+func (ec *executionContext) _ContinualImprovementRegistry_id(ctx context.Context, field graphql.CollectedField, obj *types.ContinualImprovementRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ContinualImprovementRegistry_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(gid.GID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ContinualImprovementRegistry_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ContinualImprovementRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ContinualImprovementRegistry_organization(ctx context.Context, field graphql.CollectedField, obj *types.ContinualImprovementRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ContinualImprovementRegistry_organization(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.ContinualImprovementRegistry().Organization(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.Organization)
+	fc.Result = res
+	return ec.marshalNOrganization2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐOrganization(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ContinualImprovementRegistry_organization(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ContinualImprovementRegistry",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Organization_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Organization_name(ctx, field)
+			case "logoUrl":
+				return ec.fieldContext_Organization_logoUrl(ctx, field)
+			case "users":
+				return ec.fieldContext_Organization_users(ctx, field)
+			case "connectors":
+				return ec.fieldContext_Organization_connectors(ctx, field)
+			case "frameworks":
+				return ec.fieldContext_Organization_frameworks(ctx, field)
+			case "controls":
+				return ec.fieldContext_Organization_controls(ctx, field)
+			case "vendors":
+				return ec.fieldContext_Organization_vendors(ctx, field)
+			case "peoples":
+				return ec.fieldContext_Organization_peoples(ctx, field)
+			case "documents":
+				return ec.fieldContext_Organization_documents(ctx, field)
+			case "measures":
+				return ec.fieldContext_Organization_measures(ctx, field)
+			case "risks":
+				return ec.fieldContext_Organization_risks(ctx, field)
+			case "tasks":
+				return ec.fieldContext_Organization_tasks(ctx, field)
+			case "assets":
+				return ec.fieldContext_Organization_assets(ctx, field)
+			case "data":
+				return ec.fieldContext_Organization_data(ctx, field)
+			case "audits":
+				return ec.fieldContext_Organization_audits(ctx, field)
+			case "nonconformityRegistries":
+				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
+			case "complianceRegistries":
+				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "continualImprovementRegistries":
+				return ec.fieldContext_Organization_continualImprovementRegistries(ctx, field)
+			case "snapshots":
+				return ec.fieldContext_Organization_snapshots(ctx, field)
+			case "trustCenter":
+				return ec.fieldContext_Organization_trustCenter(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Organization_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Organization_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Organization", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ContinualImprovementRegistry_referenceId(ctx context.Context, field graphql.CollectedField, obj *types.ContinualImprovementRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ContinualImprovementRegistry_referenceId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ReferenceID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ContinualImprovementRegistry_referenceId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ContinualImprovementRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ContinualImprovementRegistry_description(ctx context.Context, field graphql.CollectedField, obj *types.ContinualImprovementRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ContinualImprovementRegistry_description(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Description, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ContinualImprovementRegistry_description(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ContinualImprovementRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ContinualImprovementRegistry_audit(ctx context.Context, field graphql.CollectedField, obj *types.ContinualImprovementRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ContinualImprovementRegistry_audit(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.ContinualImprovementRegistry().Audit(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.Audit)
+	fc.Result = res
+	return ec.marshalNAudit2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐAudit(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ContinualImprovementRegistry_audit(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ContinualImprovementRegistry",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Audit_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Audit_name(ctx, field)
+			case "organization":
+				return ec.fieldContext_Audit_organization(ctx, field)
+			case "framework":
+				return ec.fieldContext_Audit_framework(ctx, field)
+			case "validFrom":
+				return ec.fieldContext_Audit_validFrom(ctx, field)
+			case "validUntil":
+				return ec.fieldContext_Audit_validUntil(ctx, field)
+			case "report":
+				return ec.fieldContext_Audit_report(ctx, field)
+			case "reportUrl":
+				return ec.fieldContext_Audit_reportUrl(ctx, field)
+			case "state":
+				return ec.fieldContext_Audit_state(ctx, field)
+			case "controls":
+				return ec.fieldContext_Audit_controls(ctx, field)
+			case "showOnTrustCenter":
+				return ec.fieldContext_Audit_showOnTrustCenter(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Audit_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Audit_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Audit", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ContinualImprovementRegistry_source(ctx context.Context, field graphql.CollectedField, obj *types.ContinualImprovementRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ContinualImprovementRegistry_source(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Source, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ContinualImprovementRegistry_source(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ContinualImprovementRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ContinualImprovementRegistry_owner(ctx context.Context, field graphql.CollectedField, obj *types.ContinualImprovementRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ContinualImprovementRegistry_owner(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.ContinualImprovementRegistry().Owner(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.People)
+	fc.Result = res
+	return ec.marshalNPeople2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐPeople(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ContinualImprovementRegistry_owner(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ContinualImprovementRegistry",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_People_id(ctx, field)
+			case "fullName":
+				return ec.fieldContext_People_fullName(ctx, field)
+			case "primaryEmailAddress":
+				return ec.fieldContext_People_primaryEmailAddress(ctx, field)
+			case "additionalEmailAddresses":
+				return ec.fieldContext_People_additionalEmailAddresses(ctx, field)
+			case "kind":
+				return ec.fieldContext_People_kind(ctx, field)
+			case "position":
+				return ec.fieldContext_People_position(ctx, field)
+			case "contractStartDate":
+				return ec.fieldContext_People_contractStartDate(ctx, field)
+			case "contractEndDate":
+				return ec.fieldContext_People_contractEndDate(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_People_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_People_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type People", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ContinualImprovementRegistry_targetDate(ctx context.Context, field graphql.CollectedField, obj *types.ContinualImprovementRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ContinualImprovementRegistry_targetDate(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TargetDate, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	fc.Result = res
+	return ec.marshalODatetime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ContinualImprovementRegistry_targetDate(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ContinualImprovementRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ContinualImprovementRegistry_status(ctx context.Context, field graphql.CollectedField, obj *types.ContinualImprovementRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ContinualImprovementRegistry_status(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Status, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(coredata.ContinualImprovementRegistriesStatus)
+	fc.Result = res
+	return ec.marshalNContinualImprovementRegistriesStatus2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesStatus(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ContinualImprovementRegistry_status(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ContinualImprovementRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ContinualImprovementRegistriesStatus does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ContinualImprovementRegistry_priority(ctx context.Context, field graphql.CollectedField, obj *types.ContinualImprovementRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ContinualImprovementRegistry_priority(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Priority, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(coredata.ContinualImprovementRegistriesPriority)
+	fc.Result = res
+	return ec.marshalNContinualImprovementRegistriesPriority2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesPriority(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ContinualImprovementRegistry_priority(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ContinualImprovementRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ContinualImprovementRegistriesPriority does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ContinualImprovementRegistry_createdAt(ctx context.Context, field graphql.CollectedField, obj *types.ContinualImprovementRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ContinualImprovementRegistry_createdAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNDatetime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ContinualImprovementRegistry_createdAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ContinualImprovementRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ContinualImprovementRegistry_updatedAt(ctx context.Context, field graphql.CollectedField, obj *types.ContinualImprovementRegistry) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ContinualImprovementRegistry_updatedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNDatetime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ContinualImprovementRegistry_updatedAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ContinualImprovementRegistry",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ContinualImprovementRegistryConnection_totalCount(ctx context.Context, field graphql.CollectedField, obj *types.ContinualImprovementRegistryConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ContinualImprovementRegistryConnection_totalCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.ContinualImprovementRegistryConnection().TotalCount(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ContinualImprovementRegistryConnection_totalCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ContinualImprovementRegistryConnection",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ContinualImprovementRegistryConnection_edges(ctx context.Context, field graphql.CollectedField, obj *types.ContinualImprovementRegistryConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ContinualImprovementRegistryConnection_edges(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Edges, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*types.ContinualImprovementRegistryEdge)
+	fc.Result = res
+	return ec.marshalNContinualImprovementRegistryEdge2ᚕᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐContinualImprovementRegistryEdgeᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ContinualImprovementRegistryConnection_edges(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ContinualImprovementRegistryConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "cursor":
+				return ec.fieldContext_ContinualImprovementRegistryEdge_cursor(ctx, field)
+			case "node":
+				return ec.fieldContext_ContinualImprovementRegistryEdge_node(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ContinualImprovementRegistryEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ContinualImprovementRegistryConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *types.ContinualImprovementRegistryConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ContinualImprovementRegistryConnection_pageInfo(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PageInfo, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(types.PageInfo)
+	fc.Result = res
+	return ec.marshalNPageInfo2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐPageInfo(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ContinualImprovementRegistryConnection_pageInfo(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ContinualImprovementRegistryConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "hasNextPage":
+				return ec.fieldContext_PageInfo_hasNextPage(ctx, field)
+			case "hasPreviousPage":
+				return ec.fieldContext_PageInfo_hasPreviousPage(ctx, field)
+			case "startCursor":
+				return ec.fieldContext_PageInfo_startCursor(ctx, field)
+			case "endCursor":
+				return ec.fieldContext_PageInfo_endCursor(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ContinualImprovementRegistryEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *types.ContinualImprovementRegistryEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ContinualImprovementRegistryEdge_cursor(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Cursor, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(page.CursorKey)
+	fc.Result = res
+	return ec.marshalNCursorKey2githubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐCursorKey(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ContinualImprovementRegistryEdge_cursor(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ContinualImprovementRegistryEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type CursorKey does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ContinualImprovementRegistryEdge_node(ctx context.Context, field graphql.CollectedField, obj *types.ContinualImprovementRegistryEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ContinualImprovementRegistryEdge_node(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Node, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.ContinualImprovementRegistry)
+	fc.Result = res
+	return ec.marshalNContinualImprovementRegistry2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐContinualImprovementRegistry(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ContinualImprovementRegistryEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ContinualImprovementRegistryEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_ContinualImprovementRegistry_id(ctx, field)
+			case "organization":
+				return ec.fieldContext_ContinualImprovementRegistry_organization(ctx, field)
+			case "referenceId":
+				return ec.fieldContext_ContinualImprovementRegistry_referenceId(ctx, field)
+			case "description":
+				return ec.fieldContext_ContinualImprovementRegistry_description(ctx, field)
+			case "audit":
+				return ec.fieldContext_ContinualImprovementRegistry_audit(ctx, field)
+			case "source":
+				return ec.fieldContext_ContinualImprovementRegistry_source(ctx, field)
+			case "owner":
+				return ec.fieldContext_ContinualImprovementRegistry_owner(ctx, field)
+			case "targetDate":
+				return ec.fieldContext_ContinualImprovementRegistry_targetDate(ctx, field)
+			case "status":
+				return ec.fieldContext_ContinualImprovementRegistry_status(ctx, field)
+			case "priority":
+				return ec.fieldContext_ContinualImprovementRegistry_priority(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_ContinualImprovementRegistry_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_ContinualImprovementRegistry_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ContinualImprovementRegistry", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Control_id(ctx context.Context, field graphql.CollectedField, obj *types.Control) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Control_id(ctx, field)
 	if err != nil {
@@ -22425,6 +23876,56 @@ func (ec *executionContext) fieldContext_CreateComplianceRegistryPayload_complia
 				return ec.fieldContext_ComplianceRegistryEdge_node(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ComplianceRegistryEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CreateContinualImprovementRegistryPayload_continualImprovementRegistryEdge(ctx context.Context, field graphql.CollectedField, obj *types.CreateContinualImprovementRegistryPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CreateContinualImprovementRegistryPayload_continualImprovementRegistryEdge(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ContinualImprovementRegistryEdge, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.ContinualImprovementRegistryEdge)
+	fc.Result = res
+	return ec.marshalNContinualImprovementRegistryEdge2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐContinualImprovementRegistryEdge(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CreateContinualImprovementRegistryPayload_continualImprovementRegistryEdge(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CreateContinualImprovementRegistryPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "cursor":
+				return ec.fieldContext_ContinualImprovementRegistryEdge_cursor(ctx, field)
+			case "node":
+				return ec.fieldContext_ContinualImprovementRegistryEdge_node(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ContinualImprovementRegistryEdge", field.Name)
 		},
 	}
 	return fc, nil
@@ -24316,6 +25817,8 @@ func (ec *executionContext) fieldContext_Datum_organization(_ context.Context, f
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "complianceRegistries":
 				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "continualImprovementRegistries":
+				return ec.fieldContext_Organization_continualImprovementRegistries(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
 			case "trustCenter":
@@ -24867,6 +26370,50 @@ func (ec *executionContext) _DeleteComplianceRegistryPayload_deletedComplianceRe
 func (ec *executionContext) fieldContext_DeleteComplianceRegistryPayload_deletedComplianceRegistryId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "DeleteComplianceRegistryPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DeleteContinualImprovementRegistryPayload_deletedContinualImprovementRegistryId(ctx context.Context, field graphql.CollectedField, obj *types.DeleteContinualImprovementRegistryPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DeleteContinualImprovementRegistryPayload_deletedContinualImprovementRegistryId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DeletedContinualImprovementRegistryID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(gid.GID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DeleteContinualImprovementRegistryPayload_deletedContinualImprovementRegistryId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DeleteContinualImprovementRegistryPayload",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -26687,6 +28234,8 @@ func (ec *executionContext) fieldContext_Document_organization(_ context.Context
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "complianceRegistries":
 				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "continualImprovementRegistries":
+				return ec.fieldContext_Organization_continualImprovementRegistries(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
 			case "trustCenter":
@@ -29854,6 +31403,8 @@ func (ec *executionContext) fieldContext_Framework_organization(_ context.Contex
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "complianceRegistries":
 				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "continualImprovementRegistries":
+				return ec.fieldContext_Organization_continualImprovementRegistries(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
 			case "trustCenter":
@@ -37304,6 +38855,183 @@ func (ec *executionContext) fieldContext_Mutation_deleteComplianceRegistry(ctx c
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_createContinualImprovementRegistry(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_createContinualImprovementRegistry(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateContinualImprovementRegistry(rctx, fc.Args["input"].(types.CreateContinualImprovementRegistryInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.CreateContinualImprovementRegistryPayload)
+	fc.Result = res
+	return ec.marshalNCreateContinualImprovementRegistryPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateContinualImprovementRegistryPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_createContinualImprovementRegistry(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "continualImprovementRegistryEdge":
+				return ec.fieldContext_CreateContinualImprovementRegistryPayload_continualImprovementRegistryEdge(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CreateContinualImprovementRegistryPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_createContinualImprovementRegistry_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_updateContinualImprovementRegistry(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_updateContinualImprovementRegistry(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UpdateContinualImprovementRegistry(rctx, fc.Args["input"].(types.UpdateContinualImprovementRegistryInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.UpdateContinualImprovementRegistryPayload)
+	fc.Result = res
+	return ec.marshalNUpdateContinualImprovementRegistryPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateContinualImprovementRegistryPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_updateContinualImprovementRegistry(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "continualImprovementRegistry":
+				return ec.fieldContext_UpdateContinualImprovementRegistryPayload_continualImprovementRegistry(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UpdateContinualImprovementRegistryPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_updateContinualImprovementRegistry_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_deleteContinualImprovementRegistry(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_deleteContinualImprovementRegistry(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteContinualImprovementRegistry(rctx, fc.Args["input"].(types.DeleteContinualImprovementRegistryInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.DeleteContinualImprovementRegistryPayload)
+	fc.Result = res
+	return ec.marshalNDeleteContinualImprovementRegistryPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteContinualImprovementRegistryPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_deleteContinualImprovementRegistry(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "deletedContinualImprovementRegistryId":
+				return ec.fieldContext_DeleteContinualImprovementRegistryPayload_deletedContinualImprovementRegistryId(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DeleteContinualImprovementRegistryPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_deleteContinualImprovementRegistry_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation_createSnapshot(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Mutation_createSnapshot(ctx, field)
 	if err != nil {
@@ -37541,6 +39269,8 @@ func (ec *executionContext) fieldContext_NonconformityRegistry_organization(_ co
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "complianceRegistries":
 				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "continualImprovementRegistries":
+				return ec.fieldContext_Organization_continualImprovementRegistries(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
 			case "trustCenter":
@@ -39455,6 +41185,69 @@ func (ec *executionContext) fieldContext_Organization_complianceRegistries(ctx c
 	return fc, nil
 }
 
+func (ec *executionContext) _Organization_continualImprovementRegistries(ctx context.Context, field graphql.CollectedField, obj *types.Organization) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Organization_continualImprovementRegistries(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Organization().ContinualImprovementRegistries(rctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey), fc.Args["orderBy"].(*types.ContinualImprovementRegistriesOrderBy))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.ContinualImprovementRegistryConnection)
+	fc.Result = res
+	return ec.marshalNContinualImprovementRegistryConnection2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐContinualImprovementRegistryConnection(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Organization_continualImprovementRegistries(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Organization",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "totalCount":
+				return ec.fieldContext_ContinualImprovementRegistryConnection_totalCount(ctx, field)
+			case "edges":
+				return ec.fieldContext_ContinualImprovementRegistryConnection_edges(ctx, field)
+			case "pageInfo":
+				return ec.fieldContext_ContinualImprovementRegistryConnection_pageInfo(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ContinualImprovementRegistryConnection", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Organization_continualImprovementRegistries_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Organization_snapshots(ctx context.Context, field graphql.CollectedField, obj *types.Organization) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Organization_snapshots(ctx, field)
 	if err != nil {
@@ -39886,6 +41679,8 @@ func (ec *executionContext) fieldContext_OrganizationEdge_node(_ context.Context
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "complianceRegistries":
 				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "continualImprovementRegistries":
+				return ec.fieldContext_Organization_continualImprovementRegistries(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
 			case "trustCenter":
@@ -42360,6 +44155,8 @@ func (ec *executionContext) fieldContext_Risk_organization(_ context.Context, fi
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "complianceRegistries":
 				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "continualImprovementRegistries":
+				return ec.fieldContext_Organization_continualImprovementRegistries(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
 			case "trustCenter":
@@ -43179,6 +44976,8 @@ func (ec *executionContext) fieldContext_Snapshot_organization(_ context.Context
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "complianceRegistries":
 				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "continualImprovementRegistries":
+				return ec.fieldContext_Organization_continualImprovementRegistries(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
 			case "trustCenter":
@@ -44078,6 +45877,8 @@ func (ec *executionContext) fieldContext_Task_organization(_ context.Context, fi
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "complianceRegistries":
 				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "continualImprovementRegistries":
+				return ec.fieldContext_Organization_continualImprovementRegistries(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
 			case "trustCenter":
@@ -44866,6 +46667,8 @@ func (ec *executionContext) fieldContext_TrustCenter_organization(_ context.Cont
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "complianceRegistries":
 				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "continualImprovementRegistries":
+				return ec.fieldContext_Organization_continualImprovementRegistries(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
 			case "trustCenter":
@@ -45906,6 +47709,76 @@ func (ec *executionContext) fieldContext_UpdateComplianceRegistryPayload_complia
 	return fc, nil
 }
 
+func (ec *executionContext) _UpdateContinualImprovementRegistryPayload_continualImprovementRegistry(ctx context.Context, field graphql.CollectedField, obj *types.UpdateContinualImprovementRegistryPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UpdateContinualImprovementRegistryPayload_continualImprovementRegistry(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ContinualImprovementRegistry, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.ContinualImprovementRegistry)
+	fc.Result = res
+	return ec.marshalNContinualImprovementRegistry2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐContinualImprovementRegistry(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UpdateContinualImprovementRegistryPayload_continualImprovementRegistry(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UpdateContinualImprovementRegistryPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_ContinualImprovementRegistry_id(ctx, field)
+			case "organization":
+				return ec.fieldContext_ContinualImprovementRegistry_organization(ctx, field)
+			case "referenceId":
+				return ec.fieldContext_ContinualImprovementRegistry_referenceId(ctx, field)
+			case "description":
+				return ec.fieldContext_ContinualImprovementRegistry_description(ctx, field)
+			case "audit":
+				return ec.fieldContext_ContinualImprovementRegistry_audit(ctx, field)
+			case "source":
+				return ec.fieldContext_ContinualImprovementRegistry_source(ctx, field)
+			case "owner":
+				return ec.fieldContext_ContinualImprovementRegistry_owner(ctx, field)
+			case "targetDate":
+				return ec.fieldContext_ContinualImprovementRegistry_targetDate(ctx, field)
+			case "status":
+				return ec.fieldContext_ContinualImprovementRegistry_status(ctx, field)
+			case "priority":
+				return ec.fieldContext_ContinualImprovementRegistry_priority(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_ContinualImprovementRegistry_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_ContinualImprovementRegistry_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ContinualImprovementRegistry", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _UpdateControlPayload_control(ctx context.Context, field graphql.CollectedField, obj *types.UpdateControlPayload) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_UpdateControlPayload_control(ctx, field)
 	if err != nil {
@@ -46459,6 +48332,8 @@ func (ec *executionContext) fieldContext_UpdateOrganizationPayload_organization(
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "complianceRegistries":
 				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "continualImprovementRegistries":
+				return ec.fieldContext_Organization_continualImprovementRegistries(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
 			case "trustCenter":
@@ -48262,6 +50137,8 @@ func (ec *executionContext) fieldContext_Vendor_organization(_ context.Context, 
 				return ec.fieldContext_Organization_nonconformityRegistries(ctx, field)
 			case "complianceRegistries":
 				return ec.fieldContext_Organization_complianceRegistries(ctx, field)
+			case "continualImprovementRegistries":
+				return ec.fieldContext_Organization_continualImprovementRegistries(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
 			case "trustCenter":
@@ -55608,6 +57485,40 @@ func (ec *executionContext) unmarshalInputConnectorOrder(ctx context.Context, ob
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputContinualImprovementRegistriesOrder(ctx context.Context, obj any) (types.ContinualImprovementRegistriesOrderBy, error) {
+	var it types.ContinualImprovementRegistriesOrderBy
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"direction", "field"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "direction":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("direction"))
+			data, err := ec.unmarshalNOrderDirection2githubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐOrderDirection(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Direction = data
+		case "field":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("field"))
+			data, err := ec.unmarshalNContinualImprovementRegistriesOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesOrderField(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Field = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputControlFilter(ctx context.Context, obj any) (types.ControlFilter, error) {
 	var it types.ControlFilter
 	asMap := map[string]any{}
@@ -55909,6 +57820,89 @@ func (ec *executionContext) unmarshalInputCreateComplianceRegistryInput(ctx cont
 				return it, err
 			}
 			it.Status = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputCreateContinualImprovementRegistryInput(ctx context.Context, obj any) (types.CreateContinualImprovementRegistryInput, error) {
+	var it types.CreateContinualImprovementRegistryInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"organizationId", "referenceId", "description", "auditId", "source", "ownerId", "targetDate", "status", "priority"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "organizationId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("organizationId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OrganizationID = data
+		case "referenceId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("referenceId"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ReferenceID = data
+		case "description":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Description = data
+		case "auditId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("auditId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AuditID = data
+		case "source":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("source"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Source = data
+		case "ownerId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("ownerId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OwnerID = data
+		case "targetDate":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("targetDate"))
+			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.TargetDate = data
+		case "status":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("status"))
+			data, err := ec.unmarshalNContinualImprovementRegistriesStatus2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesStatus(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Status = data
+		case "priority":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("priority"))
+			data, err := ec.unmarshalNContinualImprovementRegistriesPriority2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesPriority(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Priority = data
 		}
 	}
 
@@ -57419,6 +59413,33 @@ func (ec *executionContext) unmarshalInputDeleteComplianceRegistryInput(ctx cont
 				return it, err
 			}
 			it.ComplianceRegistryID = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputDeleteContinualImprovementRegistryInput(ctx context.Context, obj any) (types.DeleteContinualImprovementRegistryInput, error) {
+	var it types.DeleteContinualImprovementRegistryInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"continualImprovementRegistryId"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "continualImprovementRegistryId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("continualImprovementRegistryId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ContinualImprovementRegistryID = data
 		}
 	}
 
@@ -59484,6 +61505,89 @@ func (ec *executionContext) unmarshalInputUpdateComplianceRegistryInput(ctx cont
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputUpdateContinualImprovementRegistryInput(ctx context.Context, obj any) (types.UpdateContinualImprovementRegistryInput, error) {
+	var it types.UpdateContinualImprovementRegistryInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id", "referenceId", "description", "auditId", "source", "ownerId", "targetDate", "status", "priority"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ID = data
+		case "referenceId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("referenceId"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ReferenceID = data
+		case "description":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Description = data
+		case "auditId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("auditId"))
+			data, err := ec.unmarshalOID2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AuditID = data
+		case "source":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("source"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Source = data
+		case "ownerId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("ownerId"))
+			data, err := ec.unmarshalOID2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OwnerID = data
+		case "targetDate":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("targetDate"))
+			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.TargetDate = data
+		case "status":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("status"))
+			data, err := ec.unmarshalOContinualImprovementRegistriesStatus2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesStatus(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Status = data
+		case "priority":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("priority"))
+			data, err := ec.unmarshalOContinualImprovementRegistriesPriority2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesPriority(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Priority = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputUpdateControlInput(ctx context.Context, obj any) (types.UpdateControlInput, error) {
 	var it types.UpdateControlInput
 	asMap := map[string]any{}
@@ -61261,6 +63365,13 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._Control(ctx, sel, obj)
+	case types.ContinualImprovementRegistry:
+		return ec._ContinualImprovementRegistry(ctx, sel, &obj)
+	case *types.ContinualImprovementRegistry:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._ContinualImprovementRegistry(ctx, sel, obj)
 	case types.Connector:
 		return ec._Connector(ctx, sel, &obj)
 	case *types.Connector:
@@ -62689,6 +64800,308 @@ func (ec *executionContext) _ConnectorEdge(ctx context.Context, sel ast.Selectio
 	return out
 }
 
+var continualImprovementRegistryImplementors = []string{"ContinualImprovementRegistry", "Node"}
+
+func (ec *executionContext) _ContinualImprovementRegistry(ctx context.Context, sel ast.SelectionSet, obj *types.ContinualImprovementRegistry) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, continualImprovementRegistryImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ContinualImprovementRegistry")
+		case "id":
+			out.Values[i] = ec._ContinualImprovementRegistry_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "organization":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._ContinualImprovementRegistry_organization(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "referenceId":
+			out.Values[i] = ec._ContinualImprovementRegistry_referenceId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "description":
+			out.Values[i] = ec._ContinualImprovementRegistry_description(ctx, field, obj)
+		case "audit":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._ContinualImprovementRegistry_audit(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "source":
+			out.Values[i] = ec._ContinualImprovementRegistry_source(ctx, field, obj)
+		case "owner":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._ContinualImprovementRegistry_owner(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "targetDate":
+			out.Values[i] = ec._ContinualImprovementRegistry_targetDate(ctx, field, obj)
+		case "status":
+			out.Values[i] = ec._ContinualImprovementRegistry_status(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "priority":
+			out.Values[i] = ec._ContinualImprovementRegistry_priority(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "createdAt":
+			out.Values[i] = ec._ContinualImprovementRegistry_createdAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "updatedAt":
+			out.Values[i] = ec._ContinualImprovementRegistry_updatedAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var continualImprovementRegistryConnectionImplementors = []string{"ContinualImprovementRegistryConnection"}
+
+func (ec *executionContext) _ContinualImprovementRegistryConnection(ctx context.Context, sel ast.SelectionSet, obj *types.ContinualImprovementRegistryConnection) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, continualImprovementRegistryConnectionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ContinualImprovementRegistryConnection")
+		case "totalCount":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._ContinualImprovementRegistryConnection_totalCount(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "edges":
+			out.Values[i] = ec._ContinualImprovementRegistryConnection_edges(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "pageInfo":
+			out.Values[i] = ec._ContinualImprovementRegistryConnection_pageInfo(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var continualImprovementRegistryEdgeImplementors = []string{"ContinualImprovementRegistryEdge"}
+
+func (ec *executionContext) _ContinualImprovementRegistryEdge(ctx context.Context, sel ast.SelectionSet, obj *types.ContinualImprovementRegistryEdge) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, continualImprovementRegistryEdgeImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ContinualImprovementRegistryEdge")
+		case "cursor":
+			out.Values[i] = ec._ContinualImprovementRegistryEdge_cursor(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "node":
+			out.Values[i] = ec._ContinualImprovementRegistryEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var controlImplementors = []string{"Control", "Node"}
 
 func (ec *executionContext) _Control(ctx context.Context, sel ast.SelectionSet, obj *types.Control) graphql.Marshaler {
@@ -63155,6 +65568,45 @@ func (ec *executionContext) _CreateComplianceRegistryPayload(ctx context.Context
 			out.Values[i] = graphql.MarshalString("CreateComplianceRegistryPayload")
 		case "complianceRegistryEdge":
 			out.Values[i] = ec._CreateComplianceRegistryPayload_complianceRegistryEdge(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var createContinualImprovementRegistryPayloadImplementors = []string{"CreateContinualImprovementRegistryPayload"}
+
+func (ec *executionContext) _CreateContinualImprovementRegistryPayload(ctx context.Context, sel ast.SelectionSet, obj *types.CreateContinualImprovementRegistryPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, createContinualImprovementRegistryPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CreateContinualImprovementRegistryPayload")
+		case "continualImprovementRegistryEdge":
+			out.Values[i] = ec._CreateContinualImprovementRegistryPayload_continualImprovementRegistryEdge(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -64573,6 +67025,45 @@ func (ec *executionContext) _DeleteComplianceRegistryPayload(ctx context.Context
 			out.Values[i] = graphql.MarshalString("DeleteComplianceRegistryPayload")
 		case "deletedComplianceRegistryId":
 			out.Values[i] = ec._DeleteComplianceRegistryPayload_deletedComplianceRegistryId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var deleteContinualImprovementRegistryPayloadImplementors = []string{"DeleteContinualImprovementRegistryPayload"}
+
+func (ec *executionContext) _DeleteContinualImprovementRegistryPayload(ctx context.Context, sel ast.SelectionSet, obj *types.DeleteContinualImprovementRegistryPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, deleteContinualImprovementRegistryPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("DeleteContinualImprovementRegistryPayload")
+		case "deletedContinualImprovementRegistryId":
+			out.Values[i] = ec._DeleteContinualImprovementRegistryPayload_deletedContinualImprovementRegistryId(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -68435,6 +70926,27 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "createContinualImprovementRegistry":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_createContinualImprovementRegistry(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "updateContinualImprovementRegistry":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_updateContinualImprovementRegistry(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "deleteContinualImprovementRegistry":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_deleteContinualImprovementRegistry(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "createSnapshot":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_createSnapshot(ctx, field)
@@ -69346,6 +71858,42 @@ func (ec *executionContext) _Organization(ctx context.Context, sel ast.Selection
 					}
 				}()
 				res = ec._Organization_complianceRegistries(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "continualImprovementRegistries":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Organization_continualImprovementRegistries(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -71759,6 +74307,45 @@ func (ec *executionContext) _UpdateComplianceRegistryPayload(ctx context.Context
 			out.Values[i] = graphql.MarshalString("UpdateComplianceRegistryPayload")
 		case "complianceRegistry":
 			out.Values[i] = ec._UpdateComplianceRegistryPayload_complianceRegistry(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var updateContinualImprovementRegistryPayloadImplementors = []string{"UpdateContinualImprovementRegistryPayload"}
+
+func (ec *executionContext) _UpdateContinualImprovementRegistryPayload(ctx context.Context, sel ast.SelectionSet, obj *types.UpdateContinualImprovementRegistryPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, updateContinualImprovementRegistryPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("UpdateContinualImprovementRegistryPayload")
+		case "continualImprovementRegistry":
+			out.Values[i] = ec._UpdateContinualImprovementRegistryPayload_continualImprovementRegistry(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -75629,6 +78216,178 @@ var (
 	}
 )
 
+func (ec *executionContext) unmarshalNContinualImprovementRegistriesOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesOrderField(ctx context.Context, v any) (coredata.ContinualImprovementRegistriesOrderField, error) {
+	tmp, err := graphql.UnmarshalString(v)
+	res := unmarshalNContinualImprovementRegistriesOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesOrderField[tmp]
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNContinualImprovementRegistriesOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesOrderField(ctx context.Context, sel ast.SelectionSet, v coredata.ContinualImprovementRegistriesOrderField) graphql.Marshaler {
+	_ = sel
+	res := graphql.MarshalString(marshalNContinualImprovementRegistriesOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesOrderField[v])
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+var (
+	unmarshalNContinualImprovementRegistriesOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesOrderField = map[string]coredata.ContinualImprovementRegistriesOrderField{
+		"CREATED_AT":   coredata.ContinualImprovementRegistriesOrderFieldCreatedAt,
+		"REFERENCE_ID": coredata.ContinualImprovementRegistriesOrderFieldReferenceId,
+		"TARGET_DATE":  coredata.ContinualImprovementRegistriesOrderFieldTargetDate,
+		"STATUS":       coredata.ContinualImprovementRegistriesOrderFieldStatus,
+		"PRIORITY":     coredata.ContinualImprovementRegistriesOrderFieldPriority,
+	}
+	marshalNContinualImprovementRegistriesOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesOrderField = map[coredata.ContinualImprovementRegistriesOrderField]string{
+		coredata.ContinualImprovementRegistriesOrderFieldCreatedAt:   "CREATED_AT",
+		coredata.ContinualImprovementRegistriesOrderFieldReferenceId: "REFERENCE_ID",
+		coredata.ContinualImprovementRegistriesOrderFieldTargetDate:  "TARGET_DATE",
+		coredata.ContinualImprovementRegistriesOrderFieldStatus:      "STATUS",
+		coredata.ContinualImprovementRegistriesOrderFieldPriority:    "PRIORITY",
+	}
+)
+
+func (ec *executionContext) unmarshalNContinualImprovementRegistriesPriority2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesPriority(ctx context.Context, v any) (coredata.ContinualImprovementRegistriesPriority, error) {
+	tmp, err := graphql.UnmarshalString(v)
+	res := unmarshalNContinualImprovementRegistriesPriority2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesPriority[tmp]
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNContinualImprovementRegistriesPriority2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesPriority(ctx context.Context, sel ast.SelectionSet, v coredata.ContinualImprovementRegistriesPriority) graphql.Marshaler {
+	_ = sel
+	res := graphql.MarshalString(marshalNContinualImprovementRegistriesPriority2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesPriority[v])
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+var (
+	unmarshalNContinualImprovementRegistriesPriority2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesPriority = map[string]coredata.ContinualImprovementRegistriesPriority{
+		"LOW":    coredata.ContinualImprovementRegistriesPriorityLow,
+		"MEDIUM": coredata.ContinualImprovementRegistriesPriorityMedium,
+		"HIGH":   coredata.ContinualImprovementRegistriesPriorityHigh,
+	}
+	marshalNContinualImprovementRegistriesPriority2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesPriority = map[coredata.ContinualImprovementRegistriesPriority]string{
+		coredata.ContinualImprovementRegistriesPriorityLow:    "LOW",
+		coredata.ContinualImprovementRegistriesPriorityMedium: "MEDIUM",
+		coredata.ContinualImprovementRegistriesPriorityHigh:   "HIGH",
+	}
+)
+
+func (ec *executionContext) unmarshalNContinualImprovementRegistriesStatus2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesStatus(ctx context.Context, v any) (coredata.ContinualImprovementRegistriesStatus, error) {
+	tmp, err := graphql.UnmarshalString(v)
+	res := unmarshalNContinualImprovementRegistriesStatus2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesStatus[tmp]
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNContinualImprovementRegistriesStatus2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesStatus(ctx context.Context, sel ast.SelectionSet, v coredata.ContinualImprovementRegistriesStatus) graphql.Marshaler {
+	_ = sel
+	res := graphql.MarshalString(marshalNContinualImprovementRegistriesStatus2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesStatus[v])
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+var (
+	unmarshalNContinualImprovementRegistriesStatus2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesStatus = map[string]coredata.ContinualImprovementRegistriesStatus{
+		"OPEN":        coredata.ContinualImprovementRegistriesStatusOpen,
+		"IN_PROGRESS": coredata.ContinualImprovementRegistriesStatusInProgress,
+		"CLOSED":      coredata.ContinualImprovementRegistriesStatusClosed,
+	}
+	marshalNContinualImprovementRegistriesStatus2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesStatus = map[coredata.ContinualImprovementRegistriesStatus]string{
+		coredata.ContinualImprovementRegistriesStatusOpen:       "OPEN",
+		coredata.ContinualImprovementRegistriesStatusInProgress: "IN_PROGRESS",
+		coredata.ContinualImprovementRegistriesStatusClosed:     "CLOSED",
+	}
+)
+
+func (ec *executionContext) marshalNContinualImprovementRegistry2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐContinualImprovementRegistry(ctx context.Context, sel ast.SelectionSet, v *types.ContinualImprovementRegistry) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ContinualImprovementRegistry(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNContinualImprovementRegistryConnection2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐContinualImprovementRegistryConnection(ctx context.Context, sel ast.SelectionSet, v types.ContinualImprovementRegistryConnection) graphql.Marshaler {
+	return ec._ContinualImprovementRegistryConnection(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNContinualImprovementRegistryConnection2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐContinualImprovementRegistryConnection(ctx context.Context, sel ast.SelectionSet, v *types.ContinualImprovementRegistryConnection) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ContinualImprovementRegistryConnection(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNContinualImprovementRegistryEdge2ᚕᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐContinualImprovementRegistryEdgeᚄ(ctx context.Context, sel ast.SelectionSet, v []*types.ContinualImprovementRegistryEdge) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNContinualImprovementRegistryEdge2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐContinualImprovementRegistryEdge(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNContinualImprovementRegistryEdge2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐContinualImprovementRegistryEdge(ctx context.Context, sel ast.SelectionSet, v *types.ContinualImprovementRegistryEdge) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ContinualImprovementRegistryEdge(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalNControl2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐControl(ctx context.Context, sel ast.SelectionSet, v *types.Control) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -75818,6 +78577,25 @@ func (ec *executionContext) marshalNCreateComplianceRegistryPayload2ᚖgithubᚗ
 		return graphql.Null
 	}
 	return ec._CreateComplianceRegistryPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNCreateContinualImprovementRegistryInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateContinualImprovementRegistryInput(ctx context.Context, v any) (types.CreateContinualImprovementRegistryInput, error) {
+	res, err := ec.unmarshalInputCreateContinualImprovementRegistryInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNCreateContinualImprovementRegistryPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateContinualImprovementRegistryPayload(ctx context.Context, sel ast.SelectionSet, v types.CreateContinualImprovementRegistryPayload) graphql.Marshaler {
+	return ec._CreateContinualImprovementRegistryPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNCreateContinualImprovementRegistryPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateContinualImprovementRegistryPayload(ctx context.Context, sel ast.SelectionSet, v *types.CreateContinualImprovementRegistryPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._CreateContinualImprovementRegistryPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNCreateControlAuditMappingInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateControlAuditMappingInput(ctx context.Context, v any) (types.CreateControlAuditMappingInput, error) {
@@ -76567,6 +79345,25 @@ func (ec *executionContext) marshalNDeleteComplianceRegistryPayload2ᚖgithubᚗ
 		return graphql.Null
 	}
 	return ec._DeleteComplianceRegistryPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNDeleteContinualImprovementRegistryInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteContinualImprovementRegistryInput(ctx context.Context, v any) (types.DeleteContinualImprovementRegistryInput, error) {
+	res, err := ec.unmarshalInputDeleteContinualImprovementRegistryInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNDeleteContinualImprovementRegistryPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteContinualImprovementRegistryPayload(ctx context.Context, sel ast.SelectionSet, v types.DeleteContinualImprovementRegistryPayload) graphql.Marshaler {
+	return ec._DeleteContinualImprovementRegistryPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNDeleteContinualImprovementRegistryPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteContinualImprovementRegistryPayload(ctx context.Context, sel ast.SelectionSet, v *types.DeleteContinualImprovementRegistryPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._DeleteContinualImprovementRegistryPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNDeleteControlAuditMappingInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteControlAuditMappingInput(ctx context.Context, v any) (types.DeleteControlAuditMappingInput, error) {
@@ -79333,6 +82130,25 @@ func (ec *executionContext) marshalNUpdateComplianceRegistryPayload2ᚖgithubᚗ
 	return ec._UpdateComplianceRegistryPayload(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNUpdateContinualImprovementRegistryInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateContinualImprovementRegistryInput(ctx context.Context, v any) (types.UpdateContinualImprovementRegistryInput, error) {
+	res, err := ec.unmarshalInputUpdateContinualImprovementRegistryInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNUpdateContinualImprovementRegistryPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateContinualImprovementRegistryPayload(ctx context.Context, sel ast.SelectionSet, v types.UpdateContinualImprovementRegistryPayload) graphql.Marshaler {
+	return ec._UpdateContinualImprovementRegistryPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNUpdateContinualImprovementRegistryPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateContinualImprovementRegistryPayload(ctx context.Context, sel ast.SelectionSet, v *types.UpdateContinualImprovementRegistryPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._UpdateContinualImprovementRegistryPayload(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNUpdateControlInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateControlInput(ctx context.Context, v any) (types.UpdateControlInput, error) {
 	res, err := ec.unmarshalInputUpdateControlInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -80963,6 +83779,78 @@ func (ec *executionContext) unmarshalOConnectorOrder2ᚖgithubᚗcomᚋgetprobo�
 	res, err := ec.unmarshalInputConnectorOrder(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
+
+func (ec *executionContext) unmarshalOContinualImprovementRegistriesOrder2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐContinualImprovementRegistriesOrderBy(ctx context.Context, v any) (*types.ContinualImprovementRegistriesOrderBy, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputContinualImprovementRegistriesOrder(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOContinualImprovementRegistriesPriority2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesPriority(ctx context.Context, v any) (*coredata.ContinualImprovementRegistriesPriority, error) {
+	if v == nil {
+		return nil, nil
+	}
+	tmp, err := graphql.UnmarshalString(v)
+	res := unmarshalOContinualImprovementRegistriesPriority2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesPriority[tmp]
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOContinualImprovementRegistriesPriority2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesPriority(ctx context.Context, sel ast.SelectionSet, v *coredata.ContinualImprovementRegistriesPriority) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	_ = sel
+	_ = ctx
+	res := graphql.MarshalString(marshalOContinualImprovementRegistriesPriority2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesPriority[*v])
+	return res
+}
+
+var (
+	unmarshalOContinualImprovementRegistriesPriority2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesPriority = map[string]coredata.ContinualImprovementRegistriesPriority{
+		"LOW":    coredata.ContinualImprovementRegistriesPriorityLow,
+		"MEDIUM": coredata.ContinualImprovementRegistriesPriorityMedium,
+		"HIGH":   coredata.ContinualImprovementRegistriesPriorityHigh,
+	}
+	marshalOContinualImprovementRegistriesPriority2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesPriority = map[coredata.ContinualImprovementRegistriesPriority]string{
+		coredata.ContinualImprovementRegistriesPriorityLow:    "LOW",
+		coredata.ContinualImprovementRegistriesPriorityMedium: "MEDIUM",
+		coredata.ContinualImprovementRegistriesPriorityHigh:   "HIGH",
+	}
+)
+
+func (ec *executionContext) unmarshalOContinualImprovementRegistriesStatus2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesStatus(ctx context.Context, v any) (*coredata.ContinualImprovementRegistriesStatus, error) {
+	if v == nil {
+		return nil, nil
+	}
+	tmp, err := graphql.UnmarshalString(v)
+	res := unmarshalOContinualImprovementRegistriesStatus2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesStatus[tmp]
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOContinualImprovementRegistriesStatus2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesStatus(ctx context.Context, sel ast.SelectionSet, v *coredata.ContinualImprovementRegistriesStatus) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	_ = sel
+	_ = ctx
+	res := graphql.MarshalString(marshalOContinualImprovementRegistriesStatus2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesStatus[*v])
+	return res
+}
+
+var (
+	unmarshalOContinualImprovementRegistriesStatus2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesStatus = map[string]coredata.ContinualImprovementRegistriesStatus{
+		"OPEN":        coredata.ContinualImprovementRegistriesStatusOpen,
+		"IN_PROGRESS": coredata.ContinualImprovementRegistriesStatusInProgress,
+		"CLOSED":      coredata.ContinualImprovementRegistriesStatusClosed,
+	}
+	marshalOContinualImprovementRegistriesStatus2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementRegistriesStatus = map[coredata.ContinualImprovementRegistriesStatus]string{
+		coredata.ContinualImprovementRegistriesStatusOpen:       "OPEN",
+		coredata.ContinualImprovementRegistriesStatusInProgress: "IN_PROGRESS",
+		coredata.ContinualImprovementRegistriesStatusClosed:     "CLOSED",
+	}
+)
 
 func (ec *executionContext) unmarshalOControlFilter2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐControlFilter(ctx context.Context, v any) (*types.ControlFilter, error) {
 	if v == nil {

--- a/pkg/server/api/console/v1/types/continual_improvement_registry.go
+++ b/pkg/server/api/console/v1/types/continual_improvement_registry.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package types
+
+import (
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+)
+
+type (
+	ContinualImprovementRegistriesOrderBy OrderBy[coredata.ContinualImprovementRegistriesOrderField]
+
+	ContinualImprovementRegistryConnection struct {
+		TotalCount int
+		Edges      []*ContinualImprovementRegistryEdge
+		PageInfo   PageInfo
+
+		Resolver any
+		ParentID gid.GID
+	}
+)
+
+func NewContinualImprovementRegistryConnection(
+	p *page.Page[*coredata.ContinualImprovementRegistry, coredata.ContinualImprovementRegistriesOrderField],
+	parentType any,
+	parentID gid.GID,
+) *ContinualImprovementRegistryConnection {
+	edges := make([]*ContinualImprovementRegistryEdge, len(p.Data))
+	for i, registry := range p.Data {
+		edges[i] = NewContinualImprovementRegistryEdge(registry, p.Cursor.OrderBy.Field)
+	}
+
+	return &ContinualImprovementRegistryConnection{
+		Edges:    edges,
+		PageInfo: *NewPageInfo(p),
+
+		Resolver: parentType,
+		ParentID: parentID,
+	}
+}
+
+func NewContinualImprovementRegistry(cir *coredata.ContinualImprovementRegistry) *ContinualImprovementRegistry {
+	return &ContinualImprovementRegistry{
+		ID:          cir.ID,
+		ReferenceID: cir.ReferenceID,
+		Description: cir.Description,
+		Source:      cir.Source,
+		TargetDate:  cir.TargetDate,
+		Status:      cir.Status,
+		Priority:    cir.Priority,
+		CreatedAt:   cir.CreatedAt,
+		UpdatedAt:   cir.UpdatedAt,
+	}
+}
+
+func NewContinualImprovementRegistryEdge(cir *coredata.ContinualImprovementRegistry, orderField coredata.ContinualImprovementRegistriesOrderField) *ContinualImprovementRegistryEdge {
+	return &ContinualImprovementRegistryEdge{
+		Node:   NewContinualImprovementRegistry(cir),
+		Cursor: cir.CursorKey(orderField),
+	}
+}

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -167,6 +167,29 @@ type ConnectorOrder struct {
 	Direction page.OrderDirection          `json:"direction"`
 }
 
+type ContinualImprovementRegistry struct {
+	ID           gid.GID                                         `json:"id"`
+	Organization *Organization                                   `json:"organization"`
+	ReferenceID  string                                          `json:"referenceId"`
+	Description  *string                                         `json:"description,omitempty"`
+	Audit        *Audit                                          `json:"audit"`
+	Source       *string                                         `json:"source,omitempty"`
+	Owner        *People                                         `json:"owner"`
+	TargetDate   *time.Time                                      `json:"targetDate,omitempty"`
+	Status       coredata.ContinualImprovementRegistriesStatus   `json:"status"`
+	Priority     coredata.ContinualImprovementRegistriesPriority `json:"priority"`
+	CreatedAt    time.Time                                       `json:"createdAt"`
+	UpdatedAt    time.Time                                       `json:"updatedAt"`
+}
+
+func (ContinualImprovementRegistry) IsNode()             {}
+func (this ContinualImprovementRegistry) GetID() gid.GID { return this.ID }
+
+type ContinualImprovementRegistryEdge struct {
+	Cursor page.CursorKey                `json:"cursor"`
+	Node   *ContinualImprovementRegistry `json:"node"`
+}
+
 type Control struct {
 	ID                     gid.GID                `json:"id"`
 	SectionTitle           string                 `json:"sectionTitle"`
@@ -240,6 +263,22 @@ type CreateComplianceRegistryInput struct {
 
 type CreateComplianceRegistryPayload struct {
 	ComplianceRegistryEdge *ComplianceRegistryEdge `json:"complianceRegistryEdge"`
+}
+
+type CreateContinualImprovementRegistryInput struct {
+	OrganizationID gid.GID                                         `json:"organizationId"`
+	ReferenceID    string                                          `json:"referenceId"`
+	Description    *string                                         `json:"description,omitempty"`
+	AuditID        gid.GID                                         `json:"auditId"`
+	Source         *string                                         `json:"source,omitempty"`
+	OwnerID        gid.GID                                         `json:"ownerId"`
+	TargetDate     *time.Time                                      `json:"targetDate,omitempty"`
+	Status         coredata.ContinualImprovementRegistriesStatus   `json:"status"`
+	Priority       coredata.ContinualImprovementRegistriesPriority `json:"priority"`
+}
+
+type CreateContinualImprovementRegistryPayload struct {
+	ContinualImprovementRegistryEdge *ContinualImprovementRegistryEdge `json:"continualImprovementRegistryEdge"`
 }
 
 type CreateControlAuditMappingInput struct {
@@ -593,6 +632,14 @@ type DeleteComplianceRegistryInput struct {
 
 type DeleteComplianceRegistryPayload struct {
 	DeletedComplianceRegistryID gid.GID `json:"deletedComplianceRegistryId"`
+}
+
+type DeleteContinualImprovementRegistryInput struct {
+	ContinualImprovementRegistryID gid.GID `json:"continualImprovementRegistryId"`
+}
+
+type DeleteContinualImprovementRegistryPayload struct {
+	DeletedContinualImprovementRegistryID gid.GID `json:"deletedContinualImprovementRegistryId"`
 }
 
 type DeleteControlAuditMappingInput struct {
@@ -1065,28 +1112,29 @@ type NonconformityRegistryEdge struct {
 }
 
 type Organization struct {
-	ID                      gid.GID                          `json:"id"`
-	Name                    string                           `json:"name"`
-	LogoURL                 *string                          `json:"logoUrl,omitempty"`
-	Users                   *UserConnection                  `json:"users"`
-	Connectors              *ConnectorConnection             `json:"connectors"`
-	Frameworks              *FrameworkConnection             `json:"frameworks"`
-	Controls                *ControlConnection               `json:"controls"`
-	Vendors                 *VendorConnection                `json:"vendors"`
-	Peoples                 *PeopleConnection                `json:"peoples"`
-	Documents               *DocumentConnection              `json:"documents"`
-	Measures                *MeasureConnection               `json:"measures"`
-	Risks                   *RiskConnection                  `json:"risks"`
-	Tasks                   *TaskConnection                  `json:"tasks"`
-	Assets                  *AssetConnection                 `json:"assets"`
-	Data                    *DatumConnection                 `json:"data"`
-	Audits                  *AuditConnection                 `json:"audits"`
-	NonconformityRegistries *NonconformityRegistryConnection `json:"nonconformityRegistries"`
-	ComplianceRegistries    *ComplianceRegistryConnection    `json:"complianceRegistries"`
-	Snapshots               *SnapshotConnection              `json:"snapshots"`
-	TrustCenter             *TrustCenter                     `json:"trustCenter,omitempty"`
-	CreatedAt               time.Time                        `json:"createdAt"`
-	UpdatedAt               time.Time                        `json:"updatedAt"`
+	ID                             gid.GID                                 `json:"id"`
+	Name                           string                                  `json:"name"`
+	LogoURL                        *string                                 `json:"logoUrl,omitempty"`
+	Users                          *UserConnection                         `json:"users"`
+	Connectors                     *ConnectorConnection                    `json:"connectors"`
+	Frameworks                     *FrameworkConnection                    `json:"frameworks"`
+	Controls                       *ControlConnection                      `json:"controls"`
+	Vendors                        *VendorConnection                       `json:"vendors"`
+	Peoples                        *PeopleConnection                       `json:"peoples"`
+	Documents                      *DocumentConnection                     `json:"documents"`
+	Measures                       *MeasureConnection                      `json:"measures"`
+	Risks                          *RiskConnection                         `json:"risks"`
+	Tasks                          *TaskConnection                         `json:"tasks"`
+	Assets                         *AssetConnection                        `json:"assets"`
+	Data                           *DatumConnection                        `json:"data"`
+	Audits                         *AuditConnection                        `json:"audits"`
+	NonconformityRegistries        *NonconformityRegistryConnection        `json:"nonconformityRegistries"`
+	ComplianceRegistries           *ComplianceRegistryConnection           `json:"complianceRegistries"`
+	ContinualImprovementRegistries *ContinualImprovementRegistryConnection `json:"continualImprovementRegistries"`
+	Snapshots                      *SnapshotConnection                     `json:"snapshots"`
+	TrustCenter                    *TrustCenter                            `json:"trustCenter,omitempty"`
+	CreatedAt                      time.Time                               `json:"createdAt"`
+	UpdatedAt                      time.Time                               `json:"updatedAt"`
 }
 
 func (Organization) IsNode()             {}
@@ -1389,6 +1437,22 @@ type UpdateComplianceRegistryInput struct {
 
 type UpdateComplianceRegistryPayload struct {
 	ComplianceRegistry *ComplianceRegistry `json:"complianceRegistry"`
+}
+
+type UpdateContinualImprovementRegistryInput struct {
+	ID          gid.GID                                          `json:"id"`
+	ReferenceID *string                                          `json:"referenceId,omitempty"`
+	Description *string                                          `json:"description,omitempty"`
+	AuditID     *gid.GID                                         `json:"auditId,omitempty"`
+	Source      *string                                          `json:"source,omitempty"`
+	OwnerID     *gid.GID                                         `json:"ownerId,omitempty"`
+	TargetDate  *time.Time                                       `json:"targetDate,omitempty"`
+	Status      *coredata.ContinualImprovementRegistriesStatus   `json:"status,omitempty"`
+	Priority    *coredata.ContinualImprovementRegistriesPriority `json:"priority,omitempty"`
+}
+
+type UpdateContinualImprovementRegistryPayload struct {
+	ContinualImprovementRegistry *ContinualImprovementRegistry `json:"continualImprovementRegistry"`
 }
 
 type UpdateControlInput struct {

--- a/pkg/server/api/console/v1/v1_resolver.go
+++ b/pkg/server/api/console/v1/v1_resolver.go
@@ -287,6 +287,73 @@ func (r *complianceRegistryConnectionResolver) TotalCount(ctx context.Context, o
 	panic(fmt.Errorf("unsupported resolver: %T", obj.Resolver))
 }
 
+// Organization is the resolver for the organization field.
+func (r *continualImprovementRegistryResolver) Organization(ctx context.Context, obj *types.ContinualImprovementRegistry) (*types.Organization, error) {
+	prb := r.ProboService(ctx, obj.ID.TenantID())
+
+	registry, err := prb.ContinualImprovementRegistries.Get(ctx, obj.ID)
+	if err != nil {
+		panic(fmt.Errorf("cannot get continual improvement registry: %w", err))
+	}
+
+	organization, err := prb.Organizations.Get(ctx, registry.OrganizationID)
+	if err != nil {
+		panic(fmt.Errorf("cannot get continual improvement registry organization: %w", err))
+	}
+
+	return types.NewOrganization(organization), nil
+}
+
+// Audit is the resolver for the audit field.
+func (r *continualImprovementRegistryResolver) Audit(ctx context.Context, obj *types.ContinualImprovementRegistry) (*types.Audit, error) {
+	prb := r.ProboService(ctx, obj.ID.TenantID())
+
+	registry, err := prb.ContinualImprovementRegistries.Get(ctx, obj.ID)
+	if err != nil {
+		panic(fmt.Errorf("cannot get continual improvement registry: %w", err))
+	}
+
+	audit, err := prb.Audits.Get(ctx, registry.AuditID)
+	if err != nil {
+		panic(fmt.Errorf("cannot get continual improvement registry audit: %w", err))
+	}
+
+	return types.NewAudit(audit), nil
+}
+
+// Owner is the resolver for the owner field.
+func (r *continualImprovementRegistryResolver) Owner(ctx context.Context, obj *types.ContinualImprovementRegistry) (*types.People, error) {
+	prb := r.ProboService(ctx, obj.ID.TenantID())
+
+	registry, err := prb.ContinualImprovementRegistries.Get(ctx, obj.ID)
+	if err != nil {
+		panic(fmt.Errorf("cannot get continual improvement registry: %w", err))
+	}
+
+	people, err := prb.Peoples.Get(ctx, registry.OwnerID)
+	if err != nil {
+		panic(fmt.Errorf("cannot get continual improvement registry owner: %w", err))
+	}
+
+	return types.NewPeople(people), nil
+}
+
+// TotalCount is the resolver for the totalCount field.
+func (r *continualImprovementRegistryConnectionResolver) TotalCount(ctx context.Context, obj *types.ContinualImprovementRegistryConnection) (int, error) {
+	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+
+	switch obj.Resolver.(type) {
+	case *organizationResolver:
+		count, err := prb.ContinualImprovementRegistries.CountByOrganizationID(ctx, obj.ParentID)
+		if err != nil {
+			panic(fmt.Errorf("cannot count continual improvement registries: %w", err))
+		}
+		return count, nil
+	}
+
+	panic(fmt.Errorf("unsupported resolver: %T", obj.Resolver))
+}
+
 // Framework is the resolver for the framework field.
 func (r *controlResolver) Framework(ctx context.Context, obj *types.Control) (*types.Framework, error) {
 	prb := r.ProboService(ctx, obj.ID.TenantID())
@@ -3051,6 +3118,72 @@ func (r *mutationResolver) DeleteComplianceRegistry(ctx context.Context, input t
 	}, nil
 }
 
+// CreateContinualImprovementRegistry is the resolver for the createContinualImprovementRegistry field.
+func (r *mutationResolver) CreateContinualImprovementRegistry(ctx context.Context, input types.CreateContinualImprovementRegistryInput) (*types.CreateContinualImprovementRegistryPayload, error) {
+	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+
+	req := probo.CreateContinualImprovementRegistryRequest{
+		OrganizationID: input.OrganizationID,
+		ReferenceID:    input.ReferenceID,
+		Description:    input.Description,
+		AuditID:        input.AuditID,
+		Source:         input.Source,
+		OwnerID:        input.OwnerID,
+		TargetDate:     input.TargetDate,
+		Status:         &input.Status,
+		Priority:       &input.Priority,
+	}
+
+	registry, err := prb.ContinualImprovementRegistries.Create(ctx, &req)
+	if err != nil {
+		panic(fmt.Errorf("cannot create continual improvement registry: %w", err))
+	}
+
+	return &types.CreateContinualImprovementRegistryPayload{
+		ContinualImprovementRegistryEdge: types.NewContinualImprovementRegistryEdge(registry, coredata.ContinualImprovementRegistriesOrderFieldCreatedAt),
+	}, nil
+}
+
+// UpdateContinualImprovementRegistry is the resolver for the updateContinualImprovementRegistry field.
+func (r *mutationResolver) UpdateContinualImprovementRegistry(ctx context.Context, input types.UpdateContinualImprovementRegistryInput) (*types.UpdateContinualImprovementRegistryPayload, error) {
+	prb := r.ProboService(ctx, input.ID.TenantID())
+
+	req := probo.UpdateContinualImprovementRegistryRequest{
+		ID:          input.ID,
+		ReferenceID: input.ReferenceID,
+		Description: &input.Description,
+		AuditID:     input.AuditID,
+		Source:      &input.Source,
+		OwnerID:     input.OwnerID,
+		TargetDate:  &input.TargetDate,
+		Status:      input.Status,
+		Priority:    input.Priority,
+	}
+
+	registry, err := prb.ContinualImprovementRegistries.Update(ctx, &req)
+	if err != nil {
+		panic(fmt.Errorf("cannot update continual improvement registry: %w", err))
+	}
+
+	return &types.UpdateContinualImprovementRegistryPayload{
+		ContinualImprovementRegistry: types.NewContinualImprovementRegistry(registry),
+	}, nil
+}
+
+// DeleteContinualImprovementRegistry is the resolver for the deleteContinualImprovementRegistry field.
+func (r *mutationResolver) DeleteContinualImprovementRegistry(ctx context.Context, input types.DeleteContinualImprovementRegistryInput) (*types.DeleteContinualImprovementRegistryPayload, error) {
+	prb := r.ProboService(ctx, input.ContinualImprovementRegistryID.TenantID())
+
+	err := prb.ContinualImprovementRegistries.Delete(ctx, input.ContinualImprovementRegistryID)
+	if err != nil {
+		panic(fmt.Errorf("cannot delete continual improvement registry: %w", err))
+	}
+
+	return &types.DeleteContinualImprovementRegistryPayload{
+		DeletedContinualImprovementRegistryID: input.ContinualImprovementRegistryID,
+	}, nil
+}
+
 // CreateSnapshot is the resolver for the createSnapshot field.
 func (r *mutationResolver) CreateSnapshot(ctx context.Context, input types.CreateSnapshotInput) (*types.CreateSnapshotPayload, error) {
 	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
@@ -3562,6 +3695,32 @@ func (r *organizationResolver) ComplianceRegistries(ctx context.Context, obj *ty
 	return types.NewComplianceRegistryConnection(page, r, obj.ID), nil
 }
 
+// ContinualImprovementRegistries is the resolver for the continualImprovementRegistries field.
+func (r *organizationResolver) ContinualImprovementRegistries(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ContinualImprovementRegistriesOrderBy) (*types.ContinualImprovementRegistryConnection, error) {
+	prb := r.ProboService(ctx, obj.ID.TenantID())
+
+	pageOrderBy := page.OrderBy[coredata.ContinualImprovementRegistriesOrderField]{
+		Field:     coredata.ContinualImprovementRegistriesOrderFieldCreatedAt,
+		Direction: page.OrderDirectionDesc,
+	}
+
+	if orderBy != nil {
+		pageOrderBy = page.OrderBy[coredata.ContinualImprovementRegistriesOrderField]{
+			Field:     orderBy.Field,
+			Direction: orderBy.Direction,
+		}
+	}
+
+	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
+
+	page, err := prb.ContinualImprovementRegistries.ListForOrganizationID(ctx, obj.ID, cursor)
+	if err != nil {
+		panic(fmt.Errorf("cannot list organization continual improvement registries: %w", err))
+	}
+
+	return types.NewContinualImprovementRegistryConnection(page, r, obj.ID), nil
+}
+
 // Snapshots is the resolver for the snapshots field.
 func (r *organizationResolver) Snapshots(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.SnapshotOrderBy) (*types.SnapshotConnection, error) {
 	prb := r.ProboService(ctx, obj.ID.TenantID())
@@ -3748,6 +3907,12 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 			panic(fmt.Errorf("cannot get compliance registry: %w", err))
 		}
 		return types.NewComplianceRegistry(complianceRegistry), nil
+	case coredata.ContinualImprovementRegistryEntityType:
+		continualImprovementRegistry, err := prb.ContinualImprovementRegistries.Get(ctx, id)
+		if err != nil {
+			panic(fmt.Errorf("cannot get continual improvement registry: %w", err))
+		}
+		return types.NewContinualImprovementRegistry(continualImprovementRegistry), nil
 	case coredata.ReportEntityType:
 		report, err := prb.Reports.Get(ctx, id)
 		if err != nil {
@@ -4568,6 +4733,16 @@ func (r *Resolver) ComplianceRegistryConnection() schema.ComplianceRegistryConne
 	return &complianceRegistryConnectionResolver{r}
 }
 
+// ContinualImprovementRegistry returns schema.ContinualImprovementRegistryResolver implementation.
+func (r *Resolver) ContinualImprovementRegistry() schema.ContinualImprovementRegistryResolver {
+	return &continualImprovementRegistryResolver{r}
+}
+
+// ContinualImprovementRegistryConnection returns schema.ContinualImprovementRegistryConnectionResolver implementation.
+func (r *Resolver) ContinualImprovementRegistryConnection() schema.ContinualImprovementRegistryConnectionResolver {
+	return &continualImprovementRegistryConnectionResolver{r}
+}
+
 // Control returns schema.ControlResolver implementation.
 func (r *Resolver) Control() schema.ControlResolver { return &controlResolver{r} }
 
@@ -4722,6 +4897,8 @@ type auditResolver struct{ *Resolver }
 type auditConnectionResolver struct{ *Resolver }
 type complianceRegistryResolver struct{ *Resolver }
 type complianceRegistryConnectionResolver struct{ *Resolver }
+type continualImprovementRegistryResolver struct{ *Resolver }
+type continualImprovementRegistryConnectionResolver struct{ *Resolver }
 type controlResolver struct{ *Resolver }
 type controlConnectionResolver struct{ *Resolver }
 type datumResolver struct{ *Resolver }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds Continual Improvement Registries end-to-end. Users can create, view, edit, and delete registries with status, priority, owner, audit, and target date. Also adds a new sidebar item and standardizes registry routes to kebab-case.

- **New Features**
  - Console: list and details pages, create dialog, edit and delete actions, pagination and refetch.
  - API: new GraphQL types and CRUD (list/node queries, create/update/delete), resolvers, and service layer.
  - Data: new table plus status/priority enums.
  - Navigation: new “Continual Improvement Registries” sidebar link.
  - UI: slightly wider sidebar for labels.

- **Migration**
  - Apply DB migration 20250826T121441Z.sql.
  - Update any hardcoded links to kebab-case:
    - /organizations/:id/nonconformity-registries
    - /organizations/:id/compliance-registries
    - /organizations/:id/continual-improvement-registries

<!-- End of auto-generated description by cubic. -->

