### PR TITLE
Add nda to trust center

### DIFF
--- a/apps/console/src/hooks/graph/TrustCenterAccessGraph.ts
+++ b/apps/console/src/hooks/graph/TrustCenterAccessGraph.ts
@@ -26,6 +26,7 @@ export const trustCenterAccessesQuery = graphql`
               email
               name
               active
+              hasAcceptedNonDisclosureAgreement
               createdAt
             }
           }
@@ -48,6 +49,7 @@ export const createTrustCenterAccessMutation = graphql`
           email
           name
           active
+          hasAcceptedNonDisclosureAgreement
           createdAt
         }
       }
@@ -65,6 +67,7 @@ export const updateTrustCenterAccessMutation = graphql`
         email
         name
         active
+        hasAcceptedNonDisclosureAgreement
         createdAt
         updatedAt
       }

--- a/apps/console/src/hooks/graph/TrustCenterGraph.ts
+++ b/apps/console/src/hooks/graph/TrustCenterGraph.ts
@@ -12,6 +12,8 @@ export const trustCenterQuery = graphql`
           id
           active
           slug
+          ndaFileName
+          ndaFileUrl
           createdAt
           updatedAt
         }
@@ -66,3 +68,48 @@ export function useUpdateTrustCenterMutation() {
     }
   );
 }
+
+export const uploadTrustCenterNDAMutation = graphql`
+  mutation TrustCenterGraphUploadNDAMutation($input: UploadTrustCenterNDAInput!) {
+    uploadTrustCenterNDA(input: $input) {
+      trustCenter {
+        id
+        ndaFileName
+        updatedAt
+      }
+    }
+  }
+`;
+
+export function useUploadTrustCenterNDAMutation() {
+  return useMutationWithToasts(
+    uploadTrustCenterNDAMutation,
+    {
+      successMessage: "NDA uploaded successfully",
+      errorMessage: "Failed to upload NDA",
+    }
+  );
+}
+
+export const deleteTrustCenterNDAMutation = graphql`
+  mutation TrustCenterGraphDeleteNDAMutation($input: DeleteTrustCenterNDAInput!) {
+    deleteTrustCenterNDA(input: $input) {
+      trustCenter {
+        id
+        ndaFileName
+        updatedAt
+      }
+    }
+  }
+`;
+
+export function useDeleteTrustCenterNDAMutation() {
+  return useMutationWithToasts(
+    deleteTrustCenterNDAMutation,
+    {
+      successMessage: "NDA deleted successfully",
+      errorMessage: "Failed to delete NDA",
+    }
+  );
+}
+

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphCreateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphCreateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ae95aed7bc22c95f8cc2ab591039c810>>
+ * @generated SignedSource<<5ccaab70e4cb8c4b5bee7fbe6ba2c0b6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -27,6 +27,7 @@ export type TrustCenterAccessGraphCreateMutation$data = {
         readonly active: boolean;
         readonly createdAt: any;
         readonly email: string;
+        readonly hasAcceptedNonDisclosureAgreement: boolean;
         readonly id: string;
         readonly name: string;
       };
@@ -111,6 +112,13 @@ v3 = {
           "alias": null,
           "args": null,
           "kind": "ScalarField",
+          "name": "hasAcceptedNonDisclosureAgreement",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
           "name": "createdAt",
           "storageKey": null
         }
@@ -186,16 +194,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "eafddcd0263963235d3249c22eb50593",
+    "cacheID": "fa88b100be7598cf46159cf79199c398",
     "id": null,
     "metadata": {},
     "name": "TrustCenterAccessGraphCreateMutation",
     "operationKind": "mutation",
-    "text": "mutation TrustCenterAccessGraphCreateMutation(\n  $input: CreateTrustCenterAccessInput!\n) {\n  createTrustCenterAccess(input: $input) {\n    trustCenterAccessEdge {\n      cursor\n      node {\n        id\n        email\n        name\n        active\n        createdAt\n      }\n    }\n  }\n}\n"
+    "text": "mutation TrustCenterAccessGraphCreateMutation(\n  $input: CreateTrustCenterAccessInput!\n) {\n  createTrustCenterAccess(input: $input) {\n    trustCenterAccessEdge {\n      cursor\n      node {\n        id\n        email\n        name\n        active\n        hasAcceptedNonDisclosureAgreement\n        createdAt\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "99676fee0b2de06a92cdad66c577eee7";
+(node as any).hash = "6c6c1344730e7d908a5c6392f578ca81";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2333a6a7d5415f1a08a5612dcaceee8f>>
+ * @generated SignedSource<<e9cdda9f586cee5ffe66f238216060f6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -22,6 +22,7 @@ export type TrustCenterAccessGraphQuery$data = {
           readonly active: boolean;
           readonly createdAt: any;
           readonly email: string;
+          readonly hasAcceptedNonDisclosureAgreement: boolean;
           readonly id: string;
           readonly name: string;
         };
@@ -167,6 +168,13 @@ v5 = [
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "hasAcceptedNonDisclosureAgreement",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "createdAt",
             "storageKey": null
           },
@@ -290,7 +298,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "5b83cd4ae2434ce2e00de7230d264432",
+    "cacheID": "0286ec03fb4ae012ada7bae8a2234152",
     "id": null,
     "metadata": {
       "connection": [
@@ -307,11 +315,11 @@ return {
     },
     "name": "TrustCenterAccessGraphQuery",
     "operationKind": "query",
-    "text": "query TrustCenterAccessGraphQuery(\n  $trustCenterId: ID!\n) {\n  node(id: $trustCenterId) {\n    __typename\n    ... on TrustCenter {\n      id\n      accesses(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {\n        pageInfo {\n          hasNextPage\n          hasPreviousPage\n          startCursor\n          endCursor\n        }\n        edges {\n          cursor\n          node {\n            id\n            email\n            name\n            active\n            createdAt\n            __typename\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query TrustCenterAccessGraphQuery(\n  $trustCenterId: ID!\n) {\n  node(id: $trustCenterId) {\n    __typename\n    ... on TrustCenter {\n      id\n      accesses(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {\n        pageInfo {\n          hasNextPage\n          hasPreviousPage\n          startCursor\n          endCursor\n        }\n        edges {\n          cursor\n          node {\n            id\n            email\n            name\n            active\n            hasAcceptedNonDisclosureAgreement\n            createdAt\n            __typename\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "af598fd2af198e63ed84fd618857a985";
+(node as any).hash = "f837b96937f1397ac1a3065f58386e4d";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphUpdateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphUpdateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6de2ecb63a58c88c3008368061943b49>>
+ * @generated SignedSource<<d2f40d8fc2bd9c7627d308660dedb1e5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -23,6 +23,7 @@ export type TrustCenterAccessGraphUpdateMutation$data = {
       readonly active: boolean;
       readonly createdAt: any;
       readonly email: string;
+      readonly hasAcceptedNonDisclosureAgreement: boolean;
       readonly id: string;
       readonly name: string;
       readonly updatedAt: any;
@@ -97,6 +98,13 @@ v1 = [
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "hasAcceptedNonDisclosureAgreement",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "createdAt",
             "storageKey": null
           },
@@ -132,16 +140,16 @@ return {
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "683ee01fb5173b49b0a7f3c2d99cf002",
+    "cacheID": "223169ee8a4f65008047097ecff68fc5",
     "id": null,
     "metadata": {},
     "name": "TrustCenterAccessGraphUpdateMutation",
     "operationKind": "mutation",
-    "text": "mutation TrustCenterAccessGraphUpdateMutation(\n  $input: UpdateTrustCenterAccessInput!\n) {\n  updateTrustCenterAccess(input: $input) {\n    trustCenterAccess {\n      id\n      email\n      name\n      active\n      createdAt\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation TrustCenterAccessGraphUpdateMutation(\n  $input: UpdateTrustCenterAccessInput!\n) {\n  updateTrustCenterAccess(input: $input) {\n    trustCenterAccess {\n      id\n      email\n      name\n      active\n      hasAcceptedNonDisclosureAgreement\n      createdAt\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "cccd083b0047f6bc7b504b7494205e9d";
+(node as any).hash = "0da1f737e6ea1db7a1b9930c4b6cc545";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterGraphDeleteNDAMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterGraphDeleteNDAMutation.graphql.ts
@@ -1,0 +1,121 @@
+/**
+ * @generated SignedSource<<43a8665719f251c1bae028ff7821b14a>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type DeleteTrustCenterNDAInput = {
+  trustCenterId: string;
+};
+export type TrustCenterGraphDeleteNDAMutation$variables = {
+  input: DeleteTrustCenterNDAInput;
+};
+export type TrustCenterGraphDeleteNDAMutation$data = {
+  readonly deleteTrustCenterNDA: {
+    readonly trustCenter: {
+      readonly id: string;
+      readonly ndaFileName: string | null | undefined;
+      readonly updatedAt: any;
+    };
+  };
+};
+export type TrustCenterGraphDeleteNDAMutation = {
+  response: TrustCenterGraphDeleteNDAMutation$data;
+  variables: TrustCenterGraphDeleteNDAMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "DeleteTrustCenterNDAPayload",
+    "kind": "LinkedField",
+    "name": "deleteTrustCenterNDA",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "TrustCenter",
+        "kind": "LinkedField",
+        "name": "trustCenter",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "ndaFileName",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "updatedAt",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TrustCenterGraphDeleteNDAMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "TrustCenterGraphDeleteNDAMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "fa3ebf3593c396bf05819d357d9f909f",
+    "id": null,
+    "metadata": {},
+    "name": "TrustCenterGraphDeleteNDAMutation",
+    "operationKind": "mutation",
+    "text": "mutation TrustCenterGraphDeleteNDAMutation(\n  $input: DeleteTrustCenterNDAInput!\n) {\n  deleteTrustCenterNDA(input: $input) {\n    trustCenter {\n      id\n      ndaFileName\n      updatedAt\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "9c055069b9e2e7432fed7509f6578a07";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterGraphQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterGraphQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<25550a93c5459c3b405c782be19ac888>>
+ * @generated SignedSource<<9dbea87f398ce8189cb2431d7c03912c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -37,6 +37,8 @@ export type TrustCenterGraphQuery$data = {
       readonly active: boolean;
       readonly createdAt: any;
       readonly id: string;
+      readonly ndaFileName: string | null | undefined;
+      readonly ndaFileUrl: string | null | undefined;
       readonly slug: string;
       readonly updatedAt: any;
     } | null | undefined;
@@ -112,6 +114,20 @@ v5 = {
       "args": null,
       "kind": "ScalarField",
       "name": "slug",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "ndaFileName",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "ndaFileUrl",
       "storageKey": null
     },
     (v4/*: any*/),
@@ -544,16 +560,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "28c1a32327e2fee9320fd091100ec800",
+    "cacheID": "8dff30a639470418ba7151cb5743d3cc",
     "id": null,
     "metadata": {},
     "name": "TrustCenterGraphQuery",
     "operationKind": "query",
-    "text": "query TrustCenterGraphQuery(\n  $organizationId: ID!\n) {\n  organization: node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      id\n      name\n      trustCenter {\n        id\n        active\n        slug\n        createdAt\n        updatedAt\n      }\n      documents(first: 100) {\n        edges {\n          node {\n            id\n            ...TrustCenterDocumentsCardFragment\n          }\n        }\n      }\n      audits(first: 100) {\n        edges {\n          node {\n            id\n            ...TrustCenterAuditsCardFragment\n          }\n        }\n      }\n      vendors(first: 100) {\n        edges {\n          node {\n            id\n            ...TrustCenterVendorsCardFragment\n          }\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment TrustCenterAuditsCardFragment on Audit {\n  id\n  name\n  framework {\n    name\n    id\n  }\n  validFrom\n  validUntil\n  state\n  showOnTrustCenter\n  createdAt\n}\n\nfragment TrustCenterDocumentsCardFragment on Document {\n  id\n  title\n  createdAt\n  documentType\n  showOnTrustCenter\n  versions(first: 1) {\n    edges {\n      node {\n        id\n        status\n      }\n    }\n  }\n}\n\nfragment TrustCenterVendorsCardFragment on Vendor {\n  id\n  name\n  category\n  description\n  showOnTrustCenter\n  createdAt\n}\n"
+    "text": "query TrustCenterGraphQuery(\n  $organizationId: ID!\n) {\n  organization: node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      id\n      name\n      trustCenter {\n        id\n        active\n        slug\n        ndaFileName\n        ndaFileUrl\n        createdAt\n        updatedAt\n      }\n      documents(first: 100) {\n        edges {\n          node {\n            id\n            ...TrustCenterDocumentsCardFragment\n          }\n        }\n      }\n      audits(first: 100) {\n        edges {\n          node {\n            id\n            ...TrustCenterAuditsCardFragment\n          }\n        }\n      }\n      vendors(first: 100) {\n        edges {\n          node {\n            id\n            ...TrustCenterVendorsCardFragment\n          }\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment TrustCenterAuditsCardFragment on Audit {\n  id\n  name\n  framework {\n    name\n    id\n  }\n  validFrom\n  validUntil\n  state\n  showOnTrustCenter\n  createdAt\n}\n\nfragment TrustCenterDocumentsCardFragment on Document {\n  id\n  title\n  createdAt\n  documentType\n  showOnTrustCenter\n  versions(first: 1) {\n    edges {\n      node {\n        id\n        status\n      }\n    }\n  }\n}\n\nfragment TrustCenterVendorsCardFragment on Vendor {\n  id\n  name\n  category\n  description\n  showOnTrustCenter\n  createdAt\n}\n"
   }
 };
 })();
 
