### PR TITLE
Draft new auth model

### DIFF
--- a/pkg/authz/invitation.txt.tmpl
+++ b/pkg/authz/invitation.txt.tmpl
@@ -1,0 +1,10 @@
+Hi {{.FullName}},
+
+You have been invited to join organization {{.OrganizationName}}. Please click the link below to accept the invitation:
+
+{{.InvitationURL}}
+
+If you don't want to accept the invitation, you can ignore this email.
+
+Thanks,
+Probo Team

--- a/pkg/authz/service.go
+++ b/pkg/authz/service.go
@@ -1,0 +1,438 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package authz
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"html/template"
+	"time"
+
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+	"github.com/getprobo/probo/pkg/statelesstoken"
+	"go.gearno.de/kit/pg"
+)
+
+type (
+	// Service handles all authorization logic including organization
+	// membership and permissions. This service is completely independent
+	// of authentication methods.
+	Service struct {
+		pg                      *pg.Client
+		hostname                string
+		tokenSecret             string
+		invitationTokenValidity time.Duration
+	}
+
+	// Role represents a user's role within an organization
+	Role string
+)
+
+// Role constants
+const (
+	RoleOwner  Role = "owner"
+	RoleAdmin  Role = "admin"
+	RoleMember Role = "member"
+	RoleViewer Role = "viewer"
+)
+
+// Token types
+const (
+	TokenTypeOrganizationInvitation = "organization_invitation"
+)
+
+var (
+	// go:embed invitation.txt.tmpl
+	invitationEmailBodyData string
+
+	invitationEmailBodyTemplate = template.Must(template.New("invitation").Parse(invitationEmailBodyData))
+)
+
+// NewService creates a new authorization service
+func NewService(
+	ctx context.Context,
+	pgClient *pg.Client,
+	hostname string,
+	tokenSecret string,
+	invitationTokenValidity time.Duration,
+) (*Service, error) {
+	return &Service{
+		pg:                      pgClient,
+		hostname:                hostname,
+		tokenSecret:             tokenSecret,
+		invitationTokenValidity: invitationTokenValidity,
+	}, nil
+}
+
+// GetUserOrganizations returns all organizations a user has access to
+func (s *Service) GetUserOrganizations(
+	ctx context.Context,
+	userID gid.GID,
+) ([]*coredata.OrganizationMembership, error) {
+	var memberships coredata.OrganizationMemberships
+
+	err := s.pg.WithConn(ctx, func(conn pg.Conn) error {
+		if err := memberships.LoadByUserID(ctx, conn, userID); err != nil {
+			return fmt.Errorf("failed to load user organizations: %w", err)
+		}
+
+		return nil
+	})
+
+	return memberships, err
+}
+
+// GetOrganizationMembers returns all members of an organization
+func (s *Service) GetOrganizationMembers(
+	ctx context.Context,
+	orgID gid.GID,
+	cursor *page.Cursor[coredata.MembershipOrderField],
+) (*page.Page[*coredata.User, coredata.UserOrderField], error) {
+	var memberships coredata.OrganizationMemberships
+
+	err := s.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			if err := memberships.LoadByOrganizationID(ctx, conn, orgID, cursor); err != nil {
+				return fmt.Errorf("failed to load organization members: %w", err)
+			}
+
+			userIDs := make([]*gid.GID, len(memberships))
+			for i := range users {
+				userIDs[i] = &memberships[i].UserID
+			}
+
+			users := coredata.Users{}
+			if err := users.LoadByIDs(ctx, conn, userIDs); err != nil {
+				return fmt.Errorf("failed to load users: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return page.NewPage(memberships, cursor), nil
+}
+
+// CanUserAccessOrganization checks if a user can access an organization
+func (s *Service) CanUserAccessOrganization(
+	ctx context.Context,
+	userID gid.GID,
+	orgID gid.GID,
+) (bool, error) {
+	membership := &coredata.OrganizationMembership{}
+
+	err := s.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			if err := membership.LoadByUserAndOrg(ctx, conn, userID, orgID); err != nil {
+				if _, ok := err.(coredata.ErrMembershipNotFound); ok {
+					return nil // Not an error, just no access
+				}
+				return fmt.Errorf("failed to check organization access: %w", err)
+			}
+			return nil
+		},
+	)
+
+	if err != nil {
+		return false, err
+	}
+
+	// If LoadByUserAndOrg didn't return ErrMembershipNotFound, user has access
+	return membership.UserID != gid.Nil, nil
+}
+
+// GetUserRoleInOrganization returns the user's role in an organization
+func (s *Service) GetUserRoleInOrganization(
+	ctx context.Context,
+	userID gid.GID,
+	orgID gid.GID,
+) (string, error) {
+	membership := &coredata.OrganizationMembership{}
+
+	err := s.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			if err := membership.LoadByUserAndOrg(ctx, conn, userID, orgID); err != nil {
+				return fmt.Errorf("failed to get user role: %w", err)
+			}
+			return nil
+		},
+	)
+
+	if err != nil {
+		return "", err
+	}
+
+	return membership.Role, nil
+}
+
+func (s *Service) RemoveUserFromOrganization(
+	ctx context.Context,
+	orgID gid.GID,
+	userID gid.GID,
+) error {
+	membership := &coredata.OrganizationMembership{}
+
+	return s.pg.WithTx(
+		ctx,
+		func(tx pg.Conn) error {
+			if err := membership.LoadByUserAndOrg(ctx, tx, userID, orgID); err != nil {
+				return fmt.Errorf("failed to load membership: %w", err)
+			}
+
+			if err := membership.Delete(ctx, tx); err != nil {
+				return fmt.Errorf("failed to delete membership: %w", err)
+			}
+
+			return nil
+		},
+	)
+}
+
+// AddUserToOrganization adds a user to an organization with a specific role
+func (s *Service) AddUserToOrganization(
+	ctx context.Context,
+	userID gid.GID,
+	orgID gid.GID,
+	role string,
+) error {
+	membership := &coredata.OrganizationMembership{
+		UserID:         userID,
+		OrganizationID: orgID,
+		Role:           role,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+
+	return s.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			if err := membership.Create(ctx, conn); err != nil {
+				return fmt.Errorf("failed to add user to organization: %w", err)
+			}
+			return nil
+		},
+	)
+}
+
+// UpdateUserRole updates a user's role in an organization
+func (s *Service) UpdateUserRole(
+	ctx context.Context,
+	userID gid.GID,
+	orgID gid.GID,
+	newRole string,
+) error {
+	return s.pg.WithTx(
+		ctx,
+		func(tx pg.Conn) error {
+			membership := &coredata.OrganizationMembership{}
+			if err := membership.LoadByUserAndOrg(ctx, tx, userID, orgID); err != nil {
+				return fmt.Errorf("failed to find membership: %w", err)
+			}
+
+			membership.Role = newRole
+			membership.UpdatedAt = time.Now()
+
+			if err := membership.Update(ctx, tx); err != nil {
+				return fmt.Errorf("failed to update user role: %w", err)
+			}
+
+			return nil
+		},
+	)
+}
+
+// InviteUserToOrganization creates an invitation for a user to join an organization
+func (s *Service) InviteUserToOrganization(
+	ctx context.Context,
+	organizationID gid.GID,
+	emailAddress string,
+	fullName string,
+	role string,
+) (*coredata.Invitation, error) {
+	invitationID := gid.New(organizationID.TenantID(), coredata.InvitationEntityType)
+
+	invitationData := coredata.InvitationData{
+		InvitationID:   invitationID,
+		OrganizationID: organizationID,
+		Email:          emailAddress,
+		FullName:       fullName,
+		Role:           role,
+	}
+
+	invitationToken, err := statelesstoken.NewToken(
+		s.tokenSecret,
+		TokenTypeOrganizationInvitation,
+		s.invitationTokenValidity,
+		invitationData,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate invitation token: %w", err)
+	}
+
+	invitation := &coredata.Invitation{
+		ID:             invitationID,
+		OrganizationID: organizationID,
+		Email:          emailAddress,
+		FullName:       fullName,
+		Role:           role,
+		ExpiresAt:      time.Now().Add(s.invitationTokenValidity),
+		CreatedAt:      time.Now(),
+	}
+
+	body := bytes.NewBuffer(nil)
+	err = invitationEmailBodyTemplate.Execute(
+		body,
+		map[string]string{
+			"FullName":         fullName,
+			"OrganizationName": organizationID.String(),
+			"InvitationURL":    fmt.Sprintf("https://%s/auth/accept-invitation?token=%s", s.hostname, invitationToken),
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute template: %w", err)
+	}
+
+	email := coredata.NewEmail(
+		fullName,
+		emailAddress,
+		"Invitation to join organization",
+		body.String(),
+	)
+
+	err = s.pg.WithTx(
+		ctx,
+		func(conn pg.Conn) error {
+			if err := invitation.Create(ctx, conn); err != nil {
+				return fmt.Errorf("cannot create invitation: %w", err)
+			}
+
+			if err := email.Insert(ctx, conn); err != nil {
+				return fmt.Errorf("cannot insert email: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return invitation, nil
+}
+
+// AcceptInvitation accepts an invitation and adds the user to the organization
+func (s *Service) AcceptInvitation(
+	ctx context.Context,
+	token string,
+	userID gid.GID,
+) error {
+	// Validate and decode the token
+	payload, err := statelesstoken.ValidateToken[coredata.InvitationData](
+		s.tokenSecret,
+		TokenTypeOrganizationInvitation,
+		token,
+	)
+	if err != nil {
+		return fmt.Errorf("invalid invitation token: %w", err)
+	}
+	invitationData := payload.Data
+
+	return s.pg.WithTx(
+		ctx,
+		func(tx pg.Conn) error {
+			// Load invitation from database using ID from token
+			invitation := &coredata.Invitation{}
+			if err := invitation.LoadByID(ctx, tx, invitationData.InvitationID); err != nil {
+				return fmt.Errorf("cannot load invitation: %w", err)
+			}
+
+			// Check if already accepted
+			if invitation.AcceptedAt != nil {
+				return fmt.Errorf("invitation already accepted")
+			}
+
+			// Check if expired
+			if time.Now().After(invitation.ExpiresAt) {
+				return fmt.Errorf("invitation expired")
+			}
+
+			// Add user to organization
+			membership := &coredata.OrganizationMembership{
+				UserID:         userID,
+				OrganizationID: invitation.OrganizationID,
+				Role:           invitation.Role,
+				CreatedAt:      time.Now(),
+				UpdatedAt:      time.Now(),
+			}
+
+			if err := membership.Create(ctx, tx); err != nil {
+				return fmt.Errorf("failed to add user to organization: %w", err)
+			}
+
+			// Mark invitation as accepted
+			now := time.Now()
+			invitation.AcceptedAt = &now
+			if err := invitation.Update(ctx, tx); err != nil {
+				return fmt.Errorf("failed to mark invitation as accepted: %w", err)
+			}
+
+			return nil
+		},
+	)
+}
+
+// HasPermission checks if a user has a specific permission in an organization
+// This is a placeholder for future permission system
+func (s *Service) HasPermission(
+	ctx context.Context,
+	userID gid.GID,
+	orgID gid.GID,
+	resource string,
+	action string,
+) (bool, error) {
+	// For now, just check if user is a member
+	// In the future, this will check specific permissions based on role
+	return s.CanUserAccessOrganization(ctx, userID, orgID)
+}
+
+// ListUserInvitations returns all pending invitations for a user email
+func (s *Service) ListUserInvitations(
+	ctx context.Context,
+	email string,
+) ([]*coredata.Invitation, error) {
+	var invitations coredata.Invitations
+
+	err := s.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			if err := invitations.LoadByEmail(ctx, conn, email); err != nil {
+				return fmt.Errorf("failed to load invitations: %w", err)
+			}
+			return nil
+		},
+	)
+
+	return invitations, err
+}

--- a/pkg/coredata/entity_type_reg.go
+++ b/pkg/coredata/entity_type_reg.go
@@ -50,4 +50,6 @@ const (
 	ContinualImprovementRegistryEntityType
 	ProcessingActivityRegistryEntityType
 	FrameworkExportEntityType
+	InvitationEntityType
+	MembershipEntityType
 )

--- a/pkg/coredata/invitation.go
+++ b/pkg/coredata/invitation.go
@@ -1,0 +1,248 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"time"
+
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+	"github.com/jackc/pgx/v5"
+	"go.gearno.de/kit/pg"
+)
+
+type (
+	// Invitation represents an invitation to join an organization
+	Invitation struct {
+		ID             gid.GID    `db:"id"`
+		OrganizationID gid.GID    `db:"organization_id"`
+		Email          string     `db:"email"`
+		FullName       string     `db:"full_name"`
+		Role           string     `db:"role"`
+		ExpiresAt      time.Time  `db:"expires_at"`
+		AcceptedAt     *time.Time `db:"accepted_at"`
+		CreatedAt      time.Time  `db:"created_at"`
+	}
+
+	// Invitations is a slice of Invitation
+	Invitations []*Invitation
+
+	// InvitationData is the data stored in the invitation token
+	InvitationData struct {
+		InvitationID   gid.GID `json:"invitation_id"`
+		OrganizationID gid.GID `json:"organization_id"`
+		Email          string  `json:"email"`
+		FullName       string  `json:"full_name"`
+		Role           string  `json:"role"`
+	}
+
+	// ErrInvitationNotFound is returned when an invitation is not found
+	ErrInvitationNotFound struct {
+		Token string
+	}
+)
+
+func (e ErrInvitationNotFound) Error() string {
+	return fmt.Sprintf("invitation not found: %s", e.Token)
+}
+
+// CursorKey returns the cursor key for pagination
+func (i Invitation) CursorKey(orderBy InvitationOrderField) page.CursorKey {
+	switch orderBy {
+	case InvitationOrderFieldCreatedAt:
+		return page.NewCursorKey(i.ID, i.CreatedAt)
+	case InvitationOrderFieldExpiresAt:
+		return page.NewCursorKey(i.ID, i.ExpiresAt)
+	}
+
+	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
+}
+
+// Create creates a new invitation
+func (i *Invitation) Create(ctx context.Context, conn pg.Conn) error {
+	query := `
+		INSERT INTO authz_invitations (
+			id, organization_id, email, full_name, role, expires_at, created_at
+		) VALUES (
+			@id, @organization_id, @email, @full_name, @role, @expires_at, @created_at
+		)
+	`
+
+	args := pgx.StrictNamedArgs{
+		"id":              i.ID,
+		"organization_id": i.OrganizationID,
+		"email":           i.Email,
+		"full_name":       i.FullName,
+		"role":            i.Role,
+		"expires_at":      i.ExpiresAt,
+		"created_at":      i.CreatedAt,
+	}
+
+	_, err := conn.Exec(ctx, query, args)
+	if err != nil {
+		return fmt.Errorf("failed to create invitation: %w", err)
+	}
+
+	return nil
+}
+
+// LoadByID loads an invitation by ID
+func (i *Invitation) LoadByID(
+	ctx context.Context,
+	conn pg.Conn,
+	id gid.GID,
+) error {
+	query := `
+		SELECT id, organization_id, email, full_name, role, expires_at, accepted_at, created_at
+		FROM authz_invitations
+		WHERE id = @id
+	`
+
+	args := pgx.StrictNamedArgs{
+		"id": id,
+	}
+
+	rows, err := conn.Query(ctx, query, args)
+	if err != nil {
+		return fmt.Errorf("cannot query invitation: %w", err)
+	}
+
+	invitation, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[Invitation])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrInvitationNotFound{Token: id.String()}
+		}
+		return fmt.Errorf("cannot collect invitation: %w", err)
+	}
+
+	*i = invitation
+	return nil
+}
+
+// Update updates an existing invitation
+func (i *Invitation) Update(ctx context.Context, conn pg.Conn) error {
+	query := `
+		UPDATE authz_invitations
+		SET accepted_at = @accepted_at
+		WHERE id = @id
+	`
+
+	args := pgx.StrictNamedArgs{
+		"id":          i.ID,
+		"accepted_at": i.AcceptedAt,
+	}
+
+	result, err := conn.Exec(ctx, query, args)
+	if err != nil {
+		return fmt.Errorf("failed to update invitation: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return ErrInvitationNotFound{Token: i.ID.String()}
+	}
+
+	return nil
+}
+
+// Delete deletes an invitation
+func (i *Invitation) Delete(ctx context.Context, conn pg.Conn) error {
+	query := `
+		DELETE FROM authz_invitations
+		WHERE id = @id
+	`
+
+	args := pgx.StrictNamedArgs{
+		"id": i.ID,
+	}
+
+	result, err := conn.Exec(ctx, query, args)
+	if err != nil {
+		return fmt.Errorf("failed to delete invitation: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return ErrInvitationNotFound{Token: i.ID.String()}
+	}
+
+	return nil
+}
+
+// LoadByEmail loads all invitations for a specific email
+func (i *Invitations) LoadByEmail(
+	ctx context.Context,
+	conn pg.Conn,
+	email string,
+) error {
+	query := `
+		SELECT id, organization_id, email, full_name, role, expires_at, accepted_at, created_at
+		FROM authz_invitations
+		WHERE email = @email AND accepted_at IS NULL
+		ORDER BY created_at DESC
+	`
+
+	args := pgx.StrictNamedArgs{
+		"email": email,
+	}
+
+	rows, err := conn.Query(ctx, query, args)
+	if err != nil {
+		return fmt.Errorf("cannot query invitations: %w", err)
+	}
+
+	invitations, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[Invitation])
+	if err != nil {
+		return fmt.Errorf("cannot collect invitations: %w", err)
+	}
+
+	*i = invitations
+	return nil
+}
+
+// LoadByOrganizationID loads all invitations for a specific organization with pagination
+func (i *Invitations) LoadByOrganizationID(
+	ctx context.Context,
+	conn pg.Conn,
+	orgID gid.GID,
+	cursor *page.Cursor[InvitationOrderField],
+) error {
+	query := `
+		SELECT id, organization_id, email, full_name, role, expires_at, accepted_at, created_at
+		FROM authz_invitations
+		WHERE organization_id = @organization_id
+		AND %s
+	`
+
+	query = fmt.Sprintf(query, cursor.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": orgID}
+	maps.Copy(args, cursor.SQLArguments())
+
+	rows, err := conn.Query(ctx, query, args)
+	if err != nil {
+		return fmt.Errorf("cannot query invitations: %w", err)
+	}
+
+	invitations, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[Invitation])
+	if err != nil {
+		return fmt.Errorf("cannot collect invitations: %w", err)
+	}
+
+	*i = invitations
+	return nil
+}

--- a/pkg/coredata/invitation_order_field.go
+++ b/pkg/coredata/invitation_order_field.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import "fmt"
+
+// InvitationOrderField defines the fields that can be used to order invitations
+type InvitationOrderField string
+
+// InvitationOrderField constants
+const (
+	InvitationOrderFieldCreatedAt InvitationOrderField = "CREATED_AT"
+	InvitationOrderFieldExpiresAt InvitationOrderField = "EXPIRES_AT"
+)
+
+func (p InvitationOrderField) Column() string {
+	switch p {
+	case InvitationOrderFieldCreatedAt:
+		return "created_at"
+	case InvitationOrderFieldExpiresAt:
+		return "expires_at"
+	}
+
+	panic(fmt.Sprintf("unsupported order by: %s", p))
+}
+
+// IsValid returns true if the order field is valid
+func (e InvitationOrderField) IsValid() bool {
+	switch e {
+	case InvitationOrderFieldCreatedAt, InvitationOrderFieldExpiresAt:
+		return true
+	}
+	return false
+}
+
+func (e InvitationOrderField) String() string {
+	return string(e)
+}
+
+func (e *InvitationOrderField) UnmarshalText(text []byte) error {
+	*e = InvitationOrderField(text)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid InvitationOrderField", string(text))
+	}
+	return nil
+}
+
+func (e InvitationOrderField) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
+}

