### PR TITLE
Add trust center files

### DIFF
--- a/apps/console/src/components/trustCenter/TrustCenterFilesCard.tsx
+++ b/apps/console/src/components/trustCenter/TrustCenterFilesCard.tsx
@@ -1,0 +1,228 @@
+import { graphql } from "relay-runtime";
+import {
+  Card,
+  Button,
+  Tr,
+  Td,
+  Table,
+  Thead,
+  Tbody,
+  Th,
+  IconChevronDown,
+  Field,
+  Option,
+  Badge,
+  IconPencil,
+  IconTrashCan,
+  IconArrowLink,
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import type { TrustCenterFilesCardFragment$key, TrustCenterFilesCardFragment$data } from "./__generated__/TrustCenterFilesCardFragment.graphql";
+import { useFragment } from "react-relay";
+import { useMemo, useState, useCallback, useEffect } from "react";
+import { sprintf, getTrustCenterVisibilityOptions } from "@probo/helpers";
+import { formatDate } from "@probo/helpers";
+import clsx from "clsx";
+
+const trustCenterFileFragment = graphql`
+  fragment TrustCenterFilesCardFragment on TrustCenterFile {
+    id
+    name
+    category
+    fileUrl
+    trustCenterVisibility
+    createdAt
+    updatedAt
+  }
+`;
+
+type Mutation<Params> = (p: {
+  variables: {
+    input: {
+      id: string;
+      trustCenterVisibility: "NONE" | "PRIVATE" | "PUBLIC";
+    } & Params;
+  };
+}) => void;
+
+type Props<Params> = {
+  files: TrustCenterFilesCardFragment$key[];
+  params: Params;
+  disabled?: boolean;
+  onChangeVisibility: Mutation<Params>;
+  onEdit: (file: { id: string; name: string; category: string }) => void;
+  onDelete: (id: string) => void;
+  variant?: "card" | "table";
+};
+
+export function TrustCenterFilesCard<Params>(props: Props<Params>) {
+  const { __ } = useTranslate();
+  const [limit, setLimit] = useState<number | null>(4);
+  const files = useMemo(() => {
+    return limit ? props.files.slice(0, limit) : props.files;
+  }, [props.files, limit]);
+  const showMoreButton = limit !== null && props.files.length > limit;
+  const variant = props.variant ?? "table";
+
+  const onChangeVisibility = (fileId: string, trustCenterVisibility: "NONE" | "PRIVATE" | "PUBLIC") => {
+    props.onChangeVisibility({
+      variables: {
+        input: {
+          id: fileId,
+          trustCenterVisibility,
+          ...props.params,
+        },
+      },
+    });
+  };
+
+  const Wrapper = variant === "card" ? Card : "div";
+
+  return (
+    <Wrapper padded className="space-y-[10px]">
+      <Table className={clsx(variant === "card" && "bg-invert")}>
+        <Thead>
+          <Tr>
+            <Th>{__("Name")}</Th>
+            <Th>{__("Category")}</Th>
+            <Th>{__("Upload Date")}</Th>
+            <Th>{__("Visibility")}</Th>
+            <Th></Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {files.length === 0 && (
+            <Tr>
+              <Td colSpan={5} className="text-center text-txt-secondary">
+                {__("No files available")}
+              </Td>
+            </Tr>
+          )}
+          {files.map((fileFragmentRef, index) => (
+            <FileRowWrapper
+              key={index}
+              fileFragmentRef={fileFragmentRef}
+              onChangeVisibility={onChangeVisibility}
+              onEdit={props.onEdit}
+              onDelete={props.onDelete}
+              disabled={props.disabled}
+            />
+          ))}
+        </Tbody>
+      </Table>
+      {showMoreButton && (
+        <Button
+          variant="tertiary"
+          onClick={() => setLimit(null)}
+          className="mt-3 mx-auto"
+          icon={IconChevronDown}
+        >
+          {sprintf(__("Show %s more"), props.files.length - limit)}
+        </Button>
+      )}
+    </Wrapper>
+  );
+}
+
+function FileRowWrapper(props: {
+  fileFragmentRef: TrustCenterFilesCardFragment$key;
+  onChangeVisibility: (fileId: string, trustCenterVisibility: "NONE" | "PRIVATE" | "PUBLIC") => void;
+  onEdit: (file: { id: string; name: string; category: string }) => void;
+  onDelete: (id: string) => void;
+  disabled?: boolean;
+}) {
+  const file = useFragment(trustCenterFileFragment, props.fileFragmentRef);
+  return (
+    <FileRow
+      file={file}
+      onChangeVisibility={props.onChangeVisibility}
+      onEdit={props.onEdit}
+      onDelete={props.onDelete}
+      disabled={props.disabled}
+    />
+  );
+}
+
+function FileRow(props: {
+  file: TrustCenterFilesCardFragment$data;
+  onChangeVisibility: (fileId: string, trustCenterVisibility: "NONE" | "PRIVATE" | "PUBLIC") => void;
+  onEdit: (file: { id: string; name: string; category: string }) => void;
+  onDelete: (id: string) => void;
+  disabled?: boolean;
+}) {
+  const file = props.file;
+  const { __ } = useTranslate();
+  const [optimisticValue, setOptimisticValue] = useState<string | null>(null);
+
+  const handleValueChange = useCallback((value: string | {}) => {
+    const stringValue = typeof value === 'string' ? value : '';
+    const typedValue = stringValue as "NONE" | "PRIVATE" | "PUBLIC";
+    setOptimisticValue(typedValue);
+    props.onChangeVisibility(file.id, typedValue);
+  }, [file.id, props.onChangeVisibility]);
+
+  useEffect(() => {
+    if (optimisticValue && file.trustCenterVisibility === optimisticValue) {
+      setOptimisticValue(null);
+    }
+  }, [file.trustCenterVisibility, optimisticValue]);
+
+  const currentValue = optimisticValue || file.trustCenterVisibility;
+
+  const visibilityOptions = getTrustCenterVisibilityOptions(__);
+
+  return (
+    <Tr>
+      <Td>
+        <div className="flex gap-4 items-center">
+          {file.name}
+        </div>
+      </Td>
+      <Td>{file.category}</Td>
+      <Td>{formatDate(file.createdAt)}</Td>
+      <Td noLink width={130} className="pr-0">
+        <Field
+          type="select"
+          value={currentValue}
+          onValueChange={handleValueChange}
+          disabled={props.disabled}
+          className="w-[105px]"
+        >
+          {visibilityOptions.map((option) => (
+            <Option key={option.value} value={option.value}>
+              <div className="flex items-center justify-between w-full">
+                <Badge variant={option.variant}>
+                  {option.label}
+                </Badge>
+              </div>
+            </Option>
+          ))}
+        </Field>
+      </Td>
+      <Td noLink width={120}>
+        <div className="flex gap-2">
+          <Button
+            variant="secondary"
+            icon={IconArrowLink}
+            onClick={() => window.open(file.fileUrl, '_blank', 'noopener,noreferrer')}
+            title={__("Download")}
+          />
+          <Button
+            variant="secondary"
+            icon={IconPencil}
+            onClick={() => props.onEdit({ id: file.id, name: file.name, category: file.category })}
+            disabled={props.disabled}
+            title={__("Edit")}
+          />
+          <Button
+            variant="secondary"
+            icon={IconTrashCan}
+            onClick={() => props.onDelete(file.id)}
+            disabled={props.disabled}
+            title={__("Delete")}
+          />
+        </div>
+      </Td>
+    </Tr>
+  );
+}

--- a/apps/console/src/components/trustCenter/__generated__/TrustCenterFilesCardFragment.graphql.ts
+++ b/apps/console/src/components/trustCenter/__generated__/TrustCenterFilesCardFragment.graphql.ts
@@ -1,0 +1,91 @@
+/**
+ * @generated SignedSource<<0defaaf1ce3544420e8fbd9c9f3af139>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type TrustCenterVisibility = "NONE" | "PRIVATE" | "PUBLIC";
+import { FragmentRefs } from "relay-runtime";
+export type TrustCenterFilesCardFragment$data = {
+  readonly category: string;
+  readonly createdAt: any;
+  readonly fileUrl: string;
+  readonly id: string;
+  readonly name: string;
+  readonly trustCenterVisibility: TrustCenterVisibility;
+  readonly updatedAt: any;
+  readonly " $fragmentType": "TrustCenterFilesCardFragment";
+};
+export type TrustCenterFilesCardFragment$key = {
+  readonly " $data"?: TrustCenterFilesCardFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"TrustCenterFilesCardFragment">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "TrustCenterFilesCardFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "category",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "fileUrl",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "trustCenterVisibility",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "createdAt",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "updatedAt",
+      "storageKey": null
+    }
+  ],
+  "type": "TrustCenterFile",
+  "abstractKey": null
+};
+
+(node as any).hash = "33cb01782ca37fc776cd8e5dfde20f76";
+
+export default node;

--- a/apps/console/src/hooks/graph/TrustCenterAccessGraph.ts
+++ b/apps/console/src/hooks/graph/TrustCenterAccessGraph.ts
@@ -47,6 +47,11 @@ export const trustCenterAccessesPaginationFragment = graphql`
                     }
                   }
                 }
+                trustCenterFile {
+                  id
+                  name
+                  category
+                }
               }
             }
           }
@@ -94,16 +99,21 @@ export const createTrustCenterAccessMutation = graphql`
                   title
                   documentType
                 }
-            report {
-              id
-              filename
-              audit {
-                id
-                framework {
-                  name
+                report {
+                  id
+                  filename
+                  audit {
+                    id
+                    framework {
+                      name
+                    }
+                  }
                 }
-              }
-            }
+                trustCenterFile {
+                  id
+                  name
+                  category
+                }
               }
             }
           }
@@ -138,16 +148,21 @@ export const updateTrustCenterAccessMutation = graphql`
                 title
                 documentType
               }
-            report {
-              id
-              filename
-              audit {
+              report {
                 id
-                framework {
-                  name
+                filename
+                audit {
+                  id
+                  framework {
+                    name
+                  }
                 }
               }
-            }
+              trustCenterFile {
+                id
+                name
+                category
+              }
             }
           }
         }

--- a/apps/console/src/hooks/graph/TrustCenterFileGraph.ts
+++ b/apps/console/src/hooks/graph/TrustCenterFileGraph.ts
@@ -1,0 +1,78 @@
+import { graphql } from "relay-runtime";
+import { useMutationWithToasts } from "/hooks/useMutationWithToasts";
+
+export const createTrustCenterFileMutation = graphql`
+  mutation TrustCenterFileGraphCreateMutation(
+    $input: CreateTrustCenterFileInput!
+    $connections: [ID!]!
+  ) {
+    createTrustCenterFile(input: $input) {
+      trustCenterFileEdge @prependEdge(connections: $connections) {
+        node {
+          id
+          name
+          category
+          fileUrl
+          trustCenterVisibility
+          createdAt
+          updatedAt
+        }
+      }
+    }
+  }
+`;
+
+export function useCreateTrustCenterFileMutation() {
+  return useMutationWithToasts(
+    createTrustCenterFileMutation,
+    {
+      successMessage: "File uploaded successfully",
+      errorMessage: "Failed to upload file",
+    }
+  );
+}
+
+export const updateTrustCenterFileMutation = graphql`
+  mutation TrustCenterFileGraphUpdateMutation($input: UpdateTrustCenterFileInput!) {
+    updateTrustCenterFile(input: $input) {
+      trustCenterFile {
+        id
+        name
+        category
+        trustCenterVisibility
+        updatedAt
+      }
+    }
+  }
+`;
+
+export function useUpdateTrustCenterFileMutation() {
+  return useMutationWithToasts(
+    updateTrustCenterFileMutation,
+    {
+      successMessage: "File updated successfully",
+      errorMessage: "Failed to update file",
+    }
+  );
+}
+
+export const deleteTrustCenterFileMutation = graphql`
+  mutation TrustCenterFileGraphDeleteMutation(
+    $input: DeleteTrustCenterFileInput!
+    $connections: [ID!]!
+  ) {
+    deleteTrustCenterFile(input: $input) {
+      deletedTrustCenterFileId @deleteEdge(connections: $connections)
+    }
+  }
+`;
+
+export function useDeleteTrustCenterFileMutation() {
+  return useMutationWithToasts(
+    deleteTrustCenterFileMutation,
+    {
+      successMessage: "File deleted successfully",
+      errorMessage: "Failed to delete file",
+    }
+  );
+}

--- a/apps/console/src/hooks/graph/TrustCenterGraph.ts
+++ b/apps/console/src/hooks/graph/TrustCenterGraph.ts
@@ -57,6 +57,15 @@ export const trustCenterQuery = graphql`
             }
           }
         }
+        trustCenterFiles(first: 100) @connection(key: "TrustCenterPage_trustCenterFiles") {
+          __id
+          edges {
+            node {
+              id
+              ...TrustCenterFilesCardFragment
+            }
+          }
+        }
         slackConnections(first: 100) {
           edges {
             node {

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphCreateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphCreateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5c208d2afc4eb2968b59215d3e79231b>>
+ * @generated SignedSource<<d527603a814e765a1a2be0900d1c59e1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -47,6 +47,11 @@ export type TrustCenterAccessGraphCreateMutation$data = {
                 } | null | undefined;
                 readonly filename: string;
                 readonly id: string;
+              } | null | undefined;
+              readonly trustCenterFile: {
+                readonly category: string;
+                readonly id: string;
+                readonly name: string;
               } | null | undefined;
               readonly updatedAt: any;
             };
@@ -186,6 +191,26 @@ v13 = {
   "kind": "ScalarField",
   "name": "filename",
   "storageKey": null
+},
+v14 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "TrustCenterFile",
+  "kind": "LinkedField",
+  "name": "trustCenterFile",
+  "plural": false,
+  "selections": [
+    (v4/*: any*/),
+    (v6/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "category",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -293,7 +318,8 @@ return {
                                   }
                                 ],
                                 "storageKey": null
-                              }
+                              },
+                              (v14/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -422,7 +448,8 @@ return {
                                   }
                                 ],
                                 "storageKey": null
-                              }
+                              },
+                              (v14/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -460,16 +487,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a27b7cdf2a4cadf8cc22a95f39c3c6b0",
+    "cacheID": "4422a02632b77f81f3b5048b5acbac98",
     "id": null,
     "metadata": {},
     "name": "TrustCenterAccessGraphCreateMutation",
     "operationKind": "mutation",
-    "text": "mutation TrustCenterAccessGraphCreateMutation(\n  $input: CreateTrustCenterAccessInput!\n) {\n  createTrustCenterAccess(input: $input) {\n    trustCenterAccessEdge {\n      cursor\n      node {\n        id\n        email\n        name\n        active\n        hasAcceptedNonDisclosureAgreement\n        createdAt\n        documentAccesses(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {\n          edges {\n            node {\n              id\n              active\n              createdAt\n              updatedAt\n              document {\n                id\n                title\n                documentType\n              }\n              report {\n                id\n                filename\n                audit {\n                  id\n                  framework {\n                    name\n                    id\n                  }\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n}\n"
+    "text": "mutation TrustCenterAccessGraphCreateMutation(\n  $input: CreateTrustCenterAccessInput!\n) {\n  createTrustCenterAccess(input: $input) {\n    trustCenterAccessEdge {\n      cursor\n      node {\n        id\n        email\n        name\n        active\n        hasAcceptedNonDisclosureAgreement\n        createdAt\n        documentAccesses(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {\n          edges {\n            node {\n              id\n              active\n              createdAt\n              updatedAt\n              document {\n                id\n                title\n                documentType\n              }\n              report {\n                id\n                filename\n                audit {\n                  id\n                  framework {\n                    name\n                    id\n                  }\n                }\n              }\n              trustCenterFile {\n                id\n                name\n                category\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "091432e335b8fe3a97ac06d3765f172b";
+(node as any).hash = "c09c8a22a45226949a08f2262ddd0b1c";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphPaginationQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphPaginationQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bf8e5a74bfd588ad123f628009b6440e>>
+ * @generated SignedSource<<8c2482b7d32c42396e4645bd309e7cc2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -350,6 +350,26 @@ return {
                                           }
                                         ],
                                         "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "TrustCenterFile",
+                                        "kind": "LinkedField",
+                                        "name": "trustCenterFile",
+                                        "plural": false,
+                                        "selections": [
+                                          (v3/*: any*/),
+                                          (v6/*: any*/),
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "category",
+                                            "storageKey": null
+                                          }
+                                        ],
+                                        "storageKey": null
                                       }
                                     ],
                                     "storageKey": null
@@ -403,16 +423,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "96e9906815501bb22bca79bb63a4a149",
+    "cacheID": "12322ab403d03a821d2228ff68c3d191",
     "id": null,
     "metadata": {},
     "name": "TrustCenterAccessGraphPaginationQuery",
     "operationKind": "query",
-    "text": "query TrustCenterAccessGraphPaginationQuery(\n  $count: Int\n  $cursor: CursorKey\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...TrustCenterAccessGraph_accesses\n    id\n  }\n}\n\nfragment TrustCenterAccessGraph_accesses on TrustCenter {\n  accesses(first: $count, after: $cursor, orderBy: {field: CREATED_AT, direction: DESC}) {\n    pageInfo {\n      hasNextPage\n      hasPreviousPage\n      startCursor\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        email\n        name\n        active\n        hasAcceptedNonDisclosureAgreement\n        createdAt\n        documentAccesses(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {\n          edges {\n            node {\n              id\n              active\n              createdAt\n              updatedAt\n              document {\n                id\n                title\n                documentType\n              }\n              report {\n                id\n                filename\n                audit {\n                  id\n                  framework {\n                    name\n                    id\n                  }\n                }\n              }\n            }\n          }\n        }\n        __typename\n      }\n    }\n  }\n  id\n}\n"
+    "text": "query TrustCenterAccessGraphPaginationQuery(\n  $count: Int\n  $cursor: CursorKey\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...TrustCenterAccessGraph_accesses\n    id\n  }\n}\n\nfragment TrustCenterAccessGraph_accesses on TrustCenter {\n  accesses(first: $count, after: $cursor, orderBy: {field: CREATED_AT, direction: DESC}) {\n    pageInfo {\n      hasNextPage\n      hasPreviousPage\n      startCursor\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        email\n        name\n        active\n        hasAcceptedNonDisclosureAgreement\n        createdAt\n        documentAccesses(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {\n          edges {\n            node {\n              id\n              active\n              createdAt\n              updatedAt\n              document {\n                id\n                title\n                documentType\n              }\n              report {\n                id\n                filename\n                audit {\n                  id\n                  framework {\n                    name\n                    id\n                  }\n                }\n              }\n              trustCenterFile {\n                id\n                name\n                category\n              }\n            }\n          }\n        }\n        __typename\n      }\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "9e29aa4a382ca2d4bb9d1b014d8d81fd";
+(node as any).hash = "9c7f3e866e2593c169b1f98d0e637667";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4fcca19ac1edb0d607a9682090e0cc3e>>
+ * @generated SignedSource<<e0c9c25c78bb6c8cf63eb9437947a013>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -365,6 +365,26 @@ return {
                                           }
                                         ],
                                         "storageKey": null
+                                      },
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "TrustCenterFile",
+                                        "kind": "LinkedField",
+                                        "name": "trustCenterFile",
+                                        "plural": false,
+                                        "selections": [
+                                          (v4/*: any*/),
+                                          (v8/*: any*/),
+                                          {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "category",
+                                            "storageKey": null
+                                          }
+                                        ],
+                                        "storageKey": null
                                       }
                                     ],
                                     "storageKey": null
@@ -418,12 +438,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4ca52668a68c0789aa73c0d680ec0abe",
+    "cacheID": "37deb80fc3ff8892d2e68f7588da4e55",
     "id": null,
     "metadata": {},
     "name": "TrustCenterAccessGraphQuery",
     "operationKind": "query",
-    "text": "query TrustCenterAccessGraphQuery(\n  $trustCenterId: ID!\n  $count: Int!\n  $cursor: CursorKey\n) {\n  node(id: $trustCenterId) {\n    __typename\n    ... on TrustCenter {\n      id\n      ...TrustCenterAccessGraph_accesses\n    }\n    id\n  }\n}\n\nfragment TrustCenterAccessGraph_accesses on TrustCenter {\n  accesses(first: $count, after: $cursor, orderBy: {field: CREATED_AT, direction: DESC}) {\n    pageInfo {\n      hasNextPage\n      hasPreviousPage\n      startCursor\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        email\n        name\n        active\n        hasAcceptedNonDisclosureAgreement\n        createdAt\n        documentAccesses(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {\n          edges {\n            node {\n              id\n              active\n              createdAt\n              updatedAt\n              document {\n                id\n                title\n                documentType\n              }\n              report {\n                id\n                filename\n                audit {\n                  id\n                  framework {\n                    name\n                    id\n                  }\n                }\n              }\n            }\n          }\n        }\n        __typename\n      }\n    }\n  }\n  id\n}\n"
+    "text": "query TrustCenterAccessGraphQuery(\n  $trustCenterId: ID!\n  $count: Int!\n  $cursor: CursorKey\n) {\n  node(id: $trustCenterId) {\n    __typename\n    ... on TrustCenter {\n      id\n      ...TrustCenterAccessGraph_accesses\n    }\n    id\n  }\n}\n\nfragment TrustCenterAccessGraph_accesses on TrustCenter {\n  accesses(first: $count, after: $cursor, orderBy: {field: CREATED_AT, direction: DESC}) {\n    pageInfo {\n      hasNextPage\n      hasPreviousPage\n      startCursor\n      endCursor\n    }\n    edges {\n      cursor\n      node {\n        id\n        email\n        name\n        active\n        hasAcceptedNonDisclosureAgreement\n        createdAt\n        documentAccesses(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {\n          edges {\n            node {\n              id\n              active\n              createdAt\n              updatedAt\n              document {\n                id\n                title\n                documentType\n              }\n              report {\n                id\n                filename\n                audit {\n                  id\n                  framework {\n                    name\n                    id\n                  }\n                }\n              }\n              trustCenterFile {\n                id\n                name\n                category\n              }\n            }\n          }\n        }\n        __typename\n      }\n    }\n  }\n  id\n}\n"
   }
 };
 })();

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphUpdateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraphUpdateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<395567ba680d0a9e1bad1cdef52bc2e1>>
+ * @generated SignedSource<<8ecf71138aa0165738506f5e589d3181>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,6 +16,7 @@ export type UpdateTrustCenterAccessInput = {
   id: string;
   name?: string | null | undefined;
   reportIds?: ReadonlyArray<string> | null | undefined;
+  trustCenterFileIds?: ReadonlyArray<string> | null | undefined;
 };
 export type TrustCenterAccessGraphUpdateMutation$variables = {
   input: UpdateTrustCenterAccessInput;
@@ -45,6 +46,11 @@ export type TrustCenterAccessGraphUpdateMutation$data = {
               } | null | undefined;
               readonly filename: string;
               readonly id: string;
+            } | null | undefined;
+            readonly trustCenterFile: {
+              readonly category: string;
+              readonly id: string;
+              readonly name: string;
             } | null | undefined;
             readonly updatedAt: any;
           };
@@ -174,6 +180,26 @@ v11 = {
   "kind": "ScalarField",
   "name": "filename",
   "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "TrustCenterFile",
+  "kind": "LinkedField",
+  "name": "trustCenterFile",
+  "plural": false,
+  "selections": [
+    (v2/*: any*/),
+    (v4/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "category",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -270,7 +296,8 @@ return {
                               }
                             ],
                             "storageKey": null
-                          }
+                          },
+                          (v12/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -385,7 +412,8 @@ return {
                               }
                             ],
                             "storageKey": null
-                          }
+                          },
+                          (v12/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -404,16 +432,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "de3ddd0058b8881667e47e2bf32c8b73",
+    "cacheID": "b66da9236d9f81563608b3aa5f730908",
     "id": null,
     "metadata": {},
     "name": "TrustCenterAccessGraphUpdateMutation",
     "operationKind": "mutation",
-    "text": "mutation TrustCenterAccessGraphUpdateMutation(\n  $input: UpdateTrustCenterAccessInput!\n) {\n  updateTrustCenterAccess(input: $input) {\n    trustCenterAccess {\n      id\n      email\n      name\n      active\n      hasAcceptedNonDisclosureAgreement\n      createdAt\n      updatedAt\n      documentAccesses(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {\n        edges {\n          node {\n            id\n            active\n            createdAt\n            updatedAt\n            document {\n              id\n              title\n              documentType\n            }\n            report {\n              id\n              filename\n              audit {\n                id\n                framework {\n                  name\n                  id\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n}\n"
+    "text": "mutation TrustCenterAccessGraphUpdateMutation(\n  $input: UpdateTrustCenterAccessInput!\n) {\n  updateTrustCenterAccess(input: $input) {\n    trustCenterAccess {\n      id\n      email\n      name\n      active\n      hasAcceptedNonDisclosureAgreement\n      createdAt\n      updatedAt\n      documentAccesses(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {\n        edges {\n          node {\n            id\n            active\n            createdAt\n            updatedAt\n            document {\n              id\n              title\n              documentType\n            }\n            report {\n              id\n              filename\n              audit {\n                id\n                framework {\n                  name\n                  id\n                }\n              }\n            }\n            trustCenterFile {\n              id\n              name\n              category\n            }\n          }\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "723058aacc2e04bd2df4cf04c6df0a3c";
+(node as any).hash = "43e73cc9d80e898f1ba2a92eaf4646f5";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraph_accesses.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterAccessGraph_accesses.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ef0d644a344dbab40145e3f4128cd0ec>>
+ * @generated SignedSource<<d572a906e6afd89e4a3f1dcffa5c0528>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -39,6 +39,11 @@ export type TrustCenterAccessGraph_accesses$data = {
                 } | null | undefined;
                 readonly filename: string;
                 readonly id: string;
+              } | null | undefined;
+              readonly trustCenterFile: {
+                readonly category: string;
+                readonly id: string;
+                readonly name: string;
               } | null | undefined;
               readonly updatedAt: any;
             };
