### PR TITLE
Drop request by

### DIFF
--- a/pkg/coredata/document_version_signature.go
+++ b/pkg/coredata/document_version_signature.go
@@ -34,7 +34,6 @@ type (
 		SignedBy          gid.GID                       `json:"signed_by"`
 		SignedAt          *time.Time                    `json:"signed_at"`
 		RequestedAt       time.Time                     `json:"requested_at"`
-		RequestedBy       gid.GID                       `json:"requested_by"`
 		CreatedAt         time.Time                     `json:"created_at"`
 		UpdatedAt         time.Time                     `json:"updated_at"`
 	}
@@ -68,7 +67,6 @@ SELECT
 	signed_by,
 	signed_at,
 	requested_at,
-	requested_by,
 	created_at,
 	updated_at
 FROM
@@ -114,7 +112,6 @@ SELECT
 	signed_by,
 	signed_at,
 	requested_at,
-	requested_by,
 	created_at,
 	updated_at
 FROM
@@ -158,7 +155,6 @@ INSERT INTO document_version_signatures (
 	signed_by,
 	signed_at,
 	requested_at,
-	requested_by,
 	created_at,
 	updated_at
 ) VALUES (
@@ -169,7 +165,6 @@ INSERT INTO document_version_signatures (
 	@signed_by,
 	@signed_at,
 	@requested_at,
-	@requested_by,
 	@created_at,
 	@updated_at
 )
@@ -183,7 +178,6 @@ INSERT INTO document_version_signatures (
 		"signed_by":           pvs.SignedBy,
 		"signed_at":           pvs.SignedAt,
 		"requested_at":        pvs.RequestedAt,
-		"requested_by":        pvs.RequestedBy,
 		"created_at":          pvs.CreatedAt,
 		"updated_at":          pvs.UpdatedAt,
 	}
@@ -211,7 +205,6 @@ SELECT
 	signed_by,
 	signed_at,
 	requested_at,
-	requested_by,
 	created_at,
 	updated_at
 FROM

--- a/pkg/coredata/migrations/20250926T070601Z.sql
+++ b/pkg/coredata/migrations/20250926T070601Z.sql
@@ -1,0 +1,1 @@
+ALTER TABLE document_version_signatures DROP COLUMN requested_by;

--- a/pkg/docgen/generator.go
+++ b/pkg/docgen/generator.go
@@ -77,7 +77,6 @@ type (
 		SignedAt    *time.Time
 		State       coredata.DocumentVersionSignatureState
 		RequestedAt time.Time
-		RequestedBy string
 	}
 )
 
@@ -95,7 +94,6 @@ func RenderHTML(data DocumentData) ([]byte, error) {
 
 	for i := range data.Signatures {
 		data.Signatures[i].SignedBy = html.EscapeString(data.Signatures[i].SignedBy)
-		data.Signatures[i].RequestedBy = html.EscapeString(data.Signatures[i].RequestedBy)
 	}
 
 	var buf bytes.Buffer

--- a/pkg/docgen/generator_test.go
+++ b/pkg/docgen/generator_test.go
@@ -50,7 +50,6 @@ func TestRenderHTML(t *testing.T) {
 						SignedAt:    &now,
 						State:       coredata.DocumentVersionSignatureStateSigned,
 						RequestedAt: now,
-						RequestedBy: "Bob Johnson",
 					},
 				},
 			},