--- a/pkg/coredata/membership_order_field.go
+++ b/pkg/coredata/membership_order_field.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import "fmt"
+
+// MembershipOrderField defines the fields that can be used to order memberships
+type MembershipOrderField string
+
+// MembershipOrderField constants
+const (
+	MembershipOrderFieldCreatedAt MembershipOrderField = "CREATED_AT"
+	MembershipOrderFieldUpdatedAt MembershipOrderField = "UPDATED_AT"
+)
+
+func (p MembershipOrderField) Column() string {
+	switch p {
+	case MembershipOrderFieldCreatedAt:
+		return "created_at"
+	case MembershipOrderFieldUpdatedAt:
+		return "updated_at"
+	}
+
+	panic(fmt.Sprintf("unsupported order by: %s", p))
+}
+
+// IsValid returns true if the order field is valid
+func (e MembershipOrderField) IsValid() bool {
+	switch e {
+	case MembershipOrderFieldCreatedAt, MembershipOrderFieldUpdatedAt:
+		return true
+	}
+	return false
+}
+
+func (e MembershipOrderField) String() string {
+	return string(e)
+}
+
+func (e *MembershipOrderField) UnmarshalText(text []byte) error {
+	*e = MembershipOrderField(text)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid MembershipOrderField", string(text))
+	}
+	return nil
+}
+
+func (e MembershipOrderField) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
+}

