### PR TITLE
Add granular trust center access

### DIFF
--- a/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphCreateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphCreateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5ccaab70e4cb8c4b5bee7fbe6ba2c0b6>>
+ * @generated SignedSource<<2ff966b9632595cece04e7a5ef3f7dd7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,6 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
+export type DocumentType = "ISMS" | "OTHER" | "POLICY";
 export type CreateTrustCenterAccessInput = {
   active: boolean;
   email: string;
@@ -26,6 +27,31 @@ export type TrustCenterAccessGraphCreateMutation$data = {
       readonly node: {
         readonly active: boolean;
         readonly createdAt: any;
+        readonly documentAccesses: {
+          readonly edges: ReadonlyArray<{
+            readonly node: {
+              readonly active: boolean;
+              readonly createdAt: any;
+              readonly document: {
+                readonly documentType: DocumentType;
+                readonly id: string;
+                readonly title: string;
+              } | null | undefined;
+              readonly id: string;
+              readonly report: {
+                readonly audit: {
+                  readonly framework: {
+                    readonly name: string;
+                  };
+                  readonly id: string;
+                } | null | undefined;
+                readonly filename: string;
+                readonly id: string;
+              } | null | undefined;
+              readonly updatedAt: any;
+            };
+          }>;
+        };
         readonly email: string;
         readonly hasAcceptedNonDisclosureAgreement: boolean;
         readonly id: string;
@@ -60,72 +86,105 @@ v2 = [
 v3 = {
   "alias": null,
   "args": null,
-  "concreteType": "TrustCenterAccessEdge",
+  "kind": "ScalarField",
+  "name": "cursor",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "email",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "active",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "hasAcceptedNonDisclosureAgreement",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+},
+v10 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 100
+  },
+  {
+    "kind": "Literal",
+    "name": "orderBy",
+    "value": {
+      "direction": "DESC",
+      "field": "CREATED_AT"
+    }
+  }
+],
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "updatedAt",
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Document",
   "kind": "LinkedField",
-  "name": "trustCenterAccessEdge",
+  "name": "document",
   "plural": false,
   "selections": [
+    (v4/*: any*/),
     {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
-      "name": "cursor",
+      "name": "title",
       "storageKey": null
     },
     {
       "alias": null,
       "args": null,
-      "concreteType": "TrustCenterAccess",
-      "kind": "LinkedField",
-      "name": "node",
-      "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "id",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "email",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "name",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "active",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "hasAcceptedNonDisclosureAgreement",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "createdAt",
-          "storageKey": null
-        }
-      ],
+      "kind": "ScalarField",
+      "name": "documentType",
       "storageKey": null
     }
   ],
