### PR TITLE
Add trust center references

### DIFF
--- a/apps/console/src/components/trustCenter/DeleteTrustCenterReferenceDialog.tsx
+++ b/apps/console/src/components/trustCenter/DeleteTrustCenterReferenceDialog.tsx
@@ -1,0 +1,83 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  IconTrashCan,
+  Spinner,
+  useDialogRef,
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { sprintf } from "@probo/helpers";
+import { useMutationWithToasts } from "/hooks/useMutationWithToasts";
+import { deleteTrustCenterReferenceMutation } from "/hooks/graph/TrustCenterReferenceGraph";
+
+type Props = {
+  children: React.ReactNode;
+  referenceId: string;
+  referenceName: string;
+  connectionId: string;
+  onSuccess?: () => void;
+};
+
+export function DeleteTrustCenterReferenceDialog({
+  children,
+  referenceId,
+  referenceName,
+  connectionId,
+  onSuccess,
+}: Props) {
+  const { __ } = useTranslate();
+  const ref = useDialogRef();
+
+  const [mutate, isDeleting] = useMutationWithToasts(deleteTrustCenterReferenceMutation, {
+    successMessage: __("Reference deleted successfully"),
+    errorMessage: __("Failed to delete reference"),
+  });
+
+  const handleDelete = async () => {
+    await mutate({
+      variables: {
+        input: {
+          id: referenceId,
+        },
+        connections: [connectionId],
+      },
+    });
+
+    onSuccess?.();
+    ref.current?.close();
+  };
+
+  return (
+    <Dialog
+      ref={ref}
+      trigger={children}
+      title={__("Delete Reference")}
+      className="max-w-md"
+    >
+      <DialogContent padded>
+        <p className="text-txt-secondary">
+          {sprintf(
+            __("Are you sure you want to delete the reference \"%s\"?"),
+            referenceName
+          )}
+        </p>
+        <p className="text-txt-secondary mt-2">
+          {__("This action cannot be undone.")}
+        </p>
+      </DialogContent>
+
+      <DialogFooter>
+        <Button
+          variant="danger"
+          onClick={handleDelete}
+          disabled={isDeleting}
+          icon={isDeleting ? Spinner : IconTrashCan}
+        >
+          {isDeleting ? __("Deleting...") : __("Delete")}
+        </Button>
+      </DialogFooter>
+    </Dialog>
+  );
+}

--- a/apps/console/src/components/trustCenter/TrustCenterReferenceDialog.tsx
+++ b/apps/console/src/components/trustCenter/TrustCenterReferenceDialog.tsx
@@ -1,0 +1,262 @@
+import { useTranslate } from "@probo/i18n";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  Dropzone,
+  Field,
+  Spinner,
+  Textarea,
+  useDialogRef,
+} from "@probo/ui";
+import { type ReactNode, useState, useImperativeHandle, forwardRef } from "react";
+import { z } from "zod";
+import { useFormWithSchema } from "/hooks/useFormWithSchema";
+import {
+  useCreateTrustCenterReferenceMutation,
+  useUpdateTrustCenterReferenceMutation
+} from "/hooks/graph/TrustCenterReferenceGraph";
+
+const referenceSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  description: z.string(),
+  websiteUrl: z.string().url("Please enter a valid URL"),
+});
+
+type ReferenceFormData = z.infer<typeof referenceSchema>;
+
+export type TrustCenterReferenceDialogRef = {
+  openCreate: (trustCenterId: string, connectionId: string) => void;
+  openEdit: (reference: {
+    id: string;
+    name: string;
+    description: string;
+    websiteUrl: string;
+  }) => void;
+};
+
+type Reference = {
+  id: string;
+  name: string;
+  description: string;
+  websiteUrl: string;
+};
+
+export const TrustCenterReferenceDialog = forwardRef<TrustCenterReferenceDialogRef, { children?: ReactNode }>(
+  function TrustCenterReferenceDialog({ children }, ref) {
+    const { __ } = useTranslate();
+    const dialogRef = useDialogRef();
+    const [mode, setMode] = useState<'create' | 'edit'>('create');
+    const [trustCenterId, setTrustCenterId] = useState<string>("");
+    const [connectionId, setConnectionId] = useState<string>("");
+    const [editReference, setEditReference] = useState<Reference | null>(null);
+    const [uploadedFile, setUploadedFile] = useState<File | null>(null);
+
+    const [createReference, isCreating] = useCreateTrustCenterReferenceMutation();
+    const [updateReference, isUpdating] = useUpdateTrustCenterReferenceMutation();
+
+    const { register, handleSubmit, formState: { errors }, reset } = useFormWithSchema(
+      referenceSchema,
+      {
+        defaultValues: {
+          name: "",
+          description: "",
+          websiteUrl: "",
+        },
+      }
+    );
+
+    useImperativeHandle(ref, () => ({
+      openCreate: (tId: string, cId: string) => {
+        setMode('create');
+        setTrustCenterId(tId);
+        setConnectionId(cId);
+        setEditReference(null);
+        setUploadedFile(null);
+        reset({
+          name: "",
+          description: "",
+          websiteUrl: "",
+        });
+        dialogRef.current?.open();
+      },
+      openEdit: (reference: Reference) => {
+        setMode('edit');
+        setEditReference(reference);
+        setUploadedFile(null);
+        reset({
+          name: reference.name,
+          description: reference.description,
+          websiteUrl: reference.websiteUrl,
+        });
+        dialogRef.current?.open();
+      },
+    }));
+
+    const handleDrop = (files: File[]) => {
+      if (files.length > 0) {
+        const file = files[0];
+        setUploadedFile(file);
+      }
+    };
+
+    const onSubmit = handleSubmit(async (data: ReferenceFormData) => {
+      if (mode === 'create') {
+        if (!uploadedFile) {
+          return;
+        }
+
+        await createReference({
+          variables: {
+            input: {
+              trustCenterId,
+              name: data.name,
+              description: data.description,
+              websiteUrl: data.websiteUrl,
+              logoFile: null,
+            },
+            connections: [connectionId],
+          },
+          uploadables: {
+            "input.logoFile": uploadedFile,
+          },
+          onSuccess: () => {
+            reset();
+            setUploadedFile(null);
+            dialogRef.current?.close();
+          },
+        });
+      } else if (editReference) {
+        const input: {
+          id: string;
+          name: string;
+          description: string;
+          websiteUrl: string;
+          logoFile?: null;
+        } = {
+          id: editReference.id,
+          name: data.name,
+          description: data.description,
+          websiteUrl: data.websiteUrl,
+        };
+
+        const uploadables: Record<string, File> = {};
+
+        if (uploadedFile) {
+          input.logoFile = null;
+          uploadables["input.logoFile"] = uploadedFile;
+        }
+
+        await updateReference({
+          variables: { input },
+          uploadables: Object.keys(uploadables).length > 0 ? uploadables : undefined,
+          onSuccess: () => {
+            reset();
+            setUploadedFile(null);
+            dialogRef.current?.close();
+          },
+        });
+      }
+    });
+
+    const handleClose = () => {
+      reset();
+      setUploadedFile(null);
+    };
+
+    const isSubmitting = isCreating || isUpdating;
+    const title = mode === 'create' ? __("Add Reference") : __("Edit Reference");
+
+    return (
+      <>
+        {children && (
+          <span onClick={() => mode === 'create' && dialogRef.current?.open()}>
+            {children}
+          </span>
+        )}
+
+        <Dialog
+          ref={dialogRef}
+          title={title}
+          className="max-w-2xl"
+          onClose={handleClose}
+        >
+          <form onSubmit={onSubmit}>
+            <DialogContent padded className="space-y-6">
+              <Field
+                {...register("name")}
+                label={__("Reference Name")}
+                type="text"
+                required
+                error={errors.name?.message}
+                placeholder={__("Company or organization name")}
+              />
+
+              <Field label={__("Description")} error={errors.description?.message}>
+                <Textarea
+                  {...register("description")}
+                  placeholder={__("Brief description of the reference")}
+                  rows={3}
+                />
+              </Field>
+
+              <Field
+                {...register("websiteUrl")}
+                label={__("Website URL")}
+                type="url"
+                required
+                error={errors.websiteUrl?.message}
+                placeholder={__("https://example.com")}
+              />
+
+              <Field label={__("Logo")}>
+                <Dropzone
+                  description={__("Upload logo image (PNG, JPG, WEBP up to 5MB)")}
+                  isUploading={isSubmitting}
+                  onDrop={handleDrop}
+                  accept={{
+                    "image/png": [".png"],
+                    "image/jpeg": [".jpg", ".jpeg"],
+                    "image/webp": [".webp"],
+                  }}
+                  maxSize={5}
+                />
+                {uploadedFile && (
+                  <div className="mt-2 p-3 bg-tertiary-subtle rounded-lg">
+                    <p className="text-sm font-medium">{__("Selected file")}:</p>
+                    <p className="text-sm text-txt-secondary">{uploadedFile.name}</p>
+                  </div>
+                )}
+                {mode === 'edit' && !uploadedFile && (
+                  <div className="mt-2 p-3 bg-tertiary-subtle rounded-lg">
+                    <p className="text-sm text-txt-secondary">
+                      {__("Current logo will be kept if no new file is uploaded")}
+                    </p>
+                  </div>
+                )}
+                {mode === 'create' && !uploadedFile && (
+                  <div className="mt-2 p-3 bg-warning-subtle rounded-lg">
+                    <p className="text-sm">
+                      {__("Logo is required for new references")}
+                    </p>
+                  </div>
+                )}
+              </Field>
+            </DialogContent>
+
+            <DialogFooter>
+              <Button
+                type="submit"
+                disabled={isSubmitting || (mode === 'create' && !uploadedFile)}
+                icon={isSubmitting ? Spinner : undefined}
+              >
+                {mode === 'create' ? __("Add Reference") : __("Update Reference")}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Dialog>
+      </>
+    );
+  }
+);

