### PR TITLE
Fix asset owner deletion

### DIFF
--- a/pkg/coredata/migrations/20251003T102644Z.sql
+++ b/pkg/coredata/migrations/20251003T102644Z.sql
@@ -1,0 +1,6 @@
+ALTER TABLE assets DROP CONSTRAINT assets_owner_id_fkey;
+ALTER TABLE assets ADD CONSTRAINT assets_owner_id_fkey
+    FOREIGN KEY (owner_id)
+    REFERENCES peoples(id)
+    ON UPDATE CASCADE
+    ON DELETE RESTRICT;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes asset owner deletion by updating the assets.owner_id foreign key. Deleting a person who owns assets is now blocked (ON DELETE RESTRICT), and owner ID changes propagate to assets (ON UPDATE CASCADE).

<!-- End of auto-generated description by cubic. -->

