### PR TITLE
Decouple users from people

### DIFF
--- a/apps/console/src/components/organizations/InviteUserDialog.tsx
+++ b/apps/console/src/components/organizations/InviteUserDialog.tsx
@@ -4,6 +4,7 @@ import {
   DialogContent,
   DialogFooter,
   Field,
+  Checkbox,
   useDialogRef,
 } from "@probo/ui";
 import type { PropsWithChildren } from "react";
@@ -13,6 +14,7 @@ import { useOrganizationId } from "/hooks/useOrganizationId";
 import { useMutationWithToasts } from "/hooks/useMutationWithToasts";
 import { z } from "zod";
 import { useFormWithSchema } from "/hooks/useFormWithSchema";
+import { Controller } from "react-hook-form";
 
 const inviteMutation = graphql`
   mutation InviteUserDialogMutation($input: InviteUserInput!) {
@@ -25,6 +27,7 @@ const inviteMutation = graphql`
 const schema = z.object({
   email: z.string().email(),
   fullName: z.string(),
+  createPeople: z.boolean().default(false),
 });
 
 export function InviteUserDialog({ children }: PropsWithChildren) {
@@ -34,9 +37,9 @@ export function InviteUserDialog({ children }: PropsWithChildren) {
     successMessage: __("User invited successfully"),
     errorMessage: __("Failed to invite user"),
   });
-  const { register, handleSubmit, formState, reset } = useFormWithSchema(
+  const { register, handleSubmit, formState, reset, control } = useFormWithSchema(
     schema,
-    {},
+    { defaultValues: { createPeople: false } },
   );
 
   const dialogRef = useDialogRef();
@@ -48,6 +51,7 @@ export function InviteUserDialog({ children }: PropsWithChildren) {
           organizationId,
           email: data.email,
           fullName: data.fullName,
+          createPeople: data.createPeople,
         },
       },
       onSuccess: () => {
@@ -83,6 +87,31 @@ export function InviteUserDialog({ children }: PropsWithChildren) {
             {...register("fullName")}
             error={formState.errors.fullName?.message}
           />
+          <div className="space-y-2">
+            <div className="flex items-center space-x-3">
+              <Controller
+                name="createPeople"
+                control={control}
+                render={({ field }) => (
+                  <>
+                    <Checkbox
+                      checked={field.value}
+                      onChange={field.onChange}
+                    />
+                    <label
+                      className="text-sm font-medium cursor-pointer"
+                      onClick={() => field.onChange(!field.value)}
+                    >
+                      {__("Create people record")}
+                    </label>
+                  </>
+                )}
+              />
+            </div>
+            <p className="text-xs text-txt-secondary ml-7">
+              {__("Creates a people record for this user in addition to the user account")}
+            </p>
+          </div>
         </DialogContent>
         <DialogFooter>
           <Button type="submit" disabled={isInviting}>

--- a/apps/console/src/components/organizations/__generated__/InviteUserDialogMutation.graphql.ts
+++ b/apps/console/src/components/organizations/__generated__/InviteUserDialogMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1cf40085b2959d7ebb48ee4a90be41b1>>
+ * @generated SignedSource<<9ed3f33dde5f6a00c742b8db245ba03b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,6 +10,7 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 export type InviteUserInput = {
+  createPeople: boolean;
   email: string;
   fullName: string;
   organizationId: string;

--- a/apps/console/src/hooks/graph/VendorGraph.ts
+++ b/apps/console/src/hooks/graph/VendorGraph.ts
@@ -128,12 +128,12 @@ export const paginatedVendorsFragment = graphql`
           updatedAt
           riskAssessments(
             first: 1
-            orderBy: { direction: DESC, field: ASSESSED_AT }
+            orderBy: { direction: DESC, field: CREATED_AT }
           ) {
             edges {
               node {
                 id
-                assessedAt
+                createdAt
                 expiresAt
                 dataSensitivity
                 businessImpact
@@ -165,6 +165,7 @@ export const vendorNodeQuery = graphql`
     }
     viewer {
       user {
+        id
         people(organizationId: $organizationId) {
           id
         }

--- a/apps/console/src/hooks/graph/__generated__/DocumentGraphNodeQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/DocumentGraphNodeQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<85c6bcb5e086b05009ccfaf8ac21a23e>>
+ * @generated SignedSource<<ad33fa2c4266cca92954782c7805effc>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -389,19 +389,6 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": null,
-                            "concreteType": "People",
-                            "kind": "LinkedField",
-                            "name": "publishedBy",
-                            "plural": false,
-                            "selections": [
-                              (v4/*: any*/),
-                              (v3/*: any*/)
-                            ],
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
                             "args": (v11/*: any*/),
                             "concreteType": "DocumentVersionSignatureConnection",
                             "kind": "LinkedField",
@@ -520,12 +507,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "fbfe2cc393b8fc5349a92f3443f12e0e",
+    "cacheID": "ef08fbd3755a6ab5eff7786164842da8",
     "id": null,
     "metadata": {},
     "name": "DocumentGraphNodeQuery",
     "operationKind": "query",
-    "text": "query DocumentGraphNodeQuery(\n  $documentId: ID!\n) {\n  node(id: $documentId) {\n    __typename\n    ... on Document {\n      ...DocumentDetailPageDocumentFragment\n    }\n    id\n  }\n}\n\nfragment DocumentControlsTabFragment on Document {\n  id\n  controls(first: 20) {\n    edges {\n      node {\n        id\n        ...LinkedControlsCardFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n\nfragment DocumentDetailPageDocumentFragment on Document {\n  id\n  title\n  documentType\n  owner {\n    id\n    fullName\n  }\n  ...DocumentControlsTabFragment\n  controlsInfo: controls(first: 0) {\n    totalCount\n  }\n  versions(first: 20) {\n    edges {\n      node {\n        id\n        content\n        status\n        publishedAt\n        version\n        updatedAt\n        publishedBy {\n          fullName\n          id\n        }\n        signatures(first: 100) {\n          edges {\n            node {\n              id\n              state\n              signedBy {\n                id\n              }\n              ...DocumentSignaturesTab_signature\n              __typename\n            }\n            cursor\n          }\n          pageInfo {\n            endCursor\n            hasNextPage\n          }\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment DocumentSignaturesTab_signature on DocumentVersionSignature {\n  id\n  state\n  signedAt\n  requestedAt\n  signedBy {\n    fullName\n    primaryEmailAddress\n    id\n  }\n}\n\nfragment LinkedControlsCardFragment on Control {\n  id\n  name\n  sectionTitle\n  framework {\n    id\n    name\n  }\n}\n"
+    "text": "query DocumentGraphNodeQuery(\n  $documentId: ID!\n) {\n  node(id: $documentId) {\n    __typename\n    ... on Document {\n      ...DocumentDetailPageDocumentFragment\n    }\n    id\n  }\n}\n\nfragment DocumentControlsTabFragment on Document {\n  id\n  controls(first: 20) {\n    edges {\n      node {\n        id\n        ...LinkedControlsCardFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n\nfragment DocumentDetailPageDocumentFragment on Document {\n  id\n  title\n  documentType\n  owner {\n    id\n    fullName\n  }\n  ...DocumentControlsTabFragment\n  controlsInfo: controls(first: 0) {\n    totalCount\n  }\n  versions(first: 20) {\n    edges {\n      node {\n        id\n        content\n        status\n        publishedAt\n        version\n        updatedAt\n        signatures(first: 100) {\n          edges {\n            node {\n              id\n              state\n              signedBy {\n                id\n              }\n              ...DocumentSignaturesTab_signature\n              __typename\n            }\n            cursor\n          }\n          pageInfo {\n            endCursor\n            hasNextPage\n          }\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment DocumentSignaturesTab_signature on DocumentVersionSignature {\n  id\n  state\n  signedAt\n  requestedAt\n  signedBy {\n    fullName\n    primaryEmailAddress\n    id\n  }\n}\n\nfragment LinkedControlsCardFragment on Control {\n  id\n  name\n  sectionTitle\n  framework {\n    id\n    name\n  }\n}\n"
   }
 };
 })();

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterDocumentGraphUpdateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterDocumentGraphUpdateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5b8f324da8c4dc9302cb6f821062757d>>
+ * @generated SignedSource<<46d46472ea11f58c00df8b8827afab98>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,7 +13,6 @@ import { FragmentRefs } from "relay-runtime";
 export type DocumentType = "ISMS" | "OTHER" | "POLICY";
 export type UpdateDocumentInput = {
   content?: string | null | undefined;
-  createdBy?: string | null | undefined;
   documentType?: DocumentType | null | undefined;
   id: string;
   ownerId?: string | null | undefined;

--- a/apps/console/src/hooks/graph/__generated__/VendorGraphListQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/VendorGraphListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8b1614888dac560deff871232f91995d>>
+ * @generated SignedSource<<554f3a594f825db3f7f7da0c5c1d8b1f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -198,7 +198,7 @@ return {
                                 "name": "orderBy",
                                 "value": {
                                   "direction": "DESC",
-                                  "field": "ASSESSED_AT"
+                                  "field": "CREATED_AT"
                                 }
                               }
                             ],
@@ -228,7 +228,7 @@ return {
                                         "alias": null,
                                         "args": null,
                                         "kind": "ScalarField",
-                                        "name": "assessedAt",
+                                        "name": "createdAt",
                                         "storageKey": null
                                       },
                                       {
@@ -259,7 +259,7 @@ return {
                                 "storageKey": null
                               }
                             ],
-                            "storageKey": "riskAssessments(first:1,orderBy:{\"direction\":\"DESC\",\"field\":\"ASSESSED_AT\"})"
+                            "storageKey": "riskAssessments(first:1,orderBy:{\"direction\":\"DESC\",\"field\":\"CREATED_AT\"})"
                           },
                           (v4/*: any*/)
                         ],
@@ -350,12 +350,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4b19f6f4be47c38d8b68601ec95315a6",
+    "cacheID": "998ad60d132157090312ac11e318b2e5",
     "id": null,
     "metadata": {},
     "name": "VendorGraphListQuery",
     "operationKind": "query",
-    "text": "query VendorGraphListQuery(\n  $organizationId: ID!\n  $snapshotId: ID\n) {\n  node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      id\n      ...VendorGraphPaginatedFragment_3iomuz\n    }\n    id\n  }\n}\n\nfragment VendorGraphPaginatedFragment_3iomuz on Organization {\n  vendors(first: 50, filter: {snapshotId: $snapshotId}) {\n    edges {\n      node {\n        id\n        snapshotId\n        name\n        websiteUrl\n        updatedAt\n        riskAssessments(first: 1, orderBy: {direction: DESC, field: ASSESSED_AT}) {\n          edges {\n            node {\n              id\n              assessedAt\n              expiresAt\n              dataSensitivity\n              businessImpact\n            }\n          }\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n"
+    "text": "query VendorGraphListQuery(\n  $organizationId: ID!\n  $snapshotId: ID\n) {\n  node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      id\n      ...VendorGraphPaginatedFragment_3iomuz\n    }\n    id\n  }\n}\n\nfragment VendorGraphPaginatedFragment_3iomuz on Organization {\n  vendors(first: 50, filter: {snapshotId: $snapshotId}) {\n    edges {\n      node {\n        id\n        snapshotId\n        name\n        websiteUrl\n        updatedAt\n        riskAssessments(first: 1, orderBy: {direction: DESC, field: CREATED_AT}) {\n          edges {\n            node {\n              id\n              createdAt\n              expiresAt\n              dataSensitivity\n              businessImpact\n            }\n          }\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n"
   }
 };
 })();

