### PR TITLE
Add missing s3 metadata

### DIFF
--- a/pkg/probo/framework_service.go
+++ b/pkg/probo/framework_service.go
@@ -807,8 +807,9 @@ func (s *FrameworkService) BuildAndUploadExport(ctx context.Context, exportJobID
 					ContentLength: ref.Ref(fileInfo.Size()),
 					ContentType:   ref.Ref("application/zip"),
 					Metadata: map[string]string{
-						"type":          "framework-export",
-						"export-job-id": exportJob.ID.String(),
+						"type":            "framework-export",
+						"export-job-id":   exportJob.ID.String(),
+						"organization-id": framework.OrganizationID.String(),
 					},
 				},
 			)

--- a/pkg/probo/organization_service.go
+++ b/pkg/probo/organization_service.go
@@ -248,6 +248,10 @@ func (s OrganizationService) Update(
 					Key:         aws.String(objectKey.String()),
 					Body:        fileContent,
 					ContentType: aws.String(contentType),
+					Metadata: map[string]string{
+						"type":            "organization-logo",
+						"organization-id": organization.ID.String(),
+					},
 				})
 
 				if err != nil {

--- a/pkg/probo/vendor_business_associate_agreement_service.go
+++ b/pkg/probo/vendor_business_associate_agreement_service.go
@@ -90,31 +90,6 @@ func (s VendorBusinessAssociateAgreementService) Upload(
 		return nil, nil, fmt.Errorf("cannot generate object key: %w", err)
 	}
 
-	mimeType := mime.TypeByExtension(filepath.Ext(req.FileName))
-
-	_, err = s.svc.s3.PutObject(ctx, &s3.PutObjectInput{
-		Bucket:      &s.svc.bucket,
-		Key:         aws.String(objectKey.String()),
-		Body:        req.File,
-		ContentType: &mimeType,
-	})
-	if err != nil {
-		return nil, nil, fmt.Errorf("cannot upload file to S3: %w", err)
-	}
-
-	headOutput, err := s.svc.s3.HeadObject(ctx, &s3.HeadObjectInput{
-		Bucket: aws.String(s.svc.bucket),
-		Key:    aws.String(objectKey.String()),
-	})
-	if err != nil {
-		return nil, nil, fmt.Errorf("cannot get object metadata: %w", err)
-	}
-
-	now := time.Now()
-
-	fileID := gid.New(s.svc.scope.GetTenantID(), coredata.FileEntityType)
-	vendorBusinessAssociateAgreementID := gid.New(s.svc.scope.GetTenantID(), coredata.VendorBusinessAssociateAgreementEntityType)
-
 	var vendorBusinessAssociateAgreement *coredata.VendorBusinessAssociateAgreement
 	var file *coredata.File
 
@@ -125,6 +100,35 @@ func (s VendorBusinessAssociateAgreementService) Upload(
 			if err := vendor.LoadByID(ctx, conn, s.svc.scope, vendorID); err != nil {
 				return fmt.Errorf("cannot load vendor: %w", err)
 			}
+
+			mimeType := mime.TypeByExtension(filepath.Ext(req.FileName))
+
+			_, err := s.svc.s3.PutObject(ctx, &s3.PutObjectInput{
+				Bucket:      &s.svc.bucket,
+				Key:         aws.String(objectKey.String()),
+				Body:        req.File,
+				ContentType: &mimeType,
+				Metadata: map[string]string{
+					"type":            "vendor-business-associate-agreement",
+					"vendor-id":       vendorID.String(),
+					"organization-id": vendor.OrganizationID.String(),
+				},
+			})
+			if err != nil {
+				return fmt.Errorf("cannot upload file to S3: %w", err)
+			}
+
+			headOutput, err := s.svc.s3.HeadObject(ctx, &s3.HeadObjectInput{
+				Bucket: aws.String(s.svc.bucket),
+				Key:    aws.String(objectKey.String()),
+			})
+			if err != nil {
+				return fmt.Errorf("cannot get object metadata: %w", err)
+			}
+
+			now := time.Now()
+			fileID := gid.New(s.svc.scope.GetTenantID(), coredata.FileEntityType)
+			vendorBusinessAssociateAgreementID := gid.New(s.svc.scope.GetTenantID(), coredata.VendorBusinessAssociateAgreementEntityType)
 
 			file = &coredata.File{
 				ID:         fileID,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds consistent S3 metadata to all uploads so each object includes its type, IDs, and organization-id. Improves traceability, search, and lifecycle management across reports, evidence, exports, logos, NDAs, and vendor files.

- **Bug Fixes**
  - All uploads now set S3 metadata: type, resource ID, and organization-id (reports, evidence for measures/tasks, document/framework exports, organization logos, trust center NDAs and reference logos, vendor BAA/DPA, vendor compliance reports).

- **Refactors**
  - Moved S3 uploads inside transactions after loading entities to attach the correct organization-id.
  - Replaced ReportService.Create with AuditService.UploadReport, which writes metadata and inserts the DB record.
  - Document export validates document IDs and tags the export with organization-id.

<!-- End of auto-generated description by cubic. -->

