### PR TITLE
Display risk description

### DIFF
--- a/apps/console/src/pages/organizations/risks/RiskDetailPage.tsx
+++ b/apps/console/src/pages/organizations/risks/RiskDetailPage.tsx
@@ -140,8 +140,7 @@ export default function RiskDetailPage(props: Props) {
         )}
       </div>
 
-      <PageHeader title={risk.name} />
-
+      <PageHeader title={risk.name} description={risk.description} />
       <Tabs>
         <TabLink to={`${baseTabUrl}/overview`}>
           {__("Overview")}

--- a/apps/console/src/pages/organizations/risks/tabs/RiskOverviewTab.tsx
+++ b/apps/console/src/pages/organizations/risks/tabs/RiskOverviewTab.tsx
@@ -22,7 +22,7 @@ export default function RiskOverviewTab() {
 
   const risk = useFragment(overviewFragment, key);
   return (
-    <div className="grid grid-cols-2">
+    <div className="grid grid-cols-2 gap-4">
       <RiskOverview type="inherent" risk={risk} />
       <RiskOverview type="residual" risk={risk} />
     </div>


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Show the risk description under the title on the Risk Detail page so users see context at a glance. Also add spacing between the inherent and residual overview cards for better readability.

<!-- End of auto-generated description by cubic. -->

