### PR TITLE
Add granular trust center access

### DIFF
--- a/apps/console/src/hooks/graph/TrustCenterAccessGraph.ts
+++ b/apps/console/src/hooks/graph/TrustCenterAccessGraph.ts
@@ -28,6 +28,31 @@ export const trustCenterAccessesQuery = graphql`
               active
               hasAcceptedNonDisclosureAgreement
               createdAt
+              documentAccesses(first: 100, orderBy: { field: CREATED_AT, direction: DESC }) {
+                edges {
+                  node {
+                    id
+                    active
+                    createdAt
+                    updatedAt
+                    document {
+                      id
+                      title
+                      documentType
+                    }
+                    report {
+                      id
+                      filename
+                      audit {
+                        id
+                        framework {
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }
@@ -51,6 +76,31 @@ export const createTrustCenterAccessMutation = graphql`
           active
           hasAcceptedNonDisclosureAgreement
           createdAt
+          documentAccesses(first: 100, orderBy: { field: CREATED_AT, direction: DESC }) {
+            edges {
+              node {
+                id
+                active
+                createdAt
+                updatedAt
+                document {
+                  id
+                  title
+                  documentType
+                }
+            report {
+              id
+              filename
+              audit {
+                id
+                framework {
+                  name
+                }
+              }
+            }
+              }
+            }
+          }
         }
       }
     }
