### PR TITLE
Change trufflehog workflow permission

### DIFF
--- a/.github/workflows/secrets.yaml
+++ b/.github/workflows/secrets.yaml
@@ -6,6 +6,9 @@ on:
       - "main"
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   scan:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add read-only contents permission to the TruffleHog secrets scan workflow so it runs with a minimal-scope token. This hardens security and avoids unintended write access during scans.

<!-- End of auto-generated description by cubic. -->

