### PR TITLE
Fix document deletion and update errors

### DIFF
--- a/apps/console/src/pages/organizations/documents/DocumentDetailPage.tsx
+++ b/apps/console/src/pages/organizations/documents/DocumentDetailPage.tsx
@@ -113,6 +113,36 @@ const documentFragment = graphql`
   }
 `;
 
+graphql`
+  fragment DocumentDetailPageRowFragment on Document {
+    id
+    title
+    description
+    documentType
+    updatedAt
+    owner {
+      id
+      fullName
+    }
+    versions(first: 1) {
+      edges {
+        node {
+          id
+          status
+          signatures(first: 100) {
+            edges {
+              node {
+                id
+                state
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
 const publishDocumentVersionMutation = graphql`
   mutation DocumentDetailPagePublishMutation(
     $input: PublishDocumentVersionInput!
@@ -120,6 +150,7 @@ const publishDocumentVersionMutation = graphql`
     publishDocumentVersion(input: $input) {
       document {
         id
+        ...DocumentDetailPageRowFragment
       }
     }
   }
@@ -266,15 +297,6 @@ export default function DocumentDetailPage(props: Props) {
     publishDocumentVersion({
       variables: {
         input: { documentId: document.id },
-      },
-      onSuccess: () => {
-        // Refresh the whole query to get the new version
-        loadQuery(
-          props.queryRef.environment,
-          documentNodeQuery,
-          props.queryRef.variables,
-          { fetchPolicy: "network-only" }
-        );
       },
     });
   };

--- a/apps/console/src/pages/organizations/documents/DocumentsPage.tsx
+++ b/apps/console/src/pages/organizations/documents/DocumentsPage.tsx
@@ -89,7 +89,9 @@ export default function DocumentsPage(props: Props) {
     organization as DocumentsPageListFragment$key
   );
 
-  const documents = pagination.data.documents.edges.map((edge) => edge.node);
+  const documents = pagination.data.documents.edges
+    .map((edge) => edge.node)
+    .filter(Boolean);
   const connectionId = pagination.data.documents.__id;
   const [sendSigningNotifications] = useSendSigningNotificationsMutation();
   const { list: selection, toggle, clear, reset } = useList<string>([]);
@@ -240,10 +242,15 @@ function DocumentRow({
     rowFragment,
     documentKey
   );
-  const lastVersion = document.versions.edges[0].node;
+  const lastVersion = document.versions.edges?.[0]?.node;
+
+  if (!lastVersion) {
+    return null;
+  }
+
   const isDraft = lastVersion.status === "DRAFT";
   const { __, dateFormat } = useTranslate();
-  const signatures = lastVersion.signatures?.edges?.map((edge) => edge.node) ?? [];
+  const signatures = lastVersion.signatures?.edges?.map((edge) => edge?.node)?.filter(Boolean) ?? [];
   const signedCount = signatures.filter(
     (signature) => signature.state === "SIGNED"
   ).length;
@@ -294,8 +301,8 @@ function DocumentRow({
       <Td>{getDocumentTypeLabel(__, document.documentType)}</Td>
       <Td>
         <div className="flex gap-2 items-center">
-          <Avatar name={document.owner.fullName} />
-          {document.owner.fullName}
+          <Avatar name={document.owner?.fullName ?? ""} />
+          {document.owner?.fullName}
         </div>
       </Td>
       <Td>

--- a/apps/console/src/pages/organizations/documents/__generated__/DocumentDetailPagePublishMutation.graphql.ts
+++ b/apps/console/src/pages/organizations/documents/__generated__/DocumentDetailPagePublishMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ce29629a1c8d489463cc22edbd8b81de>>
+ * @generated SignedSource<<c802e03e4097ba191cb3738a0e45a4ed>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,6 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
 export type PublishDocumentVersionInput = {
   changelog?: string | null | undefined;
   documentId: string;
@@ -20,6 +21,7 @@ export type DocumentDetailPagePublishMutation$data = {
   readonly publishDocumentVersion: {
     readonly document: {
       readonly id: string;
+      readonly " $fragmentSpreads": FragmentRefs<"DocumentDetailPageRowFragment">;
     };
   };
 };
@@ -38,48 +40,54 @@ var v0 = [
 ],
 v1 = [
   {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "input",
-        "variableName": "input"
-      }
-    ],
-    "concreteType": "PublishDocumentVersionPayload",
-    "kind": "LinkedField",
-    "name": "publishDocumentVersion",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "Document",
-        "kind": "LinkedField",
-        "name": "document",
-        "plural": false,
-        "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          }
-        ],
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
   }
-];
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "DocumentDetailPagePublishMutation",
-    "selections": (v1/*: any*/),
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "PublishDocumentVersionPayload",
+        "kind": "LinkedField",
+        "name": "publishDocumentVersion",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Document",
+            "kind": "LinkedField",
+            "name": "document",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "DocumentDetailPageRowFragment"
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
     "type": "Mutation",
     "abstractKey": null
   },
@@ -88,19 +96,184 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "DocumentDetailPagePublishMutation",
-    "selections": (v1/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "PublishDocumentVersionPayload",
+        "kind": "LinkedField",
+        "name": "publishDocumentVersion",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Document",
+            "kind": "LinkedField",
+            "name": "document",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "title",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "description",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "documentType",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "updatedAt",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "People",
+                "kind": "LinkedField",
+                "name": "owner",
+                "plural": false,
+                "selections": [
+                  (v2/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "fullName",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 1
+                  }
+                ],
+                "concreteType": "DocumentVersionConnection",
+                "kind": "LinkedField",
+                "name": "versions",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "DocumentVersionEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "DocumentVersion",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "status",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "first",
+                                "value": 100
+                              }
+                            ],
+                            "concreteType": "DocumentVersionSignatureConnection",
+                            "kind": "LinkedField",
+                            "name": "signatures",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "DocumentVersionSignatureEdge",
+                                "kind": "LinkedField",
+                                "name": "edges",
+                                "plural": true,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "DocumentVersionSignature",
+                                    "kind": "LinkedField",
+                                    "name": "node",
+                                    "plural": false,
+                                    "selections": [
+                                      (v2/*: any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "state",
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": "signatures(first:100)"
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "versions(first:1)"
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "cacheID": "bbee8d20f444cdc0dbb012e8fecfa9c1",
+    "cacheID": "e7734d4aece1b73c9bd85eddfbda2548",
     "id": null,
     "metadata": {},
     "name": "DocumentDetailPagePublishMutation",
     "operationKind": "mutation",
-    "text": "mutation DocumentDetailPagePublishMutation(\n  $input: PublishDocumentVersionInput!\n) {\n  publishDocumentVersion(input: $input) {\n    document {\n      id\n    }\n  }\n}\n"
+    "text": "mutation DocumentDetailPagePublishMutation(\n  $input: PublishDocumentVersionInput!\n) {\n  publishDocumentVersion(input: $input) {\n    document {\n      id\n      ...DocumentDetailPageRowFragment\n    }\n  }\n}\n\nfragment DocumentDetailPageRowFragment on Document {\n  id\n  title\n  description\n  documentType\n  updatedAt\n  owner {\n    id\n    fullName\n  }\n  versions(first: 1) {\n    edges {\n      node {\n        id\n        status\n        signatures(first: 100) {\n          edges {\n            node {\n              id\n              state\n            }\n          }\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "2f5cc9855133b614896a1ac3768e669f";
+(node as any).hash = "9a5706a103ffb1a6a1804e22055851d8";
 
 export default node;

--- a/apps/console/src/pages/organizations/documents/__generated__/DocumentDetailPageRowFragment.graphql.ts
+++ b/apps/console/src/pages/organizations/documents/__generated__/DocumentDetailPageRowFragment.graphql.ts
@@ -1,0 +1,213 @@
+/**
+ * @generated SignedSource<<4cf9e23d757753509bb695aab205ee46>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type DocumentStatus = "DRAFT" | "PUBLISHED";
+export type DocumentType = "ISMS" | "OTHER" | "POLICY";
+export type DocumentVersionSignatureState = "REQUESTED" | "SIGNED";
+import { FragmentRefs } from "relay-runtime";
+export type DocumentDetailPageRowFragment$data = {
+  readonly description: string;
+  readonly documentType: DocumentType;
+  readonly id: string;
+  readonly owner: {
+    readonly fullName: string;
+    readonly id: string;
+  };
+  readonly title: string;
+  readonly updatedAt: any;
+  readonly versions: {
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly id: string;
+        readonly signatures: {
+          readonly edges: ReadonlyArray<{
+            readonly node: {
+              readonly id: string;
+              readonly state: DocumentVersionSignatureState;
+            };
+          }>;
+        };
+        readonly status: DocumentStatus;
+      };
+    }>;
+  };
+  readonly " $fragmentType": "DocumentDetailPageRowFragment";
+};
+export type DocumentDetailPageRowFragment$key = {
+  readonly " $data"?: DocumentDetailPageRowFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"DocumentDetailPageRowFragment">;
+};
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "DocumentDetailPageRowFragment",
+  "selections": [
+    (v0/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "title",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "description",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "documentType",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "updatedAt",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "People",
+      "kind": "LinkedField",
+      "name": "owner",
+      "plural": false,
+      "selections": [
+        (v0/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "fullName",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 1
+        }
+      ],
+      "concreteType": "DocumentVersionConnection",
+      "kind": "LinkedField",
+      "name": "versions",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "DocumentVersionEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "DocumentVersion",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                (v0/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "status",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": [
+                    {
+                      "kind": "Literal",
+                      "name": "first",
+                      "value": 100
+                    }
+                  ],
+                  "concreteType": "DocumentVersionSignatureConnection",
+                  "kind": "LinkedField",
+                  "name": "signatures",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "DocumentVersionSignatureEdge",
+                      "kind": "LinkedField",
+                      "name": "edges",
+                      "plural": true,
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "concreteType": "DocumentVersionSignature",
+                          "kind": "LinkedField",
+                          "name": "node",
+                          "plural": false,
+                          "selections": [
+                            (v0/*: any*/),
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "state",
+                              "storageKey": null
+                            }
+                          ],
+                          "storageKey": null
+                        }
+                      ],
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": "signatures(first:100)"
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "versions(first:1)"
+    }
+  ],
+  "type": "Document",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "2144e456e031960d8ceefd334741831e";
+
+export default node;


### PR DESCRIPTION
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes crashes and stale UI when deleting or publishing documents. The documents list now updates reliably without a full refetch.

- **Bug Fixes**
  - Guard against missing versions, signatures, and owner; filter null edges in the list.
  - Add DocumentDetailPageRowFragment and return it from publishDocumentVersion so Relay updates the cache; remove manual query refetch.

<!-- End of auto-generated description by cubic. -->

