### PR TITLE
Use parse address for email

### DIFF
--- a/pkg/probo/trust_center_access_service.go
+++ b/pkg/probo/trust_center_access_service.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/mail"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/getprobo/probo/pkg/coredata"
@@ -121,7 +121,7 @@ func (s TrustCenterAccessService) Create(
 	ctx context.Context,
 	req *CreateTrustCenterAccessRequest,
 ) (*coredata.TrustCenterAccess, error) {
-	if !strings.Contains(req.Email, "@") {
+	if _, err := mail.ParseAddress(req.Email); err != nil {
 		return nil, fmt.Errorf("invalid email address")
 	}
 

--- a/pkg/trust/trust_center_access_service.go
+++ b/pkg/trust/trust_center_access_service.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
+	"net/mail"
 	"time"
 
 	"github.com/getprobo/probo/pkg/coredata"
@@ -84,7 +84,7 @@ func (s TrustCenterAccessService) Create(
 	ctx context.Context,
 	req *CreateTrustCenterAccessRequest,
 ) (*coredata.TrustCenterAccess, error) {
-	if !strings.Contains(req.Email, "@") {
+	if _, err := mail.ParseAddress(req.Email); err != nil {
 		return nil, fmt.Errorf("invalid email address")
 	}
 

--- a/pkg/usrmgr/usrmgr.go
+++ b/pkg/usrmgr/usrmgr.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net/mail"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/getprobo/probo/pkg/coredata"
@@ -636,7 +635,7 @@ func (s Service) InviteUser(
 	fullName string,
 	emailAddress string,
 ) error {
-	if !strings.Contains(emailAddress, "@") {
+	if _, err := mail.ParseAddress(emailAddress); err != nil {
 		return &ErrInvalidEmail{emailAddress}
 	}
 	if fullName == "" {

--- a/pkg/usrmgr/usrmgr.go
+++ b/pkg/usrmgr/usrmgr.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/mail"
 	"net/url"
 	"strings"
 	"time"
@@ -251,7 +252,7 @@ func (s Service) SignUp(
 		return nil, nil, &ErrSignupDisabled{}
 	}
 
-	if !strings.Contains(email, "@") {
+	if _, err := mail.ParseAddress(email); err != nil {
 		return nil, nil, &ErrInvalidEmail{email}
 	}
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Replaced naive email checks with net/mail.ParseAddress in signup, invitations, and trust center access flows to enforce proper email validation and prevent invalid inputs.

- **Bug Fixes**
  - Use mail.ParseAddress for email validation in TrustCenterAccessService (probo and trust) and usrmgr SignUp/InviteUser.
  - Removed strings-based checks; added net/mail imports.
  - Preserved existing error types/messages for invalid emails.

<!-- End of auto-generated description by cubic. -->