--- a/apps/console/src/hooks/graph/__generated__/VendorGraphNodeQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/VendorGraphNodeQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<15c7796ac43c03708488ba03ef9d76a6>>
+ * @generated SignedSource<<d72032da6df08b84ce9c7ec87b950d08>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -24,6 +24,7 @@ export type VendorGraphNodeQuery$data = {
   };
   readonly viewer: {
     readonly user: {
+      readonly id: string;
       readonly people: {
         readonly id: string;
       } | null | undefined;
@@ -86,18 +87,30 @@ v7 = [
 ],
 v8 = {
   "alias": null,
-  "args": [
+  "args": null,
+  "concreteType": "User",
+  "kind": "LinkedField",
+  "name": "user",
+  "plural": false,
+  "selections": [
+    (v3/*: any*/),
     {
-      "kind": "Variable",
-      "name": "organizationId",
-      "variableName": "organizationId"
+      "alias": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "organizationId",
+          "variableName": "organizationId"
+        }
+      ],
+      "concreteType": "People",
+      "kind": "LinkedField",
+      "name": "people",
+      "plural": false,
+      "selections": (v7/*: any*/),
+      "storageKey": null
     }
   ],
-  "concreteType": "People",
-  "kind": "LinkedField",
-  "name": "people",
-  "plural": false,
-  "selections": (v7/*: any*/),
   "storageKey": null
 },
 v9 = {
@@ -204,24 +217,17 @@ v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "fullName",
+  "name": "createdAt",
   "storageKey": null
 },
 v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "createdAt",
-  "storageKey": null
-},
-v24 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "updatedAt",
   "storageKey": null
 },
