### PR TITLE
Translation

### DIFF
--- a/apps/console/public/locales/en.json
+++ b/apps/console/public/locales/en.json
@@ -1,0 +1,3 @@
+{
+  "Hello": "Hello"
+}

--- a/apps/console/public/locales/fr.json
+++ b/apps/console/public/locales/fr.json
@@ -1,0 +1,3 @@
+{
+  "Hello": "Bonjour"
+}

--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -1,10 +1,28 @@
 import { RouterProvider } from "react-router";
 import { router } from "./routes";
 import { Toasts } from "@probo/ui";
+import { useLang } from "./providers/TranslatorProvider";
+import { useTranslate } from "@probo/i18n";
 
 export function App() {
+  const { setLang } = useLang();
+  const { __ } = useTranslate();
+
   return (
     <>
+      <div
+        style={{
+          position: "absolute",
+          top: 0,
+          right: 0,
+          padding: "1rem",
+          zIndex: 9999,
+        }}
+      >
+        <button onClick={() => setLang("en")}>English</button>
+        <button onClick={() => setLang("fr")}>French</button>
+      </div>
+      <h1>{__("Hello")}</h1>
       <RouterProvider router={router} />
       <Toasts />
     </>

--- a/apps/console/src/main.tsx
+++ b/apps/console/src/main.tsx
@@ -3,7 +3,10 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import { App } from "./App";
 import { RelayProvider } from "./providers/RelayProviders";
-import { TranslatorProvider } from "./providers/TranslatorProvider";
+import {
+  LangProvider,
+  TranslatorProvider,
+} from "./providers/TranslatorProvider";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const queryClient = new QueryClient({
@@ -18,9 +21,11 @@ createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <RelayProvider>
-        <TranslatorProvider>
-          <App />
-        </TranslatorProvider>
+        <LangProvider>
+          <TranslatorProvider>
+            <App />
+          </TranslatorProvider>
+        </LangProvider>
       </RelayProvider>
     </QueryClientProvider>
   </StrictMode>

--- a/apps/console/src/providers/TranslatorProvider.tsx
+++ b/apps/console/src/providers/TranslatorProvider.tsx
@@ -1,17 +1,47 @@
-import type { PropsWithChildren } from "react";
+import {
+  type PropsWithChildren,
+  useState,
+  createContext,
+  useContext,
+  useMemo,
+} from "react";
 import { TranslatorProvider as ProboTranslatorProvider } from "@probo/i18n";
 
-// TODO : implement a way to retrieve translations strings
-const loader = () => {
-  return Promise.resolve({} as Record<string, string>);
+const loader = (lang: string) => {
+  return fetch(`/locales/${lang}.json`).then((res) => res.json());
 };
+
+type Lang = "en" | "fr";
+
+type LangContextType = {
+  lang: Lang;
+  setLang: (lang: Lang) => void;
+};
+
+const LangContext = createContext<LangContextType>({
+  lang: "en",
+  setLang: () => {},
+});
+
+export function useLang() {
+  return useContext(LangContext);
+}
+
+export function LangProvider({ children }: PropsWithChildren) {
+  const [lang, setLang] = useState<Lang>("en");
+
+  const value = useMemo(() => ({ lang, setLang }), [lang]);
+
+  return <LangContext.Provider value={value}>{children}</LangContext.Provider>;
+}
 
 /**
  * Provider for the translator
  */
 export function TranslatorProvider({ children }: PropsWithChildren) {
+  const { lang } = useLang();
   return (
-    <ProboTranslatorProvider lang="en" loader={loader}>
+    <ProboTranslatorProvider lang={lang} loader={loader}>
       {children}
     </ProboTranslatorProvider>
   );


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add basic i18n with dynamic language switching between English and French. Translations load at runtime and the app now uses a LangProvider to manage the current language.

- **New Features**
  - Added en.json and fr.json under public/locales.
  - Introduced LangProvider/useLang to store and switch "en" | "fr".
  - Updated TranslatorProvider to fetch /locales/{lang}.json and use current lang.
  - Added simple language switcher in App.tsx and used useTranslate to render a translated string.

<!-- End of auto-generated description by cubic. -->

