### PR TITLE
Handle missing NDA

### DIFF
--- a/apps/trust/src/layouts/MainLayout.tsx
+++ b/apps/trust/src/layouts/MainLayout.tsx
@@ -27,7 +27,8 @@ export function MainLayout(props: Props) {
   const baseTabUrl = `/trust/${trustCenter.slug}`;
   const showNDADialog =
     trustCenter.isUserAuthenticated &&
-    !trustCenter.hasAcceptedNonDisclosureAgreement;
+    !trustCenter.hasAcceptedNonDisclosureAgreement &&
+    trustCenter.ndaFileUrl;
   return (
     <AuthProvider isAuthenticated={trustCenter.isUserAuthenticated}>
       <TrustCenterProvider trustCenter={trustCenter}>

--- a/pkg/coredata/migrations/20251003T144148Z.sql
+++ b/pkg/coredata/migrations/20251003T144148Z.sql
@@ -1,0 +1,7 @@
+ALTER TABLE trust_center_accesses ADD COLUMN nda_file_id TEXT;
+
+ALTER TABLE trust_center_accesses ADD CONSTRAINT trust_center_accesses_nda_file_id_fkey
+    FOREIGN KEY (nda_file_id)
+    REFERENCES files(id)
+    ON UPDATE CASCADE
+    ON DELETE RESTRICT;

--- a/pkg/coredata/trust_center_access.go
+++ b/pkg/coredata/trust_center_access.go
@@ -38,6 +38,7 @@ type (
 		Active                                    bool            `db:"active"`
 		HasAcceptedNonDisclosureAgreement         bool            `db:"has_accepted_non_disclosure_agreement"`
 		HasAcceptedNonDisclosureAgreementMetadata json.RawMessage `db:"has_accepted_non_disclosure_agreement_metadata"`
+		NDAFileID                                 *gid.GID        `db:"nda_file_id"`
 		CreatedAt                                 time.Time       `db:"created_at"`
 		UpdatedAt                                 time.Time       `db:"updated_at"`
 	}
@@ -78,6 +79,7 @@ SELECT
 	active,
 	has_accepted_non_disclosure_agreement,
 	has_accepted_non_disclosure_agreement_metadata,
+	nda_file_id,
 	created_at,
 	updated_at
 FROM
@@ -129,6 +131,7 @@ SELECT
 	active,
 	has_accepted_non_disclosure_agreement,
 	has_accepted_non_disclosure_agreement_metadata,
+	nda_file_id,
 	created_at,
 	updated_at
 FROM
@@ -227,7 +230,8 @@ UPDATE trust_center_accesses SET
 	active = @active,
 	updated_at = @updated_at,
 	has_accepted_non_disclosure_agreement = @has_accepted_non_disclosure_agreement,
-	has_accepted_non_disclosure_agreement_metadata = @has_accepted_non_disclosure_agreement_metadata
+	has_accepted_non_disclosure_agreement_metadata = @has_accepted_non_disclosure_agreement_metadata,
+	nda_file_id = @nda_file_id
 WHERE
 	%s
 	AND id = @id
@@ -242,6 +246,7 @@ WHERE
 		"updated_at":                            tca.UpdatedAt,
 		"has_accepted_non_disclosure_agreement": tca.HasAcceptedNonDisclosureAgreement,
 		"has_accepted_non_disclosure_agreement_metadata": tca.HasAcceptedNonDisclosureAgreementMetadata,
+		"nda_file_id": tca.NDAFileID,
 	}
 	maps.Copy(args, scope.SQLArguments())
 
@@ -297,6 +302,7 @@ SELECT
 	active,
 	has_accepted_non_disclosure_agreement,
 	has_accepted_non_disclosure_agreement_metadata,
+	nda_file_id,
 	created_at,
 	updated_at
 FROM

--- a/pkg/trust/trust_center_access_service.go
+++ b/pkg/trust/trust_center_access_service.go
@@ -203,6 +203,11 @@ func (s TrustCenterAccessService) AcceptNonDisclosureAgreement(ctx context.Conte
 			return fmt.Errorf("cannot load trust center access: %w", err)
 		}
 
+		trustCenter := &coredata.TrustCenter{}
+		if err := trustCenter.LoadByID(ctx, tx, s.svc.scope, trustCenterID); err != nil {
+			return fmt.Errorf("cannot load trust center: %w", err)
+		}
+
 		acceptationLogs, err := json.Marshal(map[string]string{
 			"email":     email,
 			"timestamp": time.Now().Format(time.RFC3339),
@@ -215,6 +220,7 @@ func (s TrustCenterAccessService) AcceptNonDisclosureAgreement(ctx context.Conte
 		access.HasAcceptedNonDisclosureAgreement = true
 		access.UpdatedAt = time.Now()
 		access.HasAcceptedNonDisclosureAgreementMetadata = acceptationLogs
+		access.NDAFileID = trustCenter.NonDisclosureAgreementFileID
 		if err := access.Update(ctx, tx, s.svc.scope); err != nil {
 			return fmt.Errorf("cannot update trust center access: %w", err)
 		}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Skip NDA enforcement when a trust center has no NDA configured, and only show the NDA dialog when an NDA file exists. Also persist the NDA file ID on acceptance and make the NDA URL resolver tolerant to missing/unauthenticated cases.

- **Bug Fixes**
  - Frontend: show NDA dialog only when authenticated, not yet accepted, and ndaFileUrl exists.
  - Backend: ExportDocumentPDF/ExportReportPDF enforce NDA only if the trust center has an NDA file; still enforce document/report access.
  - GraphQL: NdaFileURL returns nil on failure or unauthenticated users to avoid breaking views.
  - Data: added nda_file_id to trust_center_accesses and persist it on acceptance; queries and updates updated accordingly.

<!-- End of auto-generated description by cubic. -->