--- a/pkg/coredata/migrations/20250907T232022Z.sql
+++ b/pkg/coredata/migrations/20250907T232022Z.sql
@@ -1,0 +1,38 @@
+-- Create authorization tables for the new authz service
+-- This migration creates the new authz tables while keeping the existing users_organizations table
+-- for backward compatibility during the transition
+
+-- Create role enum
+CREATE TYPE authz_role AS ENUM ('owner', 'admin', 'member', 'viewer');
+
+-- Create authz_memberships table (replaces users_organizations)
+CREATE TABLE authz_memberships (
+    user_id TEXT NOT NULL,
+    organization_id TEXT NOT NULL,
+    role authz_role NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    PRIMARY KEY (user_id, organization_id)
+);
+
+-- Create authz_invitations table
+CREATE TABLE authz_invitations (
+    id TEXT PRIMARY KEY,
+    organization_id TEXT NOT NULL,
+    email TEXT NOT NULL,
+    full_name TEXT NOT NULL,
+    role authz_role NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    accepted_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL
+);
+
+-- Copy data from users_organizations to authz_memberships
+INSERT INTO authz_memberships (user_id, organization_id, role, created_at, updated_at)
+SELECT 
+    user_id, 
+    organization_id, 
+    'member'::authz_role as role,  -- Default role for existing memberships
+    created_at,
+    created_at as updated_at
+FROM users_organizations;

