### PR TITLE
Remove error for nda url in public trust center

### DIFF
--- a/pkg/server/api/trust/v1/v1_resolver.go
+++ b/pkg/server/api/trust/v1/v1_resolver.go
@@ -226,7 +226,8 @@ func (r *queryResolver) TrustCenterBySlug(ctx context.Context, slug string) (*ty
 func (r *trustCenterResolver) NdaFileURL(ctx context.Context, obj *types.TrustCenter) (*string, error) {
 	privateTrustService, err := r.PrivateTrustService(ctx, obj.ID.TenantID())
 	if err != nil {
-		return nil, fmt.Errorf("failed to get private trust service: %w", err)
+		// Return nil but no error if the user is not authenticated
+		return nil, nil
 	}
 
 	fileURL, err := privateTrustService.TrustCenters.GenerateNDAFileURL(ctx, obj.ID, 15*time.Minute)


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Stops raising an error when generating the NDA file URL for unauthenticated users in the public Trust Center. The resolver now returns no URL and no error, preventing public pages from failing while keeping the NDA link available only to authenticated users.

<!-- End of auto-generated description by cubic. -->

