### PR TITLE
Fix ordered list display in documents

### DIFF
--- a/pkg/docgen/template.html
+++ b/pkg/docgen/template.html
@@ -161,7 +161,7 @@
 
         .document-content ul,
         .document-content ol {
-            padding-left: 20px;
+            padding-left: 40px;
             margin: 12px 0;
             page-break-inside: avoid;
         }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Increase left padding for unordered and ordered lists in document templates (20px → 40px) to fix misaligned/cut-off ordered list numbers and improve PDF readability.

<!-- End of auto-generated description by cubic. -->