@@ -70,6 +120,31 @@ export const updateTrustCenterAccessMutation = graphql`
         hasAcceptedNonDisclosureAgreement
         createdAt
         updatedAt
+        documentAccesses(first: 100, orderBy: { field: CREATED_AT, direction: DESC }) {
+          edges {
+            node {
+              id
+              active
+              createdAt
+              updatedAt
+              document {
+                id
+                title
+                documentType
+              }
+            report {
+              id
+              filename
+              audit {
+                id
+                framework {
+                  name
+                }
+              }
+            }
+            }
+          }
+        }
       }
     }
   }
@@ -82,6 +157,35 @@ export const deleteTrustCenterAccessMutation = graphql`
   ) {
     deleteTrustCenterAccess(input: $input) {
       deletedTrustCenterAccessId @deleteEdge(connections: $connections)
+    }
+  }
+`;
+
+export const updateTrustCenterDocumentAccessStatusMutation = graphql`
+  mutation TrustCenterAccessGraphUpdateDocumentAccessStatusMutation(
+    $input: UpdateTrustCenterDocumentAccessStatusInput!
+  ) {
+    updateTrustCenterDocumentAccessStatus(input: $input) {
+      trustCenterDocumentAccess {
+        id
+        active
+        updatedAt
+        document {
+          id
+          title
+          documentType
+        }
+            report {
+              id
+              filename
+              audit {
+                id
+                framework {
+                  name
+                }
+              }
+            }
+      }
     }
   }
 `;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphCreateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphCreateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5ccaab70e4cb8c4b5bee7fbe6ba2c0b6>>
+ * @generated SignedSource<<ce5be5c6578f34eabd9062f0a273c59f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,10 +9,13 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
+export type DocumentType = "ISMS" | "OTHER" | "POLICY";
 export type CreateTrustCenterAccessInput = {
   active: boolean;
+  documentIds?: ReadonlyArray<string> | null | undefined;
   email: string;
   name: string;
+  reportIds?: ReadonlyArray<string> | null | undefined;
   trustCenterId: string;
 };
 export type TrustCenterAccessGraphCreateMutation$variables = {
@@ -26,6 +29,31 @@ export type TrustCenterAccessGraphCreateMutation$data = {
       readonly node: {
         readonly active: boolean;
         readonly createdAt: any;
+        readonly documentAccesses: {
+          readonly edges: ReadonlyArray<{
+            readonly node: {
+              readonly active: boolean;
+              readonly createdAt: any;
+              readonly document: {
+                readonly documentType: DocumentType;
+                readonly id: string;
+                readonly title: string;
+              } | null | undefined;
+              readonly id: string;
+              readonly report: {
+                readonly audit: {
+                  readonly framework: {
+                    readonly name: string;
+                  };
+                  readonly id: string;
+                } | null | undefined;
+                readonly filename: string;
+                readonly id: string;
+              } | null | undefined;
+              readonly updatedAt: any;
+            };
+          }>;
+        };
         readonly email: string;
         readonly hasAcceptedNonDisclosureAgreement: boolean;
         readonly id: string;
@@ -60,72 +88,105 @@ v2 = [
 v3 = {
   "alias": null,
   "args": null,
-  "concreteType": "TrustCenterAccessEdge",
+  "kind": "ScalarField",
+  "name": "cursor",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "email",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "active",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "hasAcceptedNonDisclosureAgreement",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+},
+v10 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 100
+  },
+  {
+    "kind": "Literal",
+    "name": "orderBy",
+    "value": {
+      "direction": "DESC",
+      "field": "CREATED_AT"
+    }
+  }
+],
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "updatedAt",
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Document",
   "kind": "LinkedField",
-  "name": "trustCenterAccessEdge",
+  "name": "document",
   "plural": false,
   "selections": [
+    (v4/*: any*/),
     {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
-      "name": "cursor",
+      "name": "title",
       "storageKey": null
     },
     {
       "alias": null,
       "args": null,
-      "concreteType": "TrustCenterAccess",
-      "kind": "LinkedField",
-      "name": "node",
-      "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "id",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "email",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "name",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "active",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "hasAcceptedNonDisclosureAgreement",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "createdAt",
-          "storageKey": null
-        }
-      ],
+      "kind": "ScalarField",
+      "name": "documentType",
       "storageKey": null
     }
   ],
+  "storageKey": null
+},
+v13 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "filename",
   "storageKey": null
 };
 return {
@@ -146,7 +207,110 @@ return {
         "name": "createTrustCenterAccess",
         "plural": false,
         "selections": [
-          (v3/*: any*/)
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "TrustCenterAccessEdge",
+            "kind": "LinkedField",
+            "name": "trustCenterAccessEdge",
+            "plural": false,
+            "selections": [
+              (v3/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "TrustCenterAccess",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v4/*: any*/),
+                  (v5/*: any*/),
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/),
+                  {
+                    "alias": null,
+                    "args": (v10/*: any*/),
+                    "concreteType": "TrustCenterDocumentAccessConnection",
+                    "kind": "LinkedField",
+                    "name": "documentAccesses",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "TrustCenterDocumentAccessEdge",
+                        "kind": "LinkedField",
+                        "name": "edges",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "TrustCenterDocumentAccess",
+                            "kind": "LinkedField",
+                            "name": "node",
+                            "plural": false,
+                            "selections": [
+                              (v4/*: any*/),
+                              (v7/*: any*/),
+                              (v9/*: any*/),
+                              (v11/*: any*/),
+                              (v12/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Report",
+                                "kind": "LinkedField",
+                                "name": "report",
+                                "plural": false,
+                                "selections": [
+                                  (v4/*: any*/),
+                                  (v13/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Audit",
+                                    "kind": "LinkedField",
+                                    "name": "audit",
+                                    "plural": false,
+                                    "selections": [
+                                      (v4/*: any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "Framework",
+                                        "kind": "LinkedField",
+                                        "name": "framework",
+                                        "plural": false,
+                                        "selections": [
+                                          (v6/*: any*/)
+                                        ],
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "documentAccesses(first:100,orderBy:{\"direction\":\"DESC\",\"field\":\"CREATED_AT\"})"
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
         ],
         "storageKey": null
       }
@@ -171,7 +335,111 @@ return {
         "name": "createTrustCenterAccess",
         "plural": false,
         "selections": [
-          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "TrustCenterAccessEdge",
+            "kind": "LinkedField",
+            "name": "trustCenterAccessEdge",
+            "plural": false,
+            "selections": [
+              (v3/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "TrustCenterAccess",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v4/*: any*/),
+                  (v5/*: any*/),
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/),
+                  {
+                    "alias": null,
+                    "args": (v10/*: any*/),
+                    "concreteType": "TrustCenterDocumentAccessConnection",
+                    "kind": "LinkedField",
+                    "name": "documentAccesses",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "TrustCenterDocumentAccessEdge",
+                        "kind": "LinkedField",
+                        "name": "edges",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "TrustCenterDocumentAccess",
+                            "kind": "LinkedField",
+                            "name": "node",
+                            "plural": false,
+                            "selections": [
+                              (v4/*: any*/),
+                              (v7/*: any*/),
+                              (v9/*: any*/),
+                              (v11/*: any*/),
+                              (v12/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Report",
+                                "kind": "LinkedField",
+                                "name": "report",
+                                "plural": false,
+                                "selections": [
+                                  (v4/*: any*/),
+                                  (v13/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Audit",
+                                    "kind": "LinkedField",
+                                    "name": "audit",
+                                    "plural": false,
+                                    "selections": [
+                                      (v4/*: any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "Framework",
+                                        "kind": "LinkedField",
+                                        "name": "framework",
+                                        "plural": false,
+                                        "selections": [
+                                          (v6/*: any*/),
+                                          (v4/*: any*/)
+                                        ],
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "documentAccesses(first:100,orderBy:{\"direction\":\"DESC\",\"field\":\"CREATED_AT\"})"
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
           {
             "alias": null,
             "args": null,
@@ -194,16 +462,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "fa88b100be7598cf46159cf79199c398",
+    "cacheID": "a27b7cdf2a4cadf8cc22a95f39c3c6b0",
     "id": null,
     "metadata": {},
     "name": "TrustCenterAccessGraphCreateMutation",
     "operationKind": "mutation",
-    "text": "mutation TrustCenterAccessGraphCreateMutation(\n  $input: CreateTrustCenterAccessInput!\n) {\n  createTrustCenterAccess(input: $input) {\n    trustCenterAccessEdge {\n      cursor\n      node {\n        id\n        email\n        name\n        active\n        hasAcceptedNonDisclosureAgreement\n        createdAt\n      }\n    }\n  }\n}\n"
+    "text": "mutation TrustCenterAccessGraphCreateMutation(\n  $input: CreateTrustCenterAccessInput!\n) {\n  createTrustCenterAccess(input: $input) {\n    trustCenterAccessEdge {\n      cursor\n      node {\n        id\n        email\n        name\n        active\n        hasAcceptedNonDisclosureAgreement\n        createdAt\n        documentAccesses(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {\n          edges {\n            node {\n              id\n              active\n              createdAt\n              updatedAt\n              document {\n                id\n                title\n                documentType\n              }\n              report {\n                id\n                filename\n                audit {\n                  id\n                  framework {\n                    name\n                    id\n                  }\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "6c6c1344730e7d908a5c6392f578ca81";
+(node as any).hash = "091432e335b8fe3a97ac06d3765f172b";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e9cdda9f586cee5ffe66f238216060f6>>
+ * @generated SignedSource<<dc9a8dba9780e827b273ced118578604>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,6 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
+export type DocumentType = "ISMS" | "OTHER" | "POLICY";
 export type TrustCenterAccessGraphQuery$variables = {
   trustCenterId: string;
 };
@@ -21,6 +22,31 @@ export type TrustCenterAccessGraphQuery$data = {
         readonly node: {
           readonly active: boolean;
           readonly createdAt: any;
+          readonly documentAccesses: {
+            readonly edges: ReadonlyArray<{
+              readonly node: {
+                readonly active: boolean;
+                readonly createdAt: any;
+                readonly document: {
+                  readonly documentType: DocumentType;
+                  readonly id: string;
+                  readonly title: string;
+                } | null | undefined;
+                readonly id: string;
+                readonly report: {
+                  readonly audit: {
+                    readonly framework: {
+                      readonly name: string;
+                    };
+                    readonly id: string;
+                  } | null | undefined;
+                  readonly filename: string;
+                  readonly id: string;
+                } | null | undefined;
+                readonly updatedAt: any;
+              };
+            }>;
+          };
           readonly email: string;
           readonly hasAcceptedNonDisclosureAgreement: boolean;
           readonly id: string;
@@ -75,137 +101,151 @@ v3 = {
 v4 = {
   "alias": null,
   "args": null,
-  "kind": "ScalarField",
-  "name": "__typename",
+  "concreteType": "PageInfo",
+  "kind": "LinkedField",
+  "name": "pageInfo",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "hasNextPage",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "hasPreviousPage",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "startCursor",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "endCursor",
+      "storageKey": null
+    }
+  ],
   "storageKey": null
 },
-v5 = [
-  {
-    "alias": null,
-    "args": null,
-    "concreteType": "PageInfo",
-    "kind": "LinkedField",
-    "name": "pageInfo",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "hasNextPage",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "hasPreviousPage",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "startCursor",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "endCursor",
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "concreteType": "TrustCenterAccessEdge",
-    "kind": "LinkedField",
-    "name": "edges",
-    "plural": true,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "cursor",
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "TrustCenterAccess",
-        "kind": "LinkedField",
-        "name": "node",
-        "plural": false,
-        "selections": [
-          (v2/*: any*/),
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "email",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "name",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "active",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "hasAcceptedNonDisclosureAgreement",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "createdAt",
-            "storageKey": null
-          },
-          (v4/*: any*/)
-        ],
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
-  },
-  {
-    "kind": "ClientExtension",
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "__id",
-        "storageKey": null
-      }
-    ]
-  }
-],
-v6 = [
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cursor",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "email",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "active",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "hasAcceptedNonDisclosureAgreement",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+},
+v11 = [
   {
     "kind": "Literal",
     "name": "first",
     "value": 100
   },
   (v3/*: any*/)
-];
+],
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "updatedAt",
+  "storageKey": null
+},
+v13 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Document",
+  "kind": "LinkedField",
+  "name": "document",
+  "plural": false,
+  "selections": [
+    (v2/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "title",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "documentType",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v14 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "filename",
+  "storageKey": null
+},
+v15 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v16 = {
+  "kind": "ClientExtension",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "__id",
+      "storageKey": null
+    }
+  ]
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -234,7 +274,115 @@ return {
                 "kind": "LinkedField",
                 "name": "__TrustCenterAccessTab_accesses_connection",
                 "plural": false,
-                "selections": (v5/*: any*/),
+                "selections": [
+                  (v4/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "TrustCenterAccessEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      (v5/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "TrustCenterAccess",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          (v6/*: any*/),
+                          (v7/*: any*/),
+                          (v8/*: any*/),
+                          (v9/*: any*/),
+                          (v10/*: any*/),
+                          {
+                            "alias": null,
+                            "args": (v11/*: any*/),
+                            "concreteType": "TrustCenterDocumentAccessConnection",
+                            "kind": "LinkedField",
+                            "name": "documentAccesses",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "TrustCenterDocumentAccessEdge",
+                                "kind": "LinkedField",
+                                "name": "edges",
+                                "plural": true,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "TrustCenterDocumentAccess",
+                                    "kind": "LinkedField",
+                                    "name": "node",
+                                    "plural": false,
+                                    "selections": [
+                                      (v2/*: any*/),
+                                      (v8/*: any*/),
+                                      (v10/*: any*/),
+                                      (v12/*: any*/),
+                                      (v13/*: any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "Report",
+                                        "kind": "LinkedField",
+                                        "name": "report",
+                                        "plural": false,
+                                        "selections": [
+                                          (v2/*: any*/),
+                                          (v14/*: any*/),
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "concreteType": "Audit",
+                                            "kind": "LinkedField",
+                                            "name": "audit",
+                                            "plural": false,
+                                            "selections": [
+                                              (v2/*: any*/),
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "concreteType": "Framework",
+                                                "kind": "LinkedField",
+                                                "name": "framework",
+                                                "plural": false,
+                                                "selections": [
+                                                  (v7/*: any*/)
+                                                ],
+                                                "storageKey": null
+                                              }
+                                            ],
+                                            "storageKey": null
+                                          }
+                                        ],
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": "documentAccesses(first:100,orderBy:{\"direction\":\"DESC\",\"field\":\"CREATED_AT\"})"
+                          },
+                          (v15/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  (v16/*: any*/)
+                ],
                 "storageKey": "__TrustCenterAccessTab_accesses_connection(orderBy:{\"direction\":\"DESC\",\"field\":\"CREATED_AT\"})"
               }
             ],
@@ -262,24 +410,133 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          (v4/*: any*/),
+          (v15/*: any*/),
           (v2/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
               {
                 "alias": null,
-                "args": (v6/*: any*/),
+                "args": (v11/*: any*/),
                 "concreteType": "TrustCenterAccessConnection",
                 "kind": "LinkedField",
                 "name": "accesses",
                 "plural": false,
-                "selections": (v5/*: any*/),
+                "selections": [
+                  (v4/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "TrustCenterAccessEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      (v5/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "TrustCenterAccess",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          (v6/*: any*/),
+                          (v7/*: any*/),
+                          (v8/*: any*/),
+                          (v9/*: any*/),
+                          (v10/*: any*/),
+                          {
+                            "alias": null,
+                            "args": (v11/*: any*/),
+                            "concreteType": "TrustCenterDocumentAccessConnection",
+                            "kind": "LinkedField",
+                            "name": "documentAccesses",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "TrustCenterDocumentAccessEdge",
+                                "kind": "LinkedField",
+                                "name": "edges",
+                                "plural": true,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "TrustCenterDocumentAccess",
+                                    "kind": "LinkedField",
+                                    "name": "node",
+                                    "plural": false,
+                                    "selections": [
+                                      (v2/*: any*/),
+                                      (v8/*: any*/),
+                                      (v10/*: any*/),
+                                      (v12/*: any*/),
+                                      (v13/*: any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "Report",
+                                        "kind": "LinkedField",
+                                        "name": "report",
+                                        "plural": false,
+                                        "selections": [
+                                          (v2/*: any*/),
+                                          (v14/*: any*/),
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "concreteType": "Audit",
+                                            "kind": "LinkedField",
+                                            "name": "audit",
+                                            "plural": false,
+                                            "selections": [
+                                              (v2/*: any*/),
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "concreteType": "Framework",
+                                                "kind": "LinkedField",
+                                                "name": "framework",
+                                                "plural": false,
+                                                "selections": [
+                                                  (v7/*: any*/),
+                                                  (v2/*: any*/)
+                                                ],
+                                                "storageKey": null
+                                              }
+                                            ],
+                                            "storageKey": null
+                                          }
+                                        ],
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": "documentAccesses(first:100,orderBy:{\"direction\":\"DESC\",\"field\":\"CREATED_AT\"})"
+                          },
+                          (v15/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  (v16/*: any*/)
+                ],
                 "storageKey": "accesses(first:100,orderBy:{\"direction\":\"DESC\",\"field\":\"CREATED_AT\"})"
               },
               {
                 "alias": null,
-                "args": (v6/*: any*/),
+                "args": (v11/*: any*/),
                 "filters": [
                   "orderBy"
                 ],
@@ -298,7 +555,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "0286ec03fb4ae012ada7bae8a2234152",
+    "cacheID": "72db0f61769f773d6f7ba20735f93643",
     "id": null,
     "metadata": {
       "connection": [
@@ -315,11 +572,11 @@ return {
     },
     "name": "TrustCenterAccessGraphQuery",
     "operationKind": "query",
-    "text": "query TrustCenterAccessGraphQuery(\n  $trustCenterId: ID!\n) {\n  node(id: $trustCenterId) {\n    __typename\n    ... on TrustCenter {\n      id\n      accesses(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {\n        pageInfo {\n          hasNextPage\n          hasPreviousPage\n          startCursor\n          endCursor\n        }\n        edges {\n          cursor\n          node {\n            id\n            email\n            name\n            active\n            hasAcceptedNonDisclosureAgreement\n            createdAt\n            __typename\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query TrustCenterAccessGraphQuery(\n  $trustCenterId: ID!\n) {\n  node(id: $trustCenterId) {\n    __typename\n    ... on TrustCenter {\n      id\n      accesses(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {\n        pageInfo {\n          hasNextPage\n          hasPreviousPage\n          startCursor\n          endCursor\n        }\n        edges {\n          cursor\n          node {\n            id\n            email\n            name\n            active\n            hasAcceptedNonDisclosureAgreement\n            createdAt\n            documentAccesses(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {\n              edges {\n                node {\n                  id\n                  active\n                  createdAt\n                  updatedAt\n                  document {\n                    id\n                    title\n                    documentType\n                  }\n                  report {\n                    id\n                    filename\n                    audit {\n                      id\n                      framework {\n                        name\n                        id\n                      }\n                    }\n                  }\n                }\n              }\n            }\n            __typename\n          }\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "f837b96937f1397ac1a3065f58386e4d";
+(node as any).hash = "a7c9ec0c6a2a5060886b68dc2be112fa";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphUpdateDocumentAccessStatusMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphUpdateDocumentAccessStatusMutation.graphql.ts
@@ -1,0 +1,284 @@
+/**
+ * @generated SignedSource<<786bab8a5d91a80d7652fa2da6f6088b>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type DocumentType = "ISMS" | "OTHER" | "POLICY";
+export type UpdateTrustCenterDocumentAccessStatusInput = {
+  active: boolean;
+  id: string;
+};
+export type TrustCenterAccessGraphUpdateDocumentAccessStatusMutation$variables = {
+  input: UpdateTrustCenterDocumentAccessStatusInput;
+};
+export type TrustCenterAccessGraphUpdateDocumentAccessStatusMutation$data = {
+  readonly updateTrustCenterDocumentAccessStatus: {
+    readonly trustCenterDocumentAccess: {
+      readonly active: boolean;
+      readonly document: {
+        readonly documentType: DocumentType;
+        readonly id: string;
+        readonly title: string;
+      } | null | undefined;
+      readonly id: string;
+      readonly report: {
+        readonly audit: {
+          readonly framework: {
+            readonly name: string;
+          };
+          readonly id: string;
+        } | null | undefined;
+        readonly filename: string;
+        readonly id: string;
+      } | null | undefined;
+      readonly updatedAt: any;
+    };
+  };
+};
+export type TrustCenterAccessGraphUpdateDocumentAccessStatusMutation = {
+  response: TrustCenterAccessGraphUpdateDocumentAccessStatusMutation$data;
+  variables: TrustCenterAccessGraphUpdateDocumentAccessStatusMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "active",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "updatedAt",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Document",
+  "kind": "LinkedField",
+  "name": "document",
+  "plural": false,
+  "selections": [
+    (v2/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "title",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "documentType",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "filename",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TrustCenterAccessGraphUpdateDocumentAccessStatusMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "UpdateTrustCenterDocumentAccessStatusPayload",
+        "kind": "LinkedField",
+        "name": "updateTrustCenterDocumentAccessStatus",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "TrustCenterDocumentAccess",
+            "kind": "LinkedField",
+            "name": "trustCenterDocumentAccess",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Report",
+                "kind": "LinkedField",
+                "name": "report",
+                "plural": false,
+                "selections": [
+                  (v2/*: any*/),
+                  (v6/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Audit",
+                    "kind": "LinkedField",
+                    "name": "audit",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Framework",
+                        "kind": "LinkedField",
+                        "name": "framework",
+                        "plural": false,
+                        "selections": [
+                          (v7/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "TrustCenterAccessGraphUpdateDocumentAccessStatusMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "UpdateTrustCenterDocumentAccessStatusPayload",
+        "kind": "LinkedField",
+        "name": "updateTrustCenterDocumentAccessStatus",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "TrustCenterDocumentAccess",
+            "kind": "LinkedField",
+            "name": "trustCenterDocumentAccess",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Report",
+                "kind": "LinkedField",
+                "name": "report",
+                "plural": false,
+                "selections": [
+                  (v2/*: any*/),
+                  (v6/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Audit",
+                    "kind": "LinkedField",
+                    "name": "audit",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Framework",
+                        "kind": "LinkedField",
+                        "name": "framework",
+                        "plural": false,
+                        "selections": [
+                          (v7/*: any*/),
+                          (v2/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "d6551e8cf21a2342783ff8224515104f",
+    "id": null,
+    "metadata": {},
+    "name": "TrustCenterAccessGraphUpdateDocumentAccessStatusMutation",
+    "operationKind": "mutation",
+    "text": "mutation TrustCenterAccessGraphUpdateDocumentAccessStatusMutation(\n  $input: UpdateTrustCenterDocumentAccessStatusInput!\n) {\n  updateTrustCenterDocumentAccessStatus(input: $input) {\n    trustCenterDocumentAccess {\n      id\n      active\n      updatedAt\n      document {\n        id\n        title\n        documentType\n      }\n      report {\n        id\n        filename\n        audit {\n          id\n          framework {\n            name\n            id\n          }\n        }\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "bf26eeeb551b615fd6a889a9ee932ca4";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphUpdateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphUpdateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d2f40d8fc2bd9c7627d308660dedb1e5>>
+ * @generated SignedSource<<4aef541df2f5673dd3694ca275f3164d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,10 +9,13 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
+export type DocumentType = "ISMS" | "OTHER" | "POLICY";
 export type UpdateTrustCenterAccessInput = {
   active?: boolean | null | undefined;
+  documentIds?: ReadonlyArray<string> | null | undefined;
   id: string;
   name?: string | null | undefined;
+  reportIds?: ReadonlyArray<string> | null | undefined;
 };
 export type TrustCenterAccessGraphUpdateMutation$variables = {
   input: UpdateTrustCenterAccessInput;
@@ -22,6 +25,31 @@ export type TrustCenterAccessGraphUpdateMutation$data = {
     readonly trustCenterAccess: {
       readonly active: boolean;
       readonly createdAt: any;
+      readonly documentAccesses: {
+        readonly edges: ReadonlyArray<{
+          readonly node: {
+            readonly active: boolean;
+            readonly createdAt: any;
+            readonly document: {
+              readonly documentType: DocumentType;
+              readonly id: string;
+              readonly title: string;
+            } | null | undefined;
+            readonly id: string;
+            readonly report: {
+              readonly audit: {
+                readonly framework: {
+                  readonly name: string;
+                };
+                readonly id: string;
+              } | null | undefined;
+              readonly filename: string;
+              readonly id: string;
+            } | null | undefined;
+            readonly updatedAt: any;
+          };
+        }>;
+      };
       readonly email: string;
       readonly hasAcceptedNonDisclosureAgreement: boolean;
       readonly id: string;
@@ -45,90 +73,220 @@ var v0 = [
 ],
 v1 = [
   {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "input",
-        "variableName": "input"
-      }
-    ],
-    "concreteType": "UpdateTrustCenterAccessPayload",
-    "kind": "LinkedField",
-    "name": "updateTrustCenterAccess",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "TrustCenterAccess",
-        "kind": "LinkedField",
-        "name": "trustCenterAccess",
-        "plural": false,
-        "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "email",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "name",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "active",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "hasAcceptedNonDisclosureAgreement",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "createdAt",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "updatedAt",
-            "storageKey": null
-          }
-        ],
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
   }
-];
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "email",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "active",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "hasAcceptedNonDisclosureAgreement",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "updatedAt",
+  "storageKey": null
+},
+v9 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 100
+  },
+  {
+    "kind": "Literal",
+    "name": "orderBy",
+    "value": {
+      "direction": "DESC",
+      "field": "CREATED_AT"
+    }
+  }
+],
+v10 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Document",
+  "kind": "LinkedField",
+  "name": "document",
+  "plural": false,
+  "selections": [
+    (v2/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "title",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "documentType",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "filename",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "TrustCenterAccessGraphUpdateMutation",
-    "selections": (v1/*: any*/),
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "UpdateTrustCenterAccessPayload",
+        "kind": "LinkedField",
+        "name": "updateTrustCenterAccess",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "TrustCenterAccess",
+            "kind": "LinkedField",
+            "name": "trustCenterAccess",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/),
+              {
+                "alias": null,
+                "args": (v9/*: any*/),
+                "concreteType": "TrustCenterDocumentAccessConnection",
+                "kind": "LinkedField",
+                "name": "documentAccesses",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "TrustCenterDocumentAccessEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "TrustCenterDocumentAccess",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          (v5/*: any*/),
+                          (v7/*: any*/),
+                          (v8/*: any*/),
+                          (v10/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Report",
+                            "kind": "LinkedField",
+                            "name": "report",
+                            "plural": false,
+                            "selections": [
+                              (v2/*: any*/),
+                              (v11/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Audit",
+                                "kind": "LinkedField",
+                                "name": "audit",
+                                "plural": false,
+                                "selections": [
+                                  (v2/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Framework",
+                                    "kind": "LinkedField",
+                                    "name": "framework",
+                                    "plural": false,
+                                    "selections": [
+                                      (v4/*: any*/)
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "documentAccesses(first:100,orderBy:{\"direction\":\"DESC\",\"field\":\"CREATED_AT\"})"
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
     "type": "Mutation",
     "abstractKey": null
   },
@@ -137,19 +295,125 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "TrustCenterAccessGraphUpdateMutation",
-    "selections": (v1/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "UpdateTrustCenterAccessPayload",
+        "kind": "LinkedField",
+        "name": "updateTrustCenterAccess",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "TrustCenterAccess",
+            "kind": "LinkedField",
+            "name": "trustCenterAccess",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/),
+              {
+                "alias": null,
+                "args": (v9/*: any*/),
+                "concreteType": "TrustCenterDocumentAccessConnection",
+                "kind": "LinkedField",
+                "name": "documentAccesses",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "TrustCenterDocumentAccessEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "TrustCenterDocumentAccess",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          (v5/*: any*/),
+                          (v7/*: any*/),
+                          (v8/*: any*/),
+                          (v10/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Report",
+                            "kind": "LinkedField",
+                            "name": "report",
+                            "plural": false,
+                            "selections": [
+                              (v2/*: any*/),
+                              (v11/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Audit",
+                                "kind": "LinkedField",
+                                "name": "audit",
+                                "plural": false,
+                                "selections": [
+                                  (v2/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Framework",
+                                    "kind": "LinkedField",
+                                    "name": "framework",
+                                    "plural": false,
+                                    "selections": [
+                                      (v4/*: any*/),
+                                      (v2/*: any*/)
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "documentAccesses(first:100,orderBy:{\"direction\":\"DESC\",\"field\":\"CREATED_AT\"})"
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "cacheID": "223169ee8a4f65008047097ecff68fc5",
+    "cacheID": "de3ddd0058b8881667e47e2bf32c8b73",
     "id": null,
     "metadata": {},
     "name": "TrustCenterAccessGraphUpdateMutation",
     "operationKind": "mutation",
-    "text": "mutation TrustCenterAccessGraphUpdateMutation(\n  $input: UpdateTrustCenterAccessInput!\n) {\n  updateTrustCenterAccess(input: $input) {\n    trustCenterAccess {\n      id\n      email\n      name\n      active\n      hasAcceptedNonDisclosureAgreement\n      createdAt\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation TrustCenterAccessGraphUpdateMutation(\n  $input: UpdateTrustCenterAccessInput!\n) {\n  updateTrustCenterAccess(input: $input) {\n    trustCenterAccess {\n      id\n      email\n      name\n      active\n      hasAcceptedNonDisclosureAgreement\n      createdAt\n      updatedAt\n      documentAccesses(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {\n        edges {\n          node {\n            id\n            active\n            createdAt\n            updatedAt\n            document {\n              id\n              title\n              documentType\n            }\n            report {\n              id\n              filename\n              audit {\n                id\n                framework {\n                  name\n                  id\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "0da1f737e6ea1db7a1b9930c4b6cc545";
+(node as any).hash = "723058aacc2e04bd2df4cf04c6df0a3c";
 
 export default node;

--- a/apps/console/src/trust/components/PublicTrustCenterAudits.tsx
+++ b/apps/console/src/trust/components/PublicTrustCenterAudits.tsx
@@ -15,6 +15,7 @@ import { useTranslate } from "@probo/i18n";
 import { sprintf } from "@probo/helpers";
 import { FrameworkLogo } from "/components/FrameworkLogo";
 import { PublicTrustCenterAccessRequestDialog } from "./PublicTrustCenterAccessRequestDialog";
+import { RequestReportAccessDialog } from "./RequestReportAccessDialog";
 import { useExportReportPDF } from "../../hooks/useTrustCenterQueries";
 import type { TrustCenterAudit } from "../pages/PublicTrustCenterPage";
 
@@ -127,7 +128,7 @@ export function PublicTrustCenterAudits({
                       trustCenterId={trustCenterId}
                       organizationName={organizationName}
                     />
-                  ) : (
+                  ) : audit.report!.isUserAuthorized ? (
                     <Button
                       variant="secondary"
                       icon={IconArrowDown}
@@ -136,6 +137,29 @@ export function PublicTrustCenterAudits({
                     >
                       {mutation.isPending ? __("Downloading...") : __("Download")}
                     </Button>
+                  ) : audit.report!.hasUserRequestedAccess ? (
+                    <Button
+                      variant="tertiary"
+                      disabled
+                    >
+                      {__("Access Requested")}
+                    </Button>
+                  ) : (
+                    <RequestReportAccessDialog
+                      trigger={
+                        <Button
+                          variant="secondary"
+                          icon={IconLock}
+                        >
+                          {__("Request Access")}
+                        </Button>
+                      }
+                      report={audit.report!}
+                      audit={audit}
+                      trustCenterId={trustCenterId}
+                      organizationName={organizationName}
+                      isAuthenticated={isAuthenticated}
+                    />
                   )}
                 </Td>
               </Tr>

--- a/apps/console/src/trust/components/PublicTrustCenterDocuments.tsx
+++ b/apps/console/src/trust/components/PublicTrustCenterDocuments.tsx
@@ -15,6 +15,7 @@ import {
 import { useTranslate } from "@probo/i18n";
 import { useExportDocumentPDF, type TrustCenterDocument } from "/hooks/useTrustCenterQueries";
 import { PublicTrustCenterAccessRequestDialog } from "./PublicTrustCenterAccessRequestDialog";
+import { RequestDocumentAccessDialog } from "./RequestDocumentAccessDialog";
 
 type Props = {
   documents: TrustCenterDocument[];
@@ -116,7 +117,7 @@ export function PublicTrustCenterDocuments({
                       trustCenterId={trustCenterId}
                       organizationName={organizationName}
                     />
-                  ) : (
+                  ) : document.isUserAuthorized ? (
                     <Button
                       variant="secondary"
                       icon={IconArrowDown}
@@ -125,6 +126,28 @@ export function PublicTrustCenterDocuments({
                     >
                       {mutation.isPending ? __("Downloading...") : __("Download")}
                     </Button>
+                  ) : document.hasUserRequestedAccess ? (
+                    <Button
+                      variant="tertiary"
+                      disabled
+                    >
+                      {__("Access Requested")}
+                    </Button>
+                  ) : (
+                    <RequestDocumentAccessDialog
+                      trigger={
+                        <Button
+                          variant="secondary"
+                          icon={IconLock}
+                        >
+                          {__("Request Access")}
+                        </Button>
+                      }
+                      document={document}
+                      trustCenterId={trustCenterId}
+                      organizationName={organizationName}
+                      isAuthenticated={isAuthenticated}
+                    />
                   )}
                 </Td>
               </Tr>

--- a/apps/console/src/trust/components/RequestDocumentAccessDialog.tsx
+++ b/apps/console/src/trust/components/RequestDocumentAccessDialog.tsx
@@ -1,0 +1,132 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  Button,
+  Field,
+  useToast,
+  useDialogRef,
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { sprintf } from "@probo/helpers";
+import { useFormWithSchema } from "/hooks/useFormWithSchema";
+import { z } from "zod";
+import { useRequestDocumentAccess, type TrustCenterDocument } from "/hooks/useTrustCenterQueries";
+
+type Props = {
+  trigger: React.ReactNode;
+  document: TrustCenterDocument;
+  trustCenterId: string;
+  organizationName: string;
+  isAuthenticated: boolean;
+};
+
+export function RequestDocumentAccessDialog({
+  trigger,
+  document,
+  trustCenterId,
+  organizationName,
+  isAuthenticated
+}: Props) {
+  const { __ } = useTranslate();
+  const { toast } = useToast();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const dialogRef = useDialogRef();
+
+  const mutation = useRequestDocumentAccess();
+
+  const schema = z.object({
+    name: isAuthenticated
+      ? z.string().optional()
+      : z.string().min(1, __("Name is required")).min(2, __("Name must be at least 2 characters long")),
+    email: isAuthenticated
+      ? z.string().optional()
+      : z.string().min(1, __("Email is required")).email(__("Please enter a valid email address")),
+  });
+
+  const { register, handleSubmit, formState, reset } = useFormWithSchema(schema, {
+    defaultValues: { name: "", email: "" },
+  });
+
+  const onSubmit = handleSubmit(async (data) => {
+    setIsSubmitting(true);
+    mutation.mutate(
+      {
+        trustCenterId,
+        email: data.email || "",
+        name: data.name || "",
+        documentId: document.id,
+      },
+      {
+        onSuccess: () => {
+          toast({
+            title: __("Request Submitted"),
+            description: sprintf(__("Your access request for %s has been submitted successfully."), document.title),
+          });
+
+          reset();
+          dialogRef.current?.close();
+          setIsSubmitting(false);
+          window.location.reload();
+        },
+        onError: () => {
+          toast({
+            title: __("Error"),
+            description: __("Failed to submit access request. Please try again."),
+            variant: "error",
+          });
+          setIsSubmitting(false);
+        },
+      }
+    );
+  });
+
+  return (
+    <Dialog
+      ref={dialogRef}
+      trigger={trigger}
+      title={__("Request Access to Document")}
+    >
+      <form onSubmit={onSubmit}>
+        <DialogContent padded className="space-y-4">
+          <div className="text-sm text-txt-secondary">
+            {sprintf(__("Request access to %s from %s. Your request will be reviewed and you will receive an email notification with access instructions if approved."), document.title, organizationName)}
+          </div>
+
+          {!isAuthenticated && (
+            <>
+              <Field
+                label={__("Your Name")}
+                required
+                error={formState.errors.name?.message}
+                {...register("name")}
+                placeholder={__("Enter your full name")}
+                disabled={isSubmitting}
+              />
+
+              <Field
+                label={__("Email Address")}
+                required
+                type="email"
+                error={formState.errors.email?.message}
+                {...register("email")}
+                placeholder={__("Enter your email address")}
+                disabled={isSubmitting}
+              />
+            </>
+          )}
+        </DialogContent>
+
+        <DialogFooter>
+          <Button
+            type="submit"
+            disabled={isSubmitting || mutation.isPending}
+          >
+            {isSubmitting || mutation.isPending ? __("Submitting...") : __("Submit Request")}
+          </Button>
+        </DialogFooter>
+      </form>
+    </Dialog>
+  );
+}

--- a/apps/console/src/trust/components/RequestReportAccessDialog.tsx
+++ b/apps/console/src/trust/components/RequestReportAccessDialog.tsx
@@ -1,0 +1,134 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  Button,
+  Field,
+  useToast,
+  useDialogRef,
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { sprintf } from "@probo/helpers";
+import { useFormWithSchema } from "/hooks/useFormWithSchema";
+import { z } from "zod";
+import { useRequestReportAccess, type TrustCenterAudit } from "/hooks/useTrustCenterQueries";
+
+type Props = {
+  trigger: React.ReactNode;
+  report: NonNullable<TrustCenterAudit["report"]>;
+  audit: TrustCenterAudit;
+  trustCenterId: string;
+  organizationName: string;
+  isAuthenticated: boolean;
+};
+
+export function RequestReportAccessDialog({
+  trigger,
+  report,
+  audit,
+  trustCenterId,
+  organizationName,
+  isAuthenticated
+}: Props) {
+  const { __ } = useTranslate();
+  const { toast } = useToast();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const dialogRef = useDialogRef();
+
+  const mutation = useRequestReportAccess();
+
+  const schema = z.object({
+    name: isAuthenticated
+      ? z.string().optional()
+      : z.string().min(1, __("Name is required")).min(2, __("Name must be at least 2 characters long")),
+    email: isAuthenticated
+      ? z.string().optional()
+      : z.string().min(1, __("Email is required")).email(__("Please enter a valid email address")),
+  });
+
+  const { register, handleSubmit, formState, reset } = useFormWithSchema(schema, {
+    defaultValues: { name: "", email: "" },
+  });
+
+  const onSubmit = handleSubmit(async (data) => {
+    setIsSubmitting(true);
+    mutation.mutate(
+      {
+        trustCenterId,
+        email: data.email || "",
+        name: data.name || "",
+        reportId: report.id,
+      },
+      {
+        onSuccess: () => {
+          toast({
+            title: __("Request Submitted"),
+            description: sprintf(__("Your access request for %s compliance report has been submitted successfully."), audit.framework.name),
+          });
+
+          reset();
+          dialogRef.current?.close();
+          setIsSubmitting(false);
+          window.location.reload();
+        },
+        onError: () => {
+          toast({
+            title: __("Error"),
+            description: __("Failed to submit access request. Please try again."),
+            variant: "error",
+          });
+          setIsSubmitting(false);
+        },
+      }
+    );
+  });
+
+  return (
+    <Dialog
+      ref={dialogRef}
+      trigger={trigger}
+      title={__("Request Access to Compliance Report")}
+    >
+      <form onSubmit={onSubmit}>
+        <DialogContent padded className="space-y-4">
+          <div className="text-sm text-txt-secondary">
+            {sprintf(__("Request access to %s compliance report from %s. Your request will be reviewed and you will receive an email notification with access instructions if approved."), audit.framework.name, organizationName)}
+          </div>
+
+          {!isAuthenticated && (
+            <>
+              <Field
+                label={__("Your Name")}
+                required
+                error={formState.errors.name?.message}
+                {...register("name")}
+                placeholder={__("Enter your full name")}
+                disabled={isSubmitting}
+              />
+
+              <Field
+                label={__("Email Address")}
+                required
+                type="email"
+                error={formState.errors.email?.message}
+                {...register("email")}
+                placeholder={__("Enter your email address")}
+                disabled={isSubmitting}
+              />
+            </>
+          )}
+        </DialogContent>
+
+        <DialogFooter>
+          <Button
+            type="submit"
+            disabled={isSubmitting || mutation.isPending}
+          >
+            {isSubmitting || mutation.isPending ? __("Submitting...") : __("Submit Request")}
+          </Button>
+        </DialogFooter>
+      </form>
+    </Dialog>
+  );
+}

--- a/apps/console/src/trust/pages/PublicTrustCenterPage.tsx
+++ b/apps/console/src/trust/pages/PublicTrustCenterPage.tsx
@@ -5,8 +5,9 @@ import { PublicTrustCenterLayout } from "/layouts/PublicTrustCenterLayout";
 import { PublicTrustCenterAudits } from "../components/PublicTrustCenterAudits";
 import { PublicTrustCenterVendors } from "../components/PublicTrustCenterVendors";
 import { PublicTrustCenterDocuments } from "../components/PublicTrustCenterDocuments";
+import { PublicTrustCenterAccessRequestDialog } from "../components/PublicTrustCenterAccessRequestDialog";
 import { NDAAcceptanceDialog } from "../components/NDAAcceptanceDialog";
-import { Spinner } from "@probo/ui";
+import { Spinner, Button, IconLock } from "@probo/ui";
 import { useTrustCenterQuery, type TrustCenterDocument, type TrustCenterAudit, type TrustCenterVendor } from "/hooks/useTrustCenterQueries";
 
 export type { TrustCenterDocument, TrustCenterAudit, TrustCenterVendor };
@@ -75,6 +76,25 @@ export default function PublicTrustCenterPage() {
 
   const showNdaDialog = isUserAuthenticated && !hasAcceptedNonDisclosureAgreement;
 
+  let showRequestAllButton = false;
+
+  for (const doc of trustCenterDocuments) {
+    if (!doc.isUserAuthorized && !doc.hasUserRequestedAccess) {
+      showRequestAllButton = true;
+      break;
+    }
+  }
+
+  if (!showRequestAllButton) {
+    const reportsWithData = trustCenterAudits.filter(audit => audit.report !== null);
+    for (const audit of reportsWithData) {
+      if (!audit.report!.isUserAuthorized && !audit.report!.hasUserRequestedAccess) {
+        showRequestAllButton = true;
+        break;
+      }
+    }
+  }
+
   return (
     <>
       {showNdaDialog && (
@@ -89,9 +109,25 @@ export default function PublicTrustCenterPage() {
       <PublicTrustCenterLayout
         organizationName={organizationName}
         organizationLogo={organization?.logoUrl}
-        isAuthenticated={isUserAuthenticated}
       >
         <div className="space-y-12">
+          {showRequestAllButton && (
+            <div className="flex justify-end">
+              <PublicTrustCenterAccessRequestDialog
+                trigger={
+                  <Button
+                    variant="primary"
+                    icon={IconLock}
+                  >
+                    {__("Request All Access")}
+                  </Button>
+                }
+                trustCenterId={trustCenterBySlug.id}
+                organizationName={organizationName}
+              />
+            </div>
+          )}
+
           <PublicTrustCenterAudits
             audits={trustCenterAudits}
             organizationName={organizationName}

--- a/pkg/coredata/entity_type_reg.go
+++ b/pkg/coredata/entity_type_reg.go
@@ -45,6 +45,7 @@ const (
 	ReportEntityType
 	TrustCenterEntityType
 	TrustCenterAccessEntityType
+	TrustCenterDocumentAccessEntityType
 	VendorBusinessAssociateAgreementEntityType
 	FileEntityType
 	VendorContactEntityType

--- a/pkg/coredata/migrations/20250924T111957Z.sql
+++ b/pkg/coredata/migrations/20250924T111957Z.sql
@@ -1,0 +1,13 @@
+CREATE TABLE trust_center_document_accesses(
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    trust_center_access_id TEXT NOT NULL REFERENCES trust_center_accesses(id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    document_id TEXT REFERENCES documents(id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    report_id TEXT REFERENCES reports(id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    active BOOLEAN NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+);

--- a/pkg/coredata/trust_center_document_access.go
+++ b/pkg/coredata/trust_center_document_access.go
@@ -1,0 +1,389 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"time"
+
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+	"github.com/jackc/pgx/v5"
+	"go.gearno.de/kit/pg"
+)
+
+type (
+	TrustCenterDocumentAccess struct {
+		ID                  gid.GID   `db:"id"`
+		TrustCenterAccessID gid.GID   `db:"trust_center_access_id"`
+		DocumentID          *gid.GID  `db:"document_id"`
+		ReportID            *gid.GID  `db:"report_id"`
+		Active              bool      `db:"active"`
+		CreatedAt           time.Time `db:"created_at"`
+		UpdatedAt           time.Time `db:"updated_at"`
+	}
+
+	TrustCenterDocumentAccesses []*TrustCenterDocumentAccess
+
+	ErrTrustCenterDocumentAccessNotFound struct {
+		Identifier string
+	}
+)
+
+func (e ErrTrustCenterDocumentAccessNotFound) Error() string {
+	return fmt.Sprintf("trust center document access not found: %s", e.Identifier)
+}
+
+func (tcda *TrustCenterDocumentAccess) CursorKey(orderBy TrustCenterDocumentAccessOrderField) page.CursorKey {
+	switch orderBy {
+	case TrustCenterDocumentAccessOrderFieldCreatedAt:
+		return page.NewCursorKey(tcda.ID, tcda.CreatedAt)
+	}
+
+	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
+}
+
+func (tcda *TrustCenterDocumentAccess) LoadByID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	accessID gid.GID,
+) error {
+	q := `
+SELECT
+	id,
+	trust_center_access_id,
+	document_id,
+	report_id,
+	active,
+	created_at,
+	updated_at
+FROM
+	trust_center_document_accesses
+WHERE
+	%s
+	AND id = @access_id
+LIMIT 1;
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"access_id": accessID}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query trust center document access: %w", err)
+	}
+
+	access, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[TrustCenterDocumentAccess])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return &ErrTrustCenterDocumentAccessNotFound{Identifier: accessID.String()}
+		}
+
+		return fmt.Errorf("cannot collect trust center document access: %w", err)
+	}
+
+	*tcda = access
+
+	return nil
+}
+
+func (tcda *TrustCenterDocumentAccess) LoadByTrustCenterAccessIDAndDocumentID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	trustCenterAccessID gid.GID,
+	documentID gid.GID,
+) error {
+	q := `
+SELECT
+	id,
+	trust_center_access_id,
+	document_id,
+	report_id,
+	active,
+	created_at,
+	updated_at
+FROM
+	trust_center_document_accesses
+WHERE
+	%s
+	AND trust_center_access_id = @trust_center_access_id
+	AND document_id = @document_id
+LIMIT 1;
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"trust_center_access_id": trustCenterAccessID,
+		"document_id":            documentID,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query trust center document access: %w", err)
+	}
+
+	access, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[TrustCenterDocumentAccess])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return &ErrTrustCenterDocumentAccessNotFound{Identifier: fmt.Sprintf("access_id=%s,document_id=%s", trustCenterAccessID, documentID)}
+		}
+
+		return fmt.Errorf("cannot collect trust center document access: %w", err)
+	}
+
+	*tcda = access
+
+	return nil
+}
+
+func (tcda *TrustCenterDocumentAccess) LoadByTrustCenterAccessIDAndReportID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	trustCenterAccessID gid.GID,
+	reportID gid.GID,
+) error {
+	q := `
+SELECT
+	id,
+	trust_center_access_id,
+	document_id,
+	report_id,
+	active,
+	created_at,
+	updated_at
+FROM
+	trust_center_document_accesses
+WHERE
+	%s
+	AND trust_center_access_id = @trust_center_access_id
+	AND report_id = @report_id
+LIMIT 1;
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"trust_center_access_id": trustCenterAccessID,
+		"report_id":              reportID,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query trust center document access: %w", err)
+	}
+
+	access, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[TrustCenterDocumentAccess])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return &ErrTrustCenterDocumentAccessNotFound{Identifier: fmt.Sprintf("access_id=%s,report_id=%s", trustCenterAccessID, reportID)}
+		}
+
+		return fmt.Errorf("cannot collect trust center document access: %w", err)
+	}
+
+	*tcda = access
+
+	return nil
+}
+
+func (tcda *TrustCenterDocumentAccess) Insert(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+INSERT INTO trust_center_document_accesses (
+	id,
+	tenant_id,
+	trust_center_access_id,
+	document_id,
+	report_id,
+	active,
+	created_at,
+	updated_at
+) VALUES (
+	@id,
+	@tenant_id,
+	@trust_center_access_id,
+	@document_id,
+	@report_id,
+	@active,
+	@created_at,
+	@updated_at
+)
+`
+
+	args := pgx.StrictNamedArgs{
+		"id":                     tcda.ID,
+		"tenant_id":              scope.GetTenantID(),
+		"trust_center_access_id": tcda.TrustCenterAccessID,
+		"document_id":            tcda.DocumentID,
+		"report_id":              tcda.ReportID,
+		"active":                 tcda.Active,
+		"created_at":             tcda.CreatedAt,
+		"updated_at":             tcda.UpdatedAt,
+	}
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot insert trust center document access: %w", err)
+	}
+
+	return nil
+}
+
+func (tcda *TrustCenterDocumentAccess) Update(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+UPDATE trust_center_document_accesses SET
+	active = @active,
+	updated_at = @updated_at
+WHERE
+	%s
+	AND id = @id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"id":         tcda.ID,
+		"active":     tcda.Active,
+		"updated_at": tcda.UpdatedAt,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot update trust center document access: %w", err)
+	}
+
+	return nil
+}
+
+func (tcda *TrustCenterDocumentAccess) Delete(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+DELETE FROM trust_center_document_accesses
+WHERE
+	%s
+	AND id = @id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"id": tcda.ID,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete trust center document access: %w", err)
+	}
+
+	return nil
+}
+
+func (tcdas *TrustCenterDocumentAccesses) LoadByTrustCenterAccessID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	trustCenterAccessID gid.GID,
+	cursor *page.Cursor[TrustCenterDocumentAccessOrderField],
+) error {
+	q := `
+SELECT
+	id,
+	trust_center_access_id,
+	document_id,
+	report_id,
+	active,
+	created_at,
+	updated_at
+FROM
+	trust_center_document_accesses
+WHERE
+	%s
+	AND trust_center_access_id = @trust_center_access_id
+	AND %s
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"trust_center_access_id": trustCenterAccessID,
+	}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, cursor.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query trust center document accesses: %w", err)
+	}
+
+	accesses, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[TrustCenterDocumentAccess])
+	if err != nil {
+		return fmt.Errorf("cannot collect trust center document accesses: %w", err)
+	}
+
+	*tcdas = accesses
+
+	return nil
+}
+
+func DeleteByTrustCenterAccessID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	trustCenterAccessID gid.GID,
+) error {
+	q := `
+DELETE FROM trust_center_document_accesses
+WHERE
+	%s
+	AND trust_center_access_id = @trust_center_access_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"trust_center_access_id": trustCenterAccessID,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete trust center document accesses: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/trust_center_document_access_order_field.go
+++ b/pkg/coredata/trust_center_document_access_order_field.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+type TrustCenterDocumentAccessOrderField string
+
+const (
+	TrustCenterDocumentAccessOrderFieldCreatedAt TrustCenterDocumentAccessOrderField = "CREATED_AT"
+)
+
+func (tcdaof TrustCenterDocumentAccessOrderField) String() string {
+	return string(tcdaof)
+}
+
+func (tcdaof TrustCenterDocumentAccessOrderField) Column() string {
+	switch tcdaof {
+	case TrustCenterDocumentAccessOrderFieldCreatedAt:
+		return "created_at"
+	}
+
+	panic("unsupported order field: " + string(tcdaof))
+}

--- a/pkg/probo/audit_service.go
+++ b/pkg/probo/audit_service.go
@@ -83,6 +83,26 @@ func (s AuditService) Get(
 	return audit, nil
 }
 
+func (s AuditService) GetByReportID(
+	ctx context.Context,
+	reportID gid.GID,
+) (*coredata.Audit, error) {
+	audit := &coredata.Audit{}
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			return audit.LoadByReportID(ctx, conn, s.svc.scope, reportID)
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return audit, nil
+}
+
 func (s *AuditService) Create(
 	ctx context.Context,
 	req *CreateAuditRequest,

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -1103,6 +1103,14 @@ enum TrustCenterAccessOrderField
     )
 }
 
+enum TrustCenterDocumentAccessOrderField
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.TrustCenterDocumentAccessOrderField") {
+  CREATED_AT
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.TrustCenterDocumentAccessOrderFieldCreatedAt"
+    )
+}
+
 enum TrustCenterReferenceOrderField
   @goModel(model: "github.com/getprobo/probo/pkg/coredata.TrustCenterReferenceOrderField") {
   NAME
@@ -1290,6 +1298,14 @@ input TrustCenterAccessOrder
   ) {
   direction: OrderDirection!
   field: TrustCenterAccessOrderField!
+}
+
+input TrustCenterDocumentAccessOrder
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.TrustCenterDocumentAccessOrderBy"
+  ) {
+  direction: OrderDirection!
+  field: TrustCenterDocumentAccessOrderField!
 }
 
 input TrustCenterReferenceOrder
@@ -2143,6 +2159,7 @@ type Report implements Node {
   downloadUrl: String @goField(forceResolver: true)
   createdAt: Datetime!
   updatedAt: Datetime!
+  audit: Audit @goField(forceResolver: true)
 }
 
 type Session {
@@ -2193,6 +2210,38 @@ type TrustCenterAccess implements Node {
   hasAcceptedNonDisclosureAgreement: Boolean!
   createdAt: Datetime!
   updatedAt: Datetime!
+
+  documentAccesses(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+    orderBy: TrustCenterDocumentAccessOrder
+  ): TrustCenterDocumentAccessConnection! @goField(forceResolver: true)
+}
+
+type TrustCenterDocumentAccess implements Node {
+  id: ID!
+  active: Boolean!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+  trustCenterAccess: TrustCenterAccess! @goField(forceResolver: true)
+  document: Document @goField(forceResolver: true)
+  report: Report @goField(forceResolver: true)
+}
+
+type TrustCenterDocumentAccessConnection
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.TrustCenterDocumentAccessConnection"
+  ) {
+  totalCount: Int! @goField(forceResolver: true)
+  edges: [TrustCenterDocumentAccessEdge!]!
+  pageInfo: PageInfo!
+}
+
+type TrustCenterDocumentAccessEdge {
+  cursor: CursorKey!
+  node: TrustCenterDocumentAccess!
 }
 
 type TrustCenterAccessConnection {
@@ -2564,6 +2613,18 @@ type Mutation {
     input: DeleteTrustCenterAccessInput!
   ): DeleteTrustCenterAccessPayload!
 
+  updateTrustCenterDocumentAccessStatus(
+    input: UpdateTrustCenterDocumentAccessStatusInput!
+  ): UpdateTrustCenterDocumentAccessStatusPayload!
+
+  requestDocumentAccess(
+    input: RequestDocumentAccessInput!
+  ): RequestDocumentAccessPayload!
+
+  requestReportAccess(
+    input: RequestReportAccessInput!
+  ): RequestReportAccessPayload!
+
   # Trust Center Reference mutations
   createTrustCenterReference(
     input: CreateTrustCenterReferenceInput!
@@ -2881,16 +2942,39 @@ input CreateTrustCenterAccessInput {
   email: String!
   name: String!
   active: Boolean!
+  documentIds: [ID!]
+  reportIds: [ID!]
 }
 
 input UpdateTrustCenterAccessInput {
   id: ID!
   name: String
   active: Boolean
+  documentIds: [ID!]
+  reportIds: [ID!]
 }
 
 input DeleteTrustCenterAccessInput {
   id: ID!
+}
+
+input UpdateTrustCenterDocumentAccessStatusInput {
+  id: ID!
+  active: Boolean!
+}
+
+input RequestDocumentAccessInput {
+  trustCenterId: ID!
+  documentId: ID!
+  email: String!
+  name: String
+}
+
+input RequestReportAccessInput {
+  trustCenterId: ID!
+  reportId: ID!
+  email: String!
+  name: String
 }
 
 input CreateTrustCenterReferenceInput {
@@ -3556,6 +3640,18 @@ type UpdateTrustCenterAccessPayload {
 
 type DeleteTrustCenterAccessPayload {
   deletedTrustCenterAccessId: ID!
+}
+
+type UpdateTrustCenterDocumentAccessStatusPayload {
+  trustCenterDocumentAccess: TrustCenterDocumentAccess!
+}
+
+type RequestDocumentAccessPayload {
+  success: Boolean!
+}
+
+type RequestReportAccessPayload {
+  success: Boolean!
 }
 
 type CreateTrustCenterReferencePayload {

--- a/pkg/server/api/console/v1/types/trust_center_document_access.go
+++ b/pkg/server/api/console/v1/types/trust_center_document_access.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package types
+
+import (
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+)
+
+type (
+	TrustCenterDocumentAccessOrderBy = OrderBy[coredata.TrustCenterDocumentAccessOrderField]
+
+	TrustCenterDocumentAccessConnection struct {
+		TotalCount int
+		Edges      []*TrustCenterDocumentAccessEdge
+		PageInfo   PageInfo
+
+		Resolver any
+		ParentID gid.GID
+	}
+)
+
+func NewTrustCenterDocumentAccess(tcda *coredata.TrustCenterDocumentAccess) *TrustCenterDocumentAccess {
+	return &TrustCenterDocumentAccess{
+		ID:        tcda.ID,
+		Active:    tcda.Active,
+		CreatedAt: tcda.CreatedAt,
+		UpdatedAt: tcda.UpdatedAt,
+	}
+}
+
+func NewTrustCenterDocumentAccessConnection(
+	p *page.Page[*coredata.TrustCenterDocumentAccess, coredata.TrustCenterDocumentAccessOrderField],
+	parentType any,
+	parentID gid.GID,
+) *TrustCenterDocumentAccessConnection {
+	var edges = make([]*TrustCenterDocumentAccessEdge, len(p.Data))
+
+	for i := range edges {
+		edges[i] = NewTrustCenterDocumentAccessEdge(p.Data[i], p.Cursor.OrderBy.Field)
+	}
+
+	return &TrustCenterDocumentAccessConnection{
+		Edges:    edges,
+		PageInfo: *NewPageInfo(p),
+
+		Resolver: parentType,
+		ParentID: parentID,
+	}
+}
+
+func NewTrustCenterDocumentAccessEdges(accesses []*coredata.TrustCenterDocumentAccess, orderBy coredata.TrustCenterDocumentAccessOrderField) []*TrustCenterDocumentAccessEdge {
+	edges := make([]*TrustCenterDocumentAccessEdge, len(accesses))
+
+	for i := range edges {
+		edges[i] = NewTrustCenterDocumentAccessEdge(accesses[i], orderBy)
+	}
+
+	return edges
+}
+
+func NewTrustCenterDocumentAccessEdge(access *coredata.TrustCenterDocumentAccess, orderBy coredata.TrustCenterDocumentAccessOrderField) *TrustCenterDocumentAccessEdge {
+	return &TrustCenterDocumentAccessEdge{
+		Cursor: access.CursorKey(orderBy),
+		Node:   NewTrustCenterDocumentAccess(access),
+	}
+}

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -536,10 +536,12 @@ type CreateTaskPayload struct {
 }
 
 type CreateTrustCenterAccessInput struct {
-	TrustCenterID gid.GID `json:"trustCenterId"`
-	Email         string  `json:"email"`
-	Name          string  `json:"name"`
-	Active        bool    `json:"active"`
+	TrustCenterID gid.GID   `json:"trustCenterId"`
+	Email         string    `json:"email"`
+	Name          string    `json:"name"`
+	Active        bool      `json:"active"`
+	DocumentIds   []gid.GID `json:"documentIds,omitempty"`
+	ReportIds     []gid.GID `json:"reportIds,omitempty"`
 }
 
 type CreateTrustCenterAccessPayload struct {
@@ -1382,10 +1384,22 @@ type Report struct {
 	DownloadURL *string   `json:"downloadUrl,omitempty"`
 	CreatedAt   time.Time `json:"createdAt"`
 	UpdatedAt   time.Time `json:"updatedAt"`
+	Audit       *Audit    `json:"audit,omitempty"`
 }
 
 func (Report) IsNode()             {}
 func (this Report) GetID() gid.GID { return this.ID }
+
+type RequestDocumentAccessInput struct {
+	TrustCenterID gid.GID `json:"trustCenterId"`
+	DocumentID    gid.GID `json:"documentId"`
+	Email         string  `json:"email"`
+	Name          *string `json:"name,omitempty"`
+}
+
+type RequestDocumentAccessPayload struct {
+	Success bool `json:"success"`
+}
 
 type RequestEvidenceInput struct {
 	TaskID      gid.GID               `json:"taskId"`
@@ -1396,6 +1410,17 @@ type RequestEvidenceInput struct {
 
 type RequestEvidencePayload struct {
 	EvidenceEdge *EvidenceEdge `json:"evidenceEdge"`
+}
+
+type RequestReportAccessInput struct {
+	TrustCenterID gid.GID `json:"trustCenterId"`
+	ReportID      gid.GID `json:"reportId"`
+	Email         string  `json:"email"`
+	Name          *string `json:"name,omitempty"`
+}
+
+type RequestReportAccessPayload struct {
+	Success bool `json:"success"`
 }
 
 type RequestSignatureInput struct {
@@ -1515,13 +1540,14 @@ func (TrustCenter) IsNode()             {}
 func (this TrustCenter) GetID() gid.GID { return this.ID }
 
 type TrustCenterAccess struct {
-	ID                                gid.GID   `json:"id"`
-	Email                             string    `json:"email"`
-	Name                              string    `json:"name"`
-	Active                            bool      `json:"active"`
-	HasAcceptedNonDisclosureAgreement bool      `json:"hasAcceptedNonDisclosureAgreement"`
-	CreatedAt                         time.Time `json:"createdAt"`
-	UpdatedAt                         time.Time `json:"updatedAt"`
+	ID                                gid.GID                              `json:"id"`
+	Email                             string                               `json:"email"`
+	Name                              string                               `json:"name"`
+	Active                            bool                                 `json:"active"`
+	HasAcceptedNonDisclosureAgreement bool                                 `json:"hasAcceptedNonDisclosureAgreement"`
+	CreatedAt                         time.Time                            `json:"createdAt"`
+	UpdatedAt                         time.Time                            `json:"updatedAt"`
+	DocumentAccesses                  *TrustCenterDocumentAccessConnection `json:"documentAccesses"`
 }
 
 func (TrustCenterAccess) IsNode()             {}
@@ -1540,6 +1566,24 @@ type TrustCenterAccessEdge struct {
 type TrustCenterConnection struct {
 	Edges    []*TrustCenterEdge `json:"edges"`
 	PageInfo *PageInfo          `json:"pageInfo"`
+}
+
+type TrustCenterDocumentAccess struct {
+	ID                gid.GID            `json:"id"`
+	Active            bool               `json:"active"`
+	CreatedAt         time.Time          `json:"createdAt"`
+	UpdatedAt         time.Time          `json:"updatedAt"`
+	TrustCenterAccess *TrustCenterAccess `json:"trustCenterAccess"`
+	Document          *Document          `json:"document,omitempty"`
+	Report            *Report            `json:"report,omitempty"`
+}
+
+func (TrustCenterDocumentAccess) IsNode()             {}
+func (this TrustCenterDocumentAccess) GetID() gid.GID { return this.ID }
+
+type TrustCenterDocumentAccessEdge struct {
+	Cursor page.CursorKey             `json:"cursor"`
+	Node   *TrustCenterDocumentAccess `json:"node"`
 }
 
 type TrustCenterEdge struct {
@@ -1804,13 +1848,24 @@ type UpdateTaskPayload struct {
 }
 
 type UpdateTrustCenterAccessInput struct {
-	ID     gid.GID `json:"id"`
-	Name   *string `json:"name,omitempty"`
-	Active *bool   `json:"active,omitempty"`
+	ID          gid.GID   `json:"id"`
+	Name        *string   `json:"name,omitempty"`
+	Active      *bool     `json:"active,omitempty"`
+	DocumentIds []gid.GID `json:"documentIds,omitempty"`
+	ReportIds   []gid.GID `json:"reportIds,omitempty"`
 }
 
 type UpdateTrustCenterAccessPayload struct {
 	TrustCenterAccess *TrustCenterAccess `json:"trustCenterAccess"`
+}
+
+type UpdateTrustCenterDocumentAccessStatusInput struct {
+	ID     gid.GID `json:"id"`
+	Active bool    `json:"active"`
+}
+
+type UpdateTrustCenterDocumentAccessStatusPayload struct {
+	TrustCenterDocumentAccess *TrustCenterDocumentAccess `json:"trustCenterDocumentAccess"`
 }
 
 type UpdateTrustCenterInput struct {

--- a/pkg/server/api/trust/v1/schema.graphql
+++ b/pkg/server/api/trust/v1/schema.graphql
@@ -57,6 +57,8 @@ type Document implements Node {
   id: ID!
   title: String!
   documentType: DocumentType!
+  isUserAuthorized: Boolean! @goField(forceResolver: true)
+  hasUserRequestedAccess: Boolean! @goField(forceResolver: true)
 }
 
 type DocumentConnection {
@@ -78,6 +80,8 @@ type Framework implements Node {
 type Report implements Node {
   id: ID!
   filename: String!
+  isUserAuthorized: Boolean! @goField(forceResolver: true)
+  hasUserRequestedAccess: Boolean! @goField(forceResolver: true)
 }
 
 type Audit implements Node {
@@ -539,6 +543,20 @@ input AcceptNonDisclosureAgreementInput {
   trustCenterId: ID!
 }
 
+input RequestDocumentAccessInput {
+  trustCenterId: ID!
+  documentId: ID!
+  email: String!
+  name: String
+}
+
+input RequestReportAccessInput {
+  trustCenterId: ID!
+  reportId: ID!
+  email: String!
+  name: String
+}
+
 type ExportDocumentPDFPayload {
   data: String!
 }
@@ -547,7 +565,15 @@ type ExportReportPDFPayload {
   data: String!
 }
 
-type  AcceptNonDisclosureAgreementPayload{
+type AcceptNonDisclosureAgreementPayload {
+  success: Boolean!
+}
+
+type RequestDocumentAccessPayload {
+  success: Boolean!
+}
+
+type RequestReportAccessPayload {
   success: Boolean!
 }
 
@@ -571,4 +597,12 @@ type Mutation {
   acceptNonDisclosureAgreement(
     input: AcceptNonDisclosureAgreementInput!
   ): AcceptNonDisclosureAgreementPayload! @mustBeAuthenticated(role: USER)
+
+  requestDocumentAccess(
+    input: RequestDocumentAccessInput!
+  ): RequestDocumentAccessPayload! @mustBeAuthenticated(role: NONE)
+
+  requestReportAccess(
+    input: RequestReportAccessInput!
+  ): RequestReportAccessPayload! @mustBeAuthenticated(role: NONE)
 }

--- a/pkg/server/api/trust/v1/types/types.go
+++ b/pkg/server/api/trust/v1/types/types.go
@@ -57,9 +57,11 @@ type CreateTrustCenterAccessPayload struct {
 }
 
 type Document struct {
-	ID           gid.GID               `json:"id"`
-	Title        string                `json:"title"`
-	DocumentType coredata.DocumentType `json:"documentType"`
+	ID                     gid.GID               `json:"id"`
+	Title                  string                `json:"title"`
+	DocumentType           coredata.DocumentType `json:"documentType"`
+	IsUserAuthorized       bool                  `json:"isUserAuthorized"`
+	HasUserRequestedAccess bool                  `json:"hasUserRequestedAccess"`
 }
 
 func (Document) IsNode()             {}
@@ -126,12 +128,36 @@ type Query struct {
 }
 
 type Report struct {
-	ID       gid.GID `json:"id"`
-	Filename string  `json:"filename"`
+	ID                     gid.GID `json:"id"`
+	Filename               string  `json:"filename"`
+	IsUserAuthorized       bool    `json:"isUserAuthorized"`
+	HasUserRequestedAccess bool    `json:"hasUserRequestedAccess"`
 }
 
 func (Report) IsNode()             {}
 func (this Report) GetID() gid.GID { return this.ID }
+
+type RequestDocumentAccessInput struct {
+	TrustCenterID gid.GID `json:"trustCenterId"`
+	DocumentID    gid.GID `json:"documentId"`
+	Email         string  `json:"email"`
+	Name          *string `json:"name,omitempty"`
+}
+
+type RequestDocumentAccessPayload struct {
+	Success bool `json:"success"`
+}
+
+type RequestReportAccessInput struct {
+	TrustCenterID gid.GID `json:"trustCenterId"`
+	ReportID      gid.GID `json:"reportId"`
+	Email         string  `json:"email"`
+	Name          *string `json:"name,omitempty"`
+}
+
+type RequestReportAccessPayload struct {
+	Success bool `json:"success"`
+}
 
 type TrustCenter struct {
 	ID                                gid.GID                         `json:"id"`

--- a/pkg/trust/trust_center_access_service.go
+++ b/pkg/trust/trust_center_access_service.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/getprobo/probo/pkg/coredata"
 	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
 	"github.com/getprobo/probo/pkg/usrmgr"
 	"go.gearno.de/kit/pg"
 )
@@ -38,6 +39,8 @@ type (
 		TrustCenterID gid.GID
 		Email         string
 		Name          string
+		DocumentIDs   []gid.GID
+		ReportIDs     []gid.GID
 	}
 )
 
@@ -73,47 +76,151 @@ func (s TrustCenterAccessService) Create(
 		return nil, fmt.Errorf("invalid email address")
 	}
 
-	if req.Name == "" {
-		return nil, fmt.Errorf("name is required")
-	}
-
 	now := time.Now()
 
 	var access *coredata.TrustCenterAccess
 
 	err := s.svc.pg.WithTx(ctx, func(tx pg.Conn) error {
+		var trustCenter *coredata.TrustCenter
+		var organizationID gid.GID
+
+		if req.DocumentIDs == nil || req.ReportIDs == nil {
+			trustCenter = &coredata.TrustCenter{}
+			if err := trustCenter.LoadByID(ctx, tx, s.svc.scope, req.TrustCenterID); err != nil {
+				return fmt.Errorf("cannot load trust center: %w", err)
+			}
+			organizationID = trustCenter.OrganizationID
+		}
+
+		documentIDs := req.DocumentIDs
+		if req.DocumentIDs == nil {
+			var allDocuments coredata.Documents
+			cursor := &page.Cursor[coredata.DocumentOrderField]{
+				Size:     1000,
+				Position: page.Head,
+				OrderBy: page.OrderBy[coredata.DocumentOrderField]{
+					Field:     coredata.DocumentOrderFieldTitle,
+					Direction: page.OrderDirectionAsc,
+				},
+			}
+			filter := coredata.NewDocumentFilter(nil)
+
+			if err := allDocuments.LoadByOrganizationID(ctx, tx, s.svc.scope, organizationID, cursor, filter); err != nil {
+				return fmt.Errorf("cannot list documents: %w", err)
+			}
+
+			for _, doc := range allDocuments {
+				documentIDs = append(documentIDs, doc.ID)
+			}
+		}
+
+		reportIDs := req.ReportIDs
+		if req.ReportIDs == nil {
+			var allAudits coredata.Audits
+			cursor := &page.Cursor[coredata.AuditOrderField]{
+				Size:     1000,
+				Position: page.Head,
+				OrderBy: page.OrderBy[coredata.AuditOrderField]{
+					Field:     coredata.AuditOrderFieldValidFrom,
+					Direction: page.OrderDirectionDesc,
+				},
+			}
+			filter := coredata.NewAuditFilter()
+
+			if err := allAudits.LoadByOrganizationID(ctx, tx, s.svc.scope, organizationID, cursor, filter); err != nil {
+				return fmt.Errorf("cannot list audits: %w", err)
+			}
+
+			for _, audit := range allAudits {
+				if audit.ReportID != nil {
+					reportIDs = append(reportIDs, *audit.ReportID)
+				}
+			}
+		}
 		existingAccess := &coredata.TrustCenterAccess{}
 		err := existingAccess.LoadByTrustCenterIDAndEmail(ctx, tx, s.svc.scope, req.TrustCenterID, req.Email)
 
 		if err == nil {
-			if existingAccess.Active {
-				return fmt.Errorf("active trust center access already exists for this email")
-			}
-			if err := existingAccess.Delete(ctx, tx, s.svc.scope); err != nil {
-				return fmt.Errorf("cannot delete existing trust center access: %w", err)
-			}
+			access = existingAccess
 		} else {
 			var notFoundErr *coredata.ErrTrustCenterAccessNotFound
 			if !errors.As(err, &notFoundErr) {
 				return fmt.Errorf("cannot load trust center access: %w", err)
 			}
+
+			if req.Name == "" {
+				return fmt.Errorf("name is required for new access requests")
+			}
+
+			access = &coredata.TrustCenterAccess{
+				ID:                                gid.New(s.svc.scope.GetTenantID(), coredata.TrustCenterAccessEntityType),
+				TenantID:                          s.svc.scope.GetTenantID(),
+				TrustCenterID:                     req.TrustCenterID,
+				Email:                             req.Email,
+				Name:                              req.Name,
+				Active:                            false,
+				HasAcceptedNonDisclosureAgreement: false,
+				CreatedAt:                         now,
+				UpdatedAt:                         now,
+			}
+
+			if err := access.Insert(ctx, tx, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot insert trust center access: %w", err)
+			}
 		}
 
-		access = &coredata.TrustCenterAccess{
-			ID:                                gid.New(s.svc.scope.GetTenantID(), coredata.TrustCenterAccessEntityType),
-			TenantID:                          s.svc.scope.GetTenantID(),
-			TrustCenterID:                     req.TrustCenterID,
-			Email:                             req.Email,
-			Name:                              req.Name,
-			Active:                            false,
-			HasAcceptedNonDisclosureAgreement: false,
-			CreatedAt:                         now,
-			UpdatedAt:                         now,
+		for _, documentID := range documentIDs {
+			existingAccess := &coredata.TrustCenterDocumentAccess{}
+			err := existingAccess.LoadByTrustCenterAccessIDAndDocumentID(ctx, tx, s.svc.scope, access.ID, documentID)
+
+			if err != nil {
+				var notFoundErr *coredata.ErrTrustCenterDocumentAccessNotFound
+				if errors.As(err, &notFoundErr) {
+					documentAccess := &coredata.TrustCenterDocumentAccess{
+						ID:                  gid.New(s.svc.scope.GetTenantID(), coredata.TrustCenterDocumentAccessEntityType),
+						TrustCenterAccessID: access.ID,
+						DocumentID:          &documentID,
+						ReportID:            nil,
+						Active:              false,
+						CreatedAt:           now,
+						UpdatedAt:           now,
+					}
+
+					if err := documentAccess.Insert(ctx, tx, s.svc.scope); err != nil {
+						return fmt.Errorf("cannot insert trust center document access: %w", err)
+					}
+				} else {
+					return fmt.Errorf("cannot check existing document access: %w", err)
+				}
+			}
 		}
 
-		if err := access.Insert(ctx, tx, s.svc.scope); err != nil {
-			return fmt.Errorf("cannot insert trust center access: %w", err)
+		for _, reportID := range reportIDs {
+			existingAccess := &coredata.TrustCenterDocumentAccess{}
+			err := existingAccess.LoadByTrustCenterAccessIDAndReportID(ctx, tx, s.svc.scope, access.ID, reportID)
+
+			if err != nil {
+				var notFoundErr *coredata.ErrTrustCenterDocumentAccessNotFound
+				if errors.As(err, &notFoundErr) {
+					reportAccess := &coredata.TrustCenterDocumentAccess{
+						ID:                  gid.New(s.svc.scope.GetTenantID(), coredata.TrustCenterDocumentAccessEntityType),
+						TrustCenterAccessID: access.ID,
+						DocumentID:          nil,
+						ReportID:            &reportID,
+						Active:              false,
+						CreatedAt:           now,
+						UpdatedAt:           now,
+					}
+
+					if err := reportAccess.Insert(ctx, tx, s.svc.scope); err != nil {
+						return fmt.Errorf("cannot insert trust center report access: %w", err)
+					}
+				} else {
+					return fmt.Errorf("cannot check existing report access: %w", err)
+				}
+			}
 		}
+
 		return nil
 	})
 
@@ -167,4 +274,74 @@ func (s TrustCenterAccessService) AcceptNonDisclosureAgreement(ctx context.Conte
 
 		return nil
 	})
+}
+
+func (s TrustCenterAccessService) LoadDocumentAccess(
+	ctx context.Context,
+	trustCenterID gid.GID,
+	email string,
+	documentID gid.GID,
+) (*coredata.TrustCenterDocumentAccess, error) {
+	var documentAccess *coredata.TrustCenterDocumentAccess
+
+	err := s.svc.pg.WithConn(ctx, func(conn pg.Conn) error {
+		access := &coredata.TrustCenterAccess{}
+		err := access.LoadByTrustCenterIDAndEmail(ctx, conn, s.svc.scope, trustCenterID, email)
+		if err != nil {
+			return fmt.Errorf("cannot load trust center access: %w", err)
+		}
+
+		if !access.Active {
+			return fmt.Errorf("trust center access is not active")
+		}
+
+		documentAccess = &coredata.TrustCenterDocumentAccess{}
+		err = documentAccess.LoadByTrustCenterAccessIDAndDocumentID(ctx, conn, s.svc.scope, access.ID, documentID)
+		if err != nil {
+			return fmt.Errorf("cannot load document access: %w", err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return documentAccess, nil
+}
+
+func (s TrustCenterAccessService) LoadReportAccess(
+	ctx context.Context,
+	trustCenterID gid.GID,
+	email string,
+	reportID gid.GID,
+) (*coredata.TrustCenterDocumentAccess, error) {
+	var reportAccess *coredata.TrustCenterDocumentAccess
+
+	err := s.svc.pg.WithConn(ctx, func(conn pg.Conn) error {
+		access := &coredata.TrustCenterAccess{}
+		err := access.LoadByTrustCenterIDAndEmail(ctx, conn, s.svc.scope, trustCenterID, email)
+		if err != nil {
+			return fmt.Errorf("cannot load trust center access: %w", err)
+		}
+
+		if !access.Active {
+			return fmt.Errorf("trust center access is not active")
+		}
+
+		reportAccess = &coredata.TrustCenterDocumentAccess{}
+		err = reportAccess.LoadByTrustCenterAccessIDAndReportID(ctx, conn, s.svc.scope, access.ID, reportID)
+		if err != nil {
+			return fmt.Errorf("cannot load report access: %w", err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return reportAccess, nil
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds per-document and per-report access controls to Trust Centers. Admins can grant or revoke access to specific items, and visitors can request access directly from the public Trust Center.

- New Features
  - Data model: trust_center_document_accesses table and service layer for granular access.
  - Console API: create/update access now accept documentIds/reportIds; access nodes expose documentAccesses; mutation to toggle document access status.
  - Trust API: documents/reports include isUserAuthorized and hasUserRequestedAccess; added requestDocumentAccess and requestReportAccess mutations.
  - UI (Console): Manage per-item access in TrustCenterAccessTab, including enable/disable and selection of documents/reports.
  - UI (Public): Request Access dialogs for documents/reports; download buttons gated by authorization; NDA flow respected.
  - Hooks/GraphQL: new queries/mutations and generated types for the above.

- Migration
  - Run migrations 20250924T111957Z.sql and 20250926T172000Z.sql.
  - No breaking changes to existing access records; use the new fields to set granular permissions as needed.

<!-- End of auto-generated description by cubic. -->

