### PR TITLE
Remove document description and footer

### DIFF
--- a/pkg/docgen/template.html
+++ b/pkg/docgen/template.html
@@ -327,10 +327,6 @@
                             <td>{{.Approver}}</td>
                         </tr>
                         <tr>
-                            <td>Description:</td>
-                            <td>{{.Description}}</td>
-                        </tr>
-                        <tr>
                             <td>Version:</td>
                             <td>{{.Version}}</td>
                         </tr>
@@ -385,10 +381,6 @@
                 </table>
             </div>
             {{- end}}
-
-            <div class="footer">
-                <p>Document generated on {{now.Format "January 2, 2006 at 3:04 PM"}}</p>
-            </div>
         </div>
     </div>
 </body>


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed the Description row and the footer from the docgen HTML template to simplify the document layout and remove timestamped metadata. Rendered documents no longer show .Description or the “Document generated on …” footer.

<!-- End of auto-generated description by cubic. -->

