### PR TITLE
Fix noisy SSL error

### DIFF
--- a/pkg/certmanager/selector.go
+++ b/pkg/certmanager/selector.go
@@ -32,7 +32,14 @@ type (
 		cache         sync.Map
 		encryptionKey cipher.EncryptionKey
 	}
+
+	// NoSNIError is returned when a TLS client doesn't provide SNI (Server Name Indication)
+	NoSNIError struct{}
 )
+
+func (e *NoSNIError) Error() string {
+	return "no SNI provided"
+}
 
 func NewSelector(
 	pg *pg.Client,
@@ -49,7 +56,7 @@ func (s *Selector) GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate,
 
 	// Empty domain, return error
 	if domain == "" {
-		return nil, fmt.Errorf("no SNI provided")
+		return nil, &NoSNIError{}
 	}
 
 	if cached, ok := s.cache.Load(domain); ok {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Silently reject TLS connections without SNI to stop noisy SSL error logs, especially from load balancers and health checks. Adds a typed error so the server returns no certificate instead of an error.

- **Bug Fixes**
  - Introduced NoSNIError and returned it when SNI is missing in certificate selection.
  - Wrapped GetCertificate to detect NoSNIError and return nil certificate without logging an error.
  - Reduces SSL noise from non-SNI clients (load balancers, health checks, scanners).

<!-- End of auto-generated description by cubic. -->

