### PR TITLE
Fix optional empty value update

### DIFF
--- a/pkg/probo/risk_service.go
+++ b/pkg/probo/risk_service.go
@@ -50,7 +50,7 @@ type (
 		Description        *string
 		Category           *string
 		Treatment          *coredata.RiskTreatment
-		OwnerID            *gid.GID
+		OwnerID            **gid.GID
 		InherentLikelihood *int
 		InherentImpact     *int
 		ResidualLikelihood *int
@@ -495,12 +495,15 @@ func (s RiskService) Update(
 			}
 
 			if req.OwnerID != nil {
-				people := coredata.People{}
-				if err := people.LoadByID(ctx, conn, s.svc.scope, *req.OwnerID); err != nil {
-					return fmt.Errorf("cannot load owner: %w", err)
+				if *req.OwnerID != nil {
+					people := coredata.People{}
+					if err := people.LoadByID(ctx, conn, s.svc.scope, **req.OwnerID); err != nil {
+						return fmt.Errorf("cannot load owner: %w", err)
+					}
+					risk.OwnerID = *req.OwnerID
+				} else {
+					risk.OwnerID = nil
 				}
-
-				risk.OwnerID = req.OwnerID
 			}
 
 			if req.Category != nil {

--- a/pkg/probo/task_service.go
+++ b/pkg/probo/task_service.go
@@ -46,8 +46,8 @@ type (
 		Name         *string
 		Description  *string
 		State        *coredata.TaskState
-		TimeEstimate *time.Duration
-		Deadline     *time.Time
+		TimeEstimate **time.Duration
+		Deadline     **time.Time
 	}
 )
 
@@ -203,11 +203,11 @@ func (s TaskService) Update(
 			}
 
 			if req.TimeEstimate != nil {
-				task.TimeEstimate = req.TimeEstimate
+				task.TimeEstimate = *req.TimeEstimate
 			}
 
 			if req.Deadline != nil {
-				task.Deadline = req.Deadline
+				task.Deadline = *req.Deadline
 			}
 
 			task.UpdatedAt = time.Now()

--- a/pkg/probo/vendor_service.go
+++ b/pkg/probo/vendor_service.go
@@ -56,22 +56,22 @@ type (
 	UpdateVendorRequest struct {
 		ID                            gid.GID
 		Name                          *string
-		Description                   *string
-		HeadquarterAddress            *string
-		LegalName                     *string
-		WebsiteURL                    *string
-		TermsOfServiceURL             *string
+		Description                   **string
+		HeadquarterAddress            **string
+		LegalName                     **string
+		WebsiteURL                    **string
+		TermsOfServiceURL             **string
 		Category                      *coredata.VendorCategory
-		PrivacyPolicyURL              *string
-		ServiceLevelAgreementURL      *string
-		DataProcessingAgreementURL    *string
-		BusinessAssociateAgreementURL *string
-		SubprocessorsListURL          *string
+		PrivacyPolicyURL              **string
+		ServiceLevelAgreementURL      **string
+		DataProcessingAgreementURL    **string
+		BusinessAssociateAgreementURL **string
+		SubprocessorsListURL          **string
 		Certifications                []string
 		Countries                     coredata.CountryCodes
-		SecurityPageURL               *string
-		TrustPageURL                  *string
-		StatusPageURL                 *string
+		SecurityPageURL               **string
+		TrustPageURL                  **string
+		StatusPageURL                 **string
 		BusinessOwnerID               **gid.GID
 		SecurityOwnerID               **gid.GID
 		ShowOnTrustCenter             *bool
@@ -222,35 +222,35 @@ func (s VendorService) Update(
 			}
 
 			if req.Description != nil {
-				vendor.Description = req.Description
+				vendor.Description = *req.Description
 			}
 
 			if req.StatusPageURL != nil {
-				vendor.StatusPageURL = req.StatusPageURL
+				vendor.StatusPageURL = *req.StatusPageURL
 			}
 
 			if req.TermsOfServiceURL != nil {
-				vendor.TermsOfServiceURL = req.TermsOfServiceURL
+				vendor.TermsOfServiceURL = *req.TermsOfServiceURL
 			}
 
 			if req.PrivacyPolicyURL != nil {
-				vendor.PrivacyPolicyURL = req.PrivacyPolicyURL
+				vendor.PrivacyPolicyURL = *req.PrivacyPolicyURL
 			}
 
 			if req.ServiceLevelAgreementURL != nil {
-				vendor.ServiceLevelAgreementURL = req.ServiceLevelAgreementURL
+				vendor.ServiceLevelAgreementURL = *req.ServiceLevelAgreementURL
 			}
 
 			if req.DataProcessingAgreementURL != nil {
-				vendor.DataProcessingAgreementURL = req.DataProcessingAgreementURL
+				vendor.DataProcessingAgreementURL = *req.DataProcessingAgreementURL
 			}
 
 			if req.BusinessAssociateAgreementURL != nil {
-				vendor.BusinessAssociateAgreementURL = req.BusinessAssociateAgreementURL
+				vendor.BusinessAssociateAgreementURL = *req.BusinessAssociateAgreementURL
 			}
 
 			if req.SubprocessorsListURL != nil {
-				vendor.SubprocessorsListURL = req.SubprocessorsListURL
+				vendor.SubprocessorsListURL = *req.SubprocessorsListURL
 			}
 
 			if req.Category != nil {
@@ -260,7 +260,7 @@ func (s VendorService) Update(
 			}
 
 			if req.SecurityPageURL != nil {
-				vendor.SecurityPageURL = req.SecurityPageURL
+				vendor.SecurityPageURL = *req.SecurityPageURL
 			}
 
 			if req.ShowOnTrustCenter != nil {
@@ -268,23 +268,23 @@ func (s VendorService) Update(
 			}
 
 			if req.TrustPageURL != nil {
-				vendor.TrustPageURL = req.TrustPageURL
+				vendor.TrustPageURL = *req.TrustPageURL
 			}
 
 			if req.HeadquarterAddress != nil {
-				vendor.HeadquarterAddress = req.HeadquarterAddress
+				vendor.HeadquarterAddress = *req.HeadquarterAddress
 			}
 
 			if req.LegalName != nil {
-				vendor.LegalName = req.LegalName
+				vendor.LegalName = *req.LegalName
 			}
 
 			if req.WebsiteURL != nil {
-				vendor.WebsiteURL = req.WebsiteURL
+				vendor.WebsiteURL = *req.WebsiteURL
 			}
 
 			if req.TermsOfServiceURL != nil {
-				vendor.TermsOfServiceURL = req.TermsOfServiceURL
+				vendor.TermsOfServiceURL = *req.TermsOfServiceURL
 			}
 
 			if req.Certifications != nil {
@@ -293,18 +293,6 @@ func (s VendorService) Update(
 
 			if req.Countries != nil {
 				vendor.Countries = req.Countries
-			}
-
-			if req.StatusPageURL != nil {
-				vendor.StatusPageURL = req.StatusPageURL
-			}
-
-			if req.SecurityPageURL != nil {
-				vendor.SecurityPageURL = req.SecurityPageURL
-			}
-
-			if req.TrustPageURL != nil {
-				vendor.TrustPageURL = req.TrustPageURL
 			}
 
 			if req.BusinessOwnerID != nil {

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -3093,12 +3093,12 @@ input CreateOrganizationInput {
 input UpdateOrganizationInput {
   organizationId: ID!
   name: String
-  logo: Upload
+  description: String @goField(omittable: true)
+  websiteUrl: String @goField(omittable: true)
+  email: String @goField(omittable: true)
+  headquarterAddress: String @goField(omittable: true)
+  logoFile: Upload
   horizontalLogoFile: Upload
-  description: String
-  websiteUrl: String
-  email: String
-  headquarterAddress: String
 }
 
 input DeleteOrganizationHorizontalLogoInput {
@@ -3189,24 +3189,24 @@ input CreateVendorInput {
 input UpdateVendorInput {
   id: ID!
   name: String
-  description: String
-  statusPageUrl: String
-  termsOfServiceUrl: String
-  privacyPolicyUrl: String
-  serviceLevelAgreementUrl: String
-  dataProcessingAgreementUrl: String
-  businessAssociateAgreementUrl: String
-  subprocessorsListUrl: String
-  websiteUrl: String
-  legalName: String
-  headquarterAddress: String
+  description: String @goField(omittable: true)
+  statusPageUrl: String @goField(omittable: true)
+  termsOfServiceUrl: String @goField(omittable: true)
+  privacyPolicyUrl: String @goField(omittable: true)
+  serviceLevelAgreementUrl: String @goField(omittable: true)
+  dataProcessingAgreementUrl: String @goField(omittable: true)
+  businessAssociateAgreementUrl: String @goField(omittable: true)
+  subprocessorsListUrl: String @goField(omittable: true)
+  websiteUrl: String @goField(omittable: true)
+  legalName: String @goField(omittable: true)
+  headquarterAddress: String @goField(omittable: true)
   category: VendorCategory
   certifications: [String!]
   countries: [CountryCode!]
-  securityPageUrl: String
-  trustPageUrl: String
-  businessOwnerId: ID
-  securityOwnerId: ID
+  securityPageUrl: String @goField(omittable: true)
+  trustPageUrl: String @goField(omittable: true)
+  businessOwnerId: ID @goField(omittable: true)
+  securityOwnerId: ID @goField(omittable: true)
   showOnTrustCenter: Boolean
 }
 
@@ -3224,10 +3224,10 @@ input CreateVendorContactInput {
 
 input UpdateVendorContactInput {
   id: ID!
-  fullName: String
-  email: String
-  phone: String
-  role: String
+  fullName: String @goField(omittable: true)
+  email: String @goField(omittable: true)
+  phone: String @goField(omittable: true)
+  role: String @goField(omittable: true)
 }
 
 input DeleteVendorContactInput {
@@ -3245,7 +3245,7 @@ input CreateVendorServiceInput {
 input UpdateVendorServiceInput {
   id: ID!
   name: String
-  description: String
+  description: String @goField(omittable: true)
   url: String
   type: String
 }
@@ -3271,9 +3271,9 @@ input UpdatePeopleInput {
   primaryEmailAddress: String
   additionalEmailAddresses: [String!]
   kind: PeopleKind
-  position: String
-  contractStartDate: Datetime
-  contractEndDate: Datetime
+  position: String @goField(omittable: true)
+  contractStartDate: Datetime @goField(omittable: true)
+  contractEndDate: Datetime @goField(omittable: true)
 }
 
 input DeletePeopleInput {
@@ -3340,8 +3340,8 @@ input UpdateTaskInput {
   name: String
   description: String
   state: TaskState
-  timeEstimate: Duration
-  deadline: Datetime
+  timeEstimate: Duration @goField(omittable: true)
+  deadline: Datetime @goField(omittable: true)
 }
 
 input DeleteTaskInput {
@@ -3416,7 +3416,7 @@ input UpdateRiskInput {
   name: String
   description: String
   category: String
-  ownerId: ID
+  ownerId: ID @goField(omittable: true)
   treatment: RiskTreatment
   inherentLikelihood: Int
   inherentImpact: Int
@@ -3508,8 +3508,8 @@ input UploadVendorBusinessAssociateAgreementInput {
 
 input UpdateVendorBusinessAssociateAgreementInput {
   vendorId: ID!
-  validFrom: Datetime
-  validUntil: Datetime
+  validFrom: Datetime @goField(omittable: true)
+  validUntil: Datetime @goField(omittable: true)
 }
 
 input DeleteVendorBusinessAssociateAgreementInput {
@@ -3526,8 +3526,8 @@ input UploadVendorDataPrivacyAgreementInput {
 
 input UpdateVendorDataPrivacyAgreementInput {
   vendorId: ID!
-  validFrom: Datetime
-  validUntil: Datetime
+  validFrom: Datetime @goField(omittable: true)
+  validUntil: Datetime @goField(omittable: true)
 }
 
 input DeleteVendorDataPrivacyAgreementInput {
@@ -3660,15 +3660,15 @@ input CreateNonconformityInput {
 input UpdateNonconformityInput {
   id: ID!
   referenceId: String
-  description: String
-  dateIdentified: Datetime
+  description: String @goField(omittable: true)
+  dateIdentified: Datetime @goField(omittable: true)
   rootCause: String
-  correctiveAction: String
+  correctiveAction: String @goField(omittable: true)
   ownerId: ID
   auditId: ID
-  dueDate: Datetime
+  dueDate: Datetime @goField(omittable: true)
   status: NonconformityStatus
-  effectivenessCheck: String
+  effectivenessCheck: String @goField(omittable: true)
 }
 
 input DeleteNonconformityInput {
@@ -3690,14 +3690,14 @@ input CreateObligationInput {
 
 input UpdateObligationInput {
   id: ID!
-  area: String
-  source: String
-  requirement: String
-  actionsToBeImplemented: String
-  regulator: String
+  area: String @goField(omittable: true)
+  source: String @goField(omittable: true)
+  requirement: String @goField(omittable: true)
+  actionsToBeImplemented: String @goField(omittable: true)
+  regulator: String @goField(omittable: true)
   ownerId: ID
-  lastReviewDate: Datetime
-  dueDate: Datetime
+  lastReviewDate: Datetime @goField(omittable: true)
+  dueDate: Datetime @goField(omittable: true)
   status: ObligationStatus
 }
 
@@ -3719,10 +3719,10 @@ input CreateContinualImprovementInput {
 input UpdateContinualImprovementInput {
   id: ID!
   referenceId: String
-  description: String
-  source: String
+  description: String @goField(omittable: true)
+  source: String @goField(omittable: true)
   ownerId: ID
-  targetDate: Datetime
+  targetDate: Datetime @goField(omittable: true)
   status: ContinualImprovementStatus
   priority: ContinualImprovementPriority
 }
@@ -3753,18 +3753,18 @@ input CreateProcessingActivityInput {
 input UpdateProcessingActivityInput {
   id: ID!
   name: String
-  purpose: String
-  dataSubjectCategory: String
-  personalDataCategory: String
+  purpose: String @goField(omittable: true)
+  dataSubjectCategory: String @goField(omittable: true)
+  personalDataCategory: String @goField(omittable: true)
   specialOrCriminalData: ProcessingActivitySpecialOrCriminalData
   consentEvidenceLink: String
   lawfulBasis: ProcessingActivityLawfulBasis
-  recipients: String
-  location: String
+  recipients: String @goField(omittable: true)
+  location: String @goField(omittable: true)
   internationalTransfers: Boolean
-  transferSafeguards: ProcessingActivityTransferSafeguards
-  retentionPeriod: String
-  securityMeasures: String
+  transferSafeguards: ProcessingActivityTransferSafeguards @goField(omittable: true)
+  retentionPeriod: String @goField(omittable: true)
+  securityMeasures: String @goField(omittable: true)
   dataProtectionImpactAssessment: ProcessingActivityDataProtectionImpactAssessment
   transferImpactAssessment: ProcessingActivityTransferImpactAssessment
 }

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -12144,12 +12144,12 @@ input CreateOrganizationInput {
 input UpdateOrganizationInput {
   organizationId: ID!
   name: String
-  logo: Upload
+  description: String @goField(omittable: true)
+  websiteUrl: String @goField(omittable: true)
+  email: String @goField(omittable: true)
+  headquarterAddress: String @goField(omittable: true)
+  logoFile: Upload
   horizontalLogoFile: Upload
-  description: String
-  websiteUrl: String
-  email: String
-  headquarterAddress: String
 }
 
 input DeleteOrganizationHorizontalLogoInput {
@@ -12240,24 +12240,24 @@ input CreateVendorInput {
 input UpdateVendorInput {
   id: ID!
   name: String
-  description: String
-  statusPageUrl: String
-  termsOfServiceUrl: String
-  privacyPolicyUrl: String
-  serviceLevelAgreementUrl: String
-  dataProcessingAgreementUrl: String
-  businessAssociateAgreementUrl: String
-  subprocessorsListUrl: String
-  websiteUrl: String
-  legalName: String
-  headquarterAddress: String
+  description: String @goField(omittable: true)
+  statusPageUrl: String @goField(omittable: true)
+  termsOfServiceUrl: String @goField(omittable: true)
+  privacyPolicyUrl: String @goField(omittable: true)
+  serviceLevelAgreementUrl: String @goField(omittable: true)
+  dataProcessingAgreementUrl: String @goField(omittable: true)
+  businessAssociateAgreementUrl: String @goField(omittable: true)
+  subprocessorsListUrl: String @goField(omittable: true)
+  websiteUrl: String @goField(omittable: true)
+  legalName: String @goField(omittable: true)
+  headquarterAddress: String @goField(omittable: true)
   category: VendorCategory
   certifications: [String!]
   countries: [CountryCode!]
-  securityPageUrl: String
-  trustPageUrl: String
-  businessOwnerId: ID
-  securityOwnerId: ID
+  securityPageUrl: String @goField(omittable: true)
+  trustPageUrl: String @goField(omittable: true)
+  businessOwnerId: ID @goField(omittable: true)
+  securityOwnerId: ID @goField(omittable: true)
   showOnTrustCenter: Boolean
 }
 
@@ -12275,10 +12275,10 @@ input CreateVendorContactInput {
 
 input UpdateVendorContactInput {
   id: ID!
-  fullName: String
-  email: String
-  phone: String
-  role: String
+  fullName: String @goField(omittable: true)
+  email: String @goField(omittable: true)
+  phone: String @goField(omittable: true)
+  role: String @goField(omittable: true)
 }
 
 input DeleteVendorContactInput {
@@ -12296,7 +12296,7 @@ input CreateVendorServiceInput {
 input UpdateVendorServiceInput {
   id: ID!
   name: String
-  description: String
+  description: String @goField(omittable: true)
   url: String
   type: String
 }
@@ -12322,9 +12322,9 @@ input UpdatePeopleInput {
   primaryEmailAddress: String
   additionalEmailAddresses: [String!]
   kind: PeopleKind
-  position: String
-  contractStartDate: Datetime
-  contractEndDate: Datetime
+  position: String @goField(omittable: true)
+  contractStartDate: Datetime @goField(omittable: true)
+  contractEndDate: Datetime @goField(omittable: true)
 }
 
 input DeletePeopleInput {
@@ -12391,8 +12391,8 @@ input UpdateTaskInput {
   name: String
   description: String
   state: TaskState
-  timeEstimate: Duration
-  deadline: Datetime
+  timeEstimate: Duration @goField(omittable: true)
+  deadline: Datetime @goField(omittable: true)
 }
 
 input DeleteTaskInput {
@@ -12467,7 +12467,7 @@ input UpdateRiskInput {
   name: String
   description: String
   category: String
-  ownerId: ID
+  ownerId: ID @goField(omittable: true)
   treatment: RiskTreatment
   inherentLikelihood: Int
   inherentImpact: Int
@@ -12559,8 +12559,8 @@ input UploadVendorBusinessAssociateAgreementInput {
 
 input UpdateVendorBusinessAssociateAgreementInput {
   vendorId: ID!
-  validFrom: Datetime
-  validUntil: Datetime
+  validFrom: Datetime @goField(omittable: true)
+  validUntil: Datetime @goField(omittable: true)
 }
 
 input DeleteVendorBusinessAssociateAgreementInput {
@@ -12577,8 +12577,8 @@ input UploadVendorDataPrivacyAgreementInput {
 
 input UpdateVendorDataPrivacyAgreementInput {
   vendorId: ID!
-  validFrom: Datetime
-  validUntil: Datetime
+  validFrom: Datetime @goField(omittable: true)
+  validUntil: Datetime @goField(omittable: true)
 }
 
 input DeleteVendorDataPrivacyAgreementInput {
@@ -12711,15 +12711,15 @@ input CreateNonconformityInput {
 input UpdateNonconformityInput {
   id: ID!
   referenceId: String
-  description: String
-  dateIdentified: Datetime
+  description: String @goField(omittable: true)
+  dateIdentified: Datetime @goField(omittable: true)
   rootCause: String
-  correctiveAction: String
+  correctiveAction: String @goField(omittable: true)
   ownerId: ID
   auditId: ID
-  dueDate: Datetime
+  dueDate: Datetime @goField(omittable: true)
   status: NonconformityStatus
-  effectivenessCheck: String
+  effectivenessCheck: String @goField(omittable: true)
 }
 
 input DeleteNonconformityInput {
@@ -12741,14 +12741,14 @@ input CreateObligationInput {
 
 input UpdateObligationInput {
   id: ID!
-  area: String
-  source: String
-  requirement: String
-  actionsToBeImplemented: String
-  regulator: String
+  area: String @goField(omittable: true)
+  source: String @goField(omittable: true)
+  requirement: String @goField(omittable: true)
+  actionsToBeImplemented: String @goField(omittable: true)
+  regulator: String @goField(omittable: true)
   ownerId: ID
-  lastReviewDate: Datetime
-  dueDate: Datetime
+  lastReviewDate: Datetime @goField(omittable: true)
+  dueDate: Datetime @goField(omittable: true)
   status: ObligationStatus
 }
 
@@ -12770,10 +12770,10 @@ input CreateContinualImprovementInput {
 input UpdateContinualImprovementInput {
   id: ID!
   referenceId: String
-  description: String
-  source: String
+  description: String @goField(omittable: true)
+  source: String @goField(omittable: true)
   ownerId: ID
-  targetDate: Datetime
+  targetDate: Datetime @goField(omittable: true)
   status: ContinualImprovementStatus
   priority: ContinualImprovementPriority
 }
@@ -12804,18 +12804,18 @@ input CreateProcessingActivityInput {
 input UpdateProcessingActivityInput {
   id: ID!
   name: String
-  purpose: String
-  dataSubjectCategory: String
-  personalDataCategory: String
+  purpose: String @goField(omittable: true)
+  dataSubjectCategory: String @goField(omittable: true)
+  personalDataCategory: String @goField(omittable: true)
   specialOrCriminalData: ProcessingActivitySpecialOrCriminalData
   consentEvidenceLink: String
   lawfulBasis: ProcessingActivityLawfulBasis
-  recipients: String
-  location: String
+  recipients: String @goField(omittable: true)
+  location: String @goField(omittable: true)
   internationalTransfers: Boolean
-  transferSafeguards: ProcessingActivityTransferSafeguards
-  retentionPeriod: String
-  securityMeasures: String
+  transferSafeguards: ProcessingActivityTransferSafeguards @goField(omittable: true)
+  retentionPeriod: String @goField(omittable: true)
+  securityMeasures: String @goField(omittable: true)
   dataProtectionImpactAssessment: ProcessingActivityDataProtectionImpactAssessment
   transferImpactAssessment: ProcessingActivityTransferImpactAssessment
 }
@@ -73255,14 +73255,14 @@ func (ec *executionContext) unmarshalInputUpdateContinualImprovementInput(ctx co
 			if err != nil {
 				return it, err
 			}
-			it.Description = data
+			it.Description = graphql.OmittableOf(data)
 		case "source":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("source"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.Source = data
+			it.Source = graphql.OmittableOf(data)
 		case "ownerId":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("ownerId"))
 			data, err := ec.unmarshalOID2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
@@ -73276,7 +73276,7 @@ func (ec *executionContext) unmarshalInputUpdateContinualImprovementInput(ctx co
 			if err != nil {
 				return it, err
 			}
-			it.TargetDate = data
+			it.TargetDate = graphql.OmittableOf(data)
 		case "status":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("status"))
 			data, err := ec.unmarshalOContinualImprovementStatus2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐContinualImprovementStatus(ctx, v)
@@ -73640,14 +73640,14 @@ func (ec *executionContext) unmarshalInputUpdateNonconformityInput(ctx context.C
 			if err != nil {
 				return it, err
 			}
-			it.Description = data
+			it.Description = graphql.OmittableOf(data)
 		case "dateIdentified":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("dateIdentified"))
 			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.DateIdentified = data
+			it.DateIdentified = graphql.OmittableOf(data)
 		case "rootCause":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rootCause"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
@@ -73661,7 +73661,7 @@ func (ec *executionContext) unmarshalInputUpdateNonconformityInput(ctx context.C
 			if err != nil {
 				return it, err
 			}
-			it.CorrectiveAction = data
+			it.CorrectiveAction = graphql.OmittableOf(data)
 		case "ownerId":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("ownerId"))
 			data, err := ec.unmarshalOID2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
@@ -73682,7 +73682,7 @@ func (ec *executionContext) unmarshalInputUpdateNonconformityInput(ctx context.C
 			if err != nil {
 				return it, err
 			}
-			it.DueDate = data
+			it.DueDate = graphql.OmittableOf(data)
 		case "status":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("status"))
 			data, err := ec.unmarshalONonconformityStatus2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐNonconformityStatus(ctx, v)
@@ -73696,7 +73696,7 @@ func (ec *executionContext) unmarshalInputUpdateNonconformityInput(ctx context.C
 			if err != nil {
 				return it, err
 			}
-			it.EffectivenessCheck = data
+			it.EffectivenessCheck = graphql.OmittableOf(data)
 		}
 	}
 
@@ -73730,35 +73730,35 @@ func (ec *executionContext) unmarshalInputUpdateObligationInput(ctx context.Cont
 			if err != nil {
 				return it, err
 			}
-			it.Area = data
+			it.Area = graphql.OmittableOf(data)
 		case "source":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("source"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.Source = data
+			it.Source = graphql.OmittableOf(data)
 		case "requirement":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("requirement"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.Requirement = data
+			it.Requirement = graphql.OmittableOf(data)
 		case "actionsToBeImplemented":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("actionsToBeImplemented"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.ActionsToBeImplemented = data
+			it.ActionsToBeImplemented = graphql.OmittableOf(data)
 		case "regulator":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("regulator"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.Regulator = data
+			it.Regulator = graphql.OmittableOf(data)
 		case "ownerId":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("ownerId"))
 			data, err := ec.unmarshalOID2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
@@ -73772,14 +73772,14 @@ func (ec *executionContext) unmarshalInputUpdateObligationInput(ctx context.Cont
 			if err != nil {
 				return it, err
 			}
-			it.LastReviewDate = data
+			it.LastReviewDate = graphql.OmittableOf(data)
 		case "dueDate":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("dueDate"))
 			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.DueDate = data
+			it.DueDate = graphql.OmittableOf(data)
 		case "status":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("status"))
 			data, err := ec.unmarshalOObligationStatus2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐObligationStatus(ctx, v)
@@ -73800,7 +73800,7 @@ func (ec *executionContext) unmarshalInputUpdateOrganizationInput(ctx context.Co
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"organizationId", "name", "logo", "horizontalLogoFile", "description", "websiteUrl", "email", "headquarterAddress"}
+	fieldsInOrder := [...]string{"organizationId", "name", "description", "websiteUrl", "email", "headquarterAddress", "logoFile", "horizontalLogoFile"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -73821,13 +73821,41 @@ func (ec *executionContext) unmarshalInputUpdateOrganizationInput(ctx context.Co
 				return it, err
 			}
 			it.Name = data
-		case "logo":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("logo"))
+		case "description":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Description = graphql.OmittableOf(data)
+		case "websiteUrl":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("websiteUrl"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.WebsiteURL = graphql.OmittableOf(data)
+		case "email":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("email"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Email = graphql.OmittableOf(data)
+		case "headquarterAddress":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("headquarterAddress"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.HeadquarterAddress = graphql.OmittableOf(data)
+		case "logoFile":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("logoFile"))
 			data, err := ec.unmarshalOUpload2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚐUpload(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.Logo = data
+			it.LogoFile = data
 		case "horizontalLogoFile":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("horizontalLogoFile"))
 			data, err := ec.unmarshalOUpload2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚐUpload(ctx, v)
@@ -73835,34 +73863,6 @@ func (ec *executionContext) unmarshalInputUpdateOrganizationInput(ctx context.Co
 				return it, err
 			}
 			it.HorizontalLogoFile = data
-		case "description":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Description = data
-		case "websiteUrl":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("websiteUrl"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.WebsiteURL = data
-		case "email":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("email"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Email = data
-		case "headquarterAddress":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("headquarterAddress"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.HeadquarterAddress = data
 		}
 	}
 
@@ -73924,21 +73924,21 @@ func (ec *executionContext) unmarshalInputUpdatePeopleInput(ctx context.Context,
 			if err != nil {
 				return it, err
 			}
-			it.Position = data
+			it.Position = graphql.OmittableOf(data)
 		case "contractStartDate":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("contractStartDate"))
 			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.ContractStartDate = data
+			it.ContractStartDate = graphql.OmittableOf(data)
 		case "contractEndDate":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("contractEndDate"))
 			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.ContractEndDate = data
+			it.ContractEndDate = graphql.OmittableOf(data)
 		}
 	}
 
@@ -73979,21 +73979,21 @@ func (ec *executionContext) unmarshalInputUpdateProcessingActivityInput(ctx cont
 			if err != nil {
 				return it, err
 			}
-			it.Purpose = data
+			it.Purpose = graphql.OmittableOf(data)
 		case "dataSubjectCategory":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("dataSubjectCategory"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.DataSubjectCategory = data
+			it.DataSubjectCategory = graphql.OmittableOf(data)
 		case "personalDataCategory":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("personalDataCategory"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.PersonalDataCategory = data
+			it.PersonalDataCategory = graphql.OmittableOf(data)
 		case "specialOrCriminalData":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("specialOrCriminalData"))
 			data, err := ec.unmarshalOProcessingActivitySpecialOrCriminalData2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐProcessingActivitySpecialOrCriminalData(ctx, v)
@@ -74021,14 +74021,14 @@ func (ec *executionContext) unmarshalInputUpdateProcessingActivityInput(ctx cont
 			if err != nil {
 				return it, err
 			}
-			it.Recipients = data
+			it.Recipients = graphql.OmittableOf(data)
 		case "location":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("location"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.Location = data
+			it.Location = graphql.OmittableOf(data)
 		case "internationalTransfers":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("internationalTransfers"))
 			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
@@ -74042,21 +74042,21 @@ func (ec *executionContext) unmarshalInputUpdateProcessingActivityInput(ctx cont
 			if err != nil {
 				return it, err
 			}
-			it.TransferSafeguards = data
+			it.TransferSafeguards = graphql.OmittableOf(data)
 		case "retentionPeriod":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("retentionPeriod"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.RetentionPeriod = data
+			it.RetentionPeriod = graphql.OmittableOf(data)
 		case "securityMeasures":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("securityMeasures"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.SecurityMeasures = data
+			it.SecurityMeasures = graphql.OmittableOf(data)
 		case "dataProtectionImpactAssessment":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("dataProtectionImpactAssessment"))
 			data, err := ec.unmarshalOProcessingActivityDataProtectionImpactAssessment2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐProcessingActivityDataProtectionImpactAssessment(ctx, v)
@@ -74125,7 +74125,7 @@ func (ec *executionContext) unmarshalInputUpdateRiskInput(ctx context.Context, o
 			if err != nil {
 				return it, err
 			}
-			it.OwnerID = data
+			it.OwnerID = graphql.OmittableOf(data)
 		case "treatment":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("treatment"))
 			data, err := ec.unmarshalORiskTreatment2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐRiskTreatment(ctx, v)
@@ -74222,14 +74222,14 @@ func (ec *executionContext) unmarshalInputUpdateTaskInput(ctx context.Context, o
 			if err != nil {
 				return it, err
 			}
-			it.TimeEstimate = data
+			it.TimeEstimate = graphql.OmittableOf(data)
 		case "deadline":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deadline"))
 			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.Deadline = data
+			it.Deadline = graphql.OmittableOf(data)
 		}
 	}
 
@@ -74407,14 +74407,14 @@ func (ec *executionContext) unmarshalInputUpdateVendorBusinessAssociateAgreement
 			if err != nil {
 				return it, err
 			}
-			it.ValidFrom = data
+			it.ValidFrom = graphql.OmittableOf(data)
 		case "validUntil":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("validUntil"))
 			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.ValidUntil = data
+			it.ValidUntil = graphql.OmittableOf(data)
 		}
 	}
 
@@ -74448,28 +74448,28 @@ func (ec *executionContext) unmarshalInputUpdateVendorContactInput(ctx context.C
 			if err != nil {
 				return it, err
 			}
-			it.FullName = data
+			it.FullName = graphql.OmittableOf(data)
 		case "email":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("email"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.Email = data
+			it.Email = graphql.OmittableOf(data)
 		case "phone":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("phone"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.Phone = data
+			it.Phone = graphql.OmittableOf(data)
 		case "role":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("role"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.Role = data
+			it.Role = graphql.OmittableOf(data)
 		}
 	}
 
@@ -74503,14 +74503,14 @@ func (ec *executionContext) unmarshalInputUpdateVendorDataPrivacyAgreementInput(
 			if err != nil {
 				return it, err
 			}
-			it.ValidFrom = data
+			it.ValidFrom = graphql.OmittableOf(data)
 		case "validUntil":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("validUntil"))
 			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.ValidUntil = data
+			it.ValidUntil = graphql.OmittableOf(data)
 		}
 	}
 
@@ -74551,77 +74551,77 @@ func (ec *executionContext) unmarshalInputUpdateVendorInput(ctx context.Context,
 			if err != nil {
 				return it, err
 			}
-			it.Description = data
+			it.Description = graphql.OmittableOf(data)
 		case "statusPageUrl":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("statusPageUrl"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.StatusPageURL = data
+			it.StatusPageURL = graphql.OmittableOf(data)
 		case "termsOfServiceUrl":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("termsOfServiceUrl"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.TermsOfServiceURL = data
+			it.TermsOfServiceURL = graphql.OmittableOf(data)
 		case "privacyPolicyUrl":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("privacyPolicyUrl"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.PrivacyPolicyURL = data
+			it.PrivacyPolicyURL = graphql.OmittableOf(data)
 		case "serviceLevelAgreementUrl":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("serviceLevelAgreementUrl"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.ServiceLevelAgreementURL = data
+			it.ServiceLevelAgreementURL = graphql.OmittableOf(data)
 		case "dataProcessingAgreementUrl":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("dataProcessingAgreementUrl"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.DataProcessingAgreementURL = data
+			it.DataProcessingAgreementURL = graphql.OmittableOf(data)
 		case "businessAssociateAgreementUrl":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("businessAssociateAgreementUrl"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.BusinessAssociateAgreementURL = data
+			it.BusinessAssociateAgreementURL = graphql.OmittableOf(data)
 		case "subprocessorsListUrl":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("subprocessorsListUrl"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.SubprocessorsListURL = data
+			it.SubprocessorsListURL = graphql.OmittableOf(data)
 		case "websiteUrl":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("websiteUrl"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.WebsiteURL = data
+			it.WebsiteURL = graphql.OmittableOf(data)
 		case "legalName":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("legalName"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.LegalName = data
+			it.LegalName = graphql.OmittableOf(data)
 		case "headquarterAddress":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("headquarterAddress"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.HeadquarterAddress = data
+			it.HeadquarterAddress = graphql.OmittableOf(data)
 		case "category":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("category"))
 			data, err := ec.unmarshalOVendorCategory2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐVendorCategory(ctx, v)
@@ -74649,28 +74649,28 @@ func (ec *executionContext) unmarshalInputUpdateVendorInput(ctx context.Context,
 			if err != nil {
 				return it, err
 			}
-			it.SecurityPageURL = data
+			it.SecurityPageURL = graphql.OmittableOf(data)
 		case "trustPageUrl":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("trustPageUrl"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.TrustPageURL = data
+			it.TrustPageURL = graphql.OmittableOf(data)
 		case "businessOwnerId":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("businessOwnerId"))
 			data, err := ec.unmarshalOID2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.BusinessOwnerID = data
+			it.BusinessOwnerID = graphql.OmittableOf(data)
 		case "securityOwnerId":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("securityOwnerId"))
 			data, err := ec.unmarshalOID2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.SecurityOwnerID = data
+			it.SecurityOwnerID = graphql.OmittableOf(data)
 		case "showOnTrustCenter":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("showOnTrustCenter"))
 			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
@@ -74718,7 +74718,7 @@ func (ec *executionContext) unmarshalInputUpdateVendorServiceInput(ctx context.C
 			if err != nil {
 				return it, err
 			}
-			it.Description = data
+			it.Description = graphql.OmittableOf(data)
 		case "url":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("url"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -1751,10 +1751,10 @@ type UpdateAuditPayload struct {
 type UpdateContinualImprovementInput struct {
 	ID          gid.GID                                `json:"id"`
 	ReferenceID *string                                `json:"referenceId,omitempty"`
-	Description *string                                `json:"description,omitempty"`
-	Source      *string                                `json:"source,omitempty"`
+	Description graphql.Omittable[*string]             `json:"description,omitempty"`
+	Source      graphql.Omittable[*string]             `json:"source,omitempty"`
 	OwnerID     *gid.GID                               `json:"ownerId,omitempty"`
-	TargetDate  *time.Time                             `json:"targetDate,omitempty"`
+	TargetDate  graphql.Omittable[*time.Time]          `json:"targetDate,omitempty"`
 	Status      *coredata.ContinualImprovementStatus   `json:"status,omitempty"`
 	Priority    *coredata.ContinualImprovementPriority `json:"priority,omitempty"`
 }
@@ -1835,15 +1835,15 @@ type UpdateMeasurePayload struct {
 type UpdateNonconformityInput struct {
 	ID                 gid.GID                       `json:"id"`
 	ReferenceID        *string                       `json:"referenceId,omitempty"`
-	Description        *string                       `json:"description,omitempty"`
-	DateIdentified     *time.Time                    `json:"dateIdentified,omitempty"`
+	Description        graphql.Omittable[*string]    `json:"description,omitempty"`
+	DateIdentified     graphql.Omittable[*time.Time] `json:"dateIdentified,omitempty"`
 	RootCause          *string                       `json:"rootCause,omitempty"`
-	CorrectiveAction   *string                       `json:"correctiveAction,omitempty"`
+	CorrectiveAction   graphql.Omittable[*string]    `json:"correctiveAction,omitempty"`
 	OwnerID            *gid.GID                      `json:"ownerId,omitempty"`
 	AuditID            *gid.GID                      `json:"auditId,omitempty"`
-	DueDate            *time.Time                    `json:"dueDate,omitempty"`
+	DueDate            graphql.Omittable[*time.Time] `json:"dueDate,omitempty"`
 	Status             *coredata.NonconformityStatus `json:"status,omitempty"`
-	EffectivenessCheck *string                       `json:"effectivenessCheck,omitempty"`
+	EffectivenessCheck graphql.Omittable[*string]    `json:"effectivenessCheck,omitempty"`
 }
 
 type UpdateNonconformityPayload struct {
@@ -1851,16 +1851,16 @@ type UpdateNonconformityPayload struct {
 }
 
 type UpdateObligationInput struct {
-	ID                     gid.GID                    `json:"id"`
-	Area                   *string                    `json:"area,omitempty"`
-	Source                 *string                    `json:"source,omitempty"`
-	Requirement            *string                    `json:"requirement,omitempty"`
-	ActionsToBeImplemented *string                    `json:"actionsToBeImplemented,omitempty"`
-	Regulator              *string                    `json:"regulator,omitempty"`
-	OwnerID                *gid.GID                   `json:"ownerId,omitempty"`
-	LastReviewDate         *time.Time                 `json:"lastReviewDate,omitempty"`
-	DueDate                *time.Time                 `json:"dueDate,omitempty"`
-	Status                 *coredata.ObligationStatus `json:"status,omitempty"`
+	ID                     gid.GID                       `json:"id"`
+	Area                   graphql.Omittable[*string]    `json:"area,omitempty"`
+	Source                 graphql.Omittable[*string]    `json:"source,omitempty"`
+	Requirement            graphql.Omittable[*string]    `json:"requirement,omitempty"`
+	ActionsToBeImplemented graphql.Omittable[*string]    `json:"actionsToBeImplemented,omitempty"`
+	Regulator              graphql.Omittable[*string]    `json:"regulator,omitempty"`
+	OwnerID                *gid.GID                      `json:"ownerId,omitempty"`
+	LastReviewDate         graphql.Omittable[*time.Time] `json:"lastReviewDate,omitempty"`
+	DueDate                graphql.Omittable[*time.Time] `json:"dueDate,omitempty"`
+	Status                 *coredata.ObligationStatus    `json:"status,omitempty"`
 }
 
 type UpdateObligationPayload struct {
@@ -1868,14 +1868,14 @@ type UpdateObligationPayload struct {
 }
 
 type UpdateOrganizationInput struct {
-	OrganizationID     gid.GID         `json:"organizationId"`
-	Name               *string         `json:"name,omitempty"`
-	Logo               *graphql.Upload `json:"logo,omitempty"`
-	HorizontalLogoFile *graphql.Upload `json:"horizontalLogoFile,omitempty"`
-	Description        *string         `json:"description,omitempty"`
-	WebsiteURL         *string         `json:"websiteUrl,omitempty"`
-	Email              *string         `json:"email,omitempty"`
-	HeadquarterAddress *string         `json:"headquarterAddress,omitempty"`
+	OrganizationID     gid.GID                    `json:"organizationId"`
+	Name               *string                    `json:"name,omitempty"`
+	Description        graphql.Omittable[*string] `json:"description,omitempty"`
+	WebsiteURL         graphql.Omittable[*string] `json:"websiteUrl,omitempty"`
+	Email              graphql.Omittable[*string] `json:"email,omitempty"`
+	HeadquarterAddress graphql.Omittable[*string] `json:"headquarterAddress,omitempty"`
+	LogoFile           *graphql.Upload            `json:"logoFile,omitempty"`
+	HorizontalLogoFile *graphql.Upload            `json:"horizontalLogoFile,omitempty"`
 }
 
 type UpdateOrganizationPayload struct {
@@ -1883,14 +1883,14 @@ type UpdateOrganizationPayload struct {
 }
 
 type UpdatePeopleInput struct {
-	ID                       gid.GID              `json:"id"`
-	FullName                 *string              `json:"fullName,omitempty"`
-	PrimaryEmailAddress      *string              `json:"primaryEmailAddress,omitempty"`
-	AdditionalEmailAddresses []string             `json:"additionalEmailAddresses,omitempty"`
-	Kind                     *coredata.PeopleKind `json:"kind,omitempty"`
-	Position                 *string              `json:"position,omitempty"`
-	ContractStartDate        *time.Time           `json:"contractStartDate,omitempty"`
-	ContractEndDate          *time.Time           `json:"contractEndDate,omitempty"`
+	ID                       gid.GID                       `json:"id"`
+	FullName                 *string                       `json:"fullName,omitempty"`
+	PrimaryEmailAddress      *string                       `json:"primaryEmailAddress,omitempty"`
+	AdditionalEmailAddresses []string                      `json:"additionalEmailAddresses,omitempty"`
+	Kind                     *coredata.PeopleKind          `json:"kind,omitempty"`
+	Position                 graphql.Omittable[*string]    `json:"position,omitempty"`
+	ContractStartDate        graphql.Omittable[*time.Time] `json:"contractStartDate,omitempty"`
+	ContractEndDate          graphql.Omittable[*time.Time] `json:"contractEndDate,omitempty"`
 }
 
 type UpdatePeoplePayload struct {
@@ -1898,22 +1898,22 @@ type UpdatePeoplePayload struct {
 }
 
 type UpdateProcessingActivityInput struct {
-	ID                             gid.GID                                                    `json:"id"`
-	Name                           *string                                                    `json:"name,omitempty"`
-	Purpose                        *string                                                    `json:"purpose,omitempty"`
-	DataSubjectCategory            *string                                                    `json:"dataSubjectCategory,omitempty"`
-	PersonalDataCategory           *string                                                    `json:"personalDataCategory,omitempty"`
-	SpecialOrCriminalData          *coredata.ProcessingActivitySpecialOrCriminalData          `json:"specialOrCriminalData,omitempty"`
-	ConsentEvidenceLink            *string                                                    `json:"consentEvidenceLink,omitempty"`
-	LawfulBasis                    *coredata.ProcessingActivityLawfulBasis                    `json:"lawfulBasis,omitempty"`
-	Recipients                     *string                                                    `json:"recipients,omitempty"`
-	Location                       *string                                                    `json:"location,omitempty"`
-	InternationalTransfers         *bool                                                      `json:"internationalTransfers,omitempty"`
-	TransferSafeguards             *coredata.ProcessingActivityTransferSafeguards             `json:"transferSafeguards,omitempty"`
-	RetentionPeriod                *string                                                    `json:"retentionPeriod,omitempty"`
-	SecurityMeasures               *string                                                    `json:"securityMeasures,omitempty"`
-	DataProtectionImpactAssessment *coredata.ProcessingActivityDataProtectionImpactAssessment `json:"dataProtectionImpactAssessment,omitempty"`
-	TransferImpactAssessment       *coredata.ProcessingActivityTransferImpactAssessment       `json:"transferImpactAssessment,omitempty"`
+	ID                             gid.GID                                                           `json:"id"`
+	Name                           *string                                                           `json:"name,omitempty"`
+	Purpose                        graphql.Omittable[*string]                                        `json:"purpose,omitempty"`
+	DataSubjectCategory            graphql.Omittable[*string]                                        `json:"dataSubjectCategory,omitempty"`
+	PersonalDataCategory           graphql.Omittable[*string]                                        `json:"personalDataCategory,omitempty"`
+	SpecialOrCriminalData          *coredata.ProcessingActivitySpecialOrCriminalData                 `json:"specialOrCriminalData,omitempty"`
+	ConsentEvidenceLink            *string                                                           `json:"consentEvidenceLink,omitempty"`
+	LawfulBasis                    *coredata.ProcessingActivityLawfulBasis                           `json:"lawfulBasis,omitempty"`
+	Recipients                     graphql.Omittable[*string]                                        `json:"recipients,omitempty"`
+	Location                       graphql.Omittable[*string]                                        `json:"location,omitempty"`
+	InternationalTransfers         *bool                                                             `json:"internationalTransfers,omitempty"`
+	TransferSafeguards             graphql.Omittable[*coredata.ProcessingActivityTransferSafeguards] `json:"transferSafeguards,omitempty"`
+	RetentionPeriod                graphql.Omittable[*string]                                        `json:"retentionPeriod,omitempty"`
+	SecurityMeasures               graphql.Omittable[*string]                                        `json:"securityMeasures,omitempty"`
+	DataProtectionImpactAssessment *coredata.ProcessingActivityDataProtectionImpactAssessment        `json:"dataProtectionImpactAssessment,omitempty"`
+	TransferImpactAssessment       *coredata.ProcessingActivityTransferImpactAssessment              `json:"transferImpactAssessment,omitempty"`
 }
 
 type UpdateProcessingActivityPayload struct {
@@ -1921,17 +1921,17 @@ type UpdateProcessingActivityPayload struct {
 }
 
 type UpdateRiskInput struct {
-	ID                 gid.GID                 `json:"id"`
-	Name               *string                 `json:"name,omitempty"`
-	Description        *string                 `json:"description,omitempty"`
-	Category           *string                 `json:"category,omitempty"`
-	OwnerID            *gid.GID                `json:"ownerId,omitempty"`
-	Treatment          *coredata.RiskTreatment `json:"treatment,omitempty"`
-	InherentLikelihood *int                    `json:"inherentLikelihood,omitempty"`
-	InherentImpact     *int                    `json:"inherentImpact,omitempty"`
-	ResidualLikelihood *int                    `json:"residualLikelihood,omitempty"`
-	ResidualImpact     *int                    `json:"residualImpact,omitempty"`
-	Note               *string                 `json:"note,omitempty"`
+	ID                 gid.GID                     `json:"id"`
+	Name               *string                     `json:"name,omitempty"`
+	Description        *string                     `json:"description,omitempty"`
+	Category           *string                     `json:"category,omitempty"`
+	OwnerID            graphql.Omittable[*gid.GID] `json:"ownerId,omitempty"`
+	Treatment          *coredata.RiskTreatment     `json:"treatment,omitempty"`
+	InherentLikelihood *int                        `json:"inherentLikelihood,omitempty"`
+	InherentImpact     *int                        `json:"inherentImpact,omitempty"`
+	ResidualLikelihood *int                        `json:"residualLikelihood,omitempty"`
+	ResidualImpact     *int                        `json:"residualImpact,omitempty"`
+	Note               *string                     `json:"note,omitempty"`
 }
 
 type UpdateRiskPayload struct {
@@ -1939,12 +1939,12 @@ type UpdateRiskPayload struct {
 }
 
 type UpdateTaskInput struct {
-	TaskID       gid.GID             `json:"taskId"`
-	Name         *string             `json:"name,omitempty"`
-	Description  *string             `json:"description,omitempty"`
-	State        *coredata.TaskState `json:"state,omitempty"`
-	TimeEstimate *time.Duration      `json:"timeEstimate,omitempty"`
-	Deadline     *time.Time          `json:"deadline,omitempty"`
+	TaskID       gid.GID                           `json:"taskId"`
+	Name         *string                           `json:"name,omitempty"`
+	Description  *string                           `json:"description,omitempty"`
+	State        *coredata.TaskState               `json:"state,omitempty"`
+	TimeEstimate graphql.Omittable[*time.Duration] `json:"timeEstimate,omitempty"`
+	Deadline     graphql.Omittable[*time.Time]     `json:"deadline,omitempty"`
 }
 
 type UpdateTaskPayload struct {
@@ -1985,9 +1985,9 @@ type UpdateTrustCenterReferencePayload struct {
 }
 
 type UpdateVendorBusinessAssociateAgreementInput struct {
-	VendorID   gid.GID    `json:"vendorId"`
-	ValidFrom  *time.Time `json:"validFrom,omitempty"`
-	ValidUntil *time.Time `json:"validUntil,omitempty"`
+	VendorID   gid.GID                       `json:"vendorId"`
+	ValidFrom  graphql.Omittable[*time.Time] `json:"validFrom,omitempty"`
+	ValidUntil graphql.Omittable[*time.Time] `json:"validUntil,omitempty"`
 }
 
 type UpdateVendorBusinessAssociateAgreementPayload struct {
@@ -1995,11 +1995,11 @@ type UpdateVendorBusinessAssociateAgreementPayload struct {
 }
 
 type UpdateVendorContactInput struct {
-	ID       gid.GID `json:"id"`
-	FullName *string `json:"fullName,omitempty"`
-	Email    *string `json:"email,omitempty"`
-	Phone    *string `json:"phone,omitempty"`
-	Role     *string `json:"role,omitempty"`
+	ID       gid.GID                    `json:"id"`
+	FullName graphql.Omittable[*string] `json:"fullName,omitempty"`
+	Email    graphql.Omittable[*string] `json:"email,omitempty"`
+	Phone    graphql.Omittable[*string] `json:"phone,omitempty"`
+	Role     graphql.Omittable[*string] `json:"role,omitempty"`
 }
 
 type UpdateVendorContactPayload struct {
@@ -2007,9 +2007,9 @@ type UpdateVendorContactPayload struct {
 }
 
 type UpdateVendorDataPrivacyAgreementInput struct {
-	VendorID   gid.GID    `json:"vendorId"`
-	ValidFrom  *time.Time `json:"validFrom,omitempty"`
-	ValidUntil *time.Time `json:"validUntil,omitempty"`
+	VendorID   gid.GID                       `json:"vendorId"`
+	ValidFrom  graphql.Omittable[*time.Time] `json:"validFrom,omitempty"`
+	ValidUntil graphql.Omittable[*time.Time] `json:"validUntil,omitempty"`
 }
 
 type UpdateVendorDataPrivacyAgreementPayload struct {
@@ -2017,27 +2017,27 @@ type UpdateVendorDataPrivacyAgreementPayload struct {
 }
 
 type UpdateVendorInput struct {
-	ID                            gid.GID                  `json:"id"`
-	Name                          *string                  `json:"name,omitempty"`
-	Description                   *string                  `json:"description,omitempty"`
-	StatusPageURL                 *string                  `json:"statusPageUrl,omitempty"`
-	TermsOfServiceURL             *string                  `json:"termsOfServiceUrl,omitempty"`
-	PrivacyPolicyURL              *string                  `json:"privacyPolicyUrl,omitempty"`
-	ServiceLevelAgreementURL      *string                  `json:"serviceLevelAgreementUrl,omitempty"`
-	DataProcessingAgreementURL    *string                  `json:"dataProcessingAgreementUrl,omitempty"`
-	BusinessAssociateAgreementURL *string                  `json:"businessAssociateAgreementUrl,omitempty"`
-	SubprocessorsListURL          *string                  `json:"subprocessorsListUrl,omitempty"`
-	WebsiteURL                    *string                  `json:"websiteUrl,omitempty"`
-	LegalName                     *string                  `json:"legalName,omitempty"`
-	HeadquarterAddress            *string                  `json:"headquarterAddress,omitempty"`
-	Category                      *coredata.VendorCategory `json:"category,omitempty"`
-	Certifications                []string                 `json:"certifications,omitempty"`
-	Countries                     []coredata.CountryCode   `json:"countries,omitempty"`
-	SecurityPageURL               *string                  `json:"securityPageUrl,omitempty"`
-	TrustPageURL                  *string                  `json:"trustPageUrl,omitempty"`
-	BusinessOwnerID               *gid.GID                 `json:"businessOwnerId,omitempty"`
-	SecurityOwnerID               *gid.GID                 `json:"securityOwnerId,omitempty"`
-	ShowOnTrustCenter             *bool                    `json:"showOnTrustCenter,omitempty"`
+	ID                            gid.GID                     `json:"id"`
+	Name                          *string                     `json:"name,omitempty"`
+	Description                   graphql.Omittable[*string]  `json:"description,omitempty"`
+	StatusPageURL                 graphql.Omittable[*string]  `json:"statusPageUrl,omitempty"`
+	TermsOfServiceURL             graphql.Omittable[*string]  `json:"termsOfServiceUrl,omitempty"`
+	PrivacyPolicyURL              graphql.Omittable[*string]  `json:"privacyPolicyUrl,omitempty"`
+	ServiceLevelAgreementURL      graphql.Omittable[*string]  `json:"serviceLevelAgreementUrl,omitempty"`
+	DataProcessingAgreementURL    graphql.Omittable[*string]  `json:"dataProcessingAgreementUrl,omitempty"`
+	BusinessAssociateAgreementURL graphql.Omittable[*string]  `json:"businessAssociateAgreementUrl,omitempty"`
+	SubprocessorsListURL          graphql.Omittable[*string]  `json:"subprocessorsListUrl,omitempty"`
+	WebsiteURL                    graphql.Omittable[*string]  `json:"websiteUrl,omitempty"`
+	LegalName                     graphql.Omittable[*string]  `json:"legalName,omitempty"`
+	HeadquarterAddress            graphql.Omittable[*string]  `json:"headquarterAddress,omitempty"`
+	Category                      *coredata.VendorCategory    `json:"category,omitempty"`
+	Certifications                []string                    `json:"certifications,omitempty"`
+	Countries                     []coredata.CountryCode      `json:"countries,omitempty"`
+	SecurityPageURL               graphql.Omittable[*string]  `json:"securityPageUrl,omitempty"`
+	TrustPageURL                  graphql.Omittable[*string]  `json:"trustPageUrl,omitempty"`
+	BusinessOwnerID               graphql.Omittable[*gid.GID] `json:"businessOwnerId,omitempty"`
+	SecurityOwnerID               graphql.Omittable[*gid.GID] `json:"securityOwnerId,omitempty"`
+	ShowOnTrustCenter             *bool                       `json:"showOnTrustCenter,omitempty"`
 }
 
 type UpdateVendorPayload struct {
@@ -2045,11 +2045,11 @@ type UpdateVendorPayload struct {
 }
 
 type UpdateVendorServiceInput struct {
-	ID          gid.GID `json:"id"`
-	Name        *string `json:"name,omitempty"`
-	Description *string `json:"description,omitempty"`
-	URL         *string `json:"url,omitempty"`
-	Type        *string `json:"type,omitempty"`
+	ID          gid.GID                    `json:"id"`
+	Name        *string                    `json:"name,omitempty"`
+	Description graphql.Omittable[*string] `json:"description,omitempty"`
+	URL         *string                    `json:"url,omitempty"`
+	Type        *string                    `json:"type,omitempty"`
 }
 
 type UpdateVendorServicePayload struct {

--- a/pkg/server/api/console/v1/v1_resolver.go
+++ b/pkg/server/api/console/v1/v1_resolver.go
@@ -1147,18 +1147,18 @@ func (r *mutationResolver) UpdateOrganization(ctx context.Context, input types.U
 	req := probo.UpdateOrganizationRequest{
 		ID:                 input.OrganizationID,
 		Name:               input.Name,
-		Description:        &input.Description,
-		WebsiteURL:         &input.WebsiteURL,
-		Email:              &input.Email,
-		HeadquarterAddress: &input.HeadquarterAddress,
+		Description:        UnwrapOmittable(input.Description),
+		WebsiteURL:         UnwrapOmittable(input.WebsiteURL),
+		Email:              UnwrapOmittable(input.Email),
+		HeadquarterAddress: UnwrapOmittable(input.HeadquarterAddress),
 	}
 
-	if input.Logo != nil {
+	if input.LogoFile != nil {
 		req.File = &probo.File{
-			Filename:    input.Logo.Filename,
-			ContentType: input.Logo.ContentType,
-			Size:        input.Logo.Size,
-			Content:     input.Logo.File,
+			Filename:    input.LogoFile.Filename,
+			ContentType: input.LogoFile.ContentType,
+			Size:        input.LogoFile.Size,
+			Content:     input.LogoFile.File,
 		}
 	}
 
@@ -1493,9 +1493,9 @@ func (r *mutationResolver) UpdatePeople(ctx context.Context, input types.UpdateP
 		PrimaryEmailAddress:      input.PrimaryEmailAddress,
 		AdditionalEmailAddresses: &input.AdditionalEmailAddresses,
 		Kind:                     input.Kind,
-		Position:                 &input.Position,
-		ContractStartDate:        &input.ContractStartDate,
-		ContractEndDate:          &input.ContractEndDate,
+		Position:                 UnwrapOmittable(input.Position),
+		ContractStartDate:        UnwrapOmittable(input.ContractStartDate),
+		ContractEndDate:          UnwrapOmittable(input.ContractEndDate),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("cannot update people: %w", err)
@@ -1564,23 +1564,23 @@ func (r *mutationResolver) UpdateVendor(ctx context.Context, input types.UpdateV
 	vendor, err := prb.Vendors.Update(ctx, probo.UpdateVendorRequest{
 		ID:                            input.ID,
 		Name:                          input.Name,
-		Description:                   input.Description,
-		StatusPageURL:                 input.StatusPageURL,
-		TermsOfServiceURL:             input.TermsOfServiceURL,
-		PrivacyPolicyURL:              input.PrivacyPolicyURL,
-		ServiceLevelAgreementURL:      input.ServiceLevelAgreementURL,
-		DataProcessingAgreementURL:    input.DataProcessingAgreementURL,
-		BusinessAssociateAgreementURL: input.BusinessAssociateAgreementURL,
-		SubprocessorsListURL:          input.SubprocessorsListURL,
-		SecurityPageURL:               input.SecurityPageURL,
-		TrustPageURL:                  input.TrustPageURL,
-		HeadquarterAddress:            input.HeadquarterAddress,
-		LegalName:                     input.LegalName,
-		WebsiteURL:                    input.WebsiteURL,
+		Description:                   UnwrapOmittable(input.Description),
+		StatusPageURL:                 UnwrapOmittable(input.StatusPageURL),
+		TermsOfServiceURL:             UnwrapOmittable(input.TermsOfServiceURL),
+		PrivacyPolicyURL:              UnwrapOmittable(input.PrivacyPolicyURL),
+		ServiceLevelAgreementURL:      UnwrapOmittable(input.ServiceLevelAgreementURL),
+		DataProcessingAgreementURL:    UnwrapOmittable(input.DataProcessingAgreementURL),
+		BusinessAssociateAgreementURL: UnwrapOmittable(input.BusinessAssociateAgreementURL),
+		SubprocessorsListURL:          UnwrapOmittable(input.SubprocessorsListURL),
+		SecurityPageURL:               UnwrapOmittable(input.SecurityPageURL),
+		TrustPageURL:                  UnwrapOmittable(input.TrustPageURL),
+		HeadquarterAddress:            UnwrapOmittable(input.HeadquarterAddress),
+		LegalName:                     UnwrapOmittable(input.LegalName),
+		WebsiteURL:                    UnwrapOmittable(input.WebsiteURL),
 		Category:                      input.Category,
 		Certifications:                input.Certifications,
-		BusinessOwnerID:               &input.BusinessOwnerID,
-		SecurityOwnerID:               &input.SecurityOwnerID,
+		BusinessOwnerID:               UnwrapOmittable(input.BusinessOwnerID),
+		SecurityOwnerID:               UnwrapOmittable(input.SecurityOwnerID),
 		ShowOnTrustCenter:             input.ShowOnTrustCenter,
 		Countries:                     input.Countries,
 	})
@@ -1635,10 +1635,10 @@ func (r *mutationResolver) UpdateVendorContact(ctx context.Context, input types.
 
 	req := probo.UpdateVendorContactRequest{
 		ID:       input.ID,
-		FullName: &input.FullName,
-		Email:    &input.Email,
-		Phone:    &input.Phone,
-		Role:     &input.Role,
+		FullName: UnwrapOmittable(input.FullName),
+		Email:    UnwrapOmittable(input.Email),
+		Phone:    UnwrapOmittable(input.Phone),
+		Role:     UnwrapOmittable(input.Role),
 	}
 
 	vendorContact, err := prb.VendorContacts.Update(ctx, req)
@@ -1692,7 +1692,7 @@ func (r *mutationResolver) UpdateVendorService(ctx context.Context, input types.
 	req := probo.UpdateVendorServiceRequest{
 		ID:          input.ID,
 		Name:        input.Name,
-		Description: &input.Description,
+		Description: UnwrapOmittable(input.Description),
 	}
 
 	vendorService, err := prb.VendorServices.Update(ctx, req)
@@ -2127,8 +2127,8 @@ func (r *mutationResolver) UpdateTask(ctx context.Context, input types.UpdateTas
 		Name:         input.Name,
 		Description:  input.Description,
 		State:        input.State,
-		TimeEstimate: input.TimeEstimate,
-		Deadline:     input.Deadline,
+		TimeEstimate: UnwrapOmittable(input.TimeEstimate),
+		Deadline:     UnwrapOmittable(input.Deadline),
 	})
 	if err != nil {
 		panic(fmt.Errorf("cannot update task: %w", err))
@@ -2222,7 +2222,7 @@ func (r *mutationResolver) UpdateRisk(ctx context.Context, input types.UpdateRis
 			Description:        input.Description,
 			Category:           input.Category,
 			Treatment:          input.Treatment,
-			OwnerID:            input.OwnerID,
+			OwnerID:            UnwrapOmittable(input.OwnerID),
 			InherentLikelihood: input.InherentLikelihood,
 			InherentImpact:     input.InherentImpact,
 			ResidualLikelihood: input.ResidualLikelihood,
@@ -2450,8 +2450,8 @@ func (r *mutationResolver) UpdateVendorBusinessAssociateAgreement(ctx context.Co
 		ctx,
 		input.VendorID,
 		&probo.VendorBusinessAssociateAgreementUpdateRequest{
-			ValidFrom:  &input.ValidFrom,
-			ValidUntil: &input.ValidUntil,
+			ValidFrom:  UnwrapOmittable(input.ValidFrom),
+			ValidUntil: UnwrapOmittable(input.ValidUntil),
 		},
 	)
 	if err != nil {
@@ -2508,8 +2508,8 @@ func (r *mutationResolver) UpdateVendorDataPrivacyAgreement(ctx context.Context,
 		ctx,
 		input.VendorID,
 		&probo.VendorDataPrivacyAgreementUpdateRequest{
-			ValidFrom:  &input.ValidFrom,
-			ValidUntil: &input.ValidUntil,
+			ValidFrom:  UnwrapOmittable(input.ValidFrom),
+			ValidUntil: UnwrapOmittable(input.ValidUntil),
 		},
 	)
 	if err != nil {
@@ -3133,15 +3133,15 @@ func (r *mutationResolver) UpdateNonconformity(ctx context.Context, input types.
 	req := probo.UpdateNonconformityRequest{
 		ID:                 input.ID,
 		ReferenceID:        input.ReferenceID,
-		Description:        &input.Description,
-		DateIdentified:     &input.DateIdentified,
+		Description:        UnwrapOmittable(input.Description),
+		DateIdentified:     UnwrapOmittable(input.DateIdentified),
 		RootCause:          input.RootCause,
-		CorrectiveAction:   &input.CorrectiveAction,
+		CorrectiveAction:   UnwrapOmittable(input.CorrectiveAction),
 		OwnerID:            input.OwnerID,
 		AuditID:            input.AuditID,
-		DueDate:            &input.DueDate,
+		DueDate:            UnwrapOmittable(input.DueDate),
 		Status:             input.Status,
-		EffectivenessCheck: &input.EffectivenessCheck,
+		EffectivenessCheck: UnwrapOmittable(input.EffectivenessCheck),
 	}
 
 	nonconformity, err := prb.Nonconformities.Update(ctx, &req)
@@ -3201,14 +3201,14 @@ func (r *mutationResolver) UpdateObligation(ctx context.Context, input types.Upd
 
 	req := probo.UpdateObligationRequest{
 		ID:                     input.ID,
-		Area:                   &input.Area,
-		Source:                 &input.Source,
-		Requirement:            &input.Requirement,
-		ActionsToBeImplemented: &input.ActionsToBeImplemented,
-		Regulator:              &input.Regulator,
+		Area:                   UnwrapOmittable(input.Area),
+		Source:                 UnwrapOmittable(input.Source),
+		Requirement:            UnwrapOmittable(input.Requirement),
+		ActionsToBeImplemented: UnwrapOmittable(input.ActionsToBeImplemented),
+		Regulator:              UnwrapOmittable(input.Regulator),
 		OwnerID:                input.OwnerID,
-		LastReviewDate:         &input.LastReviewDate,
-		DueDate:                &input.DueDate,
+		LastReviewDate:         UnwrapOmittable(input.LastReviewDate),
+		DueDate:                UnwrapOmittable(input.DueDate),
 		Status:                 input.Status,
 	}
 
@@ -3268,10 +3268,10 @@ func (r *mutationResolver) UpdateContinualImprovement(ctx context.Context, input
 	req := probo.UpdateContinualImprovementRequest{
 		ID:          input.ID,
 		ReferenceID: input.ReferenceID,
-		Description: &input.Description,
-		Source:      &input.Source,
+		Description: UnwrapOmittable(input.Description),
+		Source:      UnwrapOmittable(input.Source),
 		OwnerID:     input.OwnerID,
-		TargetDate:  &input.TargetDate,
+		TargetDate:  UnwrapOmittable(input.TargetDate),
 		Status:      input.Status,
 		Priority:    input.Priority,
 	}
@@ -3339,17 +3339,17 @@ func (r *mutationResolver) UpdateProcessingActivity(ctx context.Context, input t
 	req := probo.UpdateProcessingActivityRequest{
 		ID:                             input.ID,
 		Name:                           input.Name,
-		Purpose:                        &input.Purpose,
-		DataSubjectCategory:            &input.DataSubjectCategory,
-		PersonalDataCategory:           &input.PersonalDataCategory,
+		Purpose:                        UnwrapOmittable(input.Purpose),
+		DataSubjectCategory:            UnwrapOmittable(input.DataSubjectCategory),
+		PersonalDataCategory:           UnwrapOmittable(input.PersonalDataCategory),
 		SpecialOrCriminalData:          input.SpecialOrCriminalData,
 		LawfulBasis:                    input.LawfulBasis,
-		Recipients:                     &input.Recipients,
-		Location:                       &input.Location,
+		Recipients:                     UnwrapOmittable(input.Recipients),
+		Location:                       UnwrapOmittable(input.Location),
 		InternationalTransfers:         input.InternationalTransfers,
-		TransferSafeguards:             &input.TransferSafeguards,
-		RetentionPeriod:                &input.RetentionPeriod,
-		SecurityMeasures:               &input.SecurityMeasures,
+		TransferSafeguards:             UnwrapOmittable(input.TransferSafeguards),
+		RetentionPeriod:                UnwrapOmittable(input.RetentionPeriod),
+		SecurityMeasures:               UnwrapOmittable(input.SecurityMeasures),
 		DataProtectionImpactAssessment: input.DataProtectionImpactAssessment,
 		TransferImpactAssessment:       input.TransferImpactAssessment,
 	}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes updates to optional fields across the API so clients can explicitly clear values without accidentally overwriting unchanged data. Also updates organization logo uploads in Console to upload immediately with clear feedback.

- **Bug Fixes**
  - Added omittable handling on many GraphQL input fields using @goField(omittable: true) to distinguish “omitted” vs “set to null”.
  - Updated Go types to graphql.Omittable and resolvers to UnwrapOmittable, enabling proper clearing of fields.
  - Renamed UpdateOrganizationInput.logo to logoFile and moved logo/horizontal logo upload to immediate, standalone uploads with an “Uploading...” state and toast feedback.

- **Migration**
  - API: Use input.logoFile instead of input.logo in UpdateOrganizationInput.
  - API: To clear a field, send null; to leave unchanged, omit the field. This applies to updated inputs (organization, people, vendor, contacts, agreements, nonconformities, obligations, processing activities, services).

<!-- End of auto-generated description by cubic. -->