@@ -348,6 +353,26 @@ return {
                                 }
                               ],
                               "storageKey": null
+                            },
+                            {
+                              "alias": null,
+                              "args": null,
+                              "concreteType": "TrustCenterFile",
+                              "kind": "LinkedField",
+                              "name": "trustCenterFile",
+                              "plural": false,
+                              "selections": [
+                                (v2/*: any*/),
+                                (v3/*: any*/),
+                                {
+                                  "alias": null,
+                                  "args": null,
+                                  "kind": "ScalarField",
+                                  "name": "category",
+                                  "storageKey": null
+                                }
+                              ],
+                              "storageKey": null
                             }
                           ],
                           "storageKey": null
@@ -393,6 +418,6 @@ return {
 };
 })();
 
-(node as any).hash = "9e29aa4a382ca2d4bb9d1b014d8d81fd";
+(node as any).hash = "9c7f3e866e2593c169b1f98d0e637667";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterFileGraphCreateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterFileGraphCreateMutation.graphql.ts
@@ -1,0 +1,211 @@
+/**
+ * @generated SignedSource<<e70731a64db78c30ad662330d2ec2099>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type TrustCenterVisibility = "NONE" | "PRIVATE" | "PUBLIC";
+export type CreateTrustCenterFileInput = {
+  category: string;
+  file: any;
+  name: string;
+  organizationId: string;
+  trustCenterVisibility: TrustCenterVisibility;
+};
+export type TrustCenterFileGraphCreateMutation$variables = {
+  connections: ReadonlyArray<string>;
+  input: CreateTrustCenterFileInput;
+};
+export type TrustCenterFileGraphCreateMutation$data = {
+  readonly createTrustCenterFile: {
+    readonly trustCenterFileEdge: {
+      readonly node: {
+        readonly category: string;
+        readonly createdAt: any;
+        readonly fileUrl: string;
+        readonly id: string;
+        readonly name: string;
+        readonly trustCenterVisibility: TrustCenterVisibility;
+        readonly updatedAt: any;
+      };
+    };
+  };
+};
+export type TrustCenterFileGraphCreateMutation = {
+  response: TrustCenterFileGraphCreateMutation$data;
+  variables: TrustCenterFileGraphCreateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "TrustCenterFileEdge",
+  "kind": "LinkedField",
+  "name": "trustCenterFileEdge",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "TrustCenterFile",
+      "kind": "LinkedField",
+      "name": "node",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "id",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "category",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "fileUrl",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "trustCenterVisibility",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "createdAt",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "updatedAt",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TrustCenterFileGraphCreateMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "CreateTrustCenterFilePayload",
+        "kind": "LinkedField",
+        "name": "createTrustCenterFile",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "TrustCenterFileGraphCreateMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "CreateTrustCenterFilePayload",
+        "kind": "LinkedField",
+        "name": "createTrustCenterFile",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "prependEdge",
+            "key": "",
+            "kind": "LinkedHandle",
+            "name": "trustCenterFileEdge",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "57c42327b83556d36745cf8218eb01b1",
+    "id": null,
+    "metadata": {},
+    "name": "TrustCenterFileGraphCreateMutation",
+    "operationKind": "mutation",
+    "text": "mutation TrustCenterFileGraphCreateMutation(\n  $input: CreateTrustCenterFileInput!\n) {\n  createTrustCenterFile(input: $input) {\n    trustCenterFileEdge {\n      node {\n        id\n        name\n        category\n        fileUrl\n        trustCenterVisibility\n        createdAt\n        updatedAt\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "fa3851bf4f5e38bc26d8a063d6afab4e";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterFileGraphDeleteMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterFileGraphDeleteMutation.graphql.ts
@@ -1,0 +1,132 @@
+/**
+ * @generated SignedSource<<f788919caaf846a6a1bdc81f19841823>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type DeleteTrustCenterFileInput = {
+  id: string;
+};
+export type TrustCenterFileGraphDeleteMutation$variables = {
+  connections: ReadonlyArray<string>;
+  input: DeleteTrustCenterFileInput;
+};
+export type TrustCenterFileGraphDeleteMutation$data = {
+  readonly deleteTrustCenterFile: {
+    readonly deletedTrustCenterFileId: string;
+  };
+};
+export type TrustCenterFileGraphDeleteMutation = {
+  response: TrustCenterFileGraphDeleteMutation$data;
+  variables: TrustCenterFileGraphDeleteMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "deletedTrustCenterFileId",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TrustCenterFileGraphDeleteMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteTrustCenterFilePayload",
+        "kind": "LinkedField",
+        "name": "deleteTrustCenterFile",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "TrustCenterFileGraphDeleteMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteTrustCenterFilePayload",
+        "kind": "LinkedField",
+        "name": "deleteTrustCenterFile",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "deleteEdge",
+            "key": "",
+            "kind": "ScalarHandle",
+            "name": "deletedTrustCenterFileId",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "ad78a064da9b58291653f8283012ffc6",
+    "id": null,
+    "metadata": {},
+    "name": "TrustCenterFileGraphDeleteMutation",
+    "operationKind": "mutation",
+    "text": "mutation TrustCenterFileGraphDeleteMutation(\n  $input: DeleteTrustCenterFileInput!\n) {\n  deleteTrustCenterFile(input: $input) {\n    deletedTrustCenterFileId\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "26c1ce69e74f3a4a39d060b38afbe3e0";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterFileGraphUpdateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterFileGraphUpdateMutation.graphql.ts
@@ -1,0 +1,141 @@
+/**
+ * @generated SignedSource<<b78cfbea93f3bccdba56cd29900ab724>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type TrustCenterVisibility = "NONE" | "PRIVATE" | "PUBLIC";
+export type UpdateTrustCenterFileInput = {
+  category?: string | null | undefined;
+  id: string;
+  name?: string | null | undefined;
+  trustCenterVisibility?: TrustCenterVisibility | null | undefined;
+};
+export type TrustCenterFileGraphUpdateMutation$variables = {
+  input: UpdateTrustCenterFileInput;
+};
+export type TrustCenterFileGraphUpdateMutation$data = {
+  readonly updateTrustCenterFile: {
+    readonly trustCenterFile: {
+      readonly category: string;
+      readonly id: string;
+      readonly name: string;
+      readonly trustCenterVisibility: TrustCenterVisibility;
+      readonly updatedAt: any;
+    };
+  };
+};
+export type TrustCenterFileGraphUpdateMutation = {
+  response: TrustCenterFileGraphUpdateMutation$data;
+  variables: TrustCenterFileGraphUpdateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "UpdateTrustCenterFilePayload",
+    "kind": "LinkedField",
+    "name": "updateTrustCenterFile",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "TrustCenterFile",
+        "kind": "LinkedField",
+        "name": "trustCenterFile",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "category",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "trustCenterVisibility",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "updatedAt",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TrustCenterFileGraphUpdateMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "TrustCenterFileGraphUpdateMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "9ad761d91cfe34e7fa905a3f6a4d9e37",
+    "id": null,
+    "metadata": {},
+    "name": "TrustCenterFileGraphUpdateMutation",
+    "operationKind": "mutation",
+    "text": "mutation TrustCenterFileGraphUpdateMutation(\n  $input: UpdateTrustCenterFileInput!\n) {\n  updateTrustCenterFile(input: $input) {\n    trustCenterFile {\n      id\n      name\n      category\n      trustCenterVisibility\n      updatedAt\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "7306c3f9530a7636adc0b6a0cf28b67e";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterGraphQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterGraphQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6d55d37aa2ddfae16f8fc829840113d4>>
+ * @generated SignedSource<<285497dfb150c3f02c055a091769f301>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -69,6 +69,15 @@ export type TrustCenterGraphQuery$data = {
       };
       readonly updatedAt: any;
     } | null | undefined;
+    readonly trustCenterFiles?: {
+      readonly __id: string;
+      readonly edges: ReadonlyArray<{
+        readonly node: {
+          readonly id: string;
+          readonly " $fragmentSpreads": FragmentRefs<"TrustCenterFilesCardFragment">;
+        };
+      }>;
+    };
     readonly vendors?: {
       readonly edges: ReadonlyArray<{
         readonly node: {
@@ -260,6 +269,57 @@ v10 = [
 ],
 v11 = {
   "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cursor",
+  "storageKey": null
+},
+v13 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "PageInfo",
+  "kind": "LinkedField",
+  "name": "pageInfo",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "endCursor",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "hasNextPage",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v14 = {
+  "kind": "ClientExtension",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "__id",
+      "storageKey": null
+    }
+  ]
+},
+v15 = {
+  "alias": null,
   "args": (v10/*: any*/),
   "concreteType": "SlackConnectionConnection",
   "kind": "LinkedField",
@@ -308,11 +368,18 @@ v11 = {
   ],
   "storageKey": "slackConnections(first:100)"
 },
-v12 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "trustCenterVisibility",
+  "storageKey": null
+},
+v17 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "category",
   "storageKey": null
 };
 return {
@@ -454,7 +521,50 @@ return {
                 ],
                 "storageKey": "vendors(first:100)"
               },
-              (v11/*: any*/)
+              {
+                "alias": "trustCenterFiles",
+                "args": null,
+                "concreteType": "TrustCenterFileConnection",
+                "kind": "LinkedField",
+                "name": "__TrustCenterPage_trustCenterFiles_connection",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "TrustCenterFileEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "TrustCenterFile",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          {
+                            "args": null,
+                            "kind": "FragmentSpread",
+                            "name": "TrustCenterFilesCardFragment"
+                          },
+                          (v11/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      (v12/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  (v13/*: any*/),
+                  (v14/*: any*/)
+                ],
+                "storageKey": null
+              },
+              (v15/*: any*/)
             ],
             "type": "Organization",
             "abstractKey": null
@@ -480,13 +590,7 @@ return {
         "name": "node",
         "plural": false,
         "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "__typename",
-            "storageKey": null
-          },
+          (v11/*: any*/),
           (v2/*: any*/),
           {
             "kind": "InlineFragment",
@@ -534,7 +638,7 @@ return {
                             "name": "documentType",
                             "storageKey": null
                           },
-                          (v12/*: any*/),
+                          (v16/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -651,7 +755,7 @@ return {
                             "name": "state",
                             "storageKey": null
                           },
-                          (v12/*: any*/),
+                          (v16/*: any*/),
                           (v5/*: any*/)
                         ],
                         "storageKey": null
@@ -688,13 +792,7 @@ return {
                         "selections": [
                           (v2/*: any*/),
                           (v3/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "category",
-                            "storageKey": null
-                          },
+                          (v17/*: any*/),
                           (v8/*: any*/),
                           {
                             "alias": null,
@@ -713,7 +811,66 @@ return {
                 ],
                 "storageKey": "vendors(first:100)"
               },
-              (v11/*: any*/)
+              {
+                "alias": null,
+                "args": (v10/*: any*/),
+                "concreteType": "TrustCenterFileConnection",
+                "kind": "LinkedField",
+                "name": "trustCenterFiles",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "TrustCenterFileEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "TrustCenterFile",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          (v3/*: any*/),
+                          (v17/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "fileUrl",
+                            "storageKey": null
+                          },
+                          (v16/*: any*/),
+                          (v5/*: any*/),
+                          (v6/*: any*/),
+                          (v11/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      (v12/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  (v13/*: any*/),
+                  (v14/*: any*/)
+                ],
+                "storageKey": "trustCenterFiles(first:100)"
+              },
+              {
+                "alias": null,
+                "args": (v10/*: any*/),
+                "filters": null,
+                "handle": "connection",
+                "key": "TrustCenterPage_trustCenterFiles",
+                "kind": "LinkedHandle",
+                "name": "trustCenterFiles"
+              },
+              (v15/*: any*/)
             ],
             "type": "Organization",
             "abstractKey": null
@@ -724,16 +881,28 @@ return {
     ]
   },
   "params": {
-    "cacheID": "06cd2015e9fc2e65d35ae3153e587c58",
+    "cacheID": "45a68d6b8fc3128a695529daa40eba3a",
     "id": null,
-    "metadata": {},
+    "metadata": {
+      "connection": [
+        {
+          "count": null,
+          "cursor": null,
+          "direction": "forward",
+          "path": [
+            "organization",
+            "trustCenterFiles"
+          ]
+        }
+      ]
+    },
     "name": "TrustCenterGraphQuery",
     "operationKind": "query",
-    "text": "query TrustCenterGraphQuery(\n  $organizationId: ID!\n) {\n  organization: node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      id\n      name\n      customDomain {\n        id\n        domain\n      }\n      trustCenter {\n        id\n        active\n        ndaFileName\n        ndaFileUrl\n        createdAt\n        updatedAt\n        references(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {\n          edges {\n            node {\n              id\n              name\n              description\n              websiteUrl\n              logoUrl\n              createdAt\n              updatedAt\n            }\n          }\n        }\n      }\n      documents(first: 100) {\n        edges {\n          node {\n            id\n            ...TrustCenterDocumentsCardFragment\n          }\n        }\n      }\n      audits(first: 100) {\n        edges {\n          node {\n            id\n            ...TrustCenterAuditsCardFragment\n          }\n        }\n      }\n      vendors(first: 100) {\n        edges {\n          node {\n            id\n            ...TrustCenterVendorsCardFragment\n          }\n        }\n      }\n      slackConnections(first: 100) {\n        edges {\n          node {\n            id\n            channel\n            channelId\n            createdAt\n            updatedAt\n          }\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment TrustCenterAuditsCardFragment on Audit {\n  id\n  name\n  framework {\n    name\n    id\n  }\n  validFrom\n  validUntil\n  state\n  trustCenterVisibility\n  createdAt\n}\n\nfragment TrustCenterDocumentsCardFragment on Document {\n  id\n  title\n  createdAt\n  documentType\n  trustCenterVisibility\n  versions(first: 1) {\n    edges {\n      node {\n        id\n        status\n      }\n    }\n  }\n}\n\nfragment TrustCenterVendorsCardFragment on Vendor {\n  id\n  name\n  category\n  description\n  showOnTrustCenter\n  createdAt\n}\n"
+    "text": "query TrustCenterGraphQuery(\n  $organizationId: ID!\n) {\n  organization: node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      id\n      name\n      customDomain {\n        id\n        domain\n      }\n      trustCenter {\n        id\n        active\n        ndaFileName\n        ndaFileUrl\n        createdAt\n        updatedAt\n        references(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {\n          edges {\n            node {\n              id\n              name\n              description\n              websiteUrl\n              logoUrl\n              createdAt\n              updatedAt\n            }\n          }\n        }\n      }\n      documents(first: 100) {\n        edges {\n          node {\n            id\n            ...TrustCenterDocumentsCardFragment\n          }\n        }\n      }\n      audits(first: 100) {\n        edges {\n          node {\n            id\n            ...TrustCenterAuditsCardFragment\n          }\n        }\n      }\n      vendors(first: 100) {\n        edges {\n          node {\n            id\n            ...TrustCenterVendorsCardFragment\n          }\n        }\n      }\n      trustCenterFiles(first: 100) {\n        edges {\n          node {\n            id\n            ...TrustCenterFilesCardFragment\n            __typename\n          }\n          cursor\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n      slackConnections(first: 100) {\n        edges {\n          node {\n            id\n            channel\n            channelId\n            createdAt\n            updatedAt\n          }\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment TrustCenterAuditsCardFragment on Audit {\n  id\n  name\n  framework {\n    name\n    id\n  }\n  validFrom\n  validUntil\n  state\n  trustCenterVisibility\n  createdAt\n}\n\nfragment TrustCenterDocumentsCardFragment on Document {\n  id\n  title\n  createdAt\n  documentType\n  trustCenterVisibility\n  versions(first: 1) {\n    edges {\n      node {\n        id\n        status\n      }\n    }\n  }\n}\n\nfragment TrustCenterFilesCardFragment on TrustCenterFile {\n  id\n  name\n  category\n  fileUrl\n  trustCenterVisibility\n  createdAt\n  updatedAt\n}\n\nfragment TrustCenterVendorsCardFragment on Vendor {\n  id\n  name\n  category\n  description\n  showOnTrustCenter\n  createdAt\n}\n"
   }
 };
 })();
 
-(node as any).hash = "7ef9a5adc70dff604a149ea156e52edc";
+(node as any).hash = "1ee50612da47b187cb55b2e228ba5945";
 
 export default node;

