### PR TITLE
Add risk snapshots

### DIFF
--- a/apps/console/src/components/SnapshotBanner.tsx
+++ b/apps/console/src/components/SnapshotBanner.tsx
@@ -3,7 +3,7 @@ import { useTranslate } from "@probo/i18n";
 import { useLazyLoadQuery, graphql } from "react-relay";
 import { useLocation } from "react-router";
 import type { SnapshotBannerQuery } from "./__generated__/SnapshotBannerQuery.graphql";
-import { getSnapshotTypeUrlPath } from "@probo/helpers";
+import { getSnapshotTypeUrlPath, getSnapshotTypeLabel, sprintf } from "@probo/helpers";
 
 const snapshotQuery = graphql`
   query SnapshotBannerQuery($snapshotId: ID!) {
@@ -50,7 +50,11 @@ export function SnapshotBanner({ snapshotId }: Props) {
           <span className="font-medium text-warning-800">{__("Snapshot")} {snapshot.name}</span>
         </div>
         <p className="text-sm text-warning-700">
-          {__("You are viewing a snapshot from")} {dateFormat(snapshot.createdAt, { year: "numeric", month: "short", day: "numeric" })}
+          {sprintf(
+            __("You are viewing a %s snapshot from %s"),
+            getSnapshotTypeLabel(__, snapshot.type).toLowerCase(),
+            dateFormat(snapshot.createdAt, { year: "numeric", month: "short", day: "numeric" })
+          )}
         </p>
       </div>
     </div>

--- a/apps/console/src/components/documents/LinkedDocumentsCard.tsx
+++ b/apps/console/src/components/documents/LinkedDocumentsCard.tsx
@@ -51,17 +51,12 @@ type Mutation<Params> = (p: {
 }) => void;
 
 type Props<Params> = {
-  // Documents linked to the element
   documents: (LinkedDocumentsCardFragment$key & { id: string })[];
-  // Extra params to send to the mutation
   params: Params;
-  // Disable (action when loading for instance)
   disabled?: boolean;
-  // ID of the connection to update
+  hideActions?: boolean;
   connectionId: string;
-  // Mutation to attach a document (will receive {documentId, ...params})
   onAttach: Mutation<Params>;
-  // Mutation to detach a document (will receive {documentId, ...params})
   onDetach: Mutation<Params>;
   variant?: "card" | "table";
 };
@@ -109,17 +104,19 @@ export function LinkedDocumentsCard<Params>(props: Props<Params>) {
       {variant === "card" && (
         <div className="flex justify-between">
           <div className="text-lg font-semibold">{__("Documents")}</div>
-          <LinkedDocumentDialog
-            connectionId={props.connectionId}
-            disabled={props.disabled}
-            linkedDocuments={props.documents}
-            onLink={onAttach}
-            onUnlink={onDetach}
-          >
-            <Button variant="tertiary" icon={IconPlusLarge}>
-              {__("Link document")}
-            </Button>
-          </LinkedDocumentDialog>
+          {!props.hideActions && (
+            <LinkedDocumentDialog
+              connectionId={props.connectionId}
+              disabled={props.disabled}
+              linkedDocuments={props.documents}
+              onLink={onAttach}
+              onUnlink={onDetach}
+            >
+              <Button variant="tertiary" icon={IconPlusLarge}>
+                {__("Link document")}
+              </Button>
+            </LinkedDocumentDialog>
+          )}
         </div>
       )}
       <Table className={clsx(variant === "card" && "bg-invert")}>
@@ -144,9 +141,10 @@ export function LinkedDocumentsCard<Params>(props: Props<Params>) {
               key={document.id}
               document={document}
               onClick={onDetach}
+              hideActions={props.hideActions}
             />
           ))}
-          {variant === "table" && (
+          {variant === "table" && !props.hideActions && (
             <LinkedDocumentDialog
               connectionId={props.connectionId}
               disabled={props.disabled}
@@ -178,6 +176,7 @@ export function LinkedDocumentsCard<Params>(props: Props<Params>) {
 function DocumentRow(props: {
   document: LinkedDocumentsCardFragment$key & { id: string };
   onClick: (documentId: string) => void;
+  hideActions?: boolean;
 }) {
   const document = useFragment(linkedDocumentFragment, props.document);
   const organizationId = useOrganizationId();
@@ -204,13 +203,15 @@ function DocumentRow(props: {
         <DocumentVersionBadge state={document.versions.edges[0].node.status} />
       </Td>
       <Td noLink width={50} className="text-end">
-        <Button
-          variant="secondary"
-          onClick={() => props.onClick(document.id)}
-          icon={IconTrashCan}
-        >
-          {__("Unlink")}
-        </Button>
+        {!props.hideActions && (
+          <Button
+            variant="secondary"
+            onClick={() => props.onClick(document.id)}
+            icon={IconTrashCan}
+          >
+            {__("Unlink")}
+          </Button>
+        )}
       </Td>
     </Tr>
   );

--- a/apps/console/src/hooks/graph/MeasureGraph.ts
+++ b/apps/console/src/hooks/graph/MeasureGraph.ts
@@ -42,6 +42,7 @@ export const measureNodeQuery = graphql`
     node(id: $measureId) {
       ... on Measure {
         id
+        snapshotId
         name
         description
         state

--- a/apps/console/src/hooks/graph/RiskGraph.ts
+++ b/apps/console/src/hooks/graph/RiskGraph.ts
@@ -31,10 +31,10 @@ export function useDeleteRiskMutation() {
 }
 
 export const risksQuery = graphql`
-  query RiskGraphListQuery($organizationId: ID!) {
+  query RiskGraphListQuery($organizationId: ID!, $snapshotId: ID) {
     organization: node(id: $organizationId) {
       id
-      ...RiskGraphFragment
+      ...RiskGraphFragment @arguments(snapshotId: $snapshotId)
     }
   }
 `;
@@ -48,6 +48,7 @@ const risksFragment = graphql`
     after: { type: "CursorKey", defaultValue: null }
     before: { type: "CursorKey", defaultValue: null }
     last: { type: "Int", defaultValue: null }
+    snapshotId: { type: "ID", defaultValue: null }
   ) {
     risks(
       first: $first
@@ -55,10 +56,12 @@ const risksFragment = graphql`
       last: $last
       before: $before
       orderBy: $order
+      filter: { snapshotId: $snapshotId }
     ) @connection(key: "RisksListQuery_risks") {
       edges {
         node {
           id
+          snapshotId
           name
           category
           treatment
@@ -98,6 +101,8 @@ export const riskNodeQuery = graphql`
   query RiskGraphNodeQuery($riskId: ID!) {
     node(id: $riskId) {
       ... on Risk {
+        id
+        snapshotId
         name
         description
         treatment

--- a/apps/console/src/hooks/graph/__generated__/MeasureGraphNodeQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/MeasureGraphNodeQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<074d65be2a59b6b8284ff6be0f75707d>>
+ * @generated SignedSource<<c813fdce5ffc6c85f717413f4b87f0f4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -29,6 +29,7 @@ export type MeasureGraphNodeQuery$data = {
     readonly risksInfos?: {
       readonly totalCount: number;
     };
+    readonly snapshotId?: string | null | undefined;
     readonly state?: MeasureState;
     readonly tasksInfos?: {
       readonly totalCount: number;
@@ -67,38 +68,45 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "snapshotId",
   "storageKey": null
 },
 v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "description",
+  "name": "name",
   "storageKey": null
 },
 v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "state",
+  "name": "description",
   "storageKey": null
 },
 v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "state",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "category",
   "storageKey": null
 },
-v7 = [
+v8 = [
   {
     "kind": "Literal",
     "name": "first",
     "value": 0
   }
 ],
-v8 = [
+v9 = [
   {
     "alias": null,
     "args": null,
@@ -107,82 +115,82 @@ v8 = [
     "storageKey": null
   }
 ],
-v9 = {
+v10 = {
   "alias": "evidencesInfos",
-  "args": (v7/*: any*/),
+  "args": (v8/*: any*/),
   "concreteType": "EvidenceConnection",
   "kind": "LinkedField",
   "name": "evidences",
   "plural": false,
-  "selections": (v8/*: any*/),
+  "selections": (v9/*: any*/),
   "storageKey": "evidences(first:0)"
 },
-v10 = {
+v11 = {
   "alias": "risksInfos",
-  "args": (v7/*: any*/),
+  "args": (v8/*: any*/),
   "concreteType": "RiskConnection",
   "kind": "LinkedField",
   "name": "risks",
   "plural": false,
-  "selections": (v8/*: any*/),
+  "selections": (v9/*: any*/),
   "storageKey": "risks(first:0)"
 },
-v11 = {
+v12 = {
   "alias": "tasksInfos",
-  "args": (v7/*: any*/),
+  "args": (v8/*: any*/),
   "concreteType": "TaskConnection",
   "kind": "LinkedField",
   "name": "tasks",
   "plural": false,
-  "selections": (v8/*: any*/),
+  "selections": (v9/*: any*/),
   "storageKey": "tasks(first:0)"
 },
-v12 = {
+v13 = {
   "alias": "controlsInfos",
-  "args": (v7/*: any*/),
+  "args": (v8/*: any*/),
   "concreteType": "ControlConnection",
   "kind": "LinkedField",
   "name": "controls",
   "plural": false,
-  "selections": (v8/*: any*/),
+  "selections": (v9/*: any*/),
   "storageKey": "controls(first:0)"
 },
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v14 = [
+v15 = [
   {
     "kind": "Literal",
     "name": "first",
     "value": 100
   }
 ],
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endCursor",
   "storageKey": null
 },
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "hasNextPage",
   "storageKey": null
 },
-v18 = {
+v19 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -190,12 +198,12 @@ v18 = {
   "name": "pageInfo",
   "plural": false,
   "selections": [
-    (v16/*: any*/),
-    (v17/*: any*/)
+    (v17/*: any*/),
+    (v18/*: any*/)
   ],
   "storageKey": null
 },
-v19 = {
+v20 = {
   "kind": "ClientExtension",
   "selections": [
     {
@@ -207,14 +215,14 @@ v19 = {
     }
   ]
 },
-v20 = [
+v21 = [
   {
     "kind": "Literal",
     "name": "first",
     "value": 20
   }
 ],
-v21 = {
+v22 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -222,8 +230,8 @@ v21 = {
   "name": "pageInfo",
   "plural": false,
   "selections": [
-    (v16/*: any*/),
     (v17/*: any*/),
+    (v18/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -241,7 +249,7 @@ v21 = {
   ],
   "storageKey": null
 },
-v22 = [
+v23 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -271,10 +279,11 @@ return {
               (v4/*: any*/),
               (v5/*: any*/),
               (v6/*: any*/),
-              (v9/*: any*/),
+              (v7/*: any*/),
               (v10/*: any*/),
               (v11/*: any*/),
               (v12/*: any*/),
+              (v13/*: any*/),
               {
                 "args": null,
                 "kind": "FragmentSpread",
@@ -325,7 +334,7 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v13/*: any*/),
+          (v14/*: any*/),
           (v2/*: any*/),
           {
             "kind": "InlineFragment",
@@ -334,13 +343,14 @@ return {
               (v4/*: any*/),
               (v5/*: any*/),
               (v6/*: any*/),
-              (v9/*: any*/),
+              (v7/*: any*/),
               (v10/*: any*/),
               (v11/*: any*/),
               (v12/*: any*/),
+              (v13/*: any*/),
               {
                 "alias": null,
-                "args": (v14/*: any*/),
+                "args": (v15/*: any*/),
                 "concreteType": "RiskConnection",
                 "kind": "LinkedField",
                 "name": "risks",
@@ -363,7 +373,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v2/*: any*/),
-                          (v3/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -378,22 +388,22 @@ return {
                             "name": "residualRiskScore",
                             "storageKey": null
                           },
-                          (v13/*: any*/)
+                          (v14/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v15/*: any*/)
+                      (v16/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v18/*: any*/),
-                  (v19/*: any*/)
+                  (v19/*: any*/),
+                  (v20/*: any*/)
                 ],
                 "storageKey": "risks(first:100)"
               },
               {
                 "alias": null,
-                "args": (v14/*: any*/),
+                "args": (v15/*: any*/),
                 "filters": null,
                 "handle": "connection",
                 "key": "Measure__risks",
@@ -402,7 +412,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v14/*: any*/),
+                "args": (v15/*: any*/),
                 "concreteType": "TaskConnection",
                 "kind": "LinkedField",
                 "name": "tasks",
@@ -425,9 +435,9 @@ return {
                         "plural": false,
                         "selections": [
                           (v2/*: any*/),
-                          (v3/*: any*/),
-                          (v5/*: any*/),
                           (v4/*: any*/),
+                          (v6/*: any*/),
+                          (v5/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -473,22 +483,22 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v13/*: any*/)
+                          (v14/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v15/*: any*/)
+                      (v16/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v18/*: any*/),
-                  (v19/*: any*/)
+                  (v19/*: any*/),
+                  (v20/*: any*/)
                 ],
                 "storageKey": "tasks(first:100)"
               },
               {
                 "alias": null,
-                "args": (v14/*: any*/),
+                "args": (v15/*: any*/),
                 "filters": null,
                 "handle": "connection",
                 "key": "Measure__tasks",
@@ -497,7 +507,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v20/*: any*/),
+                "args": (v21/*: any*/),
                 "concreteType": "ControlConnection",
                 "kind": "LinkedField",
                 "name": "controls",
@@ -520,7 +530,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v2/*: any*/),
-                          (v3/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -537,26 +547,26 @@ return {
                             "plural": false,
                             "selections": [
                               (v2/*: any*/),
-                              (v3/*: any*/)
+                              (v4/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v13/*: any*/)
+                          (v14/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v15/*: any*/)
+                      (v16/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v21/*: any*/),
-                  (v19/*: any*/)
+                  (v22/*: any*/),
+                  (v20/*: any*/)
                 ],
                 "storageKey": "controls(first:20)"
               },
               {
                 "alias": null,
-                "args": (v20/*: any*/),
+                "args": (v21/*: any*/),
                 "filters": [
                   "orderBy",
                   "filter"
@@ -568,7 +578,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v22/*: any*/),
+                "args": (v23/*: any*/),
                 "concreteType": "EvidenceConnection",
                 "kind": "LinkedField",
                 "name": "evidences",
@@ -626,22 +636,22 @@ return {
                             "name": "createdAt",
                             "storageKey": null
                           },
-                          (v13/*: any*/)
+                          (v14/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v15/*: any*/)
+                      (v16/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v21/*: any*/),
-                  (v19/*: any*/)
+                  (v22/*: any*/),
+                  (v20/*: any*/)
                 ],
                 "storageKey": "evidences(first:50)"
               },
               {
                 "alias": null,
-                "args": (v22/*: any*/),
+                "args": (v23/*: any*/),
                 "filters": [
                   "orderBy"
                 ],
@@ -660,16 +670,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6146a6fada0328c7b69652646212be05",
+    "cacheID": "265b74c861fec8f3101b207fdf9f6219",
     "id": null,
     "metadata": {},
     "name": "MeasureGraphNodeQuery",
     "operationKind": "query",
-    "text": "query MeasureGraphNodeQuery(\n  $measureId: ID!\n) {\n  node(id: $measureId) {\n    __typename\n    ... on Measure {\n      id\n      name\n      description\n      state\n      category\n      evidencesInfos: evidences(first: 0) {\n        totalCount\n      }\n      risksInfos: risks(first: 0) {\n        totalCount\n      }\n      tasksInfos: tasks(first: 0) {\n        totalCount\n      }\n      controlsInfos: controls(first: 0) {\n        totalCount\n      }\n      ...MeasureRisksTabFragment\n      ...MeasureTasksTabFragment\n      ...MeasureControlsTabFragment\n      ...MeasureFormDialogMeasureFragment\n      ...MeasureEvidencesTabFragment\n    }\n    id\n  }\n}\n\nfragment LinkedControlsCardFragment on Control {\n  id\n  name\n  sectionTitle\n  framework {\n    id\n    name\n  }\n}\n\nfragment LinkedRisksCardFragment on Risk {\n  id\n  name\n  inherentRiskScore\n  residualRiskScore\n}\n\nfragment MeasureControlsTabFragment on Measure {\n  id\n  controls(first: 20) {\n    edges {\n      node {\n        id\n        ...LinkedControlsCardFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n\nfragment MeasureEvidencesTabFragment on Measure {\n  id\n  evidences(first: 50) {\n    edges {\n      node {\n        id\n        filename\n        mimeType\n        ...MeasureEvidencesTabFragment_evidence\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n\nfragment MeasureEvidencesTabFragment_evidence on Evidence {\n  id\n  filename\n  size\n  type\n  createdAt\n  mimeType\n}\n\nfragment MeasureFormDialogMeasureFragment on Measure {\n  id\n  description\n  name\n  category\n  state\n}\n\nfragment MeasureRisksTabFragment on Measure {\n  id\n  risks(first: 100) {\n    edges {\n      node {\n        id\n        ...LinkedRisksCardFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment MeasureTasksTabFragment on Measure {\n  tasks(first: 100) {\n    edges {\n      node {\n        id\n        name\n        state\n        description\n        ...TaskFormDialogFragment\n        assignedTo {\n          id\n          fullName\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment TaskFormDialogFragment on Task {\n  id\n  description\n  name\n  state\n  timeEstimate\n  deadline\n  assignedTo {\n    id\n  }\n  measure {\n    id\n  }\n}\n"
+    "text": "query MeasureGraphNodeQuery(\n  $measureId: ID!\n) {\n  node(id: $measureId) {\n    __typename\n    ... on Measure {\n      id\n      snapshotId\n      name\n      description\n      state\n      category\n      evidencesInfos: evidences(first: 0) {\n        totalCount\n      }\n      risksInfos: risks(first: 0) {\n        totalCount\n      }\n      tasksInfos: tasks(first: 0) {\n        totalCount\n      }\n      controlsInfos: controls(first: 0) {\n        totalCount\n      }\n      ...MeasureRisksTabFragment\n      ...MeasureTasksTabFragment\n      ...MeasureControlsTabFragment\n      ...MeasureFormDialogMeasureFragment\n      ...MeasureEvidencesTabFragment\n    }\n    id\n  }\n}\n\nfragment LinkedControlsCardFragment on Control {\n  id\n  name\n  sectionTitle\n  framework {\n    id\n    name\n  }\n}\n\nfragment LinkedRisksCardFragment on Risk {\n  id\n  name\n  inherentRiskScore\n  residualRiskScore\n}\n\nfragment MeasureControlsTabFragment on Measure {\n  id\n  controls(first: 20) {\n    edges {\n      node {\n        id\n        ...LinkedControlsCardFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n\nfragment MeasureEvidencesTabFragment on Measure {\n  id\n  evidences(first: 50) {\n    edges {\n      node {\n        id\n        filename\n        mimeType\n        ...MeasureEvidencesTabFragment_evidence\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n\nfragment MeasureEvidencesTabFragment_evidence on Evidence {\n  id\n  filename\n  size\n  type\n  createdAt\n  mimeType\n}\n\nfragment MeasureFormDialogMeasureFragment on Measure {\n  id\n  description\n  name\n  category\n  state\n}\n\nfragment MeasureRisksTabFragment on Measure {\n  id\n  risks(first: 100) {\n    edges {\n      node {\n        id\n        ...LinkedRisksCardFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment MeasureTasksTabFragment on Measure {\n  tasks(first: 100) {\n    edges {\n      node {\n        id\n        name\n        state\n        description\n        ...TaskFormDialogFragment\n        assignedTo {\n          id\n          fullName\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment TaskFormDialogFragment on Task {\n  id\n  description\n  name\n  state\n  timeEstimate\n  deadline\n  assignedTo {\n    id\n  }\n  measure {\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "34931b0c662961228537121bf18bab4e";
+(node as any).hash = "fbb5b1c2b357020be17bdbf0398a15fc";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/RiskGraphFragment.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/RiskGraphFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d65dc38bcf11079a304f8a5cc4070389>>
+ * @generated SignedSource<<56ea89bc46a591546ad331c94e79ae9c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -25,6 +25,7 @@ export type RiskGraphFragment$data = {
         readonly residualImpact: number;
         readonly residualLikelihood: number;
         readonly residualRiskScore: number;
+        readonly snapshotId: string | null | undefined;
         readonly treatment: RiskTreatment;
         readonly " $fragmentSpreads": FragmentRefs<"useRiskFormFragment">;
       };
@@ -76,6 +77,11 @@ return {
       "defaultValue": null,
       "kind": "LocalArgument",
       "name": "order"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "snapshotId"
     }
   ],
   "kind": "Fragment",
@@ -116,6 +122,17 @@ return {
       "alias": "risks",
       "args": [
         {
+          "fields": [
+            {
+              "kind": "Variable",
+              "name": "snapshotId",
+              "variableName": "snapshotId"
+            }
+          ],
+          "kind": "ObjectValue",
+          "name": "filter"
+        },
+        {
           "kind": "Variable",
           "name": "orderBy",
           "variableName": "order"
@@ -143,6 +160,13 @@ return {
               "plural": false,
               "selections": [
                 (v1/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "snapshotId",
+                  "storageKey": null
+                },
                 {
                   "alias": null,
                   "args": null,
@@ -280,6 +304,6 @@ return {
 };
 })();
 
-(node as any).hash = "dc662098b9aceaa2400f4656ed1b2d01";
+(node as any).hash = "f4a8e0e71a70b692b1806d992bc18863";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/RiskGraphListQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/RiskGraphListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8ae6d82b30ec5657f8a55bd47fab4e7e>>
+ * @generated SignedSource<<e7b17c13f8d8e5d727c7fea2cdf5afc4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,7 @@ import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type RiskGraphListQuery$variables = {
   organizationId: string;
+  snapshotId?: string | null | undefined;
 };
 export type RiskGraphListQuery$data = {
   readonly organization: {
@@ -30,6 +31,11 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "organizationId"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "snapshotId"
   }
 ],
 v1 = [
@@ -46,14 +52,26 @@ v2 = {
   "name": "id",
   "storageKey": null
 },
-v3 = {
+v3 = [
+  {
+    "kind": "Variable",
+    "name": "snapshotId",
+    "variableName": "snapshotId"
+  }
+],
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v4 = [
+v5 = [
+  {
+    "fields": (v3/*: any*/),
+    "kind": "ObjectValue",
+    "name": "filter"
+  },
   {
     "kind": "Literal",
     "name": "first",
@@ -77,7 +95,7 @@ return {
         "selections": [
           (v2/*: any*/),
           {
-            "args": null,
+            "args": (v3/*: any*/),
             "kind": "FragmentSpread",
             "name": "RiskGraphFragment"
           }
@@ -102,14 +120,14 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v3/*: any*/),
+          (v4/*: any*/),
           (v2/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
               {
                 "alias": null,
-                "args": (v4/*: any*/),
+                "args": (v5/*: any*/),
                 "concreteType": "RiskConnection",
                 "kind": "LinkedField",
                 "name": "risks",
@@ -132,6 +150,13 @@ return {
                         "plural": false,
                         "selections": [
                           (v2/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "snapshotId",
+                            "storageKey": null
+                          },
                           {
                             "alias": null,
                             "args": null,
@@ -221,7 +246,7 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v4/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -275,13 +300,14 @@ return {
                     "storageKey": null
                   }
                 ],
-                "storageKey": "risks(first:50)"
+                "storageKey": null
               },
               {
                 "alias": null,
-                "args": (v4/*: any*/),
+                "args": (v5/*: any*/),
                 "filters": [
-                  "orderBy"
+                  "orderBy",
+                  "filter"
                 ],
                 "handle": "connection",
                 "key": "RisksListQuery_risks",
@@ -298,16 +324,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "36e237e142f201c74ebc23ff46d7345a",
+    "cacheID": "b2114c476ed7e095fc9d2317b6b1c554",
     "id": null,
     "metadata": {},
     "name": "RiskGraphListQuery",
     "operationKind": "query",
-    "text": "query RiskGraphListQuery(\n  $organizationId: ID!\n) {\n  organization: node(id: $organizationId) {\n    __typename\n    id\n    ...RiskGraphFragment\n  }\n}\n\nfragment RiskGraphFragment on Organization {\n  risks(first: 50) {\n    edges {\n      node {\n        id\n        name\n        category\n        treatment\n        inherentLikelihood\n        inherentImpact\n        residualLikelihood\n        residualImpact\n        inherentRiskScore\n        residualRiskScore\n        ...useRiskFormFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n\nfragment useRiskFormFragment on Risk {\n  id\n  name\n  category\n  description\n  treatment\n  inherentLikelihood\n  inherentImpact\n  residualLikelihood\n  residualImpact\n  note\n  owner {\n    id\n  }\n}\n"
+    "text": "query RiskGraphListQuery(\n  $organizationId: ID!\n  $snapshotId: ID\n) {\n  organization: node(id: $organizationId) {\n    __typename\n    id\n    ...RiskGraphFragment_3iomuz\n  }\n}\n\nfragment RiskGraphFragment_3iomuz on Organization {\n  risks(first: 50, filter: {snapshotId: $snapshotId}) {\n    edges {\n      node {\n        id\n        snapshotId\n        name\n        category\n        treatment\n        inherentLikelihood\n        inherentImpact\n        residualLikelihood\n        residualImpact\n        inherentRiskScore\n        residualRiskScore\n        ...useRiskFormFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n\nfragment useRiskFormFragment on Risk {\n  id\n  name\n  category\n  description\n  treatment\n  inherentLikelihood\n  inherentImpact\n  residualLikelihood\n  residualImpact\n  note\n  owner {\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "5d41ad11b598f63829f481ff0ae8aec7";
+(node as any).hash = "a6e146d7d0f9d2713796935d0d615311";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/RiskGraphNodeQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/RiskGraphNodeQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a4b7866dde478255ad0bb04a93ada596>>
+ * @generated SignedSource<<494ff8512e4a50c2bbc2cb3453dbab1c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -23,6 +23,7 @@ export type RiskGraphNodeQuery$data = {
     readonly documentsInfo?: {
       readonly totalCount: number;
     };
+    readonly id?: string;
     readonly inherentRiskScore?: number;
     readonly measuresInfo?: {
       readonly totalCount: number;
@@ -34,6 +35,7 @@ export type RiskGraphNodeQuery$data = {
       readonly id: string;
     } | null | undefined;
     readonly residualRiskScore?: number;
+    readonly snapshotId?: string | null | undefined;
     readonly treatment?: RiskTreatment;
     readonly " $fragmentSpreads": FragmentRefs<"RiskControlsTabFragment" | "RiskDocumentsTabFragment" | "RiskMeasuresTabFragment" | "RiskOverviewTabFragment" | "useRiskFormFragment">;
   };
@@ -62,31 +64,38 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "id",
   "storageKey": null
 },
 v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "description",
+  "name": "snapshotId",
   "storageKey": null
 },
 v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "treatment",
+  "name": "name",
   "storageKey": null
 },
 v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "description",
   "storageKey": null
 },
 v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "treatment",
+  "storageKey": null
+},
+v7 = {
   "alias": null,
   "args": null,
   "concreteType": "People",
@@ -94,7 +103,7 @@ v6 = {
   "name": "owner",
   "plural": false,
   "selections": [
-    (v5/*: any*/),
+    (v2/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -105,35 +114,35 @@ v6 = {
   ],
   "storageKey": null
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "note",
   "storageKey": null
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "inherentRiskScore",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "residualRiskScore",
   "storageKey": null
 },
-v10 = [
+v11 = [
   {
     "kind": "Literal",
     "name": "first",
     "value": 0
   }
 ],
-v11 = [
+v12 = [
   {
     "alias": null,
     "args": null,
@@ -142,72 +151,72 @@ v11 = [
     "storageKey": null
   }
 ],
-v12 = {
+v13 = {
   "alias": "measuresInfo",
-  "args": (v10/*: any*/),
+  "args": (v11/*: any*/),
   "concreteType": "MeasureConnection",
   "kind": "LinkedField",
   "name": "measures",
   "plural": false,
-  "selections": (v11/*: any*/),
+  "selections": (v12/*: any*/),
   "storageKey": "measures(first:0)"
 },
-v13 = {
+v14 = {
   "alias": "documentsInfo",
-  "args": (v10/*: any*/),
+  "args": (v11/*: any*/),
   "concreteType": "DocumentConnection",
   "kind": "LinkedField",
   "name": "documents",
   "plural": false,
-  "selections": (v11/*: any*/),
+  "selections": (v12/*: any*/),
   "storageKey": "documents(first:0)"
 },
-v14 = {
+v15 = {
   "alias": "controlsInfo",
-  "args": (v10/*: any*/),
+  "args": (v11/*: any*/),
   "concreteType": "ControlConnection",
   "kind": "LinkedField",
   "name": "controls",
   "plural": false,
-  "selections": (v11/*: any*/),
+  "selections": (v12/*: any*/),
   "storageKey": "controls(first:0)"
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v16 = [
+v17 = [
   {
     "kind": "Literal",
     "name": "first",
     "value": 100
   }
 ],
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v18 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endCursor",
   "storageKey": null
 },
-v19 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "hasNextPage",
   "storageKey": null
 },
-v20 = {
+v21 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -215,12 +224,12 @@ v20 = {
   "name": "pageInfo",
   "plural": false,
   "selections": [
-    (v18/*: any*/),
-    (v19/*: any*/)
+    (v19/*: any*/),
+    (v20/*: any*/)
   ],
   "storageKey": null
 },
-v21 = {
+v22 = {
   "kind": "ClientExtension",
   "selections": [
     {
@@ -232,7 +241,7 @@ v21 = {
     }
   ]
 },
-v22 = [
+v23 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -260,13 +269,15 @@ return {
               (v2/*: any*/),
               (v3/*: any*/),
               (v4/*: any*/),
+              (v5/*: any*/),
               (v6/*: any*/),
               (v7/*: any*/),
               (v8/*: any*/),
               (v9/*: any*/),
-              (v12/*: any*/),
+              (v10/*: any*/),
               (v13/*: any*/),
               (v14/*: any*/),
+              (v15/*: any*/),
               {
                 "args": null,
                 "kind": "FragmentSpread",
@@ -317,21 +328,22 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v15/*: any*/),
-          (v5/*: any*/),
+          (v16/*: any*/),
+          (v2/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
-              (v2/*: any*/),
               (v3/*: any*/),
               (v4/*: any*/),
+              (v5/*: any*/),
               (v6/*: any*/),
               (v7/*: any*/),
               (v8/*: any*/),
               (v9/*: any*/),
-              (v12/*: any*/),
+              (v10/*: any*/),
               (v13/*: any*/),
               (v14/*: any*/),
+              (v15/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -369,7 +381,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v16/*: any*/),
+                "args": (v17/*: any*/),
                 "concreteType": "MeasureConnection",
                 "kind": "LinkedField",
                 "name": "measures",
@@ -391,8 +403,8 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
                           (v2/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -400,22 +412,22 @@ return {
                             "name": "state",
                             "storageKey": null
                           },
-                          (v15/*: any*/)
+                          (v16/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v17/*: any*/)
+                      (v18/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v20/*: any*/),
-                  (v21/*: any*/)
+                  (v21/*: any*/),
+                  (v22/*: any*/)
                 ],
                 "storageKey": "measures(first:100)"
               },
               {
                 "alias": null,
-                "args": (v16/*: any*/),
+                "args": (v17/*: any*/),
                 "filters": null,
                 "handle": "connection",
                 "key": "Risk__measures",
@@ -424,7 +436,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v16/*: any*/),
+                "args": (v17/*: any*/),
                 "concreteType": "DocumentConnection",
                 "kind": "LinkedField",
                 "name": "documents",
@@ -446,7 +458,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
+                          (v2/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -498,7 +510,7 @@ return {
                                     "name": "node",
                                     "plural": false,
                                     "selections": [
-                                      (v5/*: any*/),
+                                      (v2/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -515,22 +527,22 @@ return {
                             ],
                             "storageKey": "versions(first:1)"
                           },
-                          (v15/*: any*/)
+                          (v16/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v17/*: any*/)
+                      (v18/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v20/*: any*/),
-                  (v21/*: any*/)
+                  (v21/*: any*/),
+                  (v22/*: any*/)
                 ],
                 "storageKey": "documents(first:100)"
               },
               {
                 "alias": null,
-                "args": (v16/*: any*/),
+                "args": (v17/*: any*/),
                 "filters": null,
                 "handle": "connection",
                 "key": "Risk__documents",
@@ -539,7 +551,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v22/*: any*/),
+                "args": (v23/*: any*/),
                 "concreteType": "ControlConnection",
                 "kind": "LinkedField",
                 "name": "controls",
@@ -561,7 +573,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
+                          (v2/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -569,7 +581,7 @@ return {
                             "name": "sectionTitle",
                             "storageKey": null
                           },
-                          (v2/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -578,16 +590,16 @@ return {
                             "name": "framework",
                             "plural": false,
                             "selections": [
-                              (v5/*: any*/),
-                              (v2/*: any*/)
+                              (v2/*: any*/),
+                              (v4/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v15/*: any*/)
+                          (v16/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v17/*: any*/)
+                      (v18/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -599,8 +611,8 @@ return {
                     "name": "pageInfo",
                     "plural": false,
                     "selections": [
-                      (v18/*: any*/),
                       (v19/*: any*/),
+                      (v20/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -623,7 +635,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v22/*: any*/),
+                "args": (v23/*: any*/),
                 "filters": [
                   "orderBy",
                   "filter"
@@ -643,16 +655,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "5cb3fdf2f48c4b0d2714a06ac2a8fc4d",
+    "cacheID": "03ef938803c52b572e23e691d50c4188",
     "id": null,
     "metadata": {},
     "name": "RiskGraphNodeQuery",
     "operationKind": "query",
-    "text": "query RiskGraphNodeQuery(\n  $riskId: ID!\n) {\n  node(id: $riskId) {\n    __typename\n    ... on Risk {\n      name\n      description\n      treatment\n      owner {\n        id\n        fullName\n      }\n      note\n      inherentRiskScore\n      residualRiskScore\n      measuresInfo: measures(first: 0) {\n        totalCount\n      }\n      documentsInfo: documents(first: 0) {\n        totalCount\n      }\n      controlsInfo: controls(first: 0) {\n        totalCount\n      }\n      ...useRiskFormFragment\n      ...RiskOverviewTabFragment\n      ...RiskMeasuresTabFragment\n      ...RiskDocumentsTabFragment\n      ...RiskControlsTabFragment\n    }\n    id\n  }\n}\n\nfragment LinkedDocumentsCardFragment on Document {\n  id\n  title\n  createdAt\n  documentType\n  versions(first: 1) {\n    edges {\n      node {\n        id\n        status\n      }\n    }\n  }\n}\n\nfragment LinkedMeasuresCardFragment on Measure {\n  id\n  name\n  state\n}\n\nfragment RiskControlsTabFragment on Risk {\n  id\n  controls(first: 20) {\n    edges {\n      node {\n        id\n        sectionTitle\n        name\n        framework {\n          id\n          name\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n\nfragment RiskDocumentsTabFragment on Risk {\n  id\n  documents(first: 100) {\n    edges {\n      node {\n        id\n        ...LinkedDocumentsCardFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment RiskMeasuresTabFragment on Risk {\n  id\n  measures(first: 100) {\n    edges {\n      node {\n        id\n        ...LinkedMeasuresCardFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment RiskOverviewTabFragment on Risk {\n  inherentLikelihood\n  inherentImpact\n  residualLikelihood\n  residualImpact\n  inherentRiskScore\n  residualRiskScore\n}\n\nfragment useRiskFormFragment on Risk {\n  id\n  name\n  category\n  description\n  treatment\n  inherentLikelihood\n  inherentImpact\n  residualLikelihood\n  residualImpact\n  note\n  owner {\n    id\n  }\n}\n"
+    "text": "query RiskGraphNodeQuery(\n  $riskId: ID!\n) {\n  node(id: $riskId) {\n    __typename\n    ... on Risk {\n      id\n      snapshotId\n      name\n      description\n      treatment\n      owner {\n        id\n        fullName\n      }\n      note\n      inherentRiskScore\n      residualRiskScore\n      measuresInfo: measures(first: 0) {\n        totalCount\n      }\n      documentsInfo: documents(first: 0) {\n        totalCount\n      }\n      controlsInfo: controls(first: 0) {\n        totalCount\n      }\n      ...useRiskFormFragment\n      ...RiskOverviewTabFragment\n      ...RiskMeasuresTabFragment\n      ...RiskDocumentsTabFragment\n      ...RiskControlsTabFragment\n    }\n    id\n  }\n}\n\nfragment LinkedDocumentsCardFragment on Document {\n  id\n  title\n  createdAt\n  documentType\n  versions(first: 1) {\n    edges {\n      node {\n        id\n        status\n      }\n    }\n  }\n}\n\nfragment LinkedMeasuresCardFragment on Measure {\n  id\n  name\n  state\n}\n\nfragment RiskControlsTabFragment on Risk {\n  id\n  controls(first: 20) {\n    edges {\n      node {\n        id\n        sectionTitle\n        name\n        framework {\n          id\n          name\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n\nfragment RiskDocumentsTabFragment on Risk {\n  id\n  documents(first: 100) {\n    edges {\n      node {\n        id\n        ...LinkedDocumentsCardFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment RiskMeasuresTabFragment on Risk {\n  id\n  measures(first: 100) {\n    edges {\n      node {\n        id\n        ...LinkedMeasuresCardFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment RiskOverviewTabFragment on Risk {\n  inherentLikelihood\n  inherentImpact\n  residualLikelihood\n  residualImpact\n  inherentRiskScore\n  residualRiskScore\n}\n\nfragment useRiskFormFragment on Risk {\n  id\n  name\n  category\n  description\n  treatment\n  inherentLikelihood\n  inherentImpact\n  residualLikelihood\n  residualImpact\n  note\n  owner {\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "a190e4ead5b381da07e69f00650d8372";
+(node as any).hash = "43dcdf60f1d1b28414650fe5f9294faa";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/RisksListQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/RisksListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6369aba92b58ca2a67d57110a829bde4>>
+ * @generated SignedSource<<7cab8b863d6327262c8821ae2df68f6f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -23,6 +23,7 @@ export type RisksListQuery$variables = {
   id: string;
   last?: number | null | undefined;
   order?: RiskOrder | null | undefined;
+  snapshotId?: string | null | undefined;
 };
 export type RisksListQuery$data = {
   readonly node: {
@@ -65,52 +66,69 @@ v5 = {
   "kind": "LocalArgument",
   "name": "order"
 },
-v6 = [
+v6 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "snapshotId"
+},
+v7 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
   }
 ],
-v7 = {
+v8 = {
   "kind": "Variable",
   "name": "after",
   "variableName": "after"
 },
-v8 = {
+v9 = {
   "kind": "Variable",
   "name": "before",
   "variableName": "before"
 },
-v9 = {
+v10 = {
   "kind": "Variable",
   "name": "first",
   "variableName": "first"
 },
-v10 = {
+v11 = {
   "kind": "Variable",
   "name": "last",
   "variableName": "last"
 },
-v11 = {
+v12 = {
+  "kind": "Variable",
+  "name": "snapshotId",
+  "variableName": "snapshotId"
+},
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v12 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v13 = [
-  (v7/*: any*/),
+v15 = [
   (v8/*: any*/),
   (v9/*: any*/),
+  {
+    "fields": [
+      (v12/*: any*/)
+    ],
+    "kind": "ObjectValue",
+    "name": "filter"
+  },
   (v10/*: any*/),
+  (v11/*: any*/),
   {
     "kind": "Variable",
     "name": "orderBy",
@@ -125,7 +143,8 @@ return {
       (v2/*: any*/),
       (v3/*: any*/),
       (v4/*: any*/),
-      (v5/*: any*/)
+      (v5/*: any*/),
+      (v6/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -133,7 +152,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v6/*: any*/),
+        "args": (v7/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
@@ -141,15 +160,16 @@ return {
         "selections": [
           {
             "args": [
-              (v7/*: any*/),
               (v8/*: any*/),
               (v9/*: any*/),
               (v10/*: any*/),
+              (v11/*: any*/),
               {
                 "kind": "Variable",
                 "name": "order",
                 "variableName": "order"
-              }
+              },
+              (v12/*: any*/)
             ],
             "kind": "FragmentSpread",
             "name": "RiskGraphFragment"
@@ -169,6 +189,7 @@ return {
       (v2/*: any*/),
       (v4/*: any*/),
       (v5/*: any*/),
+      (v6/*: any*/),
       (v3/*: any*/)
     ],
     "kind": "Operation",
@@ -176,20 +197,20 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v6/*: any*/),
+        "args": (v7/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v11/*: any*/),
-          (v12/*: any*/),
+          (v13/*: any*/),
+          (v14/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
               {
                 "alias": null,
-                "args": (v13/*: any*/),
+                "args": (v15/*: any*/),
                 "concreteType": "RiskConnection",
                 "kind": "LinkedField",
                 "name": "risks",
@@ -211,7 +232,14 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v12/*: any*/),
+                          (v14/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "snapshotId",
+                            "storageKey": null
+                          },
                           {
                             "alias": null,
                             "args": null,
@@ -297,11 +325,11 @@ return {
                             "name": "owner",
                             "plural": false,
                             "selections": [
-                              (v12/*: any*/)
+                              (v14/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v11/*: any*/)
+                          (v13/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -359,9 +387,10 @@ return {
               },
               {
                 "alias": null,
-                "args": (v13/*: any*/),
+                "args": (v15/*: any*/),
                 "filters": [
-                  "orderBy"
+                  "orderBy",
+                  "filter"
                 ],
                 "handle": "connection",
                 "key": "RisksListQuery_risks",
@@ -378,16 +407,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ca8ad189a3d134eecaaf9adfe090277e",
+    "cacheID": "161eb78d1d5100120c68db5d8106aa7e",
     "id": null,
     "metadata": {},
     "name": "RisksListQuery",
     "operationKind": "query",
-    "text": "query RisksListQuery(\n  $after: CursorKey = null\n  $before: CursorKey = null\n  $first: Int = 50\n  $last: Int = null\n  $order: RiskOrder = null\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...RiskGraphFragment_16fISc\n    id\n  }\n}\n\nfragment RiskGraphFragment_16fISc on Organization {\n  risks(first: $first, after: $after, last: $last, before: $before, orderBy: $order) {\n    edges {\n      node {\n        id\n        name\n        category\n        treatment\n        inherentLikelihood\n        inherentImpact\n        residualLikelihood\n        residualImpact\n        inherentRiskScore\n        residualRiskScore\n        ...useRiskFormFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n\nfragment useRiskFormFragment on Risk {\n  id\n  name\n  category\n  description\n  treatment\n  inherentLikelihood\n  inherentImpact\n  residualLikelihood\n  residualImpact\n  note\n  owner {\n    id\n  }\n}\n"
+    "text": "query RisksListQuery(\n  $after: CursorKey = null\n  $before: CursorKey = null\n  $first: Int = 50\n  $last: Int = null\n  $order: RiskOrder = null\n  $snapshotId: ID = null\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...RiskGraphFragment_25MC8O\n    id\n  }\n}\n\nfragment RiskGraphFragment_25MC8O on Organization {\n  risks(first: $first, after: $after, last: $last, before: $before, orderBy: $order, filter: {snapshotId: $snapshotId}) {\n    edges {\n      node {\n        id\n        snapshotId\n        name\n        category\n        treatment\n        inherentLikelihood\n        inherentImpact\n        residualLikelihood\n        residualImpact\n        inherentRiskScore\n        residualRiskScore\n        ...useRiskFormFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n\nfragment useRiskFormFragment on Risk {\n  id\n  name\n  category\n  description\n  treatment\n  inherentLikelihood\n  inherentImpact\n  residualLikelihood\n  residualImpact\n  note\n  owner {\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "dc662098b9aceaa2400f4656ed1b2d01";
+(node as any).hash = "f4a8e0e71a70b692b1806d992bc18863";
 
 export default node;

--- a/apps/console/src/pages/organizations/measures/tabs/MeasureEvidencesTab.tsx
+++ b/apps/console/src/pages/organizations/measures/tabs/MeasureEvidencesTab.tsx
@@ -85,7 +85,7 @@ export default function MeasureEvidencesTab() {
   const { measure } = useOutletContext<{
     measure: MeasureEvidencesTabFragment$key & { id: string; name: string };
   }>();
-  const { evidenceId } = useParams<{ evidenceId: string }>();
+  const { evidenceId, snapshotId } = useParams<{ evidenceId: string; snapshotId?: string }>();
   const pagination = usePaginationFragment(evidencesFragment, measure);
   const connectionId = pagination.data.evidences.__id;
   const evidences =
@@ -95,6 +95,7 @@ export default function MeasureEvidencesTab() {
   const evidence = evidences.find((e) => e.id === evidenceId);
   const organizationId = useOrganizationId();
   const dialogRef = useDialogRef();
+  const isSnapshotMode = Boolean(snapshotId);
 
   usePageTitle(measure.name + " - " + __("Evidences"));
 
@@ -118,34 +119,41 @@ export default function MeasureEvidencesTab() {
               measureId={measure.id}
               organizationId={organizationId}
               connectionId={connectionId}
+              hideActions={isSnapshotMode}
+              snapshotId={snapshotId}
             />
           ))}
-          <TrButton
-            colspan={5}
-            onClick={() => dialogRef.current?.open()}
-            icon={IconPlusLarge}
-          >
-            {__("Add evidence")}
-          </TrButton>
+          {!isSnapshotMode && (
+            <TrButton
+              colspan={5}
+              onClick={() => dialogRef.current?.open()}
+              icon={IconPlusLarge}
+            >
+              {__("Add evidence")}
+            </TrButton>
+          )}
         </Tbody>
       </SortableTable>
       {evidence && (
         <EvidencePreviewDialog
           key={evidence?.id}
-          onClose={() =>
-            navigate(
-              `/organizations/${organizationId}/measures/${measure.id}/evidences`,
-            )
-          }
+          onClose={() => {
+            const baseUrl = isSnapshotMode
+              ? `/organizations/${organizationId}/snapshots/${snapshotId}/risks/measures/${measure.id}/evidences`
+              : `/organizations/${organizationId}/measures/${measure.id}/evidences`;
+            navigate(baseUrl);
+          }}
           evidenceId={evidence.id}
           filename={evidence.filename}
         />
       )}
-      <CreateEvidenceDialog
-        ref={dialogRef}
-        measureId={measure.id}
-        connectionId={connectionId}
-      />
+      {!isSnapshotMode && (
+        <CreateEvidenceDialog
+          ref={dialogRef}
+          measureId={measure.id}
+          connectionId={connectionId}
+        />
+      )}
     </div>
   );
 }
@@ -155,6 +163,8 @@ function EvidenceRow(props: {
   measureId: string;
   organizationId: string;
   connectionId: string;
+  hideActions?: boolean;
+  snapshotId?: string;
 }) {
   const evidence = useFragment(evidenceFragment, props.evidenceKey);
   const { __, dateFormat } = useTranslate();
@@ -186,6 +196,10 @@ function EvidenceRow(props: {
     );
   };
 
+  const evidenceUrl = props.snapshotId
+    ? `/organizations/${props.organizationId}/snapshots/${props.snapshotId}/risks/measures/${props.measureId}/evidences/${evidence.id}`
+    : `/organizations/${props.organizationId}/measures/${props.measureId}/evidences/${evidence.id}`;
+
   return (
     <>
       {isDownloading && (
@@ -194,30 +208,30 @@ function EvidenceRow(props: {
           onClose={() => setIsDownloading(false)}
         />
       )}
-      <Tr
-        to={`/organizations/${props.organizationId}/measures/${props.measureId}/evidences/${evidence.id}`}
-      >
+      <Tr to={evidenceUrl}>
         <Td>{evidence.filename}</Td>
         <Td>{fileType(__, evidence)}</Td>
         <Td>{fileSize(__, evidence.size)}</Td>
         <Td>{dateFormat(evidence.createdAt)}</Td>
         <Td noLink>
-          <div className="flex gap-2">
-            <ActionDropdown>
-              <DropdownItem onClick={() => setIsDownloading(true)}>
-                <IconArrowInbox size={16} />
-                {__("Download")}
-              </DropdownItem>
-              <DropdownItem
-                variant="danger"
-                icon={IconTrashCan}
-                onClick={handleDelete}
-                disabled={isDeleting}
-              >
-                {__("Delete")}
-              </DropdownItem>
-            </ActionDropdown>
-          </div>
+          {!props.hideActions && (
+            <div className="flex gap-2">
+              <ActionDropdown>
+                <DropdownItem onClick={() => setIsDownloading(true)}>
+                  <IconArrowInbox size={16} />
+                  {__("Download")}
+                </DropdownItem>
+                <DropdownItem
+                  variant="danger"
+                  icon={IconTrashCan}
+                  onClick={handleDelete}
+                  disabled={isDeleting}
+                >
+                  {__("Delete")}
+                </DropdownItem>
+              </ActionDropdown>
+            </div>
+          )}
         </Td>
       </Tr>
     </>

--- a/apps/console/src/pages/organizations/risks/tabs/RiskDocumentsTab.tsx
+++ b/apps/console/src/pages/organizations/risks/tabs/RiskDocumentsTab.tsx
@@ -1,5 +1,5 @@
 import { graphql, useFragment, useMutation } from "react-relay";
-import { useOutletContext } from "react-router";
+import { useOutletContext, useParams } from "react-router";
 import { LinkedDocumentsCard } from "/components/documents/LinkedDocumentsCard";
 import type { RiskDocumentsTabFragment$key } from "./__generated__/RiskDocumentsTabFragment.graphql";
 
@@ -46,6 +46,9 @@ export const detachDocumentMutation = graphql`
 `;
 
 export default function RiskDocumentsTab() {
+  const { snapshotId } = useParams<{ snapshotId?: string }>();
+  const isSnapshotMode = Boolean(snapshotId);
+
   const { risk } = useOutletContext<{
     risk: RiskDocumentsTabFragment$key & { id: string };
   }>();
@@ -60,6 +63,7 @@ export default function RiskDocumentsTab() {
   return (
     <LinkedDocumentsCard
       disabled={isLoading}
+      hideActions={isSnapshotMode}
       documents={documents}
       onAttach={attachDocument}
       onDetach={detachDocument}

--- a/apps/console/src/pages/organizations/risks/tabs/RiskMeasuresTab.tsx
+++ b/apps/console/src/pages/organizations/risks/tabs/RiskMeasuresTab.tsx
@@ -1,6 +1,6 @@
 import { graphql, useFragment, useMutation } from "react-relay";
 import type { RiskMeasuresTabFragment$key } from "./__generated__/RiskMeasuresTabFragment.graphql";
-import { useOutletContext } from "react-router";
+import { useOutletContext, useParams } from "react-router";
 import { LinkedMeasuresCard } from "/components/measures/LinkedMeasuresCard";
 
 export const measuresFragment = graphql`
@@ -46,6 +46,9 @@ export const detachMeasureMutation = graphql`
 `;
 
 export default function RiskMeasuresTab() {
+  const { snapshotId } = useParams<{ snapshotId?: string }>();
+  const isSnapshotMode = Boolean(snapshotId);
+
   const { risk } = useOutletContext<{
     risk: RiskMeasuresTabFragment$key & { id: string };
   }>();
@@ -60,6 +63,7 @@ export default function RiskMeasuresTab() {
   return (
     <LinkedMeasuresCard
       disabled={isLoading}
+      hideActions={isSnapshotMode}
       measures={measures}
       onAttach={attachMeasure}
       onDetach={detachMeasure}

--- a/apps/console/src/routes/measureRoutes.ts
+++ b/apps/console/src/routes/measureRoutes.ts
@@ -70,4 +70,31 @@ export const measureRoutes = [
       },
     ],
   },
+  // Snapshot measure routes
+  {
+    path: "snapshots/:snapshotId/risks/measures/:measureId",
+    fallback: PageSkeleton,
+    queryLoader: ({ measureId }) =>
+      loadQuery(relayEnvironment, measureNodeQuery, { measureId }),
+    Component: lazy(
+      () => import("/pages/organizations/measures/MeasureDetailPage")
+    ),
+    children: [
+      {
+        path: "",
+        loader: () => {
+          throw redirect("evidences");
+        },
+        Component: Fragment,
+      },
+      {
+        path: "evidences/:evidenceId?",
+        fallback: LinkCardSkeleton,
+        Component: lazy(
+          () =>
+            import("/pages/organizations/measures/tabs/MeasureEvidencesTab.tsx")
+        ),
+      },
+    ],
+  },
 ] satisfies AppRoute[];

--- a/apps/console/src/routes/riskRoutes.ts
+++ b/apps/console/src/routes/riskRoutes.ts
@@ -14,7 +14,20 @@ export const riskRoutes = [
     path: "risks",
     fallback: RisksPageSkeleton,
     queryLoader: ({ organizationId }) =>
-      loadQuery(relayEnvironment, risksQuery, { organizationId }),
+      loadQuery(relayEnvironment, risksQuery, {
+        organizationId,
+        snapshotId: null
+      }),
+    Component: lazy(() => import("/pages/organizations/risks/RisksPage")),
+  },
+  {
+    path: "snapshots/:snapshotId/risks",
+    fallback: RisksPageSkeleton,
+    queryLoader: ({ organizationId, snapshotId }) =>
+      loadQuery(relayEnvironment, risksQuery, {
+        organizationId,
+        snapshotId
+      }),
     Component: lazy(() => import("/pages/organizations/risks/RisksPage")),
   },
   {
@@ -57,6 +70,43 @@ export const riskRoutes = [
         fallback: LinkCardSkeleton,
         Component: lazy(
           () => import("/pages/organizations/risks/tabs/RiskControlsTab.tsx")
+        ),
+      },
+    ],
+  },
+  {
+    path: "snapshots/:snapshotId/risks/:riskId",
+    fallback: PageSkeleton,
+    queryLoader: ({ riskId }) =>
+      loadQuery(relayEnvironment, riskNodeQuery, { riskId }),
+    Component: lazy(() => import("/pages/organizations/risks/RiskDetailPage")),
+    children: [
+      {
+        path: "",
+        loader: () => {
+          throw redirect("overview");
+        },
+        Component: Fragment,
+      },
+      {
+        path: "overview",
+        fallback: LinkCardSkeleton,
+        Component: lazy(
+          () => import("/pages/organizations/risks/tabs/RiskOverviewTab.tsx")
+        ),
+      },
+      {
+        path: "measures",
+        fallback: LinkCardSkeleton,
+        Component: lazy(
+          () => import("/pages/organizations/risks/tabs/RiskMeasuresTab.tsx")
+        ),
+      },
+      {
+        path: "documents",
+        fallback: LinkCardSkeleton,
+        Component: lazy(
+          () => import("/pages/organizations/risks/tabs/RiskDocumentsTab.tsx")
         ),
       },
     ],

--- a/packages/helpers/src/snapshots.ts
+++ b/packages/helpers/src/snapshots.ts
@@ -1,6 +1,7 @@
 type Translator = (s: string) => string;
 
 export const snapshotTypes = [
+  "RISKS",
   "VENDORS",
   "ASSETS",
   "DATA",
@@ -39,6 +40,8 @@ export function getSnapshotTypeLabel(__: Translator, type: string | null | undef
 
 export function getSnapshotTypeUrlPath(type?: string): string {
   switch (type) {
+    case "RISKS":
+      return "/risks";
     case "VENDORS":
       return "/vendors";
     case "ASSETS":

--- a/pkg/coredata/measure_filter.go
+++ b/pkg/coredata/measure_filter.go
@@ -15,36 +15,62 @@
 package coredata
 
 import (
+	"github.com/getprobo/probo/pkg/gid"
 	"github.com/jackc/pgx/v5"
 )
 
 type (
 	MeasureFilter struct {
-		query *string
+		query      *string
+		snapshotID **gid.GID
 	}
 )
 
-func NewMeasureFilter(query *string) *MeasureFilter {
+func NewMeasureFilter(query *string, snapshotID **gid.GID) *MeasureFilter {
 	return &MeasureFilter{
-		query: query,
+		query:      query,
+		snapshotID: snapshotID,
 	}
 }
 
-func (f *MeasureFilter) SQLArguments() pgx.NamedArgs {
-	return pgx.NamedArgs{
+func (f *MeasureFilter) SQLArguments() pgx.StrictNamedArgs {
+	args := pgx.StrictNamedArgs{
 		"query": f.query,
 	}
+
+	if f.snapshotID == nil {
+		args["has_snapshot_filter"] = false
+		args["filter_snapshot_id"] = nil
+	} else if *f.snapshotID == nil {
+		args["has_snapshot_filter"] = true
+		args["filter_snapshot_id"] = nil
+	} else {
+		args["has_snapshot_filter"] = true
+		args["filter_snapshot_id"] = **f.snapshotID
+	}
+
+	return args
 }
 
 func (f *MeasureFilter) SQLFragment() string {
-	if f.query == nil || *f.query == "" {
-		return "TRUE"
-	}
-
 	return `
-		search_vector @@ (
-			SELECT to_tsquery('simple', string_agg(lexeme || ':*', ' & '))
-			FROM unnest(regexp_split_to_array(trim(@query), '\s+')) AS lexeme
-		)
-	`
+(
+	CASE
+		WHEN @query::text IS NOT NULL AND @query::text != '' THEN
+			search_vector @@ (
+				SELECT to_tsquery('simple', string_agg(lexeme || ':*', ' & '))
+				FROM unnest(regexp_split_to_array(trim(@query), '\s+')) AS lexeme
+			)
+		ELSE TRUE
+	END
+	AND
+	CASE
+		WHEN @has_snapshot_filter::boolean = false THEN TRUE
+		WHEN @has_snapshot_filter::boolean = true AND @filter_snapshot_id::text IS NOT NULL THEN
+			snapshot_id = @filter_snapshot_id::text
+		WHEN @has_snapshot_filter::boolean = true AND @filter_snapshot_id::text IS NULL THEN
+			snapshot_id IS NULL
+		ELSE TRUE
+	END
+)`
 }

--- a/pkg/coredata/migrations/20250902T093819Z.sql
+++ b/pkg/coredata/migrations/20250902T093819Z.sql
@@ -1,0 +1,55 @@
+ALTER TABLE risks ADD COLUMN snapshot_id TEXT;
+ALTER TABLE risks ADD COLUMN source_id TEXT;
+
+ALTER TABLE risks ADD CONSTRAINT risks_snapshot_id_fkey
+    FOREIGN KEY (snapshot_id)
+    REFERENCES snapshots(id)
+    ON UPDATE CASCADE
+    ON DELETE CASCADE;
+
+ALTER TABLE risks ADD CONSTRAINT risks_source_id_snapshot_id_key
+    UNIQUE (source_id, snapshot_id);
+
+ALTER TABLE risks_documents ADD COLUMN snapshot_id TEXT;
+
+ALTER TABLE risks_documents ADD CONSTRAINT risks_documents_snapshot_id_fkey
+    FOREIGN KEY (snapshot_id)
+    REFERENCES snapshots(id)
+    ON UPDATE CASCADE
+    ON DELETE CASCADE;
+
+ALTER TABLE risks_measures ADD COLUMN snapshot_id TEXT;
+
+ALTER TABLE risks_measures ADD CONSTRAINT risks_measures_snapshot_id_fkey
+    FOREIGN KEY (snapshot_id)
+    REFERENCES snapshots(id)
+    ON UPDATE CASCADE
+    ON DELETE CASCADE;
+
+ALTER TABLE measures ADD COLUMN snapshot_id TEXT;
+ALTER TABLE measures ADD COLUMN source_id TEXT;
+
+ALTER TABLE measures ADD CONSTRAINT measures_snapshot_id_fkey
+    FOREIGN KEY (snapshot_id)
+    REFERENCES snapshots(id)
+    ON UPDATE CASCADE
+    ON DELETE CASCADE;
+
+ALTER TABLE measures ADD CONSTRAINT measures_source_id_snapshot_id_key
+    UNIQUE (source_id, snapshot_id);
+
+ALTER TABLE measures DROP CONSTRAINT mitigations_org_ref_unique;
+ALTER TABLE measures ADD CONSTRAINT mitigations_org_ref_unique
+    UNIQUE (organization_id, reference_id, source_id);
+
+ALTER TABLE evidences ADD COLUMN snapshot_id TEXT;
+ALTER TABLE evidences ADD COLUMN source_id TEXT;
+
+ALTER TABLE evidences ADD CONSTRAINT evidences_snapshot_id_fkey
+    FOREIGN KEY (snapshot_id)
+    REFERENCES snapshots(id)
+    ON UPDATE CASCADE
+    ON DELETE CASCADE;
+
+ALTER TABLE evidences ADD CONSTRAINT evidences_source_id_snapshot_id_key
+    UNIQUE (source_id, snapshot_id);

--- a/pkg/coredata/risk.go
+++ b/pkg/coredata/risk.go
@@ -42,11 +42,17 @@ type (
 		ResidualLikelihood int           `db:"residual_likelihood"`
 		ResidualImpact     int           `db:"residual_impact"`
 		ResidualRiskScore  int           `db:"residual_risk_score"`
+		SnapshotID         *gid.GID      `db:"snapshot_id"`
+		SourceID           *gid.GID      `db:"source_id"`
 		CreatedAt          time.Time     `db:"created_at"`
 		UpdatedAt          time.Time     `db:"updated_at"`
 	}
 
 	Risks []*Risk
+
+	RiskSnapshotter interface {
+		InsertRiskSnapshots(ctx context.Context, conn pg.Conn, scope Scoper, organizationID, snapshotID gid.GID) error
+	}
 )
 
 func (r *Risk) CursorKey(orderBy RiskOrderField) page.CursorKey {
@@ -79,7 +85,9 @@ func (r *Risks) CountByMeasureID(
 WITH rsks AS (
 	SELECT
 		r.id,
-		r.tenant_id
+		r.tenant_id,
+		r.search_vector,
+		r.snapshot_id
 	FROM
 		risks r
 	INNER JOIN
@@ -136,6 +144,8 @@ WITH rsks AS (
 		r.residual_likelihood,
 		r.residual_impact,
 		r.residual_risk_score,
+		r.snapshot_id,
+		r.source_id,
 		r.search_vector,
 		r.created_at,
 		r.updated_at
@@ -161,6 +171,8 @@ SELECT
 	residual_likelihood,
 	residual_impact,
 	residual_risk_score,
+	snapshot_id,
+	source_id,
 	created_at,
 	updated_at
 FROM
@@ -246,6 +258,8 @@ SELECT
 	residual_impact,
 	residual_risk_score,
 	category,
+	snapshot_id,
+	source_id,
 	created_at,
 	updated_at
 FROM risks
@@ -298,6 +312,8 @@ SELECT
 	residual_likelihood,
 	residual_impact,
 	residual_risk_score,
+	snapshot_id,
+	source_id,
 	created_at,
 	updated_at
 FROM risks
@@ -408,7 +424,7 @@ func (r *Risk) Delete(
 	riskID gid.GID,
 ) error {
 	q := `
-DELETE FROM risks WHERE %s AND id = @id
+DELETE FROM risks WHERE %s AND id = @id AND snapshot_id IS NULL
 `
 	q = fmt.Sprintf(q, scope.SQLFragment())
 
@@ -430,7 +446,8 @@ func (r *Risks) CountByDocumentID(
 WITH rsks AS (
 	SELECT
 		r.id,
-		r.tenant_id
+		r.tenant_id,
+		r.search_vector
 	FROM
 		risks r
 	INNER JOIN
@@ -459,4 +476,87 @@ WHERE %s
 	}
 
 	return count, nil
+}
+
+func (r Risks) Snapshot(ctx context.Context, conn pg.Conn, scope Scoper, organizationID, snapshotID gid.GID) error {
+	for _, snapshotter := range []RiskSnapshotter{
+		Risks{},
+		RiskDocuments{},
+		Measures{},
+		RiskMeasures{},
+		Evidences{},
+	} {
+		if err := snapshotter.InsertRiskSnapshots(ctx, conn, scope, organizationID, snapshotID); err != nil {
+			return fmt.Errorf("cannot create risk snapshots: (%T) %w", snapshotter, err)
+		}
+	}
+
+	return nil
+}
+
+func (r Risks) InsertRiskSnapshots(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	organizationID gid.GID,
+	snapshotID gid.GID,
+) error {
+	query := `
+INSERT INTO risks (
+	tenant_id,
+	id,
+	snapshot_id,
+	source_id,
+	organization_id,
+	name,
+	description,
+	category,
+	treatment,
+	note,
+	owner_id,
+	inherent_likelihood,
+	inherent_impact,
+	residual_likelihood,
+	residual_impact,
+	created_at,
+	updated_at
+)
+SELECT
+	@tenant_id,
+	generate_gid(decode_base64_unpadded(@tenant_id), @risk_entity_type),
+	@snapshot_id,
+	r.id,
+	r.organization_id,
+	r.name,
+	r.description,
+	r.category,
+	r.treatment,
+	r.note,
+	r.owner_id,
+	r.inherent_likelihood,
+	r.inherent_impact,
+	r.residual_likelihood,
+	r.residual_impact,
+	r.created_at,
+	r.updated_at
+FROM risks r
+WHERE %s AND organization_id = @organization_id AND snapshot_id IS NULL
+	`
+
+	query = fmt.Sprintf(query, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"tenant_id":        scope.GetTenantID(),
+		"snapshot_id":      snapshotID,
+		"organization_id":  organizationID,
+		"risk_entity_type": RiskEntityType,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, query, args)
+	if err != nil {
+		return fmt.Errorf("cannot insert risk snapshots: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/coredata/risk_document.go
+++ b/pkg/coredata/risk_document.go
@@ -27,10 +27,10 @@ import (
 
 type (
 	RiskDocument struct {
-		RiskID     gid.GID      `db:"risk_id"`
-		DocumentID gid.GID      `db:"document_id"`
-		TenantID   gid.TenantID `db:"tenant_id"`
-		CreatedAt  time.Time    `db:"created_at"`
+		RiskID     gid.GID   `db:"risk_id"`
+		DocumentID gid.GID   `db:"document_id"`
+		SnapshotID *gid.GID  `db:"snapshot_id"`
+		CreatedAt  time.Time `db:"created_at"`
 	}
 
 	RiskDocuments []*RiskDocument
@@ -94,4 +94,53 @@ WHERE
 
 	_, err := conn.Exec(ctx, q, args)
 	return err
+}
+
+func (rd RiskDocuments) InsertRiskSnapshots(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	organizationID gid.GID,
+	snapshotID gid.GID,
+) error {
+	query := `
+WITH
+	snapshot_risks AS (
+		SELECT id, source_id
+		FROM risks
+		WHERE organization_id = @organization_id AND snapshot_id = @snapshot_id
+	)
+INSERT INTO risks_documents (
+	tenant_id,
+	snapshot_id,
+	risk_id,
+	document_id,
+	created_at
+)
+SELECT
+	@tenant_id,
+	@snapshot_id,
+	sr.id,
+	rd.document_id,
+	rd.created_at
+FROM risks_documents rd
+INNER JOIN snapshot_risks sr ON sr.source_id = rd.risk_id
+WHERE %s AND rd.snapshot_id IS NULL
+	`
+
+	query = fmt.Sprintf(query, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"tenant_id":       scope.GetTenantID(),
+		"snapshot_id":     snapshotID,
+		"organization_id": organizationID,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, query, args)
+	if err != nil {
+		return fmt.Errorf("cannot insert risk document snapshots: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/coredata/risk_mesure.go
+++ b/pkg/coredata/risk_mesure.go
@@ -27,10 +27,10 @@ import (
 
 type (
 	RiskMeasure struct {
-		RiskID    gid.GID      `db:"risk_id"`
-		MeasureID gid.GID      `db:"measure_id"`
-		TenantID  gid.TenantID `db:"tenant_id"`
-		CreatedAt time.Time    `db:"created_at"`
+		RiskID     gid.GID   `db:"risk_id"`
+		MeasureID  gid.GID   `db:"measure_id"`
+		SnapshotID *gid.GID  `db:"snapshot_id"`
+		CreatedAt  time.Time `db:"created_at"`
 	}
 
 	RiskMeasures []*RiskMeasure
@@ -81,7 +81,8 @@ FROM
 WHERE
     %s
     AND risk_id = @risk_id
-    AND measure_id = @measure_id;
+    AND measure_id = @measure_id
+	AND snapshot_id IS NULL;
 `
 
 	q = fmt.Sprintf(q, scope.SQLFragment())
@@ -94,4 +95,68 @@ WHERE
 
 	_, err := conn.Exec(ctx, q, args)
 	return err
+}
+
+func (rm RiskMeasures) InsertRiskSnapshots(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	organizationID gid.GID,
+	snapshotID gid.GID,
+) error {
+	query := `
+WITH
+	source_risks AS (
+		SELECT id
+		FROM risks
+		WHERE organization_id = @organization_id AND snapshot_id IS NULL
+	),
+	snapshot_risks AS (
+		SELECT id, source_id
+		FROM risks
+		WHERE organization_id = @organization_id AND snapshot_id = @snapshot_id
+	),
+	snapshot_measures AS (
+		SELECT id, source_id
+		FROM measures
+		WHERE organization_id = @organization_id AND snapshot_id = @snapshot_id
+	),
+	source_risk_measures AS (
+		SELECT risk_id, measure_id, snapshot_id, created_at
+		FROM risks_measures
+		WHERE %s AND risk_id = ANY(SELECT id FROM source_risks) AND snapshot_id IS NULL
+	)
+INSERT INTO risks_measures (
+	tenant_id,
+	risk_id,
+	measure_id,
+	snapshot_id,
+	created_at
+)
+SELECT
+	@tenant_id,
+	sr.id,
+	sm.id,
+	@snapshot_id,
+	rm.created_at
+FROM source_risk_measures rm
+JOIN snapshot_risks sr ON sr.source_id = rm.risk_id
+JOIN snapshot_measures sm ON sm.source_id = rm.measure_id
+	`
+
+	query = fmt.Sprintf(query, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"tenant_id":       scope.GetTenantID(),
+		"snapshot_id":     snapshotID,
+		"organization_id": organizationID,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, query, args)
+	if err != nil {
+		return fmt.Errorf("cannot insert risk measure snapshots: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/coredata/snapshottable.go
+++ b/pkg/coredata/snapshottable.go
@@ -30,6 +30,8 @@ func GetSnapshottable(snapshotType SnapshotsType) (Snapshottable, error) {
 	switch snapshotType {
 	case SnapshotsTypeAssets:
 		return Assets{}, nil
+	case SnapshotsTypeRisks:
+		return Risks{}, nil
 	case SnapshotsTypeData:
 		return Data{}, nil
 	case SnapshotsTypeNonConformityRegistries:

--- a/pkg/probo/framework_service.go
+++ b/pkg/probo/framework_service.go
@@ -342,6 +342,7 @@ func (s FrameworkService) StateOfApplicability(ctx context.Context, frameworkID 
 				}
 
 				measures := coredata.Measures{}
+				var nilSnapshotID *gid.GID = nil
 				err = measures.LoadByControlID(
 					ctx,
 					conn,
@@ -356,7 +357,7 @@ func (s FrameworkService) StateOfApplicability(ctx context.Context, frameworkID 
 							Direction: page.OrderDirectionAsc,
 						},
 					),
-					coredata.NewMeasureFilter(nil),
+					coredata.NewMeasureFilter(nil, &nilSnapshotID),
 				)
 				if err != nil {
 					return fmt.Errorf("cannot load measures: %w", err)
@@ -364,12 +365,13 @@ func (s FrameworkService) StateOfApplicability(ctx context.Context, frameworkID 
 
 				for _, measure := range measures {
 					risks := coredata.Risks{}
+					var nilSnapshotID *gid.GID = nil
 					risksCount, err := risks.CountByMeasureID(
 						ctx,
 						conn,
 						s.svc.scope,
 						measure.ID,
-						coredata.NewRiskFilter(nil),
+						coredata.NewRiskFilter(nil, &nilSnapshotID),
 					)
 					if err != nil {
 						return fmt.Errorf("cannot count risks: %w", err)
@@ -410,7 +412,7 @@ func (s FrameworkService) StateOfApplicability(ctx context.Context, frameworkID 
 						conn,
 						s.svc.scope,
 						document.ID,
-						coredata.NewRiskFilter(nil),
+						coredata.NewRiskFilter(nil, nil),
 					)
 					if err != nil {
 						return fmt.Errorf("cannot count risks: %w", err)

--- a/pkg/probo/risk_service.go
+++ b/pkg/probo/risk_service.go
@@ -186,7 +186,6 @@ func (s RiskService) CreateDocumentMapping(
 			riskDocument := &coredata.RiskDocument{
 				RiskID:     risk.ID,
 				DocumentID: document.ID,
-				TenantID:   s.svc.scope.GetTenantID(),
 				CreatedAt:  time.Now(),
 			}
 
@@ -254,7 +253,6 @@ func (s RiskService) CreateMeasureMapping(
 			riskMeasure := &coredata.RiskMeasure{
 				RiskID:    risk.ID,
 				MeasureID: measure.ID,
-				TenantID:  s.svc.scope.GetTenantID(),
 				CreatedAt: time.Now(),
 			}
 
@@ -291,7 +289,6 @@ func (s RiskService) DeleteMeasureMapping(
 			riskMeasure := &coredata.RiskMeasure{
 				RiskID:    riskID,
 				MeasureID: measureID,
-				TenantID:  s.svc.scope.GetTenantID(),
 				CreatedAt: time.Now(),
 			}
 

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -1096,10 +1096,12 @@ input DocumentFilter {
 
 input MeasureFilter {
   query: String
+  snapshotId: ID
 }
 
 input RiskFilter {
   query: String
+  snapshotId: ID
 }
 
 input PeopleFilter {
@@ -1227,7 +1229,7 @@ type Organization implements Node {
     last: Int
     before: CursorKey
     orderBy: MeasureOrder
-    filter: MeasureFilter
+    filter: MeasureFilter = { snapshotId: null }
   ): MeasureConnection! @goField(forceResolver: true)
 
   risks(
@@ -1236,7 +1238,7 @@ type Organization implements Node {
     last: Int
     before: CursorKey
     orderBy: RiskOrder
-    filter: RiskFilter
+    filter: RiskFilter = { snapshotId: null }
   ): RiskConnection! @goField(forceResolver: true)
 
   tasks(
@@ -1545,6 +1547,7 @@ type Control implements Node {
 
 type Measure implements Node {
   id: ID!
+  snapshotId: ID
   category: String!
   name: String!
   description: String!
@@ -1664,6 +1667,7 @@ type Document implements Node {
 
 type Risk implements Node {
   id: ID!
+  snapshotId: ID
   name: String!
   description: String!
   category: String!

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -717,6 +717,7 @@ type ComplexityRoot struct {
 		ID          func(childComplexity int) int
 		Name        func(childComplexity int) int
 		Risks       func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskOrderBy, filter *types.RiskFilter) int
+		SnapshotID  func(childComplexity int) int
 		State       func(childComplexity int) int
 		Tasks       func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TaskOrderBy) int
 		UpdatedAt   func(childComplexity int) int
@@ -1027,6 +1028,7 @@ type ComplexityRoot struct {
 		ResidualImpact     func(childComplexity int) int
 		ResidualLikelihood func(childComplexity int) int
 		ResidualRiskScore  func(childComplexity int) int
+		SnapshotID         func(childComplexity int) int
 		Treatment          func(childComplexity int) int
 		UpdatedAt          func(childComplexity int) int
 	}
@@ -3882,6 +3884,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Measure.Risks(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.RiskOrderBy), args["filter"].(*types.RiskFilter)), true
 
+	case "Measure.snapshotId":
+		if e.complexity.Measure.SnapshotID == nil {
+			break
+		}
+
+		return e.complexity.Measure.SnapshotID(childComplexity), true
+
 	case "Measure.state":
 		if e.complexity.Measure.State == nil {
 			break
@@ -6223,6 +6232,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Risk.ResidualRiskScore(childComplexity), true
+
+	case "Risk.snapshotId":
+		if e.complexity.Risk.SnapshotID == nil {
+			break
+		}
+
+		return e.complexity.Risk.SnapshotID(childComplexity), true
 
 	case "Risk.treatment":
 		if e.complexity.Risk.Treatment == nil {
@@ -9057,10 +9073,12 @@ input DocumentFilter {
 
 input MeasureFilter {
   query: String
+  snapshotId: ID
 }
 
 input RiskFilter {
   query: String
+  snapshotId: ID
 }
 
 input PeopleFilter {
@@ -9188,7 +9206,7 @@ type Organization implements Node {
     last: Int
     before: CursorKey
     orderBy: MeasureOrder
-    filter: MeasureFilter
+    filter: MeasureFilter = { snapshotId: null }
   ): MeasureConnection! @goField(forceResolver: true)
 
   risks(
@@ -9197,7 +9215,7 @@ type Organization implements Node {
     last: Int
     before: CursorKey
     orderBy: RiskOrder
-    filter: RiskFilter
+    filter: RiskFilter = { snapshotId: null }
   ): RiskConnection! @goField(forceResolver: true)
 
   tasks(
@@ -9506,6 +9524,7 @@ type Control implements Node {
 
 type Measure implements Node {
   id: ID!
+  snapshotId: ID
   category: String!
   name: String!
   description: String!
@@ -9625,6 +9644,7 @@ type Document implements Node {
 
 type Risk implements Node {
   id: ID!
+  snapshotId: ID
   name: String!
   description: String!
   category: String!
@@ -31775,6 +31795,8 @@ func (ec *executionContext) fieldContext_Evidence_measure(_ context.Context, fie
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_Measure_id(ctx, field)
+			case "snapshotId":
+				return ec.fieldContext_Measure_snapshotId(ctx, field)
 			case "category":
 				return ec.fieldContext_Measure_category(ctx, field)
 			case "name":
@@ -33153,6 +33175,47 @@ func (ec *executionContext) fieldContext_Measure_id(_ context.Context, field gra
 	return fc, nil
 }
 
+func (ec *executionContext) _Measure_snapshotId(ctx context.Context, field graphql.CollectedField, obj *types.Measure) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Measure_snapshotId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SnapshotID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*gid.GID)
+	fc.Result = res
+	return ec.marshalOID2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Measure_snapshotId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Measure",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Measure_category(ctx context.Context, field graphql.CollectedField, obj *types.Measure) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Measure_category(ctx, field)
 	if err != nil {
@@ -33902,6 +33965,8 @@ func (ec *executionContext) fieldContext_MeasureEdge_node(_ context.Context, fie
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_Measure_id(ctx, field)
+			case "snapshotId":
+				return ec.fieldContext_Measure_snapshotId(ctx, field)
 			case "category":
 				return ec.fieldContext_Measure_category(ctx, field)
 			case "name":
@@ -45984,6 +46049,47 @@ func (ec *executionContext) fieldContext_Risk_id(_ context.Context, field graphq
 	return fc, nil
 }
 
+func (ec *executionContext) _Risk_snapshotId(ctx context.Context, field graphql.CollectedField, obj *types.Risk) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Risk_snapshotId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SnapshotID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*gid.GID)
+	fc.Result = res
+	return ec.marshalOID2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Risk_snapshotId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Risk",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Risk_name(ctx context.Context, field graphql.CollectedField, obj *types.Risk) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Risk_name(ctx, field)
 	if err != nil {
@@ -47135,6 +47241,8 @@ func (ec *executionContext) fieldContext_RiskEdge_node(_ context.Context, field 
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_Risk_id(ctx, field)
+			case "snapshotId":
+				return ec.fieldContext_Risk_snapshotId(ctx, field)
 			case "name":
 				return ec.fieldContext_Risk_name(ctx, field)
 			case "description":
@@ -48389,6 +48497,8 @@ func (ec *executionContext) fieldContext_Task_measure(_ context.Context, field g
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_Measure_id(ctx, field)
+			case "snapshotId":
+				return ec.fieldContext_Measure_snapshotId(ctx, field)
 			case "category":
 				return ec.fieldContext_Measure_category(ctx, field)
 			case "name":
@@ -50623,6 +50733,8 @@ func (ec *executionContext) fieldContext_UpdateMeasurePayload_measure(_ context.
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_Measure_id(ctx, field)
+			case "snapshotId":
+				return ec.fieldContext_Measure_snapshotId(ctx, field)
 			case "category":
 				return ec.fieldContext_Measure_category(ctx, field)
 			case "name":
@@ -51015,6 +51127,8 @@ func (ec *executionContext) fieldContext_UpdateRiskPayload_risk(_ context.Contex
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_Risk_id(ctx, field)
+			case "snapshotId":
+				return ec.fieldContext_Risk_snapshotId(ctx, field)
 			case "name":
 				return ec.fieldContext_Risk_name(ctx, field)
 			case "description":
@@ -63503,7 +63617,7 @@ func (ec *executionContext) unmarshalInputMeasureFilter(ctx context.Context, obj
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"query"}
+	fieldsInOrder := [...]string{"query", "snapshotId"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -63517,6 +63631,13 @@ func (ec *executionContext) unmarshalInputMeasureFilter(ctx context.Context, obj
 				return it, err
 			}
 			it.Query = data
+		case "snapshotId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("snapshotId"))
+			data, err := ec.unmarshalOID2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SnapshotID = data
 		}
 	}
 
@@ -63958,7 +64079,7 @@ func (ec *executionContext) unmarshalInputRiskFilter(ctx context.Context, obj an
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"query"}
+	fieldsInOrder := [...]string{"query", "snapshotId"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -63972,6 +64093,13 @@ func (ec *executionContext) unmarshalInputRiskFilter(ctx context.Context, obj an
 				return it, err
 			}
 			it.Query = data
+		case "snapshotId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("snapshotId"))
+			data, err := ec.unmarshalOID2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SnapshotID = data
 		}
 	}
 
@@ -72961,6 +73089,8 @@ func (ec *executionContext) _Measure(ctx context.Context, sel ast.SelectionSet, 
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "snapshotId":
+			out.Values[i] = ec._Measure_snapshotId(ctx, field, obj)
 		case "category":
 			out.Values[i] = ec._Measure_category(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -76125,6 +76255,8 @@ func (ec *executionContext) _Risk(ctx context.Context, sel ast.SelectionSet, obj
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "snapshotId":
+			out.Values[i] = ec._Risk_snapshotId(ctx, field, obj)
 		case "name":
 			out.Values[i] = ec._Risk_name(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/pkg/server/api/console/v1/types/mesure.go
+++ b/pkg/server/api/console/v1/types/mesure.go
@@ -70,6 +70,7 @@ func NewMeasure(c *coredata.Measure) *Measure {
 		Name:        c.Name,
 		Description: c.Description,
 		State:       c.State,
+		SnapshotID:  c.SnapshotID,
 		CreatedAt:   c.CreatedAt,
 		UpdatedAt:   c.UpdatedAt,
 	}

--- a/pkg/server/api/console/v1/types/risk.go
+++ b/pkg/server/api/console/v1/types/risk.go
@@ -67,6 +67,7 @@ func NewRisk(r *coredata.Risk) *Risk {
 	return &Risk{
 		ID:                 r.ID,
 		Name:               r.Name,
+		SnapshotID:         r.SnapshotID,
 		Description:        r.Description,
 		Treatment:          r.Treatment,
 		InherentLikelihood: r.InherentLikelihood,

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -1104,6 +1104,7 @@ type InviteUserPayload struct {
 
 type Measure struct {
 	ID          gid.GID               `json:"id"`
+	SnapshotID  *gid.GID              `json:"snapshotId,omitempty"`
 	Category    string                `json:"category"`
 	Name        string                `json:"name"`
 	Description string                `json:"description"`
@@ -1125,7 +1126,8 @@ type MeasureEdge struct {
 }
 
 type MeasureFilter struct {
-	Query *string `json:"query,omitempty"`
+	Query      *string  `json:"query,omitempty"`
+	SnapshotID *gid.GID `json:"snapshotId,omitempty"`
 }
 
 type Mutation struct {
@@ -1336,6 +1338,7 @@ type RequestSignaturePayload struct {
 
 type Risk struct {
 	ID                 gid.GID                `json:"id"`
+	SnapshotID         *gid.GID               `json:"snapshotId,omitempty"`
 	Name               string                 `json:"name"`
 	Description        string                 `json:"description"`
 	Category           string                 `json:"category"`
@@ -1365,7 +1368,8 @@ type RiskEdge struct {
 }
 
 type RiskFilter struct {
-	Query *string `json:"query,omitempty"`
+	Query      *string  `json:"query,omitempty"`
+	SnapshotID *gid.GID `json:"snapshotId,omitempty"`
 }
 
 type SendSigningNotificationsInput struct {

--- a/pkg/server/api/console/v1/v1_resolver.go
+++ b/pkg/server/api/console/v1/v1_resolver.go
@@ -369,9 +369,9 @@ func (r *controlResolver) Measures(ctx context.Context, obj *types.Control, firs
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	var measureFilter = coredata.NewMeasureFilter(nil)
+	var measureFilter = coredata.NewMeasureFilter(nil, nil)
 	if filter != nil {
-		measureFilter = coredata.NewMeasureFilter(filter.Query)
+		measureFilter = coredata.NewMeasureFilter(filter.Query, nil)
 	}
 
 	page, err := prb.Measures.ListForControlID(ctx, obj.ID, cursor, measureFilter)
@@ -1034,9 +1034,9 @@ func (r *measureResolver) Risks(ctx context.Context, obj *types.Measure, first *
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	var riskFilter = coredata.NewRiskFilter(nil)
+	var riskFilter = coredata.NewRiskFilter(nil, nil)
 	if filter != nil {
-		riskFilter = coredata.NewRiskFilter(filter.Query)
+		riskFilter = coredata.NewRiskFilter(filter.Query, &filter.SnapshotID)
 	}
 
 	page, err := prb.Risks.ListForMeasureID(ctx, obj.ID, cursor, riskFilter)
@@ -3565,9 +3565,9 @@ func (r *organizationResolver) Measures(ctx context.Context, obj *types.Organiza
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	var measureFilter = coredata.NewMeasureFilter(nil)
+	var measureFilter = coredata.NewMeasureFilter(nil, nil)
 	if filter != nil {
-		measureFilter = coredata.NewMeasureFilter(filter.Query)
+		measureFilter = coredata.NewMeasureFilter(filter.Query, &filter.SnapshotID)
 	}
 
 	page, err := prb.Measures.ListForOrganizationID(ctx, obj.ID, cursor, measureFilter)
@@ -3595,9 +3595,9 @@ func (r *organizationResolver) Risks(ctx context.Context, obj *types.Organizatio
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	var riskFilter = coredata.NewRiskFilter(nil)
+	var riskFilter = coredata.NewRiskFilter(nil, nil)
 	if filter != nil {
-		riskFilter = coredata.NewRiskFilter(filter.Query)
+		riskFilter = coredata.NewRiskFilter(filter.Query, &filter.SnapshotID)
 	}
 
 	page, err := prb.Risks.ListForOrganizationID(ctx, obj.ID, cursor, riskFilter)
@@ -4178,9 +4178,9 @@ func (r *riskResolver) Measures(ctx context.Context, obj *types.Risk, first *int
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	var measureFilter = coredata.NewMeasureFilter(nil)
+	var measureFilter = coredata.NewMeasureFilter(nil, nil)
 	if filter != nil {
-		measureFilter = coredata.NewMeasureFilter(filter.Query)
+		measureFilter = coredata.NewMeasureFilter(filter.Query, nil)
 	}
 
 	page, err := prb.Measures.ListForRiskID(ctx, obj.ID, cursor, measureFilter)


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add snapshot support for risks across DB, GraphQL, and the Console. You can now view risks (and linked measures/documents/evidences) in a read-only snapshot mode with clear context and safe UI.

- **New Features**
  - Snapshot routes: /snapshots/:snapshotId/risks, /snapshots/:snapshotId/risks/:riskId, and /snapshots/:snapshotId/risks/measures/:measureId.
  - Snapshot banner shows the type/date and links back to the live view; edit actions are hidden in snapshot mode.
  - GraphQL: lists accept snapshotId in RiskFilter/MeasureFilter; Risk and Measure expose snapshotId; queries updated to pass snapshotId.
  - Helpers: added RISKS snapshot type and URL path mapping; UI validates snapshot consistency.

- **Migration**
  - Run migration 20250902T093819Z.sql. It adds snapshot_id/source_id to risks, measures, evidences, and snapshot_id to risks_documents and risks_measures with FKs and constraints.
  - New core logic to copy risk links into snapshots (InsertRiskSnapshots on risks, risk_documents, risk_measures).
  - Defaults keep existing views “live” (lists use snapshotId: null). Pass a snapshotId to fetch snapshot data.

<!-- End of auto-generated description by cubic. -->

