### PR TITLE
Store sidebar state

### DIFF
--- a/packages/ui/src/Atoms/Sidebar/Sidebar.tsx
+++ b/packages/ui/src/Atoms/Sidebar/Sidebar.tsx
@@ -10,8 +10,23 @@ import { Button } from "../Button/Button";
 
 const sidebarContext = createContext({ open: true });
 
+function useSidebarState() {
+    const [open, setOpenState] = useState(() => {
+        const stored = localStorage.getItem("sidebar-open");
+        return stored !== null ? JSON.parse(stored) : true;
+    });
+
+    const setOpen = (value: boolean) => {
+        setOpenState(value);
+
+        localStorage.setItem("sidebar-open", JSON.stringify(value));
+    };
+
+    return [open, setOpen] as const;
+}
+
 export function Sidebar({ children }: PropsWithChildren) {
-    const [open, setOpen] = useState(true);
+    const [open, setOpen] = useSidebarState();
     return (
         <sidebarContext.Provider value={{ open }}>
             <aside


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Persist the sidebar open/closed state across reloads using localStorage so the app remembers the user’s preference. Replaced internal state with a small useSidebarState hook in Sidebar.

<!-- End of auto-generated description by cubic. -->

