### PR TITLE
Fix evidence deletion

### DIFF
--- a/pkg/coredata/evidence.go
+++ b/pkg/coredata/evidence.go
@@ -432,9 +432,7 @@ WHERE
 	args := pgx.StrictNamedArgs{"evidence_id": e.ID}
 	maps.Copy(args, scope.SQLArguments())
 
-	var evidenceFileId *gid.GID
-	err := conn.QueryRow(ctx, q, args).Scan(&evidenceFileId)
-
+	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
 		return fmt.Errorf("failed to delete evidence: %w", err)
 	}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fix evidence deletion so it completes reliably and shows clear user feedback in the console.

- **Bug Fixes**
  - Backend: Use Exec for the delete query instead of QueryRow+Scan to prevent scan errors and ensure the record is deleted.
  - Frontend: Replace useMutation/promisifyMutation with useMutationWithToasts for deleteEvidenceMutation, adding success and error toasts.

<!-- End of auto-generated description by cubic. -->

