### PR TITLE
Test shipfox runner

### DIFF
--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   release-snapshot:
     name: "release-snapshot"
-    runs-on: "shipfox-2vcpu-ubuntu-2204"
+    runs-on: "shipfox-32vcpu-ubuntu-2204"
     permissions:
       contents: "read"
       packages: "write"
@@ -48,7 +48,7 @@ jobs:
 
   test:
     name: "test"
-    runs-on: "shipfox-2vcpu-ubuntu-2204"
+    runs-on: "shipfox-32vcpu-ubuntu-2204"
     permissions:
       contents: "read"
     steps:


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Switch GitHub Actions release-snapshot and test jobs to the Shipfox runner (shipfox-2vcpu-ubuntu-2204) to reduce build time and queueing. Replaces ubuntu-24.04/22.04 runners; no application code changes.

<!-- End of auto-generated description by cubic. -->

