### PR TITLE
Fix audit update

### DIFF
--- a/pkg/server/api/console/v1/resolver.go
+++ b/pkg/server/api/console/v1/resolver.go
@@ -369,6 +369,14 @@ func (r *Resolver) AuthzService(ctx context.Context, tenantID gid.TenantID) *aut
 	return GetTenantAuthzService(ctx, r.authzSvc, tenantID)
 }
 
+func UnwrapOmittable[T any](field graphql.Omittable[T]) *T {
+	if !field.IsSet() {
+		return nil
+	}
+	value := field.Value()
+	return &value
+}
+
 func GetTenantService(ctx context.Context, proboSvc *probo.Service, tenantID gid.TenantID) *probo.TenantService {
 	validateTenantAccess(ctx, tenantID)
 	return proboSvc.WithTenant(tenantID)

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -3622,7 +3622,7 @@ input CreateAuditInput {
 
 input UpdateAuditInput {
   id: ID!
-  name: String
+  name: String @goField(omittable: true)
   validFrom: Datetime
   validUntil: Datetime
   state: AuditState

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -12672,7 +12672,7 @@ input CreateAuditInput {
 
 input UpdateAuditInput {
   id: ID!
-  name: String
+  name: String @goField(omittable: true)
   validFrom: Datetime
   validUntil: Datetime
   state: AuditState
@@ -73135,7 +73135,7 @@ func (ec *executionContext) unmarshalInputUpdateAuditInput(ctx context.Context, 
 			if err != nil {
 				return it, err
 			}
-			it.Name = data
+			it.Name = graphql.OmittableOf(data)
 		case "validFrom":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("validFrom"))
 			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -1733,7 +1733,7 @@ type UpdateAssetPayload struct {
 
 type UpdateAuditInput struct {
 	ID                    gid.GID                         `json:"id"`
-	Name                  *string                         `json:"name,omitempty"`
+	Name                  graphql.Omittable[*string]      `json:"name,omitempty"`
 	ValidFrom             *time.Time                      `json:"validFrom,omitempty"`
 	ValidUntil            *time.Time                      `json:"validUntil,omitempty"`
 	State                 *coredata.AuditState            `json:"state,omitempty"`

--- a/pkg/server/api/console/v1/v1_resolver.go
+++ b/pkg/server/api/console/v1/v1_resolver.go
@@ -3023,7 +3023,7 @@ func (r *mutationResolver) UpdateAudit(ctx context.Context, input types.UpdateAu
 
 	req := probo.UpdateAuditRequest{
 		ID:                    input.ID,
-		Name:                  &input.Name,
+		Name:                  UnwrapOmittable(input.Name),
 		ValidFrom:             input.ValidFrom,
 		ValidUntil:            input.ValidUntil,
 		State:                 input.State,


### PR DESCRIPTION
    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes updating an audit’s name by making the GraphQL field omittable and correctly mapping it to the backend.

- **Bug Fixes**
  - GraphQL: UpdateAuditInput.name is now omittable to distinguish “not provided” vs “null”, so updates and clears work as expected.
  - Resolver: Added UnwrapOmittable and use it to pass the correct pointer semantics to UpdateAuditRequest.
<!-- End of auto-generated description by cubic. -->