--- a/apps/console/src/pages/organizations/trustCenter/TrustCenterFilesTab.tsx
+++ b/apps/console/src/pages/organizations/trustCenter/TrustCenterFilesTab.tsx
@@ -1,0 +1,331 @@
+import {
+  Button,
+  Card,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  Field,
+  Spinner,
+  useDialogRef,
+  Dropzone,
+  Option,
+  Badge,
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { useOutletContext } from "react-router";
+import { useState, useCallback } from "react";
+import z from "zod";
+import { getTrustCenterVisibilityOptions } from "@probo/helpers";
+import {
+  useCreateTrustCenterFileMutation,
+  useUpdateTrustCenterFileMutation,
+  useDeleteTrustCenterFileMutation,
+} from "/hooks/graph/TrustCenterFileGraph";
+import { useFormWithSchema } from "/hooks/useFormWithSchema";
+import { TrustCenterFilesCard } from "/components/trustCenter/TrustCenterFilesCard";
+import type { TrustCenterFilesCardFragment$key } from "/components/trustCenter/__generated__/TrustCenterFilesCardFragment.graphql";
+
+type ContextType = {
+  organization: {
+    id: string;
+    trustCenterFiles?: {
+      __id?: string;
+      edges: Array<{
+        node: TrustCenterFilesCardFragment$key;
+      }>;
+    };
+  };
+};
+
+export default function TrustCenterFilesTab() {
+  const { __ } = useTranslate();
+  const { organization } = useOutletContext<ContextType>();
+
+  const createSchema = z.object({
+    name: z.string().min(1, __("Name is required")),
+    category: z.string().min(1, __("Category is required")),
+    trustCenterVisibility: z.enum(["NONE", "PRIVATE", "PUBLIC"]),
+  });
+
+  const editSchema = z.object({
+    name: z.string().min(1, __("Name is required")),
+    category: z.string().min(1, __("Category is required")),
+  });
+
+  const [createFile, isCreating] = useCreateTrustCenterFileMutation();
+  const [updateFile, isUpdating] = useUpdateTrustCenterFileMutation();
+  const [deleteFile, isDeleting] = useDeleteTrustCenterFileMutation();
+
+  const createDialogRef = useDialogRef();
+  const editDialogRef = useDialogRef();
+  const deleteDialogRef = useDialogRef();
+
+  const [editingFile, setEditingFile] = useState<{ id: string; name: string; category: string } | null>(null);
+  const [deletingFileId, setDeletingFileId] = useState<string | null>(null);
+  const [uploadedFile, setUploadedFile] = useState<File | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+
+  const createForm = useFormWithSchema(createSchema, {
+    defaultValues: { name: "", category: "", trustCenterVisibility: "NONE" },
+  });
+
+  const editForm = useFormWithSchema(editSchema, {
+    defaultValues: { name: "", category: "" },
+  });
+
+  const files = organization.trustCenterFiles?.edges?.map((edge) => edge.node) || [];
+
+  const handleFileUpload = useCallback((acceptedFiles: File[]) => {
+    if (acceptedFiles.length > 0) {
+      const file = acceptedFiles[0];
+
+      if (file.type !== "application/pdf") {
+        createForm.setError("root", {
+          type: "manual",
+          message: __("Only PDF files are allowed"),
+        });
+        return;
+      }
+
+      setUploadedFile(file);
+      createForm.clearErrors("root");
+      if (!createForm.getValues().name) {
+        createForm.setValue("name", file.name.replace(/\.[^/.]+$/, ""));
+      }
+    }
+  }, [createForm, __]);
+
+  const handleCreate = createForm.handleSubmit(async (data) => {
+    if (!uploadedFile) {
+      return;
+    }
+
+    setIsUploading(true);
+
+    const connectionId = organization.trustCenterFiles?.__id;
+
+    try {
+      await createFile({
+        variables: {
+          input: {
+            organizationId: organization.id,
+            name: data.name,
+            category: data.category,
+            trustCenterVisibility: data.trustCenterVisibility,
+            file: null,
+          },
+          connections: connectionId ? [connectionId] : [],
+        },
+        uploadables: {
+          "input.file": uploadedFile,
+        },
+        onSuccess: () => {
+          createDialogRef.current?.close();
+          createForm.reset();
+          setUploadedFile(null);
+        },
+      });
+    } finally {
+      setIsUploading(false);
+    }
+  });
+
+  const handleEdit = useCallback((file: { id: string; name: string; category: string }) => {
+    setEditingFile(file);
+    editForm.reset({ name: file.name, category: file.category });
+    editDialogRef.current?.open();
+  }, [editDialogRef, editForm]);
+
+  const handleUpdate = editForm.handleSubmit(async (data) => {
+    if (!editingFile) {
+      return;
+    }
+
+    await updateFile({
+      variables: {
+        input: {
+          id: editingFile.id,
+          name: data.name,
+          category: data.category,
+        },
+      },
+      onSuccess: () => {
+        editDialogRef.current?.close();
+        setEditingFile(null);
+      },
+    });
+  });
+
+  const handleDeleteClick = useCallback((id: string) => {
+    setDeletingFileId(id);
+    deleteDialogRef.current?.open();
+  }, [deleteDialogRef]);
+
+  const handleDeleteConfirm = useCallback(async () => {
+    if (!deletingFileId) {
+      return;
+    }
+
+    const connectionId = organization.trustCenterFiles?.__id;
+
+    await deleteFile({
+      variables: {
+        input: { id: deletingFileId },
+        connections: connectionId ? [connectionId] : [],
+      },
+      onSuccess: () => {
+        deleteDialogRef.current?.close();
+        setDeletingFileId(null);
+      },
+    });
+  }, [deletingFileId, deleteFile, deleteDialogRef, organization.trustCenterFiles?.__id]);
+
+  const handleChangeVisibility = useCallback((params: {
+    variables: {
+      input: {
+        id: string;
+        trustCenterVisibility: "NONE" | "PRIVATE" | "PUBLIC";
+      };
+    };
+  }) => {
+    updateFile(params);
+  }, [updateFile]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-base font-medium">{__("Files")}</h3>
+          <p className="text-sm text-txt-tertiary">
+            {__("Upload and manage files for your trust center")}
+          </p>
+        </div>
+        <Button onClick={() => createDialogRef.current?.open()}>
+          {__("Add File")}
+        </Button>
+      </div>
+      {(isUpdating || isDeleting) && (
+        <div className="flex items-center justify-center">
+          <Spinner />
+        </div>
+      )}
+      <Card padded>
+        <TrustCenterFilesCard
+          files={files}
+          params={{}}
+          disabled={isUpdating || isDeleting}
+          onChangeVisibility={handleChangeVisibility}
+          onEdit={handleEdit}
+          onDelete={handleDeleteClick}
+          variant="table"
+        />
+      </Card>
+
+      <Dialog ref={createDialogRef} title={__("Add File")}>
+        <form onSubmit={handleCreate}>
+          <DialogContent padded className="space-y-4">
+            <Dropzone
+              description={__("Upload PDF file (max 10MB)")}
+              isUploading={isUploading}
+              onDrop={handleFileUpload}
+              maxSize={10}
+              accept={{ "application/pdf": [".pdf"] }}
+            />
+            {uploadedFile && (
+              <div className="text-sm text-txt-secondary">
+                {__("Selected file")}: {uploadedFile.name}
+              </div>
+            )}
+            {createForm.formState.errors.root && (
+              <p className="text-sm text-txt-danger">
+                {createForm.formState.errors.root.message}
+              </p>
+            )}
+            <Field
+              label={__("Name")}
+              type="text"
+              {...createForm.register("name")}
+              error={createForm.formState.errors.name?.message}
+            />
+            <Field
+              label={__("Category")}
+              type="text"
+              {...createForm.register("category")}
+              error={createForm.formState.errors.category?.message}
+            />
+            <Field
+              label={__("Visibility")}
+              type="select"
+              value={createForm.watch("trustCenterVisibility")}
+              onValueChange={(value) => createForm.setValue("trustCenterVisibility", value as "NONE" | "PRIVATE" | "PUBLIC")}
+              error={createForm.formState.errors.trustCenterVisibility?.message}
+            >
+              {getTrustCenterVisibilityOptions(__).map((option) => (
+                <Option key={option.value} value={option.value}>
+                  <div className="flex items-center justify-between w-full">
+                    <Badge variant={option.variant}>
+                      {option.label}
+                    </Badge>
+                  </div>
+                </Option>
+              ))}
+            </Field>
+          </DialogContent>
+          <DialogFooter>
+            <Button
+              type="submit"
+              disabled={isCreating || isUploading || !uploadedFile}
+            >
+              {(isCreating || isUploading) && <Spinner />}
+              {__("Add File")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </Dialog>
+
+      <Dialog ref={editDialogRef} title={__("Edit File")}>
+        <form onSubmit={handleUpdate}>
+          <DialogContent padded className="space-y-4">
+            <Field
+              label={__("Name")}
+              type="text"
+              {...editForm.register("name")}
+              error={editForm.formState.errors.name?.message}
+            />
+            <Field
+              label={__("Category")}
+              type="text"
+              {...editForm.register("category")}
+              error={editForm.formState.errors.category?.message}
+            />
+          </DialogContent>
+          <DialogFooter>
+            <Button
+              type="submit"
+              disabled={isUpdating}
+            >
+              {isUpdating && <Spinner />}
+              {__("Save")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </Dialog>
+
+      <Dialog ref={deleteDialogRef} title={__("Delete File")}>
+        <DialogContent padded>
+          <p>{__("Are you sure you want to delete this file? This action cannot be undone.")}</p>
+        </DialogContent>
+        <DialogFooter>
+          <Button
+            variant="danger"
+            onClick={handleDeleteConfirm}
+            disabled={isDeleting}
+          >
+            {isDeleting && <Spinner />}
+            {__("Delete")}
+          </Button>
+        </DialogFooter>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/console/src/pages/organizations/trustCenter/TrustCenterPage.tsx
+++ b/apps/console/src/pages/organizations/trustCenter/TrustCenterPage.tsx
@@ -287,6 +287,9 @@ export default function TrustCenterPage({ queryRef }: Props) {
           <TabLink to={`/organizations/${organizationId}/trust-center/documents`}>
             {__("Documents")}
           </TabLink>
+          <TabLink to={`/organizations/${organizationId}/trust-center/files`}>
+            {__("Files")}
+          </TabLink>
           <TabLink to={`/organizations/${organizationId}/trust-center/access`}>
             {__("Access")}
           </TabLink>

--- a/apps/console/src/routes/trustCenterRoutes.ts
+++ b/apps/console/src/routes/trustCenterRoutes.ts
@@ -45,6 +45,13 @@ export const trustCenterRoutes = [
         ),
       },
       {
+        path: "files",
+        fallback: LinkCardSkeleton,
+        Component: lazy(
+          () => import("/pages/organizations/trustCenter/TrustCenterFilesTab")
+        ),
+      },
+      {
         path: "access",
         fallback: LinkCardSkeleton,
         Component: lazy(

--- a/apps/trust/src/components/TrustCenterFileRow.tsx
+++ b/apps/trust/src/components/TrustCenterFileRow.tsx
@@ -1,0 +1,88 @@
+import { graphql } from "relay-runtime";
+import type { TrustCenterFileRowFragment$key } from "./__generated__/TrustCenterFileRowFragment.graphql";
+import { useFragment } from "react-relay";
+import {
+  Button,
+  IconArrowInbox,
+  IconLock,
+  IconPageTextLine,
+  Spinner,
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import type { TrustCenterFileRowDownloadMutation } from "./__generated__/TrustCenterFileRowDownloadMutation.graphql";
+import { useMutationWithToasts } from "/hooks/useMutationWithToast";
+import { downloadFile } from "@probo/helpers";
+import { RequestAccessDialog } from "/components/RequestAccessDialog.tsx";
+import { useState } from "react";
+
+const downloadMutation = graphql`
+  mutation TrustCenterFileRowDownloadMutation($input: ExportTrustCenterFileInput!) {
+    exportTrustCenterFile(input: $input) {
+      data
+    }
+  }
+`;
+
+const trustCenterFileRowFragment = graphql`
+  fragment TrustCenterFileRowFragment on TrustCenterFile {
+    id
+    name
+    isUserAuthorized
+    hasUserRequestedAccess
+  }
+`;
+
+export function TrustCenterFileRow(props: { file: TrustCenterFileRowFragment$key }) {
+  const file = useFragment(trustCenterFileRowFragment, props.file);
+  const { __ } = useTranslate();
+  const [commitDownload, downloading] =
+    useMutationWithToasts<TrustCenterFileRowDownloadMutation>(downloadMutation);
+  const handleDownload = () => {
+    commitDownload({
+      variables: {
+        input: {
+          trustCenterFileId: file.id,
+        },
+      },
+      onSuccess(response) {
+        downloadFile(response.exportTrustCenterFile.data, file.name);
+      },
+    });
+  };
+  const [hasRequested, setHasRequested] = useState(
+    file.hasUserRequestedAccess,
+  );
+  return (
+    <div className="text-sm border-1 border-border-solid -mt-[1px] flex gap-3 flex-col md:flex-row md:justify-between px-6 py-3">
+      <div className="flex items-center gap-2">
+        <IconPageTextLine size={16} className=" flex-none text-txt-tertiary" />
+        {file.name}
+      </div>
+      {file.isUserAuthorized ? (
+        <Button
+          className="w-full md:w-max"
+          variant="secondary"
+          disabled={downloading}
+          icon={downloading ? Spinner : IconArrowInbox}
+          onClick={handleDownload}
+        >
+          {__("Download")}
+        </Button>
+      ) : (
+        <RequestAccessDialog
+          trustCenterFileId={file.id}
+          onSuccess={() => setHasRequested(true)}
+        >
+          <Button
+            disabled={hasRequested}
+            className="w-full md:w-max"
+            variant="secondary"
+            icon={IconLock}
+          >
+            {hasRequested ? __("Access requested") : __("Request access")}
+          </Button>
+        </RequestAccessDialog>
+      )}
+    </div>
+  );
+}

--- a/apps/trust/src/components/__generated__/RequestAccessDialogTrustCenterFileMutation.graphql.ts
+++ b/apps/trust/src/components/__generated__/RequestAccessDialogTrustCenterFileMutation.graphql.ts
@@ -1,0 +1,108 @@
+/**
+ * @generated SignedSource<<4c07d5c8e345a8e3015f512403927890>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type RequestTrustCenterFileAccessInput = {
+  email?: string | null | undefined;
+  name?: string | null | undefined;
+  trustCenterFileId: string;
+  trustCenterId: string;
+};
+export type RequestAccessDialogTrustCenterFileMutation$variables = {
+  input: RequestTrustCenterFileAccessInput;
+};
+export type RequestAccessDialogTrustCenterFileMutation$data = {
+  readonly requestTrustCenterFileAccess: {
+    readonly trustCenterAccess: {
+      readonly id: string;
+    };
+  };
+};
+export type RequestAccessDialogTrustCenterFileMutation = {
+  response: RequestAccessDialogTrustCenterFileMutation$data;
+  variables: RequestAccessDialogTrustCenterFileMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "RequestAccessesPayload",
+    "kind": "LinkedField",
+    "name": "requestTrustCenterFileAccess",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "TrustCenterAccess",
+        "kind": "LinkedField",
+        "name": "trustCenterAccess",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RequestAccessDialogTrustCenterFileMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "RequestAccessDialogTrustCenterFileMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "73b3007ef1a45f6dc6d31be0c627e482",
+    "id": null,
+    "metadata": {},
+    "name": "RequestAccessDialogTrustCenterFileMutation",
+    "operationKind": "mutation",
+    "text": "mutation RequestAccessDialogTrustCenterFileMutation(\n  $input: RequestTrustCenterFileAccessInput!\n) {\n  requestTrustCenterFileAccess(input: $input) {\n    trustCenterAccess {\n      id\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "a97eb6c4ec94c79a293d1cc51bf18e66";
+
+export default node;

--- a/apps/trust/src/components/__generated__/TrustCenterFileRowDownloadMutation.graphql.ts
+++ b/apps/trust/src/components/__generated__/TrustCenterFileRowDownloadMutation.graphql.ts
@@ -1,0 +1,92 @@
+/**
+ * @generated SignedSource<<8d608da0bcff489887f71f6e69f1bfe3>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type ExportTrustCenterFileInput = {
+  trustCenterFileId: string;
+};
+export type TrustCenterFileRowDownloadMutation$variables = {
+  input: ExportTrustCenterFileInput;
+};
+export type TrustCenterFileRowDownloadMutation$data = {
+  readonly exportTrustCenterFile: {
+    readonly data: string;
+  };
+};
+export type TrustCenterFileRowDownloadMutation = {
+  response: TrustCenterFileRowDownloadMutation$data;
+  variables: TrustCenterFileRowDownloadMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "ExportTrustCenterFilePayload",
+    "kind": "LinkedField",
+    "name": "exportTrustCenterFile",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "data",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TrustCenterFileRowDownloadMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "TrustCenterFileRowDownloadMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "8a97b9e7ac44deea6da6e79f1d0c662f",
+    "id": null,
+    "metadata": {},
+    "name": "TrustCenterFileRowDownloadMutation",
+    "operationKind": "mutation",
+    "text": "mutation TrustCenterFileRowDownloadMutation(\n  $input: ExportTrustCenterFileInput!\n) {\n  exportTrustCenterFile(input: $input) {\n    data\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "e6d74e96e929cf1aa79711b8315a8b85";
+
+export default node;

--- a/apps/trust/src/components/__generated__/TrustCenterFileRowFragment.graphql.ts
+++ b/apps/trust/src/components/__generated__/TrustCenterFileRowFragment.graphql.ts
@@ -1,0 +1,66 @@
+/**
+ * @generated SignedSource<<0261adc72d21035b906b6156ea9d0b40>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type TrustCenterFileRowFragment$data = {
+  readonly hasUserRequestedAccess: boolean;
+  readonly id: string;
+  readonly isUserAuthorized: boolean;
+  readonly name: string;
+  readonly " $fragmentType": "TrustCenterFileRowFragment";
+};
+export type TrustCenterFileRowFragment$key = {
+  readonly " $data"?: TrustCenterFileRowFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"TrustCenterFileRowFragment">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "TrustCenterFileRowFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "isUserAuthorized",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "hasUserRequestedAccess",
+      "storageKey": null
+    }
+  ],
+  "type": "TrustCenterFile",
+  "abstractKey": null
+};
+
+(node as any).hash = "4ff11c14e65566f0dfe3a77ea73903e8";
+
+export default node;

--- a/apps/trust/src/pages/DocumentsPage.tsx
+++ b/apps/trust/src/pages/DocumentsPage.tsx
@@ -6,6 +6,7 @@ import { documentTypeLabel } from "/helpers/documents";
 import { useTranslate } from "@probo/i18n";
 import { Fragment } from "react";
 import { DocumentRow } from "/components/DocumentRow";
+import { TrustCenterFileRow } from "/components/TrustCenterFileRow";
 import { Rows } from "/components/Rows.tsx";
 import { RowHeader } from "/components/RowHeader.tsx";
 
@@ -21,9 +22,12 @@ export function DocumentsPage({ queryRef }: Props) {
   );
   const documents =
     data.currentTrustCenter?.documents.edges.map((edge) => edge.node) ?? [];
+  const files =
+    data.currentTrustCenter?.trustCenterFiles.edges.map((edge) => edge.node) ?? [];
   const documentsPerType = groupBy(documents, (document) =>
     documentTypeLabel(document.documentType, __)
   );
+  const filesPerCategory = groupBy(files, (file) => file.category);
   return (
     <div>
       <h2 className="font-medium mb-1">{__("Documents")}</h2>
@@ -36,6 +40,14 @@ export function DocumentsPage({ queryRef }: Props) {
             <RowHeader>{label}</RowHeader>
             {documents.map((document) => (
               <DocumentRow key={document.id} document={document} />
+            ))}
+          </Fragment>
+        ))}
+        {objectEntries(filesPerCategory).map(([category, files]) => (
+          <Fragment key={category}>
+            <RowHeader>{category}</RowHeader>
+            {files.map((file) => (
+              <TrustCenterFileRow key={file.id} file={file} />
             ))}
           </Fragment>
         ))}

--- a/apps/trust/src/pages/__generated__/OverviewPageFragment.graphql.ts
+++ b/apps/trust/src/pages/__generated__/OverviewPageFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7b1972657d83c7bb17b997e287f575d8>>
+ * @generated SignedSource<<cde79d7c929ba1be8e0d033c90e7eeb7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -32,6 +32,15 @@ export type OverviewPageFragment$data = {
       };
     }>;
   };
+  readonly trustCenterFiles: {
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly category: string;
+        readonly id: string;
+        readonly " $fragmentSpreads": FragmentRefs<"TrustCenterFileRowFragment">;
+      };
+    }>;
+  };
   readonly vendors: {
     readonly edges: ReadonlyArray<{
       readonly node: {
@@ -55,7 +64,14 @@ var v0 = {
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
-};
+},
+v1 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 5
+  }
+];
 return {
   "argumentDefinitions": [],
   "kind": "Fragment",
@@ -177,13 +193,7 @@ return {
     },
     {
       "alias": null,
-      "args": [
-        {
-          "kind": "Literal",
-          "name": "first",
-          "value": 5
-        }
-      ],
+      "args": (v1/*: any*/),
       "concreteType": "DocumentConnection",
       "kind": "LinkedField",
       "name": "documents",
@@ -226,6 +236,52 @@ return {
         }
       ],
       "storageKey": "documents(first:5)"
+    },
+    {
+      "alias": null,
+      "args": (v1/*: any*/),
+      "concreteType": "TrustCenterFileConnection",
+      "kind": "LinkedField",
+      "name": "trustCenterFiles",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "TrustCenterFileEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "TrustCenterFile",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                (v0/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "category",
+                  "storageKey": null
+                },
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "TrustCenterFileRowFragment"
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "trustCenterFiles(first:5)"
     }
   ],
   "type": "TrustCenter",
@@ -233,6 +289,6 @@ return {
 };
 })();
 
-(node as any).hash = "0bda7993ef3be4cfe86083658fc77813";
+(node as any).hash = "0f4e9ac02d068ba971bb1f5be5fdaccf";
 
 export default node;

--- a/apps/trust/src/queries/TrustGraph.ts
+++ b/apps/trust/src/queries/TrustGraph.ts
@@ -46,6 +46,15 @@ export const trustDocumentsQuery = graphql`
           }
         }
       }
+      trustCenterFiles(first: 50) {
+        edges {
+          node {
+            id
+            category
+            ...TrustCenterFileRowFragment
+          }
+        }
+      }
     }
   }
 `;
@@ -114,6 +123,15 @@ export const currentTrustDocumentsQuery = graphql`
             id
             documentType
             ...DocumentRowFragment
+          }
+        }
+      }
+      trustCenterFiles(first: 50) {
+        edges {
+          node {
+            id
+            category
+            ...TrustCenterFileRowFragment
           }
         }
       }

--- a/apps/trust/src/queries/__generated__/TrustGraphCurrentDocumentsQuery.graphql.ts
+++ b/apps/trust/src/queries/__generated__/TrustGraphCurrentDocumentsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<091d468e321f2cd6cdead063c35c6a45>>
+ * @generated SignedSource<<dabe16493c003a98ed8fd555efc85ddc>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,6 +26,15 @@ export type TrustGraphCurrentDocumentsQuery$data = {
     readonly id: string;
     readonly organization: {
       readonly name: string;
+    };
+    readonly trustCenterFiles: {
+      readonly edges: ReadonlyArray<{
+        readonly node: {
+          readonly category: string;
+          readonly id: string;
+          readonly " $fragmentSpreads": FragmentRefs<"TrustCenterFileRowFragment">;
+        };
+      }>;
     };
   } | null | undefined;
 };
@@ -61,6 +70,27 @@ v3 = {
   "args": null,
   "kind": "ScalarField",
   "name": "documentType",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "category",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isUserAuthorized",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "hasUserRequestedAccess",
   "storageKey": null
 };
 return {
@@ -130,6 +160,46 @@ return {
               }
             ],
             "storageKey": "documents(first:50)"
+          },
+          {
+            "alias": null,
+            "args": (v2/*: any*/),
+            "concreteType": "TrustCenterFileConnection",
+            "kind": "LinkedField",
+            "name": "trustCenterFiles",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "TrustCenterFileEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "TrustCenterFile",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v0/*: any*/),
+                      (v4/*: any*/),
+                      {
+                        "args": null,
+                        "kind": "FragmentSpread",
+                        "name": "TrustCenterFileRowFragment"
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "trustCenterFiles(first:50)"
           }
         ],
         "storageKey": null
@@ -199,20 +269,8 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "isUserAuthorized",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "hasUserRequestedAccess",
-                        "storageKey": null
-                      }
+                      (v5/*: any*/),
+                      (v6/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -221,6 +279,44 @@ return {
               }
             ],
             "storageKey": "documents(first:50)"
+          },
+          {
+            "alias": null,
+            "args": (v2/*: any*/),
+            "concreteType": "TrustCenterFileConnection",
+            "kind": "LinkedField",
+            "name": "trustCenterFiles",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "TrustCenterFileEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "TrustCenterFile",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v0/*: any*/),
+                      (v4/*: any*/),
+                      (v1/*: any*/),
+                      (v5/*: any*/),
+                      (v6/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "trustCenterFiles(first:50)"
           }
         ],
         "storageKey": null
@@ -228,16 +324,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "9e99faf40ba87ee06df5ddd64431586e",
+    "cacheID": "c9c4cb18da98c40646fbbe21c2c5b46f",
     "id": null,
     "metadata": {},
     "name": "TrustGraphCurrentDocumentsQuery",
     "operationKind": "query",
-    "text": "query TrustGraphCurrentDocumentsQuery {\n  currentTrustCenter {\n    id\n    organization {\n      name\n      id\n    }\n    documents(first: 50) {\n      edges {\n        node {\n          id\n          documentType\n          ...DocumentRowFragment\n        }\n      }\n    }\n  }\n}\n\nfragment DocumentRowFragment on Document {\n  id\n  title\n  isUserAuthorized\n  hasUserRequestedAccess\n}\n"
+    "text": "query TrustGraphCurrentDocumentsQuery {\n  currentTrustCenter {\n    id\n    organization {\n      name\n      id\n    }\n    documents(first: 50) {\n      edges {\n        node {\n          id\n          documentType\n          ...DocumentRowFragment\n        }\n      }\n    }\n    trustCenterFiles(first: 50) {\n      edges {\n        node {\n          id\n          category\n          ...TrustCenterFileRowFragment\n        }\n      }\n    }\n  }\n}\n\nfragment DocumentRowFragment on Document {\n  id\n  title\n  isUserAuthorized\n  hasUserRequestedAccess\n}\n\nfragment TrustCenterFileRowFragment on TrustCenterFile {\n  id\n  name\n  isUserAuthorized\n  hasUserRequestedAccess\n}\n"
   }
 };
 })();
 
-(node as any).hash = "73636da5c06a16813a57b92f30ab93d2";
+(node as any).hash = "0900835ad8e59a40a2907fb787b936ef";
 
 export default node;

--- a/apps/trust/src/queries/__generated__/TrustGraphCurrentQuery.graphql.ts
+++ b/apps/trust/src/queries/__generated__/TrustGraphCurrentQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fe440b5c7a8a8ed54723161632320857>>
+ * @generated SignedSource<<fe9ca4e5a2ddb60ea7a7f353d431d18c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -139,10 +139,24 @@ v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "category",
+  "storageKey": null
+},
+v14 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 5
+  }
+],
+v15 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "isUserAuthorized",
   "storageKey": null
 },
-v14 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -358,13 +372,7 @@ return {
                         "storageKey": null
                       },
                       (v6/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "category",
-                        "storageKey": null
-                      },
+                      (v13/*: any*/),
                       (v8/*: any*/),
                       {
                         "alias": null,
@@ -384,13 +392,7 @@ return {
           },
           {
             "alias": null,
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 5
-              }
-            ],
+            "args": (v14/*: any*/),
             "concreteType": "DocumentConnection",
             "kind": "LinkedField",
             "name": "documents",
@@ -420,8 +422,8 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v13/*: any*/),
-                      (v14/*: any*/),
+                      (v15/*: any*/),
+                      (v16/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -437,6 +439,44 @@ return {
               }
             ],
             "storageKey": "documents(first:5)"
+          },
+          {
+            "alias": null,
+            "args": (v14/*: any*/),
+            "concreteType": "TrustCenterFileConnection",
+            "kind": "LinkedField",
+            "name": "trustCenterFiles",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "TrustCenterFileEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "TrustCenterFile",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v0/*: any*/),
+                      (v13/*: any*/),
+                      (v6/*: any*/),
+                      (v15/*: any*/),
+                      (v16/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "trustCenterFiles(first:5)"
           },
           {
             "alias": null,
@@ -479,8 +519,8 @@ return {
                             "name": "filename",
                             "storageKey": null
                           },
-                          (v13/*: any*/),
-                          (v14/*: any*/)
+                          (v15/*: any*/),
+                          (v16/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -512,12 +552,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d2c9b2a457cd3840f4b23d71cd399c84",
+    "cacheID": "da8080ccbc08adb03fbf360f1e472f84",
     "id": null,
     "metadata": {},
     "name": "TrustGraphCurrentQuery",
     "operationKind": "query",
-    "text": "query TrustGraphCurrentQuery {\n  currentTrustCenter {\n    id\n    slug\n    isUserAuthenticated\n    hasAcceptedNonDisclosureAgreement\n    ndaFileName\n    ndaFileUrl\n    organization {\n      name\n      description\n      websiteUrl\n      logoUrl\n      email\n      headquarterAddress\n      id\n    }\n    ...OverviewPageFragment\n    audits(first: 50) {\n      edges {\n        node {\n          id\n          ...AuditRowFragment\n        }\n      }\n    }\n  }\n}\n\nfragment AuditRowFragment on Audit {\n  report {\n    id\n    filename\n    isUserAuthorized\n    hasUserRequestedAccess\n  }\n  framework {\n    id\n    name\n  }\n}\n\nfragment DocumentRowFragment on Document {\n  id\n  title\n  isUserAuthorized\n  hasUserRequestedAccess\n}\n\nfragment OverviewPageFragment on TrustCenter {\n  references(first: 14) {\n    edges {\n      node {\n        id\n        name\n        logoUrl\n        websiteUrl\n      }\n    }\n  }\n  vendors(first: 3) {\n    edges {\n      node {\n        id\n        countries\n        ...VendorRowFragment\n      }\n    }\n  }\n  documents(first: 5) {\n    edges {\n      node {\n        id\n        ...DocumentRowFragment\n        documentType\n      }\n    }\n  }\n}\n\nfragment VendorRowFragment on Vendor {\n  id\n  name\n  category\n  websiteUrl\n  privacyPolicyUrl\n  countries\n}\n"
+    "text": "query TrustGraphCurrentQuery {\n  currentTrustCenter {\n    id\n    slug\n    isUserAuthenticated\n    hasAcceptedNonDisclosureAgreement\n    ndaFileName\n    ndaFileUrl\n    organization {\n      name\n      description\n      websiteUrl\n      logoUrl\n      email\n      headquarterAddress\n      id\n    }\n    ...OverviewPageFragment\n    audits(first: 50) {\n      edges {\n        node {\n          id\n          ...AuditRowFragment\n        }\n      }\n    }\n  }\n}\n\nfragment AuditRowFragment on Audit {\n  report {\n    id\n    filename\n    isUserAuthorized\n    hasUserRequestedAccess\n  }\n  framework {\n    id\n    name\n  }\n}\n\nfragment DocumentRowFragment on Document {\n  id\n  title\n  isUserAuthorized\n  hasUserRequestedAccess\n}\n\nfragment OverviewPageFragment on TrustCenter {\n  references(first: 14) {\n    edges {\n      node {\n        id\n        name\n        logoUrl\n        websiteUrl\n      }\n    }\n  }\n  vendors(first: 3) {\n    edges {\n      node {\n        id\n        countries\n        ...VendorRowFragment\n      }\n    }\n  }\n  documents(first: 5) {\n    edges {\n      node {\n        id\n        ...DocumentRowFragment\n        documentType\n      }\n    }\n  }\n  trustCenterFiles(first: 5) {\n    edges {\n      node {\n        id\n        category\n        ...TrustCenterFileRowFragment\n      }\n    }\n  }\n}\n\nfragment TrustCenterFileRowFragment on TrustCenterFile {\n  id\n  name\n  isUserAuthorized\n  hasUserRequestedAccess\n}\n\nfragment VendorRowFragment on Vendor {\n  id\n  name\n  category\n  websiteUrl\n  privacyPolicyUrl\n  countries\n}\n"
   }
 };
 })();

--- a/apps/trust/src/queries/__generated__/TrustGraphDocumentsQuery.graphql.ts
+++ b/apps/trust/src/queries/__generated__/TrustGraphDocumentsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<922757406dbc7a2c20b502ef6dd4c0d8>>
+ * @generated SignedSource<<0faaebe3baf4c750825599985210137d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -28,6 +28,15 @@ export type TrustGraphDocumentsQuery$data = {
     readonly id: string;
     readonly organization: {
       readonly name: string;
+    };
+    readonly trustCenterFiles: {
+      readonly edges: ReadonlyArray<{
+        readonly node: {
+          readonly category: string;
+          readonly id: string;
+          readonly " $fragmentSpreads": FragmentRefs<"TrustCenterFileRowFragment">;
+        };
+      }>;
     };
   } | null | undefined;
 };
@@ -77,6 +86,27 @@ v5 = {
   "args": null,
   "kind": "ScalarField",
   "name": "documentType",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "category",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isUserAuthorized",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "hasUserRequestedAccess",
   "storageKey": null
 };
 return {
@@ -146,6 +176,46 @@ return {
               }
             ],
             "storageKey": "documents(first:50)"
+          },
+          {
+            "alias": null,
+            "args": (v4/*: any*/),
+            "concreteType": "TrustCenterFileConnection",
+            "kind": "LinkedField",
+            "name": "trustCenterFiles",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "TrustCenterFileEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "TrustCenterFile",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      (v6/*: any*/),
+                      {
+                        "args": null,
+                        "kind": "FragmentSpread",
+                        "name": "TrustCenterFileRowFragment"
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "trustCenterFiles(first:50)"
           }
         ],
         "storageKey": null
@@ -215,20 +285,8 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "isUserAuthorized",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "hasUserRequestedAccess",
-                        "storageKey": null
-                      }
+                      (v7/*: any*/),
+                      (v8/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -237,6 +295,44 @@ return {
               }
             ],
             "storageKey": "documents(first:50)"
+          },
+          {
+            "alias": null,
+            "args": (v4/*: any*/),
+            "concreteType": "TrustCenterFileConnection",
+            "kind": "LinkedField",
+            "name": "trustCenterFiles",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "TrustCenterFileEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "TrustCenterFile",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      (v6/*: any*/),
+                      (v3/*: any*/),
+                      (v7/*: any*/),
+                      (v8/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "trustCenterFiles(first:50)"
           }
         ],
         "storageKey": null
@@ -244,16 +340,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "8a333723782b24714393e89240704cf2",
+    "cacheID": "151fc8b1cf3becb2a69d87ce978fb71b",
     "id": null,
     "metadata": {},
     "name": "TrustGraphDocumentsQuery",
     "operationKind": "query",
-    "text": "query TrustGraphDocumentsQuery(\n  $slug: String!\n) {\n  trustCenterBySlug(slug: $slug) {\n    id\n    organization {\n      name\n      id\n    }\n    documents(first: 50) {\n      edges {\n        node {\n          id\n          documentType\n          ...DocumentRowFragment\n        }\n      }\n    }\n  }\n}\n\nfragment DocumentRowFragment on Document {\n  id\n  title\n  isUserAuthorized\n  hasUserRequestedAccess\n}\n"
+    "text": "query TrustGraphDocumentsQuery(\n  $slug: String!\n) {\n  trustCenterBySlug(slug: $slug) {\n    id\n    organization {\n      name\n      id\n    }\n    documents(first: 50) {\n      edges {\n        node {\n          id\n          documentType\n          ...DocumentRowFragment\n        }\n      }\n    }\n    trustCenterFiles(first: 50) {\n      edges {\n        node {\n          id\n          category\n          ...TrustCenterFileRowFragment\n        }\n      }\n    }\n  }\n}\n\nfragment DocumentRowFragment on Document {\n  id\n  title\n  isUserAuthorized\n  hasUserRequestedAccess\n}\n\nfragment TrustCenterFileRowFragment on TrustCenterFile {\n  id\n  name\n  isUserAuthorized\n  hasUserRequestedAccess\n}\n"
   }
 };
 })();
 
-(node as any).hash = "9c56f70fca2afb316f4fd38d646ec545";
+(node as any).hash = "79e21d586ec18a0977c37df27aa9bdea";
 
 export default node;

--- a/apps/trust/src/queries/__generated__/TrustGraphQuery.graphql.ts
+++ b/apps/trust/src/queries/__generated__/TrustGraphQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e1f3b93147b9e72d9cfc41e8e0befd6e>>
+ * @generated SignedSource<<8b9ec6ee6f688ae6f6d1463104c72df4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -155,10 +155,24 @@ v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "category",
+  "storageKey": null
+},
+v16 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 5
+  }
+],
+v17 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "isUserAuthorized",
   "storageKey": null
 },
-v16 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -374,13 +388,7 @@ return {
                         "storageKey": null
                       },
                       (v8/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "category",
-                        "storageKey": null
-                      },
+                      (v15/*: any*/),
                       (v10/*: any*/),
                       {
                         "alias": null,
@@ -400,13 +408,7 @@ return {
           },
           {
             "alias": null,
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 5
-              }
-            ],
+            "args": (v16/*: any*/),
             "concreteType": "DocumentConnection",
             "kind": "LinkedField",
             "name": "documents",
@@ -436,8 +438,8 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v15/*: any*/),
-                      (v16/*: any*/),
+                      (v17/*: any*/),
+                      (v18/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -453,6 +455,44 @@ return {
               }
             ],
             "storageKey": "documents(first:5)"
+          },
+          {
+            "alias": null,
+            "args": (v16/*: any*/),
+            "concreteType": "TrustCenterFileConnection",
+            "kind": "LinkedField",
+            "name": "trustCenterFiles",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "TrustCenterFileEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "TrustCenterFile",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      (v15/*: any*/),
+                      (v8/*: any*/),
+                      (v17/*: any*/),
+                      (v18/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "trustCenterFiles(first:5)"
           },
           {
             "alias": null,
@@ -495,8 +535,8 @@ return {
                             "name": "filename",
                             "storageKey": null
                           },
-                          (v15/*: any*/),
-                          (v16/*: any*/)
+                          (v17/*: any*/),
+                          (v18/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -528,12 +568,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c3cb244842768ef771ea209a51a06c4a",
+    "cacheID": "f3ac933cf00a798d12b1a8e1fedcaee9",
     "id": null,
     "metadata": {},
     "name": "TrustGraphQuery",
     "operationKind": "query",
-    "text": "query TrustGraphQuery(\n  $slug: String!\n) {\n  trustCenterBySlug(slug: $slug) {\n    id\n    slug\n    isUserAuthenticated\n    hasAcceptedNonDisclosureAgreement\n    ndaFileName\n    ndaFileUrl\n    organization {\n      name\n      description\n      websiteUrl\n      logoUrl\n      email\n      headquarterAddress\n      id\n    }\n    ...OverviewPageFragment\n    audits(first: 50) {\n      edges {\n        node {\n          id\n          ...AuditRowFragment\n        }\n      }\n    }\n  }\n}\n\nfragment AuditRowFragment on Audit {\n  report {\n    id\n    filename\n    isUserAuthorized\n    hasUserRequestedAccess\n  }\n  framework {\n    id\n    name\n  }\n}\n\nfragment DocumentRowFragment on Document {\n  id\n  title\n  isUserAuthorized\n  hasUserRequestedAccess\n}\n\nfragment OverviewPageFragment on TrustCenter {\n  references(first: 14) {\n    edges {\n      node {\n        id\n        name\n        logoUrl\n        websiteUrl\n      }\n    }\n  }\n  vendors(first: 3) {\n    edges {\n      node {\n        id\n        countries\n        ...VendorRowFragment\n      }\n    }\n  }\n  documents(first: 5) {\n    edges {\n      node {\n        id\n        ...DocumentRowFragment\n        documentType\n      }\n    }\n  }\n}\n\nfragment VendorRowFragment on Vendor {\n  id\n  name\n  category\n  websiteUrl\n  privacyPolicyUrl\n  countries\n}\n"
+    "text": "query TrustGraphQuery(\n  $slug: String!\n) {\n  trustCenterBySlug(slug: $slug) {\n    id\n    slug\n    isUserAuthenticated\n    hasAcceptedNonDisclosureAgreement\n    ndaFileName\n    ndaFileUrl\n    organization {\n      name\n      description\n      websiteUrl\n      logoUrl\n      email\n      headquarterAddress\n      id\n    }\n    ...OverviewPageFragment\n    audits(first: 50) {\n      edges {\n        node {\n          id\n          ...AuditRowFragment\n        }\n      }\n    }\n  }\n}\n\nfragment AuditRowFragment on Audit {\n  report {\n    id\n    filename\n    isUserAuthorized\n    hasUserRequestedAccess\n  }\n  framework {\n    id\n    name\n  }\n}\n\nfragment DocumentRowFragment on Document {\n  id\n  title\n  isUserAuthorized\n  hasUserRequestedAccess\n}\n\nfragment OverviewPageFragment on TrustCenter {\n  references(first: 14) {\n    edges {\n      node {\n        id\n        name\n        logoUrl\n        websiteUrl\n      }\n    }\n  }\n  vendors(first: 3) {\n    edges {\n      node {\n        id\n        countries\n        ...VendorRowFragment\n      }\n    }\n  }\n  documents(first: 5) {\n    edges {\n      node {\n        id\n        ...DocumentRowFragment\n        documentType\n      }\n    }\n  }\n  trustCenterFiles(first: 5) {\n    edges {\n      node {\n        id\n        category\n        ...TrustCenterFileRowFragment\n      }\n    }\n  }\n}\n\nfragment TrustCenterFileRowFragment on TrustCenterFile {\n  id\n  name\n  isUserAuthorized\n  hasUserRequestedAccess\n}\n\nfragment VendorRowFragment on Vendor {\n  id\n  name\n  category\n  websiteUrl\n  privacyPolicyUrl\n  countries\n}\n"
   }
 };
 })();

--- a/pkg/coredata/entity_type_reg.go
+++ b/pkg/coredata/entity_type_reg.go
@@ -62,4 +62,5 @@ const (
 	InvitationEntityType
 	MembershipEntityType
 	SlackMessageEntityType
+	TrustCenterFileEntityType
 )

--- a/pkg/coredata/migrations/20251023T000000Z.sql
+++ b/pkg/coredata/migrations/20251023T000000Z.sql
@@ -1,0 +1,21 @@
+CREATE TABLE trust_center_files (
+    id TEXT PRIMARY KEY,
+    organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    tenant_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    category TEXT NOT NULL,
+    file_id TEXT NOT NULL REFERENCES files(id) ON UPDATE CASCADE ON DELETE RESTRICT,
+    trust_center_visibility trust_center_visibility NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+ALTER TABLE trust_center_document_accesses ADD COLUMN trust_center_file_id TEXT REFERENCES trust_center_files(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+ALTER TABLE trust_center_document_accesses DROP CONSTRAINT trust_center_document_accesses_check;
+
+ALTER TABLE trust_center_document_accesses ADD CONSTRAINT trust_center_document_accesses_check CHECK (
+    (document_id IS NOT NULL)::int + (report_id IS NOT NULL)::int + (trust_center_file_id IS NOT NULL)::int = 1
+);
+
+ALTER TABLE trust_center_document_accesses ADD CONSTRAINT trust_center_document_accesses_trust_center_file_id_key UNIQUE (trust_center_access_id, trust_center_file_id);

--- a/pkg/coredata/trust_center_file.go
+++ b/pkg/coredata/trust_center_file.go
@@ -1,0 +1,347 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"time"
+
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+	"github.com/jackc/pgx/v5"
+	"go.gearno.de/kit/pg"
+)
+
+type (
+	TrustCenterFile struct {
+		ID                    gid.GID               `db:"id"`
+		OrganizationID        gid.GID               `db:"organization_id"`
+		Name                  string                `db:"name"`
+		Category              string                `db:"category"`
+		FileID                gid.GID               `db:"file_id"`
+		TrustCenterVisibility TrustCenterVisibility `db:"trust_center_visibility"`
+		CreatedAt             time.Time             `db:"created_at"`
+		UpdatedAt             time.Time             `db:"updated_at"`
+	}
+
+	TrustCenterFiles []*TrustCenterFile
+)
+
+func (t TrustCenterFile) CursorKey(orderBy TrustCenterFileOrderField) page.CursorKey {
+	switch orderBy {
+	case TrustCenterFileOrderFieldName:
+		return page.NewCursorKey(t.ID, t.Name)
+	case TrustCenterFileOrderFieldCreatedAt:
+		return page.NewCursorKey(t.ID, t.CreatedAt)
+	case TrustCenterFileOrderFieldUpdatedAt:
+		return page.NewCursorKey(t.ID, t.UpdatedAt)
+	}
+	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
+}
+
+func (t *TrustCenterFile) LoadByID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	trustCenterFileID gid.GID,
+) error {
+	q := `
+SELECT
+    id,
+    organization_id,
+    name,
+    category,
+    file_id,
+    trust_center_visibility,
+    created_at,
+    updated_at
+FROM
+    trust_center_files
+WHERE
+    %s
+    AND id = @trust_center_file_id
+LIMIT 1;
+`
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"trust_center_file_id": trustCenterFileID}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query trust_center_files: %w", err)
+	}
+
+	file, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[TrustCenterFile])
+	if err != nil {
+		return fmt.Errorf("cannot collect trust center file: %w", err)
+	}
+
+	*t = file
+
+	return nil
+}
+
+func (t TrustCenterFile) Insert(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+INSERT INTO
+    trust_center_files (
+        tenant_id,
+        id,
+        organization_id,
+        name,
+        category,
+        file_id,
+        trust_center_visibility,
+        created_at,
+        updated_at
+    )
+VALUES (
+    @tenant_id,
+    @id,
+    @organization_id,
+    @name,
+    @category,
+    @file_id,
+    @trust_center_visibility,
+    @created_at,
+    @updated_at
+);
+`
+
+	args := pgx.StrictNamedArgs{
+		"tenant_id":               scope.GetTenantID(),
+		"id":                      t.ID,
+		"organization_id":         t.OrganizationID,
+		"name":                    t.Name,
+		"category":                t.Category,
+		"file_id":                 t.FileID,
+		"trust_center_visibility": t.TrustCenterVisibility,
+		"created_at":              t.CreatedAt,
+		"updated_at":              t.UpdatedAt,
+	}
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot insert trust center file: %w", err)
+	}
+
+	return nil
+}
+
+func (t *TrustCenterFile) Update(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+UPDATE trust_center_files
+SET
+    name = @name,
+    category = @category,
+    trust_center_visibility = @trust_center_visibility,
+    updated_at = @updated_at
+WHERE
+    %s
+    AND id = @id
+RETURNING
+    id,
+    organization_id,
+    name,
+    category,
+    file_id,
+    trust_center_visibility,
+    created_at,
+    updated_at
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"id":                      t.ID,
+		"name":                    t.Name,
+		"category":                t.Category,
+		"trust_center_visibility": t.TrustCenterVisibility,
+		"updated_at":              t.UpdatedAt,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot update trust center file: %w", err)
+	}
+
+	file, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[TrustCenterFile])
+	if err != nil {
+		return fmt.Errorf("cannot collect updated trust center file: %w", err)
+	}
+
+	*t = file
+
+	return nil
+}
+
+func (t *TrustCenterFile) Delete(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+DELETE FROM
+    trust_center_files
+WHERE
+    %s
+    AND id = @id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"id": t.ID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete trust center file: %w", err)
+	}
+
+	return nil
+}
+
+func (t *TrustCenterFiles) LoadByOrganizationID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	organizationID gid.GID,
+	cursor *page.Cursor[TrustCenterFileOrderField],
+) error {
+	q := `
+SELECT
+    id,
+    organization_id,
+    name,
+    category,
+    file_id,
+    trust_center_visibility,
+    created_at,
+    updated_at
+FROM
+    trust_center_files
+WHERE
+    %s
+    AND organization_id = @organization_id
+    AND %s
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, cursor.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query trust_center_files: %w", err)
+	}
+
+	files, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[TrustCenterFile])
+	if err != nil {
+		return fmt.Errorf("cannot collect trust center files: %w", err)
+	}
+
+	*t = files
+
+	return nil
+}
+
+func (t *TrustCenterFiles) CountByOrganizationID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	organizationID gid.GID,
+) (int, error) {
+	q := `
+SELECT
+    COUNT(*)
+FROM
+    trust_center_files
+WHERE
+    %s
+    AND organization_id = @organization_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	var count int
+	err := conn.QueryRow(ctx, q, args).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("cannot count trust center files: %w", err)
+	}
+
+	return count, nil
+}
+
+func (t *TrustCenterFiles) LoadAllByOrganizationID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	organizationID gid.GID,
+) error {
+	q := `
+SELECT
+    id,
+    organization_id,
+    name,
+    category,
+    file_id,
+    trust_center_visibility,
+    created_at,
+    updated_at
+FROM
+    trust_center_files
+WHERE
+    %s
+    AND organization_id = @organization_id
+ORDER BY
+    created_at DESC
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query trust center files: %w", err)
+	}
+
+	files, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[TrustCenterFile])
+	if err != nil {
+		return fmt.Errorf("cannot collect trust center files: %w", err)
+	}
+
+	*t = files
+
+	return nil
+}

--- a/pkg/coredata/trust_center_file_order_field.go
+++ b/pkg/coredata/trust_center_file_order_field.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+type (
+	TrustCenterFileOrderField string
+)
+
+const (
+	TrustCenterFileOrderFieldName      TrustCenterFileOrderField = "NAME"
+	TrustCenterFileOrderFieldCreatedAt TrustCenterFileOrderField = "CREATED_AT"
+	TrustCenterFileOrderFieldUpdatedAt TrustCenterFileOrderField = "UPDATED_AT"
+)
+
+func (p TrustCenterFileOrderField) Column() string {
+	switch p {
+	case TrustCenterFileOrderFieldName:
+		return "name"
+	case TrustCenterFileOrderFieldCreatedAt:
+		return "created_at"
+	case TrustCenterFileOrderFieldUpdatedAt:
+		return "updated_at"
+	default:
+		return string(p)
+	}
+}
+
+func (p TrustCenterFileOrderField) String() string {
+	return string(p)
+}
+
+func (p TrustCenterFileOrderField) MarshalText() ([]byte, error) {
+	return []byte(p.String()), nil
+}
+
+func (p *TrustCenterFileOrderField) UnmarshalText(text []byte) error {
+	*p = TrustCenterFileOrderField(text)
+	return nil
+}

--- a/pkg/probo/service.go
+++ b/pkg/probo/service.go
@@ -98,6 +98,7 @@ type (
 		TrustCenters                      *TrustCenterService
 		TrustCenterAccesses               *TrustCenterAccessService
 		TrustCenterReferences             *TrustCenterReferenceService
+		TrustCenterFiles                  *TrustCenterFileService
 		Nonconformities                   *NonconformityService
 		Obligations                       *ObligationService
 		Snapshots                         *SnapshotService
@@ -208,6 +209,18 @@ func (s *Service) WithTenant(tenantID gid.TenantID) *TenantService {
 	tenantService.TrustCenters = &TrustCenterService{svc: tenantService}
 	tenantService.TrustCenterAccesses = &TrustCenterAccessService{svc: tenantService}
 	tenantService.TrustCenterReferences = &TrustCenterReferenceService{svc: tenantService}
+	tenantService.TrustCenterFiles = &TrustCenterFileService{
+		svc: tenantService,
+		fileValidator: &filevalidation.FileValidator{
+			MaxFileSize: 10 * 1024 * 1024, // 10MB
+			AllowedMimeTypes: map[string]bool{
+				"application/pdf": true,
+			},
+			AllowedExtensions: map[string][]string{
+				".pdf": {"application/pdf"},
+			},
+		},
+	}
 	tenantService.Nonconformities = &NonconformityService{svc: tenantService}
 	tenantService.Obligations = &ObligationService{svc: tenantService}
 	tenantService.Snapshots = &SnapshotService{svc: tenantService}

--- a/pkg/probo/trust_center_file_service.go
+++ b/pkg/probo/trust_center_file_service.go
@@ -1,0 +1,405 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package probo
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"mime"
+	"path/filepath"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/filevalidation"
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+	"go.gearno.de/crypto/uuid"
+	"go.gearno.de/kit/pg"
+)
+
+type (
+	TrustCenterFileService struct {
+		svc           *TenantService
+		fileValidator *filevalidation.FileValidator
+	}
+
+	CreateTrustCenterFileRequest struct {
+		OrganizationID        gid.GID
+		Name                  string
+		Category              string
+		File                  File
+		TrustCenterVisibility coredata.TrustCenterVisibility
+	}
+
+	UpdateTrustCenterFileRequest struct {
+		ID                    gid.GID
+		Name                  *string
+		Category              *string
+		TrustCenterVisibility *coredata.TrustCenterVisibility
+	}
+
+	GetTrustCenterFileRequest struct {
+		ID gid.GID
+	}
+
+	DeleteTrustCenterFileRequest struct {
+		ID gid.GID
+	}
+)
+
+func (s TrustCenterFileService) ListForOrganizationID(
+	ctx context.Context,
+	organizationID gid.GID,
+	cursor *page.Cursor[coredata.TrustCenterFileOrderField],
+) (*page.Page[*coredata.TrustCenterFile, coredata.TrustCenterFileOrderField], error) {
+	var files coredata.TrustCenterFiles
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			if err := files.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID, cursor); err != nil {
+				return fmt.Errorf("cannot load trust center files: %w", err)
+			}
+
+			return nil
+		})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return page.NewPage(files, cursor), nil
+}
+
+func (s TrustCenterFileService) CountForOrganizationID(
+	ctx context.Context,
+	organizationID gid.GID,
+) (int, error) {
+	var count int
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			var err error
+			count, err = (&coredata.TrustCenterFiles{}).CountByOrganizationID(ctx, conn, s.svc.scope, organizationID)
+			if err != nil {
+				return fmt.Errorf("cannot count trust center files: %w", err)
+			}
+
+			return nil
+		})
+
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+func (s TrustCenterFileService) Get(
+	ctx context.Context,
+	req *GetTrustCenterFileRequest,
+) (*coredata.TrustCenterFile, error) {
+	var file *coredata.TrustCenterFile
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			file = &coredata.TrustCenterFile{}
+			if err := file.LoadByID(ctx, conn, s.svc.scope, req.ID); err != nil {
+				return fmt.Errorf("cannot load trust center file: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return file, nil
+}
+
+func (s TrustCenterFileService) Create(
+	ctx context.Context,
+	req *CreateTrustCenterFileRequest,
+) (*coredata.TrustCenterFile, error) {
+	if req.Name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+
+	// Validate file
+	filename := req.File.Filename
+	contentType := req.File.ContentType
+	fileSize, err := s.svc.fileManager.GetFileSize(req.File.Content)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get file size: %w", err)
+	}
+
+	if err := s.fileValidator.Validate(filename, contentType, fileSize); err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+
+	trustCenterFileID := gid.New(s.svc.scope.GetTenantID(), coredata.TrustCenterFileEntityType)
+
+	var file *coredata.TrustCenterFile
+	var s3Key string
+
+	err = s.svc.pg.WithTx(
+		ctx,
+		func(tx pg.Conn) error {
+			fileID, objectKey, err := s.uploadFile(ctx, tx, req.File, trustCenterFileID, req.OrganizationID, now)
+			if err != nil {
+				return fmt.Errorf("cannot upload file: %w", err)
+			}
+			s3Key = objectKey
+
+			file = &coredata.TrustCenterFile{
+				ID:                    trustCenterFileID,
+				OrganizationID:        req.OrganizationID,
+				Name:                  req.Name,
+				Category:              req.Category,
+				FileID:                fileID,
+				TrustCenterVisibility: req.TrustCenterVisibility,
+				CreatedAt:             now,
+				UpdatedAt:             now,
+			}
+
+			if err := file.Insert(ctx, tx, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot insert trust center file: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		s.cleanupS3Object(ctx, s3Key)
+		return nil, err
+	}
+
+	return file, nil
+}
+
+func (s TrustCenterFileService) Update(
+	ctx context.Context,
+	req *UpdateTrustCenterFileRequest,
+) (*coredata.TrustCenterFile, error) {
+	now := time.Now()
+
+	var file *coredata.TrustCenterFile
+
+	if req.Name != nil && *req.Name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+
+	err := s.svc.pg.WithTx(
+		ctx,
+		func(tx pg.Conn) error {
+			file = &coredata.TrustCenterFile{}
+
+			if err := file.LoadByID(ctx, tx, s.svc.scope, req.ID); err != nil {
+				return fmt.Errorf("cannot load trust center file: %w", err)
+			}
+
+			if req.Name != nil {
+				file.Name = *req.Name
+			}
+			if req.Category != nil {
+				file.Category = *req.Category
+			}
+			if req.TrustCenterVisibility != nil {
+				file.TrustCenterVisibility = *req.TrustCenterVisibility
+			}
+			file.UpdatedAt = now
+
+			if err := file.Update(ctx, tx, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot update trust center file: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return file, nil
+}
+
+func (s TrustCenterFileService) Delete(
+	ctx context.Context,
+	req *DeleteTrustCenterFileRequest,
+) error {
+	err := s.svc.pg.WithTx(
+		ctx,
+		func(tx pg.Conn) error {
+			file := &coredata.TrustCenterFile{}
+
+			if err := file.LoadByID(ctx, tx, s.svc.scope, req.ID); err != nil {
+				return fmt.Errorf("cannot load trust center file: %w", err)
+			}
+
+			if err := file.Delete(ctx, tx, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot delete trust center file: %w", err)
+			}
+
+			return nil
+		})
+
+	return err
+}
+
+func (s TrustCenterFileService) GenerateFileURL(
+	ctx context.Context,
+	trustCenterFileID gid.GID,
+	duration time.Duration,
+) (string, error) {
+	var storedFile *coredata.File
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			file := &coredata.TrustCenterFile{}
+			if err := file.LoadByID(ctx, conn, s.svc.scope, trustCenterFileID); err != nil {
+				return fmt.Errorf("cannot load trust center file: %w", err)
+			}
+
+			storedFile = &coredata.File{}
+			if err := storedFile.LoadByID(ctx, conn, s.svc.scope, file.FileID); err != nil {
+				return fmt.Errorf("cannot load file: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return "", err
+	}
+
+	fileURL, err := s.svc.fileManager.GenerateFileUrl(ctx, storedFile, duration)
+	if err != nil {
+		return "", fmt.Errorf("cannot generate file URL: %w", err)
+	}
+
+	return fileURL, nil
+}
+
+func (s TrustCenterFileService) uploadFile(
+	ctx context.Context,
+	tx pg.Conn,
+	file File,
+	trustCenterFileID gid.GID,
+	organizationID gid.GID,
+	now time.Time,
+) (gid.GID, string, error) {
+	fileID := gid.New(s.svc.scope.GetTenantID(), coredata.FileEntityType)
+
+	objectKey, err := uuid.NewV7()
+	if err != nil {
+		return gid.GID{}, "", fmt.Errorf("cannot generate object key: %w", err)
+	}
+
+	var fileSize int64
+	var fileContent io.ReadSeeker
+	filename := file.Filename
+	contentType := file.ContentType
+
+	if readSeeker, ok := file.Content.(io.ReadSeeker); ok {
+		if file.Size <= 0 {
+			size, err := readSeeker.Seek(0, io.SeekEnd)
+			if err != nil {
+				return gid.GID{}, "", fmt.Errorf("cannot determine file size: %w", err)
+			}
+			fileSize = size
+
+			_, err = readSeeker.Seek(0, io.SeekStart)
+			if err != nil {
+				return gid.GID{}, "", fmt.Errorf("cannot reset file position: %w", err)
+			}
+		} else {
+			fileSize = file.Size
+		}
+		fileContent = readSeeker
+	} else {
+		buf, err := io.ReadAll(file.Content)
+		if err != nil {
+			return gid.GID{}, "", fmt.Errorf("cannot read file: %w", err)
+		}
+		fileSize = int64(len(buf))
+		fileContent = bytes.NewReader(buf)
+	}
+
+	if contentType == "" {
+		contentType = "application/octet-stream"
+		if filename != "" {
+			if detectedType := mime.TypeByExtension(filepath.Ext(filename)); detectedType != "" {
+				contentType = detectedType
+			}
+		}
+	}
+
+	_, err = s.svc.s3.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      aws.String(s.svc.bucket),
+		Key:         aws.String(objectKey.String()),
+		Body:        fileContent,
+		ContentType: aws.String(contentType),
+		Metadata: map[string]string{
+			"type":                 "trust-center-file",
+			"trust-center-file-id": trustCenterFileID.String(),
+			"organization-id":      organizationID.String(),
+		},
+	})
+	if err != nil {
+		return gid.GID{}, "", fmt.Errorf("cannot upload file to S3: %w", err)
+	}
+
+	fileRecord := &coredata.File{
+		ID:         fileID,
+		BucketName: s.svc.bucket,
+		MimeType:   contentType,
+		FileName:   filename,
+		FileKey:    objectKey.String(),
+		FileSize:   fileSize,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+
+	if err := fileRecord.Insert(ctx, tx, s.svc.scope); err != nil {
+		return gid.GID{}, "", fmt.Errorf("cannot insert file: %w", err)
+	}
+
+	return fileID, objectKey.String(), nil
+}
+
+func (s TrustCenterFileService) cleanupS3Object(ctx context.Context, s3Key string) {
+	if s3Key == "" {
+		return
+	}
+
+	s.svc.s3.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(s.svc.bucket),
+		Key:    aws.String(s3Key),
+	})
+}

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -1187,6 +1187,24 @@ enum TrustCenterReferenceOrderField
     )
 }
 
+enum TrustCenterFileOrderField
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/coredata.TrustCenterFileOrderField"
+  ) {
+  NAME
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.TrustCenterFileOrderFieldName"
+    )
+  CREATED_AT
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.TrustCenterFileOrderFieldCreatedAt"
+    )
+  UPDATED_AT
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.TrustCenterFileOrderFieldUpdatedAt"
+    )
+}
+
 enum SnapshotsType
   @goModel(model: "github.com/getprobo/probo/pkg/coredata.SnapshotsType") {
   RISKS
@@ -1420,6 +1438,14 @@ input TrustCenterReferenceOrder
   ) {
   direction: OrderDirection!
   field: TrustCenterReferenceOrderField!
+}
+
+input TrustCenterFileOrder
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.TrustCenterFileOrderBy"
+  ) {
+  direction: OrderDirection!
+  field: TrustCenterFileOrderField!
 }
 
 input EvidenceOrder
@@ -1748,6 +1774,14 @@ type Organization implements Node {
     before: CursorKey
     orderBy: SnapshotOrder
   ): SnapshotConnection! @goField(forceResolver: true)
+
+  trustCenterFiles(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+    orderBy: TrustCenterFileOrder
+  ): TrustCenterFileConnection! @goField(forceResolver: true)
 
   trustCenter: TrustCenter @goField(forceResolver: true)
 
@@ -2391,6 +2425,7 @@ type TrustCenterDocumentAccess implements Node {
   trustCenterAccess: TrustCenterAccess! @goField(forceResolver: true)
   document: Document @goField(forceResolver: true)
   report: Report @goField(forceResolver: true)
+  trustCenterFile: TrustCenterFile @goField(forceResolver: true)
 }
 
 type TrustCenterDocumentAccessConnection
@@ -2439,6 +2474,31 @@ type TrustCenterReferenceConnection
 type TrustCenterReferenceEdge {
   cursor: CursorKey!
   node: TrustCenterReference!
+}
+
+type TrustCenterFile implements Node {
+  id: ID!
+  name: String!
+  category: String!
+  fileUrl: String! @goField(forceResolver: true)
+  trustCenterVisibility: TrustCenterVisibility!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+  organization: Organization! @goField(forceResolver: true)
+}
+
+type TrustCenterFileConnection
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.TrustCenterFileConnection"
+  ) {
+  totalCount: Int! @goField(forceResolver: true)
+  edges: [TrustCenterFileEdge!]!
+  pageInfo: PageInfo!
+}
+
+type TrustCenterFileEdge {
+  cursor: CursorKey!
+  node: TrustCenterFile!
 }
 
 type UserConnection
@@ -2824,6 +2884,23 @@ type Mutation {
     input: DeleteTrustCenterReferenceInput!
   ): DeleteTrustCenterReferencePayload!
 
+  # Trust Center File mutations
+  createTrustCenterFile(
+    input: CreateTrustCenterFileInput!
+  ): CreateTrustCenterFilePayload!
+
+  updateTrustCenterFile(
+    input: UpdateTrustCenterFileInput!
+  ): UpdateTrustCenterFilePayload!
+
+  getTrustCenterFile(
+    input: GetTrustCenterFileInput!
+  ): GetTrustCenterFilePayload!
+
+  deleteTrustCenterFile(
+    input: DeleteTrustCenterFileInput!
+  ): DeleteTrustCenterFilePayload!
+
   # User mutations
   confirmEmail(input: ConfirmEmailInput!): ConfirmEmailPayload!
   inviteUser(input: InviteUserInput!): InviteUserPayload!
@@ -3151,6 +3228,7 @@ input UpdateTrustCenterAccessInput {
   active: Boolean
   documentIds: [ID!]
   reportIds: [ID!]
+  trustCenterFileIds: [ID!]
 }
 
 input DeleteTrustCenterAccessInput {
@@ -3174,6 +3252,29 @@ input UpdateTrustCenterReferenceInput {
 }
 
 input DeleteTrustCenterReferenceInput {
+  id: ID!
+}
+
+input CreateTrustCenterFileInput {
+  organizationId: ID!
+  name: String!
+  category: String!
+  file: Upload!
+  trustCenterVisibility: TrustCenterVisibility!
+}
+
+input UpdateTrustCenterFileInput {
+  id: ID!
+  name: String
+  category: String
+  trustCenterVisibility: TrustCenterVisibility
+}
+
+input GetTrustCenterFileInput {
+  id: ID!
+}
+
+input DeleteTrustCenterFileInput {
   id: ID!
 }
 
@@ -3852,6 +3953,22 @@ type UpdateTrustCenterReferencePayload {
 
 type DeleteTrustCenterReferencePayload {
   deletedTrustCenterReferenceId: ID!
+}
+
+type CreateTrustCenterFilePayload {
+  trustCenterFileEdge: TrustCenterFileEdge!
+}
+
+type UpdateTrustCenterFilePayload {
+  trustCenterFile: TrustCenterFile!
+}
+
+type GetTrustCenterFilePayload {
+  trustCenterFile: TrustCenterFile!
+}
+
+type DeleteTrustCenterFilePayload {
+  deletedTrustCenterFileId: ID!
 }
 
 type CreateControlPayload {

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -90,6 +90,8 @@ type ResolverRoot interface {
 	TrustCenterAccess() TrustCenterAccessResolver
 	TrustCenterDocumentAccess() TrustCenterDocumentAccessResolver
 	TrustCenterDocumentAccessConnection() TrustCenterDocumentAccessConnectionResolver
+	TrustCenterFile() TrustCenterFileResolver
+	TrustCenterFileConnection() TrustCenterFileConnectionResolver
 	TrustCenterReference() TrustCenterReferenceResolver
 	TrustCenterReferenceConnection() TrustCenterReferenceConnectionResolver
 	UserConnection() UserConnectionResolver
@@ -367,6 +369,10 @@ type ComplexityRoot struct {
 		TrustCenterAccessEdge func(childComplexity int) int
 	}
 
+	CreateTrustCenterFilePayload struct {
+		TrustCenterFileEdge func(childComplexity int) int
+	}
+
 	CreateTrustCenterReferencePayload struct {
 		TrustCenterReferenceEdge func(childComplexity int) int
 	}
@@ -556,6 +562,10 @@ type ComplexityRoot struct {
 		DeletedTrustCenterAccessID func(childComplexity int) int
 	}
 
+	DeleteTrustCenterFilePayload struct {
+		DeletedTrustCenterFileID func(childComplexity int) int
+	}
+
 	DeleteTrustCenterNDAPayload struct {
 		TrustCenter func(childComplexity int) int
 	}
@@ -738,6 +748,10 @@ type ComplexityRoot struct {
 		Data func(childComplexity int) int
 	}
 
+	GetTrustCenterFilePayload struct {
+		TrustCenterFile func(childComplexity int) int
+	}
+
 	ImportFrameworkPayload struct {
 		FrameworkEdge func(childComplexity int) int
 	}
@@ -856,6 +870,7 @@ type ComplexityRoot struct {
 		CreateSnapshot                         func(childComplexity int, input types.CreateSnapshotInput) int
 		CreateTask                             func(childComplexity int, input types.CreateTaskInput) int
 		CreateTrustCenterAccess                func(childComplexity int, input types.CreateTrustCenterAccessInput) int
+		CreateTrustCenterFile                  func(childComplexity int, input types.CreateTrustCenterFileInput) int
 		CreateTrustCenterReference             func(childComplexity int, input types.CreateTrustCenterReferenceInput) int
 		CreateVendor                           func(childComplexity int, input types.CreateVendorInput) int
 		CreateVendorContact                    func(childComplexity int, input types.CreateVendorContactInput) int
@@ -891,6 +906,7 @@ type ComplexityRoot struct {
 		DeleteSnapshot                         func(childComplexity int, input types.DeleteSnapshotInput) int
 		DeleteTask                             func(childComplexity int, input types.DeleteTaskInput) int
 		DeleteTrustCenterAccess                func(childComplexity int, input types.DeleteTrustCenterAccessInput) int
+		DeleteTrustCenterFile                  func(childComplexity int, input types.DeleteTrustCenterFileInput) int
 		DeleteTrustCenterNda                   func(childComplexity int, input types.DeleteTrustCenterNDAInput) int
 		DeleteTrustCenterReference             func(childComplexity int, input types.DeleteTrustCenterReferenceInput) int
 		DeleteVendor                           func(childComplexity int, input types.DeleteVendorInput) int
@@ -903,6 +919,7 @@ type ComplexityRoot struct {
 		ExportFramework                        func(childComplexity int, input types.ExportFrameworkInput) int
 		GenerateDocumentChangelog              func(childComplexity int, input types.GenerateDocumentChangelogInput) int
 		GenerateFrameworkStateOfApplicability  func(childComplexity int, input types.GenerateFrameworkStateOfApplicabilityInput) int
+		GetTrustCenterFile                     func(childComplexity int, input types.GetTrustCenterFileInput) int
 		ImportFramework                        func(childComplexity int, input types.ImportFrameworkInput) int
 		ImportMeasure                          func(childComplexity int, input types.ImportMeasureInput) int
 		InviteUser                             func(childComplexity int, input types.InviteUserInput) int
@@ -929,6 +946,7 @@ type ComplexityRoot struct {
 		UpdateTask                             func(childComplexity int, input types.UpdateTaskInput) int
 		UpdateTrustCenter                      func(childComplexity int, input types.UpdateTrustCenterInput) int
 		UpdateTrustCenterAccess                func(childComplexity int, input types.UpdateTrustCenterAccessInput) int
+		UpdateTrustCenterFile                  func(childComplexity int, input types.UpdateTrustCenterFileInput) int
 		UpdateTrustCenterReference             func(childComplexity int, input types.UpdateTrustCenterReferenceInput) int
 		UpdateVendor                           func(childComplexity int, input types.UpdateVendorInput) int
 		UpdateVendorBusinessAssociateAgreement func(childComplexity int, input types.UpdateVendorBusinessAssociateAgreementInput) int
@@ -1030,6 +1048,7 @@ type ComplexityRoot struct {
 		Snapshots             func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.SnapshotOrderBy) int
 		Tasks                 func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TaskOrderBy) int
 		TrustCenter           func(childComplexity int) int
+		TrustCenterFiles      func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.OrderBy[coredata.TrustCenterFileOrderField]) int
 		UpdatedAt             func(childComplexity int) int
 		Vendors               func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.VendorOrderBy, filter *types.VendorFilter) int
 		WebsiteURL            func(childComplexity int) int
@@ -1299,6 +1318,7 @@ type ComplexityRoot struct {
 		ID                func(childComplexity int) int
 		Report            func(childComplexity int) int
 		TrustCenterAccess func(childComplexity int) int
+		TrustCenterFile   func(childComplexity int) int
 		UpdatedAt         func(childComplexity int) int
 	}
 
@@ -1314,6 +1334,28 @@ type ComplexityRoot struct {
 	}
 
 	TrustCenterEdge struct {
+		Cursor func(childComplexity int) int
+		Node   func(childComplexity int) int
+	}
+
+	TrustCenterFile struct {
+		Category              func(childComplexity int) int
+		CreatedAt             func(childComplexity int) int
+		FileURL               func(childComplexity int) int
+		ID                    func(childComplexity int) int
+		Name                  func(childComplexity int) int
+		Organization          func(childComplexity int) int
+		TrustCenterVisibility func(childComplexity int) int
+		UpdatedAt             func(childComplexity int) int
+	}
+
+	TrustCenterFileConnection struct {
+		Edges      func(childComplexity int) int
+		PageInfo   func(childComplexity int) int
+		TotalCount func(childComplexity int) int
+	}
+
+	TrustCenterFileEdge struct {
 		Cursor func(childComplexity int) int
 		Node   func(childComplexity int) int
 	}
@@ -1409,6 +1451,10 @@ type ComplexityRoot struct {
 
 	UpdateTrustCenterAccessPayload struct {
 		TrustCenterAccess func(childComplexity int) int
+	}
+
+	UpdateTrustCenterFilePayload struct {
+		TrustCenterFile func(childComplexity int) int
 	}
 
 	UpdateTrustCenterPayload struct {
@@ -1760,6 +1806,10 @@ type MutationResolver interface {
 	CreateTrustCenterReference(ctx context.Context, input types.CreateTrustCenterReferenceInput) (*types.CreateTrustCenterReferencePayload, error)
 	UpdateTrustCenterReference(ctx context.Context, input types.UpdateTrustCenterReferenceInput) (*types.UpdateTrustCenterReferencePayload, error)
 	DeleteTrustCenterReference(ctx context.Context, input types.DeleteTrustCenterReferenceInput) (*types.DeleteTrustCenterReferencePayload, error)
+	CreateTrustCenterFile(ctx context.Context, input types.CreateTrustCenterFileInput) (*types.CreateTrustCenterFilePayload, error)
+	UpdateTrustCenterFile(ctx context.Context, input types.UpdateTrustCenterFileInput) (*types.UpdateTrustCenterFilePayload, error)
+	GetTrustCenterFile(ctx context.Context, input types.GetTrustCenterFileInput) (*types.GetTrustCenterFilePayload, error)
+	DeleteTrustCenterFile(ctx context.Context, input types.DeleteTrustCenterFileInput) (*types.DeleteTrustCenterFilePayload, error)
 	ConfirmEmail(ctx context.Context, input types.ConfirmEmailInput) (*types.ConfirmEmailPayload, error)
 	InviteUser(ctx context.Context, input types.InviteUserInput) (*types.InviteUserPayload, error)
 	AcceptInvitation(ctx context.Context, input types.AcceptInvitationInput) (*types.AcceptInvitationPayload, error)
@@ -1909,6 +1959,7 @@ type OrganizationResolver interface {
 	ContinualImprovements(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ContinualImprovementOrderBy, filter *types.ContinualImprovementFilter) (*types.ContinualImprovementConnection, error)
 	ProcessingActivities(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ProcessingActivityOrderBy, filter *types.ProcessingActivityFilter) (*types.ProcessingActivityConnection, error)
 	Snapshots(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.SnapshotOrderBy) (*types.SnapshotConnection, error)
+	TrustCenterFiles(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.OrderBy[coredata.TrustCenterFileOrderField]) (*types.TrustCenterFileConnection, error)
 	TrustCenter(ctx context.Context, obj *types.Organization) (*types.TrustCenter, error)
 	CustomDomain(ctx context.Context, obj *types.Organization) (*types.CustomDomain, error)
 }
@@ -1972,9 +2023,18 @@ type TrustCenterDocumentAccessResolver interface {
 	TrustCenterAccess(ctx context.Context, obj *types.TrustCenterDocumentAccess) (*types.TrustCenterAccess, error)
 	Document(ctx context.Context, obj *types.TrustCenterDocumentAccess) (*types.Document, error)
 	Report(ctx context.Context, obj *types.TrustCenterDocumentAccess) (*types.Report, error)
+	TrustCenterFile(ctx context.Context, obj *types.TrustCenterDocumentAccess) (*types.TrustCenterFile, error)
 }
 type TrustCenterDocumentAccessConnectionResolver interface {
 	TotalCount(ctx context.Context, obj *types.TrustCenterDocumentAccessConnection) (int, error)
+}
+type TrustCenterFileResolver interface {
+	FileURL(ctx context.Context, obj *types.TrustCenterFile) (string, error)
+
+	Organization(ctx context.Context, obj *types.TrustCenterFile) (*types.Organization, error)
+}
+type TrustCenterFileConnectionResolver interface {
+	TotalCount(ctx context.Context, obj *types.TrustCenterFileConnection) (int, error)
 }
 type TrustCenterReferenceResolver interface {
 	LogoURL(ctx context.Context, obj *types.TrustCenterReference) (string, error)
@@ -2882,6 +2942,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.CreateTrustCenterAccessPayload.TrustCenterAccessEdge(childComplexity), true
 
+	case "CreateTrustCenterFilePayload.trustCenterFileEdge":
+		if e.complexity.CreateTrustCenterFilePayload.TrustCenterFileEdge == nil {
+			break
+		}
+
+		return e.complexity.CreateTrustCenterFilePayload.TrustCenterFileEdge(childComplexity), true
+
 	case "CreateTrustCenterReferencePayload.trustCenterReferenceEdge":
 		if e.complexity.CreateTrustCenterReferencePayload.TrustCenterReferenceEdge == nil {
 			break
@@ -3369,6 +3436,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.DeleteTrustCenterAccessPayload.DeletedTrustCenterAccessID(childComplexity), true
+
+	case "DeleteTrustCenterFilePayload.deletedTrustCenterFileId":
+		if e.complexity.DeleteTrustCenterFilePayload.DeletedTrustCenterFileID == nil {
+			break
+		}
+
+		return e.complexity.DeleteTrustCenterFilePayload.DeletedTrustCenterFileID(childComplexity), true
 
 	case "DeleteTrustCenterNDAPayload.trustCenter":
 		if e.complexity.DeleteTrustCenterNDAPayload.TrustCenter == nil {
@@ -4054,6 +4128,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.GenerateFrameworkStateOfApplicabilityPayload.Data(childComplexity), true
+
+	case "GetTrustCenterFilePayload.trustCenterFile":
+		if e.complexity.GetTrustCenterFilePayload.TrustCenterFile == nil {
+			break
+		}
+
+		return e.complexity.GetTrustCenterFilePayload.TrustCenterFile(childComplexity), true
 
 	case "ImportFrameworkPayload.frameworkEdge":
 		if e.complexity.ImportFrameworkPayload.FrameworkEdge == nil {
@@ -4817,6 +4898,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.CreateTrustCenterAccess(childComplexity, args["input"].(types.CreateTrustCenterAccessInput)), true
 
+	case "Mutation.createTrustCenterFile":
+		if e.complexity.Mutation.CreateTrustCenterFile == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_createTrustCenterFile_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreateTrustCenterFile(childComplexity, args["input"].(types.CreateTrustCenterFileInput)), true
+
 	case "Mutation.createTrustCenterReference":
 		if e.complexity.Mutation.CreateTrustCenterReference == nil {
 			break
@@ -5237,6 +5330,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.DeleteTrustCenterAccess(childComplexity, args["input"].(types.DeleteTrustCenterAccessInput)), true
 
+	case "Mutation.deleteTrustCenterFile":
+		if e.complexity.Mutation.DeleteTrustCenterFile == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_deleteTrustCenterFile_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteTrustCenterFile(childComplexity, args["input"].(types.DeleteTrustCenterFileInput)), true
+
 	case "Mutation.deleteTrustCenterNDA":
 		if e.complexity.Mutation.DeleteTrustCenterNda == nil {
 			break
@@ -5380,6 +5485,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.GenerateFrameworkStateOfApplicability(childComplexity, args["input"].(types.GenerateFrameworkStateOfApplicabilityInput)), true
+
+	case "Mutation.getTrustCenterFile":
+		if e.complexity.Mutation.GetTrustCenterFile == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_getTrustCenterFile_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.GetTrustCenterFile(childComplexity, args["input"].(types.GetTrustCenterFileInput)), true
 
 	case "Mutation.importFramework":
 		if e.complexity.Mutation.ImportFramework == nil {
@@ -5692,6 +5809,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.UpdateTrustCenterAccess(childComplexity, args["input"].(types.UpdateTrustCenterAccessInput)), true
+
+	case "Mutation.updateTrustCenterFile":
+		if e.complexity.Mutation.UpdateTrustCenterFile == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_updateTrustCenterFile_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UpdateTrustCenterFile(childComplexity, args["input"].(types.UpdateTrustCenterFileInput)), true
 
 	case "Mutation.updateTrustCenterReference":
 		if e.complexity.Mutation.UpdateTrustCenterReference == nil {
@@ -6402,6 +6531,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Organization.TrustCenter(childComplexity), true
+
+	case "Organization.trustCenterFiles":
+		if e.complexity.Organization.TrustCenterFiles == nil {
+			break
+		}
+
+		args, err := ec.field_Organization_trustCenterFiles_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.TrustCenterFiles(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.OrderBy[coredata.TrustCenterFileOrderField])), true
 
 	case "Organization.updatedAt":
 		if e.complexity.Organization.UpdatedAt == nil {
@@ -7606,6 +7747,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.TrustCenterDocumentAccess.TrustCenterAccess(childComplexity), true
 
+	case "TrustCenterDocumentAccess.trustCenterFile":
+		if e.complexity.TrustCenterDocumentAccess.TrustCenterFile == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterDocumentAccess.TrustCenterFile(childComplexity), true
+
 	case "TrustCenterDocumentAccess.updatedAt":
 		if e.complexity.TrustCenterDocumentAccess.UpdatedAt == nil {
 			break
@@ -7661,6 +7809,97 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.TrustCenterEdge.Node(childComplexity), true
+
+	case "TrustCenterFile.category":
+		if e.complexity.TrustCenterFile.Category == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterFile.Category(childComplexity), true
+
+	case "TrustCenterFile.createdAt":
+		if e.complexity.TrustCenterFile.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterFile.CreatedAt(childComplexity), true
+
+	case "TrustCenterFile.fileUrl":
+		if e.complexity.TrustCenterFile.FileURL == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterFile.FileURL(childComplexity), true
+
+	case "TrustCenterFile.id":
+		if e.complexity.TrustCenterFile.ID == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterFile.ID(childComplexity), true
+
+	case "TrustCenterFile.name":
+		if e.complexity.TrustCenterFile.Name == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterFile.Name(childComplexity), true
+
+	case "TrustCenterFile.organization":
+		if e.complexity.TrustCenterFile.Organization == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterFile.Organization(childComplexity), true
+
+	case "TrustCenterFile.trustCenterVisibility":
+		if e.complexity.TrustCenterFile.TrustCenterVisibility == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterFile.TrustCenterVisibility(childComplexity), true
+
+	case "TrustCenterFile.updatedAt":
+		if e.complexity.TrustCenterFile.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterFile.UpdatedAt(childComplexity), true
+
+	case "TrustCenterFileConnection.edges":
+		if e.complexity.TrustCenterFileConnection.Edges == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterFileConnection.Edges(childComplexity), true
+
+	case "TrustCenterFileConnection.pageInfo":
+		if e.complexity.TrustCenterFileConnection.PageInfo == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterFileConnection.PageInfo(childComplexity), true
+
+	case "TrustCenterFileConnection.totalCount":
+		if e.complexity.TrustCenterFileConnection.TotalCount == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterFileConnection.TotalCount(childComplexity), true
+
+	case "TrustCenterFileEdge.cursor":
+		if e.complexity.TrustCenterFileEdge.Cursor == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterFileEdge.Cursor(childComplexity), true
+
+	case "TrustCenterFileEdge.node":
+		if e.complexity.TrustCenterFileEdge.Node == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterFileEdge.Node(childComplexity), true
 
 	case "TrustCenterReference.createdAt":
 		if e.complexity.TrustCenterReference.CreatedAt == nil {
@@ -7871,6 +8110,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.UpdateTrustCenterAccessPayload.TrustCenterAccess(childComplexity), true
+
+	case "UpdateTrustCenterFilePayload.trustCenterFile":
+		if e.complexity.UpdateTrustCenterFilePayload.TrustCenterFile == nil {
+			break
+		}
+
+		return e.complexity.UpdateTrustCenterFilePayload.TrustCenterFile(childComplexity), true
 
 	case "UpdateTrustCenterPayload.trustCenter":
 		if e.complexity.UpdateTrustCenterPayload.TrustCenter == nil {
@@ -8842,6 +9088,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputCreateSnapshotInput,
 		ec.unmarshalInputCreateTaskInput,
 		ec.unmarshalInputCreateTrustCenterAccessInput,
+		ec.unmarshalInputCreateTrustCenterFileInput,
 		ec.unmarshalInputCreateTrustCenterReferenceInput,
 		ec.unmarshalInputCreateVendorContactInput,
 		ec.unmarshalInputCreateVendorInput,
@@ -8879,6 +9126,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputDeleteSnapshotInput,
 		ec.unmarshalInputDeleteTaskInput,
 		ec.unmarshalInputDeleteTrustCenterAccessInput,
+		ec.unmarshalInputDeleteTrustCenterFileInput,
 		ec.unmarshalInputDeleteTrustCenterNDAInput,
 		ec.unmarshalInputDeleteTrustCenterReferenceInput,
 		ec.unmarshalInputDeleteVendorBusinessAssociateAgreementInput,
@@ -8900,6 +9148,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputFulfillEvidenceInput,
 		ec.unmarshalInputGenerateDocumentChangelogInput,
 		ec.unmarshalInputGenerateFrameworkStateOfApplicabilityInput,
+		ec.unmarshalInputGetTrustCenterFileInput,
 		ec.unmarshalInputImportFrameworkInput,
 		ec.unmarshalInputImportMeasureInput,
 		ec.unmarshalInputInvitationFilter,
@@ -8928,6 +9177,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputTaskOrder,
 		ec.unmarshalInputTrustCenterAccessOrder,
 		ec.unmarshalInputTrustCenterDocumentAccessOrder,
+		ec.unmarshalInputTrustCenterFileOrder,
 		ec.unmarshalInputTrustCenterReferenceOrder,
 		ec.unmarshalInputUnassignTaskInput,
 		ec.unmarshalInputUpdateAssetInput,
@@ -8947,6 +9197,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputUpdateRiskInput,
 		ec.unmarshalInputUpdateTaskInput,
 		ec.unmarshalInputUpdateTrustCenterAccessInput,
+		ec.unmarshalInputUpdateTrustCenterFileInput,
 		ec.unmarshalInputUpdateTrustCenterInput,
 		ec.unmarshalInputUpdateTrustCenterReferenceInput,
 		ec.unmarshalInputUpdateVendorBusinessAssociateAgreementInput,
@@ -10253,6 +10504,24 @@ enum TrustCenterReferenceOrderField
     )
 }
 
+enum TrustCenterFileOrderField
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/coredata.TrustCenterFileOrderField"
+  ) {
+  NAME
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.TrustCenterFileOrderFieldName"
+    )
+  CREATED_AT
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.TrustCenterFileOrderFieldCreatedAt"
+    )
+  UPDATED_AT
+    @goEnum(
+      value: "github.com/getprobo/probo/pkg/coredata.TrustCenterFileOrderFieldUpdatedAt"
+    )
+}
+
 enum SnapshotsType
   @goModel(model: "github.com/getprobo/probo/pkg/coredata.SnapshotsType") {
   RISKS
@@ -10486,6 +10755,14 @@ input TrustCenterReferenceOrder
   ) {
   direction: OrderDirection!
   field: TrustCenterReferenceOrderField!
+}
+
+input TrustCenterFileOrder
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.TrustCenterFileOrderBy"
+  ) {
+  direction: OrderDirection!
+  field: TrustCenterFileOrderField!
 }
 
 input EvidenceOrder
@@ -10814,6 +11091,14 @@ type Organization implements Node {
     before: CursorKey
     orderBy: SnapshotOrder
   ): SnapshotConnection! @goField(forceResolver: true)
+
+  trustCenterFiles(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+    orderBy: TrustCenterFileOrder
+  ): TrustCenterFileConnection! @goField(forceResolver: true)
 
   trustCenter: TrustCenter @goField(forceResolver: true)
 
@@ -11457,6 +11742,7 @@ type TrustCenterDocumentAccess implements Node {
   trustCenterAccess: TrustCenterAccess! @goField(forceResolver: true)
   document: Document @goField(forceResolver: true)
   report: Report @goField(forceResolver: true)
+  trustCenterFile: TrustCenterFile @goField(forceResolver: true)
 }
 
 type TrustCenterDocumentAccessConnection
@@ -11505,6 +11791,31 @@ type TrustCenterReferenceConnection
 type TrustCenterReferenceEdge {
   cursor: CursorKey!
   node: TrustCenterReference!
+}
+
+type TrustCenterFile implements Node {
+  id: ID!
+  name: String!
+  category: String!
+  fileUrl: String! @goField(forceResolver: true)
+  trustCenterVisibility: TrustCenterVisibility!
+  createdAt: Datetime!
+  updatedAt: Datetime!
+  organization: Organization! @goField(forceResolver: true)
+}
+
+type TrustCenterFileConnection
+  @goModel(
+    model: "github.com/getprobo/probo/pkg/server/api/console/v1/types.TrustCenterFileConnection"
+  ) {
+  totalCount: Int! @goField(forceResolver: true)
+  edges: [TrustCenterFileEdge!]!
+  pageInfo: PageInfo!
+}
+
+type TrustCenterFileEdge {
+  cursor: CursorKey!
+  node: TrustCenterFile!
 }
 
 type UserConnection
@@ -11890,6 +12201,23 @@ type Mutation {
     input: DeleteTrustCenterReferenceInput!
   ): DeleteTrustCenterReferencePayload!
 
+  # Trust Center File mutations
+  createTrustCenterFile(
+    input: CreateTrustCenterFileInput!
+  ): CreateTrustCenterFilePayload!
+
+  updateTrustCenterFile(
+    input: UpdateTrustCenterFileInput!
+  ): UpdateTrustCenterFilePayload!
+
+  getTrustCenterFile(
+    input: GetTrustCenterFileInput!
+  ): GetTrustCenterFilePayload!
+
+  deleteTrustCenterFile(
+    input: DeleteTrustCenterFileInput!
+  ): DeleteTrustCenterFilePayload!
+
   # User mutations
   confirmEmail(input: ConfirmEmailInput!): ConfirmEmailPayload!
   inviteUser(input: InviteUserInput!): InviteUserPayload!
@@ -12217,6 +12545,7 @@ input UpdateTrustCenterAccessInput {
   active: Boolean
   documentIds: [ID!]
   reportIds: [ID!]
+  trustCenterFileIds: [ID!]
 }
 
 input DeleteTrustCenterAccessInput {
@@ -12240,6 +12569,29 @@ input UpdateTrustCenterReferenceInput {
 }
 
 input DeleteTrustCenterReferenceInput {
+  id: ID!
+}
+
+input CreateTrustCenterFileInput {
+  organizationId: ID!
+  name: String!
+  category: String!
+  file: Upload!
+  trustCenterVisibility: TrustCenterVisibility!
+}
+
+input UpdateTrustCenterFileInput {
+  id: ID!
+  name: String
+  category: String
+  trustCenterVisibility: TrustCenterVisibility
+}
+
+input GetTrustCenterFileInput {
+  id: ID!
+}
+
+input DeleteTrustCenterFileInput {
   id: ID!
 }
 
@@ -12918,6 +13270,22 @@ type UpdateTrustCenterReferencePayload {
 
 type DeleteTrustCenterReferencePayload {
   deletedTrustCenterReferenceId: ID!
+}
+
+type CreateTrustCenterFilePayload {
+  trustCenterFileEdge: TrustCenterFileEdge!
+}
+
+type UpdateTrustCenterFilePayload {
+  trustCenterFile: TrustCenterFile!
+}
+
+type GetTrustCenterFilePayload {
+  trustCenterFile: TrustCenterFile!
+}
+
+type DeleteTrustCenterFilePayload {
+  deletedTrustCenterFileId: ID!
 }
 
 type CreateControlPayload {
@@ -16134,6 +16502,29 @@ func (ec *executionContext) field_Mutation_createTrustCenterAccess_argsInput(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation_createTrustCenterFile_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_createTrustCenterFile_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_createTrustCenterFile_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.CreateTrustCenterFileInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNCreateTrustCenterFileInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateTrustCenterFileInput(ctx, tmp)
+	}
+
+	var zeroVal types.CreateTrustCenterFileInput
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation_createTrustCenterReference_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -16939,6 +17330,29 @@ func (ec *executionContext) field_Mutation_deleteTrustCenterAccess_argsInput(
 	return zeroVal, nil
 }
 
+func (ec *executionContext) field_Mutation_deleteTrustCenterFile_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_deleteTrustCenterFile_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_deleteTrustCenterFile_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.DeleteTrustCenterFileInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNDeleteTrustCenterFileInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteTrustCenterFileInput(ctx, tmp)
+	}
+
+	var zeroVal types.DeleteTrustCenterFileInput
+	return zeroVal, nil
+}
+
 func (ec *executionContext) field_Mutation_deleteTrustCenterNDA_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -17212,6 +17626,29 @@ func (ec *executionContext) field_Mutation_generateFrameworkStateOfApplicability
 	}
 
 	var zeroVal types.GenerateFrameworkStateOfApplicabilityInput
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_getTrustCenterFile_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_getTrustCenterFile_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_getTrustCenterFile_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.GetTrustCenterFileInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNGetTrustCenterFileInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐGetTrustCenterFileInput(ctx, tmp)
+	}
+
+	var zeroVal types.GetTrustCenterFileInput
 	return zeroVal, nil
 }
 
@@ -17787,6 +18224,29 @@ func (ec *executionContext) field_Mutation_updateTrustCenterAccess_argsInput(
 	}
 
 	var zeroVal types.UpdateTrustCenterAccessInput
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_updateTrustCenterFile_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Mutation_updateTrustCenterFile_argsInput(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+func (ec *executionContext) field_Mutation_updateTrustCenterFile_argsInput(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (types.UpdateTrustCenterFileInput, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+	if tmp, ok := rawArgs["input"]; ok {
+		return ec.unmarshalNUpdateTrustCenterFileInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateTrustCenterFileInput(ctx, tmp)
+	}
+
+	var zeroVal types.UpdateTrustCenterFileInput
 	return zeroVal, nil
 }
 
@@ -19994,6 +20454,101 @@ func (ec *executionContext) field_Organization_tasks_argsOrderBy(
 	}
 
 	var zeroVal *types.TaskOrderBy
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_trustCenterFiles_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := ec.field_Organization_trustCenterFiles_argsFirst(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["first"] = arg0
+	arg1, err := ec.field_Organization_trustCenterFiles_argsAfter(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["after"] = arg1
+	arg2, err := ec.field_Organization_trustCenterFiles_argsLast(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["last"] = arg2
+	arg3, err := ec.field_Organization_trustCenterFiles_argsBefore(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["before"] = arg3
+	arg4, err := ec.field_Organization_trustCenterFiles_argsOrderBy(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["orderBy"] = arg4
+	return args, nil
+}
+func (ec *executionContext) field_Organization_trustCenterFiles_argsFirst(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*int, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("first"))
+	if tmp, ok := rawArgs["first"]; ok {
+		return ec.unmarshalOInt2ᚖint(ctx, tmp)
+	}
+
+	var zeroVal *int
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_trustCenterFiles_argsAfter(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*page.CursorKey, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("after"))
+	if tmp, ok := rawArgs["after"]; ok {
+		return ec.unmarshalOCursorKey2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐCursorKey(ctx, tmp)
+	}
+
+	var zeroVal *page.CursorKey
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_trustCenterFiles_argsLast(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*int, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("last"))
+	if tmp, ok := rawArgs["last"]; ok {
+		return ec.unmarshalOInt2ᚖint(ctx, tmp)
+	}
+
+	var zeroVal *int
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_trustCenterFiles_argsBefore(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*page.CursorKey, error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("before"))
+	if tmp, ok := rawArgs["before"]; ok {
+		return ec.unmarshalOCursorKey2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐCursorKey(ctx, tmp)
+	}
+
+	var zeroVal *page.CursorKey
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Organization_trustCenterFiles_argsOrderBy(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (*types.OrderBy[coredata.TrustCenterFileOrderField], error) {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("orderBy"))
+	if tmp, ok := rawArgs["orderBy"]; ok {
+		return ec.unmarshalOTrustCenterFileOrder2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐOrderBy(ctx, tmp)
+	}
+
+	var zeroVal *types.OrderBy[coredata.TrustCenterFileOrderField]
 	return zeroVal, nil
 }
 
@@ -22444,6 +22999,8 @@ func (ec *executionContext) fieldContext_Asset_organization(_ context.Context, f
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
+			case "trustCenterFiles":
+				return ec.fieldContext_Organization_trustCenterFiles(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "customDomain":
@@ -23055,6 +23612,8 @@ func (ec *executionContext) fieldContext_Audit_organization(_ context.Context, f
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
+			case "trustCenterFiles":
+				return ec.fieldContext_Organization_trustCenterFiles(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "customDomain":
@@ -24362,6 +24921,8 @@ func (ec *executionContext) fieldContext_ContinualImprovement_organization(_ con
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
+			case "trustCenterFiles":
+				return ec.fieldContext_Organization_trustCenterFiles(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "customDomain":
@@ -27737,6 +28298,56 @@ func (ec *executionContext) fieldContext_CreateTrustCenterAccessPayload_trustCen
 	return fc, nil
 }
 
+func (ec *executionContext) _CreateTrustCenterFilePayload_trustCenterFileEdge(ctx context.Context, field graphql.CollectedField, obj *types.CreateTrustCenterFilePayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CreateTrustCenterFilePayload_trustCenterFileEdge(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TrustCenterFileEdge, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.TrustCenterFileEdge)
+	fc.Result = res
+	return ec.marshalNTrustCenterFileEdge2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterFileEdge(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CreateTrustCenterFilePayload_trustCenterFileEdge(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CreateTrustCenterFilePayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "cursor":
+				return ec.fieldContext_TrustCenterFileEdge_cursor(ctx, field)
+			case "node":
+				return ec.fieldContext_TrustCenterFileEdge_node(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustCenterFileEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _CreateTrustCenterReferencePayload_trustCenterReferenceEdge(ctx context.Context, field graphql.CollectedField, obj *types.CreateTrustCenterReferencePayload) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_CreateTrustCenterReferencePayload_trustCenterReferenceEdge(ctx, field)
 	if err != nil {
@@ -28124,6 +28735,8 @@ func (ec *executionContext) fieldContext_CustomDomain_organization(_ context.Con
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
+			case "trustCenterFiles":
+				return ec.fieldContext_Organization_trustCenterFiles(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "customDomain":
@@ -29027,6 +29640,8 @@ func (ec *executionContext) fieldContext_Datum_organization(_ context.Context, f
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
+			case "trustCenterFiles":
+				return ec.fieldContext_Organization_trustCenterFiles(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "customDomain":
@@ -30519,6 +31134,8 @@ func (ec *executionContext) fieldContext_DeleteOrganizationHorizontalLogoPayload
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
+			case "trustCenterFiles":
+				return ec.fieldContext_Organization_trustCenterFiles(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "customDomain":
@@ -31096,6 +31713,50 @@ func (ec *executionContext) _DeleteTrustCenterAccessPayload_deletedTrustCenterAc
 func (ec *executionContext) fieldContext_DeleteTrustCenterAccessPayload_deletedTrustCenterAccessId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "DeleteTrustCenterAccessPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DeleteTrustCenterFilePayload_deletedTrustCenterFileId(ctx context.Context, field graphql.CollectedField, obj *types.DeleteTrustCenterFilePayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DeleteTrustCenterFilePayload_deletedTrustCenterFileId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DeletedTrustCenterFileID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(gid.GID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DeleteTrustCenterFilePayload_deletedTrustCenterFileId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DeleteTrustCenterFilePayload",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -31942,6 +32603,8 @@ func (ec *executionContext) fieldContext_Document_organization(_ context.Context
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
+			case "trustCenterFiles":
+				return ec.fieldContext_Organization_trustCenterFiles(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "customDomain":
@@ -35320,6 +35983,8 @@ func (ec *executionContext) fieldContext_Framework_organization(_ context.Contex
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
+			case "trustCenterFiles":
+				return ec.fieldContext_Organization_trustCenterFiles(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "customDomain":
@@ -35876,6 +36541,68 @@ func (ec *executionContext) fieldContext_GenerateFrameworkStateOfApplicabilityPa
 	return fc, nil
 }
 
+func (ec *executionContext) _GetTrustCenterFilePayload_trustCenterFile(ctx context.Context, field graphql.CollectedField, obj *types.GetTrustCenterFilePayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GetTrustCenterFilePayload_trustCenterFile(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TrustCenterFile, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.TrustCenterFile)
+	fc.Result = res
+	return ec.marshalNTrustCenterFile2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterFile(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GetTrustCenterFilePayload_trustCenterFile(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GetTrustCenterFilePayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TrustCenterFile_id(ctx, field)
+			case "name":
+				return ec.fieldContext_TrustCenterFile_name(ctx, field)
+			case "category":
+				return ec.fieldContext_TrustCenterFile_category(ctx, field)
+			case "fileUrl":
+				return ec.fieldContext_TrustCenterFile_fileUrl(ctx, field)
+			case "trustCenterVisibility":
+				return ec.fieldContext_TrustCenterFile_trustCenterVisibility(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_TrustCenterFile_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_TrustCenterFile_updatedAt(ctx, field)
+			case "organization":
+				return ec.fieldContext_TrustCenterFile_organization(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustCenterFile", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _ImportFrameworkPayload_frameworkEdge(ctx context.Context, field graphql.CollectedField, obj *types.ImportFrameworkPayload) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_ImportFrameworkPayload_frameworkEdge(ctx, field)
 	if err != nil {
@@ -36418,6 +37145,8 @@ func (ec *executionContext) fieldContext_Invitation_organization(_ context.Conte
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
+			case "trustCenterFiles":
+				return ec.fieldContext_Organization_trustCenterFiles(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "customDomain":
@@ -38926,6 +39655,242 @@ func (ec *executionContext) fieldContext_Mutation_deleteTrustCenterReference(ctx
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_deleteTrustCenterReference_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_createTrustCenterFile(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_createTrustCenterFile(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateTrustCenterFile(rctx, fc.Args["input"].(types.CreateTrustCenterFileInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.CreateTrustCenterFilePayload)
+	fc.Result = res
+	return ec.marshalNCreateTrustCenterFilePayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateTrustCenterFilePayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_createTrustCenterFile(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "trustCenterFileEdge":
+				return ec.fieldContext_CreateTrustCenterFilePayload_trustCenterFileEdge(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CreateTrustCenterFilePayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_createTrustCenterFile_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_updateTrustCenterFile(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_updateTrustCenterFile(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UpdateTrustCenterFile(rctx, fc.Args["input"].(types.UpdateTrustCenterFileInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.UpdateTrustCenterFilePayload)
+	fc.Result = res
+	return ec.marshalNUpdateTrustCenterFilePayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateTrustCenterFilePayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_updateTrustCenterFile(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "trustCenterFile":
+				return ec.fieldContext_UpdateTrustCenterFilePayload_trustCenterFile(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UpdateTrustCenterFilePayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_updateTrustCenterFile_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_getTrustCenterFile(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_getTrustCenterFile(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().GetTrustCenterFile(rctx, fc.Args["input"].(types.GetTrustCenterFileInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.GetTrustCenterFilePayload)
+	fc.Result = res
+	return ec.marshalNGetTrustCenterFilePayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐGetTrustCenterFilePayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_getTrustCenterFile(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "trustCenterFile":
+				return ec.fieldContext_GetTrustCenterFilePayload_trustCenterFile(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type GetTrustCenterFilePayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_getTrustCenterFile_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_deleteTrustCenterFile(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_deleteTrustCenterFile(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteTrustCenterFile(rctx, fc.Args["input"].(types.DeleteTrustCenterFileInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.DeleteTrustCenterFilePayload)
+	fc.Result = res
+	return ec.marshalNDeleteTrustCenterFilePayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteTrustCenterFilePayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_deleteTrustCenterFile(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "deletedTrustCenterFileId":
+				return ec.fieldContext_DeleteTrustCenterFilePayload_deletedTrustCenterFileId(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DeleteTrustCenterFilePayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_deleteTrustCenterFile_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -45457,6 +46422,8 @@ func (ec *executionContext) fieldContext_Nonconformity_organization(_ context.Co
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
+			case "trustCenterFiles":
+				return ec.fieldContext_Organization_trustCenterFiles(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "customDomain":
@@ -46522,6 +47489,8 @@ func (ec *executionContext) fieldContext_Obligation_organization(_ context.Conte
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
+			case "trustCenterFiles":
+				return ec.fieldContext_Organization_trustCenterFiles(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "customDomain":
@@ -48819,6 +49788,69 @@ func (ec *executionContext) fieldContext_Organization_snapshots(ctx context.Cont
 	return fc, nil
 }
 
+func (ec *executionContext) _Organization_trustCenterFiles(ctx context.Context, field graphql.CollectedField, obj *types.Organization) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Organization_trustCenterFiles(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Organization().TrustCenterFiles(rctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey), fc.Args["orderBy"].(*types.OrderBy[coredata.TrustCenterFileOrderField]))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.TrustCenterFileConnection)
+	fc.Result = res
+	return ec.marshalNTrustCenterFileConnection2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterFileConnection(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Organization_trustCenterFiles(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Organization",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "totalCount":
+				return ec.fieldContext_TrustCenterFileConnection_totalCount(ctx, field)
+			case "edges":
+				return ec.fieldContext_TrustCenterFileConnection_edges(ctx, field)
+			case "pageInfo":
+				return ec.fieldContext_TrustCenterFileConnection_pageInfo(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustCenterFileConnection", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Organization_trustCenterFiles_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Organization_trustCenter(ctx context.Context, field graphql.CollectedField, obj *types.Organization) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Organization_trustCenter(ctx, field)
 	if err != nil {
@@ -49268,6 +50300,8 @@ func (ec *executionContext) fieldContext_OrganizationEdge_node(_ context.Context
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
+			case "trustCenterFiles":
+				return ec.fieldContext_Organization_trustCenterFiles(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "customDomain":
@@ -50361,6 +51395,8 @@ func (ec *executionContext) fieldContext_ProcessingActivity_organization(_ conte
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
+			case "trustCenterFiles":
+				return ec.fieldContext_Organization_trustCenterFiles(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "customDomain":
@@ -53048,6 +54084,8 @@ func (ec *executionContext) fieldContext_Risk_organization(_ context.Context, fi
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
+			case "trustCenterFiles":
+				return ec.fieldContext_Organization_trustCenterFiles(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "customDomain":
@@ -54370,6 +55408,8 @@ func (ec *executionContext) fieldContext_Snapshot_organization(_ context.Context
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
+			case "trustCenterFiles":
+				return ec.fieldContext_Organization_trustCenterFiles(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "customDomain":
@@ -55287,6 +56327,8 @@ func (ec *executionContext) fieldContext_Task_organization(_ context.Context, fi
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
+			case "trustCenterFiles":
+				return ec.fieldContext_Organization_trustCenterFiles(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "customDomain":
@@ -56131,6 +57173,8 @@ func (ec *executionContext) fieldContext_TrustCenter_organization(_ context.Cont
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
+			case "trustCenterFiles":
+				return ec.fieldContext_Organization_trustCenterFiles(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "customDomain":
@@ -57323,6 +58367,65 @@ func (ec *executionContext) fieldContext_TrustCenterDocumentAccess_report(_ cont
 	return fc, nil
 }
 
+func (ec *executionContext) _TrustCenterDocumentAccess_trustCenterFile(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterDocumentAccess) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterDocumentAccess_trustCenterFile(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TrustCenterDocumentAccess().TrustCenterFile(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*types.TrustCenterFile)
+	fc.Result = res
+	return ec.marshalOTrustCenterFile2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterFile(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterDocumentAccess_trustCenterFile(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterDocumentAccess",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TrustCenterFile_id(ctx, field)
+			case "name":
+				return ec.fieldContext_TrustCenterFile_name(ctx, field)
+			case "category":
+				return ec.fieldContext_TrustCenterFile_category(ctx, field)
+			case "fileUrl":
+				return ec.fieldContext_TrustCenterFile_fileUrl(ctx, field)
+			case "trustCenterVisibility":
+				return ec.fieldContext_TrustCenterFile_trustCenterVisibility(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_TrustCenterFile_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_TrustCenterFile_updatedAt(ctx, field)
+			case "organization":
+				return ec.fieldContext_TrustCenterFile_organization(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustCenterFile", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _TrustCenterDocumentAccessConnection_totalCount(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterDocumentAccessConnection) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_TrustCenterDocumentAccessConnection_totalCount(ctx, field)
 	if err != nil {
@@ -57568,6 +58671,8 @@ func (ec *executionContext) fieldContext_TrustCenterDocumentAccessEdge_node(_ co
 				return ec.fieldContext_TrustCenterDocumentAccess_document(ctx, field)
 			case "report":
 				return ec.fieldContext_TrustCenterDocumentAccess_report(ctx, field)
+			case "trustCenterFile":
+				return ec.fieldContext_TrustCenterDocumentAccess_trustCenterFile(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TrustCenterDocumentAccess", field.Name)
 		},
@@ -57678,6 +58783,678 @@ func (ec *executionContext) fieldContext_TrustCenterEdge_node(_ context.Context,
 				return ec.fieldContext_TrustCenter_references(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TrustCenter", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterFile_id(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterFile) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterFile_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(gid.GID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterFile_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterFile",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterFile_name(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterFile) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterFile_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterFile_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterFile",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterFile_category(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterFile) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterFile_category(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Category, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterFile_category(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterFile",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterFile_fileUrl(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterFile) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterFile_fileUrl(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TrustCenterFile().FileURL(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterFile_fileUrl(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterFile",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterFile_trustCenterVisibility(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterFile) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterFile_trustCenterVisibility(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TrustCenterVisibility, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(coredata.TrustCenterVisibility)
+	fc.Result = res
+	return ec.marshalNTrustCenterVisibility2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐTrustCenterVisibility(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterFile_trustCenterVisibility(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterFile",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type TrustCenterVisibility does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterFile_createdAt(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterFile) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterFile_createdAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNDatetime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterFile_createdAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterFile",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterFile_updatedAt(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterFile) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterFile_updatedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNDatetime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterFile_updatedAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterFile",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterFile_organization(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterFile) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterFile_organization(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TrustCenterFile().Organization(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.Organization)
+	fc.Result = res
+	return ec.marshalNOrganization2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐOrganization(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterFile_organization(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterFile",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Organization_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Organization_name(ctx, field)
+			case "logoUrl":
+				return ec.fieldContext_Organization_logoUrl(ctx, field)
+			case "horizontalLogoUrl":
+				return ec.fieldContext_Organization_horizontalLogoUrl(ctx, field)
+			case "description":
+				return ec.fieldContext_Organization_description(ctx, field)
+			case "websiteUrl":
+				return ec.fieldContext_Organization_websiteUrl(ctx, field)
+			case "email":
+				return ec.fieldContext_Organization_email(ctx, field)
+			case "headquarterAddress":
+				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
+			case "memberships":
+				return ec.fieldContext_Organization_memberships(ctx, field)
+			case "invitations":
+				return ec.fieldContext_Organization_invitations(ctx, field)
+			case "slackConnections":
+				return ec.fieldContext_Organization_slackConnections(ctx, field)
+			case "frameworks":
+				return ec.fieldContext_Organization_frameworks(ctx, field)
+			case "controls":
+				return ec.fieldContext_Organization_controls(ctx, field)
+			case "vendors":
+				return ec.fieldContext_Organization_vendors(ctx, field)
+			case "peoples":
+				return ec.fieldContext_Organization_peoples(ctx, field)
+			case "documents":
+				return ec.fieldContext_Organization_documents(ctx, field)
+			case "measures":
+				return ec.fieldContext_Organization_measures(ctx, field)
+			case "risks":
+				return ec.fieldContext_Organization_risks(ctx, field)
+			case "tasks":
+				return ec.fieldContext_Organization_tasks(ctx, field)
+			case "assets":
+				return ec.fieldContext_Organization_assets(ctx, field)
+			case "data":
+				return ec.fieldContext_Organization_data(ctx, field)
+			case "audits":
+				return ec.fieldContext_Organization_audits(ctx, field)
+			case "nonconformities":
+				return ec.fieldContext_Organization_nonconformities(ctx, field)
+			case "obligations":
+				return ec.fieldContext_Organization_obligations(ctx, field)
+			case "continualImprovements":
+				return ec.fieldContext_Organization_continualImprovements(ctx, field)
+			case "processingActivities":
+				return ec.fieldContext_Organization_processingActivities(ctx, field)
+			case "snapshots":
+				return ec.fieldContext_Organization_snapshots(ctx, field)
+			case "trustCenterFiles":
+				return ec.fieldContext_Organization_trustCenterFiles(ctx, field)
+			case "trustCenter":
+				return ec.fieldContext_Organization_trustCenter(ctx, field)
+			case "customDomain":
+				return ec.fieldContext_Organization_customDomain(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Organization_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Organization_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Organization", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterFileConnection_totalCount(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterFileConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterFileConnection_totalCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TrustCenterFileConnection().TotalCount(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterFileConnection_totalCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterFileConnection",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterFileConnection_edges(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterFileConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterFileConnection_edges(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Edges, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*types.TrustCenterFileEdge)
+	fc.Result = res
+	return ec.marshalNTrustCenterFileEdge2ᚕᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterFileEdgeᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterFileConnection_edges(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterFileConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "cursor":
+				return ec.fieldContext_TrustCenterFileEdge_cursor(ctx, field)
+			case "node":
+				return ec.fieldContext_TrustCenterFileEdge_node(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustCenterFileEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterFileConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterFileConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterFileConnection_pageInfo(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PageInfo, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.PageInfo)
+	fc.Result = res
+	return ec.marshalNPageInfo2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐPageInfo(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterFileConnection_pageInfo(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterFileConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "hasNextPage":
+				return ec.fieldContext_PageInfo_hasNextPage(ctx, field)
+			case "hasPreviousPage":
+				return ec.fieldContext_PageInfo_hasPreviousPage(ctx, field)
+			case "startCursor":
+				return ec.fieldContext_PageInfo_startCursor(ctx, field)
+			case "endCursor":
+				return ec.fieldContext_PageInfo_endCursor(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterFileEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterFileEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterFileEdge_cursor(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Cursor, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(page.CursorKey)
+	fc.Result = res
+	return ec.marshalNCursorKey2githubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐCursorKey(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterFileEdge_cursor(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterFileEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type CursorKey does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenterFileEdge_node(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenterFileEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TrustCenterFileEdge_node(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Node, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.TrustCenterFile)
+	fc.Result = res
+	return ec.marshalNTrustCenterFile2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterFile(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TrustCenterFileEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenterFileEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TrustCenterFile_id(ctx, field)
+			case "name":
+				return ec.fieldContext_TrustCenterFile_name(ctx, field)
+			case "category":
+				return ec.fieldContext_TrustCenterFile_category(ctx, field)
+			case "fileUrl":
+				return ec.fieldContext_TrustCenterFile_fileUrl(ctx, field)
+			case "trustCenterVisibility":
+				return ec.fieldContext_TrustCenterFile_trustCenterVisibility(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_TrustCenterFile_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_TrustCenterFile_updatedAt(ctx, field)
+			case "organization":
+				return ec.fieldContext_TrustCenterFile_organization(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustCenterFile", field.Name)
 		},
 	}
 	return fc, nil
@@ -59178,6 +60955,8 @@ func (ec *executionContext) fieldContext_UpdateOrganizationPayload_organization(
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
+			case "trustCenterFiles":
+				return ec.fieldContext_Organization_trustCenterFiles(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "customDomain":
@@ -59562,6 +61341,68 @@ func (ec *executionContext) fieldContext_UpdateTrustCenterAccessPayload_trustCen
 				return ec.fieldContext_TrustCenterAccess_documentAccesses(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TrustCenterAccess", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UpdateTrustCenterFilePayload_trustCenterFile(ctx context.Context, field graphql.CollectedField, obj *types.UpdateTrustCenterFilePayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_UpdateTrustCenterFilePayload_trustCenterFile(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TrustCenterFile, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*types.TrustCenterFile)
+	fc.Result = res
+	return ec.marshalNTrustCenterFile2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterFile(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_UpdateTrustCenterFilePayload_trustCenterFile(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UpdateTrustCenterFilePayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TrustCenterFile_id(ctx, field)
+			case "name":
+				return ec.fieldContext_TrustCenterFile_name(ctx, field)
+			case "category":
+				return ec.fieldContext_TrustCenterFile_category(ctx, field)
+			case "fileUrl":
+				return ec.fieldContext_TrustCenterFile_fileUrl(ctx, field)
+			case "trustCenterVisibility":
+				return ec.fieldContext_TrustCenterFile_trustCenterVisibility(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_TrustCenterFile_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_TrustCenterFile_updatedAt(ctx, field)
+			case "organization":
+				return ec.fieldContext_TrustCenterFile_organization(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustCenterFile", field.Name)
 		},
 	}
 	return fc, nil
@@ -61186,6 +63027,8 @@ func (ec *executionContext) fieldContext_Vendor_organization(_ context.Context, 
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "snapshots":
 				return ec.fieldContext_Organization_snapshots(ctx, field)
+			case "trustCenterFiles":
+				return ec.fieldContext_Organization_trustCenterFiles(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_Organization_trustCenter(ctx, field)
 			case "customDomain":
@@ -70235,6 +72078,61 @@ func (ec *executionContext) unmarshalInputCreateTrustCenterAccessInput(ctx conte
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputCreateTrustCenterFileInput(ctx context.Context, obj any) (types.CreateTrustCenterFileInput, error) {
+	var it types.CreateTrustCenterFileInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"organizationId", "name", "category", "file", "trustCenterVisibility"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "organizationId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("organizationId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OrganizationID = data
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "category":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("category"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Category = data
+		case "file":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("file"))
+			data, err := ec.unmarshalNUpload2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚐUpload(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.File = data
+		case "trustCenterVisibility":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("trustCenterVisibility"))
+			data, err := ec.unmarshalNTrustCenterVisibility2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐTrustCenterVisibility(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.TrustCenterVisibility = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputCreateTrustCenterReferenceInput(ctx context.Context, obj any) (types.CreateTrustCenterReferenceInput, error) {
 	var it types.CreateTrustCenterReferenceInput
 	asMap := map[string]any{}
@@ -71535,6 +73433,33 @@ func (ec *executionContext) unmarshalInputDeleteTrustCenterAccessInput(ctx conte
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputDeleteTrustCenterFileInput(ctx context.Context, obj any) (types.DeleteTrustCenterFileInput, error) {
+	var it types.DeleteTrustCenterFileInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ID = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputDeleteTrustCenterNDAInput(ctx context.Context, obj any) (types.DeleteTrustCenterNDAInput, error) {
 	var it types.DeleteTrustCenterNDAInput
 	asMap := map[string]any{}
@@ -72173,6 +74098,33 @@ func (ec *executionContext) unmarshalInputGenerateFrameworkStateOfApplicabilityI
 				return it, err
 			}
 			it.FrameworkID = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputGetTrustCenterFileInput(ctx context.Context, obj any) (types.GetTrustCenterFileInput, error) {
+	var it types.GetTrustCenterFileInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ID = data
 		}
 	}
 
@@ -73107,6 +75059,40 @@ func (ec *executionContext) unmarshalInputTrustCenterDocumentAccessOrder(ctx con
 		case "field":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("field"))
 			data, err := ec.unmarshalNTrustCenterDocumentAccessOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐTrustCenterDocumentAccessOrderField(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Field = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputTrustCenterFileOrder(ctx context.Context, obj any) (types.OrderBy[coredata.TrustCenterFileOrderField], error) {
+	var it types.OrderBy[coredata.TrustCenterFileOrderField]
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"direction", "field"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "direction":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("direction"))
+			data, err := ec.unmarshalNOrderDirection2githubᚗcomᚋgetproboᚋproboᚋpkgᚋpageᚐOrderDirection(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Direction = data
+		case "field":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("field"))
+			data, err := ec.unmarshalNTrustCenterFileOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐTrustCenterFileOrderField(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -74338,7 +76324,7 @@ func (ec *executionContext) unmarshalInputUpdateTrustCenterAccessInput(ctx conte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "name", "active", "documentIds", "reportIds"}
+	fieldsInOrder := [...]string{"id", "name", "active", "documentIds", "reportIds", "trustCenterFileIds"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -74380,6 +76366,61 @@ func (ec *executionContext) unmarshalInputUpdateTrustCenterAccessInput(ctx conte
 				return it, err
 			}
 			it.ReportIds = data
+		case "trustCenterFileIds":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("trustCenterFileIds"))
+			data, err := ec.unmarshalOID2ᚕgithubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGIDᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.TrustCenterFileIds = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputUpdateTrustCenterFileInput(ctx context.Context, obj any) (types.UpdateTrustCenterFileInput, error) {
+	var it types.UpdateTrustCenterFileInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id", "name", "category", "trustCenterVisibility"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ID = data
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "category":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("category"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Category = data
+		case "trustCenterVisibility":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("trustCenterVisibility"))
+			data, err := ec.unmarshalOTrustCenterVisibility2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐTrustCenterVisibility(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.TrustCenterVisibility = data
 		}
 	}
 
@@ -75410,6 +77451,13 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._TrustCenterReference(ctx, sel, obj)
+	case types.TrustCenterFile:
+		return ec._TrustCenterFile(ctx, sel, &obj)
+	case *types.TrustCenterFile:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._TrustCenterFile(ctx, sel, obj)
 	case types.TrustCenterDocumentAccess:
 		return ec._TrustCenterDocumentAccess(ctx, sel, &obj)
 	case *types.TrustCenterDocumentAccess:
@@ -78392,6 +80440,45 @@ func (ec *executionContext) _CreateTrustCenterAccessPayload(ctx context.Context,
 	return out
 }
 
+var createTrustCenterFilePayloadImplementors = []string{"CreateTrustCenterFilePayload"}
+
+func (ec *executionContext) _CreateTrustCenterFilePayload(ctx context.Context, sel ast.SelectionSet, obj *types.CreateTrustCenterFilePayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, createTrustCenterFilePayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CreateTrustCenterFilePayload")
+		case "trustCenterFileEdge":
+			out.Values[i] = ec._CreateTrustCenterFilePayload_trustCenterFileEdge(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var createTrustCenterReferencePayloadImplementors = []string{"CreateTrustCenterReferencePayload"}
 
 func (ec *executionContext) _CreateTrustCenterReferencePayload(ctx context.Context, sel ast.SelectionSet, obj *types.CreateTrustCenterReferencePayload) graphql.Marshaler {
@@ -80189,6 +82276,45 @@ func (ec *executionContext) _DeleteTrustCenterAccessPayload(ctx context.Context,
 			out.Values[i] = graphql.MarshalString("DeleteTrustCenterAccessPayload")
 		case "deletedTrustCenterAccessId":
 			out.Values[i] = ec._DeleteTrustCenterAccessPayload_deletedTrustCenterAccessId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var deleteTrustCenterFilePayloadImplementors = []string{"DeleteTrustCenterFilePayload"}
+
+func (ec *executionContext) _DeleteTrustCenterFilePayload(ctx context.Context, sel ast.SelectionSet, obj *types.DeleteTrustCenterFilePayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, deleteTrustCenterFilePayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("DeleteTrustCenterFilePayload")
+		case "deletedTrustCenterFileId":
+			out.Values[i] = ec._DeleteTrustCenterFilePayload_deletedTrustCenterFileId(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -82216,6 +84342,45 @@ func (ec *executionContext) _GenerateFrameworkStateOfApplicabilityPayload(ctx co
 	return out
 }
 
+var getTrustCenterFilePayloadImplementors = []string{"GetTrustCenterFilePayload"}
+
+func (ec *executionContext) _GetTrustCenterFilePayload(ctx context.Context, sel ast.SelectionSet, obj *types.GetTrustCenterFilePayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, getTrustCenterFilePayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("GetTrustCenterFilePayload")
+		case "trustCenterFile":
+			out.Values[i] = ec._GetTrustCenterFilePayload_trustCenterFile(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var importFrameworkPayloadImplementors = []string{"ImportFrameworkPayload"}
 
 func (ec *executionContext) _ImportFrameworkPayload(ctx context.Context, sel ast.SelectionSet, obj *types.ImportFrameworkPayload) graphql.Marshaler {
@@ -83205,6 +85370,34 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "deleteTrustCenterReference":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_deleteTrustCenterReference(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "createTrustCenterFile":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_createTrustCenterFile(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "updateTrustCenterFile":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_updateTrustCenterFile(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "getTrustCenterFile":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_getTrustCenterFile(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "deleteTrustCenterFile":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_deleteTrustCenterFile(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
@@ -85310,6 +87503,42 @@ func (ec *executionContext) _Organization(ctx context.Context, sel ast.Selection
 					}
 				}()
 				res = ec._Organization_snapshots(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "trustCenterFiles":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Organization_trustCenterFiles(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -88237,6 +90466,39 @@ func (ec *executionContext) _TrustCenterDocumentAccess(ctx context.Context, sel 
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "trustCenterFile":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TrustCenterDocumentAccess_trustCenterFile(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -88402,6 +90664,266 @@ func (ec *executionContext) _TrustCenterEdge(ctx context.Context, sel ast.Select
 			}
 		case "node":
 			out.Values[i] = ec._TrustCenterEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var trustCenterFileImplementors = []string{"TrustCenterFile", "Node"}
+
+func (ec *executionContext) _TrustCenterFile(ctx context.Context, sel ast.SelectionSet, obj *types.TrustCenterFile) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, trustCenterFileImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TrustCenterFile")
+		case "id":
+			out.Values[i] = ec._TrustCenterFile_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "name":
+			out.Values[i] = ec._TrustCenterFile_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "category":
+			out.Values[i] = ec._TrustCenterFile_category(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "fileUrl":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TrustCenterFile_fileUrl(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "trustCenterVisibility":
+			out.Values[i] = ec._TrustCenterFile_trustCenterVisibility(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "createdAt":
+			out.Values[i] = ec._TrustCenterFile_createdAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "updatedAt":
+			out.Values[i] = ec._TrustCenterFile_updatedAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "organization":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TrustCenterFile_organization(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var trustCenterFileConnectionImplementors = []string{"TrustCenterFileConnection"}
+
+func (ec *executionContext) _TrustCenterFileConnection(ctx context.Context, sel ast.SelectionSet, obj *types.TrustCenterFileConnection) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, trustCenterFileConnectionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TrustCenterFileConnection")
+		case "totalCount":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TrustCenterFileConnection_totalCount(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "edges":
+			out.Values[i] = ec._TrustCenterFileConnection_edges(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "pageInfo":
+			out.Values[i] = ec._TrustCenterFileConnection_pageInfo(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var trustCenterFileEdgeImplementors = []string{"TrustCenterFileEdge"}
+
+func (ec *executionContext) _TrustCenterFileEdge(ctx context.Context, sel ast.SelectionSet, obj *types.TrustCenterFileEdge) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, trustCenterFileEdgeImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TrustCenterFileEdge")
+		case "cursor":
+			out.Values[i] = ec._TrustCenterFileEdge_cursor(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "node":
+			out.Values[i] = ec._TrustCenterFileEdge_node(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -89328,6 +91850,45 @@ func (ec *executionContext) _UpdateTrustCenterAccessPayload(ctx context.Context,
 			out.Values[i] = graphql.MarshalString("UpdateTrustCenterAccessPayload")
 		case "trustCenterAccess":
 			out.Values[i] = ec._UpdateTrustCenterAccessPayload_trustCenterAccess(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var updateTrustCenterFilePayloadImplementors = []string{"UpdateTrustCenterFilePayload"}
+
+func (ec *executionContext) _UpdateTrustCenterFilePayload(ctx context.Context, sel ast.SelectionSet, obj *types.UpdateTrustCenterFilePayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, updateTrustCenterFilePayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("UpdateTrustCenterFilePayload")
+		case "trustCenterFile":
+			out.Values[i] = ec._UpdateTrustCenterFilePayload_trustCenterFile(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -94475,6 +97036,25 @@ func (ec *executionContext) marshalNCreateTrustCenterAccessPayload2ᚖgithubᚗc
 	return ec._CreateTrustCenterAccessPayload(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNCreateTrustCenterFileInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateTrustCenterFileInput(ctx context.Context, v any) (types.CreateTrustCenterFileInput, error) {
+	res, err := ec.unmarshalInputCreateTrustCenterFileInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNCreateTrustCenterFilePayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateTrustCenterFilePayload(ctx context.Context, sel ast.SelectionSet, v types.CreateTrustCenterFilePayload) graphql.Marshaler {
+	return ec._CreateTrustCenterFilePayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNCreateTrustCenterFilePayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateTrustCenterFilePayload(ctx context.Context, sel ast.SelectionSet, v *types.CreateTrustCenterFilePayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._CreateTrustCenterFilePayload(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNCreateTrustCenterReferenceInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateTrustCenterReferenceInput(ctx context.Context, v any) (types.CreateTrustCenterReferenceInput, error) {
 	res, err := ec.unmarshalInputCreateTrustCenterReferenceInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -95410,6 +97990,25 @@ func (ec *executionContext) marshalNDeleteTrustCenterAccessPayload2ᚖgithubᚗc
 	return ec._DeleteTrustCenterAccessPayload(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNDeleteTrustCenterFileInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteTrustCenterFileInput(ctx context.Context, v any) (types.DeleteTrustCenterFileInput, error) {
+	res, err := ec.unmarshalInputDeleteTrustCenterFileInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNDeleteTrustCenterFilePayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteTrustCenterFilePayload(ctx context.Context, sel ast.SelectionSet, v types.DeleteTrustCenterFilePayload) graphql.Marshaler {
+	return ec._DeleteTrustCenterFilePayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNDeleteTrustCenterFilePayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteTrustCenterFilePayload(ctx context.Context, sel ast.SelectionSet, v *types.DeleteTrustCenterFilePayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._DeleteTrustCenterFilePayload(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNDeleteTrustCenterNDAInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteTrustCenterNDAInput(ctx context.Context, v any) (types.DeleteTrustCenterNDAInput, error) {
 	res, err := ec.unmarshalInputDeleteTrustCenterNDAInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -96343,6 +98942,25 @@ func (ec *executionContext) marshalNGenerateFrameworkStateOfApplicabilityPayload
 		return graphql.Null
 	}
 	return ec._GenerateFrameworkStateOfApplicabilityPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNGetTrustCenterFileInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐGetTrustCenterFileInput(ctx context.Context, v any) (types.GetTrustCenterFileInput, error) {
+	res, err := ec.unmarshalInputGetTrustCenterFileInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNGetTrustCenterFilePayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐGetTrustCenterFilePayload(ctx context.Context, sel ast.SelectionSet, v types.GetTrustCenterFilePayload) graphql.Marshaler {
+	return ec._GetTrustCenterFilePayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNGetTrustCenterFilePayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐGetTrustCenterFilePayload(ctx context.Context, sel ast.SelectionSet, v *types.GetTrustCenterFilePayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._GetTrustCenterFilePayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx context.Context, v any) (gid.GID, error) {
@@ -98609,6 +101227,114 @@ func (ec *executionContext) marshalNTrustCenterEdge2ᚖgithubᚗcomᚋgetprobo�
 	return ec._TrustCenterEdge(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNTrustCenterFile2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterFile(ctx context.Context, sel ast.SelectionSet, v *types.TrustCenterFile) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TrustCenterFile(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNTrustCenterFileConnection2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterFileConnection(ctx context.Context, sel ast.SelectionSet, v types.TrustCenterFileConnection) graphql.Marshaler {
+	return ec._TrustCenterFileConnection(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNTrustCenterFileConnection2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterFileConnection(ctx context.Context, sel ast.SelectionSet, v *types.TrustCenterFileConnection) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TrustCenterFileConnection(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNTrustCenterFileEdge2ᚕᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterFileEdgeᚄ(ctx context.Context, sel ast.SelectionSet, v []*types.TrustCenterFileEdge) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNTrustCenterFileEdge2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterFileEdge(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNTrustCenterFileEdge2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterFileEdge(ctx context.Context, sel ast.SelectionSet, v *types.TrustCenterFileEdge) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TrustCenterFileEdge(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNTrustCenterFileOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐTrustCenterFileOrderField(ctx context.Context, v any) (coredata.TrustCenterFileOrderField, error) {
+	tmp, err := graphql.UnmarshalString(v)
+	res := unmarshalNTrustCenterFileOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐTrustCenterFileOrderField[tmp]
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNTrustCenterFileOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐTrustCenterFileOrderField(ctx context.Context, sel ast.SelectionSet, v coredata.TrustCenterFileOrderField) graphql.Marshaler {
+	_ = sel
+	res := graphql.MarshalString(marshalNTrustCenterFileOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐTrustCenterFileOrderField[v])
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+var (
+	unmarshalNTrustCenterFileOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐTrustCenterFileOrderField = map[string]coredata.TrustCenterFileOrderField{
+		"NAME":       coredata.TrustCenterFileOrderFieldName,
+		"CREATED_AT": coredata.TrustCenterFileOrderFieldCreatedAt,
+		"UPDATED_AT": coredata.TrustCenterFileOrderFieldUpdatedAt,
+	}
+	marshalNTrustCenterFileOrderField2githubᚗcomᚋgetproboᚋproboᚋpkgᚋcoredataᚐTrustCenterFileOrderField = map[coredata.TrustCenterFileOrderField]string{
+		coredata.TrustCenterFileOrderFieldName:      "NAME",
+		coredata.TrustCenterFileOrderFieldCreatedAt: "CREATED_AT",
+		coredata.TrustCenterFileOrderFieldUpdatedAt: "UPDATED_AT",
+	}
+)
+
 func (ec *executionContext) marshalNTrustCenterReference2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterReference(ctx context.Context, sel ast.SelectionSet, v *types.TrustCenterReference) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -99087,6 +101813,25 @@ func (ec *executionContext) marshalNUpdateTrustCenterAccessPayload2ᚖgithubᚗc
 		return graphql.Null
 	}
 	return ec._UpdateTrustCenterAccessPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNUpdateTrustCenterFileInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateTrustCenterFileInput(ctx context.Context, v any) (types.UpdateTrustCenterFileInput, error) {
+	res, err := ec.unmarshalInputUpdateTrustCenterFileInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNUpdateTrustCenterFilePayload2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateTrustCenterFilePayload(ctx context.Context, sel ast.SelectionSet, v types.UpdateTrustCenterFilePayload) graphql.Marshaler {
+	return ec._UpdateTrustCenterFilePayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNUpdateTrustCenterFilePayload2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateTrustCenterFilePayload(ctx context.Context, sel ast.SelectionSet, v *types.UpdateTrustCenterFilePayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._UpdateTrustCenterFilePayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNUpdateTrustCenterInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateTrustCenterInput(ctx context.Context, v any) (types.UpdateTrustCenterInput, error) {
@@ -102279,6 +105024,21 @@ func (ec *executionContext) unmarshalOTrustCenterDocumentAccessOrder2ᚖgithub�
 		return nil, nil
 	}
 	res, err := ec.unmarshalInputTrustCenterDocumentAccessOrder(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOTrustCenterFile2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐTrustCenterFile(ctx context.Context, sel ast.SelectionSet, v *types.TrustCenterFile) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._TrustCenterFile(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOTrustCenterFileOrder2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐOrderBy(ctx context.Context, v any) (*types.OrderBy[coredata.TrustCenterFileOrderField], error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputTrustCenterFileOrder(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/pkg/server/api/console/v1/types/trust_center_file.go
+++ b/pkg/server/api/console/v1/types/trust_center_file.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package types
+
+import (
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+)
+
+type TrustCenterFileOrderBy = OrderBy[coredata.TrustCenterFileOrderField]
+
+type TrustCenterFileConnection struct {
+	TotalCount int                    `json:"totalCount"`
+	Edges      []*TrustCenterFileEdge `json:"edges"`
+	PageInfo   *PageInfo              `json:"pageInfo"`
+	ParentID   gid.GID                `json:"-"`
+}
+
+func NewTrustCenterFile(tcf *coredata.TrustCenterFile) *TrustCenterFile {
+	return &TrustCenterFile{
+		ID:                    tcf.ID,
+		Name:                  tcf.Name,
+		Category:              tcf.Category,
+		TrustCenterVisibility: tcf.TrustCenterVisibility,
+		CreatedAt:             tcf.CreatedAt,
+		UpdatedAt:             tcf.UpdatedAt,
+	}
+}
+
+func NewTrustCenterFileConnection(
+	p *page.Page[*coredata.TrustCenterFile, coredata.TrustCenterFileOrderField],
+	parentID gid.GID,
+) *TrustCenterFileConnection {
+	var edges = make([]*TrustCenterFileEdge, len(p.Data))
+
+	for i := range edges {
+		edges[i] = NewTrustCenterFileEdge(p.Data[i], p.Cursor.OrderBy.Field)
+	}
+
+	return &TrustCenterFileConnection{
+		Edges:    edges,
+		PageInfo: NewPageInfo(p),
+		ParentID: parentID,
+	}
+}
+
+func NewTrustCenterFileEdge(tcf *coredata.TrustCenterFile, orderBy coredata.TrustCenterFileOrderField) *TrustCenterFileEdge {
+	return &TrustCenterFileEdge{
+		Cursor: tcf.CursorKey(orderBy),
+		Node:   NewTrustCenterFile(tcf),
+	}
+}

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -541,6 +541,18 @@ type CreateTrustCenterAccessPayload struct {
 	TrustCenterAccessEdge *TrustCenterAccessEdge `json:"trustCenterAccessEdge"`
 }
 
+type CreateTrustCenterFileInput struct {
+	OrganizationID        gid.GID                        `json:"organizationId"`
+	Name                  string                         `json:"name"`
+	Category              string                         `json:"category"`
+	File                  graphql.Upload                 `json:"file"`
+	TrustCenterVisibility coredata.TrustCenterVisibility `json:"trustCenterVisibility"`
+}
+
+type CreateTrustCenterFilePayload struct {
+	TrustCenterFileEdge *TrustCenterFileEdge `json:"trustCenterFileEdge"`
+}
+
 type CreateTrustCenterReferenceInput struct {
 	TrustCenterID gid.GID        `json:"trustCenterId"`
 	Name          string         `json:"name"`
@@ -916,6 +928,14 @@ type DeleteTrustCenterAccessPayload struct {
 	DeletedTrustCenterAccessID gid.GID `json:"deletedTrustCenterAccessId"`
 }
 
+type DeleteTrustCenterFileInput struct {
+	ID gid.GID `json:"id"`
+}
+
+type DeleteTrustCenterFilePayload struct {
+	DeletedTrustCenterFileID gid.GID `json:"deletedTrustCenterFileId"`
+}
+
 type DeleteTrustCenterNDAInput struct {
 	TrustCenterID gid.GID `json:"trustCenterId"`
 }
@@ -1170,6 +1190,14 @@ type GenerateFrameworkStateOfApplicabilityPayload struct {
 	Data string `json:"data"`
 }
 
+type GetTrustCenterFileInput struct {
+	ID gid.GID `json:"id"`
+}
+
+type GetTrustCenterFilePayload struct {
+	TrustCenterFile *TrustCenterFile `json:"trustCenterFile"`
+}
+
 type ImportFrameworkInput struct {
 	OrganizationID gid.GID        `json:"organizationId"`
 	File           graphql.Upload `json:"file"`
@@ -1365,6 +1393,7 @@ type Organization struct {
 	ContinualImprovements *ContinualImprovementConnection `json:"continualImprovements"`
 	ProcessingActivities  *ProcessingActivityConnection   `json:"processingActivities"`
 	Snapshots             *SnapshotConnection             `json:"snapshots"`
+	TrustCenterFiles      *TrustCenterFileConnection      `json:"trustCenterFiles"`
 	TrustCenter           *TrustCenter                    `json:"trustCenter,omitempty"`
 	CustomDomain          *CustomDomain                   `json:"customDomain,omitempty"`
 	CreatedAt             time.Time                       `json:"createdAt"`
@@ -1675,6 +1704,7 @@ type TrustCenterDocumentAccess struct {
 	TrustCenterAccess *TrustCenterAccess `json:"trustCenterAccess"`
 	Document          *Document          `json:"document,omitempty"`
 	Report            *Report            `json:"report,omitempty"`
+	TrustCenterFile   *TrustCenterFile   `json:"trustCenterFile,omitempty"`
 }
 
 func (TrustCenterDocumentAccess) IsNode()             {}
@@ -1688,6 +1718,25 @@ type TrustCenterDocumentAccessEdge struct {
 type TrustCenterEdge struct {
 	Cursor page.CursorKey `json:"cursor"`
 	Node   *TrustCenter   `json:"node"`
+}
+
+type TrustCenterFile struct {
+	ID                    gid.GID                        `json:"id"`
+	Name                  string                         `json:"name"`
+	Category              string                         `json:"category"`
+	FileURL               string                         `json:"fileUrl"`
+	TrustCenterVisibility coredata.TrustCenterVisibility `json:"trustCenterVisibility"`
+	CreatedAt             time.Time                      `json:"createdAt"`
+	UpdatedAt             time.Time                      `json:"updatedAt"`
+	Organization          *Organization                  `json:"organization"`
+}
+
+func (TrustCenterFile) IsNode()             {}
+func (this TrustCenterFile) GetID() gid.GID { return this.ID }
+
+type TrustCenterFileEdge struct {
+	Cursor page.CursorKey   `json:"cursor"`
+	Node   *TrustCenterFile `json:"node"`
 }
 
 type TrustCenterReference struct {
@@ -1948,15 +1997,27 @@ type UpdateTaskPayload struct {
 }
 
 type UpdateTrustCenterAccessInput struct {
-	ID          gid.GID   `json:"id"`
-	Name        *string   `json:"name,omitempty"`
-	Active      *bool     `json:"active,omitempty"`
-	DocumentIds []gid.GID `json:"documentIds,omitempty"`
-	ReportIds   []gid.GID `json:"reportIds,omitempty"`
+	ID                 gid.GID   `json:"id"`
+	Name               *string   `json:"name,omitempty"`
+	Active             *bool     `json:"active,omitempty"`
+	DocumentIds        []gid.GID `json:"documentIds,omitempty"`
+	ReportIds          []gid.GID `json:"reportIds,omitempty"`
+	TrustCenterFileIds []gid.GID `json:"trustCenterFileIds,omitempty"`
 }
 
 type UpdateTrustCenterAccessPayload struct {
 	TrustCenterAccess *TrustCenterAccess `json:"trustCenterAccess"`
+}
+
+type UpdateTrustCenterFileInput struct {
+	ID                    gid.GID                         `json:"id"`
+	Name                  *string                         `json:"name,omitempty"`
+	Category              *string                         `json:"category,omitempty"`
+	TrustCenterVisibility *coredata.TrustCenterVisibility `json:"trustCenterVisibility,omitempty"`
+}
+
+type UpdateTrustCenterFilePayload struct {
+	TrustCenterFile *TrustCenterFile `json:"trustCenterFile"`
 }
 
 type UpdateTrustCenterInput struct {

--- a/pkg/server/api/trust/v1/schema.graphql
+++ b/pkg/server/api/trust/v1/schema.graphql
@@ -476,6 +476,24 @@ type TrustCenterReferenceEdge {
   node: TrustCenterReference!
 }
 
+type TrustCenterFile implements Node {
+  id: ID!
+  name: String!
+  category: String!
+  isUserAuthorized: Boolean! @goField(forceResolver: true)
+  hasUserRequestedAccess: Boolean! @goField(forceResolver: true)
+}
+
+type TrustCenterFileConnection {
+  edges: [TrustCenterFileEdge!]!
+  pageInfo: PageInfo!
+}
+
+type TrustCenterFileEdge {
+  cursor: CursorKey!
+  node: TrustCenterFile!
+}
+
 type TrustCenter implements Node {
   id: ID!
   active: Boolean!
@@ -513,6 +531,13 @@ type TrustCenter implements Node {
     last: Int
     before: CursorKey
   ): TrustCenterReferenceConnection! @goField(forceResolver: true)
+
+  trustCenterFiles(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+  ): TrustCenterFileConnection! @goField(forceResolver: true)
 }
 
 type TrustCenterAccess implements Node {
@@ -559,11 +584,26 @@ input RequestReportAccessInput {
   name: String
 }
 
+input RequestTrustCenterFileAccessInput {
+  trustCenterId: ID!
+  trustCenterFileId: ID!
+  email: String
+  name: String
+}
+
+input ExportTrustCenterFileInput {
+  trustCenterFileId: ID!
+}
+
 type ExportDocumentPDFPayload {
   data: String!
 }
 
 type ExportReportPDFPayload {
+  data: String!
+}
+
+type ExportTrustCenterFilePayload {
   data: String!
 }
 
@@ -598,4 +638,12 @@ type Mutation {
   requestReportAccess(
     input: RequestReportAccessInput!
   ): RequestAccessesPayload! @mustBeAuthenticated(role: NONE)
+
+  requestTrustCenterFileAccess(
+    input: RequestTrustCenterFileAccessInput!
+  ): RequestAccessesPayload! @mustBeAuthenticated(role: NONE)
+
+  exportTrustCenterFile(
+    input: ExportTrustCenterFileInput!
+  ): ExportTrustCenterFilePayload! @mustBeAuthenticated(role: NONE)
 }

--- a/pkg/server/api/trust/v1/types/trust_center_file.go
+++ b/pkg/server/api/trust/v1/types/trust_center_file.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package types
+
+import (
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/page"
+)
+
+func NewTrustCenterFileConnection(
+	p *page.Page[*coredata.TrustCenterFile, coredata.TrustCenterFileOrderField],
+) *TrustCenterFileConnection {
+	edges := make([]*TrustCenterFileEdge, len(p.Data))
+	for i, trustCenterFile := range p.Data {
+		edges[i] = NewTrustCenterFileEdge(trustCenterFile, p.Cursor.OrderBy.Field)
+	}
+
+	return &TrustCenterFileConnection{
+		Edges:    edges,
+		PageInfo: NewPageInfo(p),
+	}
+}
+
+func NewTrustCenterFile(f *coredata.TrustCenterFile) *TrustCenterFile {
+	return &TrustCenterFile{
+		ID:       f.ID,
+		Name:     f.Name,
+		Category: f.Category,
+	}
+}
+
+func NewTrustCenterFileEdge(f *coredata.TrustCenterFile, orderField coredata.TrustCenterFileOrderField) *TrustCenterFileEdge {
+	return &TrustCenterFileEdge{
+		Node:   NewTrustCenterFile(f),
+		Cursor: f.CursorKey(orderField),
+	}
+}

--- a/pkg/server/api/trust/v1/types/types.go
+++ b/pkg/server/api/trust/v1/types/types.go
@@ -83,6 +83,14 @@ type ExportReportPDFPayload struct {
 	Data string `json:"data"`
 }
 
+type ExportTrustCenterFileInput struct {
+	TrustCenterFileID gid.GID `json:"trustCenterFileId"`
+}
+
+type ExportTrustCenterFilePayload struct {
+	Data string `json:"data"`
+}
+
 type Framework struct {
 	ID   gid.GID `json:"id"`
 	Name string  `json:"name"`
@@ -151,6 +159,13 @@ type RequestReportAccessInput struct {
 	Name          *string `json:"name,omitempty"`
 }
 
+type RequestTrustCenterFileAccessInput struct {
+	TrustCenterID     gid.GID `json:"trustCenterId"`
+	TrustCenterFileID gid.GID `json:"trustCenterFileId"`
+	Email             *string `json:"email,omitempty"`
+	Name              *string `json:"name,omitempty"`
+}
+
 type TrustCenter struct {
 	ID                                gid.GID                         `json:"id"`
 	Active                            bool                            `json:"active"`
@@ -164,6 +179,7 @@ type TrustCenter struct {
 	Audits                            *AuditConnection                `json:"audits"`
 	Vendors                           *VendorConnection               `json:"vendors"`
 	References                        *TrustCenterReferenceConnection `json:"references"`
+	TrustCenterFiles                  *TrustCenterFileConnection      `json:"trustCenterFiles"`
 }
 
 func (TrustCenter) IsNode()             {}
@@ -179,6 +195,27 @@ type TrustCenterAccess struct {
 
 func (TrustCenterAccess) IsNode()             {}
 func (this TrustCenterAccess) GetID() gid.GID { return this.ID }
+
+type TrustCenterFile struct {
+	ID                     gid.GID `json:"id"`
+	Name                   string  `json:"name"`
+	Category               string  `json:"category"`
+	IsUserAuthorized       bool    `json:"isUserAuthorized"`
+	HasUserRequestedAccess bool    `json:"hasUserRequestedAccess"`
+}
+
+func (TrustCenterFile) IsNode()             {}
+func (this TrustCenterFile) GetID() gid.GID { return this.ID }
+
+type TrustCenterFileConnection struct {
+	Edges    []*TrustCenterFileEdge `json:"edges"`
+	PageInfo *PageInfo              `json:"pageInfo"`
+}
+
+type TrustCenterFileEdge struct {
+	Cursor page.CursorKey   `json:"cursor"`
+	Node   *TrustCenterFile `json:"node"`
+}
 
 type TrustCenterReference struct {
 	ID          gid.GID `json:"id"`

--- a/pkg/trust/service.go
+++ b/pkg/trust/service.go
@@ -74,6 +74,7 @@ type (
 		Frameworks            *FrameworkService
 		TrustCenterAccesses   *TrustCenterAccessService
 		TrustCenterReferences *TrustCenterReferenceService
+		TrustCenterFiles      *TrustCenterFileService
 		Reports               *ReportService
 		Organizations         *OrganizationService
 		SlackMessages         *SlackMessageService
@@ -136,6 +137,7 @@ func (s *Service) WithTenant(tenantID gid.TenantID) *TenantService {
 	tenantService.Frameworks = &FrameworkService{svc: tenantService}
 	tenantService.TrustCenterAccesses = &TrustCenterAccessService{svc: tenantService, auth: s.auth, logger: s.logger}
 	tenantService.TrustCenterReferences = &TrustCenterReferenceService{svc: tenantService}
+	tenantService.TrustCenterFiles = &TrustCenterFileService{svc: tenantService}
 	tenantService.Reports = &ReportService{svc: tenantService}
 	tenantService.Organizations = &OrganizationService{svc: tenantService}
 	tenantService.SlackMessages = &SlackMessageService{svc: tenantService, slackClient: slackClient}

--- a/pkg/trust/templates/access-request.json.tmpl
+++ b/pkg/trust/templates/access-request.json.tmpl
@@ -107,6 +107,40 @@
         "value": "{{.ID}}",
         "style": "primary"
       }{{end}}
+    }{{end}}{{end}}{{if .Files}},
+    {
+      "type": "divider"
+    },
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "*📎 Requested Files*"
+      }
+    }{{range .Files}},
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "<https://{{$.Domain}}/organizations/{{$.OrganizationID}}/trust-center/files|{{jsonEscape .Name}}>{{if .Category}} ({{jsonEscape .Category}}){{end}}"
+      },
+      "accessory": {{if .Granted}}{
+        "type": "button",
+        "text": {
+          "type": "plain_text",
+          "text": "✓ Granted"
+        },
+        "url": "https://{{$.Domain}}/organizations/{{$.OrganizationID}}/trust-center/access"
+      }{{else}}{
+        "type": "button",
+        "text": {
+          "type": "plain_text",
+          "text": "Accept"
+        },
+        "action_id": "accept_file",
+        "value": "{{.ID}}",
+        "style": "primary"
+      }{{end}}
     }{{end}}{{end}},
     {
       "type": "context",

--- a/pkg/trust/trust_center_file_service.go
+++ b/pkg/trust/trust_center_file_service.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package trust
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/getprobo/probo/pkg/coredata"
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/getprobo/probo/pkg/page"
+	"github.com/getprobo/probo/pkg/watermarkpdf"
+	"go.gearno.de/kit/pg"
+)
+
+type TrustCenterFileService struct {
+	svc *TenantService
+}
+
+func (s *TrustCenterFileService) Get(
+	ctx context.Context,
+	trustCenterFileID gid.GID,
+) (*coredata.TrustCenterFile, error) {
+	trustCenterFile := &coredata.TrustCenterFile{}
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			err := trustCenterFile.LoadByID(ctx, conn, s.svc.scope, trustCenterFileID)
+			if err != nil {
+				return fmt.Errorf("cannot load trust center file: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return trustCenterFile, nil
+}
+
+func (s *TrustCenterFileService) ListForOrganizationId(
+	ctx context.Context,
+	organizationID gid.GID,
+	cursor *page.Cursor[coredata.TrustCenterFileOrderField],
+) (*page.Page[*coredata.TrustCenterFile, coredata.TrustCenterFileOrderField], error) {
+	var trustCenterFiles coredata.TrustCenterFiles
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			err := trustCenterFiles.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID, cursor)
+			if err != nil {
+				return fmt.Errorf("cannot load trust center files: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return page.NewPage(trustCenterFiles, cursor), nil
+}
+
+func (s *TrustCenterFileService) ExportFile(
+	ctx context.Context,
+	trustCenterFileID gid.GID,
+	email string,
+) ([]byte, error) {
+	pdfData, err := s.exportFileData(ctx, trustCenterFileID)
+	if err != nil {
+		return nil, fmt.Errorf("cannot export trust center file: %w", err)
+	}
+
+	watermarkedPDF, err := watermarkpdf.AddConfidentialWithTimestamp(pdfData, email)
+	if err != nil {
+		return nil, fmt.Errorf("cannot add watermark to PDF: %w", err)
+	}
+
+	return watermarkedPDF, nil
+}
+
+func (s *TrustCenterFileService) ExportFileWithoutWatermark(
+	ctx context.Context,
+	trustCenterFileID gid.GID,
+) ([]byte, error) {
+	return s.exportFileData(ctx, trustCenterFileID)
+}
+
+func (s *TrustCenterFileService) exportFileData(
+	ctx context.Context,
+	trustCenterFileID gid.GID,
+) ([]byte, error) {
+	var trustCenterFile *coredata.TrustCenterFile
+	var file *coredata.File
+
+	err := s.svc.pg.WithConn(ctx, func(conn pg.Conn) error {
+		trustCenterFile = &coredata.TrustCenterFile{}
+		if err := trustCenterFile.LoadByID(ctx, conn, s.svc.scope, trustCenterFileID); err != nil {
+			return fmt.Errorf("cannot load trust center file: %w", err)
+		}
+
+		file = &coredata.File{}
+		if err := file.LoadByID(ctx, conn, s.svc.scope, trustCenterFile.FileID); err != nil {
+			return fmt.Errorf("cannot load file: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := s.svc.s3.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.svc.bucket),
+		Key:    aws.String(file.FileKey),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot download file from S3: %w", err)
+	}
+	defer result.Body.Close()
+
+	fileData, err := io.ReadAll(result.Body)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read file data: %w", err)
+	}
+
+	return fileData, nil
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Trust Center Files so organizations can upload and manage files with visibility controls, and visitors can view, request access, and download authorized files.

- **New Features**
  - Console: New “Files” tab to upload, edit, and delete Trust Center files (name, category, visibility).
  - Console: Access tab now supports granting access to files in addition to documents and reports.
  - Trust site: Files appear in Documents and Overview pages, grouped by category, with download or request access actions.
  - Trust site: New mutations to request file access and export/download files.
  - Slack: Access request messages include requested files and support one-click acceptance.
  - Backend: New DB table for trust_center_files, file CRUD services with validation (max 10MB, mime-types), and GraphQL types/fields for files and access updates.

- **Migration**
  - Run migration 20251023 to create trust_center_files and update access checks.
  - Ensure file storage settings (e.g., S3) are configured; no manual data changes required.

<!-- End of auto-generated description by cubic. -->

