### PR TITLE
Add fields to organization

### DIFF
--- a/apps/console/src/hooks/graph/__generated__/OrganizationGraph_ViewQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/OrganizationGraph_ViewQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6f19d3ea0d16b3f4418e85261e3e4915>>
+ * @generated SignedSource<<148c6dc2b419fa0611529004e0a3535a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -54,14 +54,21 @@ v3 = {
   "name": "name",
   "storageKey": null
 },
-v4 = [
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "email",
+  "storageKey": null
+},
+v5 = [
   {
     "kind": "Literal",
     "name": "first",
     "value": 100
   }
 ],
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -139,7 +146,29 @@ return {
               },
               {
                 "alias": null,
-                "args": (v4/*: any*/),
+                "args": null,
+                "kind": "ScalarField",
+                "name": "description",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "websiteUrl",
+                "storageKey": null
+              },
+              (v4/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "headquarterAddress",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": (v5/*: any*/),
                 "concreteType": "UserConnection",
                 "kind": "LinkedField",
                 "name": "users",
@@ -169,14 +198,8 @@ return {
                             "name": "fullName",
                             "storageKey": null
                           },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "email",
-                            "storageKey": null
-                          },
-                          (v5/*: any*/)
+                          (v4/*: any*/),
+                          (v6/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -188,7 +211,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v4/*: any*/),
+                "args": (v5/*: any*/),
                 "concreteType": "ConnectorConnection",
                 "kind": "LinkedField",
                 "name": "connectors",
@@ -219,7 +242,7 @@ return {
                             "name": "type",
                             "storageKey": null
                           },