-(node as any).hash = "260529b3ca03240b07989f278bb7a539";
+(node as any).hash = "21b2915ae5002dd54c990013e94adf5d";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterGraphUploadNDAMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterGraphUploadNDAMutation.graphql.ts
@@ -1,0 +1,123 @@
+/**
+ * @generated SignedSource<<966d4aa638042469c717ddc96e5c5d78>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type UploadTrustCenterNDAInput = {
+  file: any;
+  fileName: string;
+  trustCenterId: string;
+};
+export type TrustCenterGraphUploadNDAMutation$variables = {
+  input: UploadTrustCenterNDAInput;
+};
+export type TrustCenterGraphUploadNDAMutation$data = {
+  readonly uploadTrustCenterNDA: {
+    readonly trustCenter: {
+      readonly id: string;
+      readonly ndaFileName: string | null | undefined;
+      readonly updatedAt: any;
+    };
+  };
+};
+export type TrustCenterGraphUploadNDAMutation = {
+  response: TrustCenterGraphUploadNDAMutation$data;
+  variables: TrustCenterGraphUploadNDAMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "UploadTrustCenterNDAPayload",
+    "kind": "LinkedField",
+    "name": "uploadTrustCenterNDA",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "TrustCenter",
+        "kind": "LinkedField",
+        "name": "trustCenter",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "ndaFileName",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "updatedAt",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TrustCenterGraphUploadNDAMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "TrustCenterGraphUploadNDAMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "09a5dbf73f3e279173691b235f9da2e2",
+    "id": null,
+    "metadata": {},
+    "name": "TrustCenterGraphUploadNDAMutation",
+    "operationKind": "mutation",
+    "text": "mutation TrustCenterGraphUploadNDAMutation(\n  $input: UploadTrustCenterNDAInput!\n) {\n  uploadTrustCenterNDA(input: $input) {\n    trustCenter {\n      id\n      ndaFileName\n      updatedAt\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "b9877f8a5b9c2c12addeb939360719f1";
+
+export default node;

--- a/apps/console/src/pages/TrustCenterAccessPage.tsx
+++ b/apps/console/src/pages/TrustCenterAccessPage.tsx
@@ -127,7 +127,9 @@ export default function TrustCenterAccessPage() {
   if (error) {
     const isTokenError = error.toLowerCase().includes('token') ||
                         error.toLowerCase().includes('expired') ||
-                        error.toLowerCase().includes('invalid');
+                        error.toLowerCase().includes('invalid') ||
+                        error.toLowerCase().includes('401') ||
+                        error.toLowerCase().includes('unauthorized');
 
     if (isTokenError) {
       return <TokenErrorPage error={error} />;

--- a/apps/console/src/pages/organizations/trustCenter/TrustCenterAccessTab.tsx
+++ b/apps/console/src/pages/organizations/trustCenter/TrustCenterAccessTab.tsx
@@ -16,6 +16,7 @@ import {
   useDialogRef,
   IconTrashCan,
   IconPencil,
+  IconCheckmark1,
 } from "@probo/ui";
 import { useTranslate } from "@probo/i18n";
 import { useOutletContext } from "react-router";
@@ -85,6 +86,7 @@ export default function TrustCenterAccessTab() {
     email: string;
     name: string;
     active: boolean;
+    hasAcceptedNonDisclosureAgreement: boolean;
     createdAt: Date;
     };
 
@@ -95,6 +97,7 @@ export default function TrustCenterAccessTab() {
     email: edge.node.email,
     name: edge.node.name,
     active: edge.node.active,
+    hasAcceptedNonDisclosureAgreement: edge.node.hasAcceptedNonDisclosureAgreement,
     createdAt: new Date(edge.node.createdAt)
   })) ?? [];
 
@@ -203,6 +206,7 @@ export default function TrustCenterAccessTab() {
                 <Th>{__("Email")}</Th>
                 <Th>{__("Date")}</Th>
                 <Th>{__("Active")}</Th>
+                <Th>{__("NDA")}</Th>
                 <Th></Th>
               </Tr>
             </Thead>
@@ -219,6 +223,11 @@ export default function TrustCenterAccessTab() {
                       checked={access.active}
                       onChange={(active) => handleToggleActive(access.id, active)}
                     />
+                  </Td>
+                  <Td>
+                    {access.hasAcceptedNonDisclosureAgreement && (
+                      <IconCheckmark1 size={16} className="text-txt-success" />
+                    )}
                   </Td>
                   <Td noLink width={160} className="text-end">
                     <div className="flex gap-2 justify-end">

--- a/apps/console/src/trust/components/NDAAcceptanceDialog.tsx
+++ b/apps/console/src/trust/components/NDAAcceptanceDialog.tsx
@@ -1,0 +1,187 @@
+import { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  Button,
+  Checkbox,
+  IconLock,
+  IconArrowDown,
+  useToast,
+  useDialogRef
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { useAcceptNonDisclosureAgreement } from "/hooks/useTrustCenterQueries";
+import { buildEndpoint } from "/providers/RelayProviders";
+import { sprintf } from "@probo/helpers";
+
+type Props = {
+  trustCenterId: string;
+  organizationName: string;
+  ndaFileName?: string | null;
+  ndaFileUrl?: string | null;
+};
+
+export function NDAAcceptanceDialog({ trustCenterId, organizationName, ndaFileName, ndaFileUrl }: Props) {
+  const { __ } = useTranslate();
+  const { toast } = useToast();
+  const [isChecked, setIsChecked] = useState(false);
+  const dialogRef = useDialogRef();
+  const acceptNdaMutation = useAcceptNonDisclosureAgreement();
+
+  useEffect(() => {
+    dialogRef.current?.open();
+  }, []);
+
+  const handleLogout = async () => {
+    try {
+      const response = await fetch(buildEndpoint('/api/trust/v1/auth/logout'), {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+      });
+
+      if (!response.ok) {
+        throw new Error("Logout failed");
+      }
+
+      window.location.reload();
+    } catch (error) {
+      toast({
+        title: __("Error"),
+        description: __("Logout failed"),
+        variant: "error",
+      });
+    }
+  };
+
+  const handleAccept = () => {
+    if (!isChecked) {
+      toast({
+        title: __("Agreement Required"),
+        description: __("Please check the box to confirm your agreement"),
+        variant: "error",
+      });
+      return;
+    }
+
+    acceptNdaMutation.mutate(
+      { trustCenterId },
+      {
+        onSuccess: () => {
+          window.location.reload();
+        },
+        onError: () => {
+          toast({
+            title: __("Error"),
+            description: __("Failed to accept the Non-Disclosure Agreement"),
+            variant: "error",
+          });
+        },
+      }
+    );
+  };
+
+  const handleCancel = () => {
+    handleLogout();
+  };
+
+  return (
+    <Dialog
+      ref={dialogRef}
+      closable={false}
+      onClose={handleCancel}
+    >
+        <DialogContent>
+        <div className="space-y-3 p-4">
+          <div className="text-center">
+            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-amber-50 border border-amber-200 mb-3">
+              <IconLock className="h-6 w-6 text-amber-600" />
+            </div>
+            <h2 className="text-lg font-semibold text-txt-primary mb-2">
+              {__("Non-Disclosure Agreement")}
+            </h2>
+            <p className="text-sm text-txt-secondary">
+              {sprintf(__("To access %s's trust center, you must accept the Non-Disclosure Agreement."), organizationName)}
+            </p>
+          </div>
+
+          <div className="bg-level-1 p-3 rounded-lg border border-border-subtle">
+            {ndaFileName && ndaFileUrl ? (
+              <div className="text-center">
+                <p className="text-sm font-medium text-txt-primary mb-3">
+                  {__("Please review and download the Non-Disclosure Agreement:")}
+                </p>
+                <div className="flex justify-center">
+                  <Button
+                    variant="secondary"
+                    icon={IconArrowDown}
+                    onClick={() => {
+                      const link = document.createElement('a');
+                      link.href = ndaFileUrl;
+                      link.download = ndaFileName || 'NDA.pdf';
+                      link.target = '_blank';
+                      link.rel = 'noopener noreferrer';
+                      document.body.appendChild(link);
+                      link.click();
+                      document.body.removeChild(link);
+                    }}
+                  >
+                    {sprintf(__("Download %s"), ndaFileName)}
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <>
+                <p className="text-sm font-medium text-txt-primary mb-2">
+                  {__("By accepting this agreement, you commit to:")}
+                </p>
+                <ul className="text-sm text-txt-secondary space-y-0.5">
+                  <li className="flex items-start">
+                    <span className="inline-block w-2 h-2 rounded-full bg-txt-tertiary mt-1.5 mr-2 flex-shrink-0"></span>
+                    {__("Keep confidential information secure")}
+                  </li>
+                  <li className="flex items-start">
+                    <span className="inline-block w-2 h-2 rounded-full bg-txt-tertiary mt-1.5 mr-2 flex-shrink-0"></span>
+                    {__("Not share or disclose sensitive data")}
+                  </li>
+                  <li className="flex items-start">
+                    <span className="inline-block w-2 h-2 rounded-full bg-txt-tertiary mt-1.5 mr-2 flex-shrink-0"></span>
+                    {__("Use information only for authorized purposes")}
+                  </li>
+                </ul>
+              </>
+            )}
+          </div>
+
+          <div className="flex items-start space-x-2 p-3 bg-level-0 rounded-lg border border-border-subtle">
+            <div className="mt-0.5">
+              <Checkbox
+                checked={isChecked}
+                onChange={setIsChecked}
+              />
+            </div>
+            <label
+              className="text-sm text-txt-primary cursor-pointer flex-1"
+              onClick={() => setIsChecked(!isChecked)}
+            >
+              {__("I agree to the terms of the Non-Disclosure Agreement and will handle all information accordingly.")}
+            </label>
+          </div>
+        </div>
+      </DialogContent>
+
+      <DialogFooter exitLabel={__("Disconnect")}>
+        <Button
+          variant="primary"
+          onClick={handleAccept}
+          disabled={!isChecked || acceptNdaMutation.isPending}
+        >
+          {acceptNdaMutation.isPending ? __("Accepting...") : __("Accept & Continue")}
+        </Button>
+      </DialogFooter>
+    </Dialog>
+  );
+}

--- a/apps/console/src/trust/pages/PublicTrustCenterPage.tsx
+++ b/apps/console/src/trust/pages/PublicTrustCenterPage.tsx
@@ -5,6 +5,7 @@ import { PublicTrustCenterLayout } from "/layouts/PublicTrustCenterLayout";
 import { PublicTrustCenterAudits } from "../components/PublicTrustCenterAudits";
 import { PublicTrustCenterVendors } from "../components/PublicTrustCenterVendors";
 import { PublicTrustCenterDocuments } from "../components/PublicTrustCenterDocuments";
+import { NDAAcceptanceDialog } from "../components/NDAAcceptanceDialog";
 import { Spinner } from "@probo/ui";
 import { useTrustCenterQuery, type TrustCenterDocument, type TrustCenterAudit, type TrustCenterVendor } from "/hooks/useTrustCenterQueries";
 
@@ -66,36 +67,49 @@ export default function PublicTrustCenterPage() {
   }
 
   const { trustCenterBySlug } = data;
-  const { documents, audits, vendors, isUserAuthenticated } = trustCenterBySlug;
+  const { documents, audits, vendors, isUserAuthenticated, hasAcceptedNonDisclosureAgreement } = trustCenterBySlug;
 
   const trustCenterDocuments = documents.edges.map((edge) => edge.node) as TrustCenterDocument[];
   const trustCenterAudits = audits.edges.map((edge) => edge.node) as TrustCenterAudit[];
   const trustCenterVendors = vendors.edges.map((edge) => edge.node) as TrustCenterVendor[];
 
+  const showNdaDialog = isUserAuthenticated && !hasAcceptedNonDisclosureAgreement;
+
   return (
-    <PublicTrustCenterLayout
-      organizationName={organizationName}
-      organizationLogo={organization?.logoUrl}
-      isAuthenticated={isUserAuthenticated}
-    >
-      <div className="space-y-12">
-        <PublicTrustCenterAudits
-          audits={trustCenterAudits}
-          organizationName={organizationName}
-          isAuthenticated={isUserAuthenticated}
+    <>
+      {showNdaDialog && (
+        <NDAAcceptanceDialog
           trustCenterId={trustCenterBySlug.id}
-        />
-        <PublicTrustCenterDocuments
-          documents={trustCenterDocuments}
           organizationName={organizationName}
-          isAuthenticated={isUserAuthenticated}
-          trustCenterId={trustCenterBySlug.id}
+          ndaFileName={trustCenterBySlug.ndaFileName}
+          ndaFileUrl={trustCenterBySlug.ndaFileUrl}
         />
-        <PublicTrustCenterVendors
-          vendors={trustCenterVendors}
-          organizationName={organizationName}
-        />
-      </div>
-    </PublicTrustCenterLayout>
+      )}
+
+      <PublicTrustCenterLayout
+        organizationName={organizationName}
+        organizationLogo={organization?.logoUrl}
+        isAuthenticated={isUserAuthenticated}
+      >
+        <div className="space-y-12">
+          <PublicTrustCenterAudits
+            audits={trustCenterAudits}
+            organizationName={organizationName}
+            isAuthenticated={isUserAuthenticated}
+            trustCenterId={trustCenterBySlug.id}
+          />
+          <PublicTrustCenterDocuments
+            documents={trustCenterDocuments}
+            organizationName={organizationName}
+            isAuthenticated={isUserAuthenticated}
+            trustCenterId={trustCenterBySlug.id}
+          />
+          <PublicTrustCenterVendors
+            vendors={trustCenterVendors}
+            organizationName={organizationName}
+          />
+        </div>
+      </PublicTrustCenterLayout>
+    </>
   );
 }

--- a/packages/ui/src/Molecules/Dialog/Dialog.tsx
+++ b/packages/ui/src/Molecules/Dialog/Dialog.tsx
@@ -50,6 +50,7 @@ type Props = {
     className?: string;
     ref?: DialogRef;
     onClose?: () => void;
+    closable?: boolean;
 };
 
 export const useDialogRef = (): DialogRef => {
@@ -64,6 +65,7 @@ export function Dialog({
     ref,
     defaultOpen,
     onClose,
+    closable = true,
 }: Props) {
     const { overlay, content, header, title: titleClassname } = dialog();
     const [open, setOpen] = useState(!!defaultOpen);
@@ -80,41 +82,55 @@ export function Dialog({
     }
 
     const onOpenChange = (open: boolean) => {
+        if (!open && !closable) {
+            return;
+        }
         setOpen(open);
         if (!open) {
             onClose?.();
         }
     };
 
+    const contentProps = closable ? {} : {
+        onEscapeKeyDown: (e: Event) => e.preventDefault(),
+        onPointerDownOutside: (e: Event) => e.preventDefault(),
+        onInteractOutside: (e: Event) => e.preventDefault(),
+    };
+
     return (
-        <Root open={open} onOpenChange={onOpenChange}>
+        <Root open={open} onOpenChange={closable ? onOpenChange : undefined}>
             {trigger && <Trigger asChild>{trigger}</Trigger>}
             <Portal>
                 <Overlay className={overlay()} />
                 <Content
                     aria-describedby={undefined}
                     className={content({ className })}
+                    {...contentProps}
                 >
                     {title ? (
                         <div className={header()}>
                             <Title className={titleClassname()}> {title}</Title>
+                            {closable && (
+                                <Close asChild>
+                                    <Button
+                                        tabIndex={-1}
+                                        variant="tertiary"
+                                        icon={IconCrossLargeX}
+                                    />
+                                </Close>
+                            )}
+                        </div>
+                    ) : (
+                        closable && (
                             <Close asChild>
                                 <Button
                                     tabIndex={-1}
                                     variant="tertiary"
+                                    className="absolute top-4 right-4"
                                     icon={IconCrossLargeX}
                                 />
                             </Close>
-                        </div>
-                    ) : (
-                        <Close asChild>
-                            <Button
-                                tabIndex={-1}
-                                variant="tertiary"
-                                className="absolute top-4 right-4"
-                                icon={IconCrossLargeX}
-                            />
-                        </Close>
+                        )
                     )}
                     {children}
                 </Content>

--- a/pkg/coredata/entity_type_reg.go
+++ b/pkg/coredata/entity_type_reg.go
@@ -14,6 +14,12 @@
 
 package coredata
 
+type ctxKey struct{ name string }
+
+var (
+	ContextKeyIPAddress = &ctxKey{name: "ip_address"}
+)
+
 const (
 	OrganizationEntityType uint16 = iota
 	FrameworkEntityType

--- a/pkg/coredata/migrations/20250909T114034Z.sql
+++ b/pkg/coredata/migrations/20250909T114034Z.sql
@@ -1,0 +1,10 @@
+ALTER TABLE trust_center_accesses ADD COLUMN has_accepted_non_disclosure_agreement BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE trust_center_accesses ALTER COLUMN has_accepted_non_disclosure_agreement DROP DEFAULT;
+ALTER TABLE trust_center_accesses ADD COLUMN has_accepted_non_disclosure_agreement_metadata JSONB;
+
+ALTER TABLE trust_centers ADD COLUMN non_disclosure_agreement_file_id TEXT;
+ALTER TABLE trust_centers ADD CONSTRAINT trust_centers_non_disclosure_agreement_file_id_fkey
+    FOREIGN KEY (non_disclosure_agreement_file_id)
+    REFERENCES files(id)
+    ON UPDATE CASCADE
+    ON DELETE RESTRICT;

--- a/pkg/coredata/trust_center.go
+++ b/pkg/coredata/trust_center.go
@@ -28,13 +28,14 @@ import (
 
 type (
 	TrustCenter struct {
-		ID             gid.GID      `db:"id"`
-		OrganizationID gid.GID      `db:"organization_id"`
-		TenantID       gid.TenantID `db:"tenant_id"`
-		Active         bool         `db:"active"`
-		Slug           string       `db:"slug"`
-		CreatedAt      time.Time    `db:"created_at"`
-		UpdatedAt      time.Time    `db:"updated_at"`
+		ID                           gid.GID      `db:"id"`
+		OrganizationID               gid.GID      `db:"organization_id"`
+		TenantID                     gid.TenantID `db:"tenant_id"`
+		Active                       bool         `db:"active"`
+		Slug                         string       `db:"slug"`
+		NonDisclosureAgreementFileID *gid.GID     `db:"non_disclosure_agreement_file_id"`
+		CreatedAt                    time.Time    `db:"created_at"`
+		UpdatedAt                    time.Time    `db:"updated_at"`
 	}
 
 	TrustCenters []*TrustCenter
@@ -62,6 +63,7 @@ SELECT
 	tenant_id,
 	active,
 	slug,
+	non_disclosure_agreement_file_id,
 	created_at,
 	updated_at
 FROM
@@ -105,6 +107,7 @@ SELECT
 	tenant_id,
 	active,
 	slug,
+	non_disclosure_agreement_file_id,
 	created_at,
 	updated_at
 FROM
@@ -147,6 +150,7 @@ SELECT
 	tenant_id,
 	active,
 	slug,
+	non_disclosure_agreement_file_id,
 	created_at,
 	updated_at
 FROM
@@ -185,6 +189,7 @@ INSERT INTO trust_centers (
 	tenant_id,
 	active,
 	slug,
+	non_disclosure_agreement_file_id,
 	created_at,
 	updated_at
 ) VALUES (
@@ -193,19 +198,21 @@ INSERT INTO trust_centers (
 	@tenant_id,
 	@active,
 	@slug,
+	@non_disclosure_agreement_file_id,
 	@created_at,
 	@updated_at
 )
 `
 
 	args := pgx.StrictNamedArgs{
-		"id":              tc.ID,
-		"organization_id": tc.OrganizationID,
-		"tenant_id":       tc.TenantID,
-		"active":          tc.Active,
-		"slug":            tc.Slug,
-		"created_at":      tc.CreatedAt,
-		"updated_at":      tc.UpdatedAt,
+		"id":                               tc.ID,
+		"organization_id":                  tc.OrganizationID,
+		"tenant_id":                        tc.TenantID,
+		"active":                           tc.Active,
+		"slug":                             tc.Slug,
+		"non_disclosure_agreement_file_id": tc.NonDisclosureAgreementFileID,
+		"created_at":                       tc.CreatedAt,
+		"updated_at":                       tc.UpdatedAt,
 	}
 
 	_, err := conn.Exec(ctx, q, args)
@@ -226,6 +233,7 @@ UPDATE trust_centers
 SET
 	active = @active,
 	slug = @slug,
+	non_disclosure_agreement_file_id = @non_disclosure_agreement_file_id,
 	updated_at = @updated_at
 WHERE
 	%s
@@ -235,10 +243,11 @@ WHERE
 	q = fmt.Sprintf(q, scope.SQLFragment())
 
 	args := pgx.StrictNamedArgs{
-		"id":         tc.ID,
-		"active":     tc.Active,
-		"slug":       tc.Slug,
-		"updated_at": tc.UpdatedAt,
+		"id":                               tc.ID,
+		"active":                           tc.Active,
+		"slug":                             tc.Slug,
+		"non_disclosure_agreement_file_id": tc.NonDisclosureAgreementFileID,
+		"updated_at":                       tc.UpdatedAt,
 	}
 	maps.Copy(args, scope.SQLArguments())
 

--- a/pkg/probo/trust_center_access_service.go
+++ b/pkg/probo/trust_center_access_service.go
@@ -149,14 +149,15 @@ func (s TrustCenterAccessService) Create(
 		}
 
 		access = &coredata.TrustCenterAccess{
-			ID:            gid.New(s.svc.scope.GetTenantID(), coredata.TrustCenterAccessEntityType),
-			TenantID:      s.svc.scope.GetTenantID(),
-			TrustCenterID: req.TrustCenterID,
-			Email:         req.Email,
-			Name:          req.Name,
-			Active:        req.Active,
-			CreatedAt:     now,
-			UpdatedAt:     now,
+			ID:                                gid.New(s.svc.scope.GetTenantID(), coredata.TrustCenterAccessEntityType),
+			TenantID:                          s.svc.scope.GetTenantID(),
+			TrustCenterID:                     req.TrustCenterID,
+			Email:                             req.Email,
+			Name:                              req.Name,
+			Active:                            req.Active,
+			HasAcceptedNonDisclosureAgreement: false,
+			CreatedAt:                         now,
+			UpdatedAt:                         now,
 		}
 
 		if err := access.Insert(ctx, tx, s.svc.scope); err != nil {

--- a/pkg/probo/trust_center_service.go
+++ b/pkg/probo/trust_center_service.go
@@ -17,10 +17,17 @@ package probo
 import (
 	"context"
 	"fmt"
+	"io"
+	"mime"
+	"net/url"
+	"path/filepath"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/getprobo/probo/pkg/coredata"
 	"github.com/getprobo/probo/pkg/gid"
+	"go.gearno.de/crypto/uuid"
 	"go.gearno.de/kit/pg"
 )
 
@@ -30,24 +37,43 @@ type (
 	}
 
 	UpdateTrustCenterRequest struct {
-		ID     gid.GID
-		Active *bool
-		Slug   *string
+		ID                           gid.GID
+		Active                       *bool
+		Slug                         *string
+		NonDisclosureAgreementFileID *gid.GID
+	}
+
+	UploadTrustCenterNDARequest struct {
+		TrustCenterID gid.GID
+		File          io.Reader
+		FileName      string
+	}
+
+	DeleteTrustCenterNDARequest struct {
+		TrustCenterID gid.GID
 	}
 )
 
 func (s TrustCenterService) Get(
 	ctx context.Context,
 	trustCenterID gid.GID,
-) (*coredata.TrustCenter, error) {
-	trustCenter := &coredata.TrustCenter{}
+) (*coredata.TrustCenter, *coredata.File, error) {
+	var trustCenter *coredata.TrustCenter
+	var file *coredata.File
 
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(conn pg.Conn) error {
-			err := trustCenter.LoadByID(ctx, conn, s.svc.scope, trustCenterID)
-			if err != nil {
+			trustCenter = &coredata.TrustCenter{}
+			if err := trustCenter.LoadByID(ctx, conn, s.svc.scope, trustCenterID); err != nil {
 				return fmt.Errorf("cannot load trust center: %w", err)
+			}
+
+			if trustCenter.NonDisclosureAgreementFileID != nil {
+				file = &coredata.File{}
+				if err := file.LoadByID(ctx, conn, s.svc.scope, *trustCenter.NonDisclosureAgreementFileID); err != nil {
+					return fmt.Errorf("cannot load file: %w", err)
+				}
 			}
 
 			return nil
@@ -55,24 +81,32 @@ func (s TrustCenterService) Get(
 	)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, fmt.Errorf("cannot load trust center: %w", err)
 	}
 
-	return trustCenter, nil
+	return trustCenter, file, nil
 }
 
 func (s TrustCenterService) GetByOrganizationID(
 	ctx context.Context,
 	organizationID gid.GID,
-) (*coredata.TrustCenter, error) {
-	trustCenter := &coredata.TrustCenter{}
+) (*coredata.TrustCenter, *coredata.File, error) {
+	var trustCenter *coredata.TrustCenter
+	var file *coredata.File
 
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(conn pg.Conn) error {
-			err := trustCenter.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID)
-			if err != nil {
+			trustCenter = &coredata.TrustCenter{}
+			if err := trustCenter.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID); err != nil {
 				return fmt.Errorf("cannot load trust center: %w", err)
+			}
+
+			if trustCenter.NonDisclosureAgreementFileID != nil {
+				file = &coredata.File{}
+				if err := file.LoadByID(ctx, conn, s.svc.scope, *trustCenter.NonDisclosureAgreementFileID); err != nil {
+					return fmt.Errorf("cannot load file: %w", err)
+				}
 			}
 
 			return nil
@@ -80,21 +114,23 @@ func (s TrustCenterService) GetByOrganizationID(
 	)
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return trustCenter, nil
+	return trustCenter, file, nil
 }
 
 func (s TrustCenterService) Update(
 	ctx context.Context,
 	req *UpdateTrustCenterRequest,
-) (*coredata.TrustCenter, error) {
-	trustCenter := &coredata.TrustCenter{}
+) (*coredata.TrustCenter, *coredata.File, error) {
+	var trustCenter *coredata.TrustCenter
+	var file *coredata.File
 
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(conn pg.Conn) error {
+			trustCenter = &coredata.TrustCenter{}
 			if err := trustCenter.LoadByID(ctx, conn, s.svc.scope, req.ID); err != nil {
 				return fmt.Errorf("cannot load trust center: %w", err)
 			}
@@ -112,13 +148,189 @@ func (s TrustCenterService) Update(
 				return fmt.Errorf("cannot update trust center: %w", err)
 			}
 
+			if trustCenter.NonDisclosureAgreementFileID != nil {
+				file = &coredata.File{}
+				if err := file.LoadByID(ctx, conn, s.svc.scope, *trustCenter.NonDisclosureAgreementFileID); err != nil {
+					return fmt.Errorf("cannot load file: %w", err)
+				}
+			}
+
 			return nil
 		},
 	)
 
 	if err != nil {
+		return nil, nil, err
+	}
+
+	return trustCenter, file, nil
+}
+
+func (s TrustCenterService) UploadNDA(
+	ctx context.Context,
+	req *UploadTrustCenterNDARequest,
+) (*coredata.TrustCenter, *coredata.File, error) {
+	objectKey, err := uuid.NewV7()
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot generate object key: %w", err)
+	}
+
+	mimeType := mime.TypeByExtension(filepath.Ext(req.FileName))
+
+	_, err = s.svc.s3.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      &s.svc.bucket,
+		Key:         aws.String(objectKey.String()),
+		Body:        req.File,
+		ContentType: &mimeType,
+		Metadata: map[string]string{
+			"type":            "trust-center-nda",
+			"trust-center-id": req.TrustCenterID.String(),
+		},
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot upload file to S3: %w", err)
+	}
+
+	headOutput, err := s.svc.s3.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(s.svc.bucket),
+		Key:    aws.String(objectKey.String()),
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot get object metadata: %w", err)
+	}
+
+	now := time.Now()
+
+	fileID := gid.New(s.svc.scope.GetTenantID(), coredata.FileEntityType)
+
+	var trustCenter *coredata.TrustCenter
+	var file *coredata.File
+
+	err = s.svc.pg.WithTx(
+		ctx,
+		func(conn pg.Conn) error {
+			trustCenter = &coredata.TrustCenter{}
+			if err := trustCenter.LoadByID(ctx, conn, s.svc.scope, req.TrustCenterID); err != nil {
+				return fmt.Errorf("cannot load trust center: %w", err)
+			}
+
+			file = &coredata.File{
+				ID:         fileID,
+				BucketName: s.svc.bucket,
+				MimeType:   mimeType,
+				FileName:   req.FileName,
+				FileKey:    objectKey.String(),
+				FileSize:   int(*headOutput.ContentLength),
+				CreatedAt:  now,
+				UpdatedAt:  now,
+			}
+
+			if err := file.Insert(ctx, conn, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot insert file: %w", err)
+			}
+
+			trustCenter.NonDisclosureAgreementFileID = &fileID
+			trustCenter.UpdatedAt = now
+
+			if err := trustCenter.Update(ctx, conn, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot update trust center: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return trustCenter, file, nil
+}
+
+func (s TrustCenterService) DeleteNDA(
+	ctx context.Context,
+	req *DeleteTrustCenterNDARequest,
+) (*coredata.TrustCenter, *coredata.File, error) {
+	var trustCenter *coredata.TrustCenter
+
+	err := s.svc.pg.WithTx(
+		ctx,
+		func(conn pg.Conn) error {
+			trustCenter = &coredata.TrustCenter{}
+			if err := trustCenter.LoadByID(ctx, conn, s.svc.scope, req.TrustCenterID); err != nil {
+				return fmt.Errorf("cannot load trust center: %w", err)
+			}
+
+			trustCenter.NonDisclosureAgreementFileID = nil
+			trustCenter.UpdatedAt = time.Now()
+
+			if err := trustCenter.Update(ctx, conn, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot update trust center: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return trustCenter, nil, nil // File is nil after deletion
+}
+
+func (s TrustCenterService) GenerateNDAFileURL(
+	ctx context.Context,
+	trustCenterID gid.GID,
+	expiresIn time.Duration,
+) (*string, error) {
+	var file *coredata.File
+	trustCenter := &coredata.TrustCenter{}
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			if err := trustCenter.LoadByID(ctx, conn, s.svc.scope, trustCenterID); err != nil {
+				return fmt.Errorf("cannot load trust center: %w", err)
+			}
+
+			if trustCenter.NonDisclosureAgreementFileID == nil {
+				return nil
+			}
+
+			file = &coredata.File{}
+			if err := file.LoadByID(ctx, conn, s.svc.scope, *trustCenter.NonDisclosureAgreementFileID); err != nil {
+				return fmt.Errorf("cannot load file: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
 		return nil, err
 	}
 
-	return trustCenter, nil
+	if trustCenter.NonDisclosureAgreementFileID == nil {
+		return nil, nil
+	}
+
+	presignClient := s3.NewPresignClient(s.svc.s3)
+
+	encodedFilename := url.QueryEscape(file.FileName)
+	contentDisposition := fmt.Sprintf("attachment; filename=\"%s\"; filename*=UTF-8''%s",
+		encodedFilename, encodedFilename)
+
+	presignedReq, err := presignClient.PresignGetObject(ctx, &s3.GetObjectInput{
+		Bucket:                     aws.String(s.svc.bucket),
+		Key:                        aws.String(file.FileKey),
+		ResponseCacheControl:       aws.String("max-age=3600, public"),
+		ResponseContentDisposition: aws.String(contentDisposition),
+	}, func(opts *s3.PresignOptions) {
+		opts.Expires = expiresIn
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot presign GetObject request: %w", err)
+	}
+
+	return &presignedReq.URL, nil
 }

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -1144,6 +1144,8 @@ type TrustCenter implements Node {
   id: ID!
   active: Boolean!
   slug: String!
+  ndaFileName: String
+  ndaFileUrl: String @goField(forceResolver: true)
   createdAt: Datetime!
   updatedAt: Datetime!
   organization: Organization! @goField(forceResolver: true)
@@ -1889,6 +1891,7 @@ type TrustCenterAccess implements Node {
   email: String!
   name: String!
   active: Boolean!
+  hasAcceptedNonDisclosureAgreement: Boolean!
   createdAt: Datetime!
   updatedAt: Datetime!
 }
@@ -2218,6 +2221,14 @@ type Mutation {
     input: UpdateTrustCenterInput!
   ): UpdateTrustCenterPayload!
 
+  uploadTrustCenterNDA(
+    input: UploadTrustCenterNDAInput!
+  ): UploadTrustCenterNDAPayload!
+
+  deleteTrustCenterNDA(
+    input: DeleteTrustCenterNDAInput!
+  ): DeleteTrustCenterNDAPayload!
+
   # Trust Center Access CRUD mutations
   createTrustCenterAccess(
     input: CreateTrustCenterAccessInput!
@@ -2501,6 +2512,16 @@ input UpdateTrustCenterInput {
   trustCenterId: ID!
   active: Boolean
   slug: String
+}
+
+input UploadTrustCenterNDAInput {
+  trustCenterId: ID!
+  fileName: String!
+  file: Upload!
+}
+
+input DeleteTrustCenterNDAInput {
+  trustCenterId: ID!
 }
 
 input CreateTrustCenterAccessInput {
@@ -3132,6 +3153,14 @@ type DeleteOrganizationPayload {
 }
 
 type UpdateTrustCenterPayload {
+  trustCenter: TrustCenter!
+}
+
+type UploadTrustCenterNDAPayload {
+  trustCenter: TrustCenter!
+}
+
+type DeleteTrustCenterNDAPayload {
   trustCenter: TrustCenter!
 }
 

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -504,6 +504,10 @@ type ComplexityRoot struct {
 		DeletedTrustCenterAccessID func(childComplexity int) int
 	}
 
+	DeleteTrustCenterNDAPayload struct {
+		TrustCenter func(childComplexity int) int
+	}
+
 	DeleteVendorBusinessAssociateAgreementPayload struct {
 		DeletedVendorID func(childComplexity int) int
 	}
@@ -768,6 +772,7 @@ type ComplexityRoot struct {
 		DeleteSnapshot                         func(childComplexity int, input types.DeleteSnapshotInput) int
 		DeleteTask                             func(childComplexity int, input types.DeleteTaskInput) int
 		DeleteTrustCenterAccess                func(childComplexity int, input types.DeleteTrustCenterAccessInput) int
+		DeleteTrustCenterNda                   func(childComplexity int, input types.DeleteTrustCenterNDAInput) int
 		DeleteVendor                           func(childComplexity int, input types.DeleteVendorInput) int
 		DeleteVendorBusinessAssociateAgreement func(childComplexity int, input types.DeleteVendorBusinessAssociateAgreementInput) int
 		DeleteVendorComplianceReport           func(childComplexity int, input types.DeleteVendorComplianceReportInput) int
@@ -814,6 +819,7 @@ type ComplexityRoot struct {
 		UploadAuditReport                      func(childComplexity int, input types.UploadAuditReportInput) int
 		UploadMeasureEvidence                  func(childComplexity int, input types.UploadMeasureEvidenceInput) int
 		UploadTaskEvidence                     func(childComplexity int, input types.UploadTaskEvidenceInput) int
+		UploadTrustCenterNda                   func(childComplexity int, input types.UploadTrustCenterNDAInput) int
 		UploadVendorBusinessAssociateAgreement func(childComplexity int, input types.UploadVendorBusinessAssociateAgreementInput) int
 		UploadVendorComplianceReport           func(childComplexity int, input types.UploadVendorComplianceReportInput) int
 		UploadVendorDataPrivacyAgreement       func(childComplexity int, input types.UploadVendorDataPrivacyAgreementInput) int
@@ -1109,18 +1115,21 @@ type ComplexityRoot struct {
 		Active       func(childComplexity int) int
 		CreatedAt    func(childComplexity int) int
 		ID           func(childComplexity int) int
+		NdaFileName  func(childComplexity int) int
+		NdaFileURL   func(childComplexity int) int
 		Organization func(childComplexity int) int
 		Slug         func(childComplexity int) int
 		UpdatedAt    func(childComplexity int) int
 	}
 
 	TrustCenterAccess struct {
-		Active    func(childComplexity int) int
-		CreatedAt func(childComplexity int) int
-		Email     func(childComplexity int) int
-		ID        func(childComplexity int) int
-		Name      func(childComplexity int) int
-		UpdatedAt func(childComplexity int) int
+		Active                            func(childComplexity int) int
+		CreatedAt                         func(childComplexity int) int
+		Email                             func(childComplexity int) int
+		HasAcceptedNonDisclosureAgreement func(childComplexity int) int
+		ID                                func(childComplexity int) int
+		Name                              func(childComplexity int) int
+		UpdatedAt                         func(childComplexity int) int
 	}
 
 	TrustCenterAccessConnection struct {
@@ -1249,6 +1258,10 @@ type ComplexityRoot struct {
 
 	UploadTaskEvidencePayload struct {
 		EvidenceEdge func(childComplexity int) int
+	}
+
+	UploadTrustCenterNDAPayload struct {
+		TrustCenter func(childComplexity int) int
 	}
 
 	UploadVendorBusinessAssociateAgreementPayload struct {
@@ -1544,6 +1557,8 @@ type MutationResolver interface {
 	UpdateOrganization(ctx context.Context, input types.UpdateOrganizationInput) (*types.UpdateOrganizationPayload, error)
 	DeleteOrganization(ctx context.Context, input types.DeleteOrganizationInput) (*types.DeleteOrganizationPayload, error)
 	UpdateTrustCenter(ctx context.Context, input types.UpdateTrustCenterInput) (*types.UpdateTrustCenterPayload, error)
+	UploadTrustCenterNda(ctx context.Context, input types.UploadTrustCenterNDAInput) (*types.UploadTrustCenterNDAPayload, error)
+	DeleteTrustCenterNda(ctx context.Context, input types.DeleteTrustCenterNDAInput) (*types.DeleteTrustCenterNDAPayload, error)
 	CreateTrustCenterAccess(ctx context.Context, input types.CreateTrustCenterAccessInput) (*types.CreateTrustCenterAccessPayload, error)
 	UpdateTrustCenterAccess(ctx context.Context, input types.UpdateTrustCenterAccessInput) (*types.UpdateTrustCenterAccessPayload, error)
 	DeleteTrustCenterAccess(ctx context.Context, input types.DeleteTrustCenterAccessInput) (*types.DeleteTrustCenterAccessPayload, error)
@@ -1734,6 +1749,8 @@ type TaskConnectionResolver interface {
 	TotalCount(ctx context.Context, obj *types.TaskConnection) (int, error)
 }
 type TrustCenterResolver interface {
+	NdaFileURL(ctx context.Context, obj *types.TrustCenter) (*string, error)
+
 	Organization(ctx context.Context, obj *types.TrustCenter) (*types.Organization, error)
 	Accesses(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.OrderBy[coredata.TrustCenterAccessOrderField]) (*types.TrustCenterAccessConnection, error)
 }
@@ -3020,6 +3037,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.DeleteTrustCenterAccessPayload.DeletedTrustCenterAccessID(childComplexity), true
+
+	case "DeleteTrustCenterNDAPayload.trustCenter":
+		if e.complexity.DeleteTrustCenterNDAPayload.TrustCenter == nil {
+			break
+		}
+
+		return e.complexity.DeleteTrustCenterNDAPayload.TrustCenter(childComplexity), true
 
 	case "DeleteVendorBusinessAssociateAgreementPayload.deletedVendorId":
 		if e.complexity.DeleteVendorBusinessAssociateAgreementPayload.DeletedVendorID == nil {
@@ -4530,6 +4554,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.DeleteTrustCenterAccess(childComplexity, args["input"].(types.DeleteTrustCenterAccessInput)), true
 
+	case "Mutation.deleteTrustCenterNDA":
+		if e.complexity.Mutation.DeleteTrustCenterNda == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_deleteTrustCenterNDA_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteTrustCenterNda(childComplexity, args["input"].(types.DeleteTrustCenterNDAInput)), true
+
 	case "Mutation.deleteVendor":
 		if e.complexity.Mutation.DeleteVendor == nil {
 			break
@@ -5081,6 +5117,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.UploadTaskEvidence(childComplexity, args["input"].(types.UploadTaskEvidenceInput)), true
+
+	case "Mutation.uploadTrustCenterNDA":
+		if e.complexity.Mutation.UploadTrustCenterNda == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_uploadTrustCenterNDA_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UploadTrustCenterNda(childComplexity, args["input"].(types.UploadTrustCenterNDAInput)), true
 
 	case "Mutation.uploadVendorBusinessAssociateAgreement":
 		if e.complexity.Mutation.UploadVendorBusinessAssociateAgreement == nil {
@@ -6573,6 +6621,20 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.TrustCenter.ID(childComplexity), true
 
+	case "TrustCenter.ndaFileName":
+		if e.complexity.TrustCenter.NdaFileName == nil {
+			break
+		}
+
+		return e.complexity.TrustCenter.NdaFileName(childComplexity), true
+
+	case "TrustCenter.ndaFileUrl":
+		if e.complexity.TrustCenter.NdaFileURL == nil {
+			break
+		}
+
+		return e.complexity.TrustCenter.NdaFileURL(childComplexity), true
+
 	case "TrustCenter.organization":
 		if e.complexity.TrustCenter.Organization == nil {
 			break
@@ -6614,6 +6676,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.TrustCenterAccess.Email(childComplexity), true
+
+	case "TrustCenterAccess.hasAcceptedNonDisclosureAgreement":
+		if e.complexity.TrustCenterAccess.HasAcceptedNonDisclosureAgreement == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterAccess.HasAcceptedNonDisclosureAgreement(childComplexity), true
 
 	case "TrustCenterAccess.id":
 		if e.complexity.TrustCenterAccess.ID == nil {
@@ -6880,6 +6949,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.UploadTaskEvidencePayload.EvidenceEdge(childComplexity), true
+
+	case "UploadTrustCenterNDAPayload.trustCenter":
+		if e.complexity.UploadTrustCenterNDAPayload.TrustCenter == nil {
+			break
+		}
+
+		return e.complexity.UploadTrustCenterNDAPayload.TrustCenter(childComplexity), true
 
 	case "UploadVendorBusinessAssociateAgreementPayload.vendorBusinessAssociateAgreement":
 		if e.complexity.UploadVendorBusinessAssociateAgreementPayload.VendorBusinessAssociateAgreement == nil {
@@ -7816,6 +7892,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputDeleteSnapshotInput,
 		ec.unmarshalInputDeleteTaskInput,
 		ec.unmarshalInputDeleteTrustCenterAccessInput,
+		ec.unmarshalInputDeleteTrustCenterNDAInput,
 		ec.unmarshalInputDeleteVendorBusinessAssociateAgreementInput,
 		ec.unmarshalInputDeleteVendorComplianceReportInput,
 		ec.unmarshalInputDeleteVendorContactInput,
@@ -7886,6 +7963,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputUploadAuditReportInput,
 		ec.unmarshalInputUploadMeasureEvidenceInput,
 		ec.unmarshalInputUploadTaskEvidenceInput,
+		ec.unmarshalInputUploadTrustCenterNDAInput,
 		ec.unmarshalInputUploadVendorBusinessAssociateAgreementInput,
 		ec.unmarshalInputUploadVendorComplianceReportInput,
 		ec.unmarshalInputUploadVendorDataPrivacyAgreementInput,
@@ -9139,6 +9217,8 @@ type TrustCenter implements Node {
   id: ID!
   active: Boolean!
   slug: String!
+  ndaFileName: String
+  ndaFileUrl: String @goField(forceResolver: true)
   createdAt: Datetime!
   updatedAt: Datetime!
   organization: Organization! @goField(forceResolver: true)
@@ -9884,6 +9964,7 @@ type TrustCenterAccess implements Node {
   email: String!
   name: String!
   active: Boolean!
+  hasAcceptedNonDisclosureAgreement: Boolean!
   createdAt: Datetime!
   updatedAt: Datetime!
 }
@@ -10213,6 +10294,14 @@ type Mutation {
     input: UpdateTrustCenterInput!
   ): UpdateTrustCenterPayload!
 
+  uploadTrustCenterNDA(
+    input: UploadTrustCenterNDAInput!
+  ): UploadTrustCenterNDAPayload!
+
+  deleteTrustCenterNDA(
+    input: DeleteTrustCenterNDAInput!
+  ): DeleteTrustCenterNDAPayload!
+
   # Trust Center Access CRUD mutations
   createTrustCenterAccess(
     input: CreateTrustCenterAccessInput!
@@ -10496,6 +10585,16 @@ input UpdateTrustCenterInput {
   trustCenterId: ID!
   active: Boolean
   slug: String
+}
+
+input UploadTrustCenterNDAInput {
+  trustCenterId: ID!
+  fileName: String!
+  file: Upload!
+}
+
+input DeleteTrustCenterNDAInput {
+  trustCenterId: ID!
 }
 
 input CreateTrustCenterAccessInput {
@@ -11127,6 +11226,14 @@ type DeleteOrganizationPayload {
 }
 
 type UpdateTrustCenterPayload {
+  trustCenter: TrustCenter!
+}
+
+type UploadTrustCenterNDAPayload {
+  trustCenter: TrustCenter!
+}
+
+type DeleteTrustCenterNDAPayload {
   trustCenter: TrustCenter!
 }
 
@@ -14825,6 +14932,29 @@ func (ec *executionContext) field_Mutation_deleteTrustCenterAccess_argsInput(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation_deleteTrustCenterNDA_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_deleteTrustCenterNDA_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_deleteTrustCenterNDA_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.DeleteTrustCenterNDAInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNDeleteTrustCenterNDAInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteTrustCenterNDAInput(ctx, tmp)
+	}
+
+	var zeroVal types.DeleteTrustCenterNDAInput
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation_deleteVendorBusinessAssociateAgreement_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -15880,6 +16010,29 @@ func (ec *executionContext) field_Mutation_uploadTaskEvidence_argsInput(
 	}
 
 	var zeroVal types.UploadTaskEvidenceInput
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_uploadTrustCenterNDA_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_uploadTrustCenterNDA_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_uploadTrustCenterNDA_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.UploadTrustCenterNDAInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNUploadTrustCenterNDAInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUploadTrustCenterNDAInput(ctx, tmp)
+	}
+
+	var zeroVal types.UploadTrustCenterNDAInput
 	return zeroVal, nil
 }
 
@@ -27616,6 +27769,70 @@ func (ec *executionContext) fieldContext_DeleteTrustCenterAccessPayload_deletedT
 	return fc, nil
 }
 
+func (ec *executionContext) _DeleteTrustCenterNDAPayload_trustCenter(ctx context.Context, field graphql.CollectedField, obj *types.DeleteTrustCenterNDAPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DeleteTrustCenterNDAPayload_trustCenter(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TrustCenter, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.TrustCenter)
+	fc.Result = res
+	return ec.marshalNTrustCenter2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenter(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DeleteTrustCenterNDAPayload_trustCenter(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DeleteTrustCenterNDAPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TrustCenter_id(ctx, field)
+			case "active":
+				return ec.fieldContext_TrustCenter_active(ctx, field)
+			case "slug":
+				return ec.fieldContext_TrustCenter_slug(ctx, field)
+			case "ndaFileName":
+				return ec.fieldContext_TrustCenter_ndaFileName(ctx, field)
+			case "ndaFileUrl":
+				return ec.fieldContext_TrustCenter_ndaFileUrl(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_TrustCenter_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_TrustCenter_updatedAt(ctx, field)
+			case "organization":
+				return ec.fieldContext_TrustCenter_organization(ctx, field)
+			case "accesses":
+				return ec.fieldContext_TrustCenter_accesses(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustCenter", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _DeleteVendorBusinessAssociateAgreementPayload_deletedVendorId(ctx context.Context, field graphql.CollectedField, obj *types.DeleteVendorBusinessAssociateAgreementPayload) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_DeleteVendorBusinessAssociateAgreementPayload_deletedVendorId(ctx, field)
 	if err != nil {
@@ -33251,6 +33468,124 @@ func (ec *executionContext) fieldContext_Mutation_updateTrustCenter(ctx context.
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_updateTrustCenter_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_uploadTrustCenterNDA(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_uploadTrustCenterNDA(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UploadTrustCenterNda(rctx, fc.Args["input"].(types.UploadTrustCenterNDAInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.UploadTrustCenterNDAPayload)
+	fc.Result = res
+	return ec.marshalNUploadTrustCenterNDAPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUploadTrustCenterNDAPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_uploadTrustCenterNDA(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "trustCenter":
+				return ec.fieldContext_UploadTrustCenterNDAPayload_trustCenter(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UploadTrustCenterNDAPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_uploadTrustCenterNDA_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_deleteTrustCenterNDA(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_deleteTrustCenterNDA(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteTrustCenterNda(rctx, fc.Args["input"].(types.DeleteTrustCenterNDAInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.DeleteTrustCenterNDAPayload)
+	fc.Result = res
+	return ec.marshalNDeleteTrustCenterNDAPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteTrustCenterNDAPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_deleteTrustCenterNDA(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "trustCenter":
+				return ec.fieldContext_DeleteTrustCenterNDAPayload_trustCenter(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DeleteTrustCenterNDAPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_deleteTrustCenterNDA_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -42812,6 +43147,10 @@ func (ec *executionContext) fieldContext_Organization_trustCenter(_ context.Cont
 				return ec.fieldContext_TrustCenter_active(ctx, field)
 			case "slug":
 				return ec.fieldContext_TrustCenter_slug(ctx, field)
+			case "ndaFileName":
+				return ec.fieldContext_TrustCenter_ndaFileName(ctx, field)
+			case "ndaFileUrl":
+				return ec.fieldContext_TrustCenter_ndaFileUrl(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_TrustCenter_createdAt(ctx, field)
 			case "updatedAt":
@@ -49174,6 +49513,88 @@ func (ec *executionContext) fieldContext_TrustCenter_slug(_ context.Context, fie
 	return fc, nil
 }
 
+func (ec *executionContext) _TrustCenter_ndaFileName(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenter) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenter_ndaFileName(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NdaFileName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenter_ndaFileName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenter",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenter_ndaFileUrl(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenter) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenter_ndaFileUrl(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TrustCenter().NdaFileURL(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenter_ndaFileUrl(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenter",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _TrustCenter_createdAt(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenter) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_TrustCenter_createdAt(ctx, field)
 	if err != nil {
@@ -49593,6 +50014,50 @@ func (ec *executionContext) fieldContext_TrustCenterAccess_active(_ context.Cont
 	return fc, nil
 }
 
+func (ec *executionContext) _TrustCenterAccess_hasAcceptedNonDisclosureAgreement(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterAccess) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterAccess_hasAcceptedNonDisclosureAgreement(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.HasAcceptedNonDisclosureAgreement, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterAccess_hasAcceptedNonDisclosureAgreement(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterAccess",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _TrustCenterAccess_createdAt(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterAccess) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_TrustCenterAccess_createdAt(ctx, field)
 	if err != nil {
@@ -49876,6 +50341,8 @@ func (ec *executionContext) fieldContext_TrustCenterAccessEdge_node(_ context.Co
 				return ec.fieldContext_TrustCenterAccess_name(ctx, field)
 			case "active":
 				return ec.fieldContext_TrustCenterAccess_active(ctx, field)
+			case "hasAcceptedNonDisclosureAgreement":
+				return ec.fieldContext_TrustCenterAccess_hasAcceptedNonDisclosureAgreement(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_TrustCenterAccess_createdAt(ctx, field)
 			case "updatedAt":
@@ -50080,6 +50547,10 @@ func (ec *executionContext) fieldContext_TrustCenterEdge_node(_ context.Context,
 				return ec.fieldContext_TrustCenter_active(ctx, field)
 			case "slug":
 				return ec.fieldContext_TrustCenter_slug(ctx, field)
+			case "ndaFileName":
+				return ec.fieldContext_TrustCenter_ndaFileName(ctx, field)
+			case "ndaFileUrl":
+				return ec.fieldContext_TrustCenter_ndaFileUrl(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_TrustCenter_createdAt(ctx, field)
 			case "updatedAt":
@@ -51390,6 +51861,8 @@ func (ec *executionContext) fieldContext_UpdateTrustCenterAccessPayload_trustCen
 				return ec.fieldContext_TrustCenterAccess_name(ctx, field)
 			case "active":
 				return ec.fieldContext_TrustCenterAccess_active(ctx, field)
+			case "hasAcceptedNonDisclosureAgreement":
+				return ec.fieldContext_TrustCenterAccess_hasAcceptedNonDisclosureAgreement(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_TrustCenterAccess_createdAt(ctx, field)
 			case "updatedAt":
@@ -51446,6 +51919,10 @@ func (ec *executionContext) fieldContext_UpdateTrustCenterPayload_trustCenter(_ 
 				return ec.fieldContext_TrustCenter_active(ctx, field)
 			case "slug":
 				return ec.fieldContext_TrustCenter_slug(ctx, field)
+			case "ndaFileName":
+				return ec.fieldContext_TrustCenter_ndaFileName(ctx, field)
+			case "ndaFileUrl":
+				return ec.fieldContext_TrustCenter_ndaFileUrl(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_TrustCenter_createdAt(ctx, field)
 			case "updatedAt":
@@ -51982,6 +52459,70 @@ func (ec *executionContext) fieldContext_UploadTaskEvidencePayload_evidenceEdge(
 				return ec.fieldContext_EvidenceEdge_node(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type EvidenceEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UploadTrustCenterNDAPayload_trustCenter(ctx context.Context, field graphql.CollectedField, obj *types.UploadTrustCenterNDAPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UploadTrustCenterNDAPayload_trustCenter(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TrustCenter, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.TrustCenter)
+	fc.Result = res
+	return ec.marshalNTrustCenter2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenter(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UploadTrustCenterNDAPayload_trustCenter(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UploadTrustCenterNDAPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TrustCenter_id(ctx, field)
+			case "active":
+				return ec.fieldContext_TrustCenter_active(ctx, field)
+			case "slug":
+				return ec.fieldContext_TrustCenter_slug(ctx, field)
+			case "ndaFileName":
+				return ec.fieldContext_TrustCenter_ndaFileName(ctx, field)
+			case "ndaFileUrl":
+				return ec.fieldContext_TrustCenter_ndaFileUrl(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_TrustCenter_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_TrustCenter_updatedAt(ctx, field)
+			case "organization":
+				return ec.fieldContext_TrustCenter_organization(ctx, field)
+			case "accesses":
+				return ec.fieldContext_TrustCenter_accesses(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustCenter", field.Name)
 		},
 	}
 	return fc, nil
@@ -63026,6 +63567,33 @@ func (ec *executionContext) unmarshalInputDeleteTrustCenterAccessInput(ctx conte
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputDeleteTrustCenterNDAInput(ctx context.Context, obj any) (types.DeleteTrustCenterNDAInput, error) {
+	var it types.DeleteTrustCenterNDAInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"trustCenterId"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "trustCenterId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("trustCenterId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.TrustCenterID = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputDeleteVendorBusinessAssociateAgreementInput(ctx context.Context, obj any) (types.DeleteVendorBusinessAssociateAgreementInput, error) {
 	var it types.DeleteVendorBusinessAssociateAgreementInput
 	asMap := map[string]any{}
@@ -66072,6 +66640,47 @@ func (ec *executionContext) unmarshalInputUploadTaskEvidenceInput(ctx context.Co
 				return it, err
 			}
 			it.TaskID = data
+		case "file":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("file"))
+			data, err := ec.unmarshalNUpload2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚐUpload(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.File = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputUploadTrustCenterNDAInput(ctx context.Context, obj any) (types.UploadTrustCenterNDAInput, error) {
+	var it types.UploadTrustCenterNDAInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"trustCenterId", "fileName", "file"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "trustCenterId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("trustCenterId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.TrustCenterID = data
+		case "fileName":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("fileName"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.FileName = data
 		case "file":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("file"))
 			data, err := ec.unmarshalNUpload2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚐUpload(ctx, v)
@@ -70951,6 +71560,45 @@ func (ec *executionContext) _DeleteTrustCenterAccessPayload(ctx context.Context,
 	return out
 }
 
+var deleteTrustCenterNDAPayloadImplementors = []string{"DeleteTrustCenterNDAPayload"}
+
+func (ec *executionContext) _DeleteTrustCenterNDAPayload(ctx context.Context, sel ast.SelectionSet, obj *types.DeleteTrustCenterNDAPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, deleteTrustCenterNDAPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("DeleteTrustCenterNDAPayload")
+		case "trustCenter":
+			out.Values[i] = ec._DeleteTrustCenterNDAPayload_trustCenter(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var deleteVendorBusinessAssociateAgreementPayloadImplementors = []string{"DeleteVendorBusinessAssociateAgreementPayload"}
 
 func (ec *executionContext) _DeleteVendorBusinessAssociateAgreementPayload(ctx context.Context, sel ast.SelectionSet, obj *types.DeleteVendorBusinessAssociateAgreementPayload) graphql.Marshaler {
@@ -73340,6 +73988,20 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "updateTrustCenter":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_updateTrustCenter(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "uploadTrustCenterNDA":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_uploadTrustCenterNDA(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "deleteTrustCenterNDA":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_deleteTrustCenterNDA(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
@@ -77502,6 +78164,41 @@ func (ec *executionContext) _TrustCenter(ctx context.Context, sel ast.SelectionS
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "ndaFileName":
+			out.Values[i] = ec._TrustCenter_ndaFileName(ctx, field, obj)
+		case "ndaFileUrl":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TrustCenter_ndaFileUrl(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "createdAt":
 			out.Values[i] = ec._TrustCenter_createdAt(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -77635,6 +78332,11 @@ func (ec *executionContext) _TrustCenterAccess(ctx context.Context, sel ast.Sele
 			}
 		case "active":
 			out.Values[i] = ec._TrustCenterAccess_active(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "hasAcceptedNonDisclosureAgreement":
+			out.Values[i] = ec._TrustCenterAccess_hasAcceptedNonDisclosureAgreement(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -78874,6 +79576,45 @@ func (ec *executionContext) _UploadTaskEvidencePayload(ctx context.Context, sel 
 			out.Values[i] = graphql.MarshalString("UploadTaskEvidencePayload")
 		case "evidenceEdge":
 			out.Values[i] = ec._UploadTaskEvidencePayload_evidenceEdge(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var uploadTrustCenterNDAPayloadImplementors = []string{"UploadTrustCenterNDAPayload"}
+
+func (ec *executionContext) _UploadTrustCenterNDAPayload(ctx context.Context, sel ast.SelectionSet, obj *types.UploadTrustCenterNDAPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, uploadTrustCenterNDAPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("UploadTrustCenterNDAPayload")
+		case "trustCenter":
+			out.Values[i] = ec._UploadTrustCenterNDAPayload_trustCenter(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -83353,6 +84094,25 @@ func (ec *executionContext) marshalNDeleteTrustCenterAccessPayload2ᚖgithubᚗc
 	return ec._DeleteTrustCenterAccessPayload(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNDeleteTrustCenterNDAInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteTrustCenterNDAInput(ctx context.Context, v any) (types.DeleteTrustCenterNDAInput, error) {
+	res, err := ec.unmarshalInputDeleteTrustCenterNDAInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNDeleteTrustCenterNDAPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteTrustCenterNDAPayload(ctx context.Context, sel ast.SelectionSet, v types.DeleteTrustCenterNDAPayload) graphql.Marshaler {
+	return ec._DeleteTrustCenterNDAPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNDeleteTrustCenterNDAPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteTrustCenterNDAPayload(ctx context.Context, sel ast.SelectionSet, v *types.DeleteTrustCenterNDAPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._DeleteTrustCenterNDAPayload(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNDeleteVendorBusinessAssociateAgreementInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteVendorBusinessAssociateAgreementInput(ctx context.Context, v any) (types.DeleteVendorBusinessAssociateAgreementInput, error) {
 	res, err := ec.unmarshalInputDeleteVendorBusinessAssociateAgreementInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -86567,6 +87327,25 @@ func (ec *executionContext) marshalNUploadTaskEvidencePayload2ᚖgithubᚗcomᚋ
 		return graphql.Null
 	}
 	return ec._UploadTaskEvidencePayload(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNUploadTrustCenterNDAInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUploadTrustCenterNDAInput(ctx context.Context, v any) (types.UploadTrustCenterNDAInput, error) {
+	res, err := ec.unmarshalInputUploadTrustCenterNDAInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNUploadTrustCenterNDAPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUploadTrustCenterNDAPayload(ctx context.Context, sel ast.SelectionSet, v types.UploadTrustCenterNDAPayload) graphql.Marshaler {
+	return ec._UploadTrustCenterNDAPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNUploadTrustCenterNDAPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUploadTrustCenterNDAPayload(ctx context.Context, sel ast.SelectionSet, v *types.UploadTrustCenterNDAPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._UploadTrustCenterNDAPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNUploadVendorBusinessAssociateAgreementInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUploadVendorBusinessAssociateAgreementInput(ctx context.Context, v any) (types.UploadVendorBusinessAssociateAgreementInput, error) {

--- a/pkg/server/api/console/v1/types/trust_center.go
+++ b/pkg/server/api/console/v1/types/trust_center.go
@@ -18,12 +18,18 @@ import (
 	"github.com/getprobo/probo/pkg/coredata"
 )
 
-func NewTrustCenter(tc *coredata.TrustCenter) *TrustCenter {
+func NewTrustCenter(tc *coredata.TrustCenter, file *coredata.File) *TrustCenter {
+	var ndaFileName *string
+	if file != nil {
+		ndaFileName = &file.FileName
+	}
+
 	return &TrustCenter{
-		ID:        tc.ID,
-		Active:    tc.Active,
-		Slug:      tc.Slug,
-		CreatedAt: tc.CreatedAt,
-		UpdatedAt: tc.UpdatedAt,
+		ID:          tc.ID,
+		Active:      tc.Active,
+		Slug:        tc.Slug,
+		NdaFileName: ndaFileName,
+		CreatedAt:   tc.CreatedAt,
+		UpdatedAt:   tc.UpdatedAt,
 	}
 }

--- a/pkg/server/api/console/v1/types/trust_center_access.go
+++ b/pkg/server/api/console/v1/types/trust_center_access.go
@@ -23,12 +23,13 @@ type TrustCenterAccessOrderBy = OrderBy[coredata.TrustCenterAccessOrderField]
 
 func NewTrustCenterAccess(tca *coredata.TrustCenterAccess) *TrustCenterAccess {
 	return &TrustCenterAccess{
-		ID:        tca.ID,
-		Email:     tca.Email,
-		Name:      tca.Name,
-		Active:    tca.Active,
-		CreatedAt: tca.CreatedAt,
-		UpdatedAt: tca.UpdatedAt,
+		ID:                                tca.ID,
+		Email:                             tca.Email,
+		Name:                              tca.Name,
+		Active:                            tca.Active,
+		HasAcceptedNonDisclosureAgreement: tca.HasAcceptedNonDisclosureAgreement,
+		CreatedAt:                         tca.CreatedAt,
+		UpdatedAt:                         tca.UpdatedAt,
 	}
 }
 

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -828,6 +828,14 @@ type DeleteTrustCenterAccessPayload struct {
 	DeletedTrustCenterAccessID gid.GID `json:"deletedTrustCenterAccessId"`
 }
 
+type DeleteTrustCenterNDAInput struct {
+	TrustCenterID gid.GID `json:"trustCenterId"`
+}
+
+type DeleteTrustCenterNDAPayload struct {
+	TrustCenter *TrustCenter `json:"trustCenter"`
+}
+
 type DeleteVendorBusinessAssociateAgreementInput struct {
 	VendorID gid.GID `json:"vendorId"`
 }
@@ -1436,6 +1444,8 @@ type TrustCenter struct {
 	ID           gid.GID                      `json:"id"`
 	Active       bool                         `json:"active"`
 	Slug         string                       `json:"slug"`
+	NdaFileName  *string                      `json:"ndaFileName,omitempty"`
+	NdaFileURL   *string                      `json:"ndaFileUrl,omitempty"`
 	CreatedAt    time.Time                    `json:"createdAt"`
 	UpdatedAt    time.Time                    `json:"updatedAt"`
 	Organization *Organization                `json:"organization"`
@@ -1446,12 +1456,13 @@ func (TrustCenter) IsNode()             {}
 func (this TrustCenter) GetID() gid.GID { return this.ID }
 
 type TrustCenterAccess struct {
-	ID        gid.GID   `json:"id"`
-	Email     string    `json:"email"`
-	Name      string    `json:"name"`
-	Active    bool      `json:"active"`
-	CreatedAt time.Time `json:"createdAt"`
-	UpdatedAt time.Time `json:"updatedAt"`
+	ID                                gid.GID   `json:"id"`
+	Email                             string    `json:"email"`
+	Name                              string    `json:"name"`
+	Active                            bool      `json:"active"`
+	HasAcceptedNonDisclosureAgreement bool      `json:"hasAcceptedNonDisclosureAgreement"`
+	CreatedAt                         time.Time `json:"createdAt"`
+	UpdatedAt                         time.Time `json:"updatedAt"`
 }
 
 func (TrustCenterAccess) IsNode()             {}
@@ -1829,6 +1840,16 @@ type UploadTaskEvidenceInput struct {
 
 type UploadTaskEvidencePayload struct {
 	EvidenceEdge *EvidenceEdge `json:"evidenceEdge"`
+}
+
+type UploadTrustCenterNDAInput struct {
+	TrustCenterID gid.GID        `json:"trustCenterId"`
+	FileName      string         `json:"fileName"`
+	File          graphql.Upload `json:"file"`
+}
+
+type UploadTrustCenterNDAPayload struct {
+	TrustCenter *TrustCenter `json:"trustCenter"`
 }
 
 type UploadVendorBusinessAssociateAgreementInput struct {

--- a/pkg/server/api/trust/v1/auth/auth.go
+++ b/pkg/server/api/trust/v1/auth/auth.go
@@ -31,6 +31,10 @@ type TokenAccessData struct {
 	Scope         string
 }
 
+func (t *TokenAccessData) GetEmail() string {
+	return t.Email
+}
+
 type ContextAccessor interface {
 	UserFromContext(ctx context.Context) *coredata.User
 	TokenAccessFromContext(ctx context.Context) *TokenAccessData

--- a/pkg/server/api/trust/v1/schema.graphql
+++ b/pkg/server/api/trust/v1/schema.graphql
@@ -199,8 +199,11 @@ type TrustCenter implements Node {
   id: ID!
   active: Boolean!
   slug: String!
+  ndaFileName: String
+  ndaFileUrl: String @goField(forceResolver: true)
   organization: Organization! @goField(forceResolver: true)
   isUserAuthenticated: Boolean! @goField(forceResolver: true)
+  hasAcceptedNonDisclosureAgreement: Boolean! @goField(forceResolver: true)
 
   documents(
     first: Int
@@ -246,8 +249,16 @@ input ExportDocumentPDFInput {
   documentId: ID!
 }
 
+input AcceptNonDisclosureAgreementInput {
+  trustCenterId: ID!
+}
+
 type ExportDocumentPDFPayload {
   data: String!
+}
+
+type  AcceptNonDisclosureAgreementPayload{
+  success: Boolean!
 }
 
 type Query {
@@ -262,4 +273,8 @@ type Mutation {
   exportDocumentPDF(
     input: ExportDocumentPDFInput!
   ): ExportDocumentPDFPayload! @mustBeAuthenticated(role: USER)
+
+  acceptNonDisclosureAgreement(
+    input: AcceptNonDisclosureAgreementInput!
+  ): AcceptNonDisclosureAgreementPayload! @mustBeAuthenticated(role: USER)
 }

--- a/pkg/server/api/trust/v1/schema/schema.go
+++ b/pkg/server/api/trust/v1/schema/schema.go
@@ -57,6 +57,10 @@ type DirectiveRoot struct {
 }
 
 type ComplexityRoot struct {
+	AcceptNonDisclosureAgreementPayload struct {
+		Success func(childComplexity int) int
+	}
+
 	Audit struct {
 		Framework func(childComplexity int) int
 		ID        func(childComplexity int) int
@@ -103,8 +107,9 @@ type ComplexityRoot struct {
 	}
 
 	Mutation struct {
-		CreateTrustCenterAccess func(childComplexity int, input types.CreateTrustCenterAccessInput) int
-		ExportDocumentPDF       func(childComplexity int, input types.ExportDocumentPDFInput) int
+		AcceptNonDisclosureAgreement func(childComplexity int, input types.AcceptNonDisclosureAgreementInput) int
+		CreateTrustCenterAccess      func(childComplexity int, input types.CreateTrustCenterAccessInput) int
+		ExportDocumentPDF            func(childComplexity int, input types.ExportDocumentPDFInput) int
 	}
 
 	Organization struct {
@@ -131,14 +136,17 @@ type ComplexityRoot struct {
 	}
 
 	TrustCenter struct {
-		Active              func(childComplexity int) int
-		Audits              func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey) int
-		Documents           func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey) int
-		ID                  func(childComplexity int) int
-		IsUserAuthenticated func(childComplexity int) int
-		Organization        func(childComplexity int) int
-		Slug                func(childComplexity int) int
-		Vendors             func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey) int
+		Active                            func(childComplexity int) int
+		Audits                            func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey) int
+		Documents                         func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey) int
+		HasAcceptedNonDisclosureAgreement func(childComplexity int) int
+		ID                                func(childComplexity int) int
+		IsUserAuthenticated               func(childComplexity int) int
+		NdaFileName                       func(childComplexity int) int
+		NdaFileURL                        func(childComplexity int) int
+		Organization                      func(childComplexity int) int
+		Slug                              func(childComplexity int) int
+		Vendors                           func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey) int
 	}
 
 	TrustCenterAccess struct {
@@ -175,6 +183,7 @@ type AuditResolver interface {
 type MutationResolver interface {
 	CreateTrustCenterAccess(ctx context.Context, input types.CreateTrustCenterAccessInput) (*types.CreateTrustCenterAccessPayload, error)
 	ExportDocumentPDF(ctx context.Context, input types.ExportDocumentPDFInput) (*types.ExportDocumentPDFPayload, error)
+	AcceptNonDisclosureAgreement(ctx context.Context, input types.AcceptNonDisclosureAgreementInput) (*types.AcceptNonDisclosureAgreementPayload, error)
 }
 type OrganizationResolver interface {
 	LogoURL(ctx context.Context, obj *types.Organization) (*string, error)
@@ -186,8 +195,10 @@ type ReportResolver interface {
 	DownloadURL(ctx context.Context, obj *types.Report) (*string, error)
 }
 type TrustCenterResolver interface {
+	NdaFileURL(ctx context.Context, obj *types.TrustCenter) (*string, error)
 	Organization(ctx context.Context, obj *types.TrustCenter) (*types.Organization, error)
 	IsUserAuthenticated(ctx context.Context, obj *types.TrustCenter) (bool, error)
+	HasAcceptedNonDisclosureAgreement(ctx context.Context, obj *types.TrustCenter) (bool, error)
 	Documents(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.DocumentConnection, error)
 	Audits(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.AuditConnection, error)
 	Vendors(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.VendorConnection, error)
@@ -211,6 +222,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 	ec := executionContext{nil, e, 0, 0, nil}
 	_ = ec
 	switch typeName + "." + field {
+
+	case "AcceptNonDisclosureAgreementPayload.success":
+		if e.complexity.AcceptNonDisclosureAgreementPayload.Success == nil {
+			break
+		}
+
+		return e.complexity.AcceptNonDisclosureAgreementPayload.Success(childComplexity), true
 
 	case "Audit.framework":
 		if e.complexity.Audit.Framework == nil {
@@ -337,6 +355,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Framework.Name(childComplexity), true
+
+	case "Mutation.acceptNonDisclosureAgreement":
+		if e.complexity.Mutation.AcceptNonDisclosureAgreement == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_acceptNonDisclosureAgreement_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.AcceptNonDisclosureAgreement(childComplexity, args["input"].(types.AcceptNonDisclosureAgreementInput)), true
 
 	case "Mutation.createTrustCenterAccess":
 		if e.complexity.Mutation.CreateTrustCenterAccess == nil {
@@ -475,6 +505,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.TrustCenter.Documents(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey)), true
 
+	case "TrustCenter.hasAcceptedNonDisclosureAgreement":
+		if e.complexity.TrustCenter.HasAcceptedNonDisclosureAgreement == nil {
+			break
+		}
+
+		return e.complexity.TrustCenter.HasAcceptedNonDisclosureAgreement(childComplexity), true
+
 	case "TrustCenter.id":
 		if e.complexity.TrustCenter.ID == nil {
 			break
@@ -488,6 +525,20 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.TrustCenter.IsUserAuthenticated(childComplexity), true
+
+	case "TrustCenter.ndaFileName":
+		if e.complexity.TrustCenter.NdaFileName == nil {
+			break
+		}
+
+		return e.complexity.TrustCenter.NdaFileName(childComplexity), true
+
+	case "TrustCenter.ndaFileUrl":
+		if e.complexity.TrustCenter.NdaFileURL == nil {
+			break
+		}
+
+		return e.complexity.TrustCenter.NdaFileURL(childComplexity), true
 
 	case "TrustCenter.organization":
 		if e.complexity.TrustCenter.Organization == nil {
@@ -621,6 +672,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	opCtx := graphql.GetOperationContext(ctx)
 	ec := executionContext{opCtx, e, 0, 0, make(chan graphql.DeferredResult)}
 	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
+		ec.unmarshalInputAcceptNonDisclosureAgreementInput,
 		ec.unmarshalInputCreateTrustCenterAccessInput,
 		ec.unmarshalInputExportDocumentPDFInput,
 	)
@@ -921,8 +973,11 @@ type TrustCenter implements Node {
   id: ID!
   active: Boolean!
   slug: String!
+  ndaFileName: String
+  ndaFileUrl: String @goField(forceResolver: true)
   organization: Organization! @goField(forceResolver: true)
   isUserAuthenticated: Boolean! @goField(forceResolver: true)
+  hasAcceptedNonDisclosureAgreement: Boolean! @goField(forceResolver: true)
 
   documents(
     first: Int
@@ -968,8 +1023,16 @@ input ExportDocumentPDFInput {
   documentId: ID!
 }
 
+input AcceptNonDisclosureAgreementInput {
+  trustCenterId: ID!
+}
+
 type ExportDocumentPDFPayload {
   data: String!
+}
+
+type  AcceptNonDisclosureAgreementPayload{
+  success: Boolean!
 }
 
 type Query {
@@ -984,6 +1047,10 @@ type Mutation {
   exportDocumentPDF(
     input: ExportDocumentPDFInput!
   ): ExportDocumentPDFPayload! @mustBeAuthenticated(role: USER)
+
+  acceptNonDisclosureAgreement(
+    input: AcceptNonDisclosureAgreementInput!
+  ): AcceptNonDisclosureAgreementPayload! @mustBeAuthenticated(role: USER)
 }
 `, BuiltIn: false},
 }
@@ -1018,6 +1085,29 @@ func (ec *executionContext) dir_mustBeAuthenticated_argsRole(
 	}
 
 	var zeroVal *types.Role
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_acceptNonDisclosureAgreement_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_acceptNonDisclosureAgreement_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_acceptNonDisclosureAgreement_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.AcceptNonDisclosureAgreementInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNAcceptNonDisclosureAgreementInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐAcceptNonDisclosureAgreementInput(ctx, tmp)
+	}
+
+	var zeroVal types.AcceptNonDisclosureAgreementInput
 	return zeroVal, nil
 }
 
@@ -1443,6 +1533,50 @@ func (ec *executionContext) field___Type_fields_argsIncludeDeprecated(
 // endregion ************************** directives.gotpl **************************
 
 // region    **************************** field.gotpl *****************************
+
+func (ec *executionContext) _AcceptNonDisclosureAgreementPayload_success(ctx context.Context, field graphql.CollectedField, obj *types.AcceptNonDisclosureAgreementPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AcceptNonDisclosureAgreementPayload_success(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Success, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AcceptNonDisclosureAgreementPayload_success(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AcceptNonDisclosureAgreementPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
 
 func (ec *executionContext) _Audit_id(ctx context.Context, field graphql.CollectedField, obj *types.Audit) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Audit_id(ctx, field)
@@ -2479,6 +2613,92 @@ func (ec *executionContext) fieldContext_Mutation_exportDocumentPDF(ctx context.
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_acceptNonDisclosureAgreement(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_acceptNonDisclosureAgreement(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		directive0 := func(rctx context.Context) (any, error) {
+			ctx = rctx // use context from middleware stack in children
+			return ec.resolvers.Mutation().AcceptNonDisclosureAgreement(rctx, fc.Args["input"].(types.AcceptNonDisclosureAgreementInput))
+		}
+
+		directive1 := func(ctx context.Context) (any, error) {
+			role, err := ec.unmarshalORole2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐRole(ctx, "USER")
+			if err != nil {
+				var zeroVal *types.AcceptNonDisclosureAgreementPayload
+				return zeroVal, err
+			}
+			if ec.directives.MustBeAuthenticated == nil {
+				var zeroVal *types.AcceptNonDisclosureAgreementPayload
+				return zeroVal, errors.New("directive mustBeAuthenticated is not implemented")
+			}
+			return ec.directives.MustBeAuthenticated(ctx, nil, directive0, role)
+		}
+
+		tmp, err := directive1(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.(*types.AcceptNonDisclosureAgreementPayload); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be *github.com/getprobo/probo/pkg/server/api/trust/v1/types.AcceptNonDisclosureAgreementPayload`, tmp)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.AcceptNonDisclosureAgreementPayload)
+	fc.Result = res
+	return ec.marshalNAcceptNonDisclosureAgreementPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐAcceptNonDisclosureAgreementPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_acceptNonDisclosureAgreement(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "success":
+				return ec.fieldContext_AcceptNonDisclosureAgreementPayload_success(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type AcceptNonDisclosureAgreementPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_acceptNonDisclosureAgreement_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Organization_id(ctx context.Context, field graphql.CollectedField, obj *types.Organization) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Organization_id(ctx, field)
 	if err != nil {
@@ -2847,10 +3067,16 @@ func (ec *executionContext) fieldContext_Query_trustCenterBySlug(ctx context.Con
 				return ec.fieldContext_TrustCenter_active(ctx, field)
 			case "slug":
 				return ec.fieldContext_TrustCenter_slug(ctx, field)
+			case "ndaFileName":
+				return ec.fieldContext_TrustCenter_ndaFileName(ctx, field)
+			case "ndaFileUrl":
+				return ec.fieldContext_TrustCenter_ndaFileUrl(ctx, field)
 			case "organization":
 				return ec.fieldContext_TrustCenter_organization(ctx, field)
 			case "isUserAuthenticated":
 				return ec.fieldContext_TrustCenter_isUserAuthenticated(ctx, field)
+			case "hasAcceptedNonDisclosureAgreement":
+				return ec.fieldContext_TrustCenter_hasAcceptedNonDisclosureAgreement(ctx, field)
 			case "documents":
 				return ec.fieldContext_TrustCenter_documents(ctx, field)
 			case "audits":
@@ -3294,6 +3520,88 @@ func (ec *executionContext) fieldContext_TrustCenter_slug(_ context.Context, fie
 	return fc, nil
 }
 
+func (ec *executionContext) _TrustCenter_ndaFileName(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenter) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenter_ndaFileName(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NdaFileName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenter_ndaFileName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenter",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenter_ndaFileUrl(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenter) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenter_ndaFileUrl(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TrustCenter().NdaFileURL(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenter_ndaFileUrl(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenter",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _TrustCenter_organization(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenter) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_TrustCenter_organization(ctx, field)
 	if err != nil {
@@ -3378,6 +3686,50 @@ func (ec *executionContext) _TrustCenter_isUserAuthenticated(ctx context.Context
 }
 
 func (ec *executionContext) fieldContext_TrustCenter_isUserAuthenticated(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenter",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenter_hasAcceptedNonDisclosureAgreement(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenter) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenter_hasAcceptedNonDisclosureAgreement(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TrustCenter().HasAcceptedNonDisclosureAgreement(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenter_hasAcceptedNonDisclosureAgreement(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "TrustCenter",
 		Field:      field,
@@ -6162,6 +6514,33 @@ func (ec *executionContext) fieldContext___Type_isOneOf(_ context.Context, field
 
 // region    **************************** input.gotpl *****************************
 
+func (ec *executionContext) unmarshalInputAcceptNonDisclosureAgreementInput(ctx context.Context, obj any) (types.AcceptNonDisclosureAgreementInput, error) {
+	var it types.AcceptNonDisclosureAgreementInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"trustCenterId"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "trustCenterId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("trustCenterId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.TrustCenterID = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputCreateTrustCenterAccessInput(ctx context.Context, obj any) (types.CreateTrustCenterAccessInput, error) {
 	var it types.CreateTrustCenterAccessInput
 	asMap := map[string]any{}
@@ -6302,6 +6681,45 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 // endregion ************************** interface.gotpl ***************************
 
 // region    **************************** object.gotpl ****************************
+
+var acceptNonDisclosureAgreementPayloadImplementors = []string{"AcceptNonDisclosureAgreementPayload"}
+
+func (ec *executionContext) _AcceptNonDisclosureAgreementPayload(ctx context.Context, sel ast.SelectionSet, obj *types.AcceptNonDisclosureAgreementPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, acceptNonDisclosureAgreementPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("AcceptNonDisclosureAgreementPayload")
+		case "success":
+			out.Values[i] = ec._AcceptNonDisclosureAgreementPayload_success(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
 
 var auditImplementors = []string{"Audit", "Node"}
 
@@ -6791,6 +7209,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "acceptNonDisclosureAgreement":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_acceptNonDisclosureAgreement(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -7111,6 +7536,41 @@ func (ec *executionContext) _TrustCenter(ctx context.Context, sel ast.SelectionS
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "ndaFileName":
+			out.Values[i] = ec._TrustCenter_ndaFileName(ctx, field, obj)
+		case "ndaFileUrl":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TrustCenter_ndaFileUrl(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "organization":
 			field := field
 
@@ -7157,6 +7617,42 @@ func (ec *executionContext) _TrustCenter(ctx context.Context, sel ast.SelectionS
 					}
 				}()
 				res = ec._TrustCenter_isUserAuthenticated(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "hasAcceptedNonDisclosureAgreement":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TrustCenter_hasAcceptedNonDisclosureAgreement(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -7848,6 +8344,25 @@ func (ec *executionContext) ___Type(ctx context.Context, sel ast.SelectionSet, o
 // endregion **************************** object.gotpl ****************************
 
 // region    ***************************** type.gotpl *****************************
+
+func (ec *executionContext) unmarshalNAcceptNonDisclosureAgreementInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐAcceptNonDisclosureAgreementInput(ctx context.Context, v any) (types.AcceptNonDisclosureAgreementInput, error) {
+	res, err := ec.unmarshalInputAcceptNonDisclosureAgreementInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNAcceptNonDisclosureAgreementPayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐAcceptNonDisclosureAgreementPayload(ctx context.Context, sel ast.SelectionSet, v types.AcceptNonDisclosureAgreementPayload) graphql.Marshaler {
+	return ec._AcceptNonDisclosureAgreementPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNAcceptNonDisclosureAgreementPayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐAcceptNonDisclosureAgreementPayload(ctx context.Context, sel ast.SelectionSet, v *types.AcceptNonDisclosureAgreementPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._AcceptNonDisclosureAgreementPayload(ctx, sel, v)
+}
 
 func (ec *executionContext) marshalNAudit2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐAudit(ctx context.Context, sel ast.SelectionSet, v *types.Audit) graphql.Marshaler {
 	if v == nil {

--- a/pkg/server/api/trust/v1/trust_center_access_handler.go
+++ b/pkg/server/api/trust/v1/trust_center_access_handler.go
@@ -109,15 +109,12 @@ func validateTrustCenterAccessToken(ctx context.Context, trustSvc *trust.Service
 		return nil, fmt.Errorf("cannot validate trust center access token: %w", err)
 	}
 
-	tenantID := token.Data.TrustCenterID.TenantID()
-	tenantSvc := trustSvc.WithTenant(tenantID)
-
-	accessData, err := tenantSvc.TrustCenterAccesses.ValidateToken(ctx, tokenString)
-	if err != nil {
+	tenantSvc := trustSvc.WithTenant(token.Data.TrustCenterID.TenantID())
+	if err := tenantSvc.TrustCenterAccesses.ValidateToken(ctx, token.Data.TrustCenterID, token.Data.Email); err != nil {
 		return nil, fmt.Errorf("cannot validate trust center access token: %w", err)
 	}
 
-	return accessData, nil
+	return &token.Data, nil
 }
 
 func trustCenterLogoutHandler(authCfg console_v1.AuthConfig, trustAuthCfg TrustAuthConfig) http.HandlerFunc {

--- a/pkg/server/api/trust/v1/types/trust_center.go
+++ b/pkg/server/api/trust/v1/types/trust_center.go
@@ -18,10 +18,16 @@ import (
 	"github.com/getprobo/probo/pkg/coredata"
 )
 
-func NewTrustCenter(tc *coredata.TrustCenter) *TrustCenter {
+func NewTrustCenter(tc *coredata.TrustCenter, file *coredata.File) *TrustCenter {
+	var ndaFileName *string
+	if file != nil {
+		ndaFileName = &file.FileName
+	}
+
 	return &TrustCenter{
-		ID:     tc.ID,
-		Active: tc.Active,
-		Slug:   tc.Slug,
+		ID:          tc.ID,
+		Active:      tc.Active,
+		Slug:        tc.Slug,
+		NdaFileName: ndaFileName,
 	}
 }

--- a/pkg/server/api/trust/v1/types/types.go
+++ b/pkg/server/api/trust/v1/types/types.go
@@ -19,6 +19,14 @@ type Node interface {
 	GetID() gid.GID
 }
 
+type AcceptNonDisclosureAgreementInput struct {
+	TrustCenterID gid.GID `json:"trustCenterId"`
+}
+
+type AcceptNonDisclosureAgreementPayload struct {
+	Success bool `json:"success"`
+}
+
 type Audit struct {
 	ID        gid.GID    `json:"id"`
 	Framework *Framework `json:"framework"`
@@ -115,14 +123,17 @@ func (Report) IsNode()             {}
 func (this Report) GetID() gid.GID { return this.ID }
 
 type TrustCenter struct {
-	ID                  gid.GID             `json:"id"`
-	Active              bool                `json:"active"`
-	Slug                string              `json:"slug"`
-	Organization        *Organization       `json:"organization"`
-	IsUserAuthenticated bool                `json:"isUserAuthenticated"`
-	Documents           *DocumentConnection `json:"documents"`
-	Audits              *AuditConnection    `json:"audits"`
-	Vendors             *VendorConnection   `json:"vendors"`
+	ID                                gid.GID             `json:"id"`
+	Active                            bool                `json:"active"`
+	Slug                              string              `json:"slug"`
+	NdaFileName                       *string             `json:"ndaFileName,omitempty"`
+	NdaFileURL                        *string             `json:"ndaFileUrl,omitempty"`
+	Organization                      *Organization       `json:"organization"`
+	IsUserAuthenticated               bool                `json:"isUserAuthenticated"`
+	HasAcceptedNonDisclosureAgreement bool                `json:"hasAcceptedNonDisclosureAgreement"`
+	Documents                         *DocumentConnection `json:"documents"`
+	Audits                            *AuditConnection    `json:"audits"`
+	Vendors                           *VendorConnection   `json:"vendors"`
 }
 
 func (TrustCenter) IsNode()             {}

--- a/pkg/trust/trust_center_service.go
+++ b/pkg/trust/trust_center_service.go
@@ -16,10 +16,14 @@ package trust
 
 import (
 	"context"
-
 	"fmt"
+	"net/url"
+	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/gid"
 	"go.gearno.de/kit/pg"
 )
 
@@ -50,4 +54,89 @@ func (s TrustCenterService) GetBySlug(
 	}
 
 	return trustCenter, nil
+}
+
+func (s TrustCenterService) Get(
+	ctx context.Context,
+	trustCenterID gid.GID,
+) (*coredata.TrustCenter, *coredata.File, error) {
+	var trustCenter *coredata.TrustCenter
+	var file *coredata.File
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			trustCenter = &coredata.TrustCenter{}
+			if err := trustCenter.LoadByID(ctx, conn, s.svc.scope, trustCenterID); err != nil {
+				return fmt.Errorf("cannot load trust center: %w", err)
+			}
+
+			if trustCenter.NonDisclosureAgreementFileID != nil {
+				file = &coredata.File{}
+				if err := file.LoadByID(ctx, conn, s.svc.scope, *trustCenter.NonDisclosureAgreementFileID); err != nil {
+					return fmt.Errorf("cannot load file: %w", err)
+				}
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot load trust center: %w", err)
+	}
+
+	return trustCenter, file, nil
+}
+
+func (s TrustCenterService) GenerateNDAFileURL(
+	ctx context.Context,
+	trustCenterID gid.GID,
+	expiresIn time.Duration,
+) (string, error) {
+	var file *coredata.File
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			trustCenter := &coredata.TrustCenter{}
+			if err := trustCenter.LoadByID(ctx, conn, s.svc.scope, trustCenterID); err != nil {
+				return fmt.Errorf("cannot load trust center: %w", err)
+			}
+
+			if trustCenter.NonDisclosureAgreementFileID == nil {
+				return fmt.Errorf("no NDA file found")
+			}
+
+			file = &coredata.File{}
+			if err := file.LoadByID(ctx, conn, s.svc.scope, *trustCenter.NonDisclosureAgreementFileID); err != nil {
+				return fmt.Errorf("cannot load file: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+
+	presignClient := s3.NewPresignClient(s.svc.s3)
+
+	encodedFilename := url.QueryEscape(file.FileName)
+	contentDisposition := fmt.Sprintf("attachment; filename=\"%s\"; filename*=UTF-8''%s",
+		encodedFilename, encodedFilename)
+
+	presignedReq, err := presignClient.PresignGetObject(ctx, &s3.GetObjectInput{
+		Bucket:                     aws.String(s.svc.bucket),
+		Key:                        aws.String(file.FileKey),
+		ResponseCacheControl:       aws.String("max-age=3600, public"),
+		ResponseContentDisposition: aws.String(contentDisposition),
+	}, func(opts *s3.PresignOptions) {
+		opts.Expires = expiresIn
+	})
+	if err != nil {
+		return "", fmt.Errorf("cannot presign GetObject request: %w", err)
+	}
+
+	return presignedReq.URL, nil
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds NDA support to the Trust Center: admins can upload/delete an NDA, and authenticated visitors must review and accept it before viewing content. Acceptance is tracked per access and surfaced in the console.

- New Features
  - Console: upload/delete Trust Center NDA; show NDA file name; display “NDA accepted” status in Access tab.
  - Public: NDA acceptance dialog with download link; cannot close until accepted; grants access after acceptance.
  - GraphQL: TrustCenter.ndaFileName/ndaFileUrl; uploadTrustCenterNDA/deleteTrustCenterNDA mutations; TrustCenterAccess.hasAcceptedNonDisclosureAgreement; public acceptNonDisclosureAgreement mutation.
  - Backend: stores NDA file (FK to files), returns signed URL, records acceptance with metadata (incl. IP).

- Migration
  - Run DB migrations to add NDA file and acceptance columns.

<!-- End of auto-generated description by cubic. -->

