### PR TITLE
Change file size from int to int64 

### DIFF
--- a/apps/console/src/pages/organizations/vendors/tabs/__generated__/VendorComplianceTabFragment_report.graphql.ts
+++ b/apps/console/src/pages/organizations/vendors/tabs/__generated__/VendorComplianceTabFragment_report.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8f56e9dbd8ce8cf0c81d8f2e9f1ad06e>>
+ * @generated SignedSource<<4c861a832ad2f79bd9d6ddcc364f6898>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,7 +11,7 @@
 import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type VendorComplianceTabFragment_report$data = {
-  readonly fileSize: number;
+  readonly fileSize: any;
   readonly fileUrl: string;
   readonly id: string;
   readonly reportDate: any;

--- a/pkg/coredata/file.go
+++ b/pkg/coredata/file.go
@@ -32,7 +32,7 @@ type (
 		MimeType   string     `db:"mime_type"`
 		FileName   string     `db:"file_name"`
 		FileKey    string     `db:"file_key"`
-		FileSize   int        `db:"file_size"`
+		FileSize   int64      `db:"file_size"`
 		CreatedAt  time.Time  `db:"created_at"`
 		UpdatedAt  time.Time  `db:"updated_at"`
 		DeletedAt  *time.Time `db:"deleted_at"`

--- a/pkg/coredata/migrations/20250925T184234Z.sql
+++ b/pkg/coredata/migrations/20250925T184234Z.sql
@@ -1,0 +1,5 @@
+ALTER TABLE files
+ALTER COLUMN file_size TYPE bigint;
+
+ALTER TABLE vendor_compliance_reports
+ALTER COLUMN file_size TYPE bigint;

--- a/pkg/coredata/vendor_compliance_report.go
+++ b/pkg/coredata/vendor_compliance_report.go
@@ -34,7 +34,7 @@ type (
 		ValidUntil *time.Time
 		ReportName string
 		FileKey    string
-		FileSize   int
+		FileSize   int64
 		SnapshotID *gid.GID
 		SourceID   *gid.GID
 		CreatedAt  time.Time

--- a/pkg/probo/document_service.go
+++ b/pkg/probo/document_service.go
@@ -1251,7 +1251,7 @@ func (s *DocumentService) BuildAndUploadExport(ctx context.Context, exportJobID 
 				MimeType:   "application/zip",
 				FileName:   fmt.Sprintf("Documents Export %s.zip", now.Format("2006-01-02")),
 				FileKey:    uuid.String(),
-				FileSize:   int(fileInfo.Size()),
+				FileSize:   fileInfo.Size(),
 				CreatedAt:  now,
 				UpdatedAt:  now,
 			}

--- a/pkg/probo/framework_service.go
+++ b/pkg/probo/framework_service.go
@@ -823,7 +823,7 @@ func (s *FrameworkService) BuildAndUploadExport(ctx context.Context, exportJobID
 				MimeType:   "application/zip",
 				FileName:   fmt.Sprintf("Framework Export %s.zip", now.Format("2006-01-02")),
 				FileKey:    uuid.String(),
-				FileSize:   int(fileInfo.Size()),
+				FileSize:   fileInfo.Size(),
 				CreatedAt:  now,
 				UpdatedAt:  now,
 			}

--- a/pkg/probo/trust_center_reference_service.go
+++ b/pkg/probo/trust_center_reference_service.go
@@ -384,7 +384,7 @@ func (s TrustCenterReferenceService) uploadLogoFile(
 		MimeType:   contentType,
 		FileName:   filename,
 		FileKey:    objectKey.String(),
-		FileSize:   int(fileSize),
+		FileSize:   fileSize,
 		CreatedAt:  now,
 		UpdatedAt:  now,
 	}

--- a/pkg/probo/trust_center_service.go
+++ b/pkg/probo/trust_center_service.go
@@ -220,7 +220,7 @@ func (s TrustCenterService) UploadNDA(
 				MimeType:   mimeType,
 				FileName:   req.FileName,
 				FileKey:    objectKey.String(),
-				FileSize:   int(*headOutput.ContentLength),
+				FileSize:   *headOutput.ContentLength,
 				CreatedAt:  now,
 				UpdatedAt:  now,
 			}

--- a/pkg/probo/vendor_business_associate_agreement_service.go
+++ b/pkg/probo/vendor_business_associate_agreement_service.go
@@ -132,7 +132,7 @@ func (s VendorBusinessAssociateAgreementService) Upload(
 				MimeType:   mimeType,
 				FileName:   req.FileName,
 				FileKey:    objectKey.String(),
-				FileSize:   int(*headOutput.ContentLength),
+				FileSize:   *headOutput.ContentLength,
 				CreatedAt:  now,
 				UpdatedAt:  now,
 			}

--- a/pkg/probo/vendor_compliance_report_service.go
+++ b/pkg/probo/vendor_compliance_report_service.go
@@ -107,7 +107,7 @@ func (s VendorComplianceReportService) Upload(
 		ValidUntil: req.ValidUntil,
 		ReportName: req.ReportName,
 		FileKey:    objectKey.String(),
-		FileSize:   int(*headOutput.ContentLength),
+		FileSize:   *headOutput.ContentLength,
 		CreatedAt:  now,
 		UpdatedAt:  now,
 	}

--- a/pkg/probo/vendor_data_privacy_agreement_service.go
+++ b/pkg/probo/vendor_data_privacy_agreement_service.go
@@ -132,7 +132,7 @@ func (s VendorDataPrivacyAgreementService) Upload(
 				MimeType:   mimeType,
 				FileName:   req.FileName,
 				FileKey:    objectKey.String(),
-				FileSize:   int(*headOutput.ContentLength),
+				FileSize:   *headOutput.ContentLength,
 				CreatedAt:  now,
 				UpdatedAt:  now,
 			}

--- a/pkg/server/api/console/v1/gqlgen.yaml
+++ b/pkg/server/api/console/v1/gqlgen.yaml
@@ -30,3 +30,6 @@ models:
   Duration:
     model:
       - "github.com/99designs/gqlgen/graphql.Duration"
+  BigInt:
+    model:
+      - "github.com/getprobo/probo/pkg/server/graphql/types/bigint.BigIntScalar"

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -18,6 +18,7 @@ scalar Void
 scalar Datetime
 scalar Upload
 scalar Duration
+scalar BigInt
 
 # Interfaces
 interface Node {
@@ -1719,7 +1720,7 @@ type VendorComplianceReport implements Node {
   validUntil: Datetime
   reportName: String!
   fileUrl: String! @goField(forceResolver: true)
-  fileSize: Int!
+  fileSize: BigInt!
   createdAt: Datetime!
   updatedAt: Datetime!
 }
@@ -1731,7 +1732,7 @@ type VendorBusinessAssociateAgreement implements Node {
   validUntil: Datetime
   fileName: String!
   fileUrl: String! @goField(forceResolver: true)
-  fileSize: Int!
+  fileSize: BigInt!
   createdAt: Datetime!
   updatedAt: Datetime!
 }
@@ -1763,7 +1764,7 @@ type VendorDataPrivacyAgreement implements Node {
   validUntil: Datetime
   fileName: String!
   fileUrl: String! @goField(forceResolver: true)
-  fileSize: Int!
+  fileSize: BigInt!
   createdAt: Datetime!
   updatedAt: Datetime!
 }

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -18,6 +18,7 @@ import (
 	"github.com/getprobo/probo/pkg/gid"
 	"github.com/getprobo/probo/pkg/page"
 	"github.com/getprobo/probo/pkg/server/api/console/v1/types"
+	"github.com/getprobo/probo/pkg/server/graphql/types/bigint"
 	"github.com/getprobo/probo/pkg/server/graphql/types/cursor"
 	gid1 "github.com/getprobo/probo/pkg/server/graphql/types/gid"
 	gqlparser "github.com/vektah/gqlparser/v2"
@@ -8427,6 +8428,7 @@ scalar Void
 scalar Datetime
 scalar Upload
 scalar Duration
+scalar BigInt
 
 # Interfaces
 interface Node {
@@ -10128,7 +10130,7 @@ type VendorComplianceReport implements Node {
   validUntil: Datetime
   reportName: String!
   fileUrl: String! @goField(forceResolver: true)
-  fileSize: Int!
+  fileSize: BigInt!
   createdAt: Datetime!
   updatedAt: Datetime!
 }
@@ -10140,7 +10142,7 @@ type VendorBusinessAssociateAgreement implements Node {
   validUntil: Datetime
   fileName: String!
   fileUrl: String! @goField(forceResolver: true)
-  fileSize: Int!
+  fileSize: BigInt!
   createdAt: Datetime!
   updatedAt: Datetime!
 }
@@ -10172,7 +10174,7 @@ type VendorDataPrivacyAgreement implements Node {
   validUntil: Datetime
   fileName: String!
   fileUrl: String! @goField(forceResolver: true)
-  fileSize: Int!
+  fileSize: BigInt!
   createdAt: Datetime!
   updatedAt: Datetime!
 }
@@ -57837,9 +57839,9 @@ func (ec *executionContext) _VendorBusinessAssociateAgreement_fileSize(ctx conte
 		}
 		return graphql.Null
 	}
-	res := resTmp.(int)
+	res := resTmp.(int64)
 	fc.Result = res
-	return ec.marshalNInt2int(ctx, field.Selections, res)
+	return ec.marshalNBigInt2int64(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_VendorBusinessAssociateAgreement_fileSize(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -57849,7 +57851,7 @@ func (ec *executionContext) fieldContext_VendorBusinessAssociateAgreement_fileSi
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
+			return nil, errors.New("field of type BigInt does not have child fields")
 		},
 	}
 	return fc, nil
@@ -58294,9 +58296,9 @@ func (ec *executionContext) _VendorComplianceReport_fileSize(ctx context.Context
 		}
 		return graphql.Null
 	}
-	res := resTmp.(int)
+	res := resTmp.(int64)
 	fc.Result = res
-	return ec.marshalNInt2int(ctx, field.Selections, res)
+	return ec.marshalNBigInt2int64(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_VendorComplianceReport_fileSize(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -58306,7 +58308,7 @@ func (ec *executionContext) fieldContext_VendorComplianceReport_fileSize(_ conte
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
+			return nil, errors.New("field of type BigInt does not have child fields")
 		},
 	}
 	return fc, nil
@@ -59722,9 +59724,9 @@ func (ec *executionContext) _VendorDataPrivacyAgreement_fileSize(ctx context.Con
 		}
 		return graphql.Null
 	}
-	res := resTmp.(int)
+	res := resTmp.(int64)
 	fc.Result = res
-	return ec.marshalNInt2int(ctx, field.Selections, res)
+	return ec.marshalNBigInt2int64(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_VendorDataPrivacyAgreement_fileSize(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -59734,7 +59736,7 @@ func (ec *executionContext) fieldContext_VendorDataPrivacyAgreement_fileSize(_ c
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
+			return nil, errors.New("field of type BigInt does not have child fields")
 		},
 	}
 	return fc, nil
@@ -85857,6 +85859,22 @@ var (
 		coredata.AuditStateOutdated:   "OUTDATED",
 	}
 )
+
+func (ec *executionContext) unmarshalNBigInt2int64(ctx context.Context, v any) (int64, error) {
+	res, err := bigint.UnmarshalBigIntScalar(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNBigInt2int64(ctx context.Context, sel ast.SelectionSet, v int64) graphql.Marshaler {
+	_ = sel
+	res := bigint.MarshalBigIntScalar(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
 
 func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v any) (bool, error) {
 	res, err := graphql.UnmarshalBoolean(v)

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -2046,7 +2046,7 @@ type VendorBusinessAssociateAgreement struct {
 	ValidUntil *time.Time `json:"validUntil,omitempty"`
 	FileName   string     `json:"fileName"`
 	FileURL    string     `json:"fileUrl"`
-	FileSize   int        `json:"fileSize"`
+	FileSize   int64      `json:"fileSize"`
 	CreatedAt  time.Time  `json:"createdAt"`
 	UpdatedAt  time.Time  `json:"updatedAt"`
 }
@@ -2061,7 +2061,7 @@ type VendorComplianceReport struct {
 	ValidUntil *time.Time `json:"validUntil,omitempty"`
 	ReportName string     `json:"reportName"`
 	FileURL    string     `json:"fileUrl"`
-	FileSize   int        `json:"fileSize"`
+	FileSize   int64      `json:"fileSize"`
 	CreatedAt  time.Time  `json:"createdAt"`
 	UpdatedAt  time.Time  `json:"updatedAt"`
 }
@@ -2110,7 +2110,7 @@ type VendorDataPrivacyAgreement struct {
 	ValidUntil *time.Time `json:"validUntil,omitempty"`
 	FileName   string     `json:"fileName"`
 	FileURL    string     `json:"fileUrl"`
-	FileSize   int        `json:"fileSize"`
+	FileSize   int64      `json:"fileSize"`
 	CreatedAt  time.Time  `json:"createdAt"`
 	UpdatedAt  time.Time  `json:"updatedAt"`
 }

--- a/pkg/server/graphql/types/bigint/bigint.go
+++ b/pkg/server/graphql/types/bigint/bigint.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package bigint
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/99designs/gqlgen/graphql"
+)
+
+type BigIntScalar = int64
+
+func MarshalBigIntScalar(i int64) graphql.Marshaler {
+	return graphql.WriterFunc(func(w io.Writer) {
+		w.Write([]byte(strconv.FormatInt(i, 10)))
+	})
+}
+
+func UnmarshalBigIntScalar(v any) (int64, error) {
+	switch val := v.(type) {
+	case string:
+		i, err := strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid BigInt value: %v", err)
+		}
+		return i, nil
+	case int:
+		return int64(val), nil
+	case int32:
+		return int64(val), nil
+	case int64:
+		return val, nil
+	case float32:
+		if val != float32(int64(val)) {
+			return 0, fmt.Errorf("BigInt cannot represent non-integer value: %v", val)
+		}
+		return int64(val), nil
+	case float64:
+		if val != float64(int64(val)) {
+			return 0, fmt.Errorf("BigInt cannot represent non-integer value: %v", val)
+		}
+		return int64(val), nil
+	default:
+		return 0, fmt.Errorf("cannot unmarshal %T into BigInt", v)
+	}
+}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Switched file size handling to int64 across backend and exposed it as a string in GraphQL to safely support large files; updated the console UI to parse and display the new value.

- **Refactors**
  - Changed file_size columns to bigint and Go models/services to use int64.
  - Updated GraphQL schema/resolvers to return fileSize as String for vendor documents; console now parses fileSize for display.

- **Migration**
  - Run the SQL migration to alter file_size to bigint on files and vendor_compliance_reports.
  - Update any external API consumers to treat fileSize as a string.

<!-- End of auto-generated description by cubic. -->

