### PR TITLE
Send framework export by email

### DIFF
--- a/pkg/coredata/framework_export.go
+++ b/pkg/coredata/framework_export.go
@@ -29,13 +29,15 @@ import (
 
 type (
 	FrameworkExport struct {
-		ID          gid.GID               `db:"id"`
-		FrameworkID gid.GID               `db:"framework_id"`
-		Status      FrameworkExportStatus `db:"status"`
-		FileID      *gid.GID              `db:"file_id"`
-		CreatedAt   time.Time             `db:"created_at"`
-		StartedAt   *time.Time            `db:"started_at"`
-		CompletedAt *time.Time            `db:"completed_at"`
+		ID             gid.GID               `db:"id"`
+		FrameworkID    gid.GID               `db:"framework_id"`
+		RecipientEmail string                `db:"recipient_email"`
+		RecipientName  string                `db:"recipient_name"`
+		Status         FrameworkExportStatus `db:"status"`
+		FileID         *gid.GID              `db:"file_id"`
+		CreatedAt      time.Time             `db:"created_at"`
+		StartedAt      *time.Time            `db:"started_at"`
+		CompletedAt    *time.Time            `db:"completed_at"`
 	}
 
 	FrameworkExports []*FrameworkExport
@@ -64,22 +66,28 @@ INSERT INTO framework_exports (
 	id,
 	tenant_id,
 	framework_id,
+	recipient_email,
+	recipient_name,
 	status,
 	created_at
 ) VALUES (
 	@id,
 	@tenant_id,
 	@framework_id,
+	@recipient_email,
+	@recipient_name,
 	@status,
 	@created_at
 )`
 
 	args := pgx.StrictNamedArgs{
-		"id":           fe.ID,
-		"tenant_id":    scope.GetTenantID(),
-		"framework_id": fe.FrameworkID,
-		"status":       fe.Status,
-		"created_at":   fe.CreatedAt,
+		"id":              fe.ID,
+		"tenant_id":       scope.GetTenantID(),
+		"framework_id":    fe.FrameworkID,
+		"recipient_email": fe.RecipientEmail,
+		"recipient_name":  fe.RecipientName,
+		"status":          fe.Status,
+		"created_at":      fe.CreatedAt,
 	}
 
 	_, err := conn.Exec(ctx, q, args)
@@ -127,6 +135,8 @@ func (fe *FrameworkExport) LoadNextPendingForUpdateSkipLocked(
 SELECT
 	id,
 	framework_id,
+	recipient_email,
+	recipient_name,
 	status,
 	file_id,
 	created_at,

--- a/pkg/coredata/migrations/20250911T114906Z.sql
+++ b/pkg/coredata/migrations/20250911T114906Z.sql
@@ -1,0 +1,7 @@
+ALTER TABLE framework_exports ADD COLUMN recipient_email CITEXT NOT NULL DEFAULT '';
+
+ALTER TABLE framework_exports ALTER COLUMN recipient_email DROP DEFAULT;
+
+ALTER TABLE framework_exports ADD COLUMN recipient_name TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE framework_exports ALTER COLUMN recipient_name DROP DEFAULT;

--- a/pkg/server/api/console/v1/v1_resolver.go
+++ b/pkg/server/api/console/v1/v1_resolver.go
@@ -1626,7 +1626,18 @@ func (r *mutationResolver) GenerateFrameworkStateOfApplicability(ctx context.Con
 // ExportFramework is the resolver for the exportFramework field.
 func (r *mutationResolver) ExportFramework(ctx context.Context, input types.ExportFrameworkInput) (*types.ExportFrameworkPayload, error) {
 	prb := r.ProboService(ctx, input.FrameworkID.TenantID())
-	err, exportJobID := prb.Frameworks.RequestExport(ctx, input.FrameworkID)
+
+	user := UserFromContext(ctx)
+	if user == nil {
+		panic(fmt.Errorf("user not found"))
+	}
+
+	err, exportJobID := prb.Frameworks.RequestExport(
+		ctx,
+		input.FrameworkID,
+		user.FullName,
+		user.EmailAddress,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("cannot export framework: %w", err)
 	}


### PR DESCRIPTION
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add email delivery for framework exports. Users can enter a recipient, and we send a download link when the export is ready.

- **New Features**
 - Backend saves recipient info and, on completion, emails a 24-hour presigned S3 link; export is marked completed after the email is queued with improved error handling.

- **Migration**
  - Run DB migration to add recipient_email and recipient_name to framework_exports.

<!-- End of auto-generated description by cubic. -->

