### PR TITLE
Display countries on trust center

### DIFF
--- a/apps/console/src/components/trustCenter/TrustCenterVendorsCard.tsx
+++ b/apps/console/src/components/trustCenter/TrustCenterVendorsCard.tsx
@@ -125,7 +125,7 @@ function VendorRow(props: {
   const { __ } = useTranslate();
 
   return (
-    <Tr to={`/organizations/${organizationId}/vendors/${vendor.id}`}>
+    <Tr to={`/organizations/${organizationId}/vendors/${vendor.id}/overview`}>
       <Td>
         <div className="flex gap-4 items-center">
           {vendor.name}

--- a/apps/console/src/hooks/useTrustCenterQueries.ts
+++ b/apps/console/src/hooks/useTrustCenterQueries.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { GraphQLError } from "graphql";
 import { buildEndpoint } from "/providers/RelayProviders";
+import { type CountryCode } from "@probo/helpers";
 
 export interface TrustCenterDocument {
   id: string;
@@ -25,6 +26,7 @@ export interface TrustCenterVendor {
   category: string;
   privacyPolicyUrl?: string | null;
   websiteUrl?: string | null;
+  countries: CountryCode[];
 }
 
 interface TrustCenterQueryData {

--- a/apps/console/src/trust/components/PublicTrustCenterVendors.tsx
+++ b/apps/console/src/trust/components/PublicTrustCenterVendors.tsx
@@ -8,7 +8,7 @@ import {
   Th,
 } from "@probo/ui";
 import { useTranslate } from "@probo/i18n";
-import { faviconUrl, sprintf } from "@probo/helpers";
+import { faviconUrl, sprintf, getCountryName, type CountryCode } from "@probo/helpers";
 import type { TrustCenterVendor } from "../pages/PublicTrustCenterPage";
 
 type Props = {
@@ -18,6 +18,8 @@ type Props = {
 
 export function PublicTrustCenterVendors({ vendors, organizationName }: Props) {
   const { __ } = useTranslate();
+
+  const hasCountriesData = vendors.some(vendor => vendor.countries && vendor.countries.length > 0);
 
   if (vendors.length === 0) {
     return (
@@ -50,6 +52,7 @@ export function PublicTrustCenterVendors({ vendors, organizationName }: Props) {
           <Tr>
             <Th>{__("Company")}</Th>
             <Th>{__("Website")}</Th>
+            {hasCountriesData && <Th>{__("Countries")}</Th>}
           </Tr>
         </Thead>
         <Tbody>
@@ -64,6 +67,10 @@ export function PublicTrustCenterVendors({ vendors, organizationName }: Props) {
               } catch {
                 return url.replace(/^https?:\/\//, '');
               }
+            };
+
+            const formatCountries = (countries: CountryCode[]) => {
+              return countries.map(code => getCountryName(__, code)).join(", ");
             };
 
             return (
@@ -98,6 +105,13 @@ export function PublicTrustCenterVendors({ vendors, organizationName }: Props) {
                     </span>
                   )}
                 </Td>
+                {hasCountriesData && (
+                  <Td>
+                    <span className="text-txt-secondary text-sm">
+                      {formatCountries(vendor.countries)}
+                    </span>
+                  </Td>
+                )}
               </Tr>
             );
           })}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Display vendor countries on the public Trust Center with a localized “Countries” column that appears only when data is available.

- **New Features**
  - Added countries: CountryCode[] to TrustCenterVendor.
  - Show a “Countries” column on the public vendors table when any vendor has countries.
  - Format country names using getCountryName with translations.

- **Bug Fixes**
  - Updated vendor row link to /vendors/:id/overview for correct navigation.

<!-- End of auto-generated description by cubic. -->

