### PR TITLE
Add default trust center NDA

### DIFF
--- a/apps/console/src/pages/organizations/trustCenter/TrustCenterPage.tsx
+++ b/apps/console/src/pages/organizations/trustCenter/TrustCenterPage.tsx
@@ -276,9 +276,30 @@ export default function TrustCenterPage({ queryRef }: Props) {
         <Card padded className="space-y-4">
           <div className="space-y-2">
             {!organization.trustCenter?.ndaFileName ?  (
-              <p className="text-sm text-txt-tertiary">
-                {__("Upload a Non-Disclosure Agreement that visitors must accept before accessing your trust center")}
-              </p>
+              <div className="space-y-3">
+                <p className="text-sm text-txt-tertiary">
+                  {__("Upload a Non-Disclosure Agreement that visitors must accept before accessing your trust center")}
+                </p>
+                <div className="p-4 bg-tertiary rounded-lg border border-border-solid">
+                  <div className="flex items-center justify-between">
+                    <div className="space-y-1">
+                      <p className="text-sm font-medium text-txt-secondary">
+                        {__("Default NDA Template")}
+                      </p>
+                      <p className="text-xs text-txt-tertiary">
+                        {__("If no custom NDA is uploaded, visitors will see our default template")}
+                      </p>
+                    </div>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      onClick={() => window.open("/trust/documents/nda.pdf", "_blank")}
+                    >
+                      {__("Preview PDF")}
+                    </Button>
+                  </div>
+                </div>
+              </div>
             ) : (<></>)}
             {organization.trustCenter?.ndaFileName ? (
               <div className="space-y-3">

--- a/apps/trust/public/documents/nda.pdf
+++ b/apps/trust/public/documents/nda.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 612 792 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20250930164226+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20250930164226+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1044
+>>
+stream
+GatU29iKe#&A@Zcp';\*`f:_\,:tLb$q"5G^#c!0CKncD>Y0srrUjGF,Qpq49.--T8A!TRpRYD\@7%0IJ+=B5_\1gS:*Iki=[JRLk-2LQ:WoN*8*PH_f`KGG)$SLA`/j0JLsj`M8sJ(J=./h`1:P9nNKS35K].nG]gaub1h)Bk_WppYid>lh!m;[iI,g*4UXu8moCiaNZdJRo"s`$BaClM6`koXgW+7=aW[h0rlj-tLNMr3Z8k&jBM\(D1'Ynf&,[sn$g`dQ*E4]c\:9(#(U-\sjAsPW"KU.V%7d.55&D@0i@;Cb^BIHIR7r=ZU^^kUP\EHZqZqQP&DE#U.K0a4)'cR9!9;Pk-?/g9tA^a"1i9Fa>k47'E.6Ko^<:^C`&3F8o"/b8SiO\p'`bN>,1HkjH9GSb9F\<EQ2dc]aAt$HDlG`r40[3Gb]!k6#,BQU`:aHC>k!j/=FQ(81:Q=Z,^+N8J9+5!+M\9,fZWd:tfM5opcP@[`B=#RlS*[aQ\/)3N0,eVlcU1.-kQ+?J^G4;GWh.S!WSgQMK2E)@:,Lnh\mBS+MuQ#k_T?S%@-3!uHWTXRFHK<67Ho,bT27:\#>c?cSO9r&>L_H?Q#_9M+:Q8D8OKC??bGCjJ(;[cpR<Ko>s3CKW.$o@)'dK!s43!R:FF5h47l$7,BGuL)haN+;Od=TF^*44%@n3(`XPZ0FmA)6rD"m#4HeO"leR+:$2PIZc_joZoC3bB9`C$'>>`r%^nkYk@M,Y&%CZ3!I/YVDKfQY^$:VTggK"f=VtK!#OH&oK,uGbZ4JApuS%]H>H>'a>,d5go9:uleg+GSaSAHk@Uc-BiFI%^USOLd=k51n)07%u6L?-SpdA@`M2Lfb\Wr;U*TU,hn%eE5Mm1I^t]'G=3=I.7uJmq@rKr)eRJ?q,;de\(@Zb9G"0!!29>`VXg_lKqP#*;k:U=<ggTjF8N;9OZm^Jl0%P+2R)Cl$Z4L?-Y>rBL41[1!X?cOcA^660GsqCY&HdI#Z:!7=N2.:"XLnbs,qlc?TM"Z:+@8f&KG"rpn!2Z~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000000333 00000 n 
+0000000526 00000 n 
+0000000594 00000 n 
+0000000877 00000 n 
+0000000936 00000 n 
+trailer
+<<
+/ID 
+[<e5e0ca1b4a4e78a0abbc56e9dc8f669d><e5e0ca1b4a4e78a0abbc56e9dc8f669d>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+2071
+%%EOF


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a default NDA for the Trust Center so visitors always see an NDA if no custom file is uploaded. Also adds a preview option in the console and updates the backend to fall back to the default PDF.

- **New Features**
  - Console: show “Default NDA Template” info with a Preview PDF button when no custom NDA is set.
  - Backend: return the default NDA PDF at /trust/documents/nda.pdf when no NDA file exists, instead of erroring.

<!-- End of auto-generated description by cubic. -->