--- a/pkg/coredata/organization_membership.go
+++ b/pkg/coredata/organization_membership.go
@@ -1,0 +1,265 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"time"
+
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"go.gearno.de/kit/pg"
+)
+
+type (
+	// OrganizationMembership represents a user's membership in an organization
+	OrganizationMembership struct {
+		UserID         gid.GID   `db:"user_id"`
+		OrganizationID gid.GID   `db:"organization_id"`
+		Role           string    `db:"role"`
+		CreatedAt      time.Time `db:"created_at"`
+		UpdatedAt      time.Time `db:"updated_at"`
+	}
+
+	// OrganizationMemberships is a slice of OrganizationMembership
+	OrganizationMemberships []*OrganizationMembership
+
+	// ErrMembershipNotFound is returned when a membership is not found
+	ErrMembershipNotFound struct {
+		UserID gid.GID
+		OrgID  gid.GID
+	}
+
+	// ErrMembershipAlreadyExists is returned when trying to create a duplicate membership
+	ErrMembershipAlreadyExists struct {
+		UserID gid.GID
+		OrgID  gid.GID
+	}
+)
+
+func (e ErrMembershipNotFound) Error() string {
+	return fmt.Sprintf("membership not found for user %s in organization %s", e.UserID, e.OrgID)
+}
+
+func (e ErrMembershipAlreadyExists) Error() string {
+	return fmt.Sprintf("membership already exists for user %s in organization %s", e.UserID, e.OrgID)
+}
+
+// CursorKey returns the cursor key for pagination
+func (m OrganizationMembership) CursorKey(orderBy MembershipOrderField) page.CursorKey {
+	switch orderBy {
+	case MembershipOrderFieldCreatedAt:
+		return page.NewCursorKey(m.UserID, m.CreatedAt)
+	case MembershipOrderFieldUpdatedAt:
+		return page.NewCursorKey(m.UserID, m.UpdatedAt)
+	}
+
+	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
+}
+
+// Create creates a new organization membership
+func (m *OrganizationMembership) Create(ctx context.Context, conn pg.Conn) error {
+	query := `
+		INSERT INTO authz_memberships (user_id, organization_id, role, created_at, updated_at)
+		VALUES (@user_id, @organization_id, @role, @created_at, @updated_at)
+	`
+
+	args := pgx.StrictNamedArgs{
+		"user_id":         m.UserID,
+		"organization_id": m.OrganizationID,
+		"role":            m.Role,
+		"created_at":      m.CreatedAt,
+		"updated_at":      m.UpdatedAt,
+	}
+
+	_, err := conn.Exec(ctx, query, args)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" { // unique_violation
+			return ErrMembershipAlreadyExists{UserID: m.UserID, OrgID: m.OrganizationID}
+		}
+		return fmt.Errorf("failed to create membership: %w", err)
+	}
+
+	return nil
+}
+
+// LoadByUserAndOrg loads a membership by user and organization ID
+func (m *OrganizationMembership) LoadByUserAndOrg(
+	ctx context.Context,
+	conn pg.Conn,
+	userID gid.GID,
+	orgID gid.GID,
+) error {
+	query := `
+		SELECT user_id, organization_id, role, created_at, updated_at
+		FROM authz_memberships
+		WHERE user_id = @user_id AND organization_id = @organization_id
+	`
+
+	args := pgx.StrictNamedArgs{
+		"user_id":         userID,
+		"organization_id": orgID,
+	}
+
+	rows, err := conn.Query(ctx, query, args)
+	if err != nil {
+		return fmt.Errorf("cannot query membership: %w", err)
+	}
+
+	membership, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[OrganizationMembership])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrMembershipNotFound{UserID: userID, OrgID: orgID}
+		}
+		return fmt.Errorf("cannot collect membership: %w", err)
+	}
+
+	*m = membership
+	return nil
+}
+
+// Update updates an existing membership
+func (m *OrganizationMembership) Update(ctx context.Context, conn pg.Conn) error {
+	query := `
+		UPDATE authz_memberships
+		SET role = @role, updated_at = @updated_at
+		WHERE user_id = @user_id AND organization_id = @organization_id
+	`
+
+	args := pgx.StrictNamedArgs{
+		"user_id":         m.UserID,
+		"organization_id": m.OrganizationID,
+		"role":            m.Role,
+		"updated_at":      m.UpdatedAt,
+	}
+
+	result, err := conn.Exec(ctx, query, args)
+	if err != nil {
+		return fmt.Errorf("failed to update membership: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return ErrMembershipNotFound{UserID: m.UserID, OrgID: m.OrganizationID}
+	}
+
+	return nil
+}
+
+// Delete deletes a membership
+func (m *OrganizationMembership) Delete(ctx context.Context, conn pg.Conn) error {
+	query := `
+		DELETE FROM authz_memberships
+		WHERE user_id = @user_id AND organization_id = @organization_id
+	`
+
+	args := pgx.StrictNamedArgs{
+		"user_id":         m.UserID,
+		"organization_id": m.OrganizationID,
+	}
+
+	result, err := conn.Exec(ctx, query, args)
+	if err != nil {
+		return fmt.Errorf("failed to delete membership: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return ErrMembershipNotFound{UserID: m.UserID, OrgID: m.OrganizationID}
+	}
+
+	return nil
+}
+
+// LoadByUserID loads all memberships for a specific user
+func (m *OrganizationMemberships) LoadByUserID(
+	ctx context.Context,
+	conn pg.Conn,
+	userID gid.GID,
+) error {
+	query := `
+SELECT
+	user_id,
+	organization_id,
+	role,
+	created_at,
+	updated_at
+FROM
+	authz_memberships
+WHERE
+	user_id = @user_id
+ORDER BY
+	created_at DESC
+	`
+
+	args := pgx.StrictNamedArgs{"user_id": userID}
+
+	rows, err := conn.Query(ctx, query, args)
+	if err != nil {
+		return fmt.Errorf("cannot query memberships: %w", err)
+	}
+
+	memberships, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[OrganizationMembership])
+	if err != nil {
+		return fmt.Errorf("cannot collect memberships: %w", err)
+	}
+
+	*m = memberships
+	return nil
+}
+
+// LoadByOrganizationID loads all memberships for a specific organization with pagination
+func (m *OrganizationMemberships) LoadByOrganizationID(
+	ctx context.Context,
+	conn pg.Conn,
+	orgID gid.GID,
+	cursor *page.Cursor[MembershipOrderField],
+) error {
+	query := `
+SELECT
+	user_id,
+	organization_id,
+	role,
+	created_at,
+	updated_at
+FROM
+	authz_memberships
+WHERE
+	organization_id = @organization_id
+	AND %s
+`
+
+	query = fmt.Sprintf(query, cursor.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": orgID}
+	maps.Copy(args, cursor.SQLArguments())
+
+	rows, err := conn.Query(ctx, query, args)
+	if err != nil {
+		return fmt.Errorf("cannot query memberships: %w", err)
+	}
+
+	memberships, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[OrganizationMembership])
+	if err != nil {
+		return fmt.Errorf("cannot collect memberships: %w", err)
+	}
+
+	*m = memberships
+	return nil
+}

--- a/pkg/probo/service.go
+++ b/pkg/probo/service.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/getprobo/probo/pkg/agents"
+	"github.com/getprobo/probo/pkg/authz"
 	"github.com/getprobo/probo/pkg/coredata"
 	"github.com/getprobo/probo/pkg/crypto/cipher"
 	"github.com/getprobo/probo/pkg/filevalidation"
@@ -51,6 +52,7 @@ type (
 		agentConfig       agents.Config
 		html2pdfConverter *html2pdf.Converter
 		usrmgr            *usrmgr.Service
+		authz             *authz.Service
 	}
 
 	TenantService struct {
@@ -105,6 +107,7 @@ func NewService(
 	agentConfig agents.Config,
 	html2pdfConverter *html2pdf.Converter,
 	usrmgrService *usrmgr.Service,
+	authzService *authz.Service,
 ) (*Service, error) {
 	if bucket == "" {
 		return nil, fmt.Errorf("bucket is required")
@@ -121,6 +124,7 @@ func NewService(
 		agentConfig:       agentConfig,
 		html2pdfConverter: html2pdfConverter,
 		usrmgr:            usrmgrService,
+		authz:             authzService,
 	}
 
 	return svc, nil
@@ -182,7 +186,7 @@ func (s *Service) WithTenant(tenantID gid.TenantID) *TenantService {
 	tenantService.Audits = &AuditService{svc: tenantService}
 	tenantService.Reports = &ReportService{svc: tenantService}
 	tenantService.TrustCenters = &TrustCenterService{svc: tenantService}
-	tenantService.TrustCenterAccesses = &TrustCenterAccessService{svc: tenantService, usrmgr: s.usrmgr}
+	tenantService.TrustCenterAccesses = &TrustCenterAccessService{svc: tenantService}
 	tenantService.NonconformityRegistries = &NonconformityRegistryService{svc: tenantService}
 	tenantService.ComplianceRegistries = &ComplianceRegistryService{svc: tenantService}
 	tenantService.Snapshots = &SnapshotService{svc: tenantService}

--- a/pkg/probo/trust_center_access_service.go
+++ b/pkg/probo/trust_center_access_service.go
@@ -26,14 +26,12 @@ import (
 	"github.com/getprobo/probo/pkg/gid"
 	"github.com/getprobo/probo/pkg/page"
 	"github.com/getprobo/probo/pkg/statelesstoken"
-	"github.com/getprobo/probo/pkg/usrmgr"
 	"go.gearno.de/kit/pg"
 )
 
 type (
 	TrustCenterAccessService struct {
-		svc    *TenantService
-		usrmgr *usrmgr.Service
+		svc *TenantService
 	}
 
 	CreateTrustCenterAccessRequest struct {

--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -20,6 +20,7 @@ import (
 
 	"time"
 
+	"github.com/getprobo/probo/pkg/authz"
 	"github.com/getprobo/probo/pkg/connector"
 	"github.com/getprobo/probo/pkg/probo"
 	"github.com/getprobo/probo/pkg/saferedirect"
@@ -56,6 +57,7 @@ type (
 		AllowedOrigins    []string
 		Probo             *probo.Service
 		Usrmgr            *usrmgr.Service
+		Authz             *authz.Service
 		Trust             *trust.Service
 		Auth              ConsoleAuthConfig
 		TrustAuth         TrustAuthConfig
@@ -146,6 +148,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			s.cfg.Logger.Named("console.v1"),
 			s.cfg.Probo,
 			s.cfg.Usrmgr,
+			s.cfg.Authz,
 			console_v1.AuthConfig{
 				CookieName:      s.cfg.Auth.CookieName,
 				CookieDomain:    s.cfg.Auth.CookieDomain,

--- a/pkg/server/api/console/v1/invitation_confirmation_handler.go
+++ b/pkg/server/api/console/v1/invitation_confirmation_handler.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/getprobo/probo/pkg/probo"
+	"github.com/getprobo/probo/pkg/authz"
 	"github.com/getprobo/probo/pkg/usrmgr"
 	"go.gearno.de/kit/httpserver"
 )
@@ -34,7 +34,7 @@ type (
 	}
 )
 
-func InvitationConfirmationHandler(usrmgrSvc *usrmgr.Service, proboSvc *probo.Service, authCfg AuthConfig) http.HandlerFunc {
+func InvitationConfirmationHandler(usrmgrSvc *usrmgr.Service, authzSvc *authz.Service, authCfg AuthConfig) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req InvitationConfirmationRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -42,7 +42,7 @@ func InvitationConfirmationHandler(usrmgrSvc *usrmgr.Service, proboSvc *probo.Se
 			return
 		}
 
-		_, err := usrmgrSvc.ConfirmInvitation(r.Context(), req.Token, req.Password)
+		err := authzSvc.AcceptInvitation(r.Context(), req.Token)
 		if err != nil {
 			httpserver.RenderError(w, http.StatusInternalServerError, err)
 			return

--- a/pkg/server/api/console/v1/sign_in_handler.go
+++ b/pkg/server/api/console/v1/sign_in_handler.go
@@ -55,7 +55,7 @@ func SignInHandler(usrmgrSvc *usrmgr.Service, authCfg AuthConfig) http.HandlerFu
 			return
 		}
 
-		user, session, err := usrmgrSvc.SignIn(r.Context(), req.Email, req.Password)
+		session, user, err := usrmgrSvc.SignIn(r.Context(), req.Email, req.Password)
 		if err != nil {
 			var ErrInvalidCredentials *usrmgr.ErrInvalidCredentials
 			if errors.As(err, &ErrInvalidCredentials) {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Introduces a new authorization service for organization memberships and invitations, decoupling org access from user management and wiring it through the API and GraphQL. Adds new DB tables and migrates existing data, and updates session/sign-in flows to use memberships.

- **New Features**
  - New authz service: roles (owner/admin/member/viewer), membership CRUD, invitations with stateless tokens and email template.
  - API and GraphQL now use authz for org listing, member listing, invites, and removals.
  - Pagination order fields for invitations/members; new entity types for invitations and memberships.

- **Refactors**
  - usrmgr now handles only authentication (sign up/in, sessions, email confirmation, password reset); org/invite logic removed.
  - Session flow derives tenant access from authz memberships; UpdateSession takes a session ID and extends expiry; SignIn returns (session, user).
  - DB migration creates authz_memberships and authz_invitations and copies data from users_organizations with default role=member.

<!-- End of auto-generated description by cubic. -->

