### PR TITLE
Update Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Probo is designed to be accessible, transparent, and community-driven.
 - Go 1.21+
 - Node.js 22+
 - Docker
+- mkcert
 
 ### Quick Start
 
@@ -82,6 +83,17 @@ Probo is designed to be accessible, transparent, and community-driven.
 The application will be available at:
 
 - Application: http://localhost:8080
+
+### Testing Custom Domains
+
+To test the custom domains feature locally, add the CNAME target to your hosts file:
+
+```bash
+# Add this line to /etc/hosts (macOS/Linux) or C:\Windows\System32\drivers\etc\hosts (Windows)
+127.0.0.1 custom.getprobo.com
+```
+
+This allows you to test custom trust center domains on your local machine. The CNAME target can be configured in `cfg/dev.yaml` under `custom-domains.cname-target`.
 
 For detailed setup instructions, see our [Contributing Guide](CONTRIBUTING.md).
 

--- a/cfg/dev.yaml
+++ b/cfg/dev.yaml
@@ -79,7 +79,7 @@ probod:
       directory: "https://localhost:14000/dir"
       email: "admin@getprobo.com"
       key-type: "EC256"
-      insecure-tls: true
+      root-ca: ""
 
   connectors:
     - provider: "slack"
@@ -87,7 +87,7 @@ probod:
       config:
         client-id: "slack-client-id"
         client-secret: "thisisnotasecret"
-        redirect-uri: "http://localhost:8080/api/console/v1/connectors/complete"
+        redirect-uri: "https://localhost:8080/api/console/v1/connectors/complete"
         auth-url: "https://slack.com/oauth/v2/authorize"
         token-url: "https://slack.com/api/oauth.v2.access"
         scopes:


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated configuration and installation docs to cover custom domains (ACME), trust center ports, and new notifications + Slack connector settings. Adds mkcert, clarifies local custom-domain testing, and modernizes the local stack (Postgres 17, MinIO image, postgres credentials).

- **New Features**
  - Documented custom domains with ACME (renewal/provision intervals, cname-target, root-ca/account-key) and trust center http/https addresses; dev config now uses acme.root-ca instead of insecure-tls.
  - Reworked notifications config under notifications.mailer and notifications.slack, including sender intervals; SMTP tls-required default is now false.
  - Updated Slack connector schema to provider/protocol, URLs, scopes, and added signing-secret settings.
  - README adds hosts entry instructions to test custom domains locally; CNAME target is configurable in cfg/dev.yaml.

- **Dependencies**
  - Added mkcert to prerequisites.
  - Docker Compose: upgraded Postgres to 17.4 with tuning flags and switched to postgres/postgres credentials.
  - Switched MinIO image to quay.io/minio/minio with new entrypoint and data path.

<!-- End of auto-generated description by cubic. -->

