### PR TITLE
fix: edit on measure changes to NOT_STARTED

### DIFF
--- a/apps/console/src/pages/organizations/measures/dialog/MeasureFormDialog.tsx
+++ b/apps/console/src/pages/organizations/measures/dialog/MeasureFormDialog.tsx
@@ -78,11 +78,11 @@ export default function MeasureFormDialog(props: Props) {
 
   const { control, handleSubmit, register, formState, reset } =
     useFormWithSchema(measureSchema, {
-      defaultValues: {
+      values: {
         name: measure?.name ?? "",
         description: measure?.description ?? "",
         category: measure?.category ?? "",
-        state: "NOT_STARTED",
+        state: measure?.state ?? "NOT_STARTED",
       },
     });
 


### PR DESCRIPTION
##  ISSUE 

- fix #386 

two improvements -> 

- used values instead - defaultValues as it doesn't take changed option value into account after the first render - inc this case changed by parent state dropdown.
- take current state value into account incase of Edit. 


https://github.com/user-attachments/assets/e14a1355-41a1-4082-9194-265985642a2e


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Stops the measure edit form from resetting the state to NOT_STARTED and preserves the current state, addressing #386. Form now uses live values so parent dropdown changes are reflected after the first render.

- **Bug Fixes**
  - Use values instead of defaultValues in useFormWithSchema.
  - Initialize state from measure.state, defaulting to NOT_STARTED only if missing.

<!-- End of auto-generated description by cubic. -->

