### PR TITLE
Manage errors

### DIFF
--- a/apps/console/src/components/PageError.tsx
+++ b/apps/console/src/components/PageError.tsx
@@ -46,6 +46,20 @@ export function PageError({ resetErrorBoundary, error: propsError }: Props) {
     );
   }
 
+  if (error && error.toString().includes("UNAUTHORIZED")) {
+    return (
+      <div className={classNames.wrapper}>
+        <h1 className={classNames.title}>
+          <IconPageCross size={26} />
+          {__("Access denied")}
+        </h1>
+        <p className={classNames.description}>
+          {__("You don't have permission to access this organization")}
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div className={classNames.wrapper}>
       <h1 className={classNames.title}>{__("Unexpected error :(")}</h1>

--- a/apps/console/src/hooks/forms/useDocumentForm.tsx
+++ b/apps/console/src/hooks/forms/useDocumentForm.tsx
@@ -2,9 +2,9 @@ import { z } from "zod";
 import { useFormWithSchema } from "../useFormWithSchema";
 
 export const documentSchema = z.object({
-  title: z.string(),
-  content: z.string(),
-  ownerId: z.string(),
+  title: z.string().min(1, "Title is required"),
+  content: z.string().min(1, "Content is required"),
+  ownerId: z.string().min(1, "Owner is required"),
   documentType: z.enum(["OTHER", "ISMS", "POLICY"]),
 });
 

--- a/apps/console/src/hooks/forms/useRiskForm.tsx
+++ b/apps/console/src/hooks/forms/useRiskForm.tsx
@@ -32,10 +32,10 @@ export type RiskKey = useRiskFormFragment$key & { id: string };
 
 // Export the schema so it can be used elsewhere
 export const riskSchema = z.object({
-  category: z.string(),
-  name: z.string(),
-  description: z.string(),
-  ownerId: z.string(),
+  category: z.string().min(1, "Category is required"),
+  name: z.string().min(1, "Name is required"),
+  description: z.string().min(1, "Description is required"),
+  ownerId: z.string().min(1, "Owner is required"),
   treatment: z.enum(["AVOIDED", "MITIGATED", "TRANSFERRED", "ACCEPTED"]),
   inherentLikelihood: z.number({ coerce: true }).min(1).max(5),
   inherentImpact: z.number({ coerce: true }).min(1).max(5),

--- a/apps/console/src/hooks/forms/useVendorForm.tsx
+++ b/apps/console/src/hooks/forms/useVendorForm.tsx
@@ -8,21 +8,21 @@ import { useTranslate } from "@probo/i18n";
 import { useEffect, useMemo } from "react";
 
 const schema = z.object({
-  name: z.string(),
-  description: z.string(),
+  name: z.string().min(1, "Name is required"),
+  description: z.string().min(1, "Description is required"),
   category: z.string().nullish(),
-  statusPageUrl: z.string(),
-  termsOfServiceUrl: z.string(),
-  privacyPolicyUrl: z.string(),
-  serviceLevelAgreementUrl: z.string(),
-  dataProcessingAgreementUrl: z.string(),
-  websiteUrl: z.string(),
-  legalName: z.string(),
-  headquarterAddress: z.string(),
+  statusPageUrl: z.string().optional(),
+  termsOfServiceUrl: z.string().optional(),
+  privacyPolicyUrl: z.string().optional(),
+  serviceLevelAgreementUrl: z.string().optional(),
+  dataProcessingAgreementUrl: z.string().optional(),
+  websiteUrl: z.string().optional(),
+  legalName: z.string().optional(),
+  headquarterAddress: z.string().optional(),
   certifications: z.array(z.string()),
   countries: z.array(z.string()),
-  securityPageUrl: z.string(),
-  trustPageUrl: z.string(),
+  securityPageUrl: z.string().optional(),
+  trustPageUrl: z.string().optional(),
   businessOwnerId: z.string().nullish(),
   securityOwnerId: z.string().nullish(),
 });
@@ -70,7 +70,7 @@ export function useVendorForm(vendorKey: useVendorFormFragment$key) {
 
   const [mutate] = useMutationWithToasts(vendorUpdateQuery, {
     successMessage: __("Vendor updated successfully."),
-    errorMessage: __("Failed to update vendor. Please try again."),
+    errorMessage: __("Failed to update vendor"),
   });
 
   const defaultValues = useMemo(

--- a/apps/console/src/hooks/graph/PeopleGraph.ts
+++ b/apps/console/src/hooks/graph/PeopleGraph.ts
@@ -10,9 +10,9 @@ import {
 import { useMemo } from "react";
 import type { PeopleGraphPaginatedQuery } from "./__generated__/PeopleGraphPaginatedQuery.graphql";
 import type { PeopleGraphPaginatedFragment$key } from "./__generated__/PeopleGraphPaginatedFragment.graphql";
-import { useConfirm } from "@probo/ui";
+import { useConfirm, useToast } from "@probo/ui";
 import type { PeopleGraphDeleteMutation } from "./__generated__/PeopleGraphDeleteMutation.graphql";
-import { promisifyMutation, sprintf } from "@probo/helpers";
+import { promisifyMutation, sprintf, formatError, type GraphQLError } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
 
 const peopleQuery = graphql`
@@ -132,6 +132,7 @@ export const useDeletePeople = (
 ) => {
   const [mutate] = useMutation<PeopleGraphDeleteMutation>(deletePeopleMutation);
   const confirm = useConfirm();
+  const { toast } = useToast();
   const { __ } = useTranslate();
 
   return () => {
@@ -147,6 +148,12 @@ export const useDeletePeople = (
             },
             connections: [connectionId],
           },
+        }).catch((error) => {
+          toast({
+            title: __("Error"),
+            description: formatError(__("Failed to delete people"), error as GraphQLError),
+            variant: "error",
+          });
         }),
       {
         message: sprintf(

--- a/apps/console/src/hooks/useMutationWithIncrement.ts
+++ b/apps/console/src/hooks/useMutationWithIncrement.ts
@@ -10,6 +10,9 @@ import {
   type GraphQLTaggedNode,
   type MutationParameters,
 } from "relay-runtime";
+import { useToast } from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { formatError, type GraphQLError } from "@probo/helpers";
 
 const defaultOptions = {
   field: "totalCount",
@@ -26,17 +29,27 @@ export function useMutationWithIncrement<T extends MutationParameters>(
     node: string;
     field?: string;
     value?: 1 | -1;
+    errorMessage?: string;
   },
 ) {
   const [mutate, isLoading] = useMutation<T>(query);
   const relayEnv = useRelayEnvironment();
+  const { toast } = useToast();
+  const { __ } = useTranslate();
   const options = { ...defaultOptions, ...baseOptions };
   const mutateAndIncrement = useCallback(
     (queryOptions: UseMutationConfig<T>) => {
       return mutate({
         ...queryOptions,
         onCompleted: (response, error) => {
-          if (!error) {
+          if (error) {
+            const errorTitle = options.errorMessage ?? __("Failed to commit this operation");
+            toast({
+              title: __("Error"),
+              description: formatError(errorTitle, error as GraphQLError),
+              variant: "error",
+            });
+          } else {
             updateStoreCounter(
               relayEnv,
               options.id,
@@ -47,9 +60,18 @@ export function useMutationWithIncrement<T extends MutationParameters>(
           }
           queryOptions.onCompleted?.(response, error);
         },
+        onError: (error) => {
+          const errorTitle = options.errorMessage ?? __("Failed to commit this operation");
+          toast({
+            title: __("Error"),
+            description: formatError(errorTitle, error as GraphQLError),
+            variant: "error",
+          });
+          queryOptions.onError?.(error);
+        },
       });
     },
-    [mutate, options.id, options.node, options.field, options.value, relayEnv],
+    [mutate, options.id, options.node, options.field, options.value, options.errorMessage, relayEnv, toast, __],
   );
 
   return [mutateAndIncrement, isLoading] as const;

--- a/apps/console/src/hooks/useMutationWithToasts.ts
+++ b/apps/console/src/hooks/useMutationWithToasts.ts
@@ -3,6 +3,7 @@ import { useMutation, type UseMutationConfig } from "react-relay";
 import { useToast } from "@probo/ui";
 import { useTranslate } from "@probo/i18n";
 import type { MutationParameters, GraphQLTaggedNode } from "relay-runtime";
+import { formatError, type GraphQLError } from "@probo/helpers";
 
 /**
  * A decorated useMutation hook that emits toast notifications on success or error.
@@ -32,11 +33,10 @@ export function useMutationWithToasts<T extends MutationParameters>(
           onCompleted: (response, error) => {
             options.onCompleted?.(response, error);
             if (error) {
+              const errorTitle = options.errorMessage ?? __("Failed to commit this operation");
               toast({
                 title: __("Error"),
-                description:
-                  options.errorMessage ??
-                  __("Failed to commit this operation."),
+                description: formatError(errorTitle, error as GraphQLError),
                 variant: "error",
               });
               reject(error);
@@ -57,10 +57,10 @@ export function useMutationWithToasts<T extends MutationParameters>(
             resolve();
           },
           onError: (error) => {
+            const errorTitle = options.errorMessage ?? __("Failed to commit this operation");
             toast({
               title: __("Error"),
-              description:
-                options.errorMessage ?? __("Failed to commit this operation."),
+              description: formatError(errorTitle, error as GraphQLError),
               variant: "error",
             });
             reject(error);

--- a/apps/console/src/pages/organizations/NewOrganizationPage.tsx
+++ b/apps/console/src/pages/organizations/NewOrganizationPage.tsx
@@ -6,6 +6,7 @@ import type { NewOrganizationPageQuery as NewOrganizationPageQueryType } from ".
 import type { NewOrganizationPageMutation as NewOrganizationPageMutationType } from "./__generated__/NewOrganizationPageMutation.graphql";
 import { useState, type FormEventHandler } from "react";
 import { useNavigate } from "react-router";
+import { formatError, type GraphQLError } from "@probo/helpers";
 
 const createOrganizationMutation = graphql`
   mutation NewOrganizationPageMutation(
@@ -75,11 +76,12 @@ export default function NewOrganizationPage() {
           variant: "success",
         });
       },
-      onError: (e) => {
+      onError: (e: GraphQLError) => {
         setIsFetching(false);
+
         toast({
           title: __("Error"),
-          description: e.message ?? __("Failed to create organization"),
+          description: formatError(__("Failed to create organization"), e),
           variant: "error",
         });
       },

--- a/apps/console/src/pages/organizations/SettingsPage.tsx
+++ b/apps/console/src/pages/organizations/SettingsPage.tsx
@@ -42,7 +42,7 @@ const organizationSchema = z.object({
   name: z.string().min(1, "Organization name is required"),
   description: z.string().optional(),
   websiteUrl: z.string().optional(),
-  email: z.string().optional(),
+  email: z.union([z.string().email("Please enter a valid email address"), z.literal("")]),
   headquarterAddress: z.string().optional(),
 });
 

--- a/apps/console/src/pages/organizations/audits/AuditDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/audits/AuditDetailsPage.tsx
@@ -32,7 +32,7 @@ import { FrameworkLogo } from "/components/FrameworkLogo";
 import { ControlledField } from "/components/form/ControlledField";
 import { useFormWithSchema } from "/hooks/useFormWithSchema";
 import z from "zod";
-import { getAuditStateLabel, getAuditStateVariant, auditStates, fileSize, sprintf, formatDatetime, formatDate } from "@probo/helpers";
+import { getAuditStateLabel, getAuditStateVariant, auditStates, fileSize, sprintf, formatDatetime, formatError, formatDate, type GraphQLError } from "@probo/helpers";
 import type { AuditGraphNodeQuery } from "/hooks/graph/__generated__/AuditGraphNodeQuery.graphql";
 
 const updateAuditSchema = z.object({
@@ -96,7 +96,7 @@ export default function AuditDetailsPage(props: Props) {
     } catch (error) {
       toast({
         title: __("Error"),
-        description: error instanceof Error ? error.message : __("Failed to update audit"),
+        description: formatError(__("Failed to update audit"), error as GraphQLError),
         variant: "error",
       });
     }

--- a/apps/console/src/pages/organizations/audits/dialogs/CreateAuditDialog.tsx
+++ b/apps/console/src/pages/organizations/audits/dialogs/CreateAuditDialog.tsx
@@ -16,7 +16,7 @@ import z from "zod";
 import { useFormWithSchema } from "/hooks/useFormWithSchema";
 import { ControlledField } from "/components/form/ControlledField";
 import { useCreateAudit } from "/hooks/graph/AuditGraph";
-import { auditStates, getAuditStateLabel, formatDatetime } from "@probo/helpers";
+import { auditStates, getAuditStateLabel, formatDatetime, formatError, type GraphQLError } from "@probo/helpers";
 import { useLazyLoadQuery } from "react-relay";
 import { graphql } from "relay-runtime";
 import { Suspense } from "react";
@@ -94,7 +94,7 @@ export function CreateAuditDialog({
     } catch (error) {
       toast({
         title: __("Error"),
-        description: error instanceof Error ? error.message : __("Failed to create audit"),
+        description: formatError(__("Failed to create audit"), error as GraphQLError),
         variant: "error",
       });
     }

--- a/apps/console/src/pages/organizations/continualImprovements/ContinualImprovementDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/continualImprovements/ContinualImprovementDetailsPage.tsx
@@ -30,6 +30,7 @@ import { useOrganizationId } from "/hooks/useOrganizationId";
 import { PeopleSelectField } from "/components/form/PeopleSelectField";
 import { useFormWithSchema } from "/hooks/useFormWithSchema";
 import { Controller } from "react-hook-form";
+import { formatError, type GraphQLError } from "@probo/helpers";
 import z from "zod";
 import { getStatusVariant, getStatusLabel, formatDatetime, validateSnapshotConsistency } from "@probo/helpers";
 import { SnapshotBanner } from "/components/SnapshotBanner";
@@ -113,7 +114,7 @@ export default function ContinualImprovementDetailsPage(props: Props) {
     } catch (error) {
       toast({
         title: __("Error"),
-        description: __("Failed to update continual improvement entry"),
+        description: formatError(__("Failed to update continual improvement"), error as GraphQLError),
         variant: "error",
       });
     }

--- a/apps/console/src/pages/organizations/continualImprovements/dialogs/CreateContinualImprovementDialog.tsx
+++ b/apps/console/src/pages/organizations/continualImprovements/dialogs/CreateContinualImprovementDialog.tsx
@@ -20,6 +20,7 @@ import { useFormWithSchema } from "/hooks/useFormWithSchema";
 import { useCreateContinualImprovement } from "../../../../hooks/graph/ContinualImprovementGraph";
 import { PeopleSelectField } from "/components/form/PeopleSelectField";
 import { Controller } from "react-hook-form";
+import { formatError, type GraphQLError } from "@probo/helpers";
 import { formatDatetime } from "@probo/helpers";
 
 const schema = z.object({
@@ -87,7 +88,7 @@ export function CreateContinualImprovementDialog({
     } catch (error) {
       toast({
         title: __("Error"),
-        description: __("Failed to create continual improvement entry"),
+        description: formatError(__("Failed to create continual improvement"), error as GraphQLError),
         variant: "error",
       });
     }

--- a/apps/console/src/pages/organizations/documents/DocumentDetailPage.tsx
+++ b/apps/console/src/pages/organizations/documents/DocumentDetailPage.tsx
@@ -223,7 +223,7 @@ export default function DocumentDetailPage(props: Props) {
     publishDocumentVersionMutation,
     {
       successMessage: __("Document published successfully."),
-      errorMessage: __("Failed to publish document. Please try again."),
+      errorMessage: __("Failed to publish document"),
     }
   );
   const [deleteDocument, isDeleting] = useDeleteDocumentMutation();
@@ -233,7 +233,7 @@ export default function DocumentDetailPage(props: Props) {
       exportDocumentVersionPDFMutation,
       {
         successMessage: __("PDF download started."),
-        errorMessage: __("Failed to generate PDF. Please try again."),
+        errorMessage: __("Failed to generate PDF"),
       }
     );
 
@@ -243,7 +243,7 @@ export default function DocumentDetailPage(props: Props) {
     updateDocumentMutation,
     {
       successMessage: __("Document updated successfully."),
-      errorMessage: __("Failed to update document. Please try again."),
+      errorMessage: __("Failed to update document"),
     }
   );
   const versionConnectionId = document.versions.__id;

--- a/apps/console/src/pages/organizations/documents/dialogs/CreateDocumentDialog.tsx
+++ b/apps/console/src/pages/organizations/documents/dialogs/CreateDocumentDialog.tsx
@@ -66,7 +66,7 @@ export function CreateDocumentDialog({ trigger, connection }: Props) {
         connections: [connection!],
       },
       successMessage: __("Document created successfully."),
-      errorMessage: __("Failed to create document. Please try again."),
+      errorMessage: __("Failed to create document"),
       onSuccess: () => {
         dialogRef.current?.close();
         reset();

--- a/apps/console/src/pages/organizations/documents/dialogs/UpdateVersionDialog.tsx
+++ b/apps/console/src/pages/organizations/documents/dialogs/UpdateVersionDialog.tsx
@@ -89,7 +89,7 @@ export default function UpdateVersionDialog({
       UpdateDocumentMutation,
       {
         successMessage: __("Document updated successfully."),
-        errorMessage: __("Failed to update document. Please try again."),
+        errorMessage: __("Failed to update document"),
       }
     );
   const { handleSubmit, register } = useFormWithSchema(versionSchema, {

--- a/apps/console/src/pages/organizations/documents/tabs/DocumentControlsTab.tsx
+++ b/apps/console/src/pages/organizations/documents/tabs/DocumentControlsTab.tsx
@@ -78,6 +78,7 @@ export default function DocumentControlsTab() {
     {
       ...incrementOptions,
       value: -1,
+      errorMessage: "Failed to unlink control",
     },
   );
   const [attachControl, isAttaching] = useMutationWithIncrement(
@@ -85,6 +86,7 @@ export default function DocumentControlsTab() {
     {
       ...incrementOptions,
       value: 1,
+      errorMessage: "Failed to link control",
     },
   );
   const isLoading = isDetaching || isAttaching;

--- a/apps/console/src/pages/organizations/frameworks/dialogs/FrameworkControlDialog.tsx
+++ b/apps/console/src/pages/organizations/frameworks/dialogs/FrameworkControlDialog.tsx
@@ -86,11 +86,11 @@ export function FrameworkControlDialog(props: Props) {
   const [mutate, isMutating] = props.control
     ? useMutationWithToasts(updateMutation, {
         successMessage: __("Control updated successfully."),
-        errorMessage: __("Failed to update control. Please try again."),
+        errorMessage: __("Failed to update control"),
       })
     : useMutationWithToasts(createMutation, {
         successMessage: __("Control created successfully."),
-        errorMessage: __("Failed to create control. Please try again."),
+        errorMessage: __("Failed to create control"),
       });
 
   const defaultValues = useMemo(() => ({

--- a/apps/console/src/pages/organizations/measures/MeasuresPage.tsx
+++ b/apps/console/src/pages/organizations/measures/MeasuresPage.tsx
@@ -107,7 +107,7 @@ export default function MeasuresPage(props: Props) {
     importMeasuresMutation,
     {
       successMessage: __("Measures imported successfully."),
-      errorMessage: __("Failed to import measures. Please try again."),
+      errorMessage: __("Failed to import measures"),
     }
   );
   const importFileRef = useRef<HTMLInputElement>(null);

--- a/apps/console/src/pages/organizations/measures/dialog/MeasureFormDialog.tsx
+++ b/apps/console/src/pages/organizations/measures/dialog/MeasureFormDialog.tsx
@@ -3,11 +3,11 @@ import {
   Dialog,
   DialogContent,
   DialogFooter,
+  Field,
   Input,
   Label,
   Option,
   PropertyRow,
-  Textarea,
   useDialogRef,
   type DialogRef,
 } from "@probo/ui";
@@ -51,9 +51,9 @@ const measureCreateMutation = graphql`
 `;
 
 const measureSchema = z.object({
-  name: z.string(),
-  description: z.string(),
-  category: z.string(),
+  name: z.string().min(1, "Name is required"),
+  description: z.string().min(1, "Description is required"),
+  category: z.string().min(1, "Category is required"),
   state: z.enum(measureStates),
 });
 
@@ -73,7 +73,7 @@ export default function MeasureFormDialog(props: Props) {
     ? useUpdateMeasure()
     : useMutationWithToasts(measureCreateMutation, {
         successMessage: __("Measure created successfully."),
-        errorMessage: __("Failed to create measure. Please try again."),
+        errorMessage: __("Failed to create measure"),
       });
 
   const { control, handleSubmit, register, formState, reset } =
@@ -131,20 +131,21 @@ export default function MeasureFormDialog(props: Props) {
     >
       <form onSubmit={onSubmit}>
         <DialogContent className="grid grid-cols-[1fr_420px]">
-          <div className="py-8 px-10 space-y-4">
-            <Input
-              id="title"
-              required
-              variant="title"
-              placeholder={__("Measure title")}
+          <div className="py-8 px-10 space-y-6">
+            <Field
               {...register("name")}
+              error={formState.errors.name?.message}
+              label={__("Measure name")}
+              placeholder={__("Measure title")}
+              required
             />
-            <Textarea
-              id="content"
-              variant="ghost"
-              autogrow
-              placeholder={__("Add description")}
+            <Field
               {...register("description")}
+              error={formState.errors.description?.message}
+              label={__("Description")}
+              placeholder={__("Add description")}
+              type="textarea"
+              required
             />
           </div>
           {/* Properties form */}

--- a/apps/console/src/pages/organizations/nonconformities/NonconformityDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/nonconformities/NonconformityDetailsPage.tsx
@@ -32,7 +32,7 @@ import { PeopleSelectField } from "/components/form/PeopleSelectField";
 import { AuditSelectField } from "/components/form/AuditSelectField";
 import { useFormWithSchema } from "/hooks/useFormWithSchema";
 import z from "zod";
-import { getStatusVariant, getStatusLabel, formatDatetime, validateSnapshotConsistency, getStatusOptions } from "@probo/helpers";
+import { getStatusVariant, getStatusLabel, formatDatetime, validateSnapshotConsistency, getStatusOptions, formatError, type GraphQLError } from "@probo/helpers";
 import type { NonconformityGraphNodeQuery } from "/hooks/graph/__generated__/NonconformityGraphNodeQuery.graphql";
 
 const updateNonconformitySchema = z.object({
@@ -121,7 +121,7 @@ export default function NonconformityDetailsPage(props: Props) {
     } catch (error) {
       toast({
         title: __("Error"),
-        description: error instanceof Error ? error.message : __("Failed to update nonconformity"),
+        description: formatError(__("Failed to update nonconformity"), error as GraphQLError),
         variant: "error",
       });
     }

--- a/apps/console/src/pages/organizations/nonconformities/dialogs/CreateNonconformityDialog.tsx
+++ b/apps/console/src/pages/organizations/nonconformities/dialogs/CreateNonconformityDialog.tsx
@@ -21,6 +21,7 @@ import { useCreateNonconformity } from "../../../../hooks/graph/NonconformityGra
 import { PeopleSelectField } from "/components/form/PeopleSelectField";
 import { AuditSelectField } from "/components/form/AuditSelectField";
 import { Controller } from "react-hook-form";
+import { formatError, type GraphQLError } from "@probo/helpers";
 import { formatDatetime, getStatusOptions } from "@probo/helpers";
 
 const schema = z.object({
@@ -98,7 +99,7 @@ export function CreateNonconformityDialog({
     } catch (error) {
       toast({
         title: __("Error"),
-        description: __("Failed to create nonconformity"),
+        description: formatError(__("Failed to create nonconformity"), error as GraphQLError),
         variant: "error",
       });
     }

--- a/apps/console/src/pages/organizations/obligations/ObligationDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/obligations/ObligationDetailsPage.tsx
@@ -30,6 +30,7 @@ import { useOrganizationId } from "/hooks/useOrganizationId";
 import { PeopleSelectField } from "/components/form/PeopleSelectField";
 import { useFormWithSchema } from "/hooks/useFormWithSchema";
 import { Controller } from "react-hook-form";
+import { formatError, type GraphQLError } from "@probo/helpers";
 import z from "zod";
 import { getObligationStatusVariant, getObligationStatusLabel, formatDatetime, getObligationStatusOptions, validateSnapshotConsistency } from "@probo/helpers";
 import { SnapshotBanner } from "/components/SnapshotBanner";
@@ -120,10 +121,10 @@ export default function ObligationDetailsPage(props: Props) {
         description: __("Obligation updated successfully"),
         variant: "success",
       });
-    } catch {
+    } catch (error) {
       toast({
         title: __("Error"),
-        description: __("Failed to update obligation"),
+        description: formatError(__("Failed to update obligation"), error as GraphQLError),
         variant: "error",
       });
     }

--- a/apps/console/src/pages/organizations/obligations/dialogs/CreateObligationDialog.tsx
+++ b/apps/console/src/pages/organizations/obligations/dialogs/CreateObligationDialog.tsx
@@ -20,6 +20,7 @@ import { useFormWithSchema } from "/hooks/useFormWithSchema";
 import { useCreateObligation } from "../../../../hooks/graph/ObligationGraph";
 import { PeopleSelectField } from "/components/form/PeopleSelectField";
 import { Controller } from "react-hook-form";
+import { formatError, type GraphQLError } from "@probo/helpers";
 import { formatDatetime, getObligationStatusOptions } from "@probo/helpers";
 
 const schema = z.object({
@@ -91,10 +92,10 @@ export function CreateObligationDialog({
 
       reset();
       dialogRef.current?.close();
-    } catch {
+    } catch (error) {
       toast({
         title: __("Error"),
-        description: __("Failed to create obligation"),
+        description: formatError(__("Failed to create obligation"), error as GraphQLError),
         variant: "error",
       });
     }

--- a/apps/console/src/pages/organizations/people/dialogs/CreatePeopleDialog.tsx
+++ b/apps/console/src/pages/organizations/people/dialogs/CreatePeopleDialog.tsx
@@ -68,7 +68,7 @@ export function CreatePeopleDialog({ children, connectionId }: Props) {
 
   const [mutate, isMutating] = useMutationWithToasts(createPeopleMutation, {
     successMessage: __("Person created successfully."),
-    errorMessage: __("Failed to create person. Please try again."),
+    errorMessage: __("Failed to create person"),
   });
 
   const onSubmit = handleSubmit((data) => {

--- a/apps/console/src/pages/organizations/people/tabs/PeopleProfileTab.tsx
+++ b/apps/console/src/pages/organizations/people/tabs/PeopleProfileTab.tsx
@@ -45,7 +45,7 @@ export default function PeopleProfileTab() {
     updatePeopleMutation,
     {
       successMessage: __("Member updated successfully."),
-      errorMessage: __("Failed to update member. Please try again."),
+      errorMessage: __("Failed to update member"),
     }
   );
 

--- a/apps/console/src/pages/organizations/people/tabs/PeopleRoleTab.tsx
+++ b/apps/console/src/pages/organizations/people/tabs/PeopleRoleTab.tsx
@@ -33,7 +33,7 @@ export default function PeopleRoleTab() {
     updatePeopleMutation,
     {
       successMessage: __("Member updated successfully."),
-      errorMessage: __("Failed to update member. Please try again."),
+      errorMessage: __("Failed to update member"),
     }
   );
 

--- a/apps/console/src/pages/organizations/processingActivities/ProcessingActivityDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/processingActivities/ProcessingActivityDetailsPage.tsx
@@ -27,6 +27,7 @@ import { useOrganizationId } from "/hooks/useOrganizationId";
 import { useParams } from "react-router";
 import { useFormWithSchema } from "/hooks/useFormWithSchema";
 import { Controller } from "react-hook-form";
+import { formatError, type GraphQLError } from "@probo/helpers";
 import z from "zod";
 import { validateSnapshotConsistency } from "@probo/helpers";
 import { SnapshotBanner } from "/components/SnapshotBanner";
@@ -139,7 +140,7 @@ export default function ProcessingActivityDetailsPage(props: Props) {
     } catch (error) {
       toast({
         title: __("Error"),
-        description: __("Failed to update processing activity"),
+        description: formatError(__("Failed to update processing activity"), error as GraphQLError),
         variant: "error",
       });
     }

--- a/apps/console/src/pages/organizations/processingActivities/dialogs/CreateProcessingActivityDialog.tsx
+++ b/apps/console/src/pages/organizations/processingActivities/dialogs/CreateProcessingActivityDialog.tsx
@@ -18,6 +18,7 @@ import { z } from "zod";
 import { useFormWithSchema } from "/hooks/useFormWithSchema";
 import { useCreateProcessingActivity } from "../../../../hooks/graph/ProcessingActivityGraph";
 import { Controller } from "react-hook-form";
+import { formatError, type GraphQLError } from "@probo/helpers";
 import {
   SpecialOrCriminalDataOptions,
   LawfulBasisOptions,
@@ -115,7 +116,7 @@ export function CreateProcessingActivityDialog({
     } catch (error) {
       toast({
         title: __("Error"),
-        description: __("Failed to create processing activity"),
+        description: formatError(__("Failed to create processing activity"), error as GraphQLError),
         variant: "error",
       });
     }

--- a/apps/console/src/pages/organizations/risks/FormRiskDialog.tsx
+++ b/apps/console/src/pages/organizations/risks/FormRiskDialog.tsx
@@ -113,7 +113,7 @@ export default function FormRiskDialog({
           },
         },
         successMessage: __("Risk updated successfully."),
-        errorMessage: __("Failed to update risk. Please try again."),
+        errorMessage: __("Failed to update risk"),
         onSuccess: () => {
           ref?.current?.close();
         },
@@ -129,7 +129,7 @@ export default function FormRiskDialog({
         connections: [connection!],
       },
       successMessage: __("Risk created successfully."),
-      errorMessage: __("Failed to create risk. Please try again."),
+      errorMessage: __("Failed to create risk"),
       onSuccess: () => {
         ref?.current?.close();
         reset();

--- a/apps/console/src/pages/organizations/snapshots/dialog/SnapshotFormDialog.tsx
+++ b/apps/console/src/pages/organizations/snapshots/dialog/SnapshotFormDialog.tsx
@@ -57,7 +57,7 @@ export default function SnapshotFormDialog(props: Props) {
   const organizationId = useOrganizationId();
   const [mutate] = useMutationWithToasts(snapshotCreateMutation, {
     successMessage: __("Snapshot created successfully."),
-    errorMessage: __("Failed to create snapshot. Please try again."),
+    errorMessage: __("Failed to create snapshot"),
   });
 
   const { handleSubmit, register, reset, control, formState: { errors } } =

--- a/apps/console/src/pages/organizations/trustCenter/TrustCenterAccessTab.tsx
+++ b/apps/console/src/pages/organizations/trustCenter/TrustCenterAccessTab.tsx
@@ -63,11 +63,11 @@ export default function TrustCenterAccessTab() {
   });
   const [updateInvitation, isUpdating] = useMutationWithToasts(updateTrustCenterAccessMutation, {
     successMessage: __("Access updated successfully"),
-    errorMessage: __("Failed to update access. Please try again."),
+    errorMessage: __("Failed to update access"),
   });
   const [deleteInvitation, isDeleting] = useMutationWithToasts(deleteTrustCenterAccessMutation, {
     successMessage: __("Access deleted successfully"),
-    errorMessage: __("Failed to delete access. Please try again."),
+    errorMessage: __("Failed to delete access"),
   });
 
   const dialogRef = useDialogRef();

--- a/apps/console/src/pages/organizations/vendors/dialogs/CreateContactDialog.tsx
+++ b/apps/console/src/pages/organizations/vendors/dialogs/CreateContactDialog.tsx
@@ -47,8 +47,8 @@ export function CreateContactDialog({
 
   const schema = z.object({
     fullName: z.string().optional(),
-    email: z.string().email(__("Please enter a valid email address")).optional().or(z.literal("")),
-    phone: z.string().regex(phoneRegex, __("Phone number must be in international format (e.g., +1234567890)")).optional().or(z.literal("")),
+    email: z.union([z.string().email(__("Please enter a valid email address")), z.literal("")]),
+    phone: z.union([z.string().regex(phoneRegex, __("Phone number must be in international format (e.g., +1234567890)")), z.literal("")]),
     role: z.string().optional(),
   });
 
@@ -67,7 +67,7 @@ export function CreateContactDialog({
     createContactMutation,
     {
       successMessage: __("Contact created successfully."),
-      errorMessage: __("Failed to create contact. Please try again."),
+      errorMessage: __("Failed to create contact"),
     }
   );
 

--- a/apps/console/src/pages/organizations/vendors/dialogs/CreateRiskAssessmentDialog.tsx
+++ b/apps/console/src/pages/organizations/vendors/dialogs/CreateRiskAssessmentDialog.tsx
@@ -65,7 +65,7 @@ export function CreateRiskAssessmentDialog({
     createRiskAssessmentMutation,
     {
       successMessage: __("Risk Assessment created successfully."),
-      errorMessage: __("Failed to create Risk Assessment. Please try again."),
+      errorMessage: __("Failed to create Risk Assessment"),
     }
   );
 

--- a/apps/console/src/pages/organizations/vendors/dialogs/CreateServiceDialog.tsx
+++ b/apps/console/src/pages/organizations/vendors/dialogs/CreateServiceDialog.tsx
@@ -61,7 +61,7 @@ export function CreateServiceDialog({
     createServiceMutation,
     {
       successMessage: __("Service created successfully."),
-      errorMessage: __("Failed to create service. Please try again."),
+      errorMessage: __("Failed to create service"),
     }
   );
 

--- a/apps/console/src/pages/organizations/vendors/dialogs/EditContactDialog.tsx
+++ b/apps/console/src/pages/organizations/vendors/dialogs/EditContactDialog.tsx
@@ -43,8 +43,8 @@ export function EditContactDialog({ contactId, contact, onClose }: Props) {
 
   const schema = z.object({
     fullName: z.string().optional(),
-    email: z.string().email(__("Please enter a valid email address")).optional().or(z.literal("")),
-    phone: z.string().regex(phoneRegex, __("Phone number must be in international format (e.g., +1234567890)")).optional().or(z.literal("")),
+    email: z.union([z.string().email(__("Please enter a valid email address")), z.literal("")]),
+    phone: z.union([z.string().regex(phoneRegex, __("Phone number must be in international format (e.g., +1234567890)")), z.literal("")]),
     role: z.string().optional(),
   });
 
@@ -64,7 +64,7 @@ export function EditContactDialog({ contactId, contact, onClose }: Props) {
     updateContactMutation,
     {
       successMessage: __("Contact updated successfully."),
-      errorMessage: __("Failed to update contact. Please try again."),
+      errorMessage: __("Failed to update contact"),
     }
   );
 

--- a/apps/console/src/pages/organizations/vendors/dialogs/EditServiceDialog.tsx
+++ b/apps/console/src/pages/organizations/vendors/dialogs/EditServiceDialog.tsx
@@ -56,7 +56,7 @@ export function EditServiceDialog({ serviceId, service, onClose }: Props) {
     updateServiceMutation,
     {
       successMessage: __("Service updated successfully."),
-      errorMessage: __("Failed to update service. Please try again."),
+      errorMessage: __("Failed to update service"),
     }
   );
 

--- a/apps/console/src/pages/organizations/vendors/dialogs/ImportAssessmentDialog.tsx
+++ b/apps/console/src/pages/organizations/vendors/dialogs/ImportAssessmentDialog.tsx
@@ -52,7 +52,7 @@ export function ImportAssessmentDialog({ vendorId, children }: Props) {
     importAssessmentMutation,
     {
       successMessage: __("Vendor assessed successfully."),
-      errorMessage: __("Failed to assess vendor. Please try again."),
+      errorMessage: __("Failed to assess vendor"),
     }
   );
 

--- a/apps/console/src/providers/RelayProviders.tsx
+++ b/apps/console/src/providers/RelayProviders.tsx
@@ -23,6 +23,13 @@ export class InternalServerError extends Error {
   }
 }
 
+export class UnauthorizedError extends Error {
+  constructor() {
+    super("UNAUTHORIZED");
+    this.name = "UnauthorizedError";
+  }
+}
+
 export function buildEndpoint(path: string): string {
   const host = import.meta.env.VITE_API_URL;
 
@@ -46,6 +53,9 @@ export function buildEndpoint(path: string): string {
 
 const hasUnauthenticatedError = (error: GraphQLError) =>
   error.extensions?.code == "UNAUTHENTICATED";
+
+const hasUnauthorizedError = (error: GraphQLError) =>
+  error.extensions?.code == "UNAUTHORIZED";
 
 const fetchRelay: FetchFunction = async (
   request,
@@ -117,13 +127,10 @@ const fetchRelay: FetchFunction = async (
       throw new UnAuthenticatedError();
     }
 
-    throw new Error(
-      `Error fetching GraphQL query '${
-        request.name
-      }' with variables '${JSON.stringify(variables)}': ${JSON.stringify(
-        json.errors
-      )}`
-    );
+    if (errors.find(hasUnauthorizedError)) {
+      throw new UnauthorizedError();
+    }
+
   }
 
   return json;

--- a/apps/console/src/routes.tsx
+++ b/apps/console/src/routes.tsx
@@ -12,6 +12,7 @@ import { Fragment, Suspense } from "react";
 import {
   relayEnvironment,
   UnAuthenticatedError,
+  UnauthorizedError,
 } from "./providers/RelayProviders";
 import { PageSkeleton } from "./components/skeletons/PageSkeleton.tsx";
 import { loadQuery, type PreloadedQuery } from "react-relay";
@@ -51,6 +52,10 @@ function ErrorBoundary({ error: propsError }: { error?: string }) {
 
   if (error instanceof UnAuthenticatedError) {
     return <Navigate to="/auth/login" />;
+  }
+
+  if (error instanceof UnauthorizedError) {
+    return <PageError error="UNAUTHORIZED" />;
   }
 
   return <PageError error={error?.toString()} />;

--- a/packages/helpers/src/error.ts
+++ b/packages/helpers/src/error.ts
@@ -1,0 +1,26 @@
+export interface GraphQLError {
+  message?: string;
+  source?: {
+    errors?: Array<{ message: string }>;
+  };
+}
+
+export function formatError(title: string, error: GraphQLError): string {
+  const messages: string[] = [];
+
+  if (error.source?.errors && Array.isArray(error.source.errors)) {
+    messages.push(...error.source.errors.map((e) => e.message).filter(Boolean));
+  }
+
+  if (messages.length === 0 && error.message) {
+    messages.push(error.message);
+  }
+
+  if (messages.length === 0) {
+    return title;
+  }
+
+  const errorList = messages.join(", ");
+
+  return `${title}: ${errorList}${errorList.endsWith('.') ? '' : '.'}`;
+}

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -53,3 +53,4 @@ export {
 export { promisifyMutation } from "./relay";
 export { fileType, fileSize } from "./file";
 export { formatDatetime, formatDate } from "./date";
+export { formatError, type GraphQLError } from "./error";

--- a/packages/ui/src/Molecules/Dialog/ConfirmDialog.tsx
+++ b/packages/ui/src/Molecules/Dialog/ConfirmDialog.tsx
@@ -85,6 +85,9 @@ export function ConfirmDialog() {
             .then(() => {
                 close();
             })
+            .catch(() => {
+                close();
+            })
             .finally(() => {
                 setLoading(false);
             });

--- a/pkg/coredata/control_document.go
+++ b/pkg/coredata/control_document.go
@@ -36,16 +36,7 @@ type (
 	}
 
 	ControlDocuments []*ControlDocument
-
-	ErrControlDocumentMappingAlreadyExists struct {
-		ControlID  gid.GID
-		DocumentID gid.GID
-	}
 )
-
-func (e ErrControlDocumentMappingAlreadyExists) Error() string {
-	return fmt.Sprintf("control %s is already mapped to document %s", e.ControlID, e.DocumentID)
-}
 
 func (cp ControlDocument) Insert(
 	ctx context.Context,
@@ -80,9 +71,8 @@ VALUES (
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) {
 			if pgErr.Code == "23505" && pgErr.ConstraintName == "controls_policies_pkey" {
-				return &ErrControlDocumentMappingAlreadyExists{
-					ControlID:  cp.ControlID,
-					DocumentID: cp.DocumentID,
+				return &ErrResourceAlreadyExists{
+					Resource: "control document mapping",
 				}
 			}
 		}

--- a/pkg/coredata/error.go
+++ b/pkg/coredata/error.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import "fmt"
+
+type ErrResourceNotFound struct {
+	Resource   string
+	Identifier string
+}
+
+func (e ErrResourceNotFound) Error() string {
+	return fmt.Sprintf("%s not found: %s", e.Resource, e.Identifier)
+}
+
+type ErrResourceAlreadyExists struct {
+	Resource string
+	Message  string
+}
+
+func (e ErrResourceAlreadyExists) Error() string {
+	msg := fmt.Sprintf("%s already exists", e.Resource)
+
+	if e.Message != "" {
+		msg += ": " + e.Message
+	}
+
+	return msg
+}
+
+type ErrRestrictedOperation struct {
+	Resource string
+	Message  string
+}
+
+func (e ErrRestrictedOperation) Error() string {
+	msg := fmt.Sprintf("restricted operation on %s", e.Resource)
+
+	if e.Message != "" {
+		msg += ": " + e.Message
+	}
+
+	return msg
+}
+
+type ErrInvalidValue struct {
+	Field   string
+	Value   string
+	Message string
+}
+
+func (e ErrInvalidValue) Error() string {
+	var msg string
+	if e.Value != "" {
+		msg = fmt.Sprintf("invalid value %s for %s", e.Value, e.Field)
+	} else {
+		msg = fmt.Sprintf("invalid value for %s", e.Field)
+	}
+
+	if e.Message != "" {
+		msg += ": " + e.Message
+	}
+
+	return msg
+}
+
+type ErrNoChange struct {
+	Resource string
+	Message  string
+}
+
+func (e ErrNoChange) Error() string {
+	msg := fmt.Sprintf("no changes detected for %s", e.Resource)
+
+	if e.Message != "" {
+		msg += ": " + e.Message
+	}
+
+	return msg
+}

--- a/pkg/coredata/framework.go
+++ b/pkg/coredata/framework.go
@@ -40,16 +40,7 @@ type (
 	}
 
 	Frameworks []*Framework
-
-	ErrFrameworkReferenceIDAlreadyExists struct {
-		ReferenceID    string
-		OrganizationID gid.GID
-	}
 )
-
-func (e ErrFrameworkReferenceIDAlreadyExists) Error() string {
-	return fmt.Sprintf("framework with reference ID %q already exists for organization %s", e.ReferenceID, e.OrganizationID)
-}
 
 func (f *Framework) CursorKey(orderBy FrameworkOrderField) page.CursorKey {
 	switch orderBy {
@@ -264,9 +255,9 @@ VALUES (
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) {
 			if pgErr.Code == "23505" && pgErr.ConstraintName == "frameworks_org_ref_unique" {
-				return &ErrFrameworkReferenceIDAlreadyExists{
-					ReferenceID:    f.ReferenceID,
-					OrganizationID: f.OrganizationID,
+				return &ErrResourceAlreadyExists{
+					Resource: "framework",
+					Message:  "same reference ID",
 				}
 			}
 		}
@@ -311,7 +302,7 @@ SET
   name = @name,
   description = @description,
   updated_at = @updated_at
-WHERE 
+WHERE
   %s
   AND id = @framework_id
 `

--- a/pkg/coredata/trust_center_access.go
+++ b/pkg/coredata/trust_center_access.go
@@ -44,15 +44,7 @@ type (
 	}
 
 	TrustCenterAccesses []*TrustCenterAccess
-
-	ErrTrustCenterAccessNotFound struct {
-		Identifier string
-	}
 )
-
-func (e ErrTrustCenterAccessNotFound) Error() string {
-	return fmt.Sprintf("trust center access not found: %s", e.Identifier)
-}
 
 func (tca *TrustCenterAccess) CursorKey(orderBy TrustCenterAccessOrderField) page.CursorKey {
 	switch orderBy {
@@ -103,7 +95,7 @@ LIMIT 1;
 	access, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[TrustCenterAccess])
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return &ErrTrustCenterAccessNotFound{Identifier: accessID.String()}
+			return &ErrResourceNotFound{Resource: "trust center access", Identifier: accessID.String()}
 		}
 
 		return fmt.Errorf("cannot collect trust center access: %w", err)
@@ -159,7 +151,7 @@ LIMIT 1;
 	access, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[TrustCenterAccess])
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return &ErrTrustCenterAccessNotFound{Identifier: fmt.Sprintf("trust_center_id=%s, email=%s", trustCenterID, email)}
+			return &ErrResourceNotFound{Resource: "trust center access", Identifier: fmt.Sprintf("trust_center_id=%s, email=%s", trustCenterID, email)}
 		}
 
 		return fmt.Errorf("cannot collect trust center access: %w", err)

--- a/pkg/coredata/vendor_business_associate_agreement.go
+++ b/pkg/coredata/vendor_business_associate_agreement.go
@@ -16,6 +16,7 @@ package coredata
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"time"
@@ -92,6 +93,9 @@ LIMIT 1;
 
 	vendorBusinessAssociateAgreement, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[VendorBusinessAssociateAgreement])
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return &ErrResourceNotFound{Resource: "vendor business associate agreement", Identifier: vendorID.String()}
+		}
 		return fmt.Errorf("cannot collect vendor business associate agreement: %w", err)
 	}
 

--- a/pkg/coredata/vendor_contact.go
+++ b/pkg/coredata/vendor_contact.go
@@ -42,15 +42,7 @@ type (
 	}
 
 	VendorContacts []*VendorContact
-
-	ErrVendorContactNotFound struct {
-		Identifier string
-	}
 )
-
-func (e ErrVendorContactNotFound) Error() string {
-	return fmt.Sprintf("vendor contact not found: %s", e.Identifier)
-}
 
 func (vc VendorContact) CursorKey(orderBy VendorContactOrderField) page.CursorKey {
 	switch orderBy {
@@ -105,7 +97,7 @@ LIMIT 1;
 	vendorContact, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[VendorContact])
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return &ErrVendorContactNotFound{Identifier: vendorContactID.String()}
+			return &ErrResourceNotFound{Resource: "vendor contact", Identifier: vendorContactID.String()}
 		}
 
 		return fmt.Errorf("cannot collect vendor contact: %w", err)

--- a/pkg/coredata/vendor_data_privacy_agreement.go
+++ b/pkg/coredata/vendor_data_privacy_agreement.go
@@ -16,6 +16,7 @@ package coredata
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"time"
@@ -92,6 +93,9 @@ LIMIT 1;
 
 	vendorDataPrivacyAgreement, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[VendorDataPrivacyAgreement])
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return &ErrResourceNotFound{Resource: "vendor data privacy agreement", Identifier: vendorID.String()}
+		}
 		return fmt.Errorf("cannot collect vendor data privacy agreement: %w", err)
 	}
 

--- a/pkg/coredata/vendor_service.go
+++ b/pkg/coredata/vendor_service.go
@@ -40,15 +40,7 @@ type (
 	}
 
 	VendorServices []*VendorService
-
-	ErrVendorServiceNotFound struct {
-		Identifier string
-	}
 )
-
-func (e ErrVendorServiceNotFound) Error() string {
-	return fmt.Sprintf("vendor service not found: %s", e.Identifier)
-}
 
 func (vs VendorService) CursorKey(orderBy VendorServiceOrderField) page.CursorKey {
 	switch orderBy {
@@ -99,7 +91,7 @@ LIMIT 1;
 	vendorService, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[VendorService])
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return &ErrVendorServiceNotFound{Identifier: vendorServiceID.String()}
+			return &ErrResourceNotFound{Resource: "vendor service", Identifier: vendorServiceID.String()}
 		}
 
 		return fmt.Errorf("cannot collect vendor service: %w", err)

--- a/pkg/probo/document_service.go
+++ b/pkg/probo/document_service.go
@@ -273,7 +273,9 @@ func (s *DocumentService) publishVersionInTx(
 		if publishedVersion.Content == documentVersion.Content &&
 			publishedVersion.Title == documentVersion.Title &&
 			publishedVersion.OwnerID == documentVersion.OwnerID {
-			return nil, nil, fmt.Errorf("cannot publish version: no changes detected")
+			return nil, nil, &coredata.ErrNoChange{
+				Resource: "document version",
+			}
 		}
 	}
 
@@ -847,10 +849,10 @@ func (s *DocumentService) RequestExport(
 
 	if options.WithWatermark {
 		if options.WatermarkEmail == nil {
-			return nil, fmt.Errorf("watermark email is required when with watermark is true")
+			return nil, &coredata.ErrInvalidValue{Field: "watermark email", Message: "watermark email is required when with watermark is true"}
 		}
 		if _, err := mail.ParseAddress(*options.WatermarkEmail); err != nil {
-			return nil, fmt.Errorf("invalid email address")
+			return nil, &coredata.ErrInvalidValue{Field: "watermark email"}
 		}
 	}
 
@@ -1441,10 +1443,10 @@ func exportDocumentPDF(
 
 	if options.WithWatermark {
 		if options.WatermarkEmail == nil {
-			return nil, fmt.Errorf("watermark email is required with watermark enabled")
+			return nil, &coredata.ErrInvalidValue{Field: "watermark email", Message: "watermark email is required with watermark enabled"}
 		}
 		if _, err := mail.ParseAddress(*options.WatermarkEmail); err != nil {
-			return nil, fmt.Errorf("invalid email address")
+			return nil, &coredata.ErrInvalidValue{Field: "watermark email"}
 		}
 
 		watermarkedPDF, err := watermarkpdf.AddConfidentialWithTimestamp(pdfData, *options.WatermarkEmail)

--- a/pkg/probo/organization_service.go
+++ b/pkg/probo/organization_service.go
@@ -184,7 +184,7 @@ func (s OrganizationService) Update(
 			if req.Email != nil {
 				if *req.Email != nil {
 					if _, err := mail.ParseAddress(**req.Email); err != nil {
-						return fmt.Errorf("invalid email address: %w", err)
+						return &coredata.ErrInvalidValue{Field: "email"}
 					}
 				}
 				organization.Email = *req.Email

--- a/pkg/probo/trust_center_access_service.go
+++ b/pkg/probo/trust_center_access_service.go
@@ -193,11 +193,11 @@ func (s TrustCenterAccessService) Create(
 	req *CreateTrustCenterAccessRequest,
 ) (*coredata.TrustCenterAccess, error) {
 	if _, err := mail.ParseAddress(req.Email); err != nil {
-		return nil, fmt.Errorf("invalid email address")
+		return nil, &coredata.ErrInvalidValue{Field: "email"}
 	}
 
 	if req.Name == "" {
-		return nil, fmt.Errorf("name is required")
+		return nil, &coredata.ErrInvalidValue{Field: "name", Message: "name is required"}
 	}
 
 	now := time.Now()

--- a/pkg/server/api/console/v1/reset_password_handler.go
+++ b/pkg/server/api/console/v1/reset_password_handler.go
@@ -21,6 +21,7 @@ import (
 
 	"errors"
 
+	"github.com/getprobo/probo/pkg/coredata"
 	"github.com/getprobo/probo/pkg/usrmgr"
 	"go.gearno.de/kit/httpserver"
 )
@@ -46,10 +47,10 @@ func ResetPasswordHandler(usrmgrSvc *usrmgr.Service, authCfg AuthConfig) http.Ha
 
 		err := usrmgrSvc.ResetPassword(r.Context(), req.Token, req.Password)
 		if err != nil {
-			var invalidPasswordErr *usrmgr.ErrInvalidPassword
+			var invalidValueErr *coredata.ErrInvalidValue
 			var invalidTokenErr *usrmgr.ErrInvalidTokenType
 
-			if errors.As(err, &invalidPasswordErr) {
+			if errors.As(err, &invalidValueErr) {
 				httpserver.RenderError(w, http.StatusBadRequest, err)
 				return
 			}

--- a/pkg/server/api/console/v1/resolver.go
+++ b/pkg/server/api/console/v1/resolver.go
@@ -232,6 +232,7 @@ func graphqlHandler(logger *log.Logger, proboSvc *probo.Service, usrmgrSvc *usrm
 	srv.Use(extension.Introspection{})
 	srv.Use(tracingExtension{})
 	srv.SetRecoverFunc(gqlutils.RecoverFunc)
+	srv.SetErrorPresenter(gqlutils.ErrorPresenter)
 
 	srv.AroundOperations(
 		func(ctx context.Context, next graphql.OperationHandler) graphql.ResponseHandler {

--- a/pkg/server/api/console/v1/sign_up_handler.go
+++ b/pkg/server/api/console/v1/sign_up_handler.go
@@ -53,8 +53,8 @@ func SignUpHandler(usrmgrSvc *usrmgr.Service, authCfg AuthConfig) http.HandlerFu
 			req.FullName,
 		)
 		if err != nil {
-			var errUserAlreadyExists *coredata.ErrUserAlreadyExists
-			if errors.As(err, &errUserAlreadyExists) {
+			var errResourceAlreadyExists *coredata.ErrResourceAlreadyExists
+			if errors.As(err, &errResourceAlreadyExists) {
 				httpserver.RenderError(w, http.StatusBadRequest, fmt.Errorf("cannot register user: %w", err))
 				return
 			}

--- a/pkg/server/api/console/v1/v1_resolver.go
+++ b/pkg/server/api/console/v1/v1_resolver.go
@@ -18,8 +18,6 @@ import (
 	"github.com/getprobo/probo/pkg/probo"
 	"github.com/getprobo/probo/pkg/server/api/console/v1/schema"
 	"github.com/getprobo/probo/pkg/server/api/console/v1/types"
-	pgx "github.com/jackc/pgx/v5"
-	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 // Owner is the resolver for the owner field.
@@ -321,7 +319,7 @@ func (r *controlResolver) Measures(ctx context.Context, obj *types.Control, firs
 
 	page, err := prb.Measures.ListForControlID(ctx, obj.ID, cursor, measureFilter)
 	if err != nil {
-		return nil, fmt.Errorf("cannot list measures: %w", err)
+		panic(fmt.Errorf("cannot list measures: %w", err))
 	}
 
 	return types.NewMeasureConnection(page, r, obj.ID, measureFilter), nil
@@ -351,7 +349,7 @@ func (r *controlResolver) Documents(ctx context.Context, obj *types.Control, fir
 
 	page, err := prb.Documents.ListForControlID(ctx, obj.ID, cursor, documentFilter)
 	if err != nil {
-		return nil, fmt.Errorf("cannot list documents: %w", err)
+		panic(fmt.Errorf("cannot list documents: %w", err))
 	}
 
 	return types.NewDocumentConnection(page, r, obj.ID, documentFilter), nil
@@ -376,7 +374,7 @@ func (r *controlResolver) Audits(ctx context.Context, obj *types.Control, first 
 
 	page, err := prb.Audits.ListForControlID(ctx, obj.ID, cursor)
 	if err != nil {
-		return nil, fmt.Errorf("cannot list control audits: %w", err)
+		panic(fmt.Errorf("cannot list control audits: %w", err))
 	}
 
 	return types.NewAuditConnection(page, r, obj.ID), nil
@@ -416,31 +414,31 @@ func (r *controlConnectionResolver) TotalCount(ctx context.Context, obj *types.C
 	case *organizationResolver:
 		count, err := prb.Controls.CountForOrganizationID(ctx, obj.ParentID, obj.Filters)
 		if err != nil {
-			return 0, fmt.Errorf("cannot count controls: %w", err)
+			panic(fmt.Errorf("cannot count controls: %w", err))
 		}
 		return count, nil
 	case *frameworkResolver:
 		count, err := prb.Controls.CountForFrameworkID(ctx, obj.ParentID, obj.Filters)
 		if err != nil {
-			return 0, fmt.Errorf("cannot count controls: %w", err)
+			panic(fmt.Errorf("cannot count controls: %w", err))
 		}
 		return count, nil
 	case *documentResolver:
 		count, err := prb.Controls.CountForDocumentID(ctx, obj.ParentID, obj.Filters)
 		if err != nil {
-			return 0, fmt.Errorf("cannot count controls: %w", err)
+			panic(fmt.Errorf("cannot count controls: %w", err))
 		}
 		return count, nil
 	case *measureResolver:
 		count, err := prb.Controls.CountForMeasureID(ctx, obj.ParentID, obj.Filters)
 		if err != nil {
-			return 0, fmt.Errorf("cannot count controls: %w", err)
+			panic(fmt.Errorf("cannot count controls: %w", err))
 		}
 		return count, nil
 	case *riskResolver:
 		count, err := prb.Controls.CountForRiskID(ctx, obj.ParentID, obj.Filters)
 		if err != nil {
-			return 0, fmt.Errorf("cannot count controls: %w", err)
+			panic(fmt.Errorf("cannot count controls: %w", err))
 		}
 		return count, nil
 	}
@@ -454,12 +452,12 @@ func (r *datumResolver) Owner(ctx context.Context, obj *types.Datum) (*types.Peo
 
 	data, err := prb.Data.Get(ctx, obj.ID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get datum: %w", err)
+		panic(fmt.Errorf("cannot get datum: %w", err))
 	}
 
 	people, err := prb.Peoples.Get(ctx, data.OwnerID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get owner: %w", err)
+		panic(fmt.Errorf("cannot get owner: %w", err))
 	}
 
 	return types.NewPeople(people), nil
@@ -496,7 +494,7 @@ func (r *datumResolver) Organization(ctx context.Context, obj *types.Datum) (*ty
 
 	org, err := prb.Organizations.Get(ctx, obj.Organization.ID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get organization: %w", err)
+		panic(fmt.Errorf("cannot get organization: %w", err))
 	}
 
 	return types.NewOrganization(org), nil
@@ -515,7 +513,7 @@ func (r *datumConnectionResolver) TotalCount(ctx context.Context, obj *types.Dat
 
 		count, err := prb.Data.CountForOrganizationID(ctx, obj.ParentID, datumFilter)
 		if err != nil {
-			return 0, fmt.Errorf("cannot count data: %w", err)
+			panic(fmt.Errorf("cannot count data: %w", err))
 		}
 		return count, nil
 	}
@@ -532,7 +530,6 @@ func (r *documentResolver) Owner(ctx context.Context, obj *types.Document) (*typ
 		panic(fmt.Errorf("cannot get document: %w", err))
 	}
 
-	// Get the owner
 	owner, err := prb.Peoples.Get(ctx, document.OwnerID)
 	if err != nil {
 		panic(fmt.Errorf("cannot get owner: %w", err))
@@ -744,7 +741,7 @@ func (r *evidenceResolver) FileURL(ctx context.Context, obj *types.Evidence) (*s
 
 	fileURL, err := prb.Evidences.GenerateFileURL(ctx, obj.ID, 15*time.Minute)
 	if err != nil {
-		return nil, fmt.Errorf("cannot generate file URL: %w", err)
+		panic(fmt.Errorf("cannot generate file URL: %w", err))
 	}
 
 	result := *fileURL
@@ -757,16 +754,16 @@ func (r *evidenceResolver) Task(ctx context.Context, obj *types.Evidence) (*type
 
 	evidence, err := prb.Evidences.Get(ctx, obj.ID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot load evidence: %w", err)
+		panic(fmt.Errorf("cannot load evidence: %w", err))
 	}
 
 	if evidence.TaskID == nil {
-		return nil, fmt.Errorf("evidence is not associated with a task")
+		return nil, errors.New("evidence is not associated with a task")
 	}
 
 	task, err := prb.Tasks.Get(ctx, *evidence.TaskID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot load task: %w", err)
+		panic(fmt.Errorf("cannot load task: %w", err))
 	}
 
 	return types.NewTask(task), nil
@@ -778,12 +775,12 @@ func (r *evidenceResolver) Measure(ctx context.Context, obj *types.Evidence) (*t
 
 	evidence, err := prb.Evidences.Get(ctx, obj.ID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot load evidence: %w", err)
+		panic(fmt.Errorf("cannot load evidence: %w", err))
 	}
 
 	measure, err := prb.Measures.Get(ctx, evidence.MeasureID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot load measure: %w", err)
+		panic(fmt.Errorf("cannot load measure: %w", err))
 	}
 
 	return types.NewMeasure(measure), nil
@@ -797,13 +794,13 @@ func (r *evidenceConnectionResolver) TotalCount(ctx context.Context, obj *types.
 	case *measureResolver:
 		count, err := prb.Evidences.CountForMeasureID(ctx, obj.ParentID)
 		if err != nil {
-			return 0, fmt.Errorf("cannot count tasks: %w", err)
+			panic(fmt.Errorf("cannot count evidences: %w", err))
 		}
 		return count, nil
 	case *taskResolver:
 		count, err := prb.Evidences.CountForTaskID(ctx, obj.ParentID)
 		if err != nil {
-			return 0, fmt.Errorf("cannot count tasks: %w", err)
+			panic(fmt.Errorf("cannot count evidences: %w", err))
 		}
 		return count, nil
 	}
@@ -817,12 +814,12 @@ func (r *frameworkResolver) Organization(ctx context.Context, obj *types.Framewo
 
 	framework, err := prb.Frameworks.Get(ctx, obj.ID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot load framework: %w", err)
+		panic(fmt.Errorf("cannot load framework: %w", err))
 	}
 
 	organization, err := prb.Organizations.Get(ctx, framework.OrganizationID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot load organization: %w", err)
+		panic(fmt.Errorf("cannot load organization: %w", err))
 	}
 
 	return types.NewOrganization(organization), nil
@@ -852,7 +849,7 @@ func (r *frameworkResolver) Controls(ctx context.Context, obj *types.Framework, 
 
 	page, err := prb.Controls.ListForFrameworkID(ctx, obj.ID, cursor, controlFilter)
 	if err != nil {
-		return nil, fmt.Errorf("cannot list controls: %w", err)
+		panic(fmt.Errorf("cannot list controls: %w", err))
 	}
 
 	return types.NewControlConnection(page, r, obj.ID, controlFilter), nil
@@ -866,7 +863,7 @@ func (r *frameworkConnectionResolver) TotalCount(ctx context.Context, obj *types
 	case *organizationResolver:
 		count, err := prb.Frameworks.CountForOrganizationID(ctx, obj.ParentID)
 		if err != nil {
-			return 0, fmt.Errorf("cannot count frameworks: %w", err)
+			panic(fmt.Errorf("cannot count frameworks: %w", err))
 		}
 		return count, nil
 	}
@@ -893,7 +890,7 @@ func (r *measureResolver) Evidences(ctx context.Context, obj *types.Measure, fir
 
 	page, err := prb.Evidences.ListForMeasureID(ctx, obj.ID, cursor)
 	if err != nil {
-		return nil, fmt.Errorf("cannot list measure evidences: %w", err)
+		panic(fmt.Errorf("cannot list measure evidences: %w", err))
 	}
 
 	return types.NewEvidenceConnection(page, r, obj.ID), nil
@@ -918,7 +915,7 @@ func (r *measureResolver) Tasks(ctx context.Context, obj *types.Measure, first *
 
 	page, err := prb.Tasks.ListForMeasureID(ctx, obj.ID, cursor)
 	if err != nil {
-		return nil, fmt.Errorf("cannot list measure tasks: %w", err)
+		panic(fmt.Errorf("cannot list measure tasks: %w", err))
 	}
 
 	return types.NewTaskConnection(page, r, obj.ID), nil
@@ -948,7 +945,7 @@ func (r *measureResolver) Risks(ctx context.Context, obj *types.Measure, first *
 
 	page, err := prb.Risks.ListForMeasureID(ctx, obj.ID, cursor, riskFilter)
 	if err != nil {
-		return nil, fmt.Errorf("cannot list measure risks: %w", err)
+		panic(fmt.Errorf("cannot list measure risks: %w", err))
 	}
 
 	return types.NewRiskConnection(page, r, obj.ID, riskFilter), nil
@@ -978,7 +975,7 @@ func (r *measureResolver) Controls(ctx context.Context, obj *types.Measure, firs
 
 	page, err := prb.Controls.ListForMeasureID(ctx, obj.ID, cursor, controlFilter)
 	if err != nil {
-		return nil, fmt.Errorf("cannot list measure controls: %w", err)
+		panic(fmt.Errorf("cannot list measure controls: %w", err))
 	}
 
 	return types.NewControlConnection(page, r, obj.ID, controlFilter), nil
@@ -992,19 +989,19 @@ func (r *measureConnectionResolver) TotalCount(ctx context.Context, obj *types.M
 	case *organizationResolver:
 		count, err := prb.Measures.CountForOrganizationID(ctx, obj.ParentID, obj.Filters)
 		if err != nil {
-			return 0, fmt.Errorf("cannot count measures: %w", err)
+			panic(fmt.Errorf("cannot count measures: %w", err))
 		}
 		return count, nil
 	case *controlResolver:
 		count, err := prb.Measures.CountForControlID(ctx, obj.ParentID, obj.Filters)
 		if err != nil {
-			return 0, fmt.Errorf("cannot count measures: %w", err)
+			panic(fmt.Errorf("cannot count measures: %w", err))
 		}
 		return count, nil
 	case *riskResolver:
 		count, err := prb.Measures.CountForRiskID(ctx, obj.ParentID, obj.Filters)
 		if err != nil {
-			return 0, fmt.Errorf("cannot count measures: %w", err)
+			panic(fmt.Errorf("cannot count measures: %w", err))
 		}
 		return count, nil
 	}
@@ -1023,7 +1020,7 @@ func (r *mutationResolver) CreateOrganization(ctx context.Context, input types.C
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("cannot create organization: %w", err)
+		panic(fmt.Errorf("cannot create organization: %w", err))
 	}
 
 	err = r.usrmgrSvc.EnrollUserInOrganization(
@@ -1032,7 +1029,7 @@ func (r *mutationResolver) CreateOrganization(ctx context.Context, input types.C
 		organization.ID,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("cannot add user to organization: %w", err)
+		panic(fmt.Errorf("cannot add user to organization: %w", err))
 	}
 
 	tenantIDs, _ := ctx.Value(userTenantContextKey).(*[]gid.TenantID)
@@ -1053,7 +1050,7 @@ func (r *mutationResolver) CreateOrganization(ctx context.Context, input types.C
 	)
 
 	if err != nil {
-		return nil, fmt.Errorf("cannot create people: %w", err)
+		panic(fmt.Errorf("cannot create people: %w", err))
 	}
 
 	return &types.CreateOrganizationPayload{
@@ -1085,7 +1082,7 @@ func (r *mutationResolver) UpdateOrganization(ctx context.Context, input types.U
 
 	organization, err := prb.Organizations.Update(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("cannot update organization: %w", err)
+		panic(fmt.Errorf("cannot update organization: %w", err))
 	}
 
 	return &types.UpdateOrganizationPayload{
@@ -1099,7 +1096,7 @@ func (r *mutationResolver) DeleteOrganization(ctx context.Context, input types.D
 
 	err := prb.Organizations.Delete(ctx, input.OrganizationID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot delete organization: %w", err)
+		panic(fmt.Errorf("cannot delete organization: %w", err))
 	}
 
 	return &types.DeleteOrganizationPayload{
@@ -1117,7 +1114,7 @@ func (r *mutationResolver) UpdateTrustCenter(ctx context.Context, input types.Up
 		Slug:   input.Slug,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("cannot update trust center: %w", err)
+		panic(fmt.Errorf("cannot update trust center: %w", err))
 	}
 
 	return &types.UpdateTrustCenterPayload{
@@ -1135,7 +1132,7 @@ func (r *mutationResolver) UploadTrustCenterNda(ctx context.Context, input types
 		FileName:      input.FileName,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("cannot upload trust center NDA: %w", err)
+		panic(fmt.Errorf("cannot upload trust center NDA: %w", err))
 	}
 
 	return &types.UploadTrustCenterNDAPayload{
@@ -1151,7 +1148,7 @@ func (r *mutationResolver) DeleteTrustCenterNda(ctx context.Context, input types
 		TrustCenterID: input.TrustCenterID,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("cannot delete trust center NDA: %w", err)
+		panic(fmt.Errorf("cannot delete trust center NDA: %w", err))
 	}
 
 	return &types.DeleteTrustCenterNDAPayload{
@@ -1169,7 +1166,7 @@ func (r *mutationResolver) CreateTrustCenterAccess(ctx context.Context, input ty
 		Name:          input.Name,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("cannot create trust center access: %w", err)
+		panic(fmt.Errorf("cannot create trust center access: %w", err))
 	}
 
 	return &types.CreateTrustCenterAccessPayload{
@@ -1205,7 +1202,7 @@ func (r *mutationResolver) DeleteTrustCenterAccess(ctx context.Context, input ty
 		ID: input.ID,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("cannot delete trust center access: %w", err)
+		panic(fmt.Errorf("cannot delete trust center access: %w", err))
 	}
 
 	return &types.DeleteTrustCenterAccessPayload{
@@ -1230,7 +1227,7 @@ func (r *mutationResolver) CreateTrustCenterReference(ctx context.Context, input
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("cannot create trust center reference: %w", err)
+		panic(fmt.Errorf("cannot create trust center reference: %w", err))
 	}
 
 	return &types.CreateTrustCenterReferencePayload{
@@ -1260,7 +1257,7 @@ func (r *mutationResolver) UpdateTrustCenterReference(ctx context.Context, input
 
 	reference, err := prb.TrustCenterReferences.Update(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("cannot update trust center reference: %w", err)
+		panic(fmt.Errorf("cannot update trust center reference: %w", err))
 	}
 
 	return &types.UpdateTrustCenterReferencePayload{
@@ -1276,7 +1273,7 @@ func (r *mutationResolver) DeleteTrustCenterReference(ctx context.Context, input
 		ID: input.ID,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("cannot delete trust center reference: %w", err)
+		panic(fmt.Errorf("cannot delete trust center reference: %w", err))
 	}
 
 	return &types.DeleteTrustCenterReferencePayload{
@@ -1289,7 +1286,7 @@ func (r *mutationResolver) ConfirmEmail(ctx context.Context, input types.Confirm
 	err := r.usrmgrSvc.ConfirmEmail(ctx, input.Token)
 
 	if err != nil {
-		return nil, err
+		panic(fmt.Errorf("cannot confirm email: %w", err))
 	}
 
 	return &types.ConfirmEmailPayload{Success: true}, nil
@@ -1310,14 +1307,14 @@ func (r *mutationResolver) InviteUser(ctx context.Context, input types.InviteUse
 
 			err := r.usrmgrSvc.InviteUser(ctx, input.OrganizationID, input.FullName, input.Email, createPeople)
 			if err != nil {
-				return nil, err
+				panic(fmt.Errorf("cannot invite user: %w", err))
 			}
 
 			return &types.InviteUserPayload{Success: true}, nil
 		}
 	}
 
-	return nil, fmt.Errorf("organization not found")
+	return nil, errors.New("organization not found or access denied")
 }
 
 // RemoveUser is the resolver for the removeUser field.
@@ -1333,14 +1330,14 @@ func (r *mutationResolver) RemoveUser(ctx context.Context, input types.RemoveUse
 		if organization.ID == input.OrganizationID {
 			err := r.usrmgrSvc.RemoveUser(ctx, input.OrganizationID, input.UserID)
 			if err != nil {
-				return nil, err
+				panic(fmt.Errorf("cannot remove user: %w", err))
 			}
 
 			return &types.RemoveUserPayload{Success: true}, nil
 		}
 	}
 
-	return nil, fmt.Errorf("organization not found")
+	return nil, errors.New("organization not found or access denied")
 }
 
 // CreatePeople is the resolver for the createPeople field.
@@ -1359,7 +1356,7 @@ func (r *mutationResolver) CreatePeople(ctx context.Context, input types.CreateP
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("cannot create people: %w", err)
+		panic(fmt.Errorf("cannot create people: %w", err))
 	}
 
 	return &types.CreatePeoplePayload{
@@ -1382,7 +1379,7 @@ func (r *mutationResolver) UpdatePeople(ctx context.Context, input types.UpdateP
 		ContractEndDate:          &input.ContractEndDate,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("cannot update people: %w", err)
+		panic(fmt.Errorf("cannot update people: %w", err))
 	}
 
 	return &types.UpdatePeoplePayload{
@@ -1396,7 +1393,7 @@ func (r *mutationResolver) DeletePeople(ctx context.Context, input types.DeleteP
 
 	err := prb.Peoples.Delete(ctx, input.PeopleID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot delete people: %w", err)
+		panic(fmt.Errorf("cannot delete people: %w", err))
 	}
 
 	return &types.DeletePeoplePayload{
@@ -1434,7 +1431,7 @@ func (r *mutationResolver) CreateVendor(ctx context.Context, input types.CreateV
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("cannot create vendor: %w", err)
+		panic(fmt.Errorf("cannot create vendor: %w", err))
 	}
 	return &types.CreateVendorPayload{
 		VendorEdge: types.NewVendorEdge(vendor, coredata.VendorOrderFieldName),
@@ -1469,7 +1466,7 @@ func (r *mutationResolver) UpdateVendor(ctx context.Context, input types.UpdateV
 		Countries:                     input.Countries,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("cannot update vendor: %w", err)
+		panic(fmt.Errorf("cannot update vendor: %w", err))
 	}
 
 	return &types.UpdateVendorPayload{
@@ -1483,7 +1480,7 @@ func (r *mutationResolver) DeleteVendor(ctx context.Context, input types.DeleteV
 
 	err := prb.Vendors.Delete(ctx, input.VendorID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot delete vendor: %w", err)
+		panic(fmt.Errorf("cannot delete vendor: %w", err))
 	}
 
 	return &types.DeleteVendorPayload{
@@ -1505,7 +1502,7 @@ func (r *mutationResolver) CreateVendorContact(ctx context.Context, input types.
 
 	vendorContact, err := prb.VendorContacts.Create(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create vendor contact: %w", err)
+		panic(fmt.Errorf("failed to create vendor contact: %w", err))
 	}
 
 	return &types.CreateVendorContactPayload{
@@ -1527,7 +1524,7 @@ func (r *mutationResolver) UpdateVendorContact(ctx context.Context, input types.
 
 	vendorContact, err := prb.VendorContacts.Update(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to update vendor contact: %w", err)
+		panic(fmt.Errorf("failed to update vendor contact: %w", err))
 	}
 
 	return &types.UpdateVendorContactPayload{
@@ -1541,7 +1538,7 @@ func (r *mutationResolver) DeleteVendorContact(ctx context.Context, input types.
 
 	err := prb.VendorContacts.Delete(ctx, input.VendorContactID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to delete vendor contact: %w", err)
+		panic(fmt.Errorf("failed to delete vendor contact: %w", err))
 	}
 
 	return &types.DeleteVendorContactPayload{
@@ -1561,7 +1558,7 @@ func (r *mutationResolver) CreateVendorService(ctx context.Context, input types.
 
 	vendorService, err := prb.VendorServices.Create(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create vendor service: %w", err)
+		panic(fmt.Errorf("failed to create vendor service: %w", err))
 	}
 
 	return &types.CreateVendorServicePayload{
@@ -1581,7 +1578,7 @@ func (r *mutationResolver) UpdateVendorService(ctx context.Context, input types.
 
 	vendorService, err := prb.VendorServices.Update(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to update vendor service: %w", err)
+		panic(fmt.Errorf("failed to update vendor service: %w", err))
 	}
 
 	return &types.UpdateVendorServicePayload{
@@ -1595,7 +1592,7 @@ func (r *mutationResolver) DeleteVendorService(ctx context.Context, input types.
 
 	err := prb.VendorServices.Delete(ctx, input.VendorServiceID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to delete vendor service: %w", err)
+		panic(fmt.Errorf("failed to delete vendor service: %w", err))
 	}
 
 	return &types.DeleteVendorServicePayload{
@@ -1612,7 +1609,7 @@ func (r *mutationResolver) CreateFramework(ctx context.Context, input types.Crea
 		Name:           input.Name,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("cannot create framework: %w", err)
+		panic(fmt.Errorf("cannot create framework: %w", err))
 	}
 
 	return &types.CreateFrameworkPayload{
@@ -1630,7 +1627,7 @@ func (r *mutationResolver) UpdateFramework(ctx context.Context, input types.Upda
 		Description: input.Description,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("cannot update framework: %w", err)
+		panic(fmt.Errorf("cannot update framework: %w", err))
 	}
 
 	return &types.UpdateFrameworkPayload{
@@ -1644,23 +1641,12 @@ func (r *mutationResolver) ImportFramework(ctx context.Context, input types.Impo
 
 	req := probo.ImportFrameworkRequest{}
 	if err := json.NewDecoder(input.File.File).Decode(&req.Framework); err != nil {
-		return nil, fmt.Errorf("cannot decode framework: %w", err)
+		panic(fmt.Errorf("cannot decode framework: %w", err))
 	}
 
 	framework, err := prb.Frameworks.Import(ctx, input.OrganizationID, req)
 	if err != nil {
-		var errFrameworkReferenceIDAlreadyExists *coredata.ErrFrameworkReferenceIDAlreadyExists
-		if errors.As(err, &errFrameworkReferenceIDAlreadyExists) {
-			return nil, &gqlerror.Error{
-				Err:     err,
-				Message: fmt.Sprintf("framework %q already exists", req.Framework.Name),
-				Extensions: map[string]any{
-					"frameworkReferenceId": errFrameworkReferenceIDAlreadyExists.ReferenceID,
-				},
-			}
-		}
-
-		return nil, fmt.Errorf("cannot import framework: %w", err)
+		panic(fmt.Errorf("cannot import framework: %w", err))
 	}
 
 	return &types.ImportFrameworkPayload{
@@ -1674,7 +1660,7 @@ func (r *mutationResolver) DeleteFramework(ctx context.Context, input types.Dele
 
 	err := prb.Frameworks.Delete(ctx, input.FrameworkID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot delete framework: %w", err)
+		panic(fmt.Errorf("cannot delete framework: %w", err))
 	}
 
 	return &types.DeleteFrameworkPayload{
@@ -1688,7 +1674,7 @@ func (r *mutationResolver) GenerateFrameworkStateOfApplicability(ctx context.Con
 
 	soa, err := prb.Frameworks.StateOfApplicability(ctx, input.FrameworkID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot generate framework SOA: %w", err)
+		panic(fmt.Errorf("cannot generate framework SOA: %w", err))
 	}
 
 	return &types.GenerateFrameworkStateOfApplicabilityPayload{
@@ -1705,7 +1691,7 @@ func (r *mutationResolver) ExportFramework(ctx context.Context, input types.Expo
 
 	user := UserFromContext(ctx)
 	if user == nil {
-		panic(fmt.Errorf("user not found"))
+		panic(fmt.Errorf("user authentication required"))
 	}
 
 	err, exportJobID := prb.Frameworks.RequestExport(
@@ -1715,7 +1701,7 @@ func (r *mutationResolver) ExportFramework(ctx context.Context, input types.Expo
 		user.FullName,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("cannot export framework: %w", err)
+		panic(fmt.Errorf("cannot export framework: %w", err))
 	}
 
 	return &types.ExportFrameworkPayload{
@@ -1736,7 +1722,7 @@ func (r *mutationResolver) CreateControl(ctx context.Context, input types.Create
 		ExclusionJustification: input.ExclusionJustification,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("cannot create control: %w", err)
+		panic(fmt.Errorf("cannot create control: %w", err))
 	}
 
 	return &types.CreateControlPayload{
@@ -1758,7 +1744,7 @@ func (r *mutationResolver) UpdateControl(ctx context.Context, input types.Update
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("cannot update control: %w", err)
+		panic(fmt.Errorf("cannot update control: %w", err))
 	}
 
 	return &types.UpdateControlPayload{
@@ -1772,7 +1758,7 @@ func (r *mutationResolver) DeleteControl(ctx context.Context, input types.Delete
 
 	err := prb.Controls.Delete(ctx, input.ControlID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot delete control: %w", err)
+		panic(fmt.Errorf("cannot delete control: %w", err))
 	}
 
 	return &types.DeleteControlPayload{
@@ -1825,12 +1811,12 @@ func (r *mutationResolver) ImportMeasure(ctx context.Context, input types.Import
 
 	var req probo.ImportMeasureRequest
 	if err := json.NewDecoder(input.File.File).Decode(&req.Measures); err != nil {
-		return nil, fmt.Errorf("cannot unmarshal measure: %w", err)
+		panic(fmt.Errorf("cannot unmarshal measure: %w", err))
 	}
 
 	measures, err := prb.Measures.Import(ctx, input.OrganizationID, req)
 	if err != nil {
-		return nil, fmt.Errorf("cannot import measure: %w", err)
+		panic(fmt.Errorf("cannot import measure: %w", err))
 	}
 
 	measureEdges := make([]*types.MeasureEdge, len(measures.Data))
@@ -1878,10 +1864,6 @@ func (r *mutationResolver) CreateControlDocumentMapping(ctx context.Context, inp
 
 	control, document, err := prb.Controls.CreateDocumentMapping(ctx, input.ControlID, input.DocumentID)
 	if err != nil {
-		var errMappingExists *coredata.ErrControlDocumentMappingAlreadyExists
-		if errors.As(err, &errMappingExists) {
-			return nil, errors.New(errMappingExists.Error())
-		}
 		panic(fmt.Errorf("cannot create control document mapping: %w", err))
 	}
 
@@ -1927,7 +1909,7 @@ func (r *mutationResolver) CreateControlAuditMapping(ctx context.Context, input 
 
 	control, audit, err := prb.Controls.CreateAuditMapping(ctx, input.ControlID, input.AuditID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot create control audit mapping: %w", err)
+		panic(fmt.Errorf("cannot create control audit mapping: %w", err))
 	}
 
 	return &types.CreateControlAuditMappingPayload{
@@ -1942,7 +1924,7 @@ func (r *mutationResolver) DeleteControlAuditMapping(ctx context.Context, input 
 
 	control, audit, err := prb.Controls.DeleteAuditMapping(ctx, input.ControlID, input.AuditID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot delete control audit mapping: %w", err)
+		panic(fmt.Errorf("cannot delete control audit mapping: %w", err))
 	}
 
 	return &types.DeleteControlAuditMappingPayload{
@@ -2392,7 +2374,7 @@ func (r *mutationResolver) UploadVendorBusinessAssociateAgreement(ctx context.Co
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to upload vendor business associate agreement: %w", err)
+		panic(fmt.Errorf("failed to upload vendor business associate agreement: %w", err))
 	}
 
 	return &types.UploadVendorBusinessAssociateAgreementPayload{
@@ -2413,7 +2395,7 @@ func (r *mutationResolver) UpdateVendorBusinessAssociateAgreement(ctx context.Co
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to update vendor business associate agreement: %w", err)
+		panic(fmt.Errorf("failed to update vendor business associate agreement: %w", err))
 	}
 
 	return &types.UpdateVendorBusinessAssociateAgreementPayload{
@@ -2427,7 +2409,7 @@ func (r *mutationResolver) DeleteVendorBusinessAssociateAgreement(ctx context.Co
 
 	err := prb.VendorBusinessAssociateAgreements.DeleteByVendorID(ctx, input.VendorID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to delete vendor business associate agreement: %w", err)
+		panic(fmt.Errorf("failed to delete vendor business associate agreement: %w", err))
 	}
 
 	return &types.DeleteVendorBusinessAssociateAgreementPayload{
@@ -2450,7 +2432,7 @@ func (r *mutationResolver) UploadVendorDataPrivacyAgreement(ctx context.Context,
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to upload vendor data privacy agreement: %w", err)
+		panic(fmt.Errorf("failed to upload vendor data privacy agreement: %w", err))
 	}
 
 	return &types.UploadVendorDataPrivacyAgreementPayload{
@@ -2471,7 +2453,7 @@ func (r *mutationResolver) UpdateVendorDataPrivacyAgreement(ctx context.Context,
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to update vendor data privacy agreement: %w", err)
+		panic(fmt.Errorf("failed to update vendor data privacy agreement: %w", err))
 	}
 
 	return &types.UpdateVendorDataPrivacyAgreementPayload{
@@ -2485,7 +2467,7 @@ func (r *mutationResolver) DeleteVendorDataPrivacyAgreement(ctx context.Context,
 
 	err := prb.VendorDataPrivacyAgreements.DeleteByVendorID(ctx, input.VendorID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to delete vendor data privacy agreement: %w", err)
+		panic(fmt.Errorf("failed to delete vendor data privacy agreement: %w", err))
 	}
 
 	return &types.DeleteVendorDataPrivacyAgreementPayload{
@@ -2532,7 +2514,7 @@ func (r *mutationResolver) UpdateDocument(ctx context.Context, input types.Updat
 	)
 
 	if err != nil {
-		return nil, fmt.Errorf("cannot update document: %w", err)
+		panic(fmt.Errorf("cannot update document: %w", err))
 	}
 
 	return &types.UpdateDocumentPayload{
@@ -2631,7 +2613,7 @@ func (r *mutationResolver) BulkExportDocuments(ctx context.Context, input types.
 
 	user := UserFromContext(ctx)
 	if user == nil {
-		panic(fmt.Errorf("user not found"))
+		panic(fmt.Errorf("user authentication required"))
 	}
 
 	options := probo.BulkExportOptions{
@@ -2835,7 +2817,7 @@ func (r *mutationResolver) AssessVendor(ctx context.Context, input types.AssessV
 		WebsiteURL: input.WebsiteURL,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("cannot assess vendor: %w", err)
+		panic(fmt.Errorf("cannot assess vendor: %w", err))
 	}
 
 	return &types.AssessVendorPayload{
@@ -2859,7 +2841,7 @@ func (r *mutationResolver) CreateAsset(ctx context.Context, input types.CreateAs
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("cannot create asset: %w", err)
+		panic(fmt.Errorf("cannot create asset: %w", err))
 	}
 
 	return &types.CreateAssetPayload{
@@ -2882,7 +2864,7 @@ func (r *mutationResolver) UpdateAsset(ctx context.Context, input types.UpdateAs
 		VendorIDs:       input.VendorIds,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("cannot update asset: %w", err)
+		panic(fmt.Errorf("cannot update asset: %w", err))
 	}
 
 	return &types.UpdateAssetPayload{
@@ -2896,7 +2878,7 @@ func (r *mutationResolver) DeleteAsset(ctx context.Context, input types.DeleteAs
 
 	err := prb.Assets.Delete(ctx, input.AssetID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot delete asset: %w", err)
+		panic(fmt.Errorf("cannot delete asset: %w", err))
 	}
 
 	return &types.DeleteAssetPayload{
@@ -2917,7 +2899,7 @@ func (r *mutationResolver) CreateDatum(ctx context.Context, input types.CreateDa
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("cannot create datum: %w", err)
+		panic(fmt.Errorf("cannot create datum: %w", err))
 	}
 
 	return &types.CreateDatumPayload{
@@ -2938,7 +2920,7 @@ func (r *mutationResolver) UpdateDatum(ctx context.Context, input types.UpdateDa
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("cannot update datum: %w", err)
+		panic(fmt.Errorf("cannot update datum: %w", err))
 	}
 
 	return &types.UpdateDatumPayload{
@@ -2951,7 +2933,7 @@ func (r *mutationResolver) DeleteDatum(ctx context.Context, input types.DeleteDa
 	prb := r.ProboService(ctx, input.DatumID.TenantID())
 
 	if err := prb.Data.Delete(ctx, input.DatumID); err != nil {
-		return nil, fmt.Errorf("cannot delete datum: %w", err)
+		panic(fmt.Errorf("cannot delete datum: %w", err))
 	}
 
 	return &types.DeleteDatumPayload{
@@ -3050,7 +3032,7 @@ func (r *mutationResolver) DeleteAuditReport(ctx context.Context, input types.De
 
 	audit, err := prb.Audits.DeleteReport(ctx, input.AuditID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot delete audit report: %w", err)
+		panic(fmt.Errorf("cannot delete audit report: %w", err))
 	}
 
 	return &types.DeleteAuditReportPayload{
@@ -3120,7 +3102,7 @@ func (r *mutationResolver) DeleteNonconformity(ctx context.Context, input types.
 
 	err := prb.Nonconformities.Delete(ctx, input.NonconformityID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot delete nonconformity: %w", err)
+		panic(fmt.Errorf("cannot delete nonconformity: %w", err))
 	}
 
 	return &types.DeleteNonconformityPayload{
@@ -3376,12 +3358,12 @@ func (r *nonconformityResolver) Organization(ctx context.Context, obj *types.Non
 
 	nonconformity, err := prb.Nonconformities.Get(ctx, obj.ID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get nonconformity: %w", err)
+		panic(fmt.Errorf("cannot get nonconformity: %w", err))
 	}
 
 	organization, err := prb.Organizations.Get(ctx, nonconformity.OrganizationID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get nonconformity organization: %w", err)
+		panic(fmt.Errorf("cannot get nonconformity organization: %w", err))
 	}
 
 	return types.NewOrganization(organization), nil
@@ -3393,12 +3375,12 @@ func (r *nonconformityResolver) Audit(ctx context.Context, obj *types.Nonconform
 
 	nonconformity, err := prb.Nonconformities.Get(ctx, obj.ID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get nonconformity: %w", err)
+		panic(fmt.Errorf("cannot get nonconformity: %w", err))
 	}
 
 	audit, err := prb.Audits.Get(ctx, nonconformity.AuditID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get nonconformity audit: %w", err)
+		panic(fmt.Errorf("cannot get nonconformity audit: %w", err))
 	}
 
 	return types.NewAudit(audit), nil
@@ -3410,12 +3392,12 @@ func (r *nonconformityResolver) Owner(ctx context.Context, obj *types.Nonconform
 
 	nonconformity, err := prb.Nonconformities.Get(ctx, obj.ID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get nonconformity: %w", err)
+		panic(fmt.Errorf("cannot get nonconformity: %w", err))
 	}
 
 	people, err := prb.Peoples.Get(ctx, nonconformity.OwnerID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get nonconformity owner: %w", err)
+		panic(fmt.Errorf("cannot get nonconformity owner: %w", err))
 	}
 
 	return types.NewPeople(people), nil
@@ -3434,12 +3416,12 @@ func (r *nonconformityConnectionResolver) TotalCount(ctx context.Context, obj *t
 
 		count, err := prb.Nonconformities.CountForOrganizationID(ctx, obj.ParentID, nonconformityFilter)
 		if err != nil {
-			return 0, fmt.Errorf("cannot count nonconformities: %w", err)
+			panic(fmt.Errorf("cannot count nonconformities: %w", err))
 		}
 		return count, nil
 	}
 
-	return 0, fmt.Errorf("unsupported resolver: %T", obj.Resolver)
+	panic(fmt.Errorf("unsupported resolver: %T", obj.Resolver))
 }
 
 // Organization is the resolver for the organization field.
@@ -3448,12 +3430,12 @@ func (r *obligationResolver) Organization(ctx context.Context, obj *types.Obliga
 
 	obligation, err := prb.Obligations.Get(ctx, obj.ID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get obligation: %w", err)
+		panic(fmt.Errorf("cannot get obligation: %w", err))
 	}
 
 	organization, err := prb.Organizations.Get(ctx, obligation.OrganizationID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get obligation organization: %w", err)
+		panic(fmt.Errorf("cannot get obligation organization: %w", err))
 	}
 
 	return types.NewOrganization(organization), nil
@@ -3465,12 +3447,12 @@ func (r *obligationResolver) Owner(ctx context.Context, obj *types.Obligation) (
 
 	obligation, err := prb.Obligations.Get(ctx, obj.ID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get obligation: %w", err)
+		panic(fmt.Errorf("cannot get obligation: %w", err))
 	}
 
 	people, err := prb.Peoples.Get(ctx, obligation.OwnerID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get obligation owner: %w", err)
+		panic(fmt.Errorf("cannot get obligation owner: %w", err))
 	}
 
 	return types.NewPeople(people), nil
@@ -3612,7 +3594,7 @@ func (r *organizationResolver) Controls(ctx context.Context, obj *types.Organiza
 
 	page, err := prb.Controls.ListForOrganizationID(ctx, obj.ID, cursor, controlFilter)
 	if err != nil {
-		return nil, fmt.Errorf("cannot list controls: %w", err)
+		panic(fmt.Errorf("cannot list controls: %w", err))
 	}
 
 	return types.NewControlConnection(page, r, obj.ID, controlFilter), nil
@@ -4033,7 +4015,7 @@ func (r *organizationResolver) TrustCenter(ctx context.Context, obj *types.Organ
 
 	trustCenter, file, err := prb.TrustCenters.GetByOrganizationID(ctx, obj.ID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get trust center: %w", err)
+		panic(fmt.Errorf("cannot get trust center: %w", err))
 	}
 
 	return types.NewTrustCenter(trustCenter, file), nil
@@ -4260,7 +4242,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	default:
 	}
 
-	return nil, gqlerror.Errorf("node %q not found", id)
+	return nil, fmt.Errorf("node %q not found", id)
 }
 
 // Viewer is the resolver for the viewer field.
@@ -4292,7 +4274,7 @@ func (r *reportResolver) Audit(ctx context.Context, obj *types.Report) (*types.A
 
 	audit, err := prb.Audits.GetByReportID(ctx, obj.ID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot load audit for report: %w", err)
+		panic(fmt.Errorf("cannot load audit for report: %w", err))
 	}
 
 	return types.NewAudit(audit), nil
@@ -4752,7 +4734,7 @@ func (r *trustCenterDocumentAccessResolver) Document(ctx context.Context, obj *t
 
 	documentAccess, err := prb.TrustCenterAccesses.GetDocumentAccess(ctx, obj.ID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot load trust center document access: %w", err)
+		panic(fmt.Errorf("cannot load trust center document access: %w", err))
 	}
 
 	if documentAccess.DocumentID == nil {
@@ -4761,7 +4743,7 @@ func (r *trustCenterDocumentAccessResolver) Document(ctx context.Context, obj *t
 
 	document, err := prb.Documents.Get(ctx, *documentAccess.DocumentID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot load document: %w", err)
+		panic(fmt.Errorf("cannot load document: %w", err))
 	}
 
 	return types.NewDocument(document), nil
@@ -4773,7 +4755,7 @@ func (r *trustCenterDocumentAccessResolver) Report(ctx context.Context, obj *typ
 
 	documentAccess, err := prb.TrustCenterAccesses.GetDocumentAccess(ctx, obj.ID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot load trust center document access: %w", err)
+		panic(fmt.Errorf("cannot load trust center document access: %w", err))
 	}
 
 	if documentAccess.ReportID == nil {
@@ -4782,7 +4764,7 @@ func (r *trustCenterDocumentAccessResolver) Report(ctx context.Context, obj *typ
 
 	report, err := prb.Reports.Get(ctx, *documentAccess.ReportID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot load report: %w", err)
+		panic(fmt.Errorf("cannot load report: %w", err))
 	}
 
 	return types.NewReport(report), nil
@@ -4794,7 +4776,7 @@ func (r *trustCenterDocumentAccessConnectionResolver) TotalCount(ctx context.Con
 
 	count, err := prb.TrustCenterAccesses.CountDocumentAccesses(ctx, obj.ParentID)
 	if err != nil {
-		return 0, fmt.Errorf("cannot count trust center document accesses: %w", err)
+		panic(fmt.Errorf("cannot count trust center document accesses: %w", err))
 	}
 
 	return count, nil
@@ -4829,8 +4811,8 @@ func (r *userResolver) People(ctx context.Context, obj *types.User, organization
 
 	people, err := prb.Peoples.GetByUserID(ctx, obj.ID)
 	if err != nil {
-		var errPeopleNotFound *coredata.ErrPeopleNotFound
-		if errors.As(err, &errPeopleNotFound) {
+		var errResourceNotFound *coredata.ErrResourceNotFound
+		if errors.As(err, &errResourceNotFound) {
 			return nil, nil
 		}
 		panic(fmt.Errorf("failed to get people: %w", err))
@@ -4887,7 +4869,8 @@ func (r *vendorResolver) BusinessAssociateAgreement(ctx context.Context, obj *ty
 
 	vendorBusinessAssociateAgreement, file, err := prb.VendorBusinessAssociateAgreements.GetByVendorID(ctx, obj.ID)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		var errResourceNotFound *coredata.ErrResourceNotFound
+		if errors.As(err, &errResourceNotFound) {
 			return nil, nil
 		}
 
@@ -4903,7 +4886,8 @@ func (r *vendorResolver) DataPrivacyAgreement(ctx context.Context, obj *types.Ve
 
 	vendorDataPrivacyAgreement, file, err := prb.VendorDataPrivacyAgreements.GetByVendorID(ctx, obj.ID)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		var errResourceNotFound *coredata.ErrResourceNotFound
+		if errors.As(err, &errResourceNotFound) {
 			return nil, nil
 		}
 
@@ -5035,7 +5019,7 @@ func (r *vendorBusinessAssociateAgreementResolver) Vendor(ctx context.Context, o
 
 	vendor, err := prb.Vendors.Get(ctx, obj.ID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get vendor: %w", err)
+		panic(fmt.Errorf("failed to get vendor: %w", err))
 	}
 
 	return types.NewVendor(vendor), nil

--- a/pkg/server/api/trust/v1/resolver.go
+++ b/pkg/server/api/trust/v1/resolver.go
@@ -135,6 +135,7 @@ func graphqlHandler(logger *log.Logger, usrmgrSvc *usrmgr.Service, trustSvc *tru
 	srv.Use(extension.Introspection{})
 
 	srv.SetRecoverFunc(gqlutils.RecoverFunc)
+	srv.SetErrorPresenter(gqlutils.ErrorPresenter)
 
 	return WithSession(usrmgrSvc, trustSvc, authCfg, trustAuthCfg, srv.ServeHTTP)
 }

--- a/pkg/server/graphql/presenter.go
+++ b/pkg/server/graphql/presenter.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package graphql
+
+import (
+	"context"
+	"errors"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+	"go.gearno.de/kit/httpserver"
+	"go.gearno.de/kit/log"
+)
+
+func ErrorPresenter(ctx context.Context, e error) *gqlerror.Error {
+	var rescuedErr *RescuedError
+	if !errors.As(e, &rescuedErr) {
+		return graphql.DefaultErrorPresenter(ctx, e)
+	}
+
+	err := graphql.DefaultErrorPresenter(ctx, e)
+	originalErr := rescuedErr.Original
+
+	var errResourceNotFound *coredata.ErrResourceNotFound
+	var errResourceAlreadyExists *coredata.ErrResourceAlreadyExists
+	var errRestrictedOperation *coredata.ErrRestrictedOperation
+	var errInvalidValue *coredata.ErrInvalidValue
+	var errNoChange *coredata.ErrNoChange
+
+	if errors.As(originalErr, &errResourceNotFound) {
+		err.Message = errResourceNotFound.Error()
+		err.Extensions = map[string]any{
+			"code": "NOT_FOUND",
+		}
+	} else if errors.As(originalErr, &errResourceAlreadyExists) {
+		err.Message = errResourceAlreadyExists.Error()
+		err.Extensions = map[string]any{
+			"code": "ALREADY_EXISTS",
+		}
+	} else if errors.As(originalErr, &errRestrictedOperation) {
+		err.Message = errRestrictedOperation.Error()
+		err.Extensions = map[string]any{
+			"code": "RESTRICTED_OPERATION",
+		}
+	} else if errors.As(originalErr, &errInvalidValue) {
+		err.Message = errInvalidValue.Error()
+		err.Extensions = map[string]any{
+			"code": "INVALID_VALUE",
+		}
+	} else if errors.As(originalErr, &errNoChange) {
+		err.Message = errNoChange.Error()
+		err.Extensions = map[string]any{
+			"code": "NO_CHANGE",
+		}
+	} else if originalErr.Error() == "tenant not found" {
+		err.Message = "not authorized"
+		err.Extensions = map[string]any{
+			"code": "UNAUTHORIZED",
+		}
+	} else {
+		logger := httpserver.LoggerFromContext(ctx)
+		logger.Error("unhandled rescued error in resolver", log.Any("error", originalErr))
+
+		err.Message = "Internal server error"
+		err.Extensions = map[string]any{
+			"code": "INTERNAL_SERVER_ERROR",
+		}
+	}
+
+	return err
+}

--- a/pkg/trust/trust_center_access_service.go
+++ b/pkg/trust/trust_center_access_service.go
@@ -119,17 +119,17 @@ func (s TrustCenterAccessService) Request(
 		if err == nil {
 			access = existingAccess
 		} else {
-			var notFoundErr *coredata.ErrTrustCenterAccessNotFound
+			var notFoundErr *coredata.ErrResourceNotFound
 			if !errors.As(err, &notFoundErr) {
 				return fmt.Errorf("cannot load trust center access: %w", err)
 			}
 
 			if req.Name == nil || *req.Name == "" {
-				return fmt.Errorf("name is required for new access requests")
+				return &coredata.ErrInvalidValue{Field: "name", Message: "name is required for new access requests"}
 			}
 
 			if _, err := mail.ParseAddress(req.Email); err != nil {
-				return fmt.Errorf("invalid email address")
+				return &coredata.ErrInvalidValue{Field: "email"}
 			}
 
 			access = &coredata.TrustCenterAccess{


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Standardized error handling across the backend and console, and improved validation and user feedback. Users now see clear messages (including Access denied) and mutations surface actionable errors.

- New Features
  - Shared error types in coredata (not found, already exists, invalid value, no change) with a GraphQL ErrorPresenter for consistent codes/messages.
  - Console handles UNAUTHORIZED: ErrorBoundary maps to a new UnauthorizedError and PageError shows “Access denied.”
  - Added helpers: formatError and GraphQLError type; used across pages, dialogs, and hooks for clearer toasts.
  - useMutationWithToasts/useMutationWithIncrement now format server errors and support per-call errorMessage.
  - ConfirmDialog closes even if the action fails.

- Refactors
  - Tightened form validation (zod) across tasks, documents, risks, vendors, measures, org settings, contacts, etc. (required fields, email/phone unions).
  - Replaced scattered error structs with shared types; mapped PG unique constraint errors to domain errors (e.g., duplicate framework/control/mappings).
  - GraphQL stack: added ErrorPresenter and improved recovery to wrap panics as structured errors.
  - Cleaned up toast copy for consistency (removed “Please try again” duplicates).
  - Services return typed validation errors (e.g., email/watermark checks) for clearer client messages.

<!-- End of auto-generated description by cubic. -->

