### PR TITLE
Change control exclusion justification input

### DIFF
--- a/apps/console/src/pages/organizations/frameworks/dialogs/FrameworkControlDialog.tsx
+++ b/apps/console/src/pages/organizations/frameworks/dialogs/FrameworkControlDialog.tsx
@@ -192,7 +192,8 @@ export function FrameworkControlDialog(props: Props) {
             <Option value="EXCLUDED">{__("Excluded")}</Option>
           </ControlledSelect>
           {showExclusionJustification && (
-            <Input
+            <Textarea
+              required
               id="exclusionJustification"
               variant="bordered"
               placeholder={__("Reason for exclusion")}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Changed the “Exclusion justification” field in the Framework Control dialog from a single-line input to a multiline textarea to support longer, clearer explanations. Improves readability when users provide reasons for excluding a control.

<!-- End of auto-generated description by cubic. -->