-                          (v5/*: any*/)
+                          (v6/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -239,12 +262,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "3062be33ff59b816b10d098c083db370",
+    "cacheID": "c19271fc733cfb1de051ccdd98ae9bef",
     "id": null,
     "metadata": {},
     "name": "OrganizationGraph_ViewQuery",
     "operationKind": "query",
-    "text": "query OrganizationGraph_ViewQuery(\n  $organizationId: ID!\n) {\n  node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      id\n      name\n      ...SettingsPageFragment\n    }\n    id\n  }\n}\n\nfragment SettingsPageFragment on Organization {\n  id\n  name\n  logoUrl\n  users(first: 100) {\n    edges {\n      node {\n        id\n        fullName\n        email\n        createdAt\n      }\n    }\n  }\n  connectors(first: 100) {\n    edges {\n      node {\n        id\n        name\n        type\n        createdAt\n      }\n    }\n  }\n}\n"
+    "text": "query OrganizationGraph_ViewQuery(\n  $organizationId: ID!\n) {\n  node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      id\n      name\n      ...SettingsPageFragment\n    }\n    id\n  }\n}\n\nfragment SettingsPageFragment on Organization {\n  id\n  name\n  logoUrl\n  description\n  websiteUrl\n  email\n  headquarterAddress\n  users(first: 100) {\n    edges {\n      node {\n        id\n        fullName\n        email\n        createdAt\n      }\n    }\n  }\n  connectors(first: 100) {\n    edges {\n      node {\n        id\n        name\n        type\n        createdAt\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/apps/console/src/hooks/useTrustCenterQueries.ts
+++ b/apps/console/src/hooks/useTrustCenterQueries.ts
@@ -180,6 +180,10 @@ const TRUST_CENTER_QUERY = `
         id
         name
         logoUrl
+        description
+        websiteUrl
+        email
+        headquarterAddress
       }
       documents(first: 100) {
         edges {

--- a/apps/console/src/pages/organizations/__generated__/SettingsPageFragment.graphql.ts
+++ b/apps/console/src/pages/organizations/__generated__/SettingsPageFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e5b6c1db04175ebddb21379dfd331fc6>>
+ * @generated SignedSource<<c071187d5ef9cecb128621c57f97393b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -21,6 +21,9 @@ export type SettingsPageFragment$data = {
       };
     }>;
   };
+  readonly description: string | null | undefined;
+  readonly email: string | null | undefined;
+  readonly headquarterAddress: string | null | undefined;
   readonly id: string;
   readonly logoUrl: string | null | undefined;
   readonly name: string;
@@ -34,6 +37,7 @@ export type SettingsPageFragment$data = {
       };
     }>;
   };
+  readonly websiteUrl: string | null | undefined;
   readonly " $fragmentType": "SettingsPageFragment";
 };
 export type SettingsPageFragment$key = {
@@ -56,14 +60,21 @@ v1 = {
   "name": "name",
   "storageKey": null
 },
-v2 = [
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "email",
+  "storageKey": null
+},
+v3 = [
   {
     "kind": "Literal",
     "name": "first",
     "value": 100
   }
 ],
-v3 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -87,7 +98,29 @@ return {
     },
     {
       "alias": null,
-      "args": (v2/*: any*/),
+      "args": null,
+      "kind": "ScalarField",
+      "name": "description",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "websiteUrl",
+      "storageKey": null
+    },
+    (v2/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "headquarterAddress",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": (v3/*: any*/),
       "concreteType": "UserConnection",
       "kind": "LinkedField",
       "name": "users",
@@ -117,14 +150,8 @@ return {
                   "name": "fullName",
                   "storageKey": null
                 },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "email",
-                  "storageKey": null
-                },
-                (v3/*: any*/)
+                (v2/*: any*/),
+                (v4/*: any*/)
               ],
               "storageKey": null
             }
@@ -136,7 +163,7 @@ return {
     },
     {
       "alias": null,
-      "args": (v2/*: any*/),
+      "args": (v3/*: any*/),
       "concreteType": "ConnectorConnection",
       "kind": "LinkedField",
       "name": "connectors",
@@ -167,7 +194,7 @@ return {
                   "name": "type",
                   "storageKey": null
                 },
-                (v3/*: any*/)
+                (v4/*: any*/)
               ],
               "storageKey": null
             }
@@ -183,6 +210,6 @@ return {
 };
 })();
 
-(node as any).hash = "b7ee53afcaaa0406dceeda0427afdfef";
+(node as any).hash = "bdd548b7b3fa4c1cfef32569dc63d45d";
 
 export default node;

--- a/apps/console/src/pages/organizations/__generated__/SettingsPage_UpdateMutation.graphql.ts
+++ b/apps/console/src/pages/organizations/__generated__/SettingsPage_UpdateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6dc30c35c9ce7367967d235b1a259179>>
+ * @generated SignedSource<<892a78db951d547b53d595d219b94e75>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,9 +10,13 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 export type UpdateOrganizationInput = {
+  description?: string | null | undefined;
+  email?: string | null | undefined;
+  headquarterAddress?: string | null | undefined;
   logo?: any | null | undefined;
   name?: string | null | undefined;
   organizationId: string;
+  websiteUrl?: string | null | undefined;
 };
 export type SettingsPage_UpdateMutation$variables = {
   input: UpdateOrganizationInput;
@@ -20,9 +24,13 @@ export type SettingsPage_UpdateMutation$variables = {
 export type SettingsPage_UpdateMutation$data = {
   readonly updateOrganization: {
     readonly organization: {
+      readonly description: string | null | undefined;
+      readonly email: string | null | undefined;
+      readonly headquarterAddress: string | null | undefined;
       readonly id: string;
       readonly logoUrl: string | null | undefined;
       readonly name: string;
+      readonly websiteUrl: string | null | undefined;
     };
   };
 };
@@ -82,6 +90,34 @@ v1 = [
             "kind": "ScalarField",
             "name": "logoUrl",
             "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "description",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "websiteUrl",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "email",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "headquarterAddress",
+            "storageKey": null
           }
         ],
         "storageKey": null
@@ -108,16 +144,16 @@ return {
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "ac8d86332fabe20dd7ea8fef4207b75e",
+    "cacheID": "3526d270f311db33e0563abc99c96978",
     "id": null,
     "metadata": {},
     "name": "SettingsPage_UpdateMutation",
     "operationKind": "mutation",
-    "text": "mutation SettingsPage_UpdateMutation(\n  $input: UpdateOrganizationInput!\n) {\n  updateOrganization(input: $input) {\n    organization {\n      id\n      name\n      logoUrl\n    }\n  }\n}\n"
+    "text": "mutation SettingsPage_UpdateMutation(\n  $input: UpdateOrganizationInput!\n) {\n  updateOrganization(input: $input) {\n    organization {\n      id\n      name\n      logoUrl\n      description\n      websiteUrl\n      email\n      headquarterAddress\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "85f76939223253c1d102d05cd74f7538";
+(node as any).hash = "54949158defa7f1bb8e1e578db7cd7be";
 
 export default node;

--- a/pkg/coredata/migrations/20250919T121111Z.sql
+++ b/pkg/coredata/migrations/20250919T121111Z.sql
@@ -1,0 +1,5 @@
+ALTER TABLE organizations
+    ADD COLUMN description TEXT,
+    ADD COLUMN website_url TEXT,
+    ADD COLUMN email CITEXT,
+    ADD COLUMN headquarter_address TEXT;

--- a/pkg/coredata/organization.go
+++ b/pkg/coredata/organization.go
@@ -28,12 +28,16 @@ import (
 
 type (
 	Organization struct {
-		ID            gid.GID      `db:"id"`
-		TenantID      gid.TenantID `db:"tenant_id"`
-		Name          string       `db:"name"`
-		LogoObjectKey string       `db:"logo_object_key"`
-		CreatedAt     time.Time    `db:"created_at"`
-		UpdatedAt     time.Time    `db:"updated_at"`
+		ID                 gid.GID      `db:"id"`
+		TenantID           gid.TenantID `db:"tenant_id"`
+		Name               string       `db:"name"`
+		LogoObjectKey      string       `db:"logo_object_key"`
+		Description        *string      `db:"description"`
+		WebsiteURL         *string      `db:"website_url"`
+		Email              *string      `db:"email"`
+		HeadquarterAddress *string      `db:"headquarter_address"`
+		CreatedAt          time.Time    `db:"created_at"`
+		UpdatedAt          time.Time    `db:"updated_at"`
 	}
 
 	Organizations []*Organization
@@ -64,6 +68,10 @@ SELECT
     id,
     name,
     logo_object_key,
+    description,
+    website_url,
+    email,
+    headquarter_address,
     created_at,
     updated_at
 FROM
@@ -115,6 +123,10 @@ SELECT
     id,
     name,
     logo_object_key,
+    description,
+    website_url,
+    email,
+    headquarter_address,
     created_at,
     updated_at
 FROM
@@ -155,18 +167,26 @@ INSERT INTO organizations (
     id,
     name,
     logo_object_key,
+    description,
+    website_url,
+    email,
+    headquarter_address,
     created_at,
     updated_at
-) VALUES (@tenant_id, @id, @name, @logo_object_key, @created_at, @updated_at)
+) VALUES (@tenant_id, @id, @name, @logo_object_key, @description, @website_url, @email, @headquarter_address, @created_at, @updated_at)
 `
 
 	args := pgx.StrictNamedArgs{
-		"tenant_id":       o.TenantID,
-		"id":              o.ID,
-		"name":            o.Name,
-		"logo_object_key": o.LogoObjectKey,
-		"created_at":      o.CreatedAt,
-		"updated_at":      o.UpdatedAt,
+		"tenant_id":           o.TenantID,
+		"id":                  o.ID,
+		"name":                o.Name,
+		"logo_object_key":     o.LogoObjectKey,
+		"description":         o.Description,
+		"website_url":         o.WebsiteURL,
+		"email":               o.Email,
+		"headquarter_address": o.HeadquarterAddress,
+		"created_at":          o.CreatedAt,
+		"updated_at":          o.UpdatedAt,
 	}
 
 	_, err := conn.Exec(ctx, q, args)
@@ -187,6 +207,10 @@ UPDATE organizations
 SET
     name = @name,
     logo_object_key = @logo_object_key,
+    description = @description,
+    website_url = @website_url,
+    email = @email,
+    headquarter_address = @headquarter_address,
     updated_at = @updated_at
 WHERE
     %s
@@ -196,10 +220,14 @@ WHERE
 	q = fmt.Sprintf(q, scope.SQLFragment())
 
 	args := pgx.StrictNamedArgs{
-		"id":              o.ID,
-		"name":            o.Name,
-		"logo_object_key": o.LogoObjectKey,
-		"updated_at":      o.UpdatedAt,
+		"id":                  o.ID,
+		"name":                o.Name,
+		"logo_object_key":     o.LogoObjectKey,
+		"description":         o.Description,
+		"website_url":         o.WebsiteURL,
+		"email":               o.Email,
+		"headquarter_address": o.HeadquarterAddress,
+		"updated_at":          o.UpdatedAt,
 	}
 
 	maps.Copy(args, scope.SQLArguments())

--- a/pkg/probo/organization_service.go
+++ b/pkg/probo/organization_service.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"mime"
+	"net/mail"
 	"net/url"
 	"path/filepath"
 	"time"
@@ -67,9 +68,13 @@ type (
 	}
 
 	UpdateOrganizationRequest struct {
-		ID   gid.GID
-		Name *string
-		File *File
+		ID                 gid.GID
+		Name               *string
+		File               *File
+		Description        **string
+		WebsiteURL         **string
+		Email              **string
+		HeadquarterAddress **string
 	}
 )
 