-v25 = [
+v24 = [
   (v3/*: any*/),
   {
     "alias": null,
@@ -239,7 +245,7 @@ v25 = [
     "storageKey": null
   },
   (v12/*: any*/),
-  (v23/*: any*/)
+  (v22/*: any*/)
 ];
 return {
   "fragment": {
@@ -316,18 +322,7 @@ return {
         "name": "viewer",
         "plural": false,
         "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "User",
-            "kind": "LinkedField",
-            "name": "user",
-            "plural": false,
-            "selections": [
-              (v8/*: any*/)
-            ],
-            "storageKey": null
-          }
+          (v8/*: any*/)
         ],
         "storageKey": null
       }
@@ -560,7 +555,13 @@ return {
                         "plural": false,
                         "selections": [
                           (v3/*: any*/),
-                          (v22/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "fullName",
+                            "storageKey": null
+                          },
                           {
                             "alias": null,
                             "args": null,
@@ -582,8 +583,8 @@ return {
                             "name": "role",
                             "storageKey": null
                           },
+                          (v22/*: any*/),
                           (v23/*: any*/),
-                          (v24/*: any*/),
                           (v9/*: any*/)
                         ],
                         "storageKey": null
@@ -633,8 +634,8 @@ return {
                           (v3/*: any*/),
                           (v5/*: any*/),
                           (v10/*: any*/),
+                          (v22/*: any*/),
                           (v23/*: any*/),
-                          (v24/*: any*/),
                           (v9/*: any*/)
                         ],
                         "storageKey": null
@@ -682,26 +683,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v3/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "assessedAt",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "People",
-                            "kind": "LinkedField",
-                            "name": "assessedBy",
-                            "plural": false,
-                            "selections": [
-                              (v3/*: any*/),
-                              (v22/*: any*/)
-                            ],
-                            "storageKey": null
-                          },
+                          (v22/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -773,7 +755,7 @@ return {
                 "kind": "LinkedField",
                 "name": "businessAssociateAgreement",
                 "plural": false,
-                "selections": (v25/*: any*/),
+                "selections": (v24/*: any*/),
                 "storageKey": null
               },
               {
@@ -783,7 +765,7 @@ return {
                 "kind": "LinkedField",
                 "name": "dataPrivacyAgreement",
                 "plural": false,
-                "selections": (v25/*: any*/),
+                "selections": (v24/*: any*/),
                 "storageKey": null
               }
             ],
@@ -801,19 +783,7 @@ return {
         "name": "viewer",
         "plural": false,
         "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "User",
-            "kind": "LinkedField",
-            "name": "user",
-            "plural": false,
-            "selections": [
-              (v8/*: any*/),
-              (v3/*: any*/)
-            ],
-            "storageKey": null
-          },
+          (v8/*: any*/),
           (v3/*: any*/)
         ],
         "storageKey": null
@@ -821,16 +791,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "90924936acacd1851e8e81b1d94d6655",
+    "cacheID": "4a112f861864990f5022d279ba8d43d4",
     "id": null,
     "metadata": {},
     "name": "VendorGraphNodeQuery",
     "operationKind": "query",
-    "text": "query VendorGraphNodeQuery(\n  $vendorId: ID!\n  $organizationId: ID!\n) {\n  node(id: $vendorId) {\n    __typename\n    ... on Vendor {\n      id\n      snapshotId\n      name\n      websiteUrl\n      ...useVendorFormFragment\n      ...VendorComplianceTabFragment\n      ...VendorContactsTabFragment\n      ...VendorServicesTabFragment\n      ...VendorRiskAssessmentTabFragment\n      ...VendorOverviewTabBusinessAssociateAgreementFragment\n      ...VendorOverviewTabDataPrivacyAgreementFragment\n    }\n    id\n  }\n  viewer {\n    user {\n      people(organizationId: $organizationId) {\n        id\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment VendorComplianceTabFragment on Vendor {\n  complianceReports(first: 50) {\n    edges {\n      node {\n        id\n        ...VendorComplianceTabFragment_report\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n\nfragment VendorComplianceTabFragment_report on VendorComplianceReport {\n  id\n  reportDate\n  validUntil\n  reportName\n  fileUrl\n  fileSize\n}\n\nfragment VendorContactsTabFragment on Vendor {\n  contacts(first: 50) {\n    edges {\n      node {\n        id\n        ...VendorContactsTabFragment_contact\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n\nfragment VendorContactsTabFragment_contact on VendorContact {\n  id\n  fullName\n  email\n  phone\n  role\n  createdAt\n  updatedAt\n}\n\nfragment VendorOverviewTabBusinessAssociateAgreementFragment on Vendor {\n  businessAssociateAgreement {\n    id\n    fileName\n    fileUrl\n    validFrom\n    validUntil\n    createdAt\n  }\n}\n\nfragment VendorOverviewTabDataPrivacyAgreementFragment on Vendor {\n  dataPrivacyAgreement {\n    id\n    fileName\n    fileUrl\n    validFrom\n    validUntil\n    createdAt\n  }\n}\n\nfragment VendorRiskAssessmentTabFragment on Vendor {\n  id\n  riskAssessments(first: 50) {\n    edges {\n      node {\n        id\n        ...VendorRiskAssessmentTabFragment_assessment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n\nfragment VendorRiskAssessmentTabFragment_assessment on VendorRiskAssessment {\n  id\n  assessedAt\n  assessedBy {\n    id\n    fullName\n  }\n  expiresAt\n  dataSensitivity\n  businessImpact\n  notes\n}\n\nfragment VendorServicesTabFragment on Vendor {\n  services(first: 50) {\n    edges {\n      node {\n        id\n        ...VendorServicesTabFragment_service\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n\nfragment VendorServicesTabFragment_service on VendorService {\n  id\n  name\n  description\n  createdAt\n  updatedAt\n}\n\nfragment useVendorFormFragment on Vendor {\n  id\n  name\n  description\n  category\n  statusPageUrl\n  termsOfServiceUrl\n  privacyPolicyUrl\n  serviceLevelAgreementUrl\n  dataProcessingAgreementUrl\n  websiteUrl\n  legalName\n  headquarterAddress\n  certifications\n  countries\n  securityPageUrl\n  trustPageUrl\n  businessOwner {\n    id\n  }\n  securityOwner {\n    id\n  }\n}\n"
+    "text": "query VendorGraphNodeQuery(\n  $vendorId: ID!\n  $organizationId: ID!\n) {\n  node(id: $vendorId) {\n    __typename\n    ... on Vendor {\n      id\n      snapshotId\n      name\n      websiteUrl\n      ...useVendorFormFragment\n      ...VendorComplianceTabFragment\n      ...VendorContactsTabFragment\n      ...VendorServicesTabFragment\n      ...VendorRiskAssessmentTabFragment\n      ...VendorOverviewTabBusinessAssociateAgreementFragment\n      ...VendorOverviewTabDataPrivacyAgreementFragment\n    }\n    id\n  }\n  viewer {\n    user {\n      id\n      people(organizationId: $organizationId) {\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment VendorComplianceTabFragment on Vendor {\n  complianceReports(first: 50) {\n    edges {\n      node {\n        id\n        ...VendorComplianceTabFragment_report\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n\nfragment VendorComplianceTabFragment_report on VendorComplianceReport {\n  id\n  reportDate\n  validUntil\n  reportName\n  fileUrl\n  fileSize\n}\n\nfragment VendorContactsTabFragment on Vendor {\n  contacts(first: 50) {\n    edges {\n      node {\n        id\n        ...VendorContactsTabFragment_contact\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n\nfragment VendorContactsTabFragment_contact on VendorContact {\n  id\n  fullName\n  email\n  phone\n  role\n  createdAt\n  updatedAt\n}\n\nfragment VendorOverviewTabBusinessAssociateAgreementFragment on Vendor {\n  businessAssociateAgreement {\n    id\n    fileName\n    fileUrl\n    validFrom\n    validUntil\n    createdAt\n  }\n}\n\nfragment VendorOverviewTabDataPrivacyAgreementFragment on Vendor {\n  dataPrivacyAgreement {\n    id\n    fileName\n    fileUrl\n    validFrom\n    validUntil\n    createdAt\n  }\n}\n\nfragment VendorRiskAssessmentTabFragment on Vendor {\n  id\n  riskAssessments(first: 50) {\n    edges {\n      node {\n        id\n        ...VendorRiskAssessmentTabFragment_assessment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n\nfragment VendorRiskAssessmentTabFragment_assessment on VendorRiskAssessment {\n  id\n  createdAt\n  expiresAt\n  dataSensitivity\n  businessImpact\n  notes\n}\n\nfragment VendorServicesTabFragment on Vendor {\n  services(first: 50) {\n    edges {\n      node {\n        id\n        ...VendorServicesTabFragment_service\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n\nfragment VendorServicesTabFragment_service on VendorService {\n  id\n  name\n  description\n  createdAt\n  updatedAt\n}\n\nfragment useVendorFormFragment on Vendor {\n  id\n  name\n  description\n  category\n  statusPageUrl\n  termsOfServiceUrl\n  privacyPolicyUrl\n  serviceLevelAgreementUrl\n  dataProcessingAgreementUrl\n  websiteUrl\n  legalName\n  headquarterAddress\n  certifications\n  countries\n  securityPageUrl\n  trustPageUrl\n  businessOwner {\n    id\n  }\n  securityOwner {\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "4af64d92bd85441554a2c6ad8d2ccd77";
+(node as any).hash = "5b907e5cc3446745ff2414ee06839aed";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/VendorGraphPaginatedFragment.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/VendorGraphPaginatedFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b6975a3a740bdf7e2c9914fc64770638>>
+ * @generated SignedSource<<1bb16039861951cb1726b506ce33f0ff>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -23,8 +23,8 @@ export type VendorGraphPaginatedFragment$data = {
         readonly riskAssessments: {
           readonly edges: ReadonlyArray<{
             readonly node: {
-              readonly assessedAt: any;
               readonly businessImpact: BusinessImpact;
+              readonly createdAt: any;
               readonly dataSensitivity: DataSensitivity;
               readonly expiresAt: any;
               readonly id: string;
@@ -202,7 +202,7 @@ return {
                       "name": "orderBy",
                       "value": {
                         "direction": "DESC",
-                        "field": "ASSESSED_AT"
+                        "field": "CREATED_AT"
                       }
                     }
                   ],
@@ -232,7 +232,7 @@ return {
                               "alias": null,
                               "args": null,
                               "kind": "ScalarField",
-                              "name": "assessedAt",
+                              "name": "createdAt",
                               "storageKey": null
                             },
                             {
@@ -263,7 +263,7 @@ return {
                       "storageKey": null
                     }
                   ],
-                  "storageKey": "riskAssessments(first:1,orderBy:{\"direction\":\"DESC\",\"field\":\"ASSESSED_AT\"})"
+                  "storageKey": "riskAssessments(first:1,orderBy:{\"direction\":\"DESC\",\"field\":\"CREATED_AT\"})"
                 },
                 {
                   "alias": null,
@@ -346,6 +346,6 @@ return {
 };
 })();
 
-(node as any).hash = "578772ed7c83ae174d43b0be95a02fd2";
+(node as any).hash = "bf222e31d20ebe7c9dfdedff7d5a9c68";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/VendorsListQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/VendorsListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f98b10bd4f5fb03b55b46e2554480590>>
+ * @generated SignedSource<<f55e24dc95c48a67d7908bdd7f037272>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -274,7 +274,7 @@ return {
                                 "name": "orderBy",
                                 "value": {
                                   "direction": "DESC",
-                                  "field": "ASSESSED_AT"
+                                  "field": "CREATED_AT"
                                 }
                               }
                             ],
@@ -304,7 +304,7 @@ return {
                                         "alias": null,
                                         "args": null,
                                         "kind": "ScalarField",
-                                        "name": "assessedAt",
+                                        "name": "createdAt",
                                         "storageKey": null
                                       },
                                       {
@@ -335,7 +335,7 @@ return {
                                 "storageKey": null
                               }
                             ],
-                            "storageKey": "riskAssessments(first:1,orderBy:{\"direction\":\"DESC\",\"field\":\"ASSESSED_AT\"})"
+                            "storageKey": "riskAssessments(first:1,orderBy:{\"direction\":\"DESC\",\"field\":\"CREATED_AT\"})"
                           },
                           (v13/*: any*/)
                         ],
@@ -426,16 +426,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6570f4601f6dea5b7fe738d851a7f1ba",
+    "cacheID": "bf14bba14dba4fb544d431600ea31317",
     "id": null,
     "metadata": {},
     "name": "VendorsListQuery",
     "operationKind": "query",
-    "text": "query VendorsListQuery(\n  $after: CursorKey = null\n  $before: CursorKey = null\n  $first: Int = 50\n  $last: Int = null\n  $order: VendorOrder = null\n  $snapshotId: ID = null\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...VendorGraphPaginatedFragment_25MC8O\n    id\n  }\n}\n\nfragment VendorGraphPaginatedFragment_25MC8O on Organization {\n  vendors(first: $first, after: $after, last: $last, before: $before, orderBy: $order, filter: {snapshotId: $snapshotId}) {\n    edges {\n      node {\n        id\n        snapshotId\n        name\n        websiteUrl\n        updatedAt\n        riskAssessments(first: 1, orderBy: {direction: DESC, field: ASSESSED_AT}) {\n          edges {\n            node {\n              id\n              assessedAt\n              expiresAt\n              dataSensitivity\n              businessImpact\n            }\n          }\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n"
+    "text": "query VendorsListQuery(\n  $after: CursorKey = null\n  $before: CursorKey = null\n  $first: Int = 50\n  $last: Int = null\n  $order: VendorOrder = null\n  $snapshotId: ID = null\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...VendorGraphPaginatedFragment_25MC8O\n    id\n  }\n}\n\nfragment VendorGraphPaginatedFragment_25MC8O on Organization {\n  vendors(first: $first, after: $after, last: $last, before: $before, orderBy: $order, filter: {snapshotId: $snapshotId}) {\n    edges {\n      node {\n        id\n        snapshotId\n        name\n        websiteUrl\n        updatedAt\n        riskAssessments(first: 1, orderBy: {direction: DESC, field: CREATED_AT}) {\n          edges {\n            node {\n              id\n              createdAt\n              expiresAt\n              dataSensitivity\n              businessImpact\n            }\n          }\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "578772ed7c83ae174d43b0be95a02fd2";
+(node as any).hash = "bf222e31d20ebe7c9dfdedff7d5a9c68";
 
 export default node;

--- a/apps/console/src/pages/organizations/documents/DocumentDetailPage.tsx
+++ b/apps/console/src/pages/organizations/documents/DocumentDetailPage.tsx
@@ -90,9 +90,6 @@ const documentFragment = graphql`
           publishedAt
           version
           updatedAt
-          publishedBy {
-            fullName
-          }
           signatures(first: 100)
             @connection(key: "DocumentDetailPage_signatures") {
             __id
@@ -707,9 +704,6 @@ function VersionItem({
         </div>
         <div className="flex-1 space-y-[2px] overflow-hidden">
           <div className="flex items-center gap-2 overflow-hidden">
-            <div className="text-sm text-txt-secondary whitespace-nowrap overflow-hidden text-ellipsis">
-              {version.publishedBy?.fullName ?? document.owner.fullName}
-            </div>
             {version.status === "DRAFT" && (
               <Badge variant="neutral" size="sm">
                 {__("Draft")}

--- a/apps/console/src/pages/organizations/documents/__generated__/DocumentDetailPageDocumentFragment.graphql.ts
+++ b/apps/console/src/pages/organizations/documents/__generated__/DocumentDetailPageDocumentFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8db0c7dcd7ff31c01ec5facd5a3b598a>>
+ * @generated SignedSource<<9bec5530e7a90ab3fb9f21c5c2d92286>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -31,9 +31,6 @@ export type DocumentDetailPageDocumentFragment$data = {
         readonly content: string;
         readonly id: string;
         readonly publishedAt: any | null | undefined;
-        readonly publishedBy: {
-          readonly fullName: string;
-        } | null | undefined;
         readonly signatures: {
           readonly __id: string;
           readonly edges: ReadonlyArray<{
@@ -73,24 +70,17 @@ v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "fullName",
+  "name": "__typename",
   "storageKey": null
 },
 v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "__typename",
-  "storageKey": null
-},
-v3 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -115,7 +105,7 @@ v4 = {
   ],
   "storageKey": null
 },
-v5 = {
+v4 = {
   "kind": "ClientExtension",
   "selections": [
     {
@@ -174,7 +164,13 @@ return {
       "plural": false,
       "selections": [
         (v0/*: any*/),
-        (v1/*: any*/)
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "fullName",
+          "storageKey": null
+        }
       ],
       "storageKey": null
     },
@@ -268,18 +264,6 @@ return {
                   "storageKey": null
                 },
                 {
-                  "alias": null,
-                  "args": null,
-                  "concreteType": "People",
-                  "kind": "LinkedField",
-                  "name": "publishedBy",
-                  "plural": false,
-                  "selections": [
-                    (v1/*: any*/)
-                  ],
-                  "storageKey": null
-                },
-                {
                   "alias": "signatures",
                   "args": null,
                   "concreteType": "DocumentVersionSignatureConnection",
@@ -328,29 +312,29 @@ return {
                               "kind": "FragmentSpread",
                               "name": "DocumentSignaturesTab_signature"
                             },
-                            (v2/*: any*/)
+                            (v1/*: any*/)
                           ],
                           "storageKey": null
                         },
-                        (v3/*: any*/)
+                        (v2/*: any*/)
                       ],
                       "storageKey": null
                     },
-                    (v4/*: any*/),
-                    (v5/*: any*/)
+                    (v3/*: any*/),
+                    (v4/*: any*/)
                   ],
                   "storageKey": null
                 },
-                (v2/*: any*/)
+                (v1/*: any*/)
               ],
               "storageKey": null
             },
-            (v3/*: any*/)
+            (v2/*: any*/)
           ],
           "storageKey": null
         },
-        (v4/*: any*/),
-        (v5/*: any*/)
+        (v3/*: any*/),
+        (v4/*: any*/)
       ],
       "storageKey": null
     }
@@ -360,6 +344,6 @@ return {
 };
 })();
 
-(node as any).hash = "1523ddad229ae2d6bf94d30de5579ae6";
+(node as any).hash = "1d06e505efa74bb0b564fcbfc57ce8c9";
 
 export default node;

--- a/apps/console/src/pages/organizations/documents/__generated__/DocumentDetailPageUpdateMutation.graphql.ts
+++ b/apps/console/src/pages/organizations/documents/__generated__/DocumentDetailPageUpdateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e02cdda6c1c24ac700a79ed236c6dfdc>>
+ * @generated SignedSource<<aa94f8d2cc4c6a5c29de3029d5e6d2ca>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,7 +12,6 @@ import { ConcreteRequest } from 'relay-runtime';
 export type DocumentType = "ISMS" | "OTHER" | "POLICY";
 export type UpdateDocumentInput = {
   content?: string | null | undefined;
-  createdBy?: string | null | undefined;
   documentType?: DocumentType | null | undefined;
   id: string;
   ownerId?: string | null | undefined;

--- a/apps/console/src/pages/organizations/vendors/VendorDetailPage.tsx
+++ b/apps/console/src/pages/organizations/vendors/VendorDetailPage.tsx
@@ -132,7 +132,7 @@ export default function VendorDetailPage(props: Props) {
         </TabLink>
       </Tabs>
 
-      <Outlet context={{ vendor, peopleId: data.viewer.user.people!.id }} />
+      <Outlet context={{ vendor, userId: data.viewer.user.id }} />
     </div>
   );
 }

--- a/apps/console/src/pages/organizations/vendors/VendorsPage.tsx
+++ b/apps/console/src/pages/organizations/vendors/VendorsPage.tsx
@@ -134,8 +134,8 @@ function VendorRow({
           </div>
         </Td>
         <Td>
-          {latestAssessment?.assessedAt
-            ? formatDate(latestAssessment.assessedAt)
+          {latestAssessment?.createdAt
+            ? formatDate(latestAssessment.createdAt)
             : __("Not assessed")}
         </Td>
         <Td>

--- a/apps/console/src/pages/organizations/vendors/dialogs/CreateRiskAssessmentDialog.tsx
+++ b/apps/console/src/pages/organizations/vendors/dialogs/CreateRiskAssessmentDialog.tsx
@@ -21,7 +21,7 @@ type Props = {
   children: ReactNode;
   connection: string;
   vendorId: string;
-  peopleId: string;
+  userId: string;
 };
 
 const createRiskAssessmentMutation = graphql`
@@ -52,7 +52,7 @@ export function CreateRiskAssessmentDialog({
   children,
   connection,
   vendorId,
-  peopleId,
+  userId,
 }: Props) {
   const { __ } = useTranslate();
 
@@ -79,7 +79,7 @@ export function CreateRiskAssessmentDialog({
         input: {
           ...data,
           vendorId,
-          assessedBy: peopleId,
+          assessedBy: userId,
           expiresAt: nextYear.toISOString(),
         },
         connections: [connection!],

--- a/apps/console/src/pages/organizations/vendors/dialogs/__generated__/CreateRiskAssessmentDialogMutation.graphql.ts
+++ b/apps/console/src/pages/organizations/vendors/dialogs/__generated__/CreateRiskAssessmentDialogMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f877423fd1b767f837337e1b8a917e51>>
+ * @generated SignedSource<<2cd3f372cc571cec881b9762e381f1d5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,7 +13,6 @@ import { FragmentRefs } from "relay-runtime";
 export type BusinessImpact = "CRITICAL" | "HIGH" | "LOW" | "MEDIUM";
 export type DataSensitivity = "CRITICAL" | "HIGH" | "LOW" | "MEDIUM" | "NONE";
 export type CreateVendorRiskAssessmentInput = {
-  assessedBy: string;
   businessImpact: BusinessImpact;
   dataSensitivity: DataSensitivity;
   expiresAt: any;
@@ -55,14 +54,7 @@ v2 = [
     "name": "input",
     "variableName": "input"
   }
-],
-v3 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-};
+];
 return {
   "fragment": {
     "argumentDefinitions": [
@@ -148,31 +140,18 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v3/*: any*/),
                   {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
-                    "name": "assessedAt",
+                    "name": "id",
                     "storageKey": null
                   },
                   {
                     "alias": null,
                     "args": null,
-                    "concreteType": "People",
-                    "kind": "LinkedField",
-                    "name": "assessedBy",
-                    "plural": false,
-                    "selections": [
-                      (v3/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "fullName",
-                        "storageKey": null
-                      }
-                    ],
+                    "kind": "ScalarField",
+                    "name": "createdAt",
                     "storageKey": null
                   },
                   {
@@ -231,12 +210,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c55703ef9adb6c6aabf79aafe6cbeb89",
+    "cacheID": "1bd928ac46edc24d7b7cda3e5d7e2cb2",
     "id": null,
     "metadata": {},
     "name": "CreateRiskAssessmentDialogMutation",
     "operationKind": "mutation",
-    "text": "mutation CreateRiskAssessmentDialogMutation(\n  $input: CreateVendorRiskAssessmentInput!\n) {\n  createVendorRiskAssessment(input: $input) {\n    vendorRiskAssessmentEdge {\n      node {\n        ...VendorRiskAssessmentTabFragment_assessment\n        id\n      }\n    }\n  }\n}\n\nfragment VendorRiskAssessmentTabFragment_assessment on VendorRiskAssessment {\n  id\n  assessedAt\n  assessedBy {\n    id\n    fullName\n  }\n  expiresAt\n  dataSensitivity\n  businessImpact\n  notes\n}\n"
+    "text": "mutation CreateRiskAssessmentDialogMutation(\n  $input: CreateVendorRiskAssessmentInput!\n) {\n  createVendorRiskAssessment(input: $input) {\n    vendorRiskAssessmentEdge {\n      node {\n        ...VendorRiskAssessmentTabFragment_assessment\n        id\n      }\n    }\n  }\n}\n\nfragment VendorRiskAssessmentTabFragment_assessment on VendorRiskAssessment {\n  id\n  createdAt\n  expiresAt\n  dataSensitivity\n  businessImpact\n  notes\n}\n"
   }
 };
 })();

--- a/apps/console/src/pages/organizations/vendors/dialogs/__generated__/ImportAssessmentDialogMutation.graphql.ts
+++ b/apps/console/src/pages/organizations/vendors/dialogs/__generated__/ImportAssessmentDialogMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6db92ed13cdca3a852d1b7b9c113840e>>
+ * @generated SignedSource<<22e7411298e2df9b5f5eae17bb0a510f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -447,26 +447,7 @@ return {
                             "alias": null,
                             "args": null,
                             "kind": "ScalarField",
-                            "name": "assessedAt",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "People",
-                            "kind": "LinkedField",
-                            "name": "assessedBy",
-                            "plural": false,
-                            "selections": [
-                              (v2/*: any*/),
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "fullName",
-                                "storageKey": null
-                              }
-                            ],
+                            "name": "createdAt",
                             "storageKey": null
                           },
                           {
@@ -542,12 +523,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "025f271f1dca46c6f052f0d59a4315cc",
+    "cacheID": "0cb0f301c3022d933fd9ee0d6319d3e4",
     "id": null,
     "metadata": {},
     "name": "ImportAssessmentDialogMutation",
     "operationKind": "mutation",
-    "text": "mutation ImportAssessmentDialogMutation(\n  $input: AssessVendorInput!\n) {\n  assessVendor(input: $input) {\n    vendor {\n      id\n      name\n      websiteUrl\n      ...useVendorFormFragment\n      ...VendorComplianceTabFragment\n      ...VendorRiskAssessmentTabFragment\n    }\n  }\n}\n\nfragment VendorComplianceTabFragment on Vendor {\n  complianceReports(first: 50) {\n    edges {\n      node {\n        id\n        ...VendorComplianceTabFragment_report\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n\nfragment VendorComplianceTabFragment_report on VendorComplianceReport {\n  id\n  reportDate\n  validUntil\n  reportName\n  fileUrl\n  fileSize\n}\n\nfragment VendorRiskAssessmentTabFragment on Vendor {\n  id\n  riskAssessments(first: 50) {\n    edges {\n      node {\n        id\n        ...VendorRiskAssessmentTabFragment_assessment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n\nfragment VendorRiskAssessmentTabFragment_assessment on VendorRiskAssessment {\n  id\n  assessedAt\n  assessedBy {\n    id\n    fullName\n  }\n  expiresAt\n  dataSensitivity\n  businessImpact\n  notes\n}\n\nfragment useVendorFormFragment on Vendor {\n  id\n  name\n  description\n  category\n  statusPageUrl\n  termsOfServiceUrl\n  privacyPolicyUrl\n  serviceLevelAgreementUrl\n  dataProcessingAgreementUrl\n  websiteUrl\n  legalName\n  headquarterAddress\n  certifications\n  countries\n  securityPageUrl\n  trustPageUrl\n  businessOwner {\n    id\n  }\n  securityOwner {\n    id\n  }\n}\n"
+    "text": "mutation ImportAssessmentDialogMutation(\n  $input: AssessVendorInput!\n) {\n  assessVendor(input: $input) {\n    vendor {\n      id\n      name\n      websiteUrl\n      ...useVendorFormFragment\n      ...VendorComplianceTabFragment\n      ...VendorRiskAssessmentTabFragment\n    }\n  }\n}\n\nfragment VendorComplianceTabFragment on Vendor {\n  complianceReports(first: 50) {\n    edges {\n      node {\n        id\n        ...VendorComplianceTabFragment_report\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n\nfragment VendorComplianceTabFragment_report on VendorComplianceReport {\n  id\n  reportDate\n  validUntil\n  reportName\n  fileUrl\n  fileSize\n}\n\nfragment VendorRiskAssessmentTabFragment on Vendor {\n  id\n  riskAssessments(first: 50) {\n    edges {\n      node {\n        id\n        ...VendorRiskAssessmentTabFragment_assessment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n\nfragment VendorRiskAssessmentTabFragment_assessment on VendorRiskAssessment {\n  id\n  createdAt\n  expiresAt\n  dataSensitivity\n  businessImpact\n  notes\n}\n\nfragment useVendorFormFragment on Vendor {\n  id\n  name\n  description\n  category\n  statusPageUrl\n  termsOfServiceUrl\n  privacyPolicyUrl\n  serviceLevelAgreementUrl\n  dataProcessingAgreementUrl\n  websiteUrl\n  legalName\n  headquarterAddress\n  certifications\n  countries\n  securityPageUrl\n  trustPageUrl\n  businessOwner {\n    id\n  }\n  securityOwner {\n    id\n  }\n}\n"
   }
 };
 })();

