### PR TITLE
Add assets snapshots

### DIFF
--- a/apps/console/src/hooks/graph/AssetGraph.ts
+++ b/apps/console/src/hooks/graph/AssetGraph.ts
@@ -5,10 +5,10 @@ import { useTranslate } from "@probo/i18n";
 import { promisifyMutation, sprintf } from "@probo/helpers";
 
 export const assetsQuery = graphql`
-  query AssetGraphListQuery($organizationId: ID!) {
+  query AssetGraphListQuery($organizationId: ID!, $snapshotId: ID) {
     node(id: $organizationId) {
       ... on Organization {
-        ...AssetsPageFragment
+        ...AssetsPageFragment @arguments(snapshotId: $snapshotId)
       }
     }
   }
@@ -19,6 +19,7 @@ export const assetNodeQuery = graphql`
     node(id: $assetId) {
       ... on Asset {
         id
+        snapshotId
         name
         amount
         criticity
@@ -54,6 +55,7 @@ export const createAssetMutation = graphql`
       assetEdge @prependEdge(connections: $connections) {
         node {
           id
+          snapshotId
           name
           amount
           criticity
@@ -63,7 +65,7 @@ export const createAssetMutation = graphql`
             id
             fullName
           }
-          vendors(first: 10) {
+          vendors(first: 50) {
             edges {
               node {
                 id
@@ -84,6 +86,7 @@ export const updateAssetMutation = graphql`
     updateAsset(input: $input) {
       asset {
         id
+        snapshotId
         name
         amount
         criticity

--- a/apps/console/src/hooks/graph/__generated__/AssetGraphCreateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/AssetGraphCreateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8ddee1e0195c3af2818a78e1224ad297>>
+ * @generated SignedSource<<9f6605e9adebeee2a681da0278642501>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -40,6 +40,7 @@ export type AssetGraphCreateMutation$data = {
           readonly fullName: string;
           readonly id: string;
         };
+        readonly snapshotId: string | null | undefined;
         readonly vendors: {
           readonly edges: ReadonlyArray<{
             readonly node: {
@@ -107,6 +108,13 @@ v5 = {
       "plural": false,
       "selections": [
         (v3/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "snapshotId",
+          "storageKey": null
+        },
         (v4/*: any*/),
         {
           "alias": null,
@@ -161,7 +169,7 @@ v5 = {
             {
               "kind": "Literal",
               "name": "first",
-              "value": 10
+              "value": 50
             }
           ],
           "concreteType": "VendorConnection",
@@ -201,7 +209,7 @@ v5 = {
               "storageKey": null
             }
           ],
-          "storageKey": "vendors(first:10)"
+          "storageKey": "vendors(first:50)"
         },
         {
           "alias": null,
@@ -282,16 +290,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f1d2e4e85879e08931d9d6815cc51ec1",
+    "cacheID": "f11f5052ed6dd175bd701812c0cd136b",
     "id": null,
     "metadata": {},
     "name": "AssetGraphCreateMutation",
     "operationKind": "mutation",
-    "text": "mutation AssetGraphCreateMutation(\n  $input: CreateAssetInput!\n) {\n  createAsset(input: $input) {\n    assetEdge {\n      node {\n        id\n        name\n        amount\n        criticity\n        assetType\n        dataTypesStored\n        owner {\n          id\n          fullName\n        }\n        vendors(first: 10) {\n          edges {\n            node {\n              id\n              name\n              websiteUrl\n            }\n          }\n        }\n        createdAt\n      }\n    }\n  }\n}\n"
+    "text": "mutation AssetGraphCreateMutation(\n  $input: CreateAssetInput!\n) {\n  createAsset(input: $input) {\n    assetEdge {\n      node {\n        id\n        snapshotId\n        name\n        amount\n        criticity\n        assetType\n        dataTypesStored\n        owner {\n          id\n          fullName\n        }\n        vendors(first: 50) {\n          edges {\n            node {\n              id\n              name\n              websiteUrl\n            }\n          }\n        }\n        createdAt\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "5053ed385668e9f51d916a194ea8936d";
+(node as any).hash = "3cec119022d8dffb8536d93294e2633b";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/AssetGraphListQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/AssetGraphListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8758668524dc47bc04757126d7f423b3>>
+ * @generated SignedSource<<8d257a13d23e2dd68542540dd12ca35b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,7 @@ import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type AssetGraphListQuery$variables = {
   organizationId: string;
+  snapshotId?: string | null | undefined;
 };
 export type AssetGraphListQuery$data = {
   readonly node: {
@@ -29,6 +30,11 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "organizationId"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "snapshotId"
   }
 ],
 v1 = [
@@ -38,28 +44,40 @@ v1 = [
     "variableName": "organizationId"
   }
 ],
-v2 = {
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "snapshotId",
+    "variableName": "snapshotId"
+  }
+],
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v3 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v4 = [
+v5 = [
+  {
+    "fields": (v2/*: any*/),
+    "kind": "ObjectValue",
+    "name": "filter"
+  },
   {
     "kind": "Literal",
     "name": "first",
     "value": 10
   }
 ],
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -85,7 +103,7 @@ return {
             "kind": "InlineFragment",
             "selections": [
               {
-                "args": null,
+                "args": (v2/*: any*/),
                 "kind": "FragmentSpread",
                 "name": "AssetsPageFragment"
               }
@@ -114,14 +132,14 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v2/*: any*/),
           (v3/*: any*/),
+          (v4/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
               {
                 "alias": null,
-                "args": (v4/*: any*/),
+                "args": (v5/*: any*/),
                 "concreteType": "AssetConnection",
                 "kind": "LinkedField",
                 "name": "assets",
@@ -143,8 +161,15 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v3/*: any*/),
-                          (v5/*: any*/),
+                          (v4/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "snapshotId",
+                            "storageKey": null
+                          },
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -181,7 +206,7 @@ return {
                             "name": "owner",
                             "plural": false,
                             "selections": [
-                              (v3/*: any*/),
+                              (v4/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -222,8 +247,8 @@ return {
                                     "name": "node",
                                     "plural": false,
                                     "selections": [
-                                      (v3/*: any*/),
-                                      (v5/*: any*/),
+                                      (v4/*: any*/),
+                                      (v6/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -247,7 +272,7 @@ return {
                             "name": "createdAt",
                             "storageKey": null
                           },
-                          (v2/*: any*/)
+                          (v3/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -313,13 +338,13 @@ return {
                     ]
                   }
                 ],
-                "storageKey": "assets(first:10)"
+                "storageKey": null
               },
               {
                 "alias": null,
-                "args": (v4/*: any*/),
+                "args": (v5/*: any*/),
                 "filters": [
-                  "orderBy"
+                  "filter"
                 ],
                 "handle": "connection",
                 "key": "AssetsPage_assets",
@@ -336,16 +361,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "7e293e732d5ff8246a1ed772e1c33984",
+    "cacheID": "29eec1243d3cceb5d9931562635e1f24",
     "id": null,
     "metadata": {},
     "name": "AssetGraphListQuery",
     "operationKind": "query",
-    "text": "query AssetGraphListQuery(\n  $organizationId: ID!\n) {\n  node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      ...AssetsPageFragment\n    }\n    id\n  }\n}\n\nfragment AssetsPageFragment on Organization {\n  assets(first: 10) {\n    edges {\n      node {\n        id\n        name\n        amount\n        criticity\n        assetType\n        dataTypesStored\n        owner {\n          id\n          fullName\n        }\n        vendors(first: 50) {\n          edges {\n            node {\n              id\n              name\n              websiteUrl\n            }\n          }\n        }\n        createdAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n"
+    "text": "query AssetGraphListQuery(\n  $organizationId: ID!\n  $snapshotId: ID\n) {\n  node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      ...AssetsPageFragment_3iomuz\n    }\n    id\n  }\n}\n\nfragment AssetsPageFragment_3iomuz on Organization {\n  assets(first: 10, filter: {snapshotId: $snapshotId}) {\n    edges {\n      node {\n        id\n        snapshotId\n        name\n        amount\n        criticity\n        assetType\n        dataTypesStored\n        owner {\n          id\n          fullName\n        }\n        vendors(first: 50) {\n          edges {\n            node {\n              id\n              name\n              websiteUrl\n            }\n          }\n        }\n        createdAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "88644d5fcb5f2e017df4b5d6373ce27f";
+(node as any).hash = "4cbb1234b0884823285d3660334a2b29";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/AssetGraphNodeQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/AssetGraphNodeQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bdc352ae0c426ad29ff6e0f53dc357cf>>
+ * @generated SignedSource<<f1d88685da6d13c894f029b8ac4cf3e4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -28,6 +28,7 @@ export type AssetGraphNodeQuery$data = {
       readonly fullName: string;
       readonly id: string;
     };
+    readonly snapshotId?: string | null | undefined;
     readonly updatedAt?: any;
     readonly vendors?: {
       readonly edges: ReadonlyArray<{
@@ -72,38 +73,45 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "snapshotId",
   "storageKey": null
 },
 v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "amount",
+  "name": "name",
   "storageKey": null
 },
 v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "criticity",
+  "name": "amount",
   "storageKey": null
 },
 v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "assetType",
+  "name": "criticity",
   "storageKey": null
 },
 v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "dataTypesStored",
+  "name": "assetType",
   "storageKey": null
 },
 v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "dataTypesStored",
+  "storageKey": null
+},
+v9 = {
   "alias": null,
   "args": null,
   "concreteType": "People",
@@ -122,7 +130,7 @@ v8 = {
   ],
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": [
     {
@@ -153,7 +161,7 @@ v9 = {
           "plural": false,
           "selections": [
             (v2/*: any*/),
-            (v3/*: any*/),
+            (v4/*: any*/),
             {
               "alias": null,
               "args": null,
@@ -177,14 +185,14 @@ v9 = {
   ],
   "storageKey": "vendors(first:50)"
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "createdAt",
   "storageKey": null
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -218,7 +226,8 @@ return {
               (v8/*: any*/),
               (v9/*: any*/),
               (v10/*: any*/),
-              (v11/*: any*/)
+              (v11/*: any*/),
+              (v12/*: any*/)
             ],
             "type": "Asset",
             "abstractKey": null
@@ -263,7 +272,8 @@ return {
               (v8/*: any*/),
               (v9/*: any*/),
               (v10/*: any*/),
-              (v11/*: any*/)
+              (v11/*: any*/),
+              (v12/*: any*/)
             ],
             "type": "Asset",
             "abstractKey": null
@@ -274,16 +284,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "cd1d7c48ccf01acee749af3b8948fb9a",
+    "cacheID": "6c6e10d25c9bd116703346393adb7a3f",
     "id": null,
     "metadata": {},
     "name": "AssetGraphNodeQuery",
     "operationKind": "query",
-    "text": "query AssetGraphNodeQuery(\n  $assetId: ID!\n) {\n  node(id: $assetId) {\n    __typename\n    ... on Asset {\n      id\n      name\n      amount\n      criticity\n      assetType\n      dataTypesStored\n      owner {\n        id\n        fullName\n      }\n      vendors(first: 50) {\n        edges {\n          node {\n            id\n            name\n            websiteUrl\n            category\n          }\n        }\n      }\n      createdAt\n      updatedAt\n    }\n    id\n  }\n}\n"
+    "text": "query AssetGraphNodeQuery(\n  $assetId: ID!\n) {\n  node(id: $assetId) {\n    __typename\n    ... on Asset {\n      id\n      snapshotId\n      name\n      amount\n      criticity\n      assetType\n      dataTypesStored\n      owner {\n        id\n        fullName\n      }\n      vendors(first: 50) {\n        edges {\n          node {\n            id\n            name\n            websiteUrl\n            category\n          }\n        }\n      }\n      createdAt\n      updatedAt\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "47e84c9ea1c9ab9310ad493219c12f3f";
+(node as any).hash = "60053f70c9a65d4658be7b830a3dae72";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/AssetGraphUpdateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/AssetGraphUpdateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ead1e328f3bc8ddc8f4c98cee6838ee9>>
+ * @generated SignedSource<<6bc692e9d9ab5b78611dc2a326227761>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -37,6 +37,7 @@ export type AssetGraphUpdateMutation$data = {
         readonly fullName: string;
         readonly id: string;
       };
+      readonly snapshotId: string | null | undefined;
       readonly updatedAt: any;
       readonly vendors: {
         readonly edges: ReadonlyArray<{
@@ -101,6 +102,13 @@ v3 = [
         "plural": false,
         "selections": [
           (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "snapshotId",
+            "storageKey": null
+          },
           (v2/*: any*/),
           {
             "alias": null,
@@ -229,16 +237,16 @@ return {
     "selections": (v3/*: any*/)
   },
   "params": {
-    "cacheID": "f5e4ccc38f842f4965c32676ae407012",
+    "cacheID": "1447ea6f965bbd6fcdba1ebc72e2d23f",
     "id": null,
     "metadata": {},
     "name": "AssetGraphUpdateMutation",
     "operationKind": "mutation",
-    "text": "mutation AssetGraphUpdateMutation(\n  $input: UpdateAssetInput!\n) {\n  updateAsset(input: $input) {\n    asset {\n      id\n      name\n      amount\n      criticity\n      assetType\n      dataTypesStored\n      owner {\n        id\n        fullName\n      }\n      vendors(first: 50) {\n        edges {\n          node {\n            id\n            name\n            websiteUrl\n          }\n        }\n      }\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation AssetGraphUpdateMutation(\n  $input: UpdateAssetInput!\n) {\n  updateAsset(input: $input) {\n    asset {\n      id\n      snapshotId\n      name\n      amount\n      criticity\n      assetType\n      dataTypesStored\n      owner {\n        id\n        fullName\n      }\n      vendors(first: 50) {\n        edges {\n          node {\n            id\n            name\n            websiteUrl\n          }\n        }\n      }\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "257fa8f1a9996808403fa65a06b61ba2";
+(node as any).hash = "21b0c94b6245eb849e6118a58fb97490";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/ProcessingActivityRegistryGraphNodeQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/ProcessingActivityRegistryGraphNodeQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4453e7e28a9c546de765219f287f129a>>
+ * @generated SignedSource<<676223ac3bde5a9edf7e3d68fe3ed981>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -38,7 +38,6 @@ export type ProcessingActivityRegistryGraphNodeQuery$data = {
     readonly retentionPeriod?: string | null | undefined;
     readonly securityMeasures?: string | null | undefined;
     readonly snapshotId?: string | null | undefined;
-    readonly sourceId?: string | null | undefined;
     readonly specialOrCriminalData?: ProcessingActivityRegistrySpecialOrCriminalData;
     readonly transferImpactAssessment?: ProcessingActivityRegistryTransferImpactAssessment;
     readonly transferSafeguards?: ProcessingActivityRegistryTransferSafeguards | null | undefined;
@@ -83,115 +82,108 @@ v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "sourceId",
+  "name": "name",
   "storageKey": null
 },
 v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "purpose",
   "storageKey": null
 },
 v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "purpose",
+  "name": "dataSubjectCategory",
   "storageKey": null
 },
 v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "dataSubjectCategory",
+  "name": "personalDataCategory",
   "storageKey": null
 },
 v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "personalDataCategory",
+  "name": "specialOrCriminalData",
   "storageKey": null
 },
 v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "specialOrCriminalData",
+  "name": "consentEvidenceLink",
   "storageKey": null
 },
 v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "consentEvidenceLink",
+  "name": "lawfulBasis",
   "storageKey": null
 },
 v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "lawfulBasis",
+  "name": "recipients",
   "storageKey": null
 },
 v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "recipients",
+  "name": "location",
   "storageKey": null
 },
 v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "location",
+  "name": "internationalTransfers",
   "storageKey": null
 },
 v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "internationalTransfers",
+  "name": "transferSafeguards",
   "storageKey": null
 },
 v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "transferSafeguards",
+  "name": "retentionPeriod",
   "storageKey": null
 },
 v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "retentionPeriod",
+  "name": "securityMeasures",
   "storageKey": null
 },
 v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "securityMeasures",
+  "name": "dataProtectionImpactAssessment",
   "storageKey": null
 },
 v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "dataProtectionImpactAssessment",
-  "storageKey": null
-},
-v19 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "transferImpactAssessment",
   "storageKey": null
 },
-v20 = {
+v19 = {
   "alias": null,
   "args": null,
   "concreteType": "Organization",
@@ -200,18 +192,18 @@ v20 = {
   "plural": false,
   "selections": [
     (v2/*: any*/),
-    (v5/*: any*/)
+    (v4/*: any*/)
   ],
   "storageKey": null
 },
-v21 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "createdAt",
   "storageKey": null
 },
-v22 = {
+v21 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -255,8 +247,7 @@ return {
               (v18/*: any*/),
               (v19/*: any*/),
               (v20/*: any*/),
-              (v21/*: any*/),
-              (v22/*: any*/)
+              (v21/*: any*/)
             ],
             "type": "ProcessingActivityRegistry",
             "abstractKey": null
@@ -311,8 +302,7 @@ return {
               (v18/*: any*/),
               (v19/*: any*/),
               (v20/*: any*/),
-              (v21/*: any*/),
-              (v22/*: any*/)
+              (v21/*: any*/)
             ],
             "type": "ProcessingActivityRegistry",
             "abstractKey": null
@@ -323,16 +313,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b8a3edd61ea5d94cc3594f40f181d27f",
+    "cacheID": "10b9608f3b93e930c05f415a0ac9fbec",
     "id": null,
     "metadata": {},
     "name": "ProcessingActivityRegistryGraphNodeQuery",
     "operationKind": "query",
-    "text": "query ProcessingActivityRegistryGraphNodeQuery(\n  $processingActivityRegistryId: ID!\n) {\n  node(id: $processingActivityRegistryId) {\n    __typename\n    ... on ProcessingActivityRegistry {\n      id\n      snapshotId\n      sourceId\n      name\n      purpose\n      dataSubjectCategory\n      personalDataCategory\n      specialOrCriminalData\n      consentEvidenceLink\n      lawfulBasis\n      recipients\n      location\n      internationalTransfers\n      transferSafeguards\n      retentionPeriod\n      securityMeasures\n      dataProtectionImpactAssessment\n      transferImpactAssessment\n      organization {\n        id\n        name\n      }\n      createdAt\n      updatedAt\n    }\n    id\n  }\n}\n"
+    "text": "query ProcessingActivityRegistryGraphNodeQuery(\n  $processingActivityRegistryId: ID!\n) {\n  node(id: $processingActivityRegistryId) {\n    __typename\n    ... on ProcessingActivityRegistry {\n      id\n      snapshotId\n      name\n      purpose\n      dataSubjectCategory\n      personalDataCategory\n      specialOrCriminalData\n      consentEvidenceLink\n      lawfulBasis\n      recipients\n      location\n      internationalTransfers\n      transferSafeguards\n      retentionPeriod\n      securityMeasures\n      dataProtectionImpactAssessment\n      transferImpactAssessment\n      organization {\n        id\n        name\n      }\n      createdAt\n      updatedAt\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "6714c1965f54321530f73a5b7ef86fa6";
+(node as any).hash = "c1728cff79a3773498b383bb32728cf6";
 
 export default node;

--- a/apps/console/src/pages/organizations/assets/__generated__/AssetsListQuery.graphql.ts
+++ b/apps/console/src/pages/organizations/assets/__generated__/AssetsListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<305c2e15c19e7ead66752260c29d8794>>
+ * @generated SignedSource<<f2135bf85e1d0dffde8c1bcaa7940504>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -23,6 +23,7 @@ export type AssetsListQuery$variables = {
   id: string;
   last?: number | null | undefined;
   orderBy?: AssetOrder | null | undefined;
+  snapshotId?: string | null | undefined;
 };
 export type AssetsListQuery$data = {
   readonly node: {
@@ -65,55 +66,77 @@ v5 = {
   "kind": "LocalArgument",
   "name": "orderBy"
 },
-v6 = [
+v6 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "snapshotId"
+},
+v7 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
   }
 ],
-v7 = [
-  {
-    "kind": "Variable",
-    "name": "after",
-    "variableName": "after"
-  },
-  {
-    "kind": "Variable",
-    "name": "before",
-    "variableName": "before"
-  },
-  {
-    "kind": "Variable",
-    "name": "first",
-    "variableName": "first"
-  },
-  {
-    "kind": "Variable",
-    "name": "last",
-    "variableName": "last"
-  },
-  {
-    "kind": "Variable",
-    "name": "orderBy",
-    "variableName": "orderBy"
-  }
-],
 v8 = {
+  "kind": "Variable",
+  "name": "after",
+  "variableName": "after"
+},
+v9 = {
+  "kind": "Variable",
+  "name": "before",
+  "variableName": "before"
+},
+v10 = {
+  "kind": "Variable",
+  "name": "first",
+  "variableName": "first"
+},
+v11 = {
+  "kind": "Variable",
+  "name": "last",
+  "variableName": "last"
+},
+v12 = {
+  "kind": "Variable",
+  "name": "orderBy",
+  "variableName": "orderBy"
+},
+v13 = {
+  "kind": "Variable",
+  "name": "snapshotId",
+  "variableName": "snapshotId"
+},
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v9 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v10 = {
+v16 = [
+  (v8/*: any*/),
+  (v9/*: any*/),
+  {
+    "fields": [
+      (v13/*: any*/)
+    ],
+    "kind": "ObjectValue",
+    "name": "filter"
+  },
+  (v10/*: any*/),
+  (v11/*: any*/),
+  (v12/*: any*/)
+],
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -128,7 +151,8 @@ return {
       (v2/*: any*/),
       (v3/*: any*/),
       (v4/*: any*/),
-      (v5/*: any*/)
+      (v5/*: any*/),
+      (v6/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -136,14 +160,21 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v6/*: any*/),
+        "args": (v7/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
           {
-            "args": (v7/*: any*/),
+            "args": [
+              (v8/*: any*/),
+              (v9/*: any*/),
+              (v10/*: any*/),
+              (v11/*: any*/),
+              (v12/*: any*/),
+              (v13/*: any*/)
+            ],
             "kind": "FragmentSpread",
             "name": "AssetsPageFragment"
           }
@@ -162,6 +193,7 @@ return {
       (v2/*: any*/),
       (v4/*: any*/),
       (v5/*: any*/),
+      (v6/*: any*/),
       (v3/*: any*/)
     ],
     "kind": "Operation",
@@ -169,20 +201,20 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v6/*: any*/),
+        "args": (v7/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v8/*: any*/),
-          (v9/*: any*/),
+          (v14/*: any*/),
+          (v15/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
               {
                 "alias": null,
-                "args": (v7/*: any*/),
+                "args": (v16/*: any*/),
                 "concreteType": "AssetConnection",
                 "kind": "LinkedField",
                 "name": "assets",
@@ -204,8 +236,15 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v9/*: any*/),
-                          (v10/*: any*/),
+                          (v15/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "snapshotId",
+                            "storageKey": null
+                          },
+                          (v17/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -242,7 +281,7 @@ return {
                             "name": "owner",
                             "plural": false,
                             "selections": [
-                              (v9/*: any*/),
+                              (v15/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -283,8 +322,8 @@ return {
                                     "name": "node",
                                     "plural": false,
                                     "selections": [
-                                      (v9/*: any*/),
-                                      (v10/*: any*/),
+                                      (v15/*: any*/),
+                                      (v17/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -308,7 +347,7 @@ return {
                             "name": "createdAt",
                             "storageKey": null
                           },
-                          (v8/*: any*/)
+                          (v14/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -378,9 +417,9 @@ return {
               },
               {
                 "alias": null,
-                "args": (v7/*: any*/),
+                "args": (v16/*: any*/),
                 "filters": [
-                  "orderBy"
+                  "filter"
                 ],
                 "handle": "connection",
                 "key": "AssetsPage_assets",
@@ -397,16 +436,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d712227ae7c1c1a4151005092f7eeaf9",
+    "cacheID": "2eab5fe4d402f48ac4dcd8220284ea41",
     "id": null,
     "metadata": {},
     "name": "AssetsListQuery",
     "operationKind": "query",
-    "text": "query AssetsListQuery(\n  $after: CursorKey = null\n  $before: CursorKey = null\n  $first: Int = 10\n  $last: Int = null\n  $orderBy: AssetOrder = null\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...AssetsPageFragment_sdb03\n    id\n  }\n}\n\nfragment AssetsPageFragment_sdb03 on Organization {\n  assets(first: $first, after: $after, last: $last, before: $before, orderBy: $orderBy) {\n    edges {\n      node {\n        id\n        name\n        amount\n        criticity\n        assetType\n        dataTypesStored\n        owner {\n          id\n          fullName\n        }\n        vendors(first: 50) {\n          edges {\n            node {\n              id\n              name\n              websiteUrl\n            }\n          }\n        }\n        createdAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n"
+    "text": "query AssetsListQuery(\n  $after: CursorKey = null\n  $before: CursorKey = null\n  $first: Int = 10\n  $last: Int = null\n  $orderBy: AssetOrder = null\n  $snapshotId: ID = null\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...AssetsPageFragment_38J9tm\n    id\n  }\n}\n\nfragment AssetsPageFragment_38J9tm on Organization {\n  assets(first: $first, after: $after, last: $last, before: $before, orderBy: $orderBy, filter: {snapshotId: $snapshotId}) {\n    edges {\n      node {\n        id\n        snapshotId\n        name\n        amount\n        criticity\n        assetType\n        dataTypesStored\n        owner {\n          id\n          fullName\n        }\n        vendors(first: 50) {\n          edges {\n            node {\n              id\n              name\n              websiteUrl\n            }\n          }\n        }\n        createdAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "e25e58aa9cf789614d280313c6059d5e";
+(node as any).hash = "4bc1af55d208f3c773c49b753a76aa5c";
 
 export default node;

--- a/apps/console/src/pages/organizations/assets/__generated__/AssetsPageFragment.graphql.ts
+++ b/apps/console/src/pages/organizations/assets/__generated__/AssetsPageFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8bacf647a39e3c33616be7e9159928df>>
+ * @generated SignedSource<<663b14d82ccaeebe2dda8dc256fddfc5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -28,6 +28,7 @@ export type AssetsPageFragment$data = {
           readonly fullName: string;
           readonly id: string;
         };
+        readonly snapshotId: string | null | undefined;
         readonly vendors: {
           readonly edges: ReadonlyArray<{
             readonly node: {
@@ -94,6 +95,11 @@ return {
       "defaultValue": null,
       "kind": "LocalArgument",
       "name": "orderBy"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "snapshotId"
     }
   ],
   "kind": "Fragment",
@@ -134,9 +140,15 @@ return {
       "alias": "assets",
       "args": [
         {
-          "kind": "Variable",
-          "name": "orderBy",
-          "variableName": "orderBy"
+          "fields": [
+            {
+              "kind": "Variable",
+              "name": "snapshotId",
+              "variableName": "snapshotId"
+            }
+          ],
+          "kind": "ObjectValue",
+          "name": "filter"
         }
       ],
       "concreteType": "AssetConnection",
@@ -161,6 +173,13 @@ return {
               "plural": false,
               "selections": [
                 (v1/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "snapshotId",
+                  "storageKey": null
+                },
                 (v2/*: any*/),
                 {
                   "alias": null,
@@ -345,6 +364,6 @@ return {
 };
 })();
 
-(node as any).hash = "e25e58aa9cf789614d280313c6059d5e";
+(node as any).hash = "4bc1af55d208f3c773c49b753a76aa5c";
 
 export default node;

--- a/apps/console/src/routes/assetRoutes.ts
+++ b/apps/console/src/routes/assetRoutes.ts
@@ -3,13 +3,29 @@ import { relayEnvironment } from "/providers/RelayProviders";
 import { PageSkeleton } from "/components/skeletons/PageSkeleton";
 import { lazy } from "@probo/react-lazy";
 import { assetsQuery, assetNodeQuery } from "../hooks/graph/AssetGraph";
+import type { AppRoute } from "/routes";
 
 export const assetRoutes = [
   {
     path: "assets",
     fallback: PageSkeleton,
     queryLoader: (params: Record<string, string>) =>
-      loadQuery(relayEnvironment, assetsQuery, { organizationId: params.organizationId }),
+      loadQuery(relayEnvironment, assetsQuery, {
+        organizationId: params.organizationId,
+        snapshotId: null
+      }),
+    Component: lazy(
+      () => import("/pages/organizations/assets/AssetsPage")
+    ),
+  },
+  {
+    path: "snapshots/:snapshotId/assets",
+    fallback: PageSkeleton,
+    queryLoader: (params: Record<string, string>) =>
+      loadQuery(relayEnvironment, assetsQuery, {
+        organizationId: params.organizationId,
+        snapshotId: params.snapshotId
+      }),
     Component: lazy(
       () => import("/pages/organizations/assets/AssetsPage")
     ),
@@ -23,4 +39,13 @@ export const assetRoutes = [
       () => import("/pages/organizations/assets/AssetDetailsPage")
     ),
   },
-];
+  {
+    path: "snapshots/:snapshotId/assets/:assetId",
+    fallback: PageSkeleton,
+    queryLoader: (params: Record<string, string>) =>
+      loadQuery(relayEnvironment, assetNodeQuery, { assetId: params.assetId }),
+    Component: lazy(
+      () => import("/pages/organizations/assets/AssetDetailsPage")
+    ),
+  },
+] satisfies AppRoute[];

--- a/packages/helpers/src/snapshots.ts
+++ b/packages/helpers/src/snapshots.ts
@@ -1,6 +1,7 @@
 type Translator = (s: string) => string;
 
 export const snapshotTypes = [
+  "ASSETS",
   "DATA",
   "NONCONFORMITY_REGISTRIES",
   "COMPLIANCE_REGISTRIES",
@@ -37,6 +38,8 @@ export function getSnapshotTypeLabel(__: Translator, type: string | null | undef
 
 export function getSnapshotTypeUrlPath(type?: string): string {
   switch (type) {
+    case "ASSETS":
+      return "/assets";
     case "DATA":
       return "/data";
     case "NONCONFORMITY_REGISTRIES":

--- a/pkg/coredata/asset_filter.go
+++ b/pkg/coredata/asset_filter.go
@@ -15,32 +15,40 @@
 package coredata
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/getprobo/probo/pkg/gid"
-	"go.gearno.de/kit/pg"
+	"github.com/jackc/pgx/v5"
 )
 
-type Snapshottable interface {
-	Snapshot(ctx context.Context, conn pg.Conn, scope Scoper, organizationID, snapshotID gid.GID) error
+type (
+	AssetFilter struct {
+		snapshotID **gid.GID
+	}
+)
+
+func NewAssetFilter(snapshotID **gid.GID) *AssetFilter {
+	return &AssetFilter{
+		snapshotID: snapshotID,
+	}
 }
 
-func GetSnapshottable(snapshotType SnapshotsType) (Snapshottable, error) {
-	switch snapshotType {
-	case SnapshotsTypeAssets:
-		return Assets{}, nil
-	case SnapshotsTypeData:
-		return Data{}, nil
-	case SnapshotsTypeNonConformityRegistries:
-		return NonconformityRegistries{}, nil
-	case SnapshotsTypeComplianceRegistries:
-		return ComplianceRegistries{}, nil
-	case SnapshotsTypeContinualImprovementRegistries:
-		return ContinualImprovementRegistries{}, nil
-	case SnapshotsTypeProcessingActivityRegistries:
-		return ProcessingActivityRegistries{}, nil
-	default:
-		return nil, fmt.Errorf("unsupported snapshot type: %s", snapshotType)
+func (f *AssetFilter) SQLArguments() pgx.NamedArgs {
+	args := pgx.NamedArgs{}
+
+	if f.snapshotID != nil && *f.snapshotID != nil {
+		args["filter_snapshot_id"] = **f.snapshotID
+	}
+
+	return args
+}
+
+func (f *AssetFilter) SQLFragment() string {
+	if f.snapshotID == nil {
+		return "TRUE"
+	}
+
+	if *f.snapshotID == nil {
+		return "snapshot_id IS NULL"
+	} else {
+		return "snapshot_id = @filter_snapshot_id"
 	}
 }

--- a/pkg/coredata/migrations/20250829T155558Z.sql
+++ b/pkg/coredata/migrations/20250829T155558Z.sql
@@ -1,0 +1,19 @@
+ALTER TABLE assets ADD COLUMN snapshot_id TEXT;
+ALTER TABLE assets ADD COLUMN source_id TEXT;
+
+ALTER TABLE assets ADD CONSTRAINT assets_snapshot_id_fkey
+    FOREIGN KEY (snapshot_id)
+    REFERENCES snapshots(id)
+    ON UPDATE CASCADE
+    ON DELETE CASCADE;
+
+ALTER TABLE assets ADD CONSTRAINT assets_source_id_snapshot_id_key
+    UNIQUE (source_id, snapshot_id);
+
+ALTER TABLE asset_vendors ADD COLUMN snapshot_id TEXT;
+
+ALTER TABLE asset_vendors ADD CONSTRAINT asset_vendors_snapshot_id_fkey
+    FOREIGN KEY (snapshot_id)
+    REFERENCES snapshots(id)
+    ON UPDATE CASCADE
+    ON DELETE CASCADE;

--- a/pkg/coredata/vendor.go
+++ b/pkg/coredata/vendor.go
@@ -814,3 +814,103 @@ FROM source_vendors v
 
 	return nil
 }
+
+func (vs Vendors) InsertAssetSnapshots(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	organizationID gid.GID,
+	snapshotID gid.GID,
+) error {
+	query := `
+WITH
+	source_assets AS (
+		SELECT id
+		FROM assets
+		WHERE organization_id = @organization_id AND snapshot_id IS NULL
+	),
+	source_asset_vendors AS (
+		SELECT asset_id, vendor_id, snapshot_id, created_at
+		FROM asset_vendors
+		WHERE asset_id = ANY(SELECT id FROM source_assets)
+	),
+	source_vendors AS (
+		SELECT *
+		FROM vendors
+		WHERE %s AND id = ANY(SELECT vendor_id FROM source_asset_vendors)
+	)
+INSERT INTO vendors (
+	tenant_id,
+	id,
+	snapshot_id,
+	source_id,
+	organization_id,
+	name,
+	description,
+	category,
+	headquarter_address,
+	legal_name,
+	website_url,
+	privacy_policy_url,
+	service_level_agreement_url,
+	data_processing_agreement_url,
+	business_associate_agreement_url,
+	subprocessors_list_url,
+	certifications,
+	business_owner_id,
+	security_owner_id,
+	status_page_url,
+	terms_of_service_url,
+	security_page_url,
+	trust_page_url,
+	show_on_trust_center,
+	created_at,
+	updated_at
+)
+SELECT
+	@tenant_id,
+	generate_gid(decode_base64_unpadded(@tenant_id), @vendor_entity_type),
+	@snapshot_id,
+	v.id,
+	v.organization_id,
+	v.name,
+	v.description,
+	v.category,
+	v.headquarter_address,
+	v.legal_name,
+	v.website_url,
+	v.privacy_policy_url,
+	v.service_level_agreement_url,
+	v.data_processing_agreement_url,
+	v.business_associate_agreement_url,
+	v.subprocessors_list_url,
+	v.certifications,
+	v.business_owner_id,
+	v.security_owner_id,
+	v.status_page_url,
+	v.terms_of_service_url,
+	v.security_page_url,
+	v.trust_page_url,
+	v.show_on_trust_center,
+	v.created_at,
+	v.updated_at
+FROM source_vendors v
+	`
+
+	query = fmt.Sprintf(query, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"tenant_id":          scope.GetTenantID(),
+		"snapshot_id":        snapshotID,
+		"organization_id":    organizationID,
+		"vendor_entity_type": VendorEntityType,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, query, args)
+	if err != nil {
+		return fmt.Errorf("cannot insert vendor snapshots for assets: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/probo/asset_service.go
+++ b/pkg/probo/asset_service.go
@@ -80,6 +80,7 @@ func (s AssetService) GetByOwnerID(
 func (s AssetService) CountForOrganizationID(
 	ctx context.Context,
 	organizationID gid.GID,
+	filter *coredata.AssetFilter,
 ) (int, error) {
 	var count int
 
@@ -87,7 +88,7 @@ func (s AssetService) CountForOrganizationID(
 		ctx,
 		func(conn pg.Conn) (err error) {
 			assets := coredata.Assets{}
-			count, err = assets.CountByOrganizationID(ctx, conn, s.svc.scope, organizationID)
+			count, err = assets.CountByOrganizationID(ctx, conn, s.svc.scope, organizationID, filter)
 			if err != nil {
 				return fmt.Errorf("cannot count assets: %w", err)
 			}
@@ -107,6 +108,7 @@ func (s AssetService) ListForOrganizationID(
 	ctx context.Context,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.AssetOrderField],
+	filter *coredata.AssetFilter,
 ) (*page.Page[*coredata.Asset, coredata.AssetOrderField], error) {
 	var assets coredata.Assets
 
@@ -119,6 +121,7 @@ func (s AssetService) ListForOrganizationID(
 				s.svc.scope,
 				organizationID,
 				cursor,
+				filter,
 			)
 		},
 	)

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -1130,6 +1130,10 @@ input ProcessingActivityRegistryFilter {
   snapshotId: ID
 }
 
+input AssetFilter {
+  snapshotId: ID
+}
+
 # Core Types
 type TrustCenter implements Node {
   id: ID!
@@ -1244,6 +1248,7 @@ type Organization implements Node {
     last: Int
     before: CursorKey
     orderBy: AssetOrder
+    filter: AssetFilter
   ): AssetConnection! @goField(forceResolver: true)
 
   data(
@@ -3639,6 +3644,7 @@ type AssessVendorPayload {
 
 type Asset implements Node {
   id: ID!
+  snapshotId: ID
   name: String!
   amount: Int!
   owner: People! @goField(forceResolver: true)

--- a/pkg/server/api/console/v1/types/asset.go
+++ b/pkg/server/api/console/v1/types/asset.go
@@ -16,6 +16,7 @@ type (
 
 		Resolver any
 		ParentID gid.GID
+		Filter   *AssetFilter
 	}
 )
 
@@ -23,6 +24,7 @@ func NewAssetConnection(
 	p *page.Page[*coredata.Asset, coredata.AssetOrderField],
 	resolver any,
 	parentID gid.GID,
+	filter *AssetFilter,
 ) *AssetConnection {
 	edges := make([]*AssetEdge, len(p.Data))
 	for i, asset := range p.Data {
@@ -35,12 +37,14 @@ func NewAssetConnection(
 
 		Resolver: resolver,
 		ParentID: parentID,
+		Filter:   filter,
 	}
 }
 
 func NewAsset(asset *coredata.Asset) *Asset {
 	return &Asset{
 		ID:              asset.ID,
+		SnapshotID:      asset.SnapshotID,
 		Name:            asset.Name,
 		Amount:          asset.Amount,
 		Criticity:       asset.Criticity,

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -27,6 +27,7 @@ type AssessVendorPayload struct {
 
 type Asset struct {
 	ID              gid.GID                 `json:"id"`
+	SnapshotID      *gid.GID                `json:"snapshotId,omitempty"`
 	Name            string                  `json:"name"`
 	Amount          int                     `json:"amount"`
 	Owner           *People                 `json:"owner"`
@@ -45,6 +46,10 @@ func (this Asset) GetID() gid.GID { return this.ID }
 type AssetEdge struct {
 	Cursor page.CursorKey `json:"cursor"`
 	Node   *Asset         `json:"node"`
+}
+
+type AssetFilter struct {
+	SnapshotID *gid.GID `json:"snapshotId,omitempty"`
 }
 
 type AssignTaskInput struct {

--- a/pkg/trust/vendor_service.go
+++ b/pkg/trust/vendor_service.go
@@ -64,7 +64,9 @@ func (s VendorService) ListForOrganizationId(
 		ctx,
 		func(conn pg.Conn) error {
 			showOnTrustCenter := true
-			filter := coredata.NewVendorFilter(nil, &showOnTrustCenter)
+			var nilSnapshotID *gid.GID = nil
+			filter := coredata.NewVendorFilter(&nilSnapshotID, &showOnTrustCenter)
+
 			err := vendors.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID, cursor, filter)
 			if err != nil {
 				return fmt.Errorf("cannot load vendors: %w", err)


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds snapshot support for Assets so you can view historical, read‑only states of assets and their vendor links. The console now supports snapshot routes, and the API exposes snapshotId and filtering to fetch current or snapshot data.

- **New Features**
  - GraphQL: Organization.assets accepts filter.snapshotId; Asset exposes snapshotId; counts respect filters.
  - Snapshotting: Implemented snapshot creation for assets, vendors, and asset_vendors; write ops restricted to non-snapshot rows.
  - Database: Added assets.snapshot_id, assets.source_id, asset_vendors.snapshot_id with FKs and a (source_id, snapshot_id) unique constraint.
  - Console UI: New routes for snapshots (/snapshots/:snapshotId/assets and details), SnapshotBanner, list/details filtered by snapshotId, and create/update/delete disabled in snapshot mode.
  - Helpers: Added ASSETS to snapshotTypes and URL mapping; added validateSnapshotConsistency; Relay connections include filter to scope updates.

- **Migration**
  - Run migration 20250829T155558Z.sql.
  - Changes are additive; existing routes continue to work. Snapshot views are read‑only by design.

<!-- End of auto-generated description by cubic. -->