+  "storageKey": null
+},
+v13 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "filename",
   "storageKey": null
 };
 return {
@@ -146,7 +205,110 @@ return {
         "name": "createTrustCenterAccess",
         "plural": false,
         "selections": [
-          (v3/*: any*/)
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "TrustCenterAccessEdge",
+            "kind": "LinkedField",
+            "name": "trustCenterAccessEdge",
+            "plural": false,
+            "selections": [
+              (v3/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "TrustCenterAccess",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v4/*: any*/),
+                  (v5/*: any*/),
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/),
+                  {
+                    "alias": null,
+                    "args": (v10/*: any*/),
+                    "concreteType": "TrustCenterDocumentAccessConnection",
+                    "kind": "LinkedField",
+                    "name": "documentAccesses",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "TrustCenterDocumentAccessEdge",
+                        "kind": "LinkedField",
+                        "name": "edges",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "TrustCenterDocumentAccess",
+                            "kind": "LinkedField",
+                            "name": "node",
+                            "plural": false,
+                            "selections": [
+                              (v4/*: any*/),
+                              (v7/*: any*/),
+                              (v9/*: any*/),
+                              (v11/*: any*/),
+                              (v12/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Report",
+                                "kind": "LinkedField",
+                                "name": "report",
+                                "plural": false,
+                                "selections": [
+                                  (v4/*: any*/),
+                                  (v13/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Audit",
+                                    "kind": "LinkedField",
+                                    "name": "audit",
+                                    "plural": false,
+                                    "selections": [
+                                      (v4/*: any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "Framework",
+                                        "kind": "LinkedField",
+                                        "name": "framework",
+                                        "plural": false,
+                                        "selections": [
+                                          (v6/*: any*/)
+                                        ],
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "documentAccesses(first:100,orderBy:{\"direction\":\"DESC\",\"field\":\"CREATED_AT\"})"
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
         ],
         "storageKey": null
       }
@@ -171,7 +333,111 @@ return {
         "name": "createTrustCenterAccess",
         "plural": false,
         "selections": [
-          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "TrustCenterAccessEdge",
+            "kind": "LinkedField",
+            "name": "trustCenterAccessEdge",
+            "plural": false,
+            "selections": [
+              (v3/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "TrustCenterAccess",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v4/*: any*/),
+                  (v5/*: any*/),
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/),
+                  {
+                    "alias": null,
+                    "args": (v10/*: any*/),
+                    "concreteType": "TrustCenterDocumentAccessConnection",
+                    "kind": "LinkedField",
+                    "name": "documentAccesses",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "TrustCenterDocumentAccessEdge",
+                        "kind": "LinkedField",
+                        "name": "edges",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "TrustCenterDocumentAccess",
+                            "kind": "LinkedField",
+                            "name": "node",
+                            "plural": false,
+                            "selections": [
+                              (v4/*: any*/),
+                              (v7/*: any*/),
+                              (v9/*: any*/),
+                              (v11/*: any*/),
+                              (v12/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Report",
+                                "kind": "LinkedField",
+                                "name": "report",
+                                "plural": false,
+                                "selections": [
+                                  (v4/*: any*/),
+                                  (v13/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Audit",
+                                    "kind": "LinkedField",
+                                    "name": "audit",
+                                    "plural": false,
+                                    "selections": [
+                                      (v4/*: any*/),
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "Framework",
+                                        "kind": "LinkedField",
+                                        "name": "framework",
+                                        "plural": false,
+                                        "selections": [
+                                          (v6/*: any*/),
+                                          (v4/*: any*/)
+                                        ],
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "documentAccesses(first:100,orderBy:{\"direction\":\"DESC\",\"field\":\"CREATED_AT\"})"
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
           {
             "alias": null,
             "args": null,
@@ -194,16 +460,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "fa88b100be7598cf46159cf79199c398",
+    "cacheID": "a27b7cdf2a4cadf8cc22a95f39c3c6b0",
     "id": null,
     "metadata": {},
     "name": "TrustCenterAccessGraphCreateMutation",
     "operationKind": "mutation",
-    "text": "mutation TrustCenterAccessGraphCreateMutation(\n  $input: CreateTrustCenterAccessInput!\n) {\n  createTrustCenterAccess(input: $input) {\n    trustCenterAccessEdge {\n      cursor\n      node {\n        id\n        email\n        name\n        active\n        hasAcceptedNonDisclosureAgreement\n        createdAt\n      }\n    }\n  }\n}\n"
+    "text": "mutation TrustCenterAccessGraphCreateMutation(\n  $input: CreateTrustCenterAccessInput!\n) {\n  createTrustCenterAccess(input: $input) {\n    trustCenterAccessEdge {\n      cursor\n      node {\n        id\n        email\n        name\n        active\n        hasAcceptedNonDisclosureAgreement\n        createdAt\n        documentAccesses(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {\n          edges {\n            node {\n              id\n              active\n              createdAt\n              updatedAt\n              document {\n                id\n                title\n                documentType\n              }\n              report {\n                id\n                filename\n                audit {\n                  id\n                  framework {\n                    name\n                    id\n                  }\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "6c6c1344730e7d908a5c6392f578ca81";
+(node as any).hash = "091432e335b8fe3a97ac06d3765f172b";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphPaginationQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphPaginationQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4fcca19ac1edb0d607a9682090e0cc3e>>
+ * @generated SignedSource<<bf8e5a74bfd588ad123f628009b6440e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,60 +10,61 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type TrustCenterAccessGraphQuery$variables = {
-  count: number;
+export type TrustCenterAccessGraphPaginationQuery$variables = {
+  count?: number | null | undefined;
   cursor?: any | null | undefined;
-  trustCenterId: string;
+  id: string;
 };
-export type TrustCenterAccessGraphQuery$data = {
+export type TrustCenterAccessGraphPaginationQuery$data = {
   readonly node: {
-    readonly id?: string;
     readonly " $fragmentSpreads": FragmentRefs<"TrustCenterAccessGraph_accesses">;
   };
 };
-export type TrustCenterAccessGraphQuery = {
-  response: TrustCenterAccessGraphQuery$data;
-  variables: TrustCenterAccessGraphQuery$variables;
+export type TrustCenterAccessGraphPaginationQuery = {
+  response: TrustCenterAccessGraphPaginationQuery$data;
+  variables: TrustCenterAccessGraphPaginationQuery$variables;
 };
 
 const node: ConcreteRequest = (function(){
-var v0 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "count"
-},
-v1 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "cursor"
-},
-v2 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "trustCenterId"
-},
-v3 = [
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "count"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "cursor"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
   {
     "kind": "Variable",
     "name": "id",
-    "variableName": "trustCenterId"
+    "variableName": "id"
   }
 ],
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v5 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v6 = {
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
   "kind": "Literal",
   "name": "orderBy",
   "value": {
@@ -71,7 +72,7 @@ v6 = {
     "field": "CREATED_AT"
   }
 },
-v7 = [
+v5 = [
   {
     "kind": "Variable",
     "name": "after",
@@ -82,23 +83,23 @@ v7 = [
     "name": "first",
     "variableName": "count"
   },
-  (v6/*: any*/)
+  (v4/*: any*/)
 ],
-v8 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v9 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "active",
   "storageKey": null
 },
-v10 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -107,35 +108,23 @@ v10 = {
 };
 return {
   "fragment": {
-    "argumentDefinitions": [
-      (v0/*: any*/),
-      (v1/*: any*/),
-      (v2/*: any*/)
-    ],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "TrustCenterAccessGraphQuery",
+    "name": "TrustCenterAccessGraphPaginationQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v3/*: any*/),
+        "args": (v1/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
           {
-            "kind": "InlineFragment",
-            "selections": [
-              (v4/*: any*/),
-              {
-                "args": null,
-                "kind": "FragmentSpread",
-                "name": "TrustCenterAccessGraph_accesses"
-              }
-            ],
-            "type": "TrustCenter",
-            "abstractKey": null
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "TrustCenterAccessGraph_accesses"
           }
         ],
         "storageKey": null
@@ -146,30 +135,26 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": [
-      (v2/*: any*/),
-      (v0/*: any*/),
-      (v1/*: any*/)
-    ],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "TrustCenterAccessGraphQuery",
+    "name": "TrustCenterAccessGraphPaginationQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v3/*: any*/),
+        "args": (v1/*: any*/),
         "concreteType": null,
         "kind": "LinkedField",
         "name": "node",
         "plural": false,
         "selections": [
-          (v5/*: any*/),
-          (v4/*: any*/),
+          (v2/*: any*/),
+          (v3/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
               {
                 "alias": null,
-                "args": (v7/*: any*/),
+                "args": (v5/*: any*/),
                 "concreteType": "TrustCenterAccessConnection",
                 "kind": "LinkedField",
                 "name": "accesses",
@@ -237,7 +222,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v4/*: any*/),
+                          (v3/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -245,8 +230,8 @@ return {
                             "name": "email",
                             "storageKey": null
                           },
-                          (v8/*: any*/),
-                          (v9/*: any*/),
+                          (v6/*: any*/),
+                          (v7/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -254,7 +239,7 @@ return {
                             "name": "hasAcceptedNonDisclosureAgreement",
                             "storageKey": null
                           },
-                          (v10/*: any*/),
+                          (v8/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -263,7 +248,7 @@ return {
                                 "name": "first",
                                 "value": 100
                               },
-                              (v6/*: any*/)
+                              (v4/*: any*/)
                             ],
                             "concreteType": "TrustCenterDocumentAccessConnection",
                             "kind": "LinkedField",
@@ -286,9 +271,9 @@ return {
                                     "name": "node",
                                     "plural": false,
                                     "selections": [
-                                      (v4/*: any*/),
-                                      (v9/*: any*/),
-                                      (v10/*: any*/),
+                                      (v3/*: any*/),
+                                      (v7/*: any*/),
+                                      (v8/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -304,7 +289,7 @@ return {
                                         "name": "document",
                                         "plural": false,
                                         "selections": [
-                                          (v4/*: any*/),
+                                          (v3/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -330,7 +315,7 @@ return {
                                         "name": "report",
                                         "plural": false,
                                         "selections": [
-                                          (v4/*: any*/),
+                                          (v3/*: any*/),
                                           {
                                             "alias": null,
                                             "args": null,
@@ -346,7 +331,7 @@ return {
                                             "name": "audit",
                                             "plural": false,
                                             "selections": [
-                                              (v4/*: any*/),
+                                              (v3/*: any*/),
                                               {
                                                 "alias": null,
                                                 "args": null,
@@ -355,8 +340,8 @@ return {
                                                 "name": "framework",
                                                 "plural": false,
                                                 "selections": [
-                                                  (v8/*: any*/),
-                                                  (v4/*: any*/)
+                                                  (v6/*: any*/),
+                                                  (v3/*: any*/)
                                                 ],
                                                 "storageKey": null
                                               }
@@ -375,7 +360,7 @@ return {
                             ],
                             "storageKey": "documentAccesses(first:100,orderBy:{\"direction\":\"DESC\",\"field\":\"CREATED_AT\"})"
                           },
-                          (v5/*: any*/)
+                          (v2/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -399,7 +384,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v7/*: any*/),
+                "args": (v5/*: any*/),
                 "filters": [
                   "orderBy"
                 ],
@@ -418,16 +403,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4ca52668a68c0789aa73c0d680ec0abe",
+    "cacheID": "96e9906815501bb22bca79bb63a4a149",
     "id": null,
     "metadata": {},
-    "name": "TrustCenterAccessGraphQuery",
+    "name": "TrustCenterAccessGraphPaginationQuery",
     "operationKind": "query",
-    "text": "query TrustCenterAccessGraphQuery(\n  $trustCenterId: ID!\n  $count: Int!\n  $cursor: CursorKey\n) {\n  node(id: $trustCenterId) {\n    __typename\n    ... on TrustCenter {\n      id\n      ...TrustCenterAccessGraph_accesses\n    }\n    id\n  }\n}\n\nfragment TrustCenterAccessGraph_accesses on TrustCenter {\n  accesses(first: $count, after: $cursor, orderBy: {field: CREATED_AT, direction: DESC}) {\n    pageInfo {\n      hasNextPage\n      hasPreviousPage\n      startCursor\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        email\n        name\n        active\n        hasAcceptedNonDisclosureAgreement\n        createdAt\n        documentAccesses(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {\n          edges {\n            node {\n              id\n              active\n              createdAt\n              updatedAt\n              document {\n                id\n                title\n                documentType\n              }\n              report {\n                id\n                filename\n                audit {\n                  id\n                  framework {\n                    name\n                    id\n                  }\n                }\n              }\n            }\n          }\n        }\n        __typename\n      }\n    }\n  }\n  id\n}\n"
+    "text": "query TrustCenterAccessGraphPaginationQuery(\n  $count: Int\n  $cursor: CursorKey\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...TrustCenterAccessGraph_accesses\n    id\n  }\n}\n\nfragment TrustCenterAccessGraph_accesses on TrustCenter {\n  accesses(first: $count, after: $cursor, orderBy: {field: CREATED_AT, direction: DESC}) {\n    pageInfo {\n      hasNextPage\n      hasPreviousPage\n      startCursor\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        email\n        name\n        active\n        hasAcceptedNonDisclosureAgreement\n        createdAt\n        documentAccesses(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {\n          edges {\n            node {\n              id\n              active\n              createdAt\n              updatedAt\n              document {\n                id\n                title\n                documentType\n              }\n              report {\n                id\n                filename\n                audit {\n                  id\n                  framework {\n                    name\n                    id\n                  }\n                }\n              }\n            }\n          }\n        }\n        __typename\n      }\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "da875d7c80a605898a30cf634d033380";
+(node as any).hash = "9e29aa4a382ca2d4bb9d1b014d8d81fd";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphUpdateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphUpdateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d2f40d8fc2bd9c7627d308660dedb1e5>>
+ * @generated SignedSource<<4aef541df2f5673dd3694ca275f3164d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,10 +9,13 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
+export type DocumentType = "ISMS" | "OTHER" | "POLICY";
 export type UpdateTrustCenterAccessInput = {
   active?: boolean | null | undefined;
+  documentIds?: ReadonlyArray<string> | null | undefined;
   id: string;
   name?: string | null | undefined;
+  reportIds?: ReadonlyArray<string> | null | undefined;
 };
 export type TrustCenterAccessGraphUpdateMutation$variables = {
   input: UpdateTrustCenterAccessInput;
@@ -22,6 +25,31 @@ export type TrustCenterAccessGraphUpdateMutation$data = {
     readonly trustCenterAccess: {
       readonly active: boolean;
       readonly createdAt: any;
+      readonly documentAccesses: {
+        readonly edges: ReadonlyArray<{
+          readonly node: {
+            readonly active: boolean;
+            readonly createdAt: any;
+            readonly document: {
+              readonly documentType: DocumentType;
+              readonly id: string;
+              readonly title: string;
+            } | null | undefined;
+            readonly id: string;
+            readonly report: {
+              readonly audit: {
+                readonly framework: {
+                  readonly name: string;
+                };
+                readonly id: string;
+              } | null | undefined;
+              readonly filename: string;
+              readonly id: string;
+            } | null | undefined;
+            readonly updatedAt: any;
+          };
+        }>;
+      };
       readonly email: string;
       readonly hasAcceptedNonDisclosureAgreement: boolean;
       readonly id: string;
@@ -45,90 +73,220 @@ var v0 = [
 ],
 v1 = [
   {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "input",
-        "variableName": "input"
-      }
-    ],
-    "concreteType": "UpdateTrustCenterAccessPayload",
-    "kind": "LinkedField",
-    "name": "updateTrustCenterAccess",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "TrustCenterAccess",
-        "kind": "LinkedField",
-        "name": "trustCenterAccess",
-        "plural": false,
-        "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "email",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "name",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "active",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "hasAcceptedNonDisclosureAgreement",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "createdAt",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "updatedAt",
-            "storageKey": null
-          }
-        ],
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
   }
-];
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "email",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "active",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "hasAcceptedNonDisclosureAgreement",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "updatedAt",
+  "storageKey": null
+},
+v9 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 100
+  },
+  {
+    "kind": "Literal",
+    "name": "orderBy",
+    "value": {
+      "direction": "DESC",
+      "field": "CREATED_AT"
+    }
+  }
+],
+v10 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Document",
+  "kind": "LinkedField",
+  "name": "document",
+  "plural": false,
+  "selections": [
+    (v2/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "title",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "documentType",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "filename",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "TrustCenterAccessGraphUpdateMutation",
-    "selections": (v1/*: any*/),
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "UpdateTrustCenterAccessPayload",
+        "kind": "LinkedField",
+        "name": "updateTrustCenterAccess",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "TrustCenterAccess",
+            "kind": "LinkedField",
+            "name": "trustCenterAccess",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/),
+              {
+                "alias": null,
+                "args": (v9/*: any*/),
+                "concreteType": "TrustCenterDocumentAccessConnection",
+                "kind": "LinkedField",
+                "name": "documentAccesses",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "TrustCenterDocumentAccessEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "TrustCenterDocumentAccess",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          (v5/*: any*/),
+                          (v7/*: any*/),
+                          (v8/*: any*/),
+                          (v10/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Report",
+                            "kind": "LinkedField",
+                            "name": "report",
+                            "plural": false,
+                            "selections": [
+                              (v2/*: any*/),
+                              (v11/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Audit",
+                                "kind": "LinkedField",
+                                "name": "audit",
+                                "plural": false,
+                                "selections": [
+                                  (v2/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Framework",
+                                    "kind": "LinkedField",
+                                    "name": "framework",
+                                    "plural": false,
+                                    "selections": [
+                                      (v4/*: any*/)
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "documentAccesses(first:100,orderBy:{\"direction\":\"DESC\",\"field\":\"CREATED_AT\"})"
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
     "type": "Mutation",
     "abstractKey": null
   },
@@ -137,19 +295,125 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "TrustCenterAccessGraphUpdateMutation",
-    "selections": (v1/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "UpdateTrustCenterAccessPayload",
+        "kind": "LinkedField",
+        "name": "updateTrustCenterAccess",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "TrustCenterAccess",
+            "kind": "LinkedField",
+            "name": "trustCenterAccess",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/),
+              {
+                "alias": null,
+                "args": (v9/*: any*/),
+                "concreteType": "TrustCenterDocumentAccessConnection",
+                "kind": "LinkedField",
+                "name": "documentAccesses",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "TrustCenterDocumentAccessEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "TrustCenterDocumentAccess",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          (v5/*: any*/),
+                          (v7/*: any*/),
+                          (v8/*: any*/),
+                          (v10/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Report",
+                            "kind": "LinkedField",
+                            "name": "report",
+                            "plural": false,
+                            "selections": [
+                              (v2/*: any*/),
+                              (v11/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Audit",
+                                "kind": "LinkedField",
+                                "name": "audit",
+                                "plural": false,
+                                "selections": [
+                                  (v2/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Framework",
+                                    "kind": "LinkedField",
+                                    "name": "framework",
+                                    "plural": false,
+                                    "selections": [
+                                      (v4/*: any*/),
+                                      (v2/*: any*/)
+                                    ],
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "documentAccesses(first:100,orderBy:{\"direction\":\"DESC\",\"field\":\"CREATED_AT\"})"
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "cacheID": "223169ee8a4f65008047097ecff68fc5",
+    "cacheID": "de3ddd0058b8881667e47e2bf32c8b73",
     "id": null,
     "metadata": {},
     "name": "TrustCenterAccessGraphUpdateMutation",
     "operationKind": "mutation",
-    "text": "mutation TrustCenterAccessGraphUpdateMutation(\n  $input: UpdateTrustCenterAccessInput!\n) {\n  updateTrustCenterAccess(input: $input) {\n    trustCenterAccess {\n      id\n      email\n      name\n      active\n      hasAcceptedNonDisclosureAgreement\n      createdAt\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation TrustCenterAccessGraphUpdateMutation(\n  $input: UpdateTrustCenterAccessInput!\n) {\n  updateTrustCenterAccess(input: $input) {\n    trustCenterAccess {\n      id\n      email\n      name\n      active\n      hasAcceptedNonDisclosureAgreement\n      createdAt\n      updatedAt\n      documentAccesses(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {\n        edges {\n          node {\n            id\n            active\n            createdAt\n            updatedAt\n            document {\n              id\n              title\n              documentType\n            }\n            report {\n              id\n              filename\n              audit {\n                id\n                framework {\n                  name\n                  id\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "0da1f737e6ea1db7a1b9930c4b6cc545";
+(node as any).hash = "723058aacc2e04bd2df4cf04c6df0a3c";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraph_accesses.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraph_accesses.graphql.ts
@@ -1,0 +1,398 @@
+/**
+ * @generated SignedSource<<3717625e10534aaff2d7967a1824405b>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type DocumentType = "ISMS" | "OTHER" | "POLICY";
+import { FragmentRefs } from "relay-runtime";
+export type TrustCenterAccessGraph_accesses$data = {
+  readonly accesses: {
+    readonly __id: string;
+    readonly edges: ReadonlyArray<{
+      readonly cursor: any;
+      readonly node: {
+        readonly active: boolean;
+        readonly createdAt: any;
+        readonly documentAccesses: {
+          readonly edges: ReadonlyArray<{
+            readonly node: {
+              readonly active: boolean;
+              readonly createdAt: any;
+              readonly document: {
+                readonly documentType: DocumentType;
+                readonly id: string;
+                readonly title: string;
+              } | null | undefined;
+              readonly id: string;
+              readonly report: {
+                readonly audit: {
+                  readonly framework: {
+                    readonly name: string;
+                  };
+                  readonly id: string;
+                } | null | undefined;
+                readonly filename: string;
+                readonly id: string;
+              } | null | undefined;
+              readonly updatedAt: any;
+            };
+          }>;
+        };
+        readonly email: string;
+        readonly hasAcceptedNonDisclosureAgreement: boolean;
+        readonly id: string;
+        readonly name: string;
+      };
+    }>;
+    readonly pageInfo: {
+      readonly endCursor: any | null | undefined;
+      readonly hasNextPage: boolean;
+      readonly hasPreviousPage: boolean;
+      readonly startCursor: any | null | undefined;
+    };
+  };
+  readonly id: string;
+  readonly " $fragmentType": "TrustCenterAccessGraph_accesses";
+};
+export type TrustCenterAccessGraph_accesses$key = {
+  readonly " $data"?: TrustCenterAccessGraph_accesses$data;
+  readonly " $fragmentSpreads": FragmentRefs<"TrustCenterAccessGraph_accesses">;
+};
+
+import TrustCenterAccessGraphPaginationQuery_graphql from './TrustCenterAccessGraphPaginationQuery.graphql';
+
+const node: ReaderFragment = (function(){
+var v0 = [
+  "accesses"
+],
+v1 = {
+  "kind": "Literal",
+  "name": "orderBy",
+  "value": {
+    "direction": "DESC",
+    "field": "CREATED_AT"
+  }
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "active",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [
+    {
+      "kind": "RootArgument",
+      "name": "count"
+    },
+    {
+      "kind": "RootArgument",
+      "name": "cursor"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": {
+    "connection": [
+      {
+        "count": "count",
+        "cursor": "cursor",
+        "direction": "forward",
+        "path": (v0/*: any*/)
+      }
+    ],
+    "refetch": {
+      "connection": {
+        "forward": {
+          "count": "count",
+          "cursor": "cursor"
+        },
+        "backward": null,
+        "path": (v0/*: any*/)
+      },
+      "fragmentPathInResult": [
+        "node"
+      ],
+      "operation": TrustCenterAccessGraphPaginationQuery_graphql,
+      "identifierInfo": {
+        "identifierField": "id",
+        "identifierQueryVariableName": "id"
+      }
+    }
+  },
+  "name": "TrustCenterAccessGraph_accesses",
+  "selections": [
+    {
+      "alias": "accesses",
+      "args": [
+        (v1/*: any*/)
+      ],
+      "concreteType": "TrustCenterAccessConnection",
+      "kind": "LinkedField",
+      "name": "__TrustCenterAccessGraph_accesses_connection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "kind": "LinkedField",
+          "name": "pageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasNextPage",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasPreviousPage",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "startCursor",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "endCursor",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "TrustCenterAccessEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "cursor",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "TrustCenterAccess",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                (v2/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "email",
+                  "storageKey": null
+                },
+                (v3/*: any*/),
+                (v4/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "hasAcceptedNonDisclosureAgreement",
+                  "storageKey": null
+                },
+                (v5/*: any*/),
+                {
+                  "alias": null,
+                  "args": [
+                    {
+                      "kind": "Literal",
+                      "name": "first",
+                      "value": 100
+                    },
+                    (v1/*: any*/)
+                  ],
+                  "concreteType": "TrustCenterDocumentAccessConnection",
+                  "kind": "LinkedField",
+                  "name": "documentAccesses",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "TrustCenterDocumentAccessEdge",
+                      "kind": "LinkedField",
+                      "name": "edges",
+                      "plural": true,
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "concreteType": "TrustCenterDocumentAccess",
+                          "kind": "LinkedField",
+                          "name": "node",
+                          "plural": false,
+                          "selections": [
+                            (v2/*: any*/),
+                            (v4/*: any*/),
+                            (v5/*: any*/),
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "updatedAt",
+                              "storageKey": null
+                            },
+                            {
+                              "alias": null,
+                              "args": null,
+                              "concreteType": "Document",
+                              "kind": "LinkedField",
+                              "name": "document",
+                              "plural": false,
+                              "selections": [
+                                (v2/*: any*/),
+                                {
+                                  "alias": null,
+                                  "args": null,
+                                  "kind": "ScalarField",
+                                  "name": "title",
+                                  "storageKey": null
+                                },
+                                {
+                                  "alias": null,
+                                  "args": null,
+                                  "kind": "ScalarField",
+                                  "name": "documentType",
+                                  "storageKey": null
+                                }
+                              ],
+                              "storageKey": null
+                            },
+                            {
+                              "alias": null,
+                              "args": null,
+                              "concreteType": "Report",
+                              "kind": "LinkedField",
+                              "name": "report",
+                              "plural": false,
+                              "selections": [
+                                (v2/*: any*/),
+                                {
+                                  "alias": null,
+                                  "args": null,
+                                  "kind": "ScalarField",
+                                  "name": "filename",
+                                  "storageKey": null
+                                },
+                                {
+                                  "alias": null,
+                                  "args": null,
+                                  "concreteType": "Audit",
+                                  "kind": "LinkedField",
+                                  "name": "audit",
+                                  "plural": false,
+                                  "selections": [
+                                    (v2/*: any*/),
+                                    {
+                                      "alias": null,
+                                      "args": null,
+                                      "concreteType": "Framework",
+                                      "kind": "LinkedField",
+                                      "name": "framework",
+                                      "plural": false,
+                                      "selections": [
+                                        (v3/*: any*/)
+                                      ],
+                                      "storageKey": null
+                                    }
+                                  ],
+                                  "storageKey": null
+                                }
+                              ],
+                              "storageKey": null
+                            }
+                          ],
+                          "storageKey": null
+                        }
+                      ],
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": "documentAccesses(first:100,orderBy:{\"direction\":\"DESC\",\"field\":\"CREATED_AT\"})"
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "__typename",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "kind": "ClientExtension",
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "__id",
+              "storageKey": null
+            }
+          ]
+        }
+      ],
+      "storageKey": "__TrustCenterAccessGraph_accesses_connection(orderBy:{\"direction\":\"DESC\",\"field\":\"CREATED_AT\"})"
+    },
+    (v2/*: any*/)
+  ],
+  "type": "TrustCenter",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "9e29aa4a382ca2d4bb9d1b014d8d81fd";
+
+export default node;

--- a/apps/console/src/pages/organizations/trustCenter/TrustCenterAccessTab.tsx
+++ b/apps/console/src/pages/organizations/trustCenter/TrustCenterAccessTab.tsx
@@ -17,11 +17,13 @@ import {
   IconTrashCan,
   IconPencil,
   IconCheckmark1,
+  IconCrossLargeX,
+  IconChevronDown,
 } from "@probo/ui";
 import { useTranslate } from "@probo/i18n";
 import { formatDate } from "@probo/helpers";
 import { useOutletContext } from "react-router";
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import z from "zod";
 import {
   useTrustCenterAccesses,
@@ -52,11 +54,12 @@ export default function TrustCenterAccessTab() {
 
   const editSchema = z.object({
     name: z.string().min(1, __("Name is required")).min(2, __("Name must be at least 2 characters long")),
+    active: z.boolean(),
   });
 
   const [createInvitation, isCreating] = useMutationWithToasts(createTrustCenterAccessMutation, {
-    successMessage: __("Access invitation sent successfully"),
-    errorMessage: __("Failed to send invitation. Please try again."),
+    successMessage: __("Access created successfully"),
+    errorMessage: __("Failed to create access. Please try again."),
   });
   const [updateInvitation, isUpdating] = useMutationWithToasts(updateTrustCenterAccessMutation, {
     successMessage: __("Access updated successfully"),
@@ -69,18 +72,37 @@ export default function TrustCenterAccessTab() {
 
   const dialogRef = useDialogRef();
   const editDialogRef = useDialogRef();
-  const [editingAccess, setEditingAccess] = useState<{
-    id: string;
-    name: string;
-  } | null>(null);
+  const [editingAccess, setEditingAccess] = useState<AccessType | null>(null);
+  const [selectedDocumentAccesses, setSelectedDocumentAccesses] = useState<Set<string>>(new Set());
+  const [pendingEditEmail, setPendingEditEmail] = useState<string | null>(null);
 
   const inviteForm = useFormWithSchema(inviteSchema, {
     defaultValues: { name: "", email: "" },
   });
 
   const editForm = useFormWithSchema(editSchema, {
-    defaultValues: { name: "" },
+    defaultValues: { name: "", active: false },
   });
+
+  type DocumentAccessType = {
+    id: string;
+    active: boolean;
+    document?: {
+      id: string;
+      title: string;
+      documentType: string;
+    } | null;
+    report?: {
+      id: string;
+      filename: string;
+      audit: {
+        id: string;
+        framework: {
+          name: string;
+        };
+      };
+    } | null;
+  };
 
   type AccessType = {
     id: string;
@@ -89,18 +111,26 @@ export default function TrustCenterAccessTab() {
     active: boolean;
     hasAcceptedNonDisclosureAgreement: boolean;
     createdAt: string;
+    documentAccesses: DocumentAccessType[];
   };
 
-  const trustCenterData = useTrustCenterAccesses(organization.trustCenter?.id || "");
+  const { data: trustCenterData, loadMore, hasNext, isLoadingNext } = useTrustCenterAccesses(organization.trustCenter?.id || "");
 
-  const accesses: AccessType[] = trustCenterData?.node?.accesses?.edges?.map(edge => ({
+  const accesses: AccessType[] = trustCenterData?.node?.accesses?.edges?.map((edge: any) => ({
     id: edge.node.id,
     email: edge.node.email,
     name: edge.node.name,
     active: edge.node.active,
     hasAcceptedNonDisclosureAgreement: edge.node.hasAcceptedNonDisclosureAgreement,
-    createdAt: edge.node.createdAt
+    createdAt: edge.node.createdAt,
+    documentAccesses: edge.node.documentAccesses?.edges?.map((docEdge: any) => ({
+      id: docEdge.node.id,
+      active: docEdge.node.active,
+      document: docEdge.node.document,
+      report: docEdge.node.report
+    })) ?? []
   })) ?? [];
+
 
   const handleInvite = inviteForm.handleSubmit(async (data) => {
     if (!organization.trustCenter?.id) {
@@ -108,20 +138,22 @@ export default function TrustCenterAccessTab() {
     }
 
     const connectionId = trustCenterData?.node?.accesses?.__id;
+    const email = data.email.trim();
 
     await createInvitation({
       variables: {
         input: {
           trustCenterId: organization.trustCenter.id,
-          email: data.email.trim(),
+          email: email,
           name: data.name.trim(),
-          active: true,
+          active: false,
         },
         connections: connectionId ? [connectionId] : [],
       },
       onSuccess: () => {
         dialogRef.current?.close();
         inviteForm.reset();
+        setPendingEditEmail(email);
       },
     });
   });
@@ -137,36 +169,79 @@ export default function TrustCenterAccessTab() {
     });
   }, [deleteInvitation, trustCenterData]);
 
-  const handleToggleActive = useCallback(async (id: string, active: boolean) => {
-    await updateInvitation({
-      variables: {
-        input: { id, active },
-      },
-      successMessage: active ? __("Access activated") : __("Access deactivated"),
-    });
-  }, [updateInvitation, __]);
+
+  const getActiveDocumentIds = useCallback((access: AccessType) => {
+    return access.documentAccesses
+      .filter(docAccess => docAccess.active)
+      .map(docAccess => docAccess.document?.id || docAccess.report?.id)
+      .filter((id): id is string => id !== undefined);
+  }, []);
 
   const handleEditAccess = useCallback((access: AccessType) => {
-    setEditingAccess({ id: access.id, name: access.name });
-    editForm.reset({ name: access.name });
+    setEditingAccess(access);
+    editForm.reset({ name: access.name, active: access.active });
+    setSelectedDocumentAccesses(new Set(getActiveDocumentIds(access)));
     editDialogRef.current?.open();
-  }, [editDialogRef, editForm]);
+  }, [editDialogRef, editForm, getActiveDocumentIds]);
+
+  useEffect(() => {
+    if (pendingEditEmail && accesses.length > 0) {
+      const newAccess = accesses.find(access => access.email === pendingEditEmail);
+      if (newAccess) {
+        setPendingEditEmail(null);
+        setEditingAccess(newAccess);
+        editForm.reset({ name: newAccess.name, active: true });
+        setSelectedDocumentAccesses(new Set(getActiveDocumentIds(newAccess)));
+        editDialogRef.current?.open();
+      }
+    }
+  }, [accesses, pendingEditEmail, editForm, editDialogRef, getActiveDocumentIds]);
+
+  const handleToggleDocumentAccess = useCallback((documentId: string, active: boolean) => {
+    setSelectedDocumentAccesses(prev => {
+      const newSet = new Set(prev);
+      if (active) {
+        newSet.add(documentId);
+      } else {
+        newSet.delete(documentId);
+      }
+      return newSet;
+    });
+  }, []);
 
   const handleUpdateName = editForm.handleSubmit(async (data) => {
     if (!editingAccess) return;
+
+    const { documentIds, reportIds } = editingAccess.documentAccesses.reduce(
+      (acc, docAccess) => {
+        const id = docAccess.document?.id || docAccess.report?.id;
+        if (id && selectedDocumentAccesses.has(id)) {
+          if (docAccess.document?.id) {
+            acc.documentIds.push(docAccess.document.id);
+          } else if (docAccess.report?.id) {
+            acc.reportIds.push(docAccess.report.id);
+          }
+        }
+        return acc;
+      },
+      { documentIds: [] as string[], reportIds: [] as string[] }
+    );
 
     await updateInvitation({
       variables: {
         input: {
           id: editingAccess.id,
           name: data.name.trim(),
+          active: data.active,
+          documentIds,
+          reportIds,
         },
       },
-      successMessage: __("Name updated successfully"),
       onSuccess: () => {
         editDialogRef.current?.close();
         setEditingAccess(null);
         editForm.reset();
+        setSelectedDocumentAccesses(new Set());
       },
     });
   });
@@ -185,7 +260,7 @@ export default function TrustCenterAccessTab() {
             inviteForm.reset();
             dialogRef.current?.open();
           }}>
-            {__("Invite")}
+            {__("Add Access")}
           </Button>
         )}
       </div>
@@ -200,56 +275,87 @@ export default function TrustCenterAccessTab() {
             {__("No external access granted yet")}
           </div>
         ) : (
-          <Table>
-            <Thead>
-              <Tr>
-                <Th>{__("Name")}</Th>
-                <Th>{__("Email")}</Th>
-                <Th>{__("Date")}</Th>
-                <Th>{__("Active")}</Th>
-                <Th>{__("NDA")}</Th>
-                <Th></Th>
-              </Tr>
-            </Thead>
-            <Tbody>
-              {accesses.map((access) => (
-                <Tr key={access.id}>
-                  <Td className="font-medium">{access.name}</Td>
-                  <Td>{access.email}</Td>
-                  <Td>
-                    {formatDate(access.createdAt)}
-                  </Td>
-                  <Td>
-                    <Checkbox
-                      checked={access.active}
-                      onChange={(active) => handleToggleActive(access.id, active)}
-                    />
-                  </Td>
-                  <Td>
-                    {access.hasAcceptedNonDisclosureAgreement && (
-                      <IconCheckmark1 size={16} className="text-txt-success" />
-                    )}
-                  </Td>
-                  <Td noLink width={160} className="text-end">
-                    <div className="flex gap-2 justify-end">
-                      <Button
-                        variant="secondary"
-                        onClick={() => handleEditAccess(access)}
-                        disabled={isUpdating}
-                        icon={IconPencil}
-                      />
-                      <Button
-                        variant="secondary"
-                        onClick={() => handleDelete(access.id)}
-                        disabled={isDeleting}
-                        icon={IconTrashCan}
-                      />
-                    </div>
-                  </Td>
+          <>
+            <Table>
+              <Thead>
+                <Tr>
+                  <Th>{__("Name")}</Th>
+                  <Th>{__("Email")}</Th>
+                  <Th>{__("Date")}</Th>
+                  <Th>{__("Active")}</Th>
+                  <Th>{__("Documents")}</Th>
+                  <Th>{__("NDA")}</Th>
+                  <Th></Th>
                 </Tr>
-              ))}
-            </Tbody>
-          </Table>
+              </Thead>
+              <Tbody>
+                {accesses.map((access) => {
+                  const activeDocuments = access.documentAccesses.filter(doc => doc.active).length;
+                  const totalDocuments = access.documentAccesses.length;
+
+                  return (
+                    <Tr
+                      key={access.id}
+                      onClick={() => handleEditAccess(access)}
+                      className="cursor-pointer hover:bg-bg-secondary transition-colors"
+                    >
+                      <Td className="font-medium">{access.name}</Td>
+                      <Td>{access.email}</Td>
+                      <Td>
+                        {formatDate(access.createdAt)}
+                      </Td>
+                      <Td>
+                        {access.active ? (
+                          <IconCheckmark1 size={16} className="text-txt-success" />
+                        ) : (
+                          <IconCrossLargeX size={16} className="text-txt-danger" />
+                        )}
+                      </Td>
+                      <Td>
+                        {totalDocuments > 0 ? `${activeDocuments}/${totalDocuments}` : '0/0'}
+                      </Td>
+                      <Td>
+                        {access.hasAcceptedNonDisclosureAgreement && (
+                          <IconCheckmark1 size={16} className="text-txt-success" />
+                        )}
+                      </Td>
+                    <Td noLink width={160} className="text-end">
+                      <div
+                        className="flex gap-2 justify-end"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <Button
+                          variant="secondary"
+                          onClick={() => handleEditAccess(access)}
+                          disabled={isUpdating}
+                          icon={IconPencil}
+                        />
+                        <Button
+                          variant="secondary"
+                          onClick={() => handleDelete(access.id)}
+                          disabled={isDeleting}
+                          icon={IconTrashCan}
+                        />
+                      </div>
+                    </Td>
+                  </Tr>
+                  );
+                })}
+              </Tbody>
+            </Table>
+            {hasNext && (
+              <Button
+                variant="tertiary"
+                onClick={loadMore}
+                disabled={isLoadingNext}
+                className="mt-3 mx-auto"
+                icon={IconChevronDown}
+              >
+                {isLoadingNext && <Spinner />}
+                {__("Show More")}
+              </Button>
+            )}
+          </>
         )}
       </Card>
 
@@ -284,7 +390,7 @@ export default function TrustCenterAccessTab() {
           <DialogFooter>
             <Button type="submit" disabled={isCreating}>
               {isCreating && <Spinner />}
-              {__("Send Invitation")}
+              {__("Create Access")}
             </Button>
           </DialogFooter>
         </form>
@@ -292,27 +398,122 @@ export default function TrustCenterAccessTab() {
 
       <Dialog
         ref={editDialogRef}
-        title={__("Edit Access Name")}
+        title={__("Edit Access")}
       >
         <form onSubmit={handleUpdateName}>
-          <DialogContent padded className="space-y-4">
-            <p className="text-txt-secondary text-sm">
-              {__("Update the display name for this access invitation")}
-            </p>
+          <DialogContent padded className="space-y-6">
+            <div>
+              <p className="text-txt-secondary text-sm mb-4">
+                {__("Update access settings and document permissions")}
+              </p>
 
-            <Field
-              label={__("Full Name")}
-              required
-              error={editForm.formState.errors.name?.message}
-              {...editForm.register("name")}
-              placeholder={__("John Doe")}
-            />
+              <Field
+                label={__("Full Name")}
+                required
+                error={editForm.formState.errors.name?.message}
+                {...editForm.register("name")}
+                placeholder={__("John Doe")}
+              />
+
+              <div className="flex items-center justify-between mt-6">
+                <div>
+                  <label className="font-medium text-txt-primary">
+                    {__("Active Status")}
+                  </label>
+                  <p className="text-sm text-txt-secondary">
+                    {__("Enable or disable access for this user")}
+                  </p>
+                </div>
+                <Checkbox
+                  checked={editForm.watch("active")}
+                  onChange={(checked) => editForm.setValue("active", checked)}
+                />
+              </div>
+            </div>
+
+            {editingAccess && editingAccess.documentAccesses.length > 0 && (
+              <div>
+                <h4 className="font-medium text-txt-primary mb-4">
+                  {__("Document Access Permissions")}
+                </h4>
+                <div className="bg-bg-secondary rounded-lg overflow-hidden">
+                  <Table>
+                    <Thead>
+                      <Tr>
+                        <Th>{__("Name")}</Th>
+                        <Th>{__("Type")}</Th>
+                        <Th>{__("Category")}</Th>
+                        <Th>
+                          <div className="flex justify-end">
+                            {__("Access")}
+                          </div>
+                        </Th>
+                      </Tr>
+                    </Thead>
+                    <Tbody>
+                      {editingAccess.documentAccesses.map((docAccess) => {
+                        const getDocumentInfo = () => {
+                          const isDocument = !!docAccess.document;
+                          return {
+                            isDocument,
+                            name: docAccess.document?.title || docAccess.report?.filename || __("Unknown Item"),
+                            type: isDocument ? __("Document") : __("Report"),
+                            category: isDocument
+                              ? docAccess.document?.documentType
+                              : docAccess.report?.audit?.framework?.name || __("Compliance Report"),
+                            id: docAccess.document?.id || docAccess.report?.id || ''
+                          };
+                        };
+
+                        const { isDocument, name, type, category, id } = getDocumentInfo();
+
+                        return (
+                          <Tr key={docAccess.id}>
+                            <Td>
+                              <div className="font-medium text-txt-primary">
+                                {name}
+                              </div>
+                            </Td>
+                            <Td>
+                              <div className="flex items-center space-x-2">
+                                <div className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ${
+                                  isDocument
+                                    ? 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200'
+                                    : 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
+                                }`}>
+                                  {type}
+                                </div>
+                              </div>
+                            </Td>
+                            <Td>
+                              <div className="text-txt-secondary">
+                                {category || "-"}
+                              </div>
+                            </Td>
+                            <Td>
+                              <div className="flex justify-end">
+                                <Checkbox
+                                  checked={selectedDocumentAccesses.has(id)}
+                                  onChange={(active) => {
+                                    if (id) handleToggleDocumentAccess(id, active);
+                                  }}
+                                />
+                              </div>
+                            </Td>
+                          </Tr>
+                        );
+                      })}
+                    </Tbody>
+                  </Table>
+                </div>
+              </div>
+            )}
           </DialogContent>
 
           <DialogFooter>
             <Button type="submit" disabled={isUpdating}>
               {isUpdating && <Spinner />}
-              {__("Update Name")}
+              {__("Update Access")}
             </Button>
           </DialogFooter>
         </form>

--- a/apps/trust/src/components/RequestAccessDialog.tsx
+++ b/apps/trust/src/components/RequestAccessDialog.tsx
@@ -26,8 +26,8 @@ const schema = z.object({
 });
 
 const requestAccessMutation = graphql`
-  mutation RequestAccessDialogMutation($input: CreateTrustCenterAccessInput!) {
-    createTrustCenterAccess(input: $input) {
+  mutation RequestAccessDialogMutation($input: RequestAllAccessesInput!) {
+    requestAllAccesses(input: $input) {
       trustCenterAccess {
         id
       }

--- a/apps/trust/src/components/__generated__/RequestAccessDialogMutation.graphql.ts
+++ b/apps/trust/src/components/__generated__/RequestAccessDialogMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<843902dd4fb6e2a5ee4d2d175ddcab03>>
+ * @generated SignedSource<<898167474e2680273ad8b588a63a47c5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,16 +9,16 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type CreateTrustCenterAccessInput = {
-  email: string;
-  name: string;
+export type RequestAllAccessesInput = {
+  email?: string | null | undefined;
+  name?: string | null | undefined;
   trustCenterId: string;
 };
 export type RequestAccessDialogMutation$variables = {
-  input: CreateTrustCenterAccessInput;
+  input: RequestAllAccessesInput;
 };
 export type RequestAccessDialogMutation$data = {
-  readonly createTrustCenterAccess: {
+  readonly requestAllAccesses: {
     readonly trustCenterAccess: {
       readonly id: string;
     };
@@ -47,9 +47,9 @@ v1 = [
         "variableName": "input"
       }
     ],
-    "concreteType": "CreateTrustCenterAccessPayload",
+    "concreteType": "RequestAccessesPayload",
     "kind": "LinkedField",
-    "name": "createTrustCenterAccess",
+    "name": "requestAllAccesses",
     "plural": false,
     "selections": [
       {
@@ -92,16 +92,16 @@ return {
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "13fedcfe7c72292417b76b3624c5434f",
+    "cacheID": "99eb2902ce5a921515d68db30f8a2189",
     "id": null,
     "metadata": {},
     "name": "RequestAccessDialogMutation",
     "operationKind": "mutation",
-    "text": "mutation RequestAccessDialogMutation(\n  $input: CreateTrustCenterAccessInput!\n) {\n  createTrustCenterAccess(input: $input) {\n    trustCenterAccess {\n      id\n    }\n  }\n}\n"
+    "text": "mutation RequestAccessDialogMutation(\n  $input: RequestAllAccessesInput!\n) {\n  requestAllAccesses(input: $input) {\n    trustCenterAccess {\n      id\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "18075ac4298dd3ca05bbcf8fb1717a9d";
+(node as any).hash = "cc4d5c8753438eff23833b4182dd485d";
 
 export default node;

--- a/pkg/coredata/entity_type_reg.go
+++ b/pkg/coredata/entity_type_reg.go
@@ -57,4 +57,5 @@ const (
 	ProcessingActivityEntityType
 	ExportJobEntityType
 	TrustCenterReferenceEntityType
+	TrustCenterDocumentAccessEntityType
 )

--- a/pkg/coredata/migrations/20250924T111957Z.sql
+++ b/pkg/coredata/migrations/20250924T111957Z.sql
@@ -1,0 +1,16 @@
+CREATE TABLE trust_center_document_accesses(
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    trust_center_access_id TEXT NOT NULL REFERENCES trust_center_accesses(id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    document_id TEXT REFERENCES documents(id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    report_id TEXT REFERENCES reports(id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    active BOOLEAN NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    UNIQUE (trust_center_access_id, document_id),
+    UNIQUE (trust_center_access_id, report_id),
+    CHECK ((document_id IS NOT NULL) != (report_id IS NOT NULL))
+);

--- a/pkg/coredata/trust_center_document_access.go
+++ b/pkg/coredata/trust_center_document_access.go
@@ -1,0 +1,616 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"time"
+
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+	"github.com/jackc/pgx/v5"
+	"go.gearno.de/kit/pg"
+)
+
+type (
+	TrustCenterDocumentAccess struct {
+		ID                  gid.GID   `db:"id"`
+		TrustCenterAccessID gid.GID   `db:"trust_center_access_id"`
+		DocumentID          *gid.GID  `db:"document_id"`
+		ReportID            *gid.GID  `db:"report_id"`
+		Active              bool      `db:"active"`
+		CreatedAt           time.Time `db:"created_at"`
+		UpdatedAt           time.Time `db:"updated_at"`
+	}
+
+	TrustCenterDocumentAccesses []*TrustCenterDocumentAccess
+)
+
+func (tcda *TrustCenterDocumentAccess) CursorKey(orderBy TrustCenterDocumentAccessOrderField) page.CursorKey {
+	switch orderBy {
+	case TrustCenterDocumentAccessOrderFieldCreatedAt:
+		return page.NewCursorKey(tcda.ID, tcda.CreatedAt)
+	}
+
+	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
+}
+
+func (tcda *TrustCenterDocumentAccess) LoadByID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	accessID gid.GID,
+) error {
+	q := `
+SELECT
+	id,
+	trust_center_access_id,
+	document_id,
+	report_id,
+	active,
+	created_at,
+	updated_at
+FROM
+	trust_center_document_accesses
+WHERE
+	%s
+	AND id = @access_id
+LIMIT 1;
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"access_id": accessID}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query trust center document access: %w", err)
+	}
+
+	access, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[TrustCenterDocumentAccess])
+	if err != nil {
+		return fmt.Errorf("cannot collect trust center document access: %w", err)
+	}
+
+	*tcda = access
+
+	return nil
+}
+
+func (tcda *TrustCenterDocumentAccess) LoadByTrustCenterAccessIDAndDocumentID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	trustCenterAccessID gid.GID,
+	documentID gid.GID,
+) error {
+	q := `
+SELECT
+	id,
+	trust_center_access_id,
+	document_id,
+	report_id,
+	active,
+	created_at,
+	updated_at
+FROM
+	trust_center_document_accesses
+WHERE
+	%s
+	AND trust_center_access_id = @trust_center_access_id
+	AND document_id = @document_id
+LIMIT 1;
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"trust_center_access_id": trustCenterAccessID,
+		"document_id":            documentID,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query trust center document access: %w", err)
+	}
+
+	access, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[TrustCenterDocumentAccess])
+	if err != nil {
+		return fmt.Errorf("cannot collect trust center document access: %w", err)
+	}
+
+	*tcda = access
+
+	return nil
+}
+
+func (tcda *TrustCenterDocumentAccess) LoadByTrustCenterAccessIDAndReportID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	trustCenterAccessID gid.GID,
+	reportID gid.GID,
+) error {
+	q := `
+SELECT
+	id,
+	trust_center_access_id,
+	document_id,
+	report_id,
+	active,
+	created_at,
+	updated_at
+FROM
+	trust_center_document_accesses
+WHERE
+	%s
+	AND trust_center_access_id = @trust_center_access_id
+	AND report_id = @report_id
+LIMIT 1;
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"trust_center_access_id": trustCenterAccessID,
+		"report_id":              reportID,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query trust center document access: %w", err)
+	}
+
+	access, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[TrustCenterDocumentAccess])
+	if err != nil {
+		return fmt.Errorf("cannot collect trust center document access: %w", err)
+	}
+
+	*tcda = access
+
+	return nil
+}
+
+func (tcda *TrustCenterDocumentAccess) Insert(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+INSERT INTO trust_center_document_accesses (
+	id,
+	tenant_id,
+	trust_center_access_id,
+	document_id,
+	report_id,
+	active,
+	created_at,
+	updated_at
+) VALUES (
+	@id,
+	@tenant_id,
+	@trust_center_access_id,
+	@document_id,
+	@report_id,
+	@active,
+	@created_at,
+	@updated_at
+)
+`
+
+	args := pgx.StrictNamedArgs{
+		"id":                     tcda.ID,
+		"tenant_id":              scope.GetTenantID(),
+		"trust_center_access_id": tcda.TrustCenterAccessID,
+		"document_id":            tcda.DocumentID,
+		"report_id":              tcda.ReportID,
+		"active":                 tcda.Active,
+		"created_at":             tcda.CreatedAt,
+		"updated_at":             tcda.UpdatedAt,
+	}
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot insert trust center document access: %w", err)
+	}
+
+	return nil
+}
+
+func (tcda *TrustCenterDocumentAccess) Update(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+UPDATE trust_center_document_accesses SET
+	active = @active,
+	updated_at = @updated_at
+WHERE
+	%s
+	AND id = @id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"id":         tcda.ID,
+		"active":     tcda.Active,
+		"updated_at": tcda.UpdatedAt,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot update trust center document access: %w", err)
+	}
+
+	return nil
+}
+
+func (tcda *TrustCenterDocumentAccess) Delete(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+DELETE FROM trust_center_document_accesses
+WHERE
+	%s
+	AND id = @id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"id": tcda.ID,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete trust center document access: %w", err)
+	}
+
+	return nil
+}
+
+func (tcdas *TrustCenterDocumentAccesses) CountByTrustCenterAccessID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	trustCenterAccessID gid.GID,
+) (int, error) {
+	q := `
+SELECT
+	COUNT(id)
+FROM
+	trust_center_document_accesses
+WHERE
+	%s
+	AND trust_center_access_id = @trust_center_access_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"trust_center_access_id": trustCenterAccessID,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	row := conn.QueryRow(ctx, q, args)
+
+	var count int
+	if err := row.Scan(&count); err != nil {
+		return 0, fmt.Errorf("cannot scan count: %w", err)
+	}
+
+	return count, nil
+}
+
+func (tcdas *TrustCenterDocumentAccesses) LoadByTrustCenterAccessID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	trustCenterAccessID gid.GID,
+	cursor *page.Cursor[TrustCenterDocumentAccessOrderField],
+) error {
+	q := `
+SELECT
+	id,
+	trust_center_access_id,
+	document_id,
+	report_id,
+	active,
+	created_at,
+	updated_at
+FROM
+	trust_center_document_accesses
+WHERE
+	%s
+	AND trust_center_access_id = @trust_center_access_id
+	AND %s
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"trust_center_access_id": trustCenterAccessID,
+	}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, cursor.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query trust center document accesses: %w", err)
+	}
+
+	accesses, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[TrustCenterDocumentAccess])
+	if err != nil {
+		return fmt.Errorf("cannot collect trust center document accesses: %w", err)
+	}
+
+	*tcdas = accesses
+
+	return nil
+}
+
+func (tcdas *TrustCenterDocumentAccesses) LoadAllByTrustCenterAccessID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	trustCenterAccessID gid.GID,
+) error {
+	q := `
+SELECT
+	id,
+	trust_center_access_id,
+	document_id,
+	report_id,
+	active,
+	created_at,
+	updated_at
+FROM
+	trust_center_document_accesses
+WHERE
+	%s
+	AND trust_center_access_id = @trust_center_access_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"trust_center_access_id": trustCenterAccessID,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query trust center document accesses: %w", err)
+	}
+
+	accesses, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[TrustCenterDocumentAccess])
+	if err != nil {
+		return fmt.Errorf("cannot collect trust center document accesses: %w", err)
+	}
+
+	*tcdas = accesses
+
+	return nil
+}
+
+func DeactivateByTrustCenterAccessID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	trustCenterAccessID gid.GID,
+	updatedAt time.Time,
+) error {
+	q := `
+UPDATE trust_center_document_accesses
+SET active = false, updated_at = @updated_at
+WHERE
+	%s
+	AND trust_center_access_id = @trust_center_access_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"trust_center_access_id": trustCenterAccessID,
+		"updated_at":             updatedAt,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot deactivate trust center document accesses: %w", err)
+	}
+
+	return nil
+}
+
+func ActivateByDocumentIDs(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	trustCenterAccessID gid.GID,
+	documentIDs []gid.GID,
+	updatedAt time.Time,
+) error {
+	if len(documentIDs) == 0 {
+		return nil
+	}
+
+	q := `
+UPDATE trust_center_document_accesses
+SET active = true, updated_at = @updated_at
+WHERE
+	%s
+	AND trust_center_access_id = @trust_center_access_id
+	AND document_id = ANY(@document_ids)
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"trust_center_access_id": trustCenterAccessID,
+		"document_ids":           documentIDs,
+		"updated_at":             updatedAt,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot activate trust center document accesses by document IDs: %w", err)
+	}
+
+	return nil
+}
+
+func ActivateByReportIDs(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	trustCenterAccessID gid.GID,
+	reportIDs []gid.GID,
+	updatedAt time.Time,
+) error {
+	if len(reportIDs) == 0 {
+		return nil
+	}
+
+	q := `
+UPDATE trust_center_document_accesses
+SET active = true, updated_at = @updated_at
+WHERE
+	%s
+	AND trust_center_access_id = @trust_center_access_id
+	AND report_id = ANY(@report_ids)
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"trust_center_access_id": trustCenterAccessID,
+		"report_ids":             reportIDs,
+		"updated_at":             updatedAt,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot activate trust center document accesses by report IDs: %w", err)
+	}
+
+	return nil
+}
+
+func (tcdas TrustCenterDocumentAccesses) BulkInsertDocumentAccesses(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	trustCenterAccessID gid.GID,
+	documentIDs []gid.GID,
+	createdAt time.Time,
+) error {
+	if len(documentIDs) == 0 {
+		return nil
+	}
+
+	q := `
+WITH document_access_data AS (
+	SELECT
+		generate_gid(decode_base64_unpadded(@tenant_id), @trust_center_document_access_entity_type) AS id,
+		@tenant_id AS tenant_id,
+		@trust_center_access_id AS trust_center_access_id,
+		unnest(@document_ids::text[]) AS document_id,
+		null::text AS report_id,
+		false AS active,
+		@created_at::timestamptz AS created_at,
+		@updated_at::timestamptz AS updated_at
+)
+INSERT INTO trust_center_document_accesses (
+	id, tenant_id, trust_center_access_id, document_id, report_id, active, created_at, updated_at
+)
+SELECT * FROM document_access_data
+`
+
+	args := pgx.StrictNamedArgs{
+		"tenant_id":              scope.GetTenantID(),
+		"trust_center_access_id": trustCenterAccessID,
+		"document_ids":           documentIDs,
+		"trust_center_document_access_entity_type": TrustCenterDocumentAccessEntityType,
+		"created_at": createdAt,
+		"updated_at": createdAt,
+	}
+
+	if _, err := conn.Exec(ctx, q, args); err != nil {
+		return fmt.Errorf("cannot bulk insert trust center document accesses: %w", err)
+	}
+
+	return nil
+}
+
+func (tcdas TrustCenterDocumentAccesses) BulkInsertReportAccesses(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	trustCenterAccessID gid.GID,
+	reportIDs []gid.GID,
+	createdAt time.Time,
+) error {
+	if len(reportIDs) == 0 {
+		return nil
+	}
+
+	q := `
+WITH report_access_data AS (
+	SELECT
+		generate_gid(decode_base64_unpadded(@tenant_id), @trust_center_document_access_entity_type) AS id,
+		@tenant_id AS tenant_id,
+		@trust_center_access_id AS trust_center_access_id,
+		null::text AS document_id,
+		unnest(@report_ids::text[]) AS report_id,
+		false AS active,
+		@created_at::timestamptz AS created_at,
+		@updated_at::timestamptz AS updated_at
+)
+INSERT INTO trust_center_document_accesses (
+	id, tenant_id, trust_center_access_id, document_id, report_id, active, created_at, updated_at
+)
+SELECT * FROM report_access_data
+`
+
+	args := pgx.StrictNamedArgs{
+		"tenant_id": scope.GetTenantID(),
+		"trust_center_document_access_entity_type": TrustCenterDocumentAccessEntityType,
+		"trust_center_access_id":                   trustCenterAccessID,
+		"report_ids":                               reportIDs,
+		"created_at":                               createdAt,
+		"updated_at":                               createdAt,
+	}
+
+	if _, err := conn.Exec(ctx, q, args); err != nil {
+		return fmt.Errorf("cannot bulk insert trust center report accesses: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/trust_center_document_access_order_field.go
+++ b/pkg/coredata/trust_center_document_access_order_field.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"fmt"
+)
+
+type TrustCenterDocumentAccessOrderField string
+
+const (
+	TrustCenterDocumentAccessOrderFieldCreatedAt TrustCenterDocumentAccessOrderField = "CREATED_AT"
+)
+
+func (tcdaof TrustCenterDocumentAccessOrderField) Column() string {
+	return string(tcdaof)
+}
+
+func (tcdaof TrustCenterDocumentAccessOrderField) String() string {
+	return string(tcdaof)
+}
+
+func (tcdaof TrustCenterDocumentAccessOrderField) MarshalText() ([]byte, error) {
+	return []byte(tcdaof.String()), nil
+}
+
+func (tcdaof *TrustCenterDocumentAccessOrderField) UnmarshalText(text []byte) error {
+	val := string(text)
+	switch val {
+	case string(TrustCenterDocumentAccessOrderFieldCreatedAt):
+		*tcdaof = TrustCenterDocumentAccessOrderField(val)
+		return nil
+	}
+	return fmt.Errorf("invalid TrustCenterDocumentAccessOrderField value: %q", val)
+}

--- a/pkg/probo/audit_service.go
+++ b/pkg/probo/audit_service.go
@@ -83,6 +83,26 @@ func (s AuditService) Get(
 	return audit, nil
 }
 
+func (s AuditService) GetByReportID(
+	ctx context.Context,
+	reportID gid.GID,
+) (*coredata.Audit, error) {
+	audit := &coredata.Audit{}
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			return audit.LoadByReportID(ctx, conn, s.svc.scope, reportID)
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return audit, nil
+}
+
 func (s *AuditService) Create(
 	ctx context.Context,
 	req *CreateAuditRequest,

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -1103,6 +1103,14 @@ enum TrustCenterAccessOrderField
     )
 }
 
+enum TrustCenterDocumentAccessOrderField
+  @goModel(model: "github.com/getprobo/probo/pkg/coredata.TrustCenterDocumentAccessOrderField") {
+  CREATED_AT
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.TrustCenterDocumentAccessOrderFieldCreatedAt"
+    )
+}
+
 enum TrustCenterReferenceOrderField
   @goModel(model: "github.com/getprobo/probo/pkg/coredata.TrustCenterReferenceOrderField") {
   NAME
@@ -1290,6 +1298,14 @@ input TrustCenterAccessOrder
   ) {
   direction: OrderDirection!
   field: TrustCenterAccessOrderField!
+}
+
+input TrustCenterDocumentAccessOrder
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.TrustCenterDocumentAccessOrderBy"
+  ) {
+  direction: OrderDirection!
+  field: TrustCenterDocumentAccessOrderField!
 }
 
 input TrustCenterReferenceOrder
@@ -2143,6 +2159,7 @@ type Report implements Node {
   downloadUrl: String @goField(forceResolver: true)
   createdAt: Datetime!
   updatedAt: Datetime!
+  audit: Audit @goField(forceResolver: true)
 }
 
 type Session {
@@ -2193,6 +2210,38 @@ type TrustCenterAccess implements Node {
   hasAcceptedNonDisclosureAgreement: Boolean!
   createdAt: Datetime!
   updatedAt: Datetime!
+
+  documentAccesses(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+    orderBy: TrustCenterDocumentAccessOrder
+  ): TrustCenterDocumentAccessConnection! @goField(forceResolver: true)
+}
+
+type TrustCenterDocumentAccess implements Node {
+  id: ID!
+  active: Boolean!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+  trustCenterAccess: TrustCenterAccess! @goField(forceResolver: true)
+  document: Document @goField(forceResolver: true)
+  report: Report @goField(forceResolver: true)
+}
+
+type TrustCenterDocumentAccessConnection
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.TrustCenterDocumentAccessConnection"
+  ) {
+  totalCount: Int! @goField(forceResolver: true)
+  edges: [TrustCenterDocumentAccessEdge!]!
+  pageInfo: PageInfo!
+}
+
+type TrustCenterDocumentAccessEdge {
+  cursor: CursorKey!
+  node: TrustCenterDocumentAccess!
 }
 
 type TrustCenterAccessConnection {
@@ -2887,6 +2936,8 @@ input UpdateTrustCenterAccessInput {
   id: ID!
   name: String
   active: Boolean
+  documentIds: [ID!]
+  reportIds: [ID!]
 }
 
 input DeleteTrustCenterAccessInput {

--- a/pkg/server/api/console/v1/types/trust_center_document_access.go
+++ b/pkg/server/api/console/v1/types/trust_center_document_access.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package types
+
+import (
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+)
+
+type (
+	TrustCenterDocumentAccessOrderBy = OrderBy[coredata.TrustCenterDocumentAccessOrderField]
+
+	TrustCenterDocumentAccessConnection struct {
+		TotalCount int
+		Edges      []*TrustCenterDocumentAccessEdge
+		PageInfo   PageInfo
+
+		Resolver any
+		ParentID gid.GID
+	}
+)
+
+func NewTrustCenterDocumentAccess(tcda *coredata.TrustCenterDocumentAccess) *TrustCenterDocumentAccess {
+	return &TrustCenterDocumentAccess{
+		ID:        tcda.ID,
+		Active:    tcda.Active,
+		CreatedAt: tcda.CreatedAt,
+		UpdatedAt: tcda.UpdatedAt,
+	}
+}
+
+func NewTrustCenterDocumentAccessConnection(
+	p *page.Page[*coredata.TrustCenterDocumentAccess, coredata.TrustCenterDocumentAccessOrderField],
+	parentType any,
+	parentID gid.GID,
+) *TrustCenterDocumentAccessConnection {
+	var edges = make([]*TrustCenterDocumentAccessEdge, len(p.Data))
+
+	for i := range edges {
+		edges[i] = NewTrustCenterDocumentAccessEdge(p.Data[i], p.Cursor.OrderBy.Field)
+	}
+
+	return &TrustCenterDocumentAccessConnection{
+		Edges:    edges,
+		PageInfo: *NewPageInfo(p),
+
+		Resolver: parentType,
+		ParentID: parentID,
+	}
+}
+
+func NewTrustCenterDocumentAccessEdges(accesses []*coredata.TrustCenterDocumentAccess, orderBy coredata.TrustCenterDocumentAccessOrderField) []*TrustCenterDocumentAccessEdge {
+	edges := make([]*TrustCenterDocumentAccessEdge, len(accesses))
+
+	for i := range edges {
+		edges[i] = NewTrustCenterDocumentAccessEdge(accesses[i], orderBy)
+	}
+
+	return edges
+}
+
+func NewTrustCenterDocumentAccessEdge(access *coredata.TrustCenterDocumentAccess, orderBy coredata.TrustCenterDocumentAccessOrderField) *TrustCenterDocumentAccessEdge {
+	return &TrustCenterDocumentAccessEdge{
+		Cursor: access.CursorKey(orderBy),
+		Node:   NewTrustCenterDocumentAccess(access),
+	}
+}

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -1388,6 +1388,7 @@ type Report struct {
 	DownloadURL *string   `json:"downloadUrl,omitempty"`
 	CreatedAt   time.Time `json:"createdAt"`
 	UpdatedAt   time.Time `json:"updatedAt"`
+	Audit       *Audit    `json:"audit,omitempty"`
 }
 
 func (Report) IsNode()             {}
@@ -1521,13 +1522,14 @@ func (TrustCenter) IsNode()             {}
 func (this TrustCenter) GetID() gid.GID { return this.ID }
 
 type TrustCenterAccess struct {
-	ID                                gid.GID   `json:"id"`
-	Email                             string    `json:"email"`
-	Name                              string    `json:"name"`
-	Active                            bool      `json:"active"`
-	HasAcceptedNonDisclosureAgreement bool      `json:"hasAcceptedNonDisclosureAgreement"`
-	CreatedAt                         time.Time `json:"createdAt"`
-	UpdatedAt                         time.Time `json:"updatedAt"`
+	ID                                gid.GID                              `json:"id"`
+	Email                             string                               `json:"email"`
+	Name                              string                               `json:"name"`
+	Active                            bool                                 `json:"active"`
+	HasAcceptedNonDisclosureAgreement bool                                 `json:"hasAcceptedNonDisclosureAgreement"`
+	CreatedAt                         time.Time                            `json:"createdAt"`
+	UpdatedAt                         time.Time                            `json:"updatedAt"`
+	DocumentAccesses                  *TrustCenterDocumentAccessConnection `json:"documentAccesses"`
 }
 
 func (TrustCenterAccess) IsNode()             {}
@@ -1546,6 +1548,24 @@ type TrustCenterAccessEdge struct {
 type TrustCenterConnection struct {
 	Edges    []*TrustCenterEdge `json:"edges"`
 	PageInfo *PageInfo          `json:"pageInfo"`
+}
+
+type TrustCenterDocumentAccess struct {
+	ID                gid.GID            `json:"id"`
+	Active            bool               `json:"active"`
+	CreatedAt         time.Time          `json:"createdAt"`
+	UpdatedAt         time.Time          `json:"updatedAt"`
+	TrustCenterAccess *TrustCenterAccess `json:"trustCenterAccess"`
+	Document          *Document          `json:"document,omitempty"`
+	Report            *Report            `json:"report,omitempty"`
+}
+
+func (TrustCenterDocumentAccess) IsNode()             {}
+func (this TrustCenterDocumentAccess) GetID() gid.GID { return this.ID }
+
+type TrustCenterDocumentAccessEdge struct {
+	Cursor page.CursorKey             `json:"cursor"`
+	Node   *TrustCenterDocumentAccess `json:"node"`
 }
 
 type TrustCenterEdge struct {
@@ -1810,9 +1830,11 @@ type UpdateTaskPayload struct {
 }
 
 type UpdateTrustCenterAccessInput struct {
-	ID     gid.GID `json:"id"`
-	Name   *string `json:"name,omitempty"`
-	Active *bool   `json:"active,omitempty"`
+	ID          gid.GID   `json:"id"`
+	Name        *string   `json:"name,omitempty"`
+	Active      *bool     `json:"active,omitempty"`
+	DocumentIds []gid.GID `json:"documentIds,omitempty"`
+	ReportIds   []gid.GID `json:"reportIds,omitempty"`
 }
 
 type UpdateTrustCenterAccessPayload struct {

--- a/pkg/server/api/trust/v1/schema.graphql
+++ b/pkg/server/api/trust/v1/schema.graphql
@@ -57,6 +57,8 @@ type Document implements Node {
   id: ID!
   title: String!
   documentType: DocumentType!
+  isUserAuthorized: Boolean! @goField(forceResolver: true)
+  hasUserRequestedAccess: Boolean! @goField(forceResolver: true)
 }
 
 type DocumentConnection {
@@ -78,6 +80,8 @@ type Framework implements Node {
 type Report implements Node {
   id: ID!
   filename: String!
+  isUserAuthorized: Boolean! @goField(forceResolver: true)
+  hasUserRequestedAccess: Boolean! @goField(forceResolver: true)
 }
 
 type Audit implements Node {
@@ -517,13 +521,13 @@ type TrustCenterAccess implements Node {
   updatedAt: Datetime!
 }
 
-input CreateTrustCenterAccessInput {
+input RequestAllAccessesInput {
   trustCenterId: ID!
-  email: String!
-  name: String!
+  email: String
+  name: String
 }
 
-type CreateTrustCenterAccessPayload {
+type RequestAccessesPayload {
   trustCenterAccess: TrustCenterAccess!
 }
 
@@ -539,6 +543,20 @@ input AcceptNonDisclosureAgreementInput {
   trustCenterId: ID!
 }
 
+input RequestDocumentAccessInput {
+  trustCenterId: ID!
+  documentId: ID!
+  email: String
+  name: String
+}
+
+input RequestReportAccessInput {
+  trustCenterId: ID!
+  reportId: ID!
+  email: String
+  name: String
+}
+
 type ExportDocumentPDFPayload {
   data: String!
 }
@@ -547,7 +565,7 @@ type ExportReportPDFPayload {
   data: String!
 }
 
-type  AcceptNonDisclosureAgreementPayload{
+type AcceptNonDisclosureAgreementPayload {
   success: Boolean!
 }
 
@@ -557,9 +575,9 @@ type Query {
 }
 
 type Mutation {
-  createTrustCenterAccess(
-    input: CreateTrustCenterAccessInput!
-  ): CreateTrustCenterAccessPayload! @mustBeAuthenticated(role: NONE)
+  requestAllAccesses(
+    input: RequestAllAccessesInput!
+  ): RequestAccessesPayload! @mustBeAuthenticated(role: NONE)
 
   exportDocumentPDF(
     input: ExportDocumentPDFInput!
@@ -572,4 +590,12 @@ type Mutation {
   acceptNonDisclosureAgreement(
     input: AcceptNonDisclosureAgreementInput!
   ): AcceptNonDisclosureAgreementPayload! @mustBeAuthenticated(role: USER)
+
+  requestDocumentAccess(
+    input: RequestDocumentAccessInput!
+  ): RequestAccessesPayload! @mustBeAuthenticated(role: NONE)
+
+  requestReportAccess(
+    input: RequestReportAccessInput!
+  ): RequestAccessesPayload! @mustBeAuthenticated(role: NONE)
 }

--- a/pkg/server/api/trust/v1/types/types.go
+++ b/pkg/server/api/trust/v1/types/types.go
@@ -46,20 +46,12 @@ type AuditEdge struct {
 	Node   *Audit         `json:"node"`
 }
 
-type CreateTrustCenterAccessInput struct {
-	TrustCenterID gid.GID `json:"trustCenterId"`
-	Email         string  `json:"email"`
-	Name          string  `json:"name"`
-}
-
-type CreateTrustCenterAccessPayload struct {
-	TrustCenterAccess *TrustCenterAccess `json:"trustCenterAccess"`
-}
-
 type Document struct {
-	ID           gid.GID               `json:"id"`
-	Title        string                `json:"title"`
-	DocumentType coredata.DocumentType `json:"documentType"`
+	ID                     gid.GID               `json:"id"`
+	Title                  string                `json:"title"`
+	DocumentType           coredata.DocumentType `json:"documentType"`
+	IsUserAuthorized       bool                  `json:"isUserAuthorized"`
+	HasUserRequestedAccess bool                  `json:"hasUserRequestedAccess"`
 }
 
 func (Document) IsNode()             {}
@@ -126,12 +118,38 @@ type Query struct {
 }
 
 type Report struct {
-	ID       gid.GID `json:"id"`
-	Filename string  `json:"filename"`
+	ID                     gid.GID `json:"id"`
+	Filename               string  `json:"filename"`
+	IsUserAuthorized       bool    `json:"isUserAuthorized"`
+	HasUserRequestedAccess bool    `json:"hasUserRequestedAccess"`
 }
 
 func (Report) IsNode()             {}
 func (this Report) GetID() gid.GID { return this.ID }
+
+type RequestAccessesPayload struct {
+	TrustCenterAccess *TrustCenterAccess `json:"trustCenterAccess"`
+}
+
+type RequestAllAccessesInput struct {
+	TrustCenterID gid.GID `json:"trustCenterId"`
+	Email         *string `json:"email,omitempty"`
+	Name          *string `json:"name,omitempty"`
+}
+
+type RequestDocumentAccessInput struct {
+	TrustCenterID gid.GID `json:"trustCenterId"`
+	DocumentID    gid.GID `json:"documentId"`
+	Email         *string `json:"email,omitempty"`
+	Name          *string `json:"name,omitempty"`
+}
+
+type RequestReportAccessInput struct {
+	TrustCenterID gid.GID `json:"trustCenterId"`
+	ReportID      gid.GID `json:"reportId"`
+	Email         *string `json:"email,omitempty"`
+	Name          *string `json:"name,omitempty"`
+}
 
 type TrustCenter struct {
 	ID                                gid.GID                         `json:"id"`

--- a/pkg/trust/trust_center_access_service.go
+++ b/pkg/trust/trust_center_access_service.go
@@ -34,10 +34,12 @@ type (
 		usrmgr *usrmgr.Service
 	}
 
-	CreateTrustCenterAccessRequest struct {
+	RequestTrustCenterAccessRequest struct {
 		TrustCenterID gid.GID
 		Email         string
-		Name          string
+		Name          *string
+		DocumentIDs   []gid.GID
+		ReportIDs     []gid.GID
 	}
 )
 
@@ -65,55 +67,107 @@ func (s TrustCenterAccessService) ValidateToken(
 	})
 }
 
-func (s TrustCenterAccessService) Create(
+func (s TrustCenterAccessService) Request(
 	ctx context.Context,
-	req *CreateTrustCenterAccessRequest,
+	req *RequestTrustCenterAccessRequest,
 ) (*coredata.TrustCenterAccess, error) {
-	if _, err := mail.ParseAddress(req.Email); err != nil {
-		return nil, fmt.Errorf("invalid email address")
-	}
-
-	if req.Name == "" {
-		return nil, fmt.Errorf("name is required")
-	}
-
 	now := time.Now()
 
 	var access *coredata.TrustCenterAccess
 
 	err := s.svc.pg.WithTx(ctx, func(tx pg.Conn) error {
+		var trustCenter *coredata.TrustCenter
+		var organizationID gid.GID
+		trustCenter = &coredata.TrustCenter{}
+		if err := trustCenter.LoadByID(ctx, tx, s.svc.scope, req.TrustCenterID); err != nil {
+			return fmt.Errorf("cannot load trust center: %w", err)
+		}
+		organizationID = trustCenter.OrganizationID
+
+		documentIDs := req.DocumentIDs
+		if req.DocumentIDs == nil {
+			var allDocuments coredata.Documents
+			filter := coredata.NewDocumentTrustCenterFilter()
+
+			if err := allDocuments.LoadAllByOrganizationID(ctx, tx, s.svc.scope, organizationID, filter); err != nil {
+				return fmt.Errorf("cannot list documents: %w", err)
+			}
+
+			for _, doc := range allDocuments {
+				documentIDs = append(documentIDs, doc.ID)
+			}
+		}
+
+		reportIDs := req.ReportIDs
+		if req.ReportIDs == nil {
+			var allAudits coredata.Audits
+			auditFilter := coredata.NewAuditTrustCenterFilter()
+
+			if err := allAudits.LoadAllByOrganizationID(ctx, tx, s.svc.scope, organizationID, auditFilter); err != nil {
+				return fmt.Errorf("cannot list audits: %w", err)
+			}
+
+			for _, audit := range allAudits {
+				if audit.ReportID != nil {
+					reportIDs = append(reportIDs, *audit.ReportID)
+				}
+			}
+		}
 		existingAccess := &coredata.TrustCenterAccess{}
 		err := existingAccess.LoadByTrustCenterIDAndEmail(ctx, tx, s.svc.scope, req.TrustCenterID, req.Email)
 
 		if err == nil {
-			if existingAccess.Active {
-				return fmt.Errorf("active trust center access already exists for this email")
-			}
-			if err := existingAccess.Delete(ctx, tx, s.svc.scope); err != nil {
-				return fmt.Errorf("cannot delete existing trust center access: %w", err)
-			}
+			access = existingAccess
 		} else {
 			var notFoundErr *coredata.ErrTrustCenterAccessNotFound
 			if !errors.As(err, &notFoundErr) {
 				return fmt.Errorf("cannot load trust center access: %w", err)
 			}
+
+			if req.Name == nil || *req.Name == "" {
+				return fmt.Errorf("name is required for new access requests")
+			}
+
+			if _, err := mail.ParseAddress(req.Email); err != nil {
+				return fmt.Errorf("invalid email address")
+			}
+
+			access = &coredata.TrustCenterAccess{
+				ID:                                gid.New(s.svc.scope.GetTenantID(), coredata.TrustCenterAccessEntityType),
+				TenantID:                          s.svc.scope.GetTenantID(),
+				TrustCenterID:                     req.TrustCenterID,
+				Email:                             req.Email,
+				Name:                              *req.Name,
+				Active:                            false,
+				HasAcceptedNonDisclosureAgreement: false,
+				CreatedAt:                         now,
+				UpdatedAt:                         now,
+			}
+
+			if err := access.Insert(ctx, tx, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot insert trust center access: %w", err)
+			}
 		}
 
-		access = &coredata.TrustCenterAccess{
-			ID:                                gid.New(s.svc.scope.GetTenantID(), coredata.TrustCenterAccessEntityType),
-			TenantID:                          s.svc.scope.GetTenantID(),
-			TrustCenterID:                     req.TrustCenterID,
-			Email:                             req.Email,
-			Name:                              req.Name,
-			Active:                            false,
-			HasAcceptedNonDisclosureAgreement: false,
-			CreatedAt:                         now,
-			UpdatedAt:                         now,
+		var existingAccesses coredata.TrustCenterDocumentAccesses
+		if err := existingAccesses.LoadAllByTrustCenterAccessID(ctx, tx, s.svc.scope, access.ID); err != nil {
+			return fmt.Errorf("cannot load existing access records: %w", err)
 		}
 
-		if err := access.Insert(ctx, tx, s.svc.scope); err != nil {
-			return fmt.Errorf("cannot insert trust center access: %w", err)
+		existingDocumentIDs, existingReportIDs := extractExistingIDs(existingAccesses)
+		newDocumentIDs := filterExistingIDs(documentIDs, existingDocumentIDs)
+		newReportIDs := filterExistingIDs(reportIDs, existingReportIDs)
+
+		var accesses coredata.TrustCenterDocumentAccesses
+
+		if err := accesses.BulkInsertDocumentAccesses(ctx, tx, s.svc.scope, access.ID, newDocumentIDs, now); err != nil {
+			return fmt.Errorf("cannot bulk insert trust center document accesses: %w", err)
 		}
+
+		if err := accesses.BulkInsertReportAccesses(ctx, tx, s.svc.scope, access.ID, newReportIDs, now); err != nil {
+			return fmt.Errorf("cannot bulk insert trust center report accesses: %w", err)
+		}
+
 		return nil
 	})
 
@@ -167,4 +221,106 @@ func (s TrustCenterAccessService) AcceptNonDisclosureAgreement(ctx context.Conte
 
 		return nil
 	})
+}
+
+func (s TrustCenterAccessService) LoadDocumentAccess(
+	ctx context.Context,
+	trustCenterID gid.GID,
+	email string,
+	documentID gid.GID,
+) (*coredata.TrustCenterDocumentAccess, error) {
+	var documentAccess *coredata.TrustCenterDocumentAccess
+
+	err := s.svc.pg.WithConn(ctx, func(conn pg.Conn) error {
+		access := &coredata.TrustCenterAccess{}
+		err := access.LoadByTrustCenterIDAndEmail(ctx, conn, s.svc.scope, trustCenterID, email)
+		if err != nil {
+			return fmt.Errorf("cannot load trust center access: %w", err)
+		}
+
+		if !access.Active {
+			return fmt.Errorf("trust center access is not active")
+		}
+
+		documentAccess = &coredata.TrustCenterDocumentAccess{}
+		err = documentAccess.LoadByTrustCenterAccessIDAndDocumentID(ctx, conn, s.svc.scope, access.ID, documentID)
+		if err != nil {
+			return fmt.Errorf("cannot load document access: %w", err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return documentAccess, nil
+}
+
+func (s TrustCenterAccessService) LoadReportAccess(
+	ctx context.Context,
+	trustCenterID gid.GID,
+	email string,
+	reportID gid.GID,
+) (*coredata.TrustCenterDocumentAccess, error) {
+	var reportAccess *coredata.TrustCenterDocumentAccess
+
+	err := s.svc.pg.WithConn(ctx, func(conn pg.Conn) error {
+		access := &coredata.TrustCenterAccess{}
+		err := access.LoadByTrustCenterIDAndEmail(ctx, conn, s.svc.scope, trustCenterID, email)
+		if err != nil {
+			return fmt.Errorf("cannot load trust center access: %w", err)
+		}
+
+		if !access.Active {
+			return fmt.Errorf("trust center access is not active")
+		}
+
+		reportAccess = &coredata.TrustCenterDocumentAccess{}
+		err = reportAccess.LoadByTrustCenterAccessIDAndReportID(ctx, conn, s.svc.scope, access.ID, reportID)
+		if err != nil {
+			return fmt.Errorf("cannot load report access: %w", err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return reportAccess, nil
+}
+
+func extractExistingIDs(accesses coredata.TrustCenterDocumentAccesses) ([]gid.GID, []gid.GID) {
+	var documentIDs []gid.GID
+	var reportIDs []gid.GID
+
+	for _, access := range accesses {
+		if access.DocumentID != nil {
+			documentIDs = append(documentIDs, *access.DocumentID)
+		}
+		if access.ReportID != nil {
+			reportIDs = append(reportIDs, *access.ReportID)
+		}
+	}
+
+	return documentIDs, reportIDs
+}
+
+func filterExistingIDs(allIDs []gid.GID, existingIDs []gid.GID) []gid.GID {
+	existingMap := make(map[gid.GID]bool)
+	for _, id := range existingIDs {
+		existingMap[id] = true
+	}
+
+	var newIDs []gid.GID
+	for _, id := range allIDs {
+		if !existingMap[id] {
+			newIDs = append(newIDs, id)
+		}
+	}
+
+	return newIDs
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds granular access control to the Trust Center so admins can grant or revoke access per document and per audit report, and users can request access individually or request all. The public Trust Center now shows “Download”, “Access Requested”, or a request dialog based on authorization.

- **New Features**
  - New trust_center_document_accesses table and model to track per-document/report access.
  - Console: Trust Center Access tab lists document/report accesses and lets admins toggle status via a new mutation.
  - Public Trust Center: users can request access to a specific document or report, or request all; UI reflects isUserAuthorized and hasUserRequestedAccess.
  - GraphQL: added documentAccesses to TrustCenterAccess, authorization flags on Document/Report, and mutations to update access and request accesses.

- **Migration**
  - Run migration 20250924T111957Z to create trust_center_document_accesses.
  - Trust API: replace CreateTrustCenterAccess with RequestAllAccesses (payload: RequestAccessesPayload). Update clients accordingly.

<!-- End of auto-generated description by cubic. -->