@@ -64,7 +63,6 @@ func TestRenderHTML(t *testing.T) {
 				"John Doe",
 				"Test document description",
 				"Alice Smith",
-				"Bob Johnson",
 			},
 		},
 		{
@@ -76,9 +74,8 @@ func TestRenderHTML(t *testing.T) {
 				Description: "Description with & symbols and <tags>",
 				Signatures: []SignatureData{
 					{
-						SignedBy:    "Alice & <Bob>",
-						RequestedBy: "Carol <script>",
-						State:       coredata.DocumentVersionSignatureStateRequested,
+						SignedBy: "Alice & <Bob>",
+						State:    coredata.DocumentVersionSignatureStateRequested,
 					},
 				},
 			},
@@ -87,7 +84,6 @@ func TestRenderHTML(t *testing.T) {
 				"John &amp;lt;script&amp;gt;alert(&amp;#39;xss&amp;#39;)&amp;lt;/script&amp;gt; Doe",
 				"Description with &amp;amp; symbols and &amp;lt;tags&amp;gt;",
 				"Alice &amp;amp; &amp;lt;Bob&amp;gt;",
-				"Carol &amp;lt;script&amp;gt;",
 			},
 			wantNotContains: []string{
 				"<script>alert('xss')</script>",
@@ -138,21 +134,17 @@ func TestRenderHTML(t *testing.T) {
 						SignedAt:    &now,
 						State:       coredata.DocumentVersionSignatureStateSigned,
 						RequestedAt: now,
-						RequestedBy: "Requester 1",
 					},
 					{
 						SignedBy:    "Signer 2",
 						State:       coredata.DocumentVersionSignatureStateRequested,
 						RequestedAt: now,
-						RequestedBy: "Requester 2",
 					},
 				},
 			},
 			wantContains: []string{
 				"Signer 1",
 				"Signer 2",
-				"Requester 1",
-				"Requester 2",
 			},
 		},
 	}
@@ -268,9 +260,8 @@ func TestHTMLEscaping(t *testing.T) {
 		Description: "Text with 'quotes' & \"double quotes\"",
 		Signatures: []SignatureData{
 			{
-				SignedBy:    "<malicious>tag",
-				RequestedBy: "User & Company",
-				State:       coredata.DocumentVersionSignatureStateRequested,
+				SignedBy: "<malicious>tag",
+				State:    coredata.DocumentVersionSignatureStateRequested,
 			},
 		},
 	}
@@ -357,7 +348,6 @@ func TestDocumentVersionSignatureStates(t *testing.T) {
 						SignedBy:    "Test User",
 						State:       state,
 						RequestedAt: now,
-						RequestedBy: "Requester",
 					},
 				},
 			}
@@ -407,7 +397,6 @@ func BenchmarkGenerateHTML(b *testing.B) {
 				SignedAt:    &now,
 				State:       coredata.DocumentVersionSignatureStateSigned,
 				RequestedAt: now,
-				RequestedBy: "Bob Johnson",
 			},
 		},
 	}

--- a/pkg/docgen/template.html
+++ b/pkg/docgen/template.html
@@ -358,7 +358,6 @@
                             <th>Status</th>
                             <th>Requested Date</th>
                             <th>Signed Date</th>
-                            <th>Requested By</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -380,7 +379,6 @@
                                 -
                                 {{- end}}
                             </td>