@@ -166,6 +171,27 @@ func (s OrganizationService) Update(
 
 			if req.Name != nil {
 				organization.Name = *req.Name
+			}
+
+			if req.Description != nil {
+				organization.Description = *req.Description
+			}
+
+			if req.WebsiteURL != nil {
+				organization.WebsiteURL = *req.WebsiteURL
+			}
+
+			if req.Email != nil {
+				if *req.Email != nil {
+					if _, err := mail.ParseAddress(**req.Email); err != nil {
+						return fmt.Errorf("invalid email address: %w", err)
+					}
+				}
+				organization.Email = *req.Email
+			}
+
+			if req.HeadquarterAddress != nil {
+				organization.HeadquarterAddress = *req.HeadquarterAddress
 			}
 
 			if req.File != nil {

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -1420,6 +1420,11 @@ type Organization implements Node {
   name: String!
   logoUrl: String @goField(forceResolver: true)
 
+  description: String
+  websiteUrl: String
+  email: String
+  headquarterAddress: String
+
   users(
     first: Int
     after: CursorKey
@@ -2765,6 +2770,10 @@ input UpdateOrganizationInput {
   organizationId: ID!
   name: String
   logo: Upload
+  description: String
+  websiteUrl: String
+  email: String
+  headquarterAddress: String
 }
 
 input DeleteOrganizationInput {

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -902,8 +902,11 @@ type ComplexityRoot struct {
 		Controls              func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ControlOrderBy, filter *types.ControlFilter) int
 		CreatedAt             func(childComplexity int) int
 		Data                  func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DatumOrderBy, filter *types.DatumFilter) int
+		Description           func(childComplexity int) int
 		Documents             func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy, filter *types.DocumentFilter) int
+		Email                 func(childComplexity int) int
 		Frameworks            func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.FrameworkOrderBy) int
+		HeadquarterAddress    func(childComplexity int) int
 		ID                    func(childComplexity int) int
 		LogoURL               func(childComplexity int) int
 		Measures              func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy, filter *types.MeasureFilter) int
@@ -919,6 +922,7 @@ type ComplexityRoot struct {
 		UpdatedAt             func(childComplexity int) int
 		Users                 func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.UserOrderBy) int
 		Vendors               func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.VendorOrderBy, filter *types.VendorFilter) int
