### PR TITLE
Add measure name order

### DIFF
--- a/apps/console/src/hooks/graph/__generated__/usePaginatedMeasuresQuery_fragment.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/usePaginatedMeasuresQuery_fragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fa04c379d9d79cc9d49a08c4ed70b994>>
+ * @generated SignedSource<<d80ecca972bcfbb40f578e64b6fbf4f3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,7 +10,7 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type MeasureOrderField = "CREATED_AT";
+export type MeasureOrderField = "CREATED_AT" | "NAME";
 export type OrderDirection = "ASC" | "DESC";
 export type MeasureOrder = {
   direction: OrderDirection;

--- a/pkg/coredata/measure.go
+++ b/pkg/coredata/measure.go
@@ -47,6 +47,8 @@ func (m Measure) CursorKey(orderBy MeasureOrderField) page.CursorKey {
 	switch orderBy {
 	case MeasureOrderFieldCreatedAt:
 		return page.NewCursorKey(m.ID, m.CreatedAt)
+	case MeasureOrderFieldName:
+		return page.NewCursorKey(m.ID, m.Name)
 	}
 
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))

--- a/pkg/coredata/mesure_order_field.go
+++ b/pkg/coredata/mesure_order_field.go
@@ -20,6 +20,7 @@ type (
 
 const (
 	MeasureOrderFieldCreatedAt MeasureOrderField = "CREATED_AT"
+	MeasureOrderFieldName      MeasureOrderField = "NAME"
 )
 
 func (p MeasureOrderField) Column() string {

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -381,6 +381,10 @@ enum MeasureOrderField
     @goEnum(
       value: "github.com/getprobo/probo/pkg/coredata.MeasureOrderFieldCreatedAt"
     )
+  NAME
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.MeasureOrderFieldName"
+    )
 }
 
 enum TaskOrderField

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -8934,6 +8934,10 @@ enum MeasureOrderField
     @goEnum(
       value: "github.com/getprobo/probo/pkg/coredata.MeasureOrderFieldCreatedAt"
     )
+  NAME
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.MeasureOrderFieldName"
+    )
 }
 
 enum TaskOrderField
@@ -91489,9 +91493,11 @@ func (ec *executionContext) marshalNMeasureOrderField2githubᚗcomᚋgetproboᚋ
 var (
 	unmarshalNMeasureOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐMeasureOrderField = map[string]coredata.MeasureOrderField{
 		"CREATED_AT": coredata.MeasureOrderFieldCreatedAt,
+		"NAME":       coredata.MeasureOrderFieldName,
 	}
 	marshalNMeasureOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐMeasureOrderField = map[coredata.MeasureOrderField]string{
 		coredata.MeasureOrderFieldCreatedAt: "CREATED_AT",
+		coredata.MeasureOrderFieldName:      "NAME",
 	}
 )
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add support for sorting measures by name across the API and console. This enables alphabetical ordering with stable pagination.

- **New Features**
  - Added MeasureOrderField.NAME to the GraphQL schema and server mappings.
  - Implemented name-based cursor keys for Measure when ordering by NAME.
  - Updated client-generated types to include the NAME order field.

<!-- End of auto-generated description by cubic. -->

