### PR TITLE
Reset password redirect

### DIFF
--- a/apps/console/src/pages/auth/ForgotPasswordPage.tsx
+++ b/apps/console/src/pages/auth/ForgotPasswordPage.tsx
@@ -81,7 +81,7 @@ export default function ForgotPasswordPage() {
           <p className="text-sm text-txt-tertiary">
             {__("Remember your password?")}{" "}
             <Link
-              to="/login"
+              to="/auth/login"
               className="underline text-txt-primary hover:text-txt-secondary"
             >
               {__("Back to login")}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed the “Back to login” link on the Forgot Password page to redirect to /auth/login (was /login), ensuring users land on the correct login screen.

<!-- End of auto-generated description by cubic. -->

