### PR TITLE
Remove registries from titles

### DIFF
--- a/apps/console/src/hooks/graph/ComplianceRegistryGraph.ts
+++ b/apps/console/src/hooks/graph/ComplianceRegistryGraph.ts
@@ -118,8 +118,8 @@ export const useDeleteComplianceRegistry = (
 ) => {
   const { __ } = useTranslate();
   const [mutate] = useMutationWithToasts(deleteComplianceRegistryMutation, {
-    successMessage: __("Compliance registry entry deleted successfully"),
-    errorMessage: __("Failed to delete compliance registry entry"),
+    successMessage: __("Compliance entry deleted successfully"),
+    errorMessage: __("Failed to delete compliance entry"),
   });
   const confirm = useConfirm();
 
@@ -164,13 +164,13 @@ export const useCreateComplianceRegistry = (connectionId: string) => {
     status: string;
   }) => {
     if (!input.organizationId) {
-      return alert(__("Failed to create compliance registry entry: organization is required"));
+      return alert(__("Failed to create compliance entry: organization is required"));
     }
     if (!input.referenceId) {
-      return alert(__("Failed to create compliance registry entry: reference ID is required"));
+      return alert(__("Failed to create compliance entry: reference ID is required"));
     }
     if (!input.ownerId) {
-      return alert(__("Failed to create compliance registry entry: owner is required"));
+      return alert(__("Failed to create compliance entry: owner is required"));
     }
 
     return promisifyMutation(mutate)({
@@ -212,7 +212,7 @@ export const useUpdateComplianceRegistry = () => {
     status?: string;
   }) => {
     if (!input.id) {
-      return alert(__("Failed to update compliance registry entry: registry ID is required"));
+      return alert(__("Failed to update compliance entry: entry ID is required"));
     }
 
     return promisifyMutation(mutate)({

--- a/apps/console/src/hooks/graph/ContinualImprovementRegistryGraph.ts
+++ b/apps/console/src/hooks/graph/ContinualImprovementRegistryGraph.ts
@@ -109,8 +109,8 @@ export const useDeleteContinualImprovementRegistry = (
 ) => {
   const { __ } = useTranslate();
   const [mutate] = useMutationWithToasts(deleteContinualImprovementRegistryMutation, {
-    successMessage: __("Continual improvement registry entry deleted successfully"),
-    errorMessage: __("Failed to delete continual improvement registry entry"),
+    successMessage: __("Continual improvement entry deleted successfully"),
+    errorMessage: __("Failed to delete continual improvement entry"),
   });
   const confirm = useConfirm();
 
@@ -152,13 +152,13 @@ export const useCreateContinualImprovementRegistry = (connectionId: string) => {
     priority: string;
   }) => {
     if (!input.organizationId) {
-      return alert(__("Failed to create continual improvement registry entry: organization is required"));
+      return alert(__("Failed to create continual improvement entry: organization is required"));
     }
     if (!input.referenceId) {
-      return alert(__("Failed to create continual improvement registry entry: reference ID is required"));
+      return alert(__("Failed to create continual improvement entry: reference ID is required"));
     }
     if (!input.ownerId) {
-      return alert(__("Failed to create continual improvement registry entry: owner is required"));
+      return alert(__("Failed to create continual improvement entry: owner is required"));
     }
 
     return promisifyMutation(mutate)({
@@ -194,7 +194,7 @@ export const useUpdateContinualImprovementRegistry = () => {
     priority?: string;
   }) => {
     if (!input.id) {
-      return alert(__("Failed to update continual improvement registry entry: registry ID is required"));
+      return alert(__("Failed to update continual improvement entry: entry ID is required"));
     }
 
     return promisifyMutation(mutate)({

--- a/apps/console/src/hooks/graph/NonconformityRegistryGraph.ts
+++ b/apps/console/src/hooks/graph/NonconformityRegistryGraph.ts
@@ -132,8 +132,8 @@ export const useDeleteNonconformityRegistry = (
 ) => {
   const { __ } = useTranslate();
   const [mutate] = useMutationWithToasts(deleteNonconformityRegistryMutation, {
-    successMessage: __("Non conformity registry entry deleted successfully"),
-    errorMessage: __("Failed to delete non conformity registry entry"),
+    successMessage: __("Non conformity entry deleted successfully"),
+    errorMessage: __("Failed to delete non conformity entry"),
   });
   const confirm = useConfirm();
 
@@ -178,19 +178,19 @@ export const useCreateNonconformityRegistry = (connectionId: string) => {
     effectivenessCheck?: string;
   }) => {
     if (!input.organizationId) {
-      return alert(__("Failed to create non conformity registry entry: organization is required"));
+      return alert(__("Failed to create non conformity entry: organization is required"));
     }
     if (!input.referenceId) {
-      return alert(__("Failed to create non conformity registry entry: reference ID is required"));
+      return alert(__("Failed to create non conformity entry: reference ID is required"));
     }
     if (!input.auditId) {
-      return alert(__("Failed to create non conformity registry entry: audit is required"));
+      return alert(__("Failed to create non conformity entry: audit is required"));
     }
     if (!input.ownerId) {
-      return alert(__("Failed to create non conformity registry entry: owner is required"));
+      return alert(__("Failed to create non conformity entry: owner is required"));
     }
     if (!input.rootCause) {
-      return alert(__("Failed to create non conformity registry entry: root cause is required"));
+      return alert(__("Failed to create non conformity entry: root cause is required"));
     }
 
     return promisifyMutation(mutate)({
@@ -232,7 +232,7 @@ export const useUpdateNonconformityRegistry = () => {
     effectivenessCheck?: string;
   }) => {
     if (!input.id) {
-      return alert(__("Failed to update non conformity registry entry: registry ID is required"));
+      return alert(__("Failed to update non conformity entry: entry ID is required"));
     }
 
     return promisifyMutation(mutate)({

--- a/apps/console/src/hooks/graph/ProcessingActivityRegistryGraph.ts
+++ b/apps/console/src/hooks/graph/ProcessingActivityRegistryGraph.ts
@@ -123,8 +123,8 @@ export const useDeleteProcessingActivityRegistry = (
 ) => {
   const { __ } = useTranslate();
   const [mutate] = useMutationWithToasts(deleteProcessingActivityRegistryMutation, {
-    successMessage: __("Processing activity registry entry deleted successfully"),
-    errorMessage: __("Failed to delete processing activity registry entry"),
+    successMessage: __("Processing activity entry deleted successfully"),
+    errorMessage: __("Failed to delete processing activity entry"),
   });
   const confirm = useConfirm();
 
@@ -174,10 +174,10 @@ export const useCreateProcessingActivityRegistry = (connectionId?: string) => {
     transferImpactAssessment?: string;
   }) => {
     if (!input.organizationId) {
-      return alert(__("Failed to create processing activity registry entry: organization is required"));
+      return alert(__("Failed to create processing activity entry: organization is required"));
     }
     if (!input.name) {
-      return alert(__("Failed to create processing activity registry entry: name is required"));
+      return alert(__("Failed to create processing activity entry: name is required"));
     }
 
     return promisifyMutation(mutate)({
@@ -229,7 +229,7 @@ export const useUpdateProcessingActivityRegistry = () => {
     transferImpactAssessment?: string;
   }) => {
     if (!input.id) {
-      return alert(__("Failed to update processing activity registry entry: registry ID is required"));
+      return alert(__("Failed to update processing activity entry: entry ID is required"));
     }
 
     return promisifyMutation(mutate)({

--- a/apps/console/src/layouts/MainLayout.tsx
+++ b/apps/console/src/layouts/MainLayout.tsx
@@ -144,22 +144,22 @@ export function MainLayout() {
             to={`${prefix}/audits`}
           />
           <SidebarItem
-            label={__("Nonconformity Registries")}
+            label={__("Nonconformities")}
             icon={IconCrossLargeX}
             to={`${prefix}/nonconformity-registries`}
           />
           <SidebarItem
-            label={__("Compliance Registries")}
+            label={__("Compliances")}
             icon={IconBook}
             to={`${prefix}/compliance-registries`}
           />
            <SidebarItem
-            label={__("Continual Improvement Registries")}
+            label={__("Continual Improvements")}
             icon={IconRotateCw}
             to={`${prefix}/continual-improvement-registries`}
           />
           <SidebarItem
-            label={__("Processing Activity Registries")}
+            label={__("Processing Activities")}
             icon={IconCircleProgress}
             to={`${prefix}/processing-activity-registries`}
           />

--- a/apps/console/src/pages/organizations/complianceRegistries/ComplianceRegistriesPage.tsx
+++ b/apps/console/src/pages/organizations/complianceRegistries/ComplianceRegistriesPage.tsx
@@ -95,7 +95,7 @@ export default function ComplianceRegistriesPage({ queryRef }: ComplianceRegistr
   const { snapshotId } = useParams<{ snapshotId?: string }>();
   const isSnapshotMode = Boolean(snapshotId);
 
-  usePageTitle(__("Compliance Registries"));
+  usePageTitle(__("Compliances"));
 
   const organization = usePreloadedQuery(
     graphql`
@@ -124,14 +124,14 @@ export default function ComplianceRegistriesPage({ queryRef }: ComplianceRegistr
         <SnapshotBanner snapshotId={snapshotId} />
       )}
       <PageHeader
-        title={__("Compliance Registries")}
+        title={__("Compliances")}
         description={__(
           "Manage your organization's compliance registry entries."
         )}
       >
         {!snapshotId && (
           <CreateComplianceRegistryDialog organizationId={organizationId} connection={connectionId}>
-            <Button icon={IconPlusLarge}>{__("Add compliance registry")}</Button>
+            <Button icon={IconPlusLarge}>{__("Add compliance")}</Button>
           </CreateComplianceRegistryDialog>
         )}
       </PageHeader>
@@ -140,10 +140,10 @@ export default function ComplianceRegistriesPage({ queryRef }: ComplianceRegistr
         <Card padded>
           <div className="text-center py-12">
             <h3 className="text-lg font-semibold mb-2">
-              {__("No compliance registry entries yet")}
+              {__("No compliance entries yet")}
             </h3>
             <p className="text-txt-tertiary mb-4">
-              {__("Create your first compliance registry entry to get started.")}
+              {__("Create your first compliance entry to get started.")}
             </p>
           </div>
         </Card>

--- a/apps/console/src/pages/organizations/complianceRegistries/ComplianceRegistryDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/complianceRegistries/ComplianceRegistryDetailsPage.tsx
@@ -62,7 +62,7 @@ export default function ComplianceRegistryDetailsPage(props: Props) {
   const isSnapshotMode = Boolean(snapshotId);
 
   if (!registry) {
-    return <div>{__("Compliance registry entry not found")}</div>;
+    return <div>{__("Compliance entry not found")}</div>;
   }
 
   validateSnapshotConsistency(registry, snapshotId);
@@ -118,13 +118,13 @@ export default function ComplianceRegistryDetailsPage(props: Props) {
 
       toast({
         title: __("Success"),
-        description: __("Compliance registry entry updated successfully"),
+        description: __("Compliance entry updated successfully"),
         variant: "success",
       });
     } catch (error) {
       toast({
         title: __("Error"),
-        description: __("Failed to update compliance registry entry"),
+        description: __("Failed to update compliance entry"),
         variant: "error",
       });
     }
@@ -143,7 +143,7 @@ export default function ComplianceRegistryDetailsPage(props: Props) {
         <div>
                    <Breadcrumb
            items={[
-             { label: __("Compliance Registries"), to: breadcrumbComplianceRegistriesUrl },
+             { label: __("Compliances"), to: breadcrumbComplianceRegistriesUrl },
              { label: registry.referenceId! },
            ]}
          />

--- a/apps/console/src/pages/organizations/complianceRegistries/dialogs/CreateComplianceRegistryDialog.tsx
+++ b/apps/console/src/pages/organizations/complianceRegistries/dialogs/CreateComplianceRegistryDialog.tsx
@@ -88,7 +88,7 @@ export function CreateComplianceRegistryDialog({
 
       toast({
         title: __("Success"),
-        description: __("Compliance registry entry created successfully"),
+        description: __("Compliance entry created successfully"),
         variant: "success",
       });
 
@@ -97,7 +97,7 @@ export function CreateComplianceRegistryDialog({
     } catch (error) {
       toast({
         title: __("Error"),
-        description: __("Failed to create compliance registry entry"),
+        description: __("Failed to create compliance entry"),
         variant: "error",
       });
     }
@@ -107,7 +107,7 @@ export function CreateComplianceRegistryDialog({
     <Dialog
       ref={dialogRef}
       trigger={children}
-      title={<Breadcrumb items={[__("Registries"), __("Create Compliance Entry")]} />}
+      title={<Breadcrumb items={[__("Compliances"), __("Create Entry")]} />}
       className="max-w-2xl"
     >
       <form onSubmit={onSubmit}>
@@ -230,7 +230,7 @@ export function CreateComplianceRegistryDialog({
 
         <DialogFooter>
           <Button type="submit" disabled={formState.isSubmitting}>
-            {formState.isSubmitting ? __("Creating...") : __("Create Compliance Registry Entry")}
+            {formState.isSubmitting ? __("Creating...") : __("Create Compliance Entry")}
           </Button>
         </DialogFooter>
       </form>

--- a/apps/console/src/pages/organizations/continualImprovementRegistries/ContinualImprovementRegistriesPage.tsx
+++ b/apps/console/src/pages/organizations/continualImprovementRegistries/ContinualImprovementRegistriesPage.tsx
@@ -92,7 +92,7 @@ export default function ContinualImprovementRegistriesPage({ queryRef }: Continu
   const { snapshotId } = useParams<{ snapshotId?: string }>();
   const isSnapshotMode = Boolean(snapshotId);
 
-  usePageTitle(__("Continual Improvement Registries"));
+  usePageTitle(__("Continual Improvements"));
 
   const organization = usePreloadedQuery(
     graphql`
@@ -132,14 +132,14 @@ export default function ContinualImprovementRegistriesPage({ queryRef }: Continu
       {isSnapshotMode && snapshotId && (
         <SnapshotBanner snapshotId={snapshotId} />
       )}
-      <PageHeader title={__("Continual Improvement Registries")} description={__("Manage your continual improvement registry entries")}>
+      <PageHeader title={__("Continual Improvements")} description={__("Manage your continual improvement entries")}>
         {!isSnapshotMode && (
           <CreateContinualImprovementRegistryDialog
             organizationId={organizationId}
             connectionId={connectionId}
           >
             <Button icon={IconPlusLarge}>
-              {__("Add continual improvement registry")}
+              {__("Add continual improvement")}
             </Button>
           </CreateContinualImprovementRegistryDialog>
         )}
@@ -187,10 +187,10 @@ export default function ContinualImprovementRegistriesPage({ queryRef }: Continu
         <Card padded>
           <div className="text-center py-12">
             <h3 className="text-lg font-semibold mb-2">
-              {__("No continual improvement registry entries yet")}
+              {__("No continual improvement entries yet")}
             </h3>
             <p className="text-txt-tertiary mb-4">
-              {__("Create your first continual improvement registry entry to get started.")}
+              {__("Create your first continual improvement entry to get started.")}
             </p>
           </div>
         </Card>

--- a/apps/console/src/pages/organizations/continualImprovementRegistries/ContinualImprovementRegistryDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/continualImprovementRegistries/ContinualImprovementRegistryDetailsPage.tsx
@@ -59,7 +59,7 @@ export default function ContinualImprovementRegistryDetailsPage(props: Props) {
   const isSnapshotMode = Boolean(snapshotId);
 
   if (!registry) {
-    return <div>{__("Continual improvement registry entry not found")}</div>;
+    return <div>{__("Continual improvement entry not found")}</div>;
   }
 
   validateSnapshotConsistency(registry, snapshotId);
@@ -107,13 +107,13 @@ export default function ContinualImprovementRegistryDetailsPage(props: Props) {
 
       toast({
         title: __("Success"),
-        description: __("Continual improvement registry entry updated successfully"),
+        description: __("Continual improvement entry updated successfully"),
         variant: "success",
       });
     } catch (error) {
       toast({
         title: __("Error"),
-        description: __("Failed to update continual improvement registry entry"),
+        description: __("Failed to update continual improvement entry"),
         variant: "error",
       });
     }
@@ -143,7 +143,7 @@ export default function ContinualImprovementRegistryDetailsPage(props: Props) {
       <div className="flex items-center justify-between">
         <Breadcrumb
           items={[
-            { label: __("Continual Improvement Registries"), to: breadcrumbRegistriesUrl },
+            { label: __("Continual Improvements"), to: breadcrumbRegistriesUrl },
             { label: registry.referenceId! },
           ]}
         />

--- a/apps/console/src/pages/organizations/continualImprovementRegistries/dialogs/CreateContinualImprovementRegistryDialog.tsx
+++ b/apps/console/src/pages/organizations/continualImprovementRegistries/dialogs/CreateContinualImprovementRegistryDialog.tsx
@@ -78,7 +78,7 @@ export function CreateContinualImprovementRegistryDialog({
 
       toast({
         title: __("Success"),
-        description: __("Continual improvement registry entry created successfully"),
+        description: __("Continual improvement entry created successfully"),
         variant: "success",
       });
 
@@ -87,7 +87,7 @@ export function CreateContinualImprovementRegistryDialog({
     } catch (error) {
       toast({
         title: __("Error"),
-        description: __("Failed to create continual improvement registry entry"),
+        description: __("Failed to create continual improvement entry"),
         variant: "error",
       });
     }
@@ -109,7 +109,7 @@ export function CreateContinualImprovementRegistryDialog({
     <Dialog
       ref={dialogRef}
       trigger={children}
-      title={<Breadcrumb items={[__("Registries"), __("Create Continual Improvement Entry")]} />}
+      title={<Breadcrumb items={[__("Continual Improvements"), __("Create Entry")]} />}
       className="max-w-2xl"
     >
       <form onSubmit={onSubmit}>

--- a/apps/console/src/pages/organizations/nonconformityRegistries/NonconformityRegistriesPage.tsx
+++ b/apps/console/src/pages/organizations/nonconformityRegistries/NonconformityRegistriesPage.tsx
@@ -102,7 +102,7 @@ export default function NonconformityRegistriesPage({ queryRef }: NonconformityR
   const { snapshotId } = useParams<{ snapshotId?: string }>();
   const isSnapshotMode = Boolean(snapshotId);
 
-  usePageTitle(__("Nonconformity Registries"));
+  usePageTitle(__("Nonconformities"));
 
   const organization = usePreloadedQuery(
     graphql`
@@ -135,14 +135,14 @@ export default function NonconformityRegistriesPage({ queryRef }: NonconformityR
         <SnapshotBanner snapshotId={snapshotId!} />
       )}
       <PageHeader
-        title={__("Nonconformity Registries")}
+        title={__("Nonconformities")}
         description={__(
           "Manage your organization's non conformity registries."
         )}
       >
         {!isSnapshotMode && (
           <CreateNonconformityRegistryDialog organizationId={organizationId} connection={connectionId}>
-            <Button icon={IconPlusLarge}>{__("Add nonconformity registry")}</Button>
+            <Button icon={IconPlusLarge}>{__("Add nonconformity")}</Button>
           </CreateNonconformityRegistryDialog>
         )}
       </PageHeader>
@@ -151,10 +151,10 @@ export default function NonconformityRegistriesPage({ queryRef }: NonconformityR
         <Card padded>
           <div className="text-center py-12">
             <h3 className="text-lg font-semibold mb-2">
-              {__("No nonconformity registry entries yet")}
+              {__("No nonconformity entries yet")}
             </h3>
             <p className="text-txt-tertiary mb-4">
-              {__("Create your first nonconformity registry entry to get started.")}
+              {__("Create your first nonconformity entry to get started.")}
             </p>
           </div>
         </Card>

--- a/apps/console/src/pages/organizations/nonconformityRegistries/NonconformityRegistryDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/nonconformityRegistries/NonconformityRegistryDetailsPage.tsx
@@ -115,13 +115,13 @@ export default function NonconformityRegistryDetailsPage(props: Props) {
       reset(formData);
       toast({
         title: __("Success"),
-        description: __("Non conformity registry entry updated successfully"),
+        description: __("Non conformity entry updated successfully"),
         variant: "success",
       });
     } catch (error) {
       toast({
         title: __("Error"),
-        description: error instanceof Error ? error.message : __("Failed to update non conformity registry entry"),
+        description: error instanceof Error ? error.message : __("Failed to update non conformity entry"),
         variant: "error",
       });
     }
@@ -141,11 +141,11 @@ export default function NonconformityRegistryDetailsPage(props: Props) {
       <Breadcrumb
         items={[
           {
-            label: __("Nonconformity Registries"),
+            label: __("Nonconformities"),
             to: breadcrumbNonconformityRegistriesUrl,
           },
           {
-            label: registry.referenceId || __("Unknown Nonconformity Registry"),
+            label: registry.referenceId || __("Unknown Nonconformity"),
           },
         ]}
       />

--- a/apps/console/src/pages/organizations/nonconformityRegistries/dialogs/CreateNonconformityRegistryDialog.tsx
+++ b/apps/console/src/pages/organizations/nonconformityRegistries/dialogs/CreateNonconformityRegistryDialog.tsx
@@ -91,7 +91,7 @@ export function CreateNonconformityRegistryDialog({
 
       toast({
         title: __("Success"),
-                    description: __("Non conformity registry entry created successfully"),
+                    description: __("Non conformity entry created successfully"),
         variant: "success",
       });
 
@@ -100,7 +100,7 @@ export function CreateNonconformityRegistryDialog({
     } catch (error) {
       toast({
         title: __("Error"),
-                    description: __("Failed to create non conformity registry entry"),
+                    description: __("Failed to create non conformity entry"),
         variant: "error",
       });
     }
@@ -110,7 +110,7 @@ export function CreateNonconformityRegistryDialog({
     <Dialog
       ref={dialogRef}
       trigger={children}
-      title={<Breadcrumb items={[__("Registries"), __("Create Entry")]} />}
+      title={<Breadcrumb items={[__("Nonconformities"), __("Create Entry")]} />}
       className="max-w-2xl"
     >
       <form onSubmit={onSubmit}>
@@ -240,7 +240,7 @@ export function CreateNonconformityRegistryDialog({
 
         <DialogFooter>
           <Button type="submit" disabled={formState.isSubmitting}>
-            {formState.isSubmitting ? __("Creating...") : __("Create Nonconformity Registry Entry")}
+            {formState.isSubmitting ? __("Creating...") : __("Create Nonconformity Entry")}
           </Button>
         </DialogFooter>
       </form>

--- a/apps/console/src/pages/organizations/processingActivityRegistries/ProcessingActivityRegistriesPage.tsx
+++ b/apps/console/src/pages/organizations/processingActivityRegistries/ProcessingActivityRegistriesPage.tsx
@@ -91,7 +91,7 @@ export default function ProcessingActivityRegistriesPage({ queryRef }: Processin
   const isSnapshotMode = Boolean(snapshotId);
 
 
-  usePageTitle(__("Processing Activity Registries"));
+  usePageTitle(__("Processing Activities"));
 
   const organization = usePreloadedQuery(
     graphql`
@@ -131,14 +131,14 @@ export default function ProcessingActivityRegistriesPage({ queryRef }: Processin
       {isSnapshotMode && snapshotId && (
         <SnapshotBanner snapshotId={snapshotId} />
       )}
-      <PageHeader title={__("Processing Activity Registries")} description={__("Manage your processing activity registry entries under GDPR")}>
+      <PageHeader title={__("Processing Activities")} description={__("Manage your processing activity entries under GDPR")}>
         {!isSnapshotMode && (
           <CreateProcessingActivityRegistryDialog
             organizationId={organizationId}
             connectionId={connectionId}
           >
             <Button icon={IconPlusLarge}>
-              {__("Add processing activity registry")}
+              {__("Add processing activity")}
             </Button>
           </CreateProcessingActivityRegistryDialog>
         )}
@@ -185,10 +185,10 @@ export default function ProcessingActivityRegistriesPage({ queryRef }: Processin
         <Card padded>
           <div className="text-center py-12">
             <h3 className="text-lg font-semibold mb-2">
-              {__("No processing activity registry entries yet")}
+              {__("No processing activity entries yet")}
             </h3>
             <p className="text-txt-tertiary mb-4">
-              {__("Create your first processing activity registry entry to get started with GDPR compliance.")}
+              {__("Create your first processing activity entry to get started with GDPR compliance.")}
             </p>
           </div>
         </Card>

--- a/apps/console/src/pages/organizations/processingActivityRegistries/ProcessingActivityRegistryDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/processingActivityRegistries/ProcessingActivityRegistryDetailsPage.tsx
@@ -72,7 +72,7 @@ export default function ProcessingActivityRegistryDetailsPage(props: Props) {
   const isSnapshotMode = Boolean(snapshotId);
 
   if (!registry) {
-    return <div>{__("Processing activity registry entry not found")}</div>;
+    return <div>{__("Processing activity entry not found")}</div>;
   }
 
   validateSnapshotConsistency(registry, snapshotId);
@@ -133,13 +133,13 @@ export default function ProcessingActivityRegistryDetailsPage(props: Props) {
 
       toast({
         title: __("Success"),
-        description: __("Processing activity registry entry updated successfully"),
+        description: __("Processing activity entry updated successfully"),
         variant: "success",
       });
     } catch (error) {
       toast({
         title: __("Error"),
-        description: __("Failed to update processing activity registry entry"),
+        description: __("Failed to update processing activity entry"),
         variant: "error",
       });
     }
@@ -157,7 +157,7 @@ export default function ProcessingActivityRegistryDetailsPage(props: Props) {
       <div className="flex items-center justify-between">
         <Breadcrumb
           items={[
-            { label: __("Processing Activity Registries"), to: breadcrumbRegistriesUrl },
+            { label: __("Processing Activities"), to: breadcrumbRegistriesUrl },
             { label: registry.name! },
           ]}
         />

--- a/apps/console/src/pages/organizations/processingActivityRegistries/dialogs/CreateProcessingActivityRegistryDialog.tsx
+++ b/apps/console/src/pages/organizations/processingActivityRegistries/dialogs/CreateProcessingActivityRegistryDialog.tsx
@@ -106,7 +106,7 @@ export function CreateProcessingActivityRegistryDialog({
 
       toast({
         title: __("Success"),
-        description: __("Processing activity registry entry created successfully"),
+        description: __("Processing activity entry created successfully"),
         variant: "success",
       });
 
@@ -115,7 +115,7 @@ export function CreateProcessingActivityRegistryDialog({
     } catch (error) {
       toast({
         title: __("Error"),
-        description: __("Failed to create processing activity registry entry"),
+        description: __("Failed to create processing activity entry"),
         variant: "error",
       });
     }
@@ -125,7 +125,7 @@ export function CreateProcessingActivityRegistryDialog({
     <Dialog
       ref={dialogRef}
       trigger={children}
-      title={<Breadcrumb items={[__("Registries"), __("Create Processing Activity Entry")]} />}
+      title={<Breadcrumb items={[__("Processing Activities"), __("Create Entry")]} />}
       className="max-w-4xl"
     >
       <form onSubmit={onSubmit}>

--- a/packages/ui/src/Atoms/Sidebar/Sidebar.tsx
+++ b/packages/ui/src/Atoms/Sidebar/Sidebar.tsx
@@ -17,7 +17,7 @@ export function Sidebar({ children }: PropsWithChildren) {
             <aside
                 className={clsx(
                     "border-r border-border-solid relative pt-16 flex-none",
-                    open ? "px-4 w-[330px]" : "px-2",
+                    open ? "px-4 w-[260px]" : "px-2",
                 )}
             >
                 {children}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Simplified terminology by removing “registry/registries” from the console UI. Updated labels, titles, and messages across Compliance, Nonconformity, Continual Improvement, and Processing Activity; also narrowed the expanded sidebar to 260px.

- **Refactors**
  - Sidebar labels: Nonconformities, Compliances, Continual Improvements, Processing Activities.
  - Page titles, headers, empty states, and button text updated to drop “registry”.
  - Dialog titles and submit buttons reworded (e.g., “Create Entry”, “Add compliance”).
  - Toasts, alerts, and validation messages standardized (“entry” vs “registry entry”).
  - Breadcrumbs aligned with new names.
  - Sidebar width reduced from 330px to 260px.

<!-- End of auto-generated description by cubic. -->