-                            <td>{{.RequestedBy}}</td>
                         </tr>
                         {{- end}}
                     </tbody>

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -3963,7 +3963,6 @@ type DocumentVersionSignature implements Node {
   signedBy: People! @goField(forceResolver: true)
   signedAt: Datetime
   requestedAt: Datetime!
-  requestedBy: People! @goField(forceResolver: true)
   createdAt: Datetime!
   updatedAt: Datetime!
 }

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -616,7 +616,6 @@ type ComplexityRoot struct {
 		DocumentVersion func(childComplexity int) int
 		ID              func(childComplexity int) int
 		RequestedAt     func(childComplexity int) int
-		RequestedBy     func(childComplexity int) int
 		SignedAt        func(childComplexity int) int
 		SignedBy        func(childComplexity int) int
 		State           func(childComplexity int) int
@@ -1586,8 +1585,6 @@ type DocumentVersionSignatureResolver interface {
 	DocumentVersion(ctx context.Context, obj *types.DocumentVersionSignature) (*types.DocumentVersion, error)
 
 	SignedBy(ctx context.Context, obj *types.DocumentVersionSignature) (*types.People, error)
-
-	RequestedBy(ctx context.Context, obj *types.DocumentVersionSignature) (*types.People, error)
 }
 type EvidenceResolver interface {
 	FileURL(ctx context.Context, obj *types.Evidence) (*string, error)
@@ -3492,13 +3489,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.DocumentVersionSignature.RequestedAt(childComplexity), true
-
-	case "DocumentVersionSignature.requestedBy":
-		if e.complexity.DocumentVersionSignature.RequestedBy == nil {
-			break
-		}
-
-		return e.complexity.DocumentVersionSignature.RequestedBy(childComplexity), true
 
 	case "DocumentVersionSignature.signedAt":
 		if e.complexity.DocumentVersionSignature.SignedAt == nil {
@@ -12382,7 +12372,6 @@ type DocumentVersionSignature implements Node {
   signedBy: People! @goField(forceResolver: true)
   signedAt: Datetime
   requestedAt: Datetime!
-  requestedBy: People! @goField(forceResolver: true)
   createdAt: Datetime!
   updatedAt: Datetime!
 }
@@ -31649,72 +31638,6 @@ func (ec *executionContext) fieldContext_DocumentVersionSignature_requestedAt(_ 
 	return fc, nil
 }
 
-func (ec *executionContext) _DocumentVersionSignature_requestedBy(ctx context.Context, field graphql.CollectedField, obj *types.DocumentVersionSignature) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_DocumentVersionSignature_requestedBy(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.DocumentVersionSignature().RequestedBy(rctx, obj)
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*types.People)
-	fc.Result = res
-	return ec.marshalNPeople2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐPeople(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_DocumentVersionSignature_requestedBy(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "DocumentVersionSignature",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_People_id(ctx, field)
-			case "fullName":
-				return ec.fieldContext_People_fullName(ctx, field)
-			case "primaryEmailAddress":
-				return ec.fieldContext_People_primaryEmailAddress(ctx, field)
-			case "additionalEmailAddresses":
-				return ec.fieldContext_People_additionalEmailAddresses(ctx, field)
-			case "kind":
-				return ec.fieldContext_People_kind(ctx, field)
-			case "position":
-				return ec.fieldContext_People_position(ctx, field)
-			case "contractStartDate":
-				return ec.fieldContext_People_contractStartDate(ctx, field)
-			case "contractEndDate":
-				return ec.fieldContext_People_contractEndDate(ctx, field)
-			case "createdAt":
-				return ec.fieldContext_People_createdAt(ctx, field)
-			case "updatedAt":
-				return ec.fieldContext_People_updatedAt(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type People", field.Name)
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _DocumentVersionSignature_createdAt(ctx context.Context, field graphql.CollectedField, obj *types.DocumentVersionSignature) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_DocumentVersionSignature_createdAt(ctx, field)
 	if err != nil {
@@ -32002,8 +31925,6 @@ func (ec *executionContext) fieldContext_DocumentVersionSignatureEdge_node(_ con
 				return ec.fieldContext_DocumentVersionSignature_signedAt(ctx, field)
 			case "requestedAt":
 				return ec.fieldContext_DocumentVersionSignature_requestedAt(ctx, field)
-			case "requestedBy":
-				return ec.fieldContext_DocumentVersionSignature_requestedBy(ctx, field)
 			case "createdAt":
 				return ec.fieldContext_DocumentVersionSignature_createdAt(ctx, field)
 			case "updatedAt":
@@ -75903,42 +75824,6 @@ func (ec *executionContext) _DocumentVersionSignature(ctx context.Context, sel a
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
-		case "requestedBy":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._DocumentVersionSignature_requestedBy(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "createdAt":
 			out.Values[i] = ec._DocumentVersionSignature_createdAt(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -1005,7 +1005,6 @@ type DocumentVersionSignature struct {
 	SignedBy        *People                                `json:"signedBy"`
 	SignedAt        *time.Time                             `json:"signedAt,omitempty"`
 	RequestedAt     time.Time                              `json:"requestedAt"`
-	RequestedBy     *People                                `json:"requestedBy"`
 	CreatedAt       time.Time                              `json:"createdAt"`
 	UpdatedAt       time.Time                              `json:"updatedAt"`
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed requested_by from document_version_signatures and all related code paths. Added a DB migration to drop the column since it’s no longer used.

- **Migration**
  - Apply migration 20250926T070601Z to drop document_version_signatures.requested_by.
  - Update any consumers that referenced requested_by before deploying.

<!-- End of auto-generated description by cubic. -->