--- a/apps/console/src/components/trustCenter/TrustCenterReferencesSection.tsx
+++ b/apps/console/src/components/trustCenter/TrustCenterReferencesSection.tsx
@@ -1,0 +1,164 @@
+import { useTranslate } from "@probo/i18n";
+import { safeOpenUrl } from "@probo/helpers";
+import {
+  Avatar,
+  Button,
+  Card,
+  IconPlusLarge,
+  IconTrashCan,
+  IconPencil,
+} from "@probo/ui";
+import { type ReactNode, useRef } from "react";
+import {
+  useTrustCenterReferences,
+} from "/hooks/graph/TrustCenterReferenceGraph";
+import { TrustCenterReferenceDialog, type TrustCenterReferenceDialogRef } from "./TrustCenterReferenceDialog";
+import { DeleteTrustCenterReferenceDialog } from "./DeleteTrustCenterReferenceDialog";
+
+type Props = {
+  trustCenterId: string;
+  children?: ReactNode;
+};
+
+type Reference = {
+  id: string;
+  name: string;
+  description: string;
+  websiteUrl: string;
+  logoUrl: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export function TrustCenterReferencesSection({ trustCenterId }: Props) {
+  const { __ } = useTranslate();
+  const dialogRef = useRef<TrustCenterReferenceDialogRef>(null);
+  const data = useTrustCenterReferences(trustCenterId);
+
+  const trustCenterNode = data?.node;
+  const references = trustCenterNode?.references?.edges?.map((edge) => edge.node) || [];
+  const referencesConnectionId = trustCenterNode?.references?.__id || "";
+
+  const handleCreate = () => {
+    if (referencesConnectionId) {
+      dialogRef.current?.openCreate(trustCenterId, referencesConnectionId);
+    }
+  };
+
+  const handleEdit = (reference: Reference) => {
+    dialogRef.current?.openEdit(reference);
+  };
+
+
+  const handleVisitWebsite = (websiteUrl: string) => {
+    safeOpenUrl(websiteUrl);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-base font-medium">{__("Trusted by")}</h2>
+          <p className="text-sm text-txt-tertiary">
+            {__("Showcase your customers and partners on your trust center")}
+          </p>
+        </div>
+        <Button
+          variant="secondary"
+          icon={IconPlusLarge}
+          onClick={handleCreate}
+        >
+          {__("Add Reference")}
+        </Button>
+      </div>
+
+      <Card padded>
+        {references.length === 0 ? (
+          <div className="text-center py-12">
+            <div className="mx-auto w-12 h-12 bg-tertiary rounded-lg flex items-center justify-center mb-4">
+              <IconPlusLarge size={24} className="text-txt-tertiary" />
+            </div>
+            <h3 className="text-lg font-medium text-txt-primary mb-2">
+              {__("No references yet")}
+            </h3>
+            <p className="text-txt-tertiary mb-4">
+              {__("Add customer testimonials and partner references to build trust")}
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {references.map((reference: Reference) => (
+              <ReferenceRow
+                key={reference.id}
+                reference={reference}
+                onEdit={() => handleEdit(reference)}
+                connectionId={referencesConnectionId}
+                onVisitWebsite={() => handleVisitWebsite(reference.websiteUrl)}
+              />
+            ))}
+          </div>
+        )}
+      </Card>
+
+      <TrustCenterReferenceDialog ref={dialogRef} />
+    </div>
+  );
+}
+
+type ReferenceRowProps = {
+  reference: Reference;
+  onEdit: () => void;
+  connectionId: string;
+  onVisitWebsite: () => void;
+};
+
+function ReferenceRow({ reference, onEdit, connectionId, onVisitWebsite }: ReferenceRowProps) {
+
+  return (
+    <div className="flex items-center justify-between p-4 bg-level-1 rounded-lg">
+      <div className="flex items-center space-x-4 flex-1">
+        <Avatar
+          src={reference.logoUrl}
+          name={reference.name}
+          size="l"
+        />
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center space-x-2 mb-1">
+            <button
+              type="button"
+              onClick={onVisitWebsite}
+              className="font-medium text-txt-primary truncate hover:text-primary hover:underline text-left cursor-pointer"
+            >
+              {reference.name}
+            </button>
+          </div>
+
+          <p className="text-sm text-txt-secondary line-clamp-2 mb-2">
+            {reference.description}
+          </p>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-center space-x-2 ml-4">
+        <Button
+          variant="tertiary"
+          icon={IconPencil}
+          onClick={onEdit}
+          aria-label="Edit reference"
+        />
+        <DeleteTrustCenterReferenceDialog
+          referenceId={reference.id}
+          referenceName={reference.name}
+          connectionId={connectionId}
+        >
+          <Button
+            variant="danger"
+            icon={IconTrashCan}
+            aria-label="Delete reference"
+          />
+        </DeleteTrustCenterReferenceDialog>
+      </div>
+    </div>
+  );
+}

--- a/apps/console/src/hooks/graph/TrustCenterGraph.ts
+++ b/apps/console/src/hooks/graph/TrustCenterGraph.ts
@@ -16,6 +16,19 @@ export const trustCenterQuery = graphql`
           ndaFileUrl
           createdAt
           updatedAt
+          references(first: 100, orderBy: { field: CREATED_AT, direction: DESC }) {
+            edges {
+              node {
+                id
+                name
+                description
+                websiteUrl
+                logoUrl
+                createdAt
+                updatedAt
+              }
+            }
+          }
         }
         documents(first: 100) {
           edges {
@@ -112,4 +125,3 @@ export function useDeleteTrustCenterNDAMutation() {
     }
   );
 }
-

--- a/apps/console/src/hooks/graph/TrustCenterReferenceGraph.ts
+++ b/apps/console/src/hooks/graph/TrustCenterReferenceGraph.ts
@@ -1,0 +1,133 @@
+import { graphql } from 'react-relay';
+import { useLazyLoadQuery } from 'react-relay';
+import { useMutationWithToasts } from "/hooks/useMutationWithToasts";
+import type {
+  TrustCenterReferenceGraphQuery,
+  TrustCenterReferenceGraphQuery$data
+} from "./__generated__/TrustCenterReferenceGraphQuery.graphql";
+import type { TrustCenterReferenceGraphCreateMutation } from "./__generated__/TrustCenterReferenceGraphCreateMutation.graphql";
+import type { TrustCenterReferenceGraphUpdateMutation } from "./__generated__/TrustCenterReferenceGraphUpdateMutation.graphql";
+import type { TrustCenterReferenceGraphDeleteMutation } from "./__generated__/TrustCenterReferenceGraphDeleteMutation.graphql";
+
+export const trustCenterReferencesQuery = graphql`
+  query TrustCenterReferenceGraphQuery($trustCenterId: ID!) {
+    node(id: $trustCenterId) {
+      ... on TrustCenter {
+        id
+        references(first: 100, orderBy: { field: CREATED_AT, direction: DESC })
+          @connection(key: "TrustCenterReferencesSection_references") {
+          __id
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
+            startCursor
+            endCursor
+          }
+          edges {
+            cursor
+            node {
+              id
+              name
+              description
+              websiteUrl
+              logoUrl
+              createdAt
+              updatedAt
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const createTrustCenterReferenceMutation = graphql`
+  mutation TrustCenterReferenceGraphCreateMutation(
+    $input: CreateTrustCenterReferenceInput!
+    $connections: [ID!]!
+  ) {
+    createTrustCenterReference(input: $input) {
+      trustCenterReferenceEdge @prependEdge(connections: $connections) {
+        cursor
+        node {
+          id
+          name
+          description
+          websiteUrl
+          logoUrl
+          createdAt
+          updatedAt
+        }
+      }
+    }
+  }
+`;
+
+export const updateTrustCenterReferenceMutation = graphql`
+  mutation TrustCenterReferenceGraphUpdateMutation(
+    $input: UpdateTrustCenterReferenceInput!
+  ) {
+    updateTrustCenterReference(input: $input) {
+      trustCenterReference {
+        id
+        name
+        description
+        websiteUrl
+        logoUrl
+        createdAt
+        updatedAt
+      }
+    }
+  }
+`;
+
+export const deleteTrustCenterReferenceMutation = graphql`
+  mutation TrustCenterReferenceGraphDeleteMutation(
+    $input: DeleteTrustCenterReferenceInput!
+    $connections: [ID!]!
+  ) {
+    deleteTrustCenterReference(input: $input) {
+      deletedTrustCenterReferenceId @deleteEdge(connections: $connections)
+    }
+  }
+`;
+
+export function useTrustCenterReferences(trustCenterId: string): TrustCenterReferenceGraphQuery$data | null {
+  const data = useLazyLoadQuery<TrustCenterReferenceGraphQuery>(
+    trustCenterReferencesQuery,
+    { trustCenterId: trustCenterId || "" },
+    { fetchPolicy: 'network-only' }
+  );
+
+  return trustCenterId ? data : null;
+}
+
+export function useCreateTrustCenterReferenceMutation() {
+  return useMutationWithToasts<TrustCenterReferenceGraphCreateMutation>(
+    createTrustCenterReferenceMutation,
+    {
+      successMessage: "Reference created successfully",
+      errorMessage: "Failed to create reference",
+    }
+  );
+}
+
+export function useUpdateTrustCenterReferenceMutation() {
+  return useMutationWithToasts<TrustCenterReferenceGraphUpdateMutation>(
+    updateTrustCenterReferenceMutation,
+    {
+      successMessage: "Reference updated successfully",
+      errorMessage: "Failed to update reference",
+    }
+  );
+}
+
+export function useDeleteTrustCenterReferenceMutation() {
+  return useMutationWithToasts<TrustCenterReferenceGraphDeleteMutation>(
+    deleteTrustCenterReferenceMutation,
+    {
+      successMessage: "Reference deleted successfully",
+      errorMessage: "Failed to delete reference",
+    }
+  );
+}

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterGraphQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterGraphQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9dbea87f398ce8189cb2431d7c03912c>>
+ * @generated SignedSource<<241faf24f6f9e1ca0e5f8171e40e5cd3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -39,6 +39,19 @@ export type TrustCenterGraphQuery$data = {
       readonly id: string;
       readonly ndaFileName: string | null | undefined;
       readonly ndaFileUrl: string | null | undefined;
+      readonly references: {
+        readonly edges: ReadonlyArray<{
+          readonly node: {
+            readonly createdAt: any;
+            readonly description: string;
+            readonly id: string;
+            readonly logoUrl: string;
+            readonly name: string;
+            readonly updatedAt: any;
+            readonly websiteUrl: string;
+          };
+        }>;
+      };
       readonly slug: string;
       readonly updatedAt: any;
     } | null | undefined;
@@ -96,6 +109,25 @@ v4 = {
 v5 = {
   "alias": null,
   "args": null,
+  "kind": "ScalarField",
+  "name": "updatedAt",
+  "storageKey": null
+},
+v6 = {
+  "kind": "Literal",
+  "name": "first",
+  "value": 100
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "description",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
   "concreteType": "TrustCenter",
   "kind": "LinkedField",
   "name": "trustCenter",
@@ -131,24 +163,76 @@ v5 = {
       "storageKey": null
     },
     (v4/*: any*/),
+    (v5/*: any*/),
     {
       "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "updatedAt",
-      "storageKey": null
+      "args": [
+        (v6/*: any*/),
+        {
+          "kind": "Literal",
+          "name": "orderBy",
+          "value": {
+            "direction": "DESC",
+            "field": "CREATED_AT"
+          }
+        }
+      ],
+      "concreteType": "TrustCenterReferenceConnection",
+      "kind": "LinkedField",
+      "name": "references",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "TrustCenterReferenceEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "TrustCenterReference",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                (v2/*: any*/),
+                (v3/*: any*/),
+                (v7/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "websiteUrl",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "logoUrl",
+                  "storageKey": null
+                },
+                (v4/*: any*/),
+                (v5/*: any*/)
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "references(first:100,orderBy:{\"direction\":\"DESC\",\"field\":\"CREATED_AT\"})"
     }
   ],
   "storageKey": null
 },
-v6 = [
-  {
-    "kind": "Literal",
-    "name": "first",
-    "value": 100
-  }
+v9 = [
+  (v6/*: any*/)
 ],
-v7 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -175,10 +259,10 @@ return {
             "selections": [
               (v2/*: any*/),
               (v3/*: any*/),
-              (v5/*: any*/),
+              (v8/*: any*/),
               {
                 "alias": null,
-                "args": (v6/*: any*/),
+                "args": (v9/*: any*/),
                 "concreteType": "DocumentConnection",
                 "kind": "LinkedField",
                 "name": "documents",
@@ -217,7 +301,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v6/*: any*/),
+                "args": (v9/*: any*/),
                 "concreteType": "AuditConnection",
                 "kind": "LinkedField",
                 "name": "audits",
@@ -256,7 +340,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v6/*: any*/),
+                "args": (v9/*: any*/),
                 "concreteType": "VendorConnection",
                 "kind": "LinkedField",
                 "name": "vendors",
@@ -330,10 +414,10 @@ return {
             "kind": "InlineFragment",
             "selections": [
               (v3/*: any*/),
-              (v5/*: any*/),
+              (v8/*: any*/),
               {
                 "alias": null,
-                "args": (v6/*: any*/),
+                "args": (v9/*: any*/),
                 "concreteType": "DocumentConnection",
                 "kind": "LinkedField",
                 "name": "documents",
@@ -371,7 +455,7 @@ return {
                             "name": "documentType",
                             "storageKey": null
                           },
-                          (v7/*: any*/),
+                          (v10/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -430,7 +514,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v6/*: any*/),
+                "args": (v9/*: any*/),
                 "concreteType": "AuditConnection",
                 "kind": "LinkedField",
                 "name": "audits",
@@ -488,7 +572,7 @@ return {
                             "name": "state",
                             "storageKey": null
                           },
-                          (v7/*: any*/),
+                          (v10/*: any*/),
                           (v4/*: any*/)
                         ],
                         "storageKey": null
@@ -501,7 +585,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v6/*: any*/),
+                "args": (v9/*: any*/),
                 "concreteType": "VendorConnection",
                 "kind": "LinkedField",
                 "name": "vendors",
@@ -532,14 +616,8 @@ return {
                             "name": "category",
                             "storageKey": null
                           },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "description",
-                            "storageKey": null
-                          },
                           (v7/*: any*/),
+                          (v10/*: any*/),
                           (v4/*: any*/)
                         ],
                         "storageKey": null
@@ -560,16 +638,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "8dff30a639470418ba7151cb5743d3cc",
+    "cacheID": "d08519f604d27066ddaabb667d234552",
     "id": null,
     "metadata": {},
     "name": "TrustCenterGraphQuery",
     "operationKind": "query",
-    "text": "query TrustCenterGraphQuery(\n  $organizationId: ID!\n) {\n  organization: node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      id\n      name\n      trustCenter {\n        id\n        active\n        slug\n        ndaFileName\n        ndaFileUrl\n        createdAt\n        updatedAt\n      }\n      documents(first: 100) {\n        edges {\n          node {\n            id\n            ...TrustCenterDocumentsCardFragment\n          }\n        }\n      }\n      audits(first: 100) {\n        edges {\n          node {\n            id\n            ...TrustCenterAuditsCardFragment\n          }\n        }\n      }\n      vendors(first: 100) {\n        edges {\n          node {\n            id\n            ...TrustCenterVendorsCardFragment\n          }\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment TrustCenterAuditsCardFragment on Audit {\n  id\n  name\n  framework {\n    name\n    id\n  }\n  validFrom\n  validUntil\n  state\n  showOnTrustCenter\n  createdAt\n}\n\nfragment TrustCenterDocumentsCardFragment on Document {\n  id\n  title\n  createdAt\n  documentType\n  showOnTrustCenter\n  versions(first: 1) {\n    edges {\n      node {\n        id\n        status\n      }\n    }\n  }\n}\n\nfragment TrustCenterVendorsCardFragment on Vendor {\n  id\n  name\n  category\n  description\n  showOnTrustCenter\n  createdAt\n}\n"
+    "text": "query TrustCenterGraphQuery(\n  $organizationId: ID!\n) {\n  organization: node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      id\n      name\n      trustCenter {\n        id\n        active\n        slug\n        ndaFileName\n        ndaFileUrl\n        createdAt\n        updatedAt\n        references(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {\n          edges {\n            node {\n              id\n              name\n              description\n              websiteUrl\n              logoUrl\n              createdAt\n              updatedAt\n            }\n          }\n        }\n      }\n      documents(first: 100) {\n        edges {\n          node {\n            id\n            ...TrustCenterDocumentsCardFragment\n          }\n        }\n      }\n      audits(first: 100) {\n        edges {\n          node {\n            id\n            ...TrustCenterAuditsCardFragment\n          }\n        }\n      }\n      vendors(first: 100) {\n        edges {\n          node {\n            id\n            ...TrustCenterVendorsCardFragment\n          }\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment TrustCenterAuditsCardFragment on Audit {\n  id\n  name\n  framework {\n    name\n    id\n  }\n  validFrom\n  validUntil\n  state\n  showOnTrustCenter\n  createdAt\n}\n\nfragment TrustCenterDocumentsCardFragment on Document {\n  id\n  title\n  createdAt\n  documentType\n  showOnTrustCenter\n  versions(first: 1) {\n    edges {\n      node {\n        id\n        status\n      }\n    }\n  }\n}\n\nfragment TrustCenterVendorsCardFragment on Vendor {\n  id\n  name\n  category\n  description\n  showOnTrustCenter\n  createdAt\n}\n"
   }
 };
 })();
 
-(node as any).hash = "21b2915ae5002dd54c990013e94adf5d";
+(node as any).hash = "4d70dd23cdcdac7cd715b3eb9020ed37";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterReferenceGraphCreateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterReferenceGraphCreateMutation.graphql.ts
@@ -1,0 +1,218 @@
+/**
+ * @generated SignedSource<<216f3e7b4510c3d1127c3910bebc8b95>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type CreateTrustCenterReferenceInput = {
+  description: string;
+  logoFile: any;
+  name: string;
+  trustCenterId: string;
+  websiteUrl: string;
+};
+export type TrustCenterReferenceGraphCreateMutation$variables = {
+  connections: ReadonlyArray<string>;
+  input: CreateTrustCenterReferenceInput;
+};
+export type TrustCenterReferenceGraphCreateMutation$data = {
+  readonly createTrustCenterReference: {
+    readonly trustCenterReferenceEdge: {
+      readonly cursor: any;
+      readonly node: {
+        readonly createdAt: any;
+        readonly description: string;
+        readonly id: string;
+        readonly logoUrl: string;
+        readonly name: string;
+        readonly updatedAt: any;
+        readonly websiteUrl: string;
+      };
+    };
+  };
+};
+export type TrustCenterReferenceGraphCreateMutation = {
+  response: TrustCenterReferenceGraphCreateMutation$data;
+  variables: TrustCenterReferenceGraphCreateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "TrustCenterReferenceEdge",
+  "kind": "LinkedField",
+  "name": "trustCenterReferenceEdge",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "cursor",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "TrustCenterReference",
+      "kind": "LinkedField",
+      "name": "node",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "id",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "description",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "websiteUrl",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "logoUrl",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "createdAt",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "updatedAt",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TrustCenterReferenceGraphCreateMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "CreateTrustCenterReferencePayload",
+        "kind": "LinkedField",
+        "name": "createTrustCenterReference",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "TrustCenterReferenceGraphCreateMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "CreateTrustCenterReferencePayload",
+        "kind": "LinkedField",
+        "name": "createTrustCenterReference",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "prependEdge",
+            "key": "",
+            "kind": "LinkedHandle",
+            "name": "trustCenterReferenceEdge",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "17a206ba4702d641ffd7631cb8e3e03b",
+    "id": null,
+    "metadata": {},
+    "name": "TrustCenterReferenceGraphCreateMutation",
+    "operationKind": "mutation",
+    "text": "mutation TrustCenterReferenceGraphCreateMutation(\n  $input: CreateTrustCenterReferenceInput!\n) {\n  createTrustCenterReference(input: $input) {\n    trustCenterReferenceEdge {\n      cursor\n      node {\n        id\n        name\n        description\n        websiteUrl\n        logoUrl\n        createdAt\n        updatedAt\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "e0a76c3f5582bf1ed5def08db36d9e25";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterReferenceGraphDeleteMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterReferenceGraphDeleteMutation.graphql.ts
@@ -1,0 +1,132 @@
+/**
+ * @generated SignedSource<<1f4c8af006c90496e08b285944c83eac>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type DeleteTrustCenterReferenceInput = {
+  id: string;
+};
+export type TrustCenterReferenceGraphDeleteMutation$variables = {
+  connections: ReadonlyArray<string>;
+  input: DeleteTrustCenterReferenceInput;
+};
+export type TrustCenterReferenceGraphDeleteMutation$data = {
+  readonly deleteTrustCenterReference: {
+    readonly deletedTrustCenterReferenceId: string;
+  };
+};
+export type TrustCenterReferenceGraphDeleteMutation = {
+  response: TrustCenterReferenceGraphDeleteMutation$data;
+  variables: TrustCenterReferenceGraphDeleteMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "deletedTrustCenterReferenceId",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TrustCenterReferenceGraphDeleteMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteTrustCenterReferencePayload",
+        "kind": "LinkedField",
+        "name": "deleteTrustCenterReference",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "TrustCenterReferenceGraphDeleteMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteTrustCenterReferencePayload",
+        "kind": "LinkedField",
+        "name": "deleteTrustCenterReference",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "deleteEdge",
+            "key": "",
+            "kind": "ScalarHandle",
+            "name": "deletedTrustCenterReferenceId",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "6d22b36eb6ce9b568bfc091741a63ea8",
+    "id": null,
+    "metadata": {},
+    "name": "TrustCenterReferenceGraphDeleteMutation",
+    "operationKind": "mutation",
+    "text": "mutation TrustCenterReferenceGraphDeleteMutation(\n  $input: DeleteTrustCenterReferenceInput!\n) {\n  deleteTrustCenterReference(input: $input) {\n    deletedTrustCenterReferenceId\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "31a0fcb302daa8f42bc5ecb74fadfd0b";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterReferenceGraphQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterReferenceGraphQuery.graphql.ts
@@ -1,0 +1,333 @@
+/**
+ * @generated SignedSource<<f53f001d217e4c6f5b353f2243f700f2>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type TrustCenterReferenceGraphQuery$variables = {
+  trustCenterId: string;
+};
+export type TrustCenterReferenceGraphQuery$data = {
+  readonly node: {
+    readonly id?: string;
+    readonly references?: {
+      readonly __id: string;
+      readonly edges: ReadonlyArray<{
+        readonly cursor: any;
+        readonly node: {
+          readonly createdAt: any;
+          readonly description: string;
+          readonly id: string;
+          readonly logoUrl: string;
+          readonly name: string;
+          readonly updatedAt: any;
+          readonly websiteUrl: string;
+        };
+      }>;
+      readonly pageInfo: {
+        readonly endCursor: any | null | undefined;
+        readonly hasNextPage: boolean;
+        readonly hasPreviousPage: boolean;
+        readonly startCursor: any | null | undefined;
+      };
+    };
+  };
+};
+export type TrustCenterReferenceGraphQuery = {
+  response: TrustCenterReferenceGraphQuery$data;
+  variables: TrustCenterReferenceGraphQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "trustCenterId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "trustCenterId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "kind": "Literal",
+  "name": "orderBy",
+  "value": {
+    "direction": "DESC",
+    "field": "CREATED_AT"
+  }
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v5 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "PageInfo",
+    "kind": "LinkedField",
+    "name": "pageInfo",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "hasNextPage",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "hasPreviousPage",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "startCursor",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "endCursor",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "TrustCenterReferenceEdge",
+    "kind": "LinkedField",
+    "name": "edges",
+    "plural": true,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "cursor",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "TrustCenterReference",
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "description",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "websiteUrl",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "logoUrl",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "createdAt",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "updatedAt",
+            "storageKey": null
+          },
+          (v4/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  },
+  {
+    "kind": "ClientExtension",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "__id",
+        "storageKey": null
+      }
+    ]
+  }
+],
+v6 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 100
+  },
+  (v3/*: any*/)
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TrustCenterReferenceGraphQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v2/*: any*/),
+              {
+                "alias": "references",
+                "args": [
+                  (v3/*: any*/)
+                ],
+                "concreteType": "TrustCenterReferenceConnection",
+                "kind": "LinkedField",
+                "name": "__TrustCenterReferencesSection_references_connection",
+                "plural": false,
+                "selections": (v5/*: any*/),
+                "storageKey": "__TrustCenterReferencesSection_references_connection(orderBy:{\"direction\":\"DESC\",\"field\":\"CREATED_AT\"})"
+              }
+            ],
+            "type": "TrustCenter",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "TrustCenterReferenceGraphQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v4/*: any*/),
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": (v6/*: any*/),
+                "concreteType": "TrustCenterReferenceConnection",
+                "kind": "LinkedField",
+                "name": "references",
+                "plural": false,
+                "selections": (v5/*: any*/),
+                "storageKey": "references(first:100,orderBy:{\"direction\":\"DESC\",\"field\":\"CREATED_AT\"})"
+              },
+              {
+                "alias": null,
+                "args": (v6/*: any*/),
+                "filters": [
+                  "orderBy"
+                ],
+                "handle": "connection",
+                "key": "TrustCenterReferencesSection_references",
+                "kind": "LinkedHandle",
+                "name": "references"
+              }
+            ],
+            "type": "TrustCenter",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "8e9fd111488feb14deeedf47bfa4a0f0",
+    "id": null,
+    "metadata": {
+      "connection": [
+        {
+          "count": null,
+          "cursor": null,
+          "direction": "forward",
+          "path": [
+            "node",
+            "references"
+          ]
+        }
+      ]
+    },
+    "name": "TrustCenterReferenceGraphQuery",
+    "operationKind": "query",
+    "text": "query TrustCenterReferenceGraphQuery(\n  $trustCenterId: ID!\n) {\n  node(id: $trustCenterId) {\n    __typename\n    ... on TrustCenter {\n      id\n      references(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {\n        pageInfo {\n          hasNextPage\n          hasPreviousPage\n          startCursor\n          endCursor\n        }\n        edges {\n          cursor\n          node {\n            id\n            name\n            description\n            websiteUrl\n            logoUrl\n            createdAt\n            updatedAt\n            __typename\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "8b62ed10055cff04e117a31dd598eee4";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterReferenceGraphUpdateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterReferenceGraphUpdateMutation.graphql.ts
@@ -1,0 +1,157 @@
+/**
+ * @generated SignedSource<<3b02f7734c467adddc8f8abe1c18c4e5>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type UpdateTrustCenterReferenceInput = {
+  description?: string | null | undefined;
+  id: string;
+  logoFile?: any | null | undefined;
+  name?: string | null | undefined;
+  websiteUrl?: string | null | undefined;
+};
+export type TrustCenterReferenceGraphUpdateMutation$variables = {
+  input: UpdateTrustCenterReferenceInput;
+};
+export type TrustCenterReferenceGraphUpdateMutation$data = {
+  readonly updateTrustCenterReference: {
+    readonly trustCenterReference: {
+      readonly createdAt: any;
+      readonly description: string;
+      readonly id: string;
+      readonly logoUrl: string;
+      readonly name: string;
+      readonly updatedAt: any;
+      readonly websiteUrl: string;
+    };
+  };
+};
+export type TrustCenterReferenceGraphUpdateMutation = {
+  response: TrustCenterReferenceGraphUpdateMutation$data;
+  variables: TrustCenterReferenceGraphUpdateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "UpdateTrustCenterReferencePayload",
+    "kind": "LinkedField",
+    "name": "updateTrustCenterReference",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "TrustCenterReference",
+        "kind": "LinkedField",
+        "name": "trustCenterReference",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "description",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "websiteUrl",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "logoUrl",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "createdAt",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "updatedAt",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TrustCenterReferenceGraphUpdateMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "TrustCenterReferenceGraphUpdateMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "e5fa3bdb21897523c1491d6cfbf816cf",
+    "id": null,
+    "metadata": {},
+    "name": "TrustCenterReferenceGraphUpdateMutation",
+    "operationKind": "mutation",
+    "text": "mutation TrustCenterReferenceGraphUpdateMutation(\n  $input: UpdateTrustCenterReferenceInput!\n) {\n  updateTrustCenterReference(input: $input) {\n    trustCenterReference {\n      id\n      name\n      description\n      websiteUrl\n      logoUrl\n      createdAt\n      updatedAt\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "2340a9c559d302025df08a5748c18b80";
+
+export default node;

--- a/apps/console/src/hooks/useTrustCenterQueries.ts
+++ b/apps/console/src/hooks/useTrustCenterQueries.ts
@@ -222,6 +222,17 @@ const TRUST_CENTER_QUERY = `
           }
         }
       }
+      references(first: 100) {
+        edges {
+          node {
+            id
+            name
+            description
+            websiteUrl
+            logoUrl
+          }
+        }
+      }
     }
   }
 `;

--- a/apps/console/src/pages/organizations/trustCenter/TrustCenterPage.tsx
+++ b/apps/console/src/pages/organizations/trustCenter/TrustCenterPage.tsx
@@ -21,6 +21,7 @@ import type { TrustCenterGraphQuery } from "/hooks/graph/__generated__/TrustCent
 import { useState } from "react";
 import { useOrganizationId } from "/hooks/useOrganizationId";
 import { Outlet, useLocation, Link } from "react-router";
+import { TrustCenterReferencesSection } from "/components/trustCenter/TrustCenterReferencesSection";
 
 type Props = {
   queryRef: PreloadedQuery<TrustCenterGraphQuery>;
@@ -327,6 +328,10 @@ export default function TrustCenterPage({ queryRef }: Props) {
           </div>
         </Card>
       </div>
+
+      {organization.trustCenter?.id && (
+        <TrustCenterReferencesSection trustCenterId={organization.trustCenter.id} />
+      )}
 
       <div className="space-y-4">
         <Tabs>

--- a/packages/helpers/src/dom.ts
+++ b/packages/helpers/src/dom.ts
@@ -20,3 +20,16 @@ export function downloadFile(url: string | undefined | null, filename: string) {
     link.click();
     document.body.removeChild(link);
 }
+
+export function safeOpenUrl(url: string) {
+    try {
+        const parsedUrl = new URL(url);
+        if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+            window.open(url, '_blank', 'noopener,noreferrer');
+        } else {
+            console.error('Invalid URL protocol. Only HTTP and HTTPS URLs are allowed:', url);
+        }
+    } catch (error) {
+        console.error('Invalid URL format:', url, error);
+    }
+}

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -6,7 +6,7 @@ export {
     getRiskLikelihoods,
     getSeverity,
 } from "./risk";
-export { withViewTransition, downloadFile } from "./dom";
+export { withViewTransition, downloadFile, safeOpenUrl } from "./dom";
 export { times, groupBy, isEmpty } from "./array";
 export { randomInt } from "./number";
 export { getMeasureStateLabel, measureStates } from "./measure";

--- a/pkg/coredata/entity_type_reg.go
+++ b/pkg/coredata/entity_type_reg.go
@@ -56,4 +56,5 @@ const (
 	ContinualImprovementEntityType
 	ProcessingActivityEntityType
 	ExportJobEntityType
+	TrustCenterReferenceEntityType
 )

--- a/pkg/coredata/migrations/20250919T142754Z.sql
+++ b/pkg/coredata/migrations/20250919T142754Z.sql
@@ -1,0 +1,13 @@
+CREATE TABLE trust_center_references (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    trust_center_id TEXT NOT NULL REFERENCES trust_centers(id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL,
+    website_url TEXT NOT NULL,
+    logo_file_id TEXT NOT NULL REFERENCES files(id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+);

--- a/pkg/coredata/trust_center_reference.go
+++ b/pkg/coredata/trust_center_reference.go
@@ -1,0 +1,304 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"time"
+
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+	"github.com/jackc/pgx/v5"
+	"go.gearno.de/kit/pg"
+)
+
+type (
+	TrustCenterReference struct {
+		ID            gid.GID   `db:"id"`
+		TrustCenterID gid.GID   `db:"trust_center_id"`
+		Name          string    `db:"name"`
+		Description   string    `db:"description"`
+		WebsiteURL    string    `db:"website_url"`
+		LogoFileID    gid.GID   `db:"logo_file_id"`
+		CreatedAt     time.Time `db:"created_at"`
+		UpdatedAt     time.Time `db:"updated_at"`
+	}
+
+	TrustCenterReferences []*TrustCenterReference
+)
+
+func (t TrustCenterReference) CursorKey(orderBy TrustCenterReferenceOrderField) page.CursorKey {
+	switch orderBy {
+	case TrustCenterReferenceOrderFieldName:
+		return page.NewCursorKey(t.ID, t.Name)
+	case TrustCenterReferenceOrderFieldCreatedAt:
+		return page.NewCursorKey(t.ID, t.CreatedAt)
+	case TrustCenterReferenceOrderFieldUpdatedAt:
+		return page.NewCursorKey(t.ID, t.UpdatedAt)
+	}
+	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
+}
+
+func (t *TrustCenterReference) LoadByID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	trustCenterReferenceID gid.GID,
+) error {
+	q := `
+SELECT
+    id,
+    trust_center_id,
+    name,
+    description,
+    website_url,
+    logo_file_id,
+    created_at,
+    updated_at
+FROM
+    trust_center_references
+WHERE
+    %s
+    AND id = @trust_center_reference_id
+LIMIT 1;
+`
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"trust_center_reference_id": trustCenterReferenceID}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query trust_center_references: %w", err)
+	}
+
+	reference, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[TrustCenterReference])
+	if err != nil {
+		return fmt.Errorf("cannot collect trust center reference: %w", err)
+	}
+
+	*t = reference
+
+	return nil
+}
+
+func (t TrustCenterReference) Insert(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+INSERT INTO
+    trust_center_references (
+        tenant_id,
+        id,
+        trust_center_id,
+        name,
+        description,
+        website_url,
+        logo_file_id,
+        created_at,
+        updated_at
+    )
+VALUES (
+    @tenant_id,
+    @id,
+    @trust_center_id,
+    @name,
+    @description,
+    @website_url,
+    @logo_file_id,
+    @created_at,
+    @updated_at
+);
+`
+
+	args := pgx.StrictNamedArgs{
+		"tenant_id":       scope.GetTenantID(),
+		"id":              t.ID,
+		"trust_center_id": t.TrustCenterID,
+		"name":            t.Name,
+		"description":     t.Description,
+		"website_url":     t.WebsiteURL,
+		"logo_file_id":    t.LogoFileID,
+		"created_at":      t.CreatedAt,
+		"updated_at":      t.UpdatedAt,
+	}
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot insert trust center reference: %w", err)
+	}
+
+	return nil
+}
+
+func (t *TrustCenterReference) Update(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+UPDATE trust_center_references
+SET
+    name = @name,
+    description = @description,
+    website_url = @website_url,
+    logo_file_id = @logo_file_id,
+    updated_at = @updated_at
+WHERE
+    %s
+    AND id = @id
+RETURNING
+    id,
+    trust_center_id,
+    name,
+    description,
+    website_url,
+    logo_file_id,
+    created_at,
+    updated_at
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"id":           t.ID,
+		"name":         t.Name,
+		"description":  t.Description,
+		"website_url":  t.WebsiteURL,
+		"logo_file_id": t.LogoFileID,
+		"updated_at":   t.UpdatedAt,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot update trust center reference: %w", err)
+	}
+
+	reference, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[TrustCenterReference])
+	if err != nil {
+		return fmt.Errorf("cannot collect updated trust center reference: %w", err)
+	}
+
+	*t = reference
+
+	return nil
+}
+
+func (t *TrustCenterReference) Delete(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+DELETE FROM
+    trust_center_references
+WHERE
+    %s
+    AND id = @id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"id": t.ID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete trust center reference: %w", err)
+	}
+
+	return nil
+}
+
+func (t *TrustCenterReferences) LoadByTrustCenterID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	trustCenterID gid.GID,
+	cursor *page.Cursor[TrustCenterReferenceOrderField],
+) error {
+	q := `
+SELECT
+    id,
+    trust_center_id,
+    name,
+    description,
+    website_url,
+    logo_file_id,
+    created_at,
+    updated_at
+FROM
+    trust_center_references
+WHERE
+    %s
+    AND trust_center_id = @trust_center_id
+    AND %s
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"trust_center_id": trustCenterID}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, cursor.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query trust_center_references: %w", err)
+	}
+
+	references, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[TrustCenterReference])
+	if err != nil {
+		return fmt.Errorf("cannot collect trust center references: %w", err)
+	}
+
+	*t = references
+
+	return nil
+}
+
+func (t *TrustCenterReferences) CountByTrustCenterID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	trustCenterID gid.GID,
+) (int, error) {
+	q := `
+SELECT
+    COUNT(*)
+FROM
+    trust_center_references
+WHERE
+    %s
+    AND trust_center_id = @trust_center_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"trust_center_id": trustCenterID}
+	maps.Copy(args, scope.SQLArguments())
+
+	var count int
+	err := conn.QueryRow(ctx, q, args).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("cannot count trust center references: %w", err)
+	}
+
+	return count, nil
+}

--- a/pkg/coredata/trust_center_reference_order_field.go
+++ b/pkg/coredata/trust_center_reference_order_field.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+type (
+	TrustCenterReferenceOrderField string
+)
+
+const (
+	TrustCenterReferenceOrderFieldName      TrustCenterReferenceOrderField = "NAME"
+	TrustCenterReferenceOrderFieldCreatedAt TrustCenterReferenceOrderField = "CREATED_AT"
+	TrustCenterReferenceOrderFieldUpdatedAt TrustCenterReferenceOrderField = "UPDATED_AT"
+)
+
+func (p TrustCenterReferenceOrderField) Column() string {
+	switch p {
+	case TrustCenterReferenceOrderFieldName:
+		return "name"
+	case TrustCenterReferenceOrderFieldCreatedAt:
+		return "created_at"
+	case TrustCenterReferenceOrderFieldUpdatedAt:
+		return "updated_at"
+	default:
+		return string(p)
+	}
+}
+
+func (p TrustCenterReferenceOrderField) String() string {
+	return string(p)
+}
+
+func (p TrustCenterReferenceOrderField) MarshalText() ([]byte, error) {
+	return []byte(p.String()), nil
+}
+
+func (p *TrustCenterReferenceOrderField) UnmarshalText(text []byte) error {
+	*p = TrustCenterReferenceOrderField(text)
+	return nil
+}

--- a/pkg/probo/service.go
+++ b/pkg/probo/service.go
@@ -88,6 +88,7 @@ type (
 		Reports                           *ReportService
 		TrustCenters                      *TrustCenterService
 		TrustCenterAccesses               *TrustCenterAccessService
+		TrustCenterReferences             *TrustCenterReferenceService
 		Nonconformities                   *NonconformityService
 		Obligations                       *ObligationService
 		Snapshots                         *SnapshotService
@@ -186,6 +187,7 @@ func (s *Service) WithTenant(tenantID gid.TenantID) *TenantService {
 	tenantService.Reports = &ReportService{svc: tenantService}
 	tenantService.TrustCenters = &TrustCenterService{svc: tenantService}
 	tenantService.TrustCenterAccesses = &TrustCenterAccessService{svc: tenantService, usrmgr: s.usrmgr}
+	tenantService.TrustCenterReferences = &TrustCenterReferenceService{svc: tenantService}
 	tenantService.Nonconformities = &NonconformityService{svc: tenantService}
 	tenantService.Obligations = &ObligationService{svc: tenantService}
 	tenantService.Snapshots = &SnapshotService{svc: tenantService}

--- a/pkg/probo/trust_center_reference_service.go
+++ b/pkg/probo/trust_center_reference_service.go
@@ -1,0 +1,408 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package probo
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"mime"
+	"net/url"
+	"path/filepath"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+	"go.gearno.de/crypto/uuid"
+	"go.gearno.de/kit/pg"
+)
+
+type (
+	TrustCenterReferenceService struct {
+		svc *TenantService
+	}
+
+	CreateTrustCenterReferenceRequest struct {
+		TrustCenterID gid.GID
+		Name          string
+		Description   string
+		WebsiteURL    string
+		LogoFile      File
+	}
+
+	UpdateTrustCenterReferenceRequest struct {
+		ID          gid.GID
+		Name        *string
+		Description *string
+		WebsiteURL  *string
+		LogoFile    *File
+	}
+
+	DeleteTrustCenterReferenceRequest struct {
+		ID gid.GID
+	}
+)
+
+func (s TrustCenterReferenceService) ListForTrustCenterID(
+	ctx context.Context,
+	trustCenterID gid.GID,
+	cursor *page.Cursor[coredata.TrustCenterReferenceOrderField],
+) (*page.Page[*coredata.TrustCenterReference, coredata.TrustCenterReferenceOrderField], error) {
+	var references coredata.TrustCenterReferences
+
+	err := s.svc.pg.WithConn(ctx, func(conn pg.Conn) error {
+		err := references.LoadByTrustCenterID(ctx, conn, s.svc.scope, trustCenterID, cursor)
+		if err != nil {
+			return fmt.Errorf("cannot load trust center references: %w", err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return page.NewPage(references, cursor), nil
+}
+
+func (s TrustCenterReferenceService) CountForTrustCenterID(
+	ctx context.Context,
+	trustCenterID gid.GID,
+) (int, error) {
+	var count int
+
+	err := s.svc.pg.WithConn(ctx, func(conn pg.Conn) (err error) {
+		references := coredata.TrustCenterReferences{}
+		count, err = references.CountByTrustCenterID(ctx, conn, s.svc.scope, trustCenterID)
+		if err != nil {
+			return fmt.Errorf("cannot count trust center references: %w", err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+func (s TrustCenterReferenceService) Get(
+	ctx context.Context,
+	referenceID gid.GID,
+) (*coredata.TrustCenterReference, error) {
+	var reference coredata.TrustCenterReference
+
+	err := s.svc.pg.WithConn(ctx, func(conn pg.Conn) error {
+		err := reference.LoadByID(ctx, conn, s.svc.scope, referenceID)
+		if err != nil {
+			return fmt.Errorf("cannot load trust center reference: %w", err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &reference, nil
+}
+
+func (s TrustCenterReferenceService) Create(
+	ctx context.Context,
+	req *CreateTrustCenterReferenceRequest,
+) (*coredata.TrustCenterReference, error) {
+	if req.Name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+
+	if req.WebsiteURL == "" {
+		return nil, fmt.Errorf("website URL is required")
+	}
+
+	now := time.Now()
+
+	referenceID := gid.New(s.svc.scope.GetTenantID(), coredata.TrustCenterReferenceEntityType)
+
+	var reference *coredata.TrustCenterReference
+
+	var logoKey string
+
+	err := s.svc.pg.WithTx(ctx, func(tx pg.Conn) error {
+		fileID, s3Key, err := s.uploadLogoFile(ctx, tx, req.LogoFile, referenceID, now)
+		if err != nil {
+			return fmt.Errorf("cannot upload logo file: %w", err)
+		}
+		logoKey = s3Key
+
+		reference = &coredata.TrustCenterReference{
+			ID:            referenceID,
+			TrustCenterID: req.TrustCenterID,
+			Name:          req.Name,
+			Description:   req.Description,
+			WebsiteURL:    req.WebsiteURL,
+			LogoFileID:    fileID,
+			CreatedAt:     now,
+			UpdatedAt:     now,
+		}
+
+		if err := reference.Insert(ctx, tx, s.svc.scope); err != nil {
+			return fmt.Errorf("cannot insert trust center reference: %w", err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		s.cleanupS3Object(ctx, logoKey)
+		return nil, err
+	}
+
+	return reference, nil
+}
+
+func (s TrustCenterReferenceService) Update(
+	ctx context.Context,
+	req *UpdateTrustCenterReferenceRequest,
+) (*coredata.TrustCenterReference, error) {
+	now := time.Now()
+
+	var reference *coredata.TrustCenterReference
+	var newFileID *gid.GID
+
+	if req.Name != nil && *req.Name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+
+	if req.WebsiteURL != nil && *req.WebsiteURL == "" {
+		return nil, fmt.Errorf("website URL is required")
+	}
+
+	var logoKey string
+
+	err := s.svc.pg.WithTx(ctx, func(tx pg.Conn) error {
+		if req.LogoFile != nil {
+			fileID, s3Key, err := s.uploadLogoFile(ctx, tx, *req.LogoFile, req.ID, now)
+			if err != nil {
+				return fmt.Errorf("cannot upload logo file: %w", err)
+			}
+			newFileID = &fileID
+			logoKey = s3Key
+		}
+
+		reference = &coredata.TrustCenterReference{}
+
+		if err := reference.LoadByID(ctx, tx, s.svc.scope, req.ID); err != nil {
+			return fmt.Errorf("cannot load trust center reference: %w", err)
+		}
+
+		if req.Name != nil {
+			reference.Name = *req.Name
+		}
+		if req.Description != nil {
+			reference.Description = *req.Description
+		}
+		if req.WebsiteURL != nil {
+			reference.WebsiteURL = *req.WebsiteURL
+		}
+		if newFileID != nil {
+			reference.LogoFileID = *newFileID
+		}
+		reference.UpdatedAt = now
+
+		if err := reference.Update(ctx, tx, s.svc.scope); err != nil {
+			return fmt.Errorf("cannot update trust center reference: %w", err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		s.cleanupS3Object(ctx, logoKey)
+		return nil, err
+	}
+
+	return reference, nil
+}
+
+func (s TrustCenterReferenceService) Delete(
+	ctx context.Context,
+	req *DeleteTrustCenterReferenceRequest,
+) error {
+	err := s.svc.pg.WithTx(ctx, func(tx pg.Conn) error {
+		reference := &coredata.TrustCenterReference{}
+
+		if err := reference.LoadByID(ctx, tx, s.svc.scope, req.ID); err != nil {
+			return fmt.Errorf("cannot load trust center reference: %w", err)
+		}
+
+		if err := reference.Delete(ctx, tx, s.svc.scope); err != nil {
+			return fmt.Errorf("cannot delete trust center reference: %w", err)
+		}
+
+		return nil
+	})
+
+	return err
+}
+
+func (s TrustCenterReferenceService) GenerateLogoURL(
+	ctx context.Context,
+	referenceID gid.GID,
+	duration time.Duration,
+) (string, error) {
+	reference := &coredata.TrustCenterReference{}
+	file := &coredata.File{}
+	err := s.svc.pg.WithTx(ctx, func(tx pg.Conn) error {
+		err := reference.LoadByID(ctx, tx, s.svc.scope, referenceID)
+		if err != nil {
+			return fmt.Errorf("cannot load trust center reference: %w", err)
+		}
+
+		err = file.LoadByID(ctx, tx, s.svc.scope, reference.LogoFileID)
+		if err != nil {
+			return fmt.Errorf("cannot load logo file: %w", err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return "", nil
+	}
+
+	presignClient := s3.NewPresignClient(s.svc.s3)
+
+	encodedFilename := url.PathEscape(file.FileName)
+	contentDisposition := fmt.Sprintf("inline; filename=\"%s\"; filename*=UTF-8''%s",
+		encodedFilename, encodedFilename)
+
+	presignedReq, err := presignClient.PresignGetObject(ctx, &s3.GetObjectInput{
+		Bucket:                     aws.String(s.svc.bucket),
+		Key:                        aws.String(file.FileKey),
+		ResponseCacheControl:       aws.String("max-age=3600, public"),
+		ResponseContentDisposition: aws.String(contentDisposition),
+	}, func(opts *s3.PresignOptions) {
+		opts.Expires = duration
+	})
+	if err != nil {
+		return "", fmt.Errorf("cannot presign GetObject request: %w", err)
+	}
+
+	return presignedReq.URL, nil
+}
+
+func (s TrustCenterReferenceService) uploadLogoFile(
+	ctx context.Context,
+	tx pg.Conn,
+	file File,
+	referenceID gid.GID,
+	now time.Time,
+) (gid.GID, string, error) {
+	fileID := gid.New(s.svc.scope.GetTenantID(), coredata.FileEntityType)
+
+	objectKey, err := uuid.NewV7()
+	if err != nil {
+		return gid.GID{}, "", fmt.Errorf("cannot generate object key: %w", err)
+	}
+
+	var fileSize int64
+	var fileContent io.ReadSeeker
+	filename := file.Filename
+	contentType := file.ContentType
+
+	if readSeeker, ok := file.Content.(io.ReadSeeker); ok {
+		if file.Size <= 0 {
+			size, err := readSeeker.Seek(0, io.SeekEnd)
+			if err != nil {
+				return gid.GID{}, "", fmt.Errorf("cannot determine file size: %w", err)
+			}
+			fileSize = size
+
+			_, err = readSeeker.Seek(0, io.SeekStart)
+			if err != nil {
+				return gid.GID{}, "", fmt.Errorf("cannot reset file position: %w", err)
+			}
+		} else {
+			fileSize = file.Size
+		}
+		fileContent = readSeeker
+	} else {
+		buf, err := io.ReadAll(file.Content)
+		if err != nil {
+			return gid.GID{}, "", fmt.Errorf("cannot read file: %w", err)
+		}
+		fileSize = int64(len(buf))
+		fileContent = bytes.NewReader(buf)
+	}
+
+	if contentType == "" {
+		contentType = "application/octet-stream"
+		if filename != "" {
+			if detectedType := mime.TypeByExtension(filepath.Ext(filename)); detectedType != "" {
+				contentType = detectedType
+			}
+		}
+	}
+
+	_, err = s.svc.s3.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      aws.String(s.svc.bucket),
+		Key:         aws.String(objectKey.String()),
+		Body:        fileContent,
+		ContentType: aws.String(contentType),
+		Metadata: map[string]string{
+			"type":                      "trust-center-reference-logo",
+			"trust-center-reference-id": referenceID.String(),
+		},
+	})
+	if err != nil {
+		return gid.GID{}, "", fmt.Errorf("cannot upload logo file to S3: %w", err)
+	}
+
+	fileRecord := &coredata.File{
+		ID:         fileID,
+		BucketName: s.svc.bucket,
+		MimeType:   contentType,
+		FileName:   filename,
+		FileKey:    objectKey.String(),
+		FileSize:   int(fileSize),
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+
+	if err := fileRecord.Insert(ctx, tx, s.svc.scope); err != nil {
+		return gid.GID{}, "", fmt.Errorf("cannot insert file: %w", err)
+	}
+
+	return fileID, objectKey.String(), nil
+}
+
+func (s TrustCenterReferenceService) cleanupS3Object(ctx context.Context, s3Key string) {
+	if s3Key == "" {
+		return
+	}
+
+	s.svc.s3.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(s.svc.bucket),
+		Key:    aws.String(s3Key),
+	})
+}

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -1106,6 +1106,22 @@ enum TrustCenterAccessOrderField
     )
 }
 
+enum TrustCenterReferenceOrderField
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.TrustCenterReferenceOrderField") {
+  NAME
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.TrustCenterReferenceOrderFieldName"
+    )
+  CREATED_AT
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.TrustCenterReferenceOrderFieldCreatedAt"
+    )
+  UPDATED_AT
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.TrustCenterReferenceOrderFieldUpdatedAt"
+    )
+}
+
 enum SnapshotsType
   @goModel(model: "github.com/getprobo/probo/pkg/coredata.SnapshotsType") {
   RISKS
@@ -1279,6 +1295,14 @@ input TrustCenterAccessOrder
   field: TrustCenterAccessOrderField!
 }
 
+input TrustCenterReferenceOrder
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.TrustCenterReferenceOrderBy"
+  ) {
+  direction: OrderDirection!
+  field: TrustCenterReferenceOrderField!
+}
+
 input EvidenceOrder
   @goModel(
     model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.EvidenceOrderBy"
@@ -1413,6 +1437,14 @@ type TrustCenter implements Node {
     before: CursorKey
     orderBy: TrustCenterAccessOrder
   ): TrustCenterAccessConnection! @goField(forceResolver: true)
+
+  references(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+    orderBy: TrustCenterReferenceOrder
+  ): TrustCenterReferenceConnection! @goField(forceResolver: true)
 }
 
 type Organization implements Node {
@@ -2168,6 +2200,29 @@ type TrustCenterAccessEdge {
   node: TrustCenterAccess!
 }
 
+type TrustCenterReference implements Node {
+  id: ID!
+  name: String!
+  description: String!
+  websiteUrl: String!
+  logoUrl: String! @goField(forceResolver: true)
+  createdAt: Datetime!
+  updatedAt: Datetime!
+}
+
+type TrustCenterReferenceConnection @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.TrustCenterReferenceConnection"
+  ){
+  totalCount: Int! @goField(forceResolver: true)
+  edges: [TrustCenterReferenceEdge!]!
+  pageInfo: PageInfo!
+}
+
+type TrustCenterReferenceEdge {
+  cursor: CursorKey!
+  node: TrustCenterReference!
+}
+
 type UserConnection {
   edges: [UserEdge!]!
   pageInfo: PageInfo!
@@ -2504,6 +2559,19 @@ type Mutation {
     input: DeleteTrustCenterAccessInput!
   ): DeleteTrustCenterAccessPayload!
 
+  # Trust Center Reference mutations
+  createTrustCenterReference(
+    input: CreateTrustCenterReferenceInput!
+  ): CreateTrustCenterReferencePayload!
+
+  updateTrustCenterReference(
+    input: UpdateTrustCenterReferenceInput!
+  ): UpdateTrustCenterReferencePayload!
+
+  deleteTrustCenterReference(
+    input: DeleteTrustCenterReferenceInput!
+  ): DeleteTrustCenterReferencePayload!
+
   # User mutations
   confirmEmail(input: ConfirmEmailInput!): ConfirmEmailPayload!
   inviteUser(input: InviteUserInput!): InviteUserPayload!
@@ -2810,6 +2878,26 @@ input UpdateTrustCenterAccessInput {
 }
 
 input DeleteTrustCenterAccessInput {
+  id: ID!
+}
+
+input CreateTrustCenterReferenceInput {
+  trustCenterId: ID!
+  name: String!
+  description: String!
+  websiteUrl: String!
+  logoFile: Upload!
+}
+
+input UpdateTrustCenterReferenceInput {
+  id: ID!
+  name: String
+  description: String
+  websiteUrl: String
+  logoFile: Upload
+}
+
+input DeleteTrustCenterReferenceInput {
   id: ID!
 }
 
@@ -3448,6 +3536,18 @@ type UpdateTrustCenterAccessPayload {
 
 type DeleteTrustCenterAccessPayload {
   deletedTrustCenterAccessId: ID!
+}
+
+type CreateTrustCenterReferencePayload {
+  trustCenterReferenceEdge: TrustCenterReferenceEdge!
+}
+
+type UpdateTrustCenterReferencePayload {
+  trustCenterReference: TrustCenterReference!
+}
+
+type DeleteTrustCenterReferencePayload {
+  deletedTrustCenterReferenceId: ID!
 }
 
 type CreateControlPayload {

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -82,6 +82,8 @@ type ResolverRoot interface {
 	Task() TaskResolver
 	TaskConnection() TaskConnectionResolver
 	TrustCenter() TrustCenterResolver
+	TrustCenterReference() TrustCenterReferenceResolver
+	TrustCenterReferenceConnection() TrustCenterReferenceConnectionResolver
 	User() UserResolver
 	Vendor() VendorResolver
 	VendorBusinessAssociateAgreement() VendorBusinessAssociateAgreementResolver
@@ -363,6 +365,10 @@ type ComplexityRoot struct {
 		TrustCenterAccessEdge func(childComplexity int) int
 	}
 
+	CreateTrustCenterReferencePayload struct {
+		TrustCenterReferenceEdge func(childComplexity int) int
+	}
+
 	CreateVendorContactPayload struct {
 		VendorContactEdge func(childComplexity int) int
 	}
@@ -514,6 +520,10 @@ type ComplexityRoot struct {
 
 	DeleteTrustCenterNDAPayload struct {
 		TrustCenter func(childComplexity int) int
+	}
+
+	DeleteTrustCenterReferencePayload struct {
+		DeletedTrustCenterReferenceID func(childComplexity int) int
 	}
 
 	DeleteVendorBusinessAssociateAgreementPayload struct {
@@ -751,6 +761,7 @@ type ComplexityRoot struct {
 		CreateSnapshot                         func(childComplexity int, input types.CreateSnapshotInput) int
 		CreateTask                             func(childComplexity int, input types.CreateTaskInput) int
 		CreateTrustCenterAccess                func(childComplexity int, input types.CreateTrustCenterAccessInput) int
+		CreateTrustCenterReference             func(childComplexity int, input types.CreateTrustCenterReferenceInput) int
 		CreateVendor                           func(childComplexity int, input types.CreateVendorInput) int
 		CreateVendorContact                    func(childComplexity int, input types.CreateVendorContactInput) int
 		CreateVendorRiskAssessment             func(childComplexity int, input types.CreateVendorRiskAssessmentInput) int
@@ -782,6 +793,7 @@ type ComplexityRoot struct {
 		DeleteTask                             func(childComplexity int, input types.DeleteTaskInput) int
 		DeleteTrustCenterAccess                func(childComplexity int, input types.DeleteTrustCenterAccessInput) int
 		DeleteTrustCenterNda                   func(childComplexity int, input types.DeleteTrustCenterNDAInput) int
+		DeleteTrustCenterReference             func(childComplexity int, input types.DeleteTrustCenterReferenceInput) int
 		DeleteVendor                           func(childComplexity int, input types.DeleteVendorInput) int
 		DeleteVendorBusinessAssociateAgreement func(childComplexity int, input types.DeleteVendorBusinessAssociateAgreementInput) int
 		DeleteVendorComplianceReport           func(childComplexity int, input types.DeleteVendorComplianceReportInput) int
@@ -820,6 +832,7 @@ type ComplexityRoot struct {
 		UpdateTask                             func(childComplexity int, input types.UpdateTaskInput) int
 		UpdateTrustCenter                      func(childComplexity int, input types.UpdateTrustCenterInput) int
 		UpdateTrustCenterAccess                func(childComplexity int, input types.UpdateTrustCenterAccessInput) int
+		UpdateTrustCenterReference             func(childComplexity int, input types.UpdateTrustCenterReferenceInput) int
 		UpdateVendor                           func(childComplexity int, input types.UpdateVendorInput) int
 		UpdateVendorBusinessAssociateAgreement func(childComplexity int, input types.UpdateVendorBusinessAssociateAgreementInput) int
 		UpdateVendorContact                    func(childComplexity int, input types.UpdateVendorContactInput) int
@@ -1131,6 +1144,7 @@ type ComplexityRoot struct {
 		NdaFileName  func(childComplexity int) int
 		NdaFileURL   func(childComplexity int) int
 		Organization func(childComplexity int) int
+		References   func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.OrderBy[coredata.TrustCenterReferenceOrderField]) int
 		Slug         func(childComplexity int) int
 		UpdatedAt    func(childComplexity int) int
 	}
@@ -1161,6 +1175,27 @@ type ComplexityRoot struct {
 	}
 
 	TrustCenterEdge struct {
+		Cursor func(childComplexity int) int
+		Node   func(childComplexity int) int
+	}
+
+	TrustCenterReference struct {
+		CreatedAt   func(childComplexity int) int
+		Description func(childComplexity int) int
+		ID          func(childComplexity int) int
+		LogoURL     func(childComplexity int) int
+		Name        func(childComplexity int) int
+		UpdatedAt   func(childComplexity int) int
+		WebsiteURL  func(childComplexity int) int
+	}
+
+	TrustCenterReferenceConnection struct {
+		Edges      func(childComplexity int) int
+		PageInfo   func(childComplexity int) int
+		TotalCount func(childComplexity int) int
+	}
+
+	TrustCenterReferenceEdge struct {
 		Cursor func(childComplexity int) int
 		Node   func(childComplexity int) int
 	}
@@ -1239,6 +1274,10 @@ type ComplexityRoot struct {
 
 	UpdateTrustCenterPayload struct {
 		TrustCenter func(childComplexity int) int
+	}
+
+	UpdateTrustCenterReferencePayload struct {
+		TrustCenterReference func(childComplexity int) int
 	}
 
 	UpdateVendorBusinessAssociateAgreementPayload struct {
@@ -1573,6 +1612,9 @@ type MutationResolver interface {
 	CreateTrustCenterAccess(ctx context.Context, input types.CreateTrustCenterAccessInput) (*types.CreateTrustCenterAccessPayload, error)
 	UpdateTrustCenterAccess(ctx context.Context, input types.UpdateTrustCenterAccessInput) (*types.UpdateTrustCenterAccessPayload, error)
 	DeleteTrustCenterAccess(ctx context.Context, input types.DeleteTrustCenterAccessInput) (*types.DeleteTrustCenterAccessPayload, error)
+	CreateTrustCenterReference(ctx context.Context, input types.CreateTrustCenterReferenceInput) (*types.CreateTrustCenterReferencePayload, error)
+	UpdateTrustCenterReference(ctx context.Context, input types.UpdateTrustCenterReferenceInput) (*types.UpdateTrustCenterReferencePayload, error)
+	DeleteTrustCenterReference(ctx context.Context, input types.DeleteTrustCenterReferenceInput) (*types.DeleteTrustCenterReferencePayload, error)
 	ConfirmEmail(ctx context.Context, input types.ConfirmEmailInput) (*types.ConfirmEmailPayload, error)
 	InviteUser(ctx context.Context, input types.InviteUserInput) (*types.InviteUserPayload, error)
 	RemoveUser(ctx context.Context, input types.RemoveUserInput) (*types.RemoveUserPayload, error)
@@ -1767,6 +1809,13 @@ type TrustCenterResolver interface {
 
 	Organization(ctx context.Context, obj *types.TrustCenter) (*types.Organization, error)
 	Accesses(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.OrderBy[coredata.TrustCenterAccessOrderField]) (*types.TrustCenterAccessConnection, error)
+	References(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.OrderBy[coredata.TrustCenterReferenceOrderField]) (*types.TrustCenterReferenceConnection, error)
+}
+type TrustCenterReferenceResolver interface {
+	LogoURL(ctx context.Context, obj *types.TrustCenterReference) (string, error)
+}
+type TrustCenterReferenceConnectionResolver interface {
+	TotalCount(ctx context.Context, obj *types.TrustCenterReferenceConnection) (int, error)
 }
 type UserResolver interface {
 	People(ctx context.Context, obj *types.User, organizationID gid.GID) (*types.People, error)
@@ -2709,6 +2758,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.CreateTrustCenterAccessPayload.TrustCenterAccessEdge(childComplexity), true
 
+	case "CreateTrustCenterReferencePayload.trustCenterReferenceEdge":
+		if e.complexity.CreateTrustCenterReferencePayload.TrustCenterReferenceEdge == nil {
+			break
+		}
+
+		return e.complexity.CreateTrustCenterReferencePayload.TrustCenterReferenceEdge(childComplexity), true
+
 	case "CreateVendorContactPayload.vendorContactEdge":
 		if e.complexity.CreateVendorContactPayload.VendorContactEdge == nil {
 			break
@@ -3070,6 +3126,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.DeleteTrustCenterNDAPayload.TrustCenter(childComplexity), true
+
+	case "DeleteTrustCenterReferencePayload.deletedTrustCenterReferenceId":
+		if e.complexity.DeleteTrustCenterReferencePayload.DeletedTrustCenterReferenceID == nil {
+			break
+		}
+
+		return e.complexity.DeleteTrustCenterReferencePayload.DeletedTrustCenterReferenceID(childComplexity), true
 
 	case "DeleteVendorBusinessAssociateAgreementPayload.deletedVendorId":
 		if e.complexity.DeleteVendorBusinessAssociateAgreementPayload.DeletedVendorID == nil {
@@ -4237,6 +4300,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.CreateTrustCenterAccess(childComplexity, args["input"].(types.CreateTrustCenterAccessInput)), true
 
+	case "Mutation.createTrustCenterReference":
+		if e.complexity.Mutation.CreateTrustCenterReference == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_createTrustCenterReference_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreateTrustCenterReference(childComplexity, args["input"].(types.CreateTrustCenterReferenceInput)), true
+
 	case "Mutation.createVendor":
 		if e.complexity.Mutation.CreateVendor == nil {
 			break
@@ -4608,6 +4683,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.DeleteTrustCenterNda(childComplexity, args["input"].(types.DeleteTrustCenterNDAInput)), true
+
+	case "Mutation.deleteTrustCenterReference":
+		if e.complexity.Mutation.DeleteTrustCenterReference == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_deleteTrustCenterReference_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteTrustCenterReference(childComplexity, args["input"].(types.DeleteTrustCenterReferenceInput)), true
 
 	case "Mutation.deleteVendor":
 		if e.complexity.Mutation.DeleteVendor == nil {
@@ -5064,6 +5151,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.UpdateTrustCenterAccess(childComplexity, args["input"].(types.UpdateTrustCenterAccessInput)), true
+
+	case "Mutation.updateTrustCenterReference":
+		if e.complexity.Mutation.UpdateTrustCenterReference == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_updateTrustCenterReference_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UpdateTrustCenterReference(childComplexity, args["input"].(types.UpdateTrustCenterReferenceInput)), true
 
 	case "Mutation.updateVendor":
 		if e.complexity.Mutation.UpdateVendor == nil {
@@ -6713,6 +6812,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.TrustCenter.Organization(childComplexity), true
 
+	case "TrustCenter.references":
+		if e.complexity.TrustCenter.References == nil {
+			break
+		}
+
+		args, err := ec.field_TrustCenter_references_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.TrustCenter.References(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.OrderBy[coredata.TrustCenterReferenceOrderField])), true
+
 	case "TrustCenter.slug":
 		if e.complexity.TrustCenter.Slug == nil {
 			break
@@ -6831,6 +6942,90 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.TrustCenterEdge.Node(childComplexity), true
+
+	case "TrustCenterReference.createdAt":
+		if e.complexity.TrustCenterReference.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterReference.CreatedAt(childComplexity), true
+
+	case "TrustCenterReference.description":
+		if e.complexity.TrustCenterReference.Description == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterReference.Description(childComplexity), true
+
+	case "TrustCenterReference.id":
+		if e.complexity.TrustCenterReference.ID == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterReference.ID(childComplexity), true
+
+	case "TrustCenterReference.logoUrl":
+		if e.complexity.TrustCenterReference.LogoURL == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterReference.LogoURL(childComplexity), true
+
+	case "TrustCenterReference.name":
+		if e.complexity.TrustCenterReference.Name == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterReference.Name(childComplexity), true
+
+	case "TrustCenterReference.updatedAt":
+		if e.complexity.TrustCenterReference.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterReference.UpdatedAt(childComplexity), true
+
+	case "TrustCenterReference.websiteUrl":
+		if e.complexity.TrustCenterReference.WebsiteURL == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterReference.WebsiteURL(childComplexity), true
+
+	case "TrustCenterReferenceConnection.edges":
+		if e.complexity.TrustCenterReferenceConnection.Edges == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterReferenceConnection.Edges(childComplexity), true
+
+	case "TrustCenterReferenceConnection.pageInfo":
+		if e.complexity.TrustCenterReferenceConnection.PageInfo == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterReferenceConnection.PageInfo(childComplexity), true
+
+	case "TrustCenterReferenceConnection.totalCount":
+		if e.complexity.TrustCenterReferenceConnection.TotalCount == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterReferenceConnection.TotalCount(childComplexity), true
+
+	case "TrustCenterReferenceEdge.cursor":
+		if e.complexity.TrustCenterReferenceEdge.Cursor == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterReferenceEdge.Cursor(childComplexity), true
+
+	case "TrustCenterReferenceEdge.node":
+		if e.complexity.TrustCenterReferenceEdge.Node == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterReferenceEdge.Node(childComplexity), true
 
 	case "UnassignTaskPayload.task":
 		if e.complexity.UnassignTaskPayload.Task == nil {
@@ -6964,6 +7159,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.UpdateTrustCenterPayload.TrustCenter(childComplexity), true
+
+	case "UpdateTrustCenterReferencePayload.trustCenterReference":
+		if e.complexity.UpdateTrustCenterReferencePayload.TrustCenterReference == nil {
+			break
+		}
+
+		return e.complexity.UpdateTrustCenterReferencePayload.TrustCenterReference(childComplexity), true
 
 	case "UpdateVendorBusinessAssociateAgreementPayload.vendorBusinessAssociateAgreement":
 		if e.complexity.UpdateVendorBusinessAssociateAgreementPayload.VendorBusinessAssociateAgreement == nil {
@@ -7926,6 +8128,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputCreateSnapshotInput,
 		ec.unmarshalInputCreateTaskInput,
 		ec.unmarshalInputCreateTrustCenterAccessInput,
+		ec.unmarshalInputCreateTrustCenterReferenceInput,
 		ec.unmarshalInputCreateVendorContactInput,
 		ec.unmarshalInputCreateVendorInput,
 		ec.unmarshalInputCreateVendorRiskAssessmentInput,
@@ -7959,6 +8162,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputDeleteTaskInput,
 		ec.unmarshalInputDeleteTrustCenterAccessInput,
 		ec.unmarshalInputDeleteTrustCenterNDAInput,
+		ec.unmarshalInputDeleteTrustCenterReferenceInput,
 		ec.unmarshalInputDeleteVendorBusinessAssociateAgreementInput,
 		ec.unmarshalInputDeleteVendorComplianceReportInput,
 		ec.unmarshalInputDeleteVendorContactInput,
@@ -8002,6 +8206,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputSnapshotOrder,
 		ec.unmarshalInputTaskOrder,
 		ec.unmarshalInputTrustCenterAccessOrder,
+		ec.unmarshalInputTrustCenterReferenceOrder,
 		ec.unmarshalInputUnassignTaskInput,
 		ec.unmarshalInputUpdateAssetInput,
 		ec.unmarshalInputUpdateAuditInput,
@@ -8021,6 +8226,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputUpdateTaskInput,
 		ec.unmarshalInputUpdateTrustCenterAccessInput,
 		ec.unmarshalInputUpdateTrustCenterInput,
+		ec.unmarshalInputUpdateTrustCenterReferenceInput,
 		ec.unmarshalInputUpdateVendorBusinessAssociateAgreementInput,
 		ec.unmarshalInputUpdateVendorContactInput,
 		ec.unmarshalInputUpdateVendorDataPrivacyAgreementInput,
@@ -9245,6 +9451,22 @@ enum TrustCenterAccessOrderField
     )
 }
 
+enum TrustCenterReferenceOrderField
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.TrustCenterReferenceOrderField") {
+  NAME
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.TrustCenterReferenceOrderFieldName"
+    )
+  CREATED_AT
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.TrustCenterReferenceOrderFieldCreatedAt"
+    )
+  UPDATED_AT
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.TrustCenterReferenceOrderFieldUpdatedAt"
+    )
+}
+
 enum SnapshotsType
   @goModel(model: "github.com/getprobo/probo/pkg/coredata.SnapshotsType") {
   RISKS
@@ -9418,6 +9640,14 @@ input TrustCenterAccessOrder
   field: TrustCenterAccessOrderField!
 }
 
+input TrustCenterReferenceOrder
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.TrustCenterReferenceOrderBy"
+  ) {
+  direction: OrderDirection!
+  field: TrustCenterReferenceOrderField!
+}
+
 input EvidenceOrder
   @goModel(
     model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.EvidenceOrderBy"
@@ -9552,6 +9782,14 @@ type TrustCenter implements Node {
     before: CursorKey
     orderBy: TrustCenterAccessOrder
   ): TrustCenterAccessConnection! @goField(forceResolver: true)
+
+  references(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+    orderBy: TrustCenterReferenceOrder
+  ): TrustCenterReferenceConnection! @goField(forceResolver: true)
 }
 
 type Organization implements Node {
@@ -10307,6 +10545,29 @@ type TrustCenterAccessEdge {
   node: TrustCenterAccess!
 }
 
+type TrustCenterReference implements Node {
+  id: ID!
+  name: String!
+  description: String!
+  websiteUrl: String!
+  logoUrl: String! @goField(forceResolver: true)
+  createdAt: Datetime!
+  updatedAt: Datetime!
+}
+
+type TrustCenterReferenceConnection @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.TrustCenterReferenceConnection"
+  ){
+  totalCount: Int! @goField(forceResolver: true)
+  edges: [TrustCenterReferenceEdge!]!
+  pageInfo: PageInfo!
+}
+
+type TrustCenterReferenceEdge {
+  cursor: CursorKey!
+  node: TrustCenterReference!
+}
+
 type UserConnection {
   edges: [UserEdge!]!
   pageInfo: PageInfo!
@@ -10643,6 +10904,19 @@ type Mutation {
     input: DeleteTrustCenterAccessInput!
   ): DeleteTrustCenterAccessPayload!
 
+  # Trust Center Reference mutations
+  createTrustCenterReference(
+    input: CreateTrustCenterReferenceInput!
+  ): CreateTrustCenterReferencePayload!
+
+  updateTrustCenterReference(
+    input: UpdateTrustCenterReferenceInput!
+  ): UpdateTrustCenterReferencePayload!
+
+  deleteTrustCenterReference(
+    input: DeleteTrustCenterReferenceInput!
+  ): DeleteTrustCenterReferencePayload!
+
   # User mutations
   confirmEmail(input: ConfirmEmailInput!): ConfirmEmailPayload!
   inviteUser(input: InviteUserInput!): InviteUserPayload!
@@ -10949,6 +11223,26 @@ input UpdateTrustCenterAccessInput {
 }
 
 input DeleteTrustCenterAccessInput {
+  id: ID!
+}
+
+input CreateTrustCenterReferenceInput {
+  trustCenterId: ID!
+  name: String!
+  description: String!
+  websiteUrl: String!
+  logoFile: Upload!
+}
+
+input UpdateTrustCenterReferenceInput {
+  id: ID!
+  name: String
+  description: String
+  websiteUrl: String
+  logoFile: Upload
+}
+
+input DeleteTrustCenterReferenceInput {
   id: ID!
 }
 
@@ -11587,6 +11881,18 @@ type UpdateTrustCenterAccessPayload {
 
 type DeleteTrustCenterAccessPayload {
   deletedTrustCenterAccessId: ID!
+}
+
+type CreateTrustCenterReferencePayload {
+  trustCenterReferenceEdge: TrustCenterReferenceEdge!
+}
+
+type UpdateTrustCenterReferencePayload {
+  trustCenterReference: TrustCenterReference!
+}
+
+type DeleteTrustCenterReferencePayload {
+  deletedTrustCenterReferenceId: ID!
 }
 
 type CreateControlPayload {
@@ -14636,6 +14942,29 @@ func (ec *executionContext) field_Mutation_createTrustCenterAccess_argsInput(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation_createTrustCenterReference_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_createTrustCenterReference_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_createTrustCenterReference_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.CreateTrustCenterReferenceInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNCreateTrustCenterReferenceInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateTrustCenterReferenceInput(ctx, tmp)
+	}
+
+	var zeroVal types.CreateTrustCenterReferenceInput
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation_createVendorContact_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -15346,6 +15675,29 @@ func (ec *executionContext) field_Mutation_deleteTrustCenterNDA_argsInput(
 	}
 
 	var zeroVal types.DeleteTrustCenterNDAInput
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_deleteTrustCenterReference_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_deleteTrustCenterReference_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_deleteTrustCenterReference_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.DeleteTrustCenterReferenceInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNDeleteTrustCenterReferenceInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteTrustCenterReferenceInput(ctx, tmp)
+	}
+
+	var zeroVal types.DeleteTrustCenterReferenceInput
 	return zeroVal, nil
 }
 
@@ -16197,6 +16549,29 @@ func (ec *executionContext) field_Mutation_updateTrustCenterAccess_argsInput(
 	}
 
 	var zeroVal types.UpdateTrustCenterAccessInput
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_updateTrustCenterReference_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_updateTrustCenterReference_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_updateTrustCenterReference_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.UpdateTrustCenterReferenceInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNUpdateTrustCenterReferenceInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateTrustCenterReferenceInput(ctx, tmp)
+	}
+
+	var zeroVal types.UpdateTrustCenterReferenceInput
 	return zeroVal, nil
 }
 
@@ -19110,6 +19485,101 @@ func (ec *executionContext) field_TrustCenter_accesses_argsOrderBy(
 	}
 
 	var zeroVal *types.OrderBy[coredata.TrustCenterAccessOrderField]
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_TrustCenter_references_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_TrustCenter_references_argsFirst(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["first"] = arg0
+	arg1, err := ec.field_TrustCenter_references_argsAfter(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["after"] = arg1
+	arg2, err := ec.field_TrustCenter_references_argsLast(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["last"] = arg2
+	arg3, err := ec.field_TrustCenter_references_argsBefore(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["before"] = arg3
+	arg4, err := ec.field_TrustCenter_references_argsOrderBy(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["orderBy"] = arg4
+	return args, nil
+}
+func (ec *executionContext) field_TrustCenter_references_argsFirst(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*int, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("first"))
+	if tmp, ok := rawArgs["first"]; ok {
+		return ec.unmarshalOInt2ᚖint(ctx, tmp)
+	}
+
+	var zeroVal *int
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_TrustCenter_references_argsAfter(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*page.CursorKey, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("after"))
+	if tmp, ok := rawArgs["after"]; ok {
+		return ec.unmarshalOCursorKey2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐCursorKey(ctx, tmp)
+	}
+
+	var zeroVal *page.CursorKey
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_TrustCenter_references_argsLast(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*int, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("last"))
+	if tmp, ok := rawArgs["last"]; ok {
+		return ec.unmarshalOInt2ᚖint(ctx, tmp)
+	}
+
+	var zeroVal *int
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_TrustCenter_references_argsBefore(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*page.CursorKey, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("before"))
+	if tmp, ok := rawArgs["before"]; ok {
+		return ec.unmarshalOCursorKey2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐCursorKey(ctx, tmp)
+	}
+
+	var zeroVal *page.CursorKey
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_TrustCenter_references_argsOrderBy(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*types.OrderBy[coredata.TrustCenterReferenceOrderField], error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("orderBy"))
+	if tmp, ok := rawArgs["orderBy"]; ok {
+		return ec.unmarshalOTrustCenterReferenceOrder2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐOrderBy(ctx, tmp)
+	}
+
+	var zeroVal *types.OrderBy[coredata.TrustCenterReferenceOrderField]
 	return zeroVal, nil
 }
 
@@ -25901,6 +26371,56 @@ func (ec *executionContext) fieldContext_CreateTrustCenterAccessPayload_trustCen
 	return fc, nil
 }
 
+func (ec *executionContext) _CreateTrustCenterReferencePayload_trustCenterReferenceEdge(ctx context.Context, field graphql.CollectedField, obj *types.CreateTrustCenterReferencePayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CreateTrustCenterReferencePayload_trustCenterReferenceEdge(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TrustCenterReferenceEdge, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.TrustCenterReferenceEdge)
+	fc.Result = res
+	return ec.marshalNTrustCenterReferenceEdge2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterReferenceEdge(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CreateTrustCenterReferencePayload_trustCenterReferenceEdge(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CreateTrustCenterReferencePayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "cursor":
+				return ec.fieldContext_TrustCenterReferenceEdge_cursor(ctx, field)
+			case "node":
+				return ec.fieldContext_TrustCenterReferenceEdge_node(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustCenterReferenceEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _CreateVendorContactPayload_vendorContactEdge(ctx context.Context, field graphql.CollectedField, obj *types.CreateVendorContactPayload) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_CreateVendorContactPayload_vendorContactEdge(ctx, field)
 	if err != nil {
@@ -28342,8 +28862,54 @@ func (ec *executionContext) fieldContext_DeleteTrustCenterNDAPayload_trustCenter
 				return ec.fieldContext_TrustCenter_organization(ctx, field)
 			case "accesses":
 				return ec.fieldContext_TrustCenter_accesses(ctx, field)
+			case "references":
+				return ec.fieldContext_TrustCenter_references(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TrustCenter", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DeleteTrustCenterReferencePayload_deletedTrustCenterReferenceId(ctx context.Context, field graphql.CollectedField, obj *types.DeleteTrustCenterReferencePayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DeleteTrustCenterReferencePayload_deletedTrustCenterReferenceId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DeletedTrustCenterReferenceID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(gid.GID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DeleteTrustCenterReferencePayload_deletedTrustCenterReferenceId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DeleteTrustCenterReferencePayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	return fc, nil
@@ -34228,6 +34794,183 @@ func (ec *executionContext) fieldContext_Mutation_deleteTrustCenterAccess(ctx co
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_deleteTrustCenterAccess_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_createTrustCenterReference(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_createTrustCenterReference(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateTrustCenterReference(rctx, fc.Args["input"].(types.CreateTrustCenterReferenceInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.CreateTrustCenterReferencePayload)
+	fc.Result = res
+	return ec.marshalNCreateTrustCenterReferencePayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateTrustCenterReferencePayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_createTrustCenterReference(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "trustCenterReferenceEdge":
+				return ec.fieldContext_CreateTrustCenterReferencePayload_trustCenterReferenceEdge(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CreateTrustCenterReferencePayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_createTrustCenterReference_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_updateTrustCenterReference(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_updateTrustCenterReference(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UpdateTrustCenterReference(rctx, fc.Args["input"].(types.UpdateTrustCenterReferenceInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.UpdateTrustCenterReferencePayload)
+	fc.Result = res
+	return ec.marshalNUpdateTrustCenterReferencePayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateTrustCenterReferencePayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_updateTrustCenterReference(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "trustCenterReference":
+				return ec.fieldContext_UpdateTrustCenterReferencePayload_trustCenterReference(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UpdateTrustCenterReferencePayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_updateTrustCenterReference_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_deleteTrustCenterReference(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_deleteTrustCenterReference(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteTrustCenterReference(rctx, fc.Args["input"].(types.DeleteTrustCenterReferenceInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.DeleteTrustCenterReferencePayload)
+	fc.Result = res
+	return ec.marshalNDeleteTrustCenterReferencePayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteTrustCenterReferencePayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_deleteTrustCenterReference(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "deletedTrustCenterReferenceId":
+				return ec.fieldContext_DeleteTrustCenterReferencePayload_deletedTrustCenterReferenceId(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DeleteTrustCenterReferencePayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_deleteTrustCenterReference_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -43922,6 +44665,8 @@ func (ec *executionContext) fieldContext_Organization_trustCenter(_ context.Cont
 				return ec.fieldContext_TrustCenter_organization(ctx, field)
 			case "accesses":
 				return ec.fieldContext_TrustCenter_accesses(ctx, field)
+			case "references":
+				return ec.fieldContext_TrustCenter_references(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TrustCenter", field.Name)
 		},
@@ -50647,6 +51392,69 @@ func (ec *executionContext) fieldContext_TrustCenter_accesses(ctx context.Contex
 	return fc, nil
 }
 
+func (ec *executionContext) _TrustCenter_references(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenter) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenter_references(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TrustCenter().References(rctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey), fc.Args["orderBy"].(*types.OrderBy[coredata.TrustCenterReferenceOrderField]))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.TrustCenterReferenceConnection)
+	fc.Result = res
+	return ec.marshalNTrustCenterReferenceConnection2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterReferenceConnection(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenter_references(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenter",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "totalCount":
+				return ec.fieldContext_TrustCenterReferenceConnection_totalCount(ctx, field)
+			case "edges":
+				return ec.fieldContext_TrustCenterReferenceConnection_edges(ctx, field)
+			case "pageInfo":
+				return ec.fieldContext_TrustCenterReferenceConnection_pageInfo(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustCenterReferenceConnection", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_TrustCenter_references_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _TrustCenterAccess_id(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterAccess) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_TrustCenterAccess_id(ctx, field)
 	if err != nil {
@@ -51368,8 +52176,570 @@ func (ec *executionContext) fieldContext_TrustCenterEdge_node(_ context.Context,
 				return ec.fieldContext_TrustCenter_organization(ctx, field)
 			case "accesses":
 				return ec.fieldContext_TrustCenter_accesses(ctx, field)
+			case "references":
+				return ec.fieldContext_TrustCenter_references(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TrustCenter", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterReference_id(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterReference) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterReference_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(gid.GID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterReference_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterReference",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterReference_name(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterReference) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterReference_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterReference_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterReference",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterReference_description(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterReference) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterReference_description(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Description, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterReference_description(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterReference",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterReference_websiteUrl(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterReference) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterReference_websiteUrl(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.WebsiteURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterReference_websiteUrl(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterReference",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterReference_logoUrl(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterReference) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterReference_logoUrl(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TrustCenterReference().LogoURL(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterReference_logoUrl(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterReference",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterReference_createdAt(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterReference) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterReference_createdAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNDatetime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterReference_createdAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterReference",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterReference_updatedAt(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterReference) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterReference_updatedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNDatetime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterReference_updatedAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterReference",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterReferenceConnection_totalCount(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterReferenceConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterReferenceConnection_totalCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TrustCenterReferenceConnection().TotalCount(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterReferenceConnection_totalCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterReferenceConnection",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterReferenceConnection_edges(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterReferenceConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterReferenceConnection_edges(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Edges, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*types.TrustCenterReferenceEdge)
+	fc.Result = res
+	return ec.marshalNTrustCenterReferenceEdge2ᚕᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterReferenceEdgeᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterReferenceConnection_edges(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterReferenceConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "cursor":
+				return ec.fieldContext_TrustCenterReferenceEdge_cursor(ctx, field)
+			case "node":
+				return ec.fieldContext_TrustCenterReferenceEdge_node(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustCenterReferenceEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterReferenceConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterReferenceConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterReferenceConnection_pageInfo(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PageInfo, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.PageInfo)
+	fc.Result = res
+	return ec.marshalNPageInfo2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐPageInfo(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterReferenceConnection_pageInfo(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterReferenceConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "hasNextPage":
+				return ec.fieldContext_PageInfo_hasNextPage(ctx, field)
+			case "hasPreviousPage":
+				return ec.fieldContext_PageInfo_hasPreviousPage(ctx, field)
+			case "startCursor":
+				return ec.fieldContext_PageInfo_startCursor(ctx, field)
+			case "endCursor":
+				return ec.fieldContext_PageInfo_endCursor(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterReferenceEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterReferenceEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterReferenceEdge_cursor(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Cursor, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(page.CursorKey)
+	fc.Result = res
+	return ec.marshalNCursorKey2githubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐCursorKey(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterReferenceEdge_cursor(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterReferenceEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type CursorKey does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterReferenceEdge_node(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterReferenceEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterReferenceEdge_node(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Node, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.TrustCenterReference)
+	fc.Result = res
+	return ec.marshalNTrustCenterReference2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterReference(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterReferenceEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterReferenceEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TrustCenterReference_id(ctx, field)
+			case "name":
+				return ec.fieldContext_TrustCenterReference_name(ctx, field)
+			case "description":
+				return ec.fieldContext_TrustCenterReference_description(ctx, field)
+			case "websiteUrl":
+				return ec.fieldContext_TrustCenterReference_websiteUrl(ctx, field)
+			case "logoUrl":
+				return ec.fieldContext_TrustCenterReference_logoUrl(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_TrustCenterReference_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_TrustCenterReference_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustCenterReference", field.Name)
 		},
 	}
 	return fc, nil
@@ -52746,8 +54116,70 @@ func (ec *executionContext) fieldContext_UpdateTrustCenterPayload_trustCenter(_ 
 				return ec.fieldContext_TrustCenter_organization(ctx, field)
 			case "accesses":
 				return ec.fieldContext_TrustCenter_accesses(ctx, field)
+			case "references":
+				return ec.fieldContext_TrustCenter_references(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TrustCenter", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UpdateTrustCenterReferencePayload_trustCenterReference(ctx context.Context, field graphql.CollectedField, obj *types.UpdateTrustCenterReferencePayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UpdateTrustCenterReferencePayload_trustCenterReference(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TrustCenterReference, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.TrustCenterReference)
+	fc.Result = res
+	return ec.marshalNTrustCenterReference2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterReference(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UpdateTrustCenterReferencePayload_trustCenterReference(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UpdateTrustCenterReferencePayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TrustCenterReference_id(ctx, field)
+			case "name":
+				return ec.fieldContext_TrustCenterReference_name(ctx, field)
+			case "description":
+				return ec.fieldContext_TrustCenterReference_description(ctx, field)
+			case "websiteUrl":
+				return ec.fieldContext_TrustCenterReference_websiteUrl(ctx, field)
+			case "logoUrl":
+				return ec.fieldContext_TrustCenterReference_logoUrl(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_TrustCenterReference_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_TrustCenterReference_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustCenterReference", field.Name)
 		},
 	}
 	return fc, nil
@@ -53338,6 +54770,8 @@ func (ec *executionContext) fieldContext_UploadTrustCenterNDAPayload_trustCenter
 				return ec.fieldContext_TrustCenter_organization(ctx, field)
 			case "accesses":
 				return ec.fieldContext_TrustCenter_accesses(ctx, field)
+			case "references":
+				return ec.fieldContext_TrustCenter_references(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TrustCenter", field.Name)
 		},
@@ -63260,6 +64694,61 @@ func (ec *executionContext) unmarshalInputCreateTrustCenterAccessInput(ctx conte
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputCreateTrustCenterReferenceInput(ctx context.Context, obj any) (types.CreateTrustCenterReferenceInput, error) {
+	var it types.CreateTrustCenterReferenceInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"trustCenterId", "name", "description", "websiteUrl", "logoFile"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "trustCenterId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("trustCenterId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.TrustCenterID = data
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "description":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Description = data
+		case "websiteUrl":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("websiteUrl"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.WebsiteURL = data
+		case "logoFile":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("logoFile"))
+			data, err := ec.unmarshalNUpload2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚐUpload(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.LogoFile = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputCreateVendorContactInput(ctx context.Context, obj any) (types.CreateVendorContactInput, error) {
 	var it types.CreateVendorContactInput
 	asMap := map[string]any{}
@@ -64411,6 +65900,33 @@ func (ec *executionContext) unmarshalInputDeleteTrustCenterNDAInput(ctx context.
 				return it, err
 			}
 			it.TrustCenterID = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputDeleteTrustCenterReferenceInput(ctx context.Context, obj any) (types.DeleteTrustCenterReferenceInput, error) {
+	var it types.DeleteTrustCenterReferenceInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ID = data
 		}
 	}
 
@@ -65788,6 +67304,40 @@ func (ec *executionContext) unmarshalInputTrustCenterAccessOrder(ctx context.Con
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputTrustCenterReferenceOrder(ctx context.Context, obj any) (types.OrderBy[coredata.TrustCenterReferenceOrderField], error) {
+	var it types.OrderBy[coredata.TrustCenterReferenceOrderField]
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"direction", "field"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "direction":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("direction"))
+			data, err := ec.unmarshalNOrderDirection2githubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐOrderDirection(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Direction = data
+		case "field":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("field"))
+			data, err := ec.unmarshalNTrustCenterReferenceOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐTrustCenterReferenceOrderField(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Field = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputUnassignTaskInput(ctx context.Context, obj any) (types.UnassignTaskInput, error) {
 	var it types.UnassignTaskInput
 	asMap := map[string]any{}
@@ -67050,6 +68600,61 @@ func (ec *executionContext) unmarshalInputUpdateTrustCenterInput(ctx context.Con
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputUpdateTrustCenterReferenceInput(ctx context.Context, obj any) (types.UpdateTrustCenterReferenceInput, error) {
+	var it types.UpdateTrustCenterReferenceInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id", "name", "description", "websiteUrl", "logoFile"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ID = data
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "description":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Description = data
+		case "websiteUrl":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("websiteUrl"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.WebsiteURL = data
+		case "logoFile":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("logoFile"))
+			data, err := ec.unmarshalOUpload2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚐUpload(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.LogoFile = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputUpdateVendorBusinessAssociateAgreementInput(ctx context.Context, obj any) (types.UpdateVendorBusinessAssociateAgreementInput, error) {
 	var it types.UpdateVendorBusinessAssociateAgreementInput
 	asMap := map[string]any{}
@@ -68012,6 +69617,13 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._User(ctx, sel, obj)
+	case types.TrustCenterReference:
+		return ec._TrustCenterReference(ctx, sel, &obj)
+	case *types.TrustCenterReference:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._TrustCenterReference(ctx, sel, obj)
 	case types.TrustCenterAccess:
 		return ec._TrustCenterAccess(ctx, sel, &obj)
 	case *types.TrustCenterAccess:
@@ -71003,6 +72615,45 @@ func (ec *executionContext) _CreateTrustCenterAccessPayload(ctx context.Context,
 	return out
 }
 
+var createTrustCenterReferencePayloadImplementors = []string{"CreateTrustCenterReferencePayload"}
+
+func (ec *executionContext) _CreateTrustCenterReferencePayload(ctx context.Context, sel ast.SelectionSet, obj *types.CreateTrustCenterReferencePayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, createTrustCenterReferencePayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CreateTrustCenterReferencePayload")
+		case "trustCenterReferenceEdge":
+			out.Values[i] = ec._CreateTrustCenterReferencePayload_trustCenterReferenceEdge(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var createVendorContactPayloadImplementors = []string{"CreateVendorContactPayload"}
 
 func (ec *executionContext) _CreateVendorContactPayload(ctx context.Context, sel ast.SelectionSet, obj *types.CreateVendorContactPayload) graphql.Marshaler {
@@ -72509,6 +74160,45 @@ func (ec *executionContext) _DeleteTrustCenterNDAPayload(ctx context.Context, se
 			out.Values[i] = graphql.MarshalString("DeleteTrustCenterNDAPayload")
 		case "trustCenter":
 			out.Values[i] = ec._DeleteTrustCenterNDAPayload_trustCenter(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var deleteTrustCenterReferencePayloadImplementors = []string{"DeleteTrustCenterReferencePayload"}
+
+func (ec *executionContext) _DeleteTrustCenterReferencePayload(ctx context.Context, sel ast.SelectionSet, obj *types.DeleteTrustCenterReferencePayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, deleteTrustCenterReferencePayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("DeleteTrustCenterReferencePayload")
+		case "deletedTrustCenterReferenceId":
+			out.Values[i] = ec._DeleteTrustCenterReferencePayload_deletedTrustCenterReferenceId(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -74926,6 +76616,27 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "deleteTrustCenterAccess":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_deleteTrustCenterAccess(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "createTrustCenterReference":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_createTrustCenterReference(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "updateTrustCenterReference":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_updateTrustCenterReference(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "deleteTrustCenterReference":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_deleteTrustCenterReference(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
@@ -79206,6 +80917,42 @@ func (ec *executionContext) _TrustCenter(ctx context.Context, sel ast.SelectionS
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "references":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TrustCenter_references(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -79448,6 +81195,230 @@ func (ec *executionContext) _TrustCenterEdge(ctx context.Context, sel ast.Select
 			}
 		case "node":
 			out.Values[i] = ec._TrustCenterEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var trustCenterReferenceImplementors = []string{"TrustCenterReference", "Node"}
+
+func (ec *executionContext) _TrustCenterReference(ctx context.Context, sel ast.SelectionSet, obj *types.TrustCenterReference) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, trustCenterReferenceImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TrustCenterReference")
+		case "id":
+			out.Values[i] = ec._TrustCenterReference_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "name":
+			out.Values[i] = ec._TrustCenterReference_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "description":
+			out.Values[i] = ec._TrustCenterReference_description(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "websiteUrl":
+			out.Values[i] = ec._TrustCenterReference_websiteUrl(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "logoUrl":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TrustCenterReference_logoUrl(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "createdAt":
+			out.Values[i] = ec._TrustCenterReference_createdAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "updatedAt":
+			out.Values[i] = ec._TrustCenterReference_updatedAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var trustCenterReferenceConnectionImplementors = []string{"TrustCenterReferenceConnection"}
+
+func (ec *executionContext) _TrustCenterReferenceConnection(ctx context.Context, sel ast.SelectionSet, obj *types.TrustCenterReferenceConnection) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, trustCenterReferenceConnectionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TrustCenterReferenceConnection")
+		case "totalCount":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TrustCenterReferenceConnection_totalCount(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "edges":
+			out.Values[i] = ec._TrustCenterReferenceConnection_edges(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "pageInfo":
+			out.Values[i] = ec._TrustCenterReferenceConnection_pageInfo(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var trustCenterReferenceEdgeImplementors = []string{"TrustCenterReferenceEdge"}
+
+func (ec *executionContext) _TrustCenterReferenceEdge(ctx context.Context, sel ast.SelectionSet, obj *types.TrustCenterReferenceEdge) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, trustCenterReferenceEdgeImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TrustCenterReferenceEdge")
+		case "cursor":
+			out.Values[i] = ec._TrustCenterReferenceEdge_cursor(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "node":
+			out.Values[i] = ec._TrustCenterReferenceEdge_node(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -80189,6 +82160,45 @@ func (ec *executionContext) _UpdateTrustCenterPayload(ctx context.Context, sel a
 			out.Values[i] = graphql.MarshalString("UpdateTrustCenterPayload")
 		case "trustCenter":
 			out.Values[i] = ec._UpdateTrustCenterPayload_trustCenter(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var updateTrustCenterReferencePayloadImplementors = []string{"UpdateTrustCenterReferencePayload"}
+
+func (ec *executionContext) _UpdateTrustCenterReferencePayload(ctx context.Context, sel ast.SelectionSet, obj *types.UpdateTrustCenterReferencePayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, updateTrustCenterReferencePayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("UpdateTrustCenterReferencePayload")
+		case "trustCenterReference":
+			out.Values[i] = ec._UpdateTrustCenterReferencePayload_trustCenterReference(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -85297,6 +87307,25 @@ func (ec *executionContext) marshalNCreateTrustCenterAccessPayload2ᚖgithubᚗc
 	return ec._CreateTrustCenterAccessPayload(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNCreateTrustCenterReferenceInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateTrustCenterReferenceInput(ctx context.Context, v any) (types.CreateTrustCenterReferenceInput, error) {
+	res, err := ec.unmarshalInputCreateTrustCenterReferenceInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNCreateTrustCenterReferencePayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateTrustCenterReferencePayload(ctx context.Context, sel ast.SelectionSet, v types.CreateTrustCenterReferencePayload) graphql.Marshaler {
+	return ec._CreateTrustCenterReferencePayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNCreateTrustCenterReferencePayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateTrustCenterReferencePayload(ctx context.Context, sel ast.SelectionSet, v *types.CreateTrustCenterReferencePayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._CreateTrustCenterReferencePayload(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNCreateVendorContactInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateVendorContactInput(ctx context.Context, v any) (types.CreateVendorContactInput, error) {
 	res, err := ec.unmarshalInputCreateVendorContactInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -86120,6 +88149,25 @@ func (ec *executionContext) marshalNDeleteTrustCenterNDAPayload2ᚖgithubᚗcom�
 		return graphql.Null
 	}
 	return ec._DeleteTrustCenterNDAPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNDeleteTrustCenterReferenceInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteTrustCenterReferenceInput(ctx context.Context, v any) (types.DeleteTrustCenterReferenceInput, error) {
+	res, err := ec.unmarshalInputDeleteTrustCenterReferenceInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNDeleteTrustCenterReferencePayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteTrustCenterReferencePayload(ctx context.Context, sel ast.SelectionSet, v types.DeleteTrustCenterReferencePayload) graphql.Marshaler {
+	return ec._DeleteTrustCenterReferencePayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNDeleteTrustCenterReferencePayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteTrustCenterReferencePayload(ctx context.Context, sel ast.SelectionSet, v *types.DeleteTrustCenterReferencePayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._DeleteTrustCenterReferencePayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNDeleteVendorBusinessAssociateAgreementInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteVendorBusinessAssociateAgreementInput(ctx context.Context, v any) (types.DeleteVendorBusinessAssociateAgreementInput, error) {
@@ -88811,6 +90859,114 @@ func (ec *executionContext) marshalNTrustCenterEdge2ᚖgithubᚗcomᚋgetprobo�
 	return ec._TrustCenterEdge(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNTrustCenterReference2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterReference(ctx context.Context, sel ast.SelectionSet, v *types.TrustCenterReference) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TrustCenterReference(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNTrustCenterReferenceConnection2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterReferenceConnection(ctx context.Context, sel ast.SelectionSet, v types.TrustCenterReferenceConnection) graphql.Marshaler {
+	return ec._TrustCenterReferenceConnection(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNTrustCenterReferenceConnection2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterReferenceConnection(ctx context.Context, sel ast.SelectionSet, v *types.TrustCenterReferenceConnection) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TrustCenterReferenceConnection(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNTrustCenterReferenceEdge2ᚕᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterReferenceEdgeᚄ(ctx context.Context, sel ast.SelectionSet, v []*types.TrustCenterReferenceEdge) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNTrustCenterReferenceEdge2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterReferenceEdge(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNTrustCenterReferenceEdge2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterReferenceEdge(ctx context.Context, sel ast.SelectionSet, v *types.TrustCenterReferenceEdge) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TrustCenterReferenceEdge(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNTrustCenterReferenceOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐTrustCenterReferenceOrderField(ctx context.Context, v any) (coredata.TrustCenterReferenceOrderField, error) {
+	tmp, err := graphql.UnmarshalString(v)
+	res := unmarshalNTrustCenterReferenceOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐTrustCenterReferenceOrderField[tmp]
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNTrustCenterReferenceOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐTrustCenterReferenceOrderField(ctx context.Context, sel ast.SelectionSet, v coredata.TrustCenterReferenceOrderField) graphql.Marshaler {
+	_ = sel
+	res := graphql.MarshalString(marshalNTrustCenterReferenceOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐTrustCenterReferenceOrderField[v])
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+var (
+	unmarshalNTrustCenterReferenceOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐTrustCenterReferenceOrderField = map[string]coredata.TrustCenterReferenceOrderField{
+		"NAME":       coredata.TrustCenterReferenceOrderFieldName,
+		"CREATED_AT": coredata.TrustCenterReferenceOrderFieldCreatedAt,
+		"UPDATED_AT": coredata.TrustCenterReferenceOrderFieldUpdatedAt,
+	}
+	marshalNTrustCenterReferenceOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐTrustCenterReferenceOrderField = map[coredata.TrustCenterReferenceOrderField]string{
+		coredata.TrustCenterReferenceOrderFieldName:      "NAME",
+		coredata.TrustCenterReferenceOrderFieldCreatedAt: "CREATED_AT",
+		coredata.TrustCenterReferenceOrderFieldUpdatedAt: "UPDATED_AT",
+	}
+)
+
 func (ec *executionContext) unmarshalNUnassignTaskInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUnassignTaskInput(ctx context.Context, v any) (types.UnassignTaskInput, error) {
 	res, err := ec.unmarshalInputUnassignTaskInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -89170,6 +91326,25 @@ func (ec *executionContext) marshalNUpdateTrustCenterPayload2ᚖgithubᚗcomᚋg
 		return graphql.Null
 	}
 	return ec._UpdateTrustCenterPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNUpdateTrustCenterReferenceInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateTrustCenterReferenceInput(ctx context.Context, v any) (types.UpdateTrustCenterReferenceInput, error) {
+	res, err := ec.unmarshalInputUpdateTrustCenterReferenceInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNUpdateTrustCenterReferencePayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateTrustCenterReferencePayload(ctx context.Context, sel ast.SelectionSet, v types.UpdateTrustCenterReferencePayload) graphql.Marshaler {
+	return ec._UpdateTrustCenterReferencePayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNUpdateTrustCenterReferencePayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateTrustCenterReferencePayload(ctx context.Context, sel ast.SelectionSet, v *types.UpdateTrustCenterReferencePayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._UpdateTrustCenterReferencePayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNUpdateVendorBusinessAssociateAgreementInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateVendorBusinessAssociateAgreementInput(ctx context.Context, v any) (types.UpdateVendorBusinessAssociateAgreementInput, error) {
@@ -92145,6 +94320,14 @@ func (ec *executionContext) unmarshalOTrustCenterAccessOrder2ᚖgithubᚗcomᚋg
 		return nil, nil
 	}
 	res, err := ec.unmarshalInputTrustCenterAccessOrder(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOTrustCenterReferenceOrder2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐOrderBy(ctx context.Context, v any) (*types.OrderBy[coredata.TrustCenterReferenceOrderField], error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputTrustCenterReferenceOrder(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/pkg/server/api/console/v1/types/trust_center_access.go
+++ b/pkg/server/api/console/v1/types/trust_center_access.go
@@ -54,5 +54,3 @@ func NewTrustCenterAccessEdge(tca *coredata.TrustCenterAccess, orderBy coredata.
 		Node:   NewTrustCenterAccess(tca),
 	}
 }
-
-// Types are auto-generated in types.go - only helper functions remain here

--- a/pkg/server/api/console/v1/types/trust_center_reference.go
+++ b/pkg/server/api/console/v1/types/trust_center_reference.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package types
+
+import (
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+)
+
+type TrustCenterReferenceOrderBy = OrderBy[coredata.TrustCenterReferenceOrderField]
+
+type TrustCenterReferenceConnection struct {
+	TotalCount int                         `json:"totalCount"`
+	Edges      []*TrustCenterReferenceEdge `json:"edges"`
+	PageInfo   *PageInfo                   `json:"pageInfo"`
+	ParentID   gid.GID                     `json:"-"`
+}
+
+func NewTrustCenterReference(tcc *coredata.TrustCenterReference) *TrustCenterReference {
+	return &TrustCenterReference{
+		ID:          tcc.ID,
+		Name:        tcc.Name,
+		Description: tcc.Description,
+		WebsiteURL:  tcc.WebsiteURL,
+		CreatedAt:   tcc.CreatedAt,
+		UpdatedAt:   tcc.UpdatedAt,
+	}
+}
+
+func NewTrustCenterReferenceConnection(
+	p *page.Page[*coredata.TrustCenterReference, coredata.TrustCenterReferenceOrderField],
+	parentID gid.GID,
+) *TrustCenterReferenceConnection {
+	var edges = make([]*TrustCenterReferenceEdge, len(p.Data))
+
+	for i := range edges {
+		edges[i] = NewTrustCenterReferenceEdge(p.Data[i], p.Cursor.OrderBy.Field)
+	}
+
+	return &TrustCenterReferenceConnection{
+		Edges:    edges,
+		PageInfo: NewPageInfo(p),
+		ParentID: parentID,
+	}
+}
+
+func NewTrustCenterReferenceEdge(tcc *coredata.TrustCenterReference, orderBy coredata.TrustCenterReferenceOrderField) *TrustCenterReferenceEdge {
+	return &TrustCenterReferenceEdge{
+		Cursor: tcc.CursorKey(orderBy),
+		Node:   NewTrustCenterReference(tcc),
+	}
+}

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -537,6 +537,18 @@ type CreateTrustCenterAccessPayload struct {
 	TrustCenterAccessEdge *TrustCenterAccessEdge `json:"trustCenterAccessEdge"`
 }
 
+type CreateTrustCenterReferenceInput struct {
+	TrustCenterID gid.GID        `json:"trustCenterId"`
+	Name          string         `json:"name"`
+	Description   string         `json:"description"`
+	WebsiteURL    string         `json:"websiteUrl"`
+	LogoFile      graphql.Upload `json:"logoFile"`
+}
+
+type CreateTrustCenterReferencePayload struct {
+	TrustCenterReferenceEdge *TrustCenterReferenceEdge `json:"trustCenterReferenceEdge"`
+}
+
 type CreateVendorContactInput struct {
 	VendorID gid.GID `json:"vendorId"`
 	FullName *string `json:"fullName,omitempty"`
@@ -850,6 +862,14 @@ type DeleteTrustCenterNDAInput struct {
 
 type DeleteTrustCenterNDAPayload struct {
 	TrustCenter *TrustCenter `json:"trustCenter"`
+}
+
+type DeleteTrustCenterReferenceInput struct {
+	ID gid.GID `json:"id"`
+}
+
+type DeleteTrustCenterReferencePayload struct {
+	DeletedTrustCenterReferenceID gid.GID `json:"deletedTrustCenterReferenceId"`
 }
 
 type DeleteVendorBusinessAssociateAgreementInput struct {
@@ -1461,15 +1481,16 @@ type TaskEdge struct {
 }
 
 type TrustCenter struct {
-	ID           gid.GID                      `json:"id"`
-	Active       bool                         `json:"active"`
-	Slug         string                       `json:"slug"`
-	NdaFileName  *string                      `json:"ndaFileName,omitempty"`
-	NdaFileURL   *string                      `json:"ndaFileUrl,omitempty"`
-	CreatedAt    time.Time                    `json:"createdAt"`
-	UpdatedAt    time.Time                    `json:"updatedAt"`
-	Organization *Organization                `json:"organization"`
-	Accesses     *TrustCenterAccessConnection `json:"accesses"`
+	ID           gid.GID                         `json:"id"`
+	Active       bool                            `json:"active"`
+	Slug         string                          `json:"slug"`
+	NdaFileName  *string                         `json:"ndaFileName,omitempty"`
+	NdaFileURL   *string                         `json:"ndaFileUrl,omitempty"`
+	CreatedAt    time.Time                       `json:"createdAt"`
+	UpdatedAt    time.Time                       `json:"updatedAt"`
+	Organization *Organization                   `json:"organization"`
+	Accesses     *TrustCenterAccessConnection    `json:"accesses"`
+	References   *TrustCenterReferenceConnection `json:"references"`
 }
 
 func (TrustCenter) IsNode()             {}
@@ -1506,6 +1527,24 @@ type TrustCenterConnection struct {
 type TrustCenterEdge struct {
 	Cursor page.CursorKey `json:"cursor"`
 	Node   *TrustCenter   `json:"node"`
+}
+
+type TrustCenterReference struct {
+	ID          gid.GID   `json:"id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	WebsiteURL  string    `json:"websiteUrl"`
+	LogoURL     string    `json:"logoUrl"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+}
+
+func (TrustCenterReference) IsNode()             {}
+func (this TrustCenterReference) GetID() gid.GID { return this.ID }
+
+type TrustCenterReferenceEdge struct {
+	Cursor page.CursorKey        `json:"cursor"`
+	Node   *TrustCenterReference `json:"node"`
 }
 
 type UnassignTaskInput struct {
@@ -1765,6 +1804,18 @@ type UpdateTrustCenterInput struct {
 
 type UpdateTrustCenterPayload struct {
 	TrustCenter *TrustCenter `json:"trustCenter"`
+}
+
+type UpdateTrustCenterReferenceInput struct {
+	ID          gid.GID         `json:"id"`
+	Name        *string         `json:"name,omitempty"`
+	Description *string         `json:"description,omitempty"`
+	WebsiteURL  *string         `json:"websiteUrl,omitempty"`
+	LogoFile    *graphql.Upload `json:"logoFile,omitempty"`
+}
+
+type UpdateTrustCenterReferencePayload struct {
+	TrustCenterReference *TrustCenterReference `json:"trustCenterReference"`
 }
 
 type UpdateVendorBusinessAssociateAgreementInput struct {

--- a/pkg/server/api/trust/v1/schema.graphql
+++ b/pkg/server/api/trust/v1/schema.graphql
@@ -452,6 +452,24 @@ type VendorEdge {
   node: Vendor!
 }
 
+type TrustCenterReference implements Node {
+  id: ID!
+  name: String!
+  description: String!
+  websiteUrl: String!
+  logoUrl: String! @goField(forceResolver: true)
+}
+
+type TrustCenterReferenceConnection {
+  edges: [TrustCenterReferenceEdge!]!
+  pageInfo: PageInfo!
+}
+
+type TrustCenterReferenceEdge {
+  cursor: CursorKey!
+  node: TrustCenterReference!
+}
+
 type TrustCenter implements Node {
   id: ID!
   active: Boolean!
@@ -482,6 +500,13 @@ type TrustCenter implements Node {
     last: Int
     before: CursorKey
   ): VendorConnection! @goField(forceResolver: true)
+
+  references(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+  ): TrustCenterReferenceConnection! @goField(forceResolver: true)
 }
 
 type TrustCenterAccess implements Node {

--- a/pkg/server/api/trust/v1/schema/schema.go
+++ b/pkg/server/api/trust/v1/schema/schema.go
@@ -49,6 +49,7 @@ type ResolverRoot interface {
 	Organization() OrganizationResolver
 	Query() QueryResolver
 	TrustCenter() TrustCenterResolver
+	TrustCenterReference() TrustCenterReferenceResolver
 }
 
 type DirectiveRoot struct {
@@ -152,6 +153,7 @@ type ComplexityRoot struct {
 		NdaFileName                       func(childComplexity int) int
 		NdaFileURL                        func(childComplexity int) int
 		Organization                      func(childComplexity int) int
+		References                        func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey) int
 		Slug                              func(childComplexity int) int
 		Vendors                           func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey) int
 	}
@@ -162,6 +164,24 @@ type ComplexityRoot struct {
 		ID        func(childComplexity int) int
 		Name      func(childComplexity int) int
 		UpdatedAt func(childComplexity int) int
+	}
+
+	TrustCenterReference struct {
+		Description func(childComplexity int) int
+		ID          func(childComplexity int) int
+		LogoURL     func(childComplexity int) int
+		Name        func(childComplexity int) int
+		WebsiteURL  func(childComplexity int) int
+	}
+
+	TrustCenterReferenceConnection struct {
+		Edges    func(childComplexity int) int
+		PageInfo func(childComplexity int) int
+	}
+
+	TrustCenterReferenceEdge struct {
+		Cursor func(childComplexity int) int
+		Node   func(childComplexity int) int
 	}
 
 	Vendor struct {
@@ -208,6 +228,10 @@ type TrustCenterResolver interface {
 	Documents(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.DocumentConnection, error)
 	Audits(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.AuditConnection, error)
 	Vendors(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.VendorConnection, error)
+	References(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.TrustCenterReferenceConnection, error)
+}
+type TrustCenterReferenceResolver interface {
+	LogoURL(ctx context.Context, obj *types.TrustCenterReference) (string, error)
 }
 
 type executableSchema struct {
@@ -593,6 +617,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.TrustCenter.Organization(childComplexity), true
 
+	case "TrustCenter.references":
+		if e.complexity.TrustCenter.References == nil {
+			break
+		}
+
+		args, err := ec.field_TrustCenter_references_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.TrustCenter.References(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey)), true
+
 	case "TrustCenter.slug":
 		if e.complexity.TrustCenter.Slug == nil {
 			break
@@ -646,6 +682,69 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.TrustCenterAccess.UpdatedAt(childComplexity), true
+
+	case "TrustCenterReference.description":
+		if e.complexity.TrustCenterReference.Description == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterReference.Description(childComplexity), true
+
+	case "TrustCenterReference.id":
+		if e.complexity.TrustCenterReference.ID == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterReference.ID(childComplexity), true
+
+	case "TrustCenterReference.logoUrl":
+		if e.complexity.TrustCenterReference.LogoURL == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterReference.LogoURL(childComplexity), true
+
+	case "TrustCenterReference.name":
+		if e.complexity.TrustCenterReference.Name == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterReference.Name(childComplexity), true
+
+	case "TrustCenterReference.websiteUrl":
+		if e.complexity.TrustCenterReference.WebsiteURL == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterReference.WebsiteURL(childComplexity), true
+
+	case "TrustCenterReferenceConnection.edges":
+		if e.complexity.TrustCenterReferenceConnection.Edges == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterReferenceConnection.Edges(childComplexity), true
+
+	case "TrustCenterReferenceConnection.pageInfo":
+		if e.complexity.TrustCenterReferenceConnection.PageInfo == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterReferenceConnection.PageInfo(childComplexity), true
+
+	case "TrustCenterReferenceEdge.cursor":
+		if e.complexity.TrustCenterReferenceEdge.Cursor == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterReferenceEdge.Cursor(childComplexity), true
+
+	case "TrustCenterReferenceEdge.node":
+		if e.complexity.TrustCenterReferenceEdge.Node == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterReferenceEdge.Node(childComplexity), true
 
 	case "Vendor.category":
 		if e.complexity.Vendor.Category == nil {
@@ -1280,6 +1379,24 @@ type VendorEdge {
   node: Vendor!
 }
 
+type TrustCenterReference implements Node {
+  id: ID!
+  name: String!
+  description: String!
+  websiteUrl: String!
+  logoUrl: String! @goField(forceResolver: true)
+}
+
+type TrustCenterReferenceConnection {
+  edges: [TrustCenterReferenceEdge!]!
+  pageInfo: PageInfo!
+}
+
+type TrustCenterReferenceEdge {
+  cursor: CursorKey!
+  node: TrustCenterReference!
+}
+
 type TrustCenter implements Node {
   id: ID!
   active: Boolean!
@@ -1310,6 +1427,13 @@ type TrustCenter implements Node {
     last: Int
     before: CursorKey
   ): VendorConnection! @goField(forceResolver: true)
+
+  references(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+  ): TrustCenterReferenceConnection! @goField(forceResolver: true)
 }
 
 type TrustCenterAccess implements Node {
@@ -1691,6 +1815,83 @@ func (ec *executionContext) field_TrustCenter_documents_argsLast(
 }
 
 func (ec *executionContext) field_TrustCenter_documents_argsBefore(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*page.CursorKey, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("before"))
+	if tmp, ok := rawArgs["before"]; ok {
+		return ec.unmarshalOCursorKey2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐCursorKey(ctx, tmp)
+	}
+
+	var zeroVal *page.CursorKey
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_TrustCenter_references_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_TrustCenter_references_argsFirst(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["first"] = arg0
+	arg1, err := ec.field_TrustCenter_references_argsAfter(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["after"] = arg1
+	arg2, err := ec.field_TrustCenter_references_argsLast(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["last"] = arg2
+	arg3, err := ec.field_TrustCenter_references_argsBefore(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["before"] = arg3
+	return args, nil
+}
+func (ec *executionContext) field_TrustCenter_references_argsFirst(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*int, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("first"))
+	if tmp, ok := rawArgs["first"]; ok {
+		return ec.unmarshalOInt2ᚖint(ctx, tmp)
+	}
+
+	var zeroVal *int
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_TrustCenter_references_argsAfter(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*page.CursorKey, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("after"))
+	if tmp, ok := rawArgs["after"]; ok {
+		return ec.unmarshalOCursorKey2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐCursorKey(ctx, tmp)
+	}
+
+	var zeroVal *page.CursorKey
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_TrustCenter_references_argsLast(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*int, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("last"))
+	if tmp, ok := rawArgs["last"]; ok {
+		return ec.unmarshalOInt2ᚖint(ctx, tmp)
+	}
+
+	var zeroVal *int
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_TrustCenter_references_argsBefore(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (*page.CursorKey, error) {
@@ -3721,6 +3922,8 @@ func (ec *executionContext) fieldContext_Query_trustCenterBySlug(ctx context.Con
 				return ec.fieldContext_TrustCenter_audits(ctx, field)
 			case "vendors":
 				return ec.fieldContext_TrustCenter_vendors(ctx, field)
+			case "references":
+				return ec.fieldContext_TrustCenter_references(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TrustCenter", field.Name)
 		},
@@ -4503,6 +4706,67 @@ func (ec *executionContext) fieldContext_TrustCenter_vendors(ctx context.Context
 	return fc, nil
 }
 
+func (ec *executionContext) _TrustCenter_references(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenter) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenter_references(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TrustCenter().References(rctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.TrustCenterReferenceConnection)
+	fc.Result = res
+	return ec.marshalNTrustCenterReferenceConnection2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐTrustCenterReferenceConnection(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenter_references(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenter",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "edges":
+				return ec.fieldContext_TrustCenterReferenceConnection_edges(ctx, field)
+			case "pageInfo":
+				return ec.fieldContext_TrustCenterReferenceConnection_pageInfo(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustCenterReferenceConnection", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_TrustCenter_references_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _TrustCenterAccess_id(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterAccess) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_TrustCenterAccess_id(ctx, field)
 	if err != nil {
@@ -4718,6 +4982,430 @@ func (ec *executionContext) fieldContext_TrustCenterAccess_updatedAt(_ context.C
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterReference_id(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterReference) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterReference_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(gid.GID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterReference_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterReference",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterReference_name(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterReference) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterReference_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterReference_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterReference",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterReference_description(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterReference) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterReference_description(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Description, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterReference_description(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterReference",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterReference_websiteUrl(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterReference) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterReference_websiteUrl(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.WebsiteURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterReference_websiteUrl(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterReference",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterReference_logoUrl(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterReference) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterReference_logoUrl(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TrustCenterReference().LogoURL(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterReference_logoUrl(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterReference",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterReferenceConnection_edges(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterReferenceConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterReferenceConnection_edges(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Edges, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*types.TrustCenterReferenceEdge)
+	fc.Result = res
+	return ec.marshalNTrustCenterReferenceEdge2ᚕᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐTrustCenterReferenceEdgeᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterReferenceConnection_edges(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterReferenceConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "cursor":
+				return ec.fieldContext_TrustCenterReferenceEdge_cursor(ctx, field)
+			case "node":
+				return ec.fieldContext_TrustCenterReferenceEdge_node(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustCenterReferenceEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterReferenceConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterReferenceConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterReferenceConnection_pageInfo(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PageInfo, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.PageInfo)
+	fc.Result = res
+	return ec.marshalNPageInfo2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐPageInfo(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterReferenceConnection_pageInfo(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterReferenceConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "hasNextPage":
+				return ec.fieldContext_PageInfo_hasNextPage(ctx, field)
+			case "hasPreviousPage":
+				return ec.fieldContext_PageInfo_hasPreviousPage(ctx, field)
+			case "startCursor":
+				return ec.fieldContext_PageInfo_startCursor(ctx, field)
+			case "endCursor":
+				return ec.fieldContext_PageInfo_endCursor(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterReferenceEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterReferenceEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterReferenceEdge_cursor(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Cursor, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(page.CursorKey)
+	fc.Result = res
+	return ec.marshalNCursorKey2githubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐCursorKey(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterReferenceEdge_cursor(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterReferenceEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type CursorKey does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterReferenceEdge_node(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterReferenceEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterReferenceEdge_node(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Node, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.TrustCenterReference)
+	fc.Result = res
+	return ec.marshalNTrustCenterReference2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐTrustCenterReference(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterReferenceEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterReferenceEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TrustCenterReference_id(ctx, field)
+			case "name":
+				return ec.fieldContext_TrustCenterReference_name(ctx, field)
+			case "description":
+				return ec.fieldContext_TrustCenterReference_description(ctx, field)
+			case "websiteUrl":
+				return ec.fieldContext_TrustCenterReference_websiteUrl(ctx, field)
+			case "logoUrl":
+				return ec.fieldContext_TrustCenterReference_logoUrl(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustCenterReference", field.Name)
 		},
 	}
 	return fc, nil
@@ -7275,6 +7963,13 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._Vendor(ctx, sel, obj)
+	case types.TrustCenterReference:
+		return ec._TrustCenterReference(ctx, sel, &obj)
+	case *types.TrustCenterReference:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._TrustCenterReference(ctx, sel, obj)
 	case types.TrustCenterAccess:
 		return ec._TrustCenterAccess(ctx, sel, &obj)
 	case *types.TrustCenterAccess:
@@ -8459,6 +9154,42 @@ func (ec *executionContext) _TrustCenter(ctx context.Context, sel ast.SelectionS
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "references":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TrustCenter_references(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -8515,6 +9246,184 @@ func (ec *executionContext) _TrustCenterAccess(ctx context.Context, sel ast.Sele
 			}
 		case "updatedAt":
 			out.Values[i] = ec._TrustCenterAccess_updatedAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var trustCenterReferenceImplementors = []string{"TrustCenterReference", "Node"}
+
+func (ec *executionContext) _TrustCenterReference(ctx context.Context, sel ast.SelectionSet, obj *types.TrustCenterReference) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, trustCenterReferenceImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TrustCenterReference")
+		case "id":
+			out.Values[i] = ec._TrustCenterReference_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "name":
+			out.Values[i] = ec._TrustCenterReference_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "description":
+			out.Values[i] = ec._TrustCenterReference_description(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "websiteUrl":
+			out.Values[i] = ec._TrustCenterReference_websiteUrl(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "logoUrl":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TrustCenterReference_logoUrl(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var trustCenterReferenceConnectionImplementors = []string{"TrustCenterReferenceConnection"}
+
+func (ec *executionContext) _TrustCenterReferenceConnection(ctx context.Context, sel ast.SelectionSet, obj *types.TrustCenterReferenceConnection) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, trustCenterReferenceConnectionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TrustCenterReferenceConnection")
+		case "edges":
+			out.Values[i] = ec._TrustCenterReferenceConnection_edges(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "pageInfo":
+			out.Values[i] = ec._TrustCenterReferenceConnection_pageInfo(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var trustCenterReferenceEdgeImplementors = []string{"TrustCenterReferenceEdge"}
+
+func (ec *executionContext) _TrustCenterReferenceEdge(ctx context.Context, sel ast.SelectionSet, obj *types.TrustCenterReferenceEdge) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, trustCenterReferenceEdgeImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TrustCenterReferenceEdge")
+		case "cursor":
+			out.Values[i] = ec._TrustCenterReferenceEdge_cursor(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "node":
+			out.Values[i] = ec._TrustCenterReferenceEdge_node(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -10492,6 +11401,84 @@ func (ec *executionContext) marshalNTrustCenterAccess2ᚖgithubᚗcomᚋgetprobo
 		return graphql.Null
 	}
 	return ec._TrustCenterAccess(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNTrustCenterReference2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐTrustCenterReference(ctx context.Context, sel ast.SelectionSet, v *types.TrustCenterReference) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TrustCenterReference(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNTrustCenterReferenceConnection2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐTrustCenterReferenceConnection(ctx context.Context, sel ast.SelectionSet, v types.TrustCenterReferenceConnection) graphql.Marshaler {
+	return ec._TrustCenterReferenceConnection(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNTrustCenterReferenceConnection2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐTrustCenterReferenceConnection(ctx context.Context, sel ast.SelectionSet, v *types.TrustCenterReferenceConnection) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TrustCenterReferenceConnection(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNTrustCenterReferenceEdge2ᚕᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐTrustCenterReferenceEdgeᚄ(ctx context.Context, sel ast.SelectionSet, v []*types.TrustCenterReferenceEdge) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNTrustCenterReferenceEdge2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐTrustCenterReferenceEdge(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNTrustCenterReferenceEdge2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐTrustCenterReferenceEdge(ctx context.Context, sel ast.SelectionSet, v *types.TrustCenterReferenceEdge) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TrustCenterReferenceEdge(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNVendor2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐVendor(ctx context.Context, sel ast.SelectionSet, v *types.Vendor) graphql.Marshaler {

--- a/pkg/server/api/trust/v1/types/trust_center_reference.go
+++ b/pkg/server/api/trust/v1/types/trust_center_reference.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package types
+
+import (
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/page"
+)
+
+func NewTrustCenterReference(tcc *coredata.TrustCenterReference) *TrustCenterReference {
+	return &TrustCenterReference{
+		ID:          tcc.ID,
+		Name:        tcc.Name,
+		Description: tcc.Description,
+		WebsiteURL:  tcc.WebsiteURL,
+	}
+}
+
+func NewTrustCenterReferenceConnection(p *page.Page[*coredata.TrustCenterReference, coredata.TrustCenterReferenceOrderField]) *TrustCenterReferenceConnection {
+	edges := make([]*TrustCenterReferenceEdge, len(p.Data))
+
+	for i, item := range p.Data {
+		edges[i] = NewTrustCenterReferenceEdge(item, p.Cursor.OrderBy.Field)
+	}
+
+	return &TrustCenterReferenceConnection{
+		Edges:    edges,
+		PageInfo: NewPageInfo(p),
+	}
+}
+
+func NewTrustCenterReferenceEdge(tcc *coredata.TrustCenterReference, orderBy coredata.TrustCenterReferenceOrderField) *TrustCenterReferenceEdge {
+	return &TrustCenterReferenceEdge{
+		Cursor: tcc.CursorKey(orderBy),
+		Node:   NewTrustCenterReference(tcc),
+	}
+}

--- a/pkg/server/api/trust/v1/types/types.go
+++ b/pkg/server/api/trust/v1/types/types.go
@@ -134,17 +134,18 @@ func (Report) IsNode()             {}
 func (this Report) GetID() gid.GID { return this.ID }
 
 type TrustCenter struct {
-	ID                                gid.GID             `json:"id"`
-	Active                            bool                `json:"active"`
-	Slug                              string              `json:"slug"`
-	NdaFileName                       *string             `json:"ndaFileName,omitempty"`
-	NdaFileURL                        *string             `json:"ndaFileUrl,omitempty"`
-	Organization                      *Organization       `json:"organization"`
-	IsUserAuthenticated               bool                `json:"isUserAuthenticated"`
-	HasAcceptedNonDisclosureAgreement bool                `json:"hasAcceptedNonDisclosureAgreement"`
-	Documents                         *DocumentConnection `json:"documents"`
-	Audits                            *AuditConnection    `json:"audits"`
-	Vendors                           *VendorConnection   `json:"vendors"`
+	ID                                gid.GID                         `json:"id"`
+	Active                            bool                            `json:"active"`
+	Slug                              string                          `json:"slug"`
+	NdaFileName                       *string                         `json:"ndaFileName,omitempty"`
+	NdaFileURL                        *string                         `json:"ndaFileUrl,omitempty"`
+	Organization                      *Organization                   `json:"organization"`
+	IsUserAuthenticated               bool                            `json:"isUserAuthenticated"`
+	HasAcceptedNonDisclosureAgreement bool                            `json:"hasAcceptedNonDisclosureAgreement"`
+	Documents                         *DocumentConnection             `json:"documents"`
+	Audits                            *AuditConnection                `json:"audits"`
+	Vendors                           *VendorConnection               `json:"vendors"`
+	References                        *TrustCenterReferenceConnection `json:"references"`
 }
 
 func (TrustCenter) IsNode()             {}
@@ -160,6 +161,27 @@ type TrustCenterAccess struct {
 
 func (TrustCenterAccess) IsNode()             {}
 func (this TrustCenterAccess) GetID() gid.GID { return this.ID }
+
+type TrustCenterReference struct {
+	ID          gid.GID `json:"id"`
+	Name        string  `json:"name"`
+	Description string  `json:"description"`
+	WebsiteURL  string  `json:"websiteUrl"`
+	LogoURL     string  `json:"logoUrl"`
+}
+
+func (TrustCenterReference) IsNode()             {}
+func (this TrustCenterReference) GetID() gid.GID { return this.ID }
+
+type TrustCenterReferenceConnection struct {
+	Edges    []*TrustCenterReferenceEdge `json:"edges"`
+	PageInfo *PageInfo                   `json:"pageInfo"`
+}
+
+type TrustCenterReferenceEdge struct {
+	Cursor page.CursorKey        `json:"cursor"`
+	Node   *TrustCenterReference `json:"node"`
+}
 
 type Vendor struct {
 	ID               gid.GID                 `json:"id"`

--- a/pkg/trust/service.go
+++ b/pkg/trust/service.go
@@ -53,6 +53,7 @@ type (
 		Vendors             *VendorService
 		Frameworks          *FrameworkService
 		TrustCenterAccesses *TrustCenterAccessService
+		TrustCenterReferences *TrustCenterReferenceService
 		Reports             *ReportService
 		Organizations       *OrganizationService
 	}
@@ -97,6 +98,7 @@ func (s *Service) WithTenant(tenantID gid.TenantID) *TenantService {
 	tenantService.Vendors = &VendorService{svc: tenantService}
 	tenantService.Frameworks = &FrameworkService{svc: tenantService}
 	tenantService.TrustCenterAccesses = &TrustCenterAccessService{svc: tenantService, usrmgr: s.usrmgr}
+	tenantService.TrustCenterReferences = &TrustCenterReferenceService{svc: tenantService}
 	tenantService.Reports = &ReportService{svc: tenantService}
 	tenantService.Organizations = &OrganizationService{svc: tenantService}
 

--- a/pkg/trust/trust_center_reference_service.go
+++ b/pkg/trust/trust_center_reference_service.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package trust
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+	"go.gearno.de/kit/pg"
+)
+
+type TrustCenterReferenceService struct {
+	svc *TenantService
+}
+
+func (s TrustCenterReferenceService) ListForTrustCenterID(
+	ctx context.Context,
+	trustCenterID gid.GID,
+	cursor *page.Cursor[coredata.TrustCenterReferenceOrderField],
+) (*page.Page[*coredata.TrustCenterReference, coredata.TrustCenterReferenceOrderField], error) {
+	var references coredata.TrustCenterReferences
+
+	err := s.svc.pg.WithConn(ctx, func(conn pg.Conn) error {
+		err := references.LoadByTrustCenterID(ctx, conn, s.svc.scope, trustCenterID, cursor)
+		if err != nil {
+			return fmt.Errorf("cannot load trust center references: %w", err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return page.NewPage(references, cursor), nil
+}
+
+func (s TrustCenterReferenceService) GenerateLogoURL(
+	ctx context.Context,
+	referenceID gid.GID,
+	duration time.Duration,
+) (string, error) {
+	reference := &coredata.TrustCenterReference{}
+	file := &coredata.File{}
+	err := s.svc.pg.WithTx(ctx, func(tx pg.Conn) error {
+		err := reference.LoadByID(ctx, tx, s.svc.scope, referenceID)
+		if err != nil {
+			return fmt.Errorf("cannot load trust center reference: %w", err)
+		}
+
+		err = file.LoadByID(ctx, tx, s.svc.scope, reference.LogoFileID)
+		if err != nil {
+			return fmt.Errorf("cannot load logo file: %w", err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return "", nil
+	}
+
+	presignClient := s3.NewPresignClient(s.svc.s3)
+
+	encodedFilename := url.PathEscape(file.FileName)
+	contentDisposition := fmt.Sprintf("inline; filename=\"%s\"; filename*=UTF-8''%s",
+		encodedFilename, encodedFilename)
+
+	presignedReq, err := presignClient.PresignGetObject(ctx, &s3.GetObjectInput{
+		Bucket:                     aws.String(s.svc.bucket),
+		Key:                        aws.String(file.FileKey),
+		ResponseCacheControl:       aws.String("max-age=3600, public"),
+		ResponseContentDisposition: aws.String(contentDisposition),
+	}, func(opts *s3.PresignOptions) {
+		opts.Expires = duration
+	})
+	if err != nil {
+		return "", fmt.Errorf("cannot presign GetObject request: %w", err)
+	}
+
+	return presignedReq.URL, nil
+}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds Trust Center References so organizations can showcase third‑party logos with name, description, and website. Includes full CRUD in Console and public Trust API, with storage and signed URLs for logos.

- New Features
  - Console: new References section on Trust Center page with create/edit dialog (URL validation, logo upload) and delete confirmation; list ordered by createdAt desc.
  - Console GraphQL: references connection on TrustCenter plus create/update/delete mutations and ordering.
  - Data/Services: new trust_center_references table and entity; backend services for CRUD, pagination/ordering, logo file handling via S3.
  - Public Trust API: exposes references connection and logoUrl resolver for public pages.

- Migration
  - Run migration 20250919T142754Z.sql.
  - Uses existing file storage/S3 configuration; no new env vars.
  - No breaking changes; references are additive.

<!-- End of auto-generated description by cubic. -->