--- a/apps/console/src/pages/organizations/vendors/tabs/VendorRiskAssessmentTab.tsx
+++ b/apps/console/src/pages/organizations/vendors/tabs/VendorRiskAssessmentTab.tsx
@@ -59,11 +59,7 @@ const riskAssessmentsFragment = graphql`
 const riskAssessmentFragment = graphql`
   fragment VendorRiskAssessmentTabFragment_assessment on VendorRiskAssessment {
     id
-    assessedAt
-    assessedBy {
-      id
-      fullName
-    }
+    createdAt
     expiresAt
     dataSensitivity
     businessImpact
@@ -72,9 +68,9 @@ const riskAssessmentFragment = graphql`
 `;
 
 export default function VendorRiskAssessmentTab() {
-  const { vendor, peopleId } = useOutletContext<{
+  const { vendor, userId } = useOutletContext<{
     vendor: VendorRiskAssessmentTabFragment$key & { name: string; id: string };
-    peopleId: string;
+    userId: string;
   }>();
   const [data, refetch] = useRefetchableFragment(
     riskAssessmentsFragment,
@@ -96,7 +92,7 @@ export default function VendorRiskAssessmentTab() {
           <CreateRiskAssessmentDialog
             vendorId={vendor.id}
             connection={data.riskAssessments.__id}
-            peopleId={peopleId}
+            userId={userId}
           >
             <Button icon={IconPlusLarge} variant="secondary">
               {__("Add Risk Assessment")}
@@ -114,7 +110,7 @@ export default function VendorRiskAssessmentTab() {
         <SortableTable refetch={refetch}>
           <Thead>
             <Tr>
-              <SortableTh field="ASSESSED_AT">{__("Assessed By")}</SortableTh>
+              <SortableTh field="CREATED_AT">{__("Assessed By")}</SortableTh>
               <SortableTh field="EXPIRES_AT">{__("Expires")}</SortableTh>
               <Th>{__("Data sensitivity")}</Th>
               <Th>{__("Business impact")}</Th>
@@ -125,7 +121,7 @@ export default function VendorRiskAssessmentTab() {
               <CreateRiskAssessmentDialog
                 vendorId={vendor.id}
                 connection={data.riskAssessments.__id}
-                peopleId={peopleId}
+                userId={userId}
               >
                 <TrButton colspan={5} onClick={() => {}}>
                   {__("Add Risk Assessment")}
@@ -178,9 +174,8 @@ function AssessmentRow(props: AssessmentRowProps) {
         onClick={() => props.onClick(assessment.id)}
       >
         <Td>
-          {assessment.assessedBy?.fullName}
           <span className="text-xs text-txt-secondary ml-1">
-            ({relativeDateFormat(assessment.assessedAt)})
+            ({relativeDateFormat(assessment.createdAt)})
           </span>
         </Td>
         <Td>

--- a/apps/console/src/pages/organizations/vendors/tabs/__generated__/VendorRiskAssessmentTabFragment_assessment.graphql.ts
+++ b/apps/console/src/pages/organizations/vendors/tabs/__generated__/VendorRiskAssessmentTabFragment_assessment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<68ddff15cd65f5367f7e9ae6b3c38f34>>
+ * @generated SignedSource<<b6963cdf0e4c8a5c6bb293cb53f8d404>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,12 +13,8 @@ export type BusinessImpact = "CRITICAL" | "HIGH" | "LOW" | "MEDIUM";
 export type DataSensitivity = "CRITICAL" | "HIGH" | "LOW" | "MEDIUM" | "NONE";
 import { FragmentRefs } from "relay-runtime";
 export type VendorRiskAssessmentTabFragment_assessment$data = {
-  readonly assessedAt: any;
-  readonly assessedBy: {
-    readonly fullName: string;
-    readonly id: string;
-  };
   readonly businessImpact: BusinessImpact;
+  readonly createdAt: any;
   readonly dataSensitivity: DataSensitivity;
   readonly expiresAt: any;
   readonly id: string;
@@ -30,45 +26,24 @@ export type VendorRiskAssessmentTabFragment_assessment$key = {
   readonly " $fragmentSpreads": FragmentRefs<"VendorRiskAssessmentTabFragment_assessment">;
 };
 
-const node: ReaderFragment = (function(){
-var v0 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-};
-return {
+const node: ReaderFragment = {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
   "name": "VendorRiskAssessmentTabFragment_assessment",
   "selections": [
-    (v0/*: any*/),
     {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
-      "name": "assessedAt",
+      "name": "id",
       "storageKey": null
     },
     {
       "alias": null,
       "args": null,
-      "concreteType": "People",
-      "kind": "LinkedField",
-      "name": "assessedBy",
-      "plural": false,
-      "selections": [
-        (v0/*: any*/),
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "fullName",
-          "storageKey": null
-        }
-      ],
+      "kind": "ScalarField",
+      "name": "createdAt",
       "storageKey": null
     },
     {
@@ -103,8 +78,7 @@ return {
   "type": "VendorRiskAssessment",
   "abstractKey": null
 };
-})();
 
-(node as any).hash = "08d6de198077f9b5985258466bbc33c0";
+(node as any).hash = "533771f5fac9e732556929fa2b1d0dc5";
 
 export default node;

--- a/apps/console/src/pages/organizations/vendors/tabs/__generated__/VendorRiskAssessmentTabQuery.graphql.ts
+++ b/apps/console/src/pages/organizations/vendors/tabs/__generated__/VendorRiskAssessmentTabQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0bca6db2c1a834fd326761b3544d00ae>>
+ * @generated SignedSource<<121b4497478f4b5ff67fb8a9daab3774>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,7 +11,7 @@
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type OrderDirection = "ASC" | "DESC";
-export type VendorRiskAssessmentOrderField = "ASSESSED_AT" | "CREATED_AT" | "EXPIRES_AT";
+export type VendorRiskAssessmentOrderField = "CREATED_AT" | "EXPIRES_AT";
 export type VendorRiskAssessmentOrder = {
   direction: OrderDirection;
   field: VendorRiskAssessmentOrderField;
@@ -216,26 +216,7 @@ return {
                             "alias": null,
                             "args": null,
                             "kind": "ScalarField",
-                            "name": "assessedAt",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "People",
-                            "kind": "LinkedField",
-                            "name": "assessedBy",
-                            "plural": false,
-                            "selections": [
-                              (v12/*: any*/),
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "fullName",
-                                "storageKey": null
-                              }
-                            ],
+                            "name": "createdAt",
                             "storageKey": null
                           },
                           {
@@ -355,12 +336,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "26ab0b864c4e22a21c078f70ed7caf93",
+    "cacheID": "5bf6eff01e3ca53e8da78cba59316a0c",
     "id": null,
     "metadata": {},
     "name": "VendorRiskAssessmentTabQuery",
     "operationKind": "query",
-    "text": "query VendorRiskAssessmentTabQuery(\n  $after: CursorKey = null\n  $before: CursorKey = null\n  $first: Int = 50\n  $last: Int = null\n  $order: VendorRiskAssessmentOrder = null\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...VendorRiskAssessmentTabFragment_16fISc\n    id\n  }\n}\n\nfragment VendorRiskAssessmentTabFragment_16fISc on Vendor {\n  id\n  riskAssessments(first: $first, after: $after, last: $last, before: $before, orderBy: $order) {\n    edges {\n      node {\n        id\n        ...VendorRiskAssessmentTabFragment_assessment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n\nfragment VendorRiskAssessmentTabFragment_assessment on VendorRiskAssessment {\n  id\n  assessedAt\n  assessedBy {\n    id\n    fullName\n  }\n  expiresAt\n  dataSensitivity\n  businessImpact\n  notes\n}\n"
+    "text": "query VendorRiskAssessmentTabQuery(\n  $after: CursorKey = null\n  $before: CursorKey = null\n  $first: Int = 50\n  $last: Int = null\n  $order: VendorRiskAssessmentOrder = null\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...VendorRiskAssessmentTabFragment_16fISc\n    id\n  }\n}\n\nfragment VendorRiskAssessmentTabFragment_16fISc on Vendor {\n  id\n  riskAssessments(first: $first, after: $after, last: $last, before: $before, orderBy: $order) {\n    edges {\n      node {\n        id\n        ...VendorRiskAssessmentTabFragment_assessment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n      hasPreviousPage\n      startCursor\n    }\n  }\n}\n\nfragment VendorRiskAssessmentTabFragment_assessment on VendorRiskAssessment {\n  id\n  createdAt\n  expiresAt\n  dataSensitivity\n  businessImpact\n  notes\n}\n"
   }
 };
 })();

--- a/pkg/coredata/document_version.go
+++ b/pkg/coredata/document_version.go
@@ -35,9 +35,7 @@ type (
 		VersionNumber int            `db:"version_number"`
 		Content       string         `db:"content"`
 		Changelog     string         `db:"changelog"`
-		CreatedBy     gid.GID        `db:"created_by"`
 		Status        DocumentStatus `db:"status"`
-		PublishedBy   *gid.GID       `db:"published_by"`
 		PublishedAt   *time.Time     `db:"published_at"`
 		CreatedAt     time.Time      `db:"created_at"`
 		UpdatedAt     time.Time      `db:"updated_at"`
@@ -62,9 +60,7 @@ SELECT
 	version_number,
 	content,
 	changelog,
-	created_by,
 	status,
-	published_by,
 	published_at,
 	created_at,
 	updated_at
@@ -122,9 +118,7 @@ SELECT
 	version_number,
 	content,
 	changelog,
-	created_by,
 	status,
-	published_by,
 	published_at,
 	created_at,
 	updated_at
@@ -173,7 +167,6 @@ INSERT INTO document_versions (
 	version_number,
 	content,
 	changelog,
-	created_by,
 	status,
 	created_at,
 	updated_at
@@ -187,7 +180,6 @@ VALUES (
 	@version_number,
 	@content,
 	@changelog,
-	@created_by,
 	@status,
 	@created_at,
 	@updated_at
@@ -202,7 +194,6 @@ VALUES (
 		"version_number": p.VersionNumber,
 		"content":        p.Content,
 		"changelog":      p.Changelog,
-		"created_by":     p.CreatedBy,
 		"status":         p.Status,
 		"created_at":     p.CreatedAt,
 		"updated_at":     p.UpdatedAt,
@@ -232,9 +223,7 @@ SELECT
 	version_number,
 	content,
 	changelog,
-	created_by,
 	status,
-	published_by,
 	published_at,
 	created_at,
 	updated_at
@@ -285,9 +274,7 @@ SELECT
 	version_number,
 	content,
 	changelog,
-	created_by,
 	status,
-	published_by,
 	published_at,
 	created_at,
 	updated_at
@@ -336,9 +323,7 @@ SELECT
 	version_number,
 	content,
 	changelog,
-	created_by,
 	status,
-	published_by,
 	published_at,
 	created_at,
 	updated_at
@@ -386,7 +371,6 @@ UPDATE document_versions SET
 	changelog = @changelog,
 	status = @status,
 	content = @content,
-	published_by = @published_by,
 	published_at = @published_at,
 	updated_at = @updated_at
 WHERE %s
@@ -402,7 +386,6 @@ WHERE %s
 		"changelog":           p.Changelog,
 		"status":              p.Status,
 		"content":             p.Content,
-		"published_by":        p.PublishedBy,
 		"published_at":        p.PublishedAt,
 		"updated_at":          p.UpdatedAt,
 	}

--- a/pkg/coredata/migrations/20250922T120000Z.sql
+++ b/pkg/coredata/migrations/20250922T120000Z.sql
@@ -1,0 +1,6 @@
+ALTER TABLE vendor_risk_assessments DROP COLUMN approved_at;
+ALTER TABLE vendor_risk_assessments DROP COLUMN approved_by;
+ALTER TABLE vendor_risk_assessments DROP COLUMN assessed_by;
+ALTER TABLE vendor_risk_assessments DROP COLUMN assessed_at;
+ALTER TABLE document_versions DROP COLUMN created_by;
+ALTER TABLE document_versions DROP COLUMN published_by;

--- a/pkg/coredata/vendor_risk_assessment.go
+++ b/pkg/coredata/vendor_risk_assessment.go
@@ -31,10 +31,6 @@ type (
 	VendorRiskAssessment struct {
 		ID              gid.GID         `db:"id"`
 		VendorID        gid.GID         `db:"vendor_id"`
-		AssessedAt      time.Time       `db:"assessed_at"`
-		AssessedBy      gid.GID         `db:"assessed_by"`
-		ApprovedBy      *gid.GID        `db:"approved_by"`
-		ApprovedAt      *time.Time      `db:"approved_at"`
 		ExpiresAt       time.Time       `db:"expires_at"`
 		DataSensitivity DataSensitivity `db:"data_sensitivity"`
 		BusinessImpact  BusinessImpact  `db:"business_impact"`
@@ -54,8 +50,6 @@ func (v VendorRiskAssessment) CursorKey(orderBy VendorRiskAssessmentOrderField) 
 		return page.NewCursorKey(v.ID, v.CreatedAt)
 	case VendorRiskAssessmentOrderFieldExpiresAt:
 		return page.NewCursorKey(v.ID, v.ExpiresAt)
-	case VendorRiskAssessmentOrderFieldAssessedAt:
-		return page.NewCursorKey(v.ID, v.AssessedAt)
 	}
 
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
@@ -73,10 +67,6 @@ INSERT INTO
         tenant_id,
         id,
         vendor_id,
-        assessed_at,
-        assessed_by,
-        approved_by,
-        approved_at,
         expires_at,
         data_sensitivity,
         business_impact,
@@ -88,10 +78,6 @@ VALUES (
     @tenant_id,
     @id,
     @vendor_id,
-    @assessed_at,
-    @assessed_by,
-    @approved_by,
-    @approved_at,
     @expires_at,
     @data_sensitivity,
     @business_impact,
@@ -105,10 +91,6 @@ VALUES (
 		"tenant_id":        scope.GetTenantID(),
 		"id":               r.ID,
 		"vendor_id":        r.VendorID,
-		"assessed_at":      r.AssessedAt,
-		"assessed_by":      r.AssessedBy,
-		"approved_by":      r.ApprovedBy,
-		"approved_at":      r.ApprovedAt,
 		"expires_at":       r.ExpiresAt,
 		"data_sensitivity": r.DataSensitivity,
 		"business_impact":  r.BusinessImpact,
@@ -131,10 +113,6 @@ func (r *VendorRiskAssessment) LoadByID(
 SELECT
     id,
     vendor_id,
-    assessed_at,
-    assessed_by,
-    approved_by,
-    approved_at,
     expires_at,
     data_sensitivity,
     business_impact,
@@ -183,10 +161,6 @@ func (r *VendorRiskAssessment) LoadLatestByVendorID(
 SELECT
     id,
     vendor_id,
-    assessed_at,
-    assessed_by,
-    approved_by,
-    approved_at,
     expires_at,
     data_sensitivity,
     business_impact,
@@ -201,7 +175,7 @@ WHERE
     %s
     AND vendor_id = @vendor_id
 ORDER BY
-    assessed_at DESC
+    created_at DESC
 LIMIT 1;
 `
 
@@ -238,10 +212,6 @@ func (r *VendorRiskAssessments) LoadByVendorID(
 SELECT
     id,
     vendor_id,
-    assessed_at,
-    assessed_by,
-    approved_by,
-    approved_at,
     expires_at,
     data_sensitivity,
     business_impact,
@@ -299,10 +269,6 @@ INSERT INTO vendor_risk_assessments (
 	snapshot_id,
 	source_id,
 	vendor_id,
-	assessed_at,
-	assessed_by,
-	approved_by,
-	approved_at,
 	expires_at,
 	data_sensitivity,
 	business_impact,
@@ -316,10 +282,6 @@ SELECT
 	@snapshot_id,
 	vra.id,
 	sv.id,
-	vra.assessed_at,
-	vra.assessed_by,
-	vra.approved_by,
-	vra.approved_at,
 	vra.expires_at,
 	vra.data_sensitivity,
 	vra.business_impact,

--- a/pkg/coredata/vendor_risk_assessment_order_field.go
+++ b/pkg/coredata/vendor_risk_assessment_order_field.go
@@ -19,9 +19,8 @@ type (
 )
 
 const (
-	VendorRiskAssessmentOrderFieldCreatedAt  VendorRiskAssessmentOrderField = "CREATED_AT"
-	VendorRiskAssessmentOrderFieldExpiresAt  VendorRiskAssessmentOrderField = "EXPIRES_AT"
-	VendorRiskAssessmentOrderFieldAssessedAt VendorRiskAssessmentOrderField = "ASSESSED_AT"
+	VendorRiskAssessmentOrderFieldCreatedAt VendorRiskAssessmentOrderField = "CREATED_AT"
+	VendorRiskAssessmentOrderFieldExpiresAt VendorRiskAssessmentOrderField = "EXPIRES_AT"
 )
 
 func (p VendorRiskAssessmentOrderField) Column() string {

--- a/pkg/docgen/generator.go
+++ b/pkg/docgen/generator.go
@@ -69,7 +69,6 @@ type (
 		Approver       string
 		Description    string
 		PublishedAt    *time.Time
-		PublishedBy    string
 		Signatures     []SignatureData
 	}
 

--- a/pkg/docgen/template.html
+++ b/pkg/docgen/template.html
@@ -16,7 +16,7 @@
                 color: #666;
             }
         }
-        
+
         body {
             font-family: 'Times New Roman', Times, serif;
             font-size: 11pt;
@@ -26,7 +26,7 @@
             padding: 20px 0;
             background: #f5f5f5;
         }
-        
+
         /* Document container that simulates A4 pages */
         .document-container {
             width: 21cm;
@@ -34,7 +34,7 @@
             background: white;
             box-shadow: 0 0 10px rgba(0,0,0,0.1);
         }
-        
+
         /* Individual page sections */
         .page-section {
             padding: 2.5cm;
@@ -43,21 +43,21 @@
             border-bottom: 2px dashed #ddd;
             page-break-after: always;
         }
-        
+
         .page-section:last-child {
             border-bottom: none;
             page-break-after: auto;
         }
-        
 
-        
+
+
         .document-header {
             border-bottom: 1px solid #333;
             padding-bottom: 15px;
             margin-bottom: 25px;
             page-break-after: avoid;
         }
-        
+
         .document-title {
             font-size: 18pt;
             font-weight: bold;
@@ -65,7 +65,7 @@
             margin: 0 0 10px 0;
             text-align: center;
         }
-        
+
         .document-meta {
             background: #f9f9f9;
             padding: 12px;
@@ -73,35 +73,35 @@
             margin: 15px 0;
             font-size: 9pt;
         }
-        
+
         .meta-table {
             width: 100%;
             border-collapse: collapse;
         }
-        
+
         .meta-table td {
             padding: 4px 8px;
             border-bottom: 1px solid #eee;
             vertical-align: top;
         }
-        
+
         .meta-table td:first-child {
             font-weight: bold;
             color: #333;
             width: 120px;
         }
-        
+
         .classification {
             font-weight: bold;
             text-transform: uppercase;
         }
-        
+
         /* Content styling with page break controls */
         .document-content {
             orphans: 3;
             widows: 3;
         }
-        
+
         .document-content h1 {
             font-size: 14pt;
             font-weight: bold;
@@ -112,7 +112,7 @@
             page-break-after: avoid;
             page-break-inside: avoid;
         }
-        
+
         .document-content h2 {
             font-size: 13pt;
             font-weight: bold;
@@ -121,7 +121,7 @@
             page-break-after: avoid;
             page-break-inside: avoid;
         }
-        
+
         .document-content h3 {
             font-size: 12pt;
             font-weight: bold;
@@ -130,7 +130,7 @@
             page-break-after: avoid;
             page-break-inside: avoid;
         }
-        
+
         .document-content h4 {
             font-size: 11pt;
             font-weight: bold;
@@ -139,33 +139,33 @@
             page-break-after: avoid;
             page-break-inside: avoid;
         }
-        
+
         .document-content p {
             margin-bottom: 12px;
             text-align: justify;
             orphans: 3;
             widows: 3;
         }
-        
+
         .document-content ul,
         .document-content ol {
             padding-left: 20px;
             margin: 12px 0;
             page-break-inside: avoid;
         }
-        
+
         .document-content li {
             margin-bottom: 4px;
         }
-        
+
         .document-content strong {
             font-weight: bold;
         }
-        
+
         .document-content em {
             font-style: italic;
         }
-        
+
         /* Force page breaks at strategic points */
         .document-content h2:nth-of-type(3),
         .document-content h2:nth-of-type(5),
@@ -173,7 +173,7 @@
         .document-content h2:nth-of-type(9) {
             page-break-before: always;
         }
-        
+
         /* Signatures section */
         .signatures-section {
             margin-top: 30px;
@@ -182,7 +182,7 @@
             page-break-before: always;
             page-break-inside: avoid;
         }
-        
+
         .signatures-title {
             font-size: 13pt;
             font-weight: bold;
@@ -190,7 +190,7 @@
             margin-bottom: 15px;
             page-break-after: avoid;
         }
-        
+
         .signatures-table {
             width: 100%;
             border-collapse: collapse;
@@ -198,34 +198,34 @@
             margin-top: 10px;
             page-break-inside: avoid;
         }
-        
+
         .signatures-table th,
         .signatures-table td {
             padding: 6px 8px;
             text-align: left;
             border: 1px solid #ddd;
         }
-        
+
         .signatures-table th {
             background: #f5f5f5;
             font-weight: bold;
             color: #333;
         }
-        
+
         .signatures-table tr {
             page-break-inside: avoid;
         }
-        
+
         .signature-signed {
             color: #000;
             font-weight: bold;
         }
-        
+
         .signature-requested {
             color: #666;
             font-style: italic;
         }
-        
+
         .footer {
             margin-top: 30px;
             padding-top: 15px;
@@ -234,42 +234,42 @@
             color: #666;
             text-align: center;
         }
-        
+
         /* Prevent bad page breaks */
         h1, h2, h3, h4, h5, h6 {
             page-break-after: avoid;
             page-break-inside: avoid;
         }
-        
+
         p, li {
             page-break-inside: avoid;
         }
-        
+
         table, .signatures-section {
             page-break-inside: avoid;
         }
-        
+
         @media print {
             body {
                 background: white;
                 padding: 0;
             }
-            
+
             .document-container {
                 box-shadow: none;
                 width: auto;
             }
-            
+
             .page-section {
                 box-shadow: none;
                 border-bottom: none;
                 padding: 0;
                 min-height: auto;
             }
-            
+
 
         }
-        
+
         @media screen and (max-width: 21cm) {
             .document-container {
                 width: 95%;
@@ -313,7 +313,7 @@
         <div class="page-section">
             <div class="document-header">
                 <h1 class="document-title">{{.Title}}</h1>
-                
+
                 <div class="document-meta">
                     <table class="meta-table">
                         <tr>
@@ -337,7 +337,7 @@
                         {{- if .PublishedAt}}
                         <tr>
                             <td>Published:</td>
-                            <td>{{.PublishedAt.Format "January 2, 2006"}}{{if .PublishedBy}} ({{.PublishedBy}}){{end}}</td>
+                            <td>{{.PublishedAt.Format "January 2, 2006"}}</td>
                         </tr>
                         {{- end}}
                     </table>

--- a/pkg/probo/vendor_service.go
+++ b/pkg/probo/vendor_service.go
@@ -84,7 +84,6 @@ type (
 
 	CreateVendorRiskAssessmentRequest struct {
 		VendorID        gid.GID
-		AssessedByID    gid.GID
 		ExpiresAt       time.Time
 		DataSensitivity coredata.DataSensitivity
 		BusinessImpact  coredata.BusinessImpact
@@ -536,8 +535,6 @@ func (s VendorService) CreateRiskAssessment(
 	vendorRiskAssessment := &coredata.VendorRiskAssessment{
 		ID:              vendorRiskAssessmentID,
 		VendorID:        req.VendorID,
-		AssessedBy:      req.AssessedByID,
-		AssessedAt:      now,
 		ExpiresAt:       req.ExpiresAt,
 		DataSensitivity: req.DataSensitivity,
 		BusinessImpact:  req.BusinessImpact,

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -3187,7 +3187,6 @@ input UpdateDocumentInput {
   title: String
   content: String
   ownerId: ID
-  createdBy: ID
   documentType: DocumentType
   showOnTrustCenter: Boolean
 }
@@ -3208,6 +3207,7 @@ input InviteUserInput {
   organizationId: ID!
   email: String!
   fullName: String!
+  createPeople: Boolean!
 }
 
 input RemoveUserInput {
@@ -3719,8 +3719,6 @@ input VendorRiskAssessmentOrder {
 type VendorRiskAssessment implements Node {
   id: ID!
   vendor: Vendor! @goField(forceResolver: true)
-  assessedAt: Datetime!
-  assessedBy: People! @goField(forceResolver: true)
   expiresAt: Datetime!
   dataSensitivity: DataSensitivity!
   businessImpact: BusinessImpact!
@@ -3741,15 +3739,10 @@ enum VendorRiskAssessmentOrderField
     @goEnum(
       value: "github.com/getprobo/probo/pkg/coredata.VendorRiskAssessmentOrderFieldExpiresAt"
     )
-  ASSESSED_AT
-    @goEnum(
-      value: "github.com/getprobo/probo/pkg/coredata.VendorRiskAssessmentOrderFieldAssessedAt"
-    )
 }
 
 input CreateVendorRiskAssessmentInput {
   vendorId: ID!
-  assessedBy: ID!
   expiresAt: Datetime!
   dataSensitivity: DataSensitivity!
   businessImpact: BusinessImpact!
@@ -3786,7 +3779,6 @@ type DocumentVersion implements Node {
     orderBy: DocumentVersionSignatureOrder
   ): DocumentVersionSignatureConnection! @goField(forceResolver: true)
 
-  publishedBy: People @goField(forceResolver: true)
   publishedAt: Datetime
   createdAt: Datetime!
   updatedAt: Datetime!

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -574,7 +574,6 @@ type ComplexityRoot struct {
 		ID          func(childComplexity int) int
 		Owner       func(childComplexity int) int
 		PublishedAt func(childComplexity int) int
-		PublishedBy func(childComplexity int) int
 		Signatures  func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentVersionSignatureOrder) int
 		Status      func(childComplexity int) int
 		Title       func(childComplexity int) int
@@ -1422,8 +1421,6 @@ type ComplexityRoot struct {
 	}
 
 	VendorRiskAssessment struct {
-		AssessedAt      func(childComplexity int) int
-		AssessedBy      func(childComplexity int) int
 		BusinessImpact  func(childComplexity int) int
 		CreatedAt       func(childComplexity int) int
 		DataSensitivity func(childComplexity int) int
@@ -1533,7 +1530,6 @@ type DocumentVersionResolver interface {
 
 	Owner(ctx context.Context, obj *types.DocumentVersion) (*types.People, error)
 	Signatures(ctx context.Context, obj *types.DocumentVersion, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentVersionSignatureOrder) (*types.DocumentVersionSignatureConnection, error)
-	PublishedBy(ctx context.Context, obj *types.DocumentVersion) (*types.People, error)
 }
 type DocumentVersionSignatureResolver interface {
 	DocumentVersion(ctx context.Context, obj *types.DocumentVersionSignature) (*types.DocumentVersion, error)
@@ -1809,8 +1805,6 @@ type VendorDataPrivacyAgreementResolver interface {
 }
 type VendorRiskAssessmentResolver interface {
 	Vendor(ctx context.Context, obj *types.VendorRiskAssessment) (*types.Vendor, error)
-
-	AssessedBy(ctx context.Context, obj *types.VendorRiskAssessment) (*types.People, error)
 }
 type VendorServiceResolver interface {
 	Vendor(ctx context.Context, obj *types.VendorService) (*types.Vendor, error)
@@ -3296,13 +3290,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.DocumentVersion.PublishedAt(childComplexity), true
-
-	case "DocumentVersion.publishedBy":
-		if e.complexity.DocumentVersion.PublishedBy == nil {
-			break
-		}
-
-		return e.complexity.DocumentVersion.PublishedBy(childComplexity), true
 
 	case "DocumentVersion.signatures":
 		if e.complexity.DocumentVersion.Signatures == nil {
@@ -7710,20 +7697,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.VendorEdge.Node(childComplexity), true
 
-	case "VendorRiskAssessment.assessedAt":
-		if e.complexity.VendorRiskAssessment.AssessedAt == nil {
-			break
-		}
-
-		return e.complexity.VendorRiskAssessment.AssessedAt(childComplexity), true
-
-	case "VendorRiskAssessment.assessedBy":
-		if e.complexity.VendorRiskAssessment.AssessedBy == nil {
-			break
-		}
-
-		return e.complexity.VendorRiskAssessment.AssessedBy(childComplexity), true
-
 	case "VendorRiskAssessment.businessImpact":
 		if e.complexity.VendorRiskAssessment.BusinessImpact == nil {
 			break
@@ -11353,7 +11326,6 @@ input UpdateDocumentInput {
   title: String
   content: String
   ownerId: ID
-  createdBy: ID
   documentType: DocumentType
   showOnTrustCenter: Boolean
 }
@@ -11374,6 +11346,7 @@ input InviteUserInput {
   organizationId: ID!
   email: String!
   fullName: String!
+  createPeople: Boolean!
 }
 
 input RemoveUserInput {
@@ -11885,8 +11858,6 @@ input VendorRiskAssessmentOrder {
 type VendorRiskAssessment implements Node {
   id: ID!
   vendor: Vendor! @goField(forceResolver: true)
-  assessedAt: Datetime!
-  assessedBy: People! @goField(forceResolver: true)
   expiresAt: Datetime!
   dataSensitivity: DataSensitivity!
   businessImpact: BusinessImpact!
@@ -11907,15 +11878,10 @@ enum VendorRiskAssessmentOrderField
     @goEnum(
       value: "github.com/getprobo/probo/pkg/coredata.VendorRiskAssessmentOrderFieldExpiresAt"
     )
-  ASSESSED_AT
-    @goEnum(
-      value: "github.com/getprobo/probo/pkg/coredata.VendorRiskAssessmentOrderFieldAssessedAt"
-    )
 }
 
 input CreateVendorRiskAssessmentInput {
   vendorId: ID!
-  assessedBy: ID!
   expiresAt: Datetime!
   dataSensitivity: DataSensitivity!
   businessImpact: BusinessImpact!
@@ -11952,7 +11918,6 @@ type DocumentVersion implements Node {
     orderBy: DocumentVersionSignatureOrder
   ): DocumentVersionSignatureConnection! @goField(forceResolver: true)
 
-  publishedBy: People @goField(forceResolver: true)
   publishedAt: Datetime
   createdAt: Datetime!
   updatedAt: Datetime!
@@ -30012,69 +29977,6 @@ func (ec *executionContext) fieldContext_DocumentVersion_signatures(ctx context.
 	return fc, nil
 }
 
-func (ec *executionContext) _DocumentVersion_publishedBy(ctx context.Context, field graphql.CollectedField, obj *types.DocumentVersion) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_DocumentVersion_publishedBy(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.DocumentVersion().PublishedBy(rctx, obj)
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*types.People)
-	fc.Result = res
-	return ec.marshalOPeople2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐPeople(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_DocumentVersion_publishedBy(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "DocumentVersion",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_People_id(ctx, field)
-			case "fullName":
-				return ec.fieldContext_People_fullName(ctx, field)
-			case "primaryEmailAddress":
-				return ec.fieldContext_People_primaryEmailAddress(ctx, field)
-			case "additionalEmailAddresses":
-				return ec.fieldContext_People_additionalEmailAddresses(ctx, field)
-			case "kind":
-				return ec.fieldContext_People_kind(ctx, field)
-			case "position":
-				return ec.fieldContext_People_position(ctx, field)
-			case "contractStartDate":
-				return ec.fieldContext_People_contractStartDate(ctx, field)
-			case "contractEndDate":
-				return ec.fieldContext_People_contractEndDate(ctx, field)
-			case "createdAt":
-				return ec.fieldContext_People_createdAt(ctx, field)
-			case "updatedAt":
-				return ec.fieldContext_People_updatedAt(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type People", field.Name)
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _DocumentVersion_publishedAt(ctx context.Context, field graphql.CollectedField, obj *types.DocumentVersion) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_DocumentVersion_publishedAt(ctx, field)
 	if err != nil {
@@ -30409,8 +30311,6 @@ func (ec *executionContext) fieldContext_DocumentVersionEdge_node(_ context.Cont
 				return ec.fieldContext_DocumentVersion_owner(ctx, field)
 			case "signatures":
 				return ec.fieldContext_DocumentVersion_signatures(ctx, field)
-			case "publishedBy":
-				return ec.fieldContext_DocumentVersion_publishedBy(ctx, field)
 			case "publishedAt":
 				return ec.fieldContext_DocumentVersion_publishedAt(ctx, field)
 			case "createdAt":
@@ -30525,8 +30425,6 @@ func (ec *executionContext) fieldContext_DocumentVersionSignature_documentVersio
 				return ec.fieldContext_DocumentVersion_owner(ctx, field)
 			case "signatures":
 				return ec.fieldContext_DocumentVersion_signatures(ctx, field)
-			case "publishedBy":
-				return ec.fieldContext_DocumentVersion_publishedBy(ctx, field)
 			case "publishedAt":
 				return ec.fieldContext_DocumentVersion_publishedAt(ctx, field)
 			case "createdAt":
@@ -46514,8 +46412,6 @@ func (ec *executionContext) fieldContext_PublishDocumentVersionPayload_documentV
 				return ec.fieldContext_DocumentVersion_owner(ctx, field)
 			case "signatures":
 				return ec.fieldContext_DocumentVersion_signatures(ctx, field)
-			case "publishedBy":
-				return ec.fieldContext_DocumentVersion_publishedBy(ctx, field)
 			case "publishedAt":
 				return ec.fieldContext_DocumentVersion_publishedAt(ctx, field)
 			case "createdAt":
@@ -52026,8 +51922,6 @@ func (ec *executionContext) fieldContext_UpdateDocumentVersionPayload_documentVe
 				return ec.fieldContext_DocumentVersion_owner(ctx, field)
 			case "signatures":
 				return ec.fieldContext_DocumentVersion_signatures(ctx, field)
-			case "publishedBy":
-				return ec.fieldContext_DocumentVersion_publishedBy(ctx, field)
 			case "publishedAt":
 				return ec.fieldContext_DocumentVersion_publishedAt(ctx, field)
 			case "createdAt":
@@ -58292,116 +58186,6 @@ func (ec *executionContext) fieldContext_VendorRiskAssessment_vendor(_ context.C
 	return fc, nil
 }
 
-func (ec *executionContext) _VendorRiskAssessment_assessedAt(ctx context.Context, field graphql.CollectedField, obj *types.VendorRiskAssessment) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_VendorRiskAssessment_assessedAt(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.AssessedAt, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(time.Time)
-	fc.Result = res
-	return ec.marshalNDatetime2timeᚐTime(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_VendorRiskAssessment_assessedAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "VendorRiskAssessment",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Datetime does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _VendorRiskAssessment_assessedBy(ctx context.Context, field graphql.CollectedField, obj *types.VendorRiskAssessment) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_VendorRiskAssessment_assessedBy(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.VendorRiskAssessment().AssessedBy(rctx, obj)
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*types.People)
-	fc.Result = res
-	return ec.marshalNPeople2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐPeople(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_VendorRiskAssessment_assessedBy(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "VendorRiskAssessment",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_People_id(ctx, field)
-			case "fullName":
-				return ec.fieldContext_People_fullName(ctx, field)
-			case "primaryEmailAddress":
-				return ec.fieldContext_People_primaryEmailAddress(ctx, field)
-			case "additionalEmailAddresses":
-				return ec.fieldContext_People_additionalEmailAddresses(ctx, field)
-			case "kind":
-				return ec.fieldContext_People_kind(ctx, field)
-			case "position":
-				return ec.fieldContext_People_position(ctx, field)
-			case "contractStartDate":
-				return ec.fieldContext_People_contractStartDate(ctx, field)
-			case "contractEndDate":
-				return ec.fieldContext_People_contractEndDate(ctx, field)
-			case "createdAt":
-				return ec.fieldContext_People_createdAt(ctx, field)
-			case "updatedAt":
-				return ec.fieldContext_People_updatedAt(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type People", field.Name)
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _VendorRiskAssessment_expiresAt(ctx context.Context, field graphql.CollectedField, obj *types.VendorRiskAssessment) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_VendorRiskAssessment_expiresAt(ctx, field)
 	if err != nil {
@@ -58854,10 +58638,6 @@ func (ec *executionContext) fieldContext_VendorRiskAssessmentEdge_node(_ context
 				return ec.fieldContext_VendorRiskAssessment_id(ctx, field)
 			case "vendor":
 				return ec.fieldContext_VendorRiskAssessment_vendor(ctx, field)
-			case "assessedAt":
-				return ec.fieldContext_VendorRiskAssessment_assessedAt(ctx, field)
-			case "assessedBy":
-				return ec.fieldContext_VendorRiskAssessment_assessedBy(ctx, field)
 			case "expiresAt":
 				return ec.fieldContext_VendorRiskAssessment_expiresAt(ctx, field)
 			case "dataSensitivity":
@@ -63702,7 +63482,7 @@ func (ec *executionContext) unmarshalInputCreateVendorRiskAssessmentInput(ctx co
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"vendorId", "assessedBy", "expiresAt", "dataSensitivity", "businessImpact", "notes"}
+	fieldsInOrder := [...]string{"vendorId", "expiresAt", "dataSensitivity", "businessImpact", "notes"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -63716,13 +63496,6 @@ func (ec *executionContext) unmarshalInputCreateVendorRiskAssessmentInput(ctx co
 				return it, err
 			}
 			it.VendorID = data
-		case "assessedBy":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("assessedBy"))
-			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.AssessedBy = data
 		case "expiresAt":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("expiresAt"))
 			data, err := ec.unmarshalNDatetime2timeᚐTime(ctx, v)
@@ -65261,7 +65034,7 @@ func (ec *executionContext) unmarshalInputInviteUserInput(ctx context.Context, o
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"organizationId", "email", "fullName"}
+	fieldsInOrder := [...]string{"organizationId", "email", "fullName", "createPeople"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -65289,6 +65062,13 @@ func (ec *executionContext) unmarshalInputInviteUserInput(ctx context.Context, o
 				return it, err
 			}
 			it.FullName = data
+		case "createPeople":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("createPeople"))
+			data, err := ec.unmarshalNBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.CreatePeople = data
 		}
 	}
 
@@ -66373,7 +66153,7 @@ func (ec *executionContext) unmarshalInputUpdateDocumentInput(ctx context.Contex
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "title", "content", "ownerId", "createdBy", "documentType", "showOnTrustCenter"}
+	fieldsInOrder := [...]string{"id", "title", "content", "ownerId", "documentType", "showOnTrustCenter"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -66408,13 +66188,6 @@ func (ec *executionContext) unmarshalInputUpdateDocumentInput(ctx context.Contex
 				return it, err
 			}
 			it.OwnerID = data
-		case "createdBy":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("createdBy"))
-			data, err := ec.unmarshalOID2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.CreatedBy = data
 		case "documentType":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("documentType"))
 			data, err := ec.unmarshalODocumentType2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐDocumentType(ctx, v)
@@ -73461,39 +73234,6 @@ func (ec *executionContext) _DocumentVersion(ctx context.Context, sel ast.Select
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-		case "publishedBy":
-			field := field
-
-			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._DocumentVersion_publishedBy(ctx, field, obj)
 				return res
 			}
 
@@ -82390,47 +82130,6 @@ func (ec *executionContext) _VendorRiskAssessment(ctx context.Context, sel ast.S
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-		case "assessedAt":
-			out.Values[i] = ec._VendorRiskAssessment_assessedAt(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
-		case "assessedBy":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._VendorRiskAssessment_assessedBy(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "expiresAt":
 			out.Values[i] = ec._VendorRiskAssessment_expiresAt(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -90332,14 +90031,12 @@ func (ec *executionContext) marshalNVendorRiskAssessmentOrderField2githubᚗcom�
 
 var (
 	unmarshalNVendorRiskAssessmentOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐVendorRiskAssessmentOrderField = map[string]coredata.VendorRiskAssessmentOrderField{
-		"CREATED_AT":  coredata.VendorRiskAssessmentOrderFieldCreatedAt,
-		"EXPIRES_AT":  coredata.VendorRiskAssessmentOrderFieldExpiresAt,
-		"ASSESSED_AT": coredata.VendorRiskAssessmentOrderFieldAssessedAt,
+		"CREATED_AT": coredata.VendorRiskAssessmentOrderFieldCreatedAt,
+		"EXPIRES_AT": coredata.VendorRiskAssessmentOrderFieldExpiresAt,
 	}
 	marshalNVendorRiskAssessmentOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐVendorRiskAssessmentOrderField = map[coredata.VendorRiskAssessmentOrderField]string{
-		coredata.VendorRiskAssessmentOrderFieldCreatedAt:  "CREATED_AT",
-		coredata.VendorRiskAssessmentOrderFieldExpiresAt:  "EXPIRES_AT",
-		coredata.VendorRiskAssessmentOrderFieldAssessedAt: "ASSESSED_AT",
+		coredata.VendorRiskAssessmentOrderFieldCreatedAt: "CREATED_AT",
+		coredata.VendorRiskAssessmentOrderFieldExpiresAt: "EXPIRES_AT",
 	}
 )
 

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -578,7 +578,6 @@ type CreateVendorPayload struct {
 
 type CreateVendorRiskAssessmentInput struct {
 	VendorID        gid.GID                  `json:"vendorId"`
-	AssessedBy      gid.GID                  `json:"assessedBy"`
 	ExpiresAt       time.Time                `json:"expiresAt"`
 	DataSensitivity coredata.DataSensitivity `json:"dataSensitivity"`
 	BusinessImpact  coredata.BusinessImpact  `json:"businessImpact"`
@@ -938,7 +937,6 @@ type DocumentVersion struct {
 	Title       string                              `json:"title"`
 	Owner       *People                             `json:"owner"`
 	Signatures  *DocumentVersionSignatureConnection `json:"signatures"`
-	PublishedBy *People                             `json:"publishedBy,omitempty"`
 	PublishedAt *time.Time                          `json:"publishedAt,omitempty"`
 	CreatedAt   time.Time                           `json:"createdAt"`
 	UpdatedAt   time.Time                           `json:"updatedAt"`
@@ -1098,6 +1096,7 @@ type InviteUserInput struct {
 	OrganizationID gid.GID `json:"organizationId"`
 	Email          string  `json:"email"`
 	FullName       string  `json:"fullName"`
+	CreatePeople   bool    `json:"createPeople"`
 }
 
 type InviteUserPayload struct {
@@ -1590,7 +1589,6 @@ type UpdateDocumentInput struct {
 	Title             *string                `json:"title,omitempty"`
 	Content           *string                `json:"content,omitempty"`
 	OwnerID           *gid.GID               `json:"ownerId,omitempty"`
-	CreatedBy         *gid.GID               `json:"createdBy,omitempty"`
 	DocumentType      *coredata.DocumentType `json:"documentType,omitempty"`
 	ShowOnTrustCenter *bool                  `json:"showOnTrustCenter,omitempty"`
 }
@@ -2064,8 +2062,6 @@ type VendorFilter struct {
 type VendorRiskAssessment struct {
 	ID              gid.GID                  `json:"id"`
 	Vendor          *Vendor                  `json:"vendor"`
-	AssessedAt      time.Time                `json:"assessedAt"`
-	AssessedBy      *People                  `json:"assessedBy"`
 	ExpiresAt       time.Time                `json:"expiresAt"`
 	DataSensitivity coredata.DataSensitivity `json:"dataSensitivity"`
 	BusinessImpact  coredata.BusinessImpact  `json:"businessImpact"`

--- a/pkg/server/api/console/v1/types/vendor_risk_assessment.go
+++ b/pkg/server/api/console/v1/types/vendor_risk_assessment.go
@@ -46,7 +46,6 @@ func NewVendorRiskAssessmentEdge(c *coredata.VendorRiskAssessment, orderBy cored
 func NewVendorRiskAssessment(c *coredata.VendorRiskAssessment) *VendorRiskAssessment {
 	return &VendorRiskAssessment{
 		ID:              c.ID,
-		AssessedAt:      c.AssessedAt,
 		ExpiresAt:       c.ExpiresAt,
 		DataSensitivity: c.DataSensitivity,
 		BusinessImpact:  c.BusinessImpact,

--- a/pkg/trust/document_service.go
+++ b/pkg/trust/document_service.go
@@ -92,7 +92,6 @@ func (s *DocumentService) ExportPDF(
 	document := &coredata.Document{}
 	version := &coredata.DocumentVersion{}
 	owner := &coredata.People{}
-	publishedBy := &coredata.People{}
 
 	err := s.svc.pg.WithConn(
 		ctx,
@@ -107,12 +106,6 @@ func (s *DocumentService) ExportPDF(
 
 			if err := version.LoadLatestPublishedVersion(ctx, conn, s.svc.scope, documentID); err != nil {
 				return fmt.Errorf("cannot load latest published document version: %w", err)
-			}
-
-			if version.PublishedBy != nil {
-				if err := publishedBy.LoadByID(ctx, conn, s.svc.scope, *version.PublishedBy); err != nil {
-					return fmt.Errorf("cannot load published by person: %w", err)
-				}
 			}
 
 			if err := owner.LoadByID(ctx, conn, s.svc.scope, document.OwnerID); err != nil {
@@ -143,7 +136,6 @@ func (s *DocumentService) ExportPDF(
 		Approver:       owner.FullName,
 		Description:    version.Changelog,
 		PublishedAt:    version.PublishedAt,
-		PublishedBy:    publishedBy.FullName,
 	}
 
 	htmlContent, err := docgen.RenderHTML(docData)


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Decouples user accounts from people records across the app to reduce coupling and simplify author/assessor fields. Key fields now reference User, and creating a people record is optional during user invites.

- **API Changes**
  - GraphQL: DocumentVersion.createdBy: User! (new), DocumentVersion.publishedBy: User (type changed), VendorRiskAssessment.assessedBy: User! (type changed), InviteUserInput.createPeople: Boolean! (new).
  - Resolvers/services now use user IDs for creating, drafting, and publishing documents; assessedBy on risk assessments uses user ID.
  - Console: Invite dialog adds “Create people record” checkbox; risk assessment flows pass userId instead of peopleId; queries expose viewer.user.id. viewer.user.people(...) may be null.

- **Migration**
  - Backfilled document_versions.created_by/published_by and vendor_risk_assessments.assessed_by from peoples to users (via people.user_id or email match), then enforced FKs to users.
  - Dropped vendor_risk_assessments.approved_by and approved_at.
  - Adoption: Run both migrations; update any client code expecting People in these fields to use User; include createPeople when calling InviteUser if a people record is desired.

<!-- End of auto-generated description by cubic. -->