+		WebsiteURL            func(childComplexity int) int
 	}
 
 	OrganizationConnection struct {
@@ -1698,6 +1702,7 @@ type ObligationConnectionResolver interface {
 }
 type OrganizationResolver interface {
 	LogoURL(ctx context.Context, obj *types.Organization) (*string, error)
+
 	Users(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.UserOrderBy) (*types.UserConnection, error)
 	Connectors(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ConnectorOrder) (*types.ConnectorConnection, error)
 	Frameworks(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.FrameworkOrderBy) (*types.FrameworkConnection, error)
@@ -5583,6 +5588,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Organization.Data(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.DatumOrderBy), args["filter"].(*types.DatumFilter)), true
 
+	case "Organization.description":
+		if e.complexity.Organization.Description == nil {
+			break
+		}
+
+		return e.complexity.Organization.Description(childComplexity), true
+
 	case "Organization.documents":
 		if e.complexity.Organization.Documents == nil {
 			break
@@ -5595,6 +5607,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Organization.Documents(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.DocumentOrderBy), args["filter"].(*types.DocumentFilter)), true
 
+	case "Organization.email":
+		if e.complexity.Organization.Email == nil {
+			break
+		}
+
+		return e.complexity.Organization.Email(childComplexity), true
+
 	case "Organization.frameworks":
 		if e.complexity.Organization.Frameworks == nil {
 			break
@@ -5606,6 +5625,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Organization.Frameworks(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.FrameworkOrderBy)), true
+
+	case "Organization.headquarterAddress":
+		if e.complexity.Organization.HeadquarterAddress == nil {
+			break
+		}
+
+		return e.complexity.Organization.HeadquarterAddress(childComplexity), true
 
 	case "Organization.id":
 		if e.complexity.Organization.ID == nil {
@@ -5761,6 +5787,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Organization.Vendors(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.VendorOrderBy), args["filter"].(*types.VendorFilter)), true
+
+	case "Organization.websiteUrl":
+		if e.complexity.Organization.WebsiteURL == nil {
+			break
+		}
+
+		return e.complexity.Organization.WebsiteURL(childComplexity), true
 
 	case "OrganizationConnection.edges":
 		if e.complexity.OrganizationConnection.Edges == nil {
@@ -9553,6 +9586,11 @@ type Organization implements Node {
   name: String!
   logoUrl: String @goField(forceResolver: true)
 
+  description: String
+  websiteUrl: String
+  email: String
+  headquarterAddress: String
+
   users(
     first: Int
     after: CursorKey
@@ -10898,6 +10936,10 @@ input UpdateOrganizationInput {
   organizationId: ID!
   name: String
   logo: Upload
+  description: String
+  websiteUrl: String
+  email: String
+  headquarterAddress: String
 }
 
 input DeleteOrganizationInput {
@@ -20309,6 +20351,14 @@ func (ec *executionContext) fieldContext_Asset_organization(_ context.Context, f
 				return ec.fieldContext_Organization_name(ctx, field)
 			case "logoUrl":
 				return ec.fieldContext_Organization_logoUrl(ctx, field)
+			case "description":
+				return ec.fieldContext_Organization_description(ctx, field)
+			case "websiteUrl":
+				return ec.fieldContext_Organization_websiteUrl(ctx, field)
+			case "email":
+				return ec.fieldContext_Organization_email(ctx, field)
+			case "headquarterAddress":
+				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
 			case "users":
 				return ec.fieldContext_Organization_users(ctx, field)
 			case "connectors":
@@ -20908,6 +20958,14 @@ func (ec *executionContext) fieldContext_Audit_organization(_ context.Context, f
 				return ec.fieldContext_Organization_name(ctx, field)
 			case "logoUrl":
 				return ec.fieldContext_Organization_logoUrl(ctx, field)
+			case "description":
+				return ec.fieldContext_Organization_description(ctx, field)
+			case "websiteUrl":
+				return ec.fieldContext_Organization_websiteUrl(ctx, field)
+			case "email":
+				return ec.fieldContext_Organization_email(ctx, field)
+			case "headquarterAddress":
+				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
 			case "users":
 				return ec.fieldContext_Organization_users(ctx, field)
 			case "connectors":
@@ -22623,6 +22681,14 @@ func (ec *executionContext) fieldContext_ContinualImprovement_organization(_ con
 				return ec.fieldContext_Organization_name(ctx, field)
 			case "logoUrl":
 				return ec.fieldContext_Organization_logoUrl(ctx, field)
+			case "description":
+				return ec.fieldContext_Organization_description(ctx, field)
+			case "websiteUrl":
+				return ec.fieldContext_Organization_websiteUrl(ctx, field)
+			case "email":
+				return ec.fieldContext_Organization_email(ctx, field)
+			case "headquarterAddress":
+				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
 			case "users":
 				return ec.fieldContext_Organization_users(ctx, field)
 			case "connectors":
@@ -26417,6 +26483,14 @@ func (ec *executionContext) fieldContext_Datum_organization(_ context.Context, f
 				return ec.fieldContext_Organization_name(ctx, field)
 			case "logoUrl":
 				return ec.fieldContext_Organization_logoUrl(ctx, field)
+			case "description":
+				return ec.fieldContext_Organization_description(ctx, field)
+			case "websiteUrl":
+				return ec.fieldContext_Organization_websiteUrl(ctx, field)
+			case "email":
+				return ec.fieldContext_Organization_email(ctx, field)
+			case "headquarterAddress":
+				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
 			case "users":
 				return ec.fieldContext_Organization_users(ctx, field)
 			case "connectors":
@@ -28946,6 +29020,14 @@ func (ec *executionContext) fieldContext_Document_organization(_ context.Context
 				return ec.fieldContext_Organization_name(ctx, field)
 			case "logoUrl":
 				return ec.fieldContext_Organization_logoUrl(ctx, field)
+			case "description":
+				return ec.fieldContext_Organization_description(ctx, field)
+			case "websiteUrl":
+				return ec.fieldContext_Organization_websiteUrl(ctx, field)
+			case "email":
+				return ec.fieldContext_Organization_email(ctx, field)
+			case "headquarterAddress":
+				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
 			case "users":
 				return ec.fieldContext_Organization_users(ctx, field)
 			case "connectors":
@@ -32161,6 +32243,14 @@ func (ec *executionContext) fieldContext_Framework_organization(_ context.Contex
 				return ec.fieldContext_Organization_name(ctx, field)
 			case "logoUrl":
 				return ec.fieldContext_Organization_logoUrl(ctx, field)
+			case "description":
+				return ec.fieldContext_Organization_description(ctx, field)
+			case "websiteUrl":
+				return ec.fieldContext_Organization_websiteUrl(ctx, field)
+			case "email":
+				return ec.fieldContext_Organization_email(ctx, field)
+			case "headquarterAddress":
+				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
 			case "users":
 				return ec.fieldContext_Organization_users(ctx, field)
 			case "connectors":
@@ -40542,6 +40632,14 @@ func (ec *executionContext) fieldContext_Nonconformity_organization(_ context.Co
 				return ec.fieldContext_Organization_name(ctx, field)
 			case "logoUrl":
 				return ec.fieldContext_Organization_logoUrl(ctx, field)
+			case "description":
+				return ec.fieldContext_Organization_description(ctx, field)
+			case "websiteUrl":
+				return ec.fieldContext_Organization_websiteUrl(ctx, field)
+			case "email":
+				return ec.fieldContext_Organization_email(ctx, field)
+			case "headquarterAddress":
+				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
 			case "users":
 				return ec.fieldContext_Organization_users(ctx, field)
 			case "connectors":
@@ -41593,6 +41691,14 @@ func (ec *executionContext) fieldContext_Obligation_organization(_ context.Conte
 				return ec.fieldContext_Organization_name(ctx, field)
 			case "logoUrl":
 				return ec.fieldContext_Organization_logoUrl(ctx, field)
+			case "description":
+				return ec.fieldContext_Organization_description(ctx, field)
+			case "websiteUrl":
+				return ec.fieldContext_Organization_websiteUrl(ctx, field)
+			case "email":
+				return ec.fieldContext_Organization_email(ctx, field)
+			case "headquarterAddress":
+				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
 			case "users":
 				return ec.fieldContext_Organization_users(ctx, field)
 			case "connectors":
@@ -42563,6 +42669,170 @@ func (ec *executionContext) fieldContext_Organization_logoUrl(_ context.Context,
 		Field:      field,
 		IsMethod:   true,
 		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Organization_description(ctx context.Context, field graphql.CollectedField, obj *types.Organization) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Organization_description(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Description, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Organization_description(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Organization",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Organization_websiteUrl(ctx context.Context, field graphql.CollectedField, obj *types.Organization) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Organization_websiteUrl(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.WebsiteURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Organization_websiteUrl(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Organization",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Organization_email(ctx context.Context, field graphql.CollectedField, obj *types.Organization) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Organization_email(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Email, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Organization_email(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Organization",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Organization_headquarterAddress(ctx context.Context, field graphql.CollectedField, obj *types.Organization) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Organization_headquarterAddress(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.HeadquarterAddress, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Organization_headquarterAddress(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Organization",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
 		},
@@ -44042,6 +44312,14 @@ func (ec *executionContext) fieldContext_OrganizationEdge_node(_ context.Context
 				return ec.fieldContext_Organization_name(ctx, field)
 			case "logoUrl":
 				return ec.fieldContext_Organization_logoUrl(ctx, field)
+			case "description":
+				return ec.fieldContext_Organization_description(ctx, field)
+			case "websiteUrl":
+				return ec.fieldContext_Organization_websiteUrl(ctx, field)
+			case "email":
+				return ec.fieldContext_Organization_email(ctx, field)
+			case "headquarterAddress":
+				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
 			case "users":
 				return ec.fieldContext_Organization_users(ctx, field)
 			case "connectors":
@@ -45121,6 +45399,14 @@ func (ec *executionContext) fieldContext_ProcessingActivity_organization(_ conte
 				return ec.fieldContext_Organization_name(ctx, field)
 			case "logoUrl":
 				return ec.fieldContext_Organization_logoUrl(ctx, field)
+			case "description":
+				return ec.fieldContext_Organization_description(ctx, field)
+			case "websiteUrl":
+				return ec.fieldContext_Organization_websiteUrl(ctx, field)
+			case "email":
+				return ec.fieldContext_Organization_email(ctx, field)
+			case "headquarterAddress":
+				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
 			case "users":
 				return ec.fieldContext_Organization_users(ctx, field)
 			case "connectors":
@@ -47721,6 +48007,14 @@ func (ec *executionContext) fieldContext_Risk_organization(_ context.Context, fi
 				return ec.fieldContext_Organization_name(ctx, field)
 			case "logoUrl":
 				return ec.fieldContext_Organization_logoUrl(ctx, field)
+			case "description":
+				return ec.fieldContext_Organization_description(ctx, field)
+			case "websiteUrl":
+				return ec.fieldContext_Organization_websiteUrl(ctx, field)
+			case "email":
+				return ec.fieldContext_Organization_email(ctx, field)
+			case "headquarterAddress":
+				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
 			case "users":
 				return ec.fieldContext_Organization_users(ctx, field)
 			case "connectors":
@@ -48546,6 +48840,14 @@ func (ec *executionContext) fieldContext_Snapshot_organization(_ context.Context
 				return ec.fieldContext_Organization_name(ctx, field)
 			case "logoUrl":
 				return ec.fieldContext_Organization_logoUrl(ctx, field)
+			case "description":
+				return ec.fieldContext_Organization_description(ctx, field)
+			case "websiteUrl":
+				return ec.fieldContext_Organization_websiteUrl(ctx, field)
+			case "email":
+				return ec.fieldContext_Organization_email(ctx, field)
+			case "headquarterAddress":
+				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
 			case "users":
 				return ec.fieldContext_Organization_users(ctx, field)
 			case "connectors":
@@ -49449,6 +49751,14 @@ func (ec *executionContext) fieldContext_Task_organization(_ context.Context, fi
 				return ec.fieldContext_Organization_name(ctx, field)
 			case "logoUrl":
 				return ec.fieldContext_Organization_logoUrl(ctx, field)
+			case "description":
+				return ec.fieldContext_Organization_description(ctx, field)
+			case "websiteUrl":
+				return ec.fieldContext_Organization_websiteUrl(ctx, field)
+			case "email":
+				return ec.fieldContext_Organization_email(ctx, field)
+			case "headquarterAddress":
+				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
 			case "users":
 				return ec.fieldContext_Organization_users(ctx, field)
 			case "connectors":
@@ -50323,6 +50633,14 @@ func (ec *executionContext) fieldContext_TrustCenter_organization(_ context.Cont
 				return ec.fieldContext_Organization_name(ctx, field)
 			case "logoUrl":
 				return ec.fieldContext_Organization_logoUrl(ctx, field)
+			case "description":
+				return ec.fieldContext_Organization_description(ctx, field)
+			case "websiteUrl":
+				return ec.fieldContext_Organization_websiteUrl(ctx, field)
+			case "email":
+				return ec.fieldContext_Organization_email(ctx, field)
+			case "headquarterAddress":
+				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
 			case "users":
 				return ec.fieldContext_Organization_users(ctx, field)
 			case "connectors":
@@ -52050,6 +52368,14 @@ func (ec *executionContext) fieldContext_UpdateOrganizationPayload_organization(
 				return ec.fieldContext_Organization_name(ctx, field)
 			case "logoUrl":
 				return ec.fieldContext_Organization_logoUrl(ctx, field)
+			case "description":
+				return ec.fieldContext_Organization_description(ctx, field)
+			case "websiteUrl":
+				return ec.fieldContext_Organization_websiteUrl(ctx, field)
+			case "email":
+				return ec.fieldContext_Organization_email(ctx, field)
+			case "headquarterAddress":
+				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
 			case "users":
 				return ec.fieldContext_Organization_users(ctx, field)
 			case "connectors":
@@ -54062,6 +54388,14 @@ func (ec *executionContext) fieldContext_Vendor_organization(_ context.Context, 
 				return ec.fieldContext_Organization_name(ctx, field)
 			case "logoUrl":
 				return ec.fieldContext_Organization_logoUrl(ctx, field)
+			case "description":
+				return ec.fieldContext_Organization_description(ctx, field)
+			case "websiteUrl":
+				return ec.fieldContext_Organization_websiteUrl(ctx, field)
+			case "email":
+				return ec.fieldContext_Organization_email(ctx, field)
+			case "headquarterAddress":
+				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
 			case "users":
 				return ec.fieldContext_Organization_users(ctx, field)
 			case "connectors":
@@ -66432,7 +66766,7 @@ func (ec *executionContext) unmarshalInputUpdateOrganizationInput(ctx context.Co
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"organizationId", "name", "logo"}
+	fieldsInOrder := [...]string{"organizationId", "name", "logo", "description", "websiteUrl", "email", "headquarterAddress"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -66460,6 +66794,34 @@ func (ec *executionContext) unmarshalInputUpdateOrganizationInput(ctx context.Co
 				return it, err
 			}
 			it.Logo = data
+		case "description":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Description = data
+		case "websiteUrl":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("websiteUrl"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.WebsiteURL = data
+		case "email":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("email"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Email = data
+		case "headquarterAddress":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("headquarterAddress"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.HeadquarterAddress = data
 		}
 	}
 
@@ -76214,6 +76576,14 @@ func (ec *executionContext) _Organization(ctx context.Context, sel ast.Selection
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "description":
+			out.Values[i] = ec._Organization_description(ctx, field, obj)
+		case "websiteUrl":
+			out.Values[i] = ec._Organization_websiteUrl(ctx, field, obj)
+		case "email":
+			out.Values[i] = ec._Organization_email(ctx, field, obj)
+		case "headquarterAddress":
+			out.Values[i] = ec._Organization_headquarterAddress(ctx, field, obj)
 		case "users":
 			field := field
 

--- a/pkg/server/api/console/v1/types/organization.go
+++ b/pkg/server/api/console/v1/types/organization.go
@@ -45,9 +45,13 @@ func NewOrganizationEdge(o *coredata.Organization, orderBy coredata.Organization
 
 func NewOrganization(o *coredata.Organization) *Organization {
 	return &Organization{
-		ID:        o.ID,
-		Name:      o.Name,
-		CreatedAt: o.CreatedAt,
-		UpdatedAt: o.UpdatedAt,
+		ID:                 o.ID,
+		Name:               o.Name,
+		Description:        o.Description,
+		WebsiteURL:         o.WebsiteURL,
+		Email:              o.Email,
+		HeadquarterAddress: o.HeadquarterAddress,
+		CreatedAt:          o.CreatedAt,
+		UpdatedAt:          o.UpdatedAt,
 	}
 }

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -1198,6 +1198,10 @@ type Organization struct {
 	ID                    gid.GID                         `json:"id"`
 	Name                  string                          `json:"name"`
 	LogoURL               *string                         `json:"logoUrl,omitempty"`
+	Description           *string                         `json:"description,omitempty"`
+	WebsiteURL            *string                         `json:"websiteUrl,omitempty"`
+	Email                 *string                         `json:"email,omitempty"`
+	HeadquarterAddress    *string                         `json:"headquarterAddress,omitempty"`
 	Users                 *UserConnection                 `json:"users"`
 	Connectors            *ConnectorConnection            `json:"connectors"`
 	Frameworks            *FrameworkConnection            `json:"frameworks"`
@@ -1663,9 +1667,13 @@ type UpdateObligationPayload struct {
 }
 
 type UpdateOrganizationInput struct {
-	OrganizationID gid.GID         `json:"organizationId"`
-	Name           *string         `json:"name,omitempty"`
-	Logo           *graphql.Upload `json:"logo,omitempty"`
+	OrganizationID     gid.GID         `json:"organizationId"`
+	Name               *string         `json:"name,omitempty"`
+	Logo               *graphql.Upload `json:"logo,omitempty"`
+	Description        *string         `json:"description,omitempty"`
+	WebsiteURL         *string         `json:"websiteUrl,omitempty"`
+	Email              *string         `json:"email,omitempty"`
+	HeadquarterAddress *string         `json:"headquarterAddress,omitempty"`
 }
 
 type UpdateOrganizationPayload struct {

--- a/pkg/server/api/console/v1/v1_resolver.go
+++ b/pkg/server/api/console/v1/v1_resolver.go
@@ -1104,8 +1104,12 @@ func (r *mutationResolver) UpdateOrganization(ctx context.Context, input types.U
 	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
 
 	req := probo.UpdateOrganizationRequest{
-		ID:   input.OrganizationID,
-		Name: input.Name,
+		ID:                 input.OrganizationID,
+		Name:               input.Name,
+		Description:        &input.Description,
+		WebsiteURL:         &input.WebsiteURL,
+		Email:              &input.Email,
+		HeadquarterAddress: &input.HeadquarterAddress,
 	}
 
 	if input.Logo != nil {

--- a/pkg/server/api/trust/v1/schema.graphql
+++ b/pkg/server/api/trust/v1/schema.graphql
@@ -37,6 +37,11 @@ type Organization implements Node {
   id: ID!
   name: String!
   logoUrl: String @goField(forceResolver: true)
+
+  description: String
+  websiteUrl: String
+  email: String
+  headquarterAddress: String
 }
 
 enum DocumentType

--- a/pkg/server/api/trust/v1/schema/schema.go
+++ b/pkg/server/api/trust/v1/schema/schema.go
@@ -117,9 +117,13 @@ type ComplexityRoot struct {
 	}
 
 	Organization struct {
-		ID      func(childComplexity int) int
-		LogoURL func(childComplexity int) int
-		Name    func(childComplexity int) int
+		Description        func(childComplexity int) int
+		Email              func(childComplexity int) int
+		HeadquarterAddress func(childComplexity int) int
+		ID                 func(childComplexity int) int
+		LogoURL            func(childComplexity int) int
+		Name               func(childComplexity int) int
+		WebsiteURL         func(childComplexity int) int
 	}
 
 	PageInfo struct {
@@ -413,6 +417,27 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.ExportReportPDF(childComplexity, args["input"].(types.ExportReportPDFInput)), true
 
+	case "Organization.description":
+		if e.complexity.Organization.Description == nil {
+			break
+		}
+
+		return e.complexity.Organization.Description(childComplexity), true
+
+	case "Organization.email":
+		if e.complexity.Organization.Email == nil {
+			break
+		}
+
+		return e.complexity.Organization.Email(childComplexity), true
+
+	case "Organization.headquarterAddress":
+		if e.complexity.Organization.HeadquarterAddress == nil {
+			break
+		}
+
+		return e.complexity.Organization.HeadquarterAddress(childComplexity), true
+
 	case "Organization.id":
 		if e.complexity.Organization.ID == nil {
 			break
@@ -433,6 +458,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Organization.Name(childComplexity), true
+
+	case "Organization.websiteUrl":
+		if e.complexity.Organization.WebsiteURL == nil {
+			break
+		}
+
+		return e.complexity.Organization.WebsiteURL(childComplexity), true
 
 	case "PageInfo.endCursor":
 		if e.complexity.PageInfo.EndCursor == nil {
@@ -833,6 +865,11 @@ type Organization implements Node {
   id: ID!
   name: String!
   logoUrl: String @goField(forceResolver: true)
+
+  description: String
+  websiteUrl: String
+  email: String
+  headquarterAddress: String
 }
 
 enum DocumentType
@@ -3265,6 +3302,170 @@ func (ec *executionContext) fieldContext_Organization_logoUrl(_ context.Context,
 	return fc, nil
 }
 
+func (ec *executionContext) _Organization_description(ctx context.Context, field graphql.CollectedField, obj *types.Organization) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Organization_description(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Description, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Organization_description(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Organization",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Organization_websiteUrl(ctx context.Context, field graphql.CollectedField, obj *types.Organization) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Organization_websiteUrl(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.WebsiteURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Organization_websiteUrl(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Organization",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Organization_email(ctx context.Context, field graphql.CollectedField, obj *types.Organization) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Organization_email(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Email, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Organization_email(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Organization",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Organization_headquarterAddress(ctx context.Context, field graphql.CollectedField, obj *types.Organization) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Organization_headquarterAddress(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.HeadquarterAddress, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Organization_headquarterAddress(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Organization",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _PageInfo_hasNextPage(ctx context.Context, field graphql.CollectedField, obj *types.PageInfo) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_PageInfo_hasNextPage(ctx, field)
 	if err != nil {
@@ -4016,6 +4217,14 @@ func (ec *executionContext) fieldContext_TrustCenter_organization(_ context.Cont
 				return ec.fieldContext_Organization_name(ctx, field)
 			case "logoUrl":
 				return ec.fieldContext_Organization_logoUrl(ctx, field)
+			case "description":
+				return ec.fieldContext_Organization_description(ctx, field)
+			case "websiteUrl":
+				return ec.fieldContext_Organization_websiteUrl(ctx, field)
+			case "email":
+				return ec.fieldContext_Organization_email(ctx, field)
+			case "headquarterAddress":
+				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Organization", field.Name)
 		},
@@ -7781,6 +7990,14 @@ func (ec *executionContext) _Organization(ctx context.Context, sel ast.Selection
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "description":
+			out.Values[i] = ec._Organization_description(ctx, field, obj)
+		case "websiteUrl":
+			out.Values[i] = ec._Organization_websiteUrl(ctx, field, obj)
+		case "email":
+			out.Values[i] = ec._Organization_email(ctx, field, obj)
+		case "headquarterAddress":
+			out.Values[i] = ec._Organization_headquarterAddress(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/server/api/trust/v1/types/organization.go
+++ b/pkg/server/api/trust/v1/types/organization.go
@@ -20,7 +20,11 @@ import (
 
 func NewOrganization(o *coredata.Organization) *Organization {
 	return &Organization{
-		ID:   o.ID,
-		Name: o.Name,
+		ID:                 o.ID,
+		Name:               o.Name,
+		Description:        o.Description,
+		WebsiteURL:         o.WebsiteURL,
+		Email:              o.Email,
+		HeadquarterAddress: o.HeadquarterAddress,
 	}
 }

--- a/pkg/server/api/trust/v1/types/types.go
+++ b/pkg/server/api/trust/v1/types/types.go
@@ -103,9 +103,13 @@ type Mutation struct {
 }
 
 type Organization struct {
-	ID      gid.GID `json:"id"`
-	Name    string  `json:"name"`
-	LogoURL *string `json:"logoUrl,omitempty"`
+	ID                 gid.GID `json:"id"`
+	Name               string  `json:"name"`
+	LogoURL            *string `json:"logoUrl,omitempty"`
+	Description        *string `json:"description,omitempty"`
+	WebsiteURL         *string `json:"websiteUrl,omitempty"`
+	Email              *string `json:"email,omitempty"`
+	HeadquarterAddress *string `json:"headquarterAddress,omitempty"`
 }
 
 func (Organization) IsNode()             {}


### PR DESCRIPTION
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds rich organization profile fields across the database, GraphQL APIs, and Console settings UI. Admins can now view and update details like description, website, email, HQ address, founding year, and business attributes; the Trust Center exposes a subset.

- **New Features**
  - Console Settings: form controls for description, website, email, HQ address.
  - GraphQL (Console): Organization and UpdateOrganizationInput include all new fields; mutations support partial updates.
  - GraphQL (Trust): Organization exposes description, websiteUrl, email, and headquarterAddress.
  - Data/Services: SQL migration adds nullable columns; core models and service layer updated for partial field updates; Relay fragments/queries/mutations regenerated.

- **Migration**
  - Apply migration: pkg/coredata/migrations/20250919T121111Z.sql.
  - Redeploy API and Console to pick up schema and UI changes.

<!-- End of auto-generated description by cubic. -->

