### PR TITLE
Generate relay code

### DIFF
--- a/apps/console/src/components/organizations/__generated__/InviteUserDialogMutation.graphql.ts
+++ b/apps/console/src/components/organizations/__generated__/InviteUserDialogMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8efbb638045cb24913b04b4de2033357>>
+ * @generated SignedSource<<617ea2708c8402c706671dc1a63b1316>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,6 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
+export type Role = "ADMIN" | "MEMBER" | "OWNER" | "VIEWER";
 export type InviteUserInput = {
   createPeople: boolean;
   email: string;
@@ -29,7 +30,7 @@ export type InviteUserDialogMutation$data = {
         readonly expiresAt: any;
         readonly fullName: string;
         readonly id: string;
-        readonly role: string;
+        readonly role: Role;
       };
     };
   };

--- a/apps/console/src/pages/organizations/settings/__generated__/MembersSettingsTabInvitationsFragment.graphql.ts
+++ b/apps/console/src/pages/organizations/settings/__generated__/MembersSettingsTabInvitationsFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1077fac0cf9631664adf53347f21a5b0>>
+ * @generated SignedSource<<8df0455e495843c9db156c36f38c97d6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,6 +10,7 @@
 
 import { ReaderFragment } from 'relay-runtime';
 export type InvitationStatus = "ACCEPTED" | "EXPIRED" | "PENDING";
+export type Role = "ADMIN" | "MEMBER" | "OWNER" | "VIEWER";
 import { FragmentRefs } from "relay-runtime";
 export type MembersSettingsTabInvitationsFragment$data = {
   readonly id: string;
@@ -23,7 +24,7 @@ export type MembersSettingsTabInvitationsFragment$data = {
         readonly expiresAt: any;
         readonly fullName: string;
         readonly id: string;
-        readonly role: string;
+        readonly role: Role;
         readonly status: InvitationStatus;
       };
     }>;

--- a/apps/console/src/pages/organizations/settings/__generated__/MembersSettingsTabMembershipsFragment.graphql.ts
+++ b/apps/console/src/pages/organizations/settings/__generated__/MembersSettingsTabMembershipsFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f4c0ddd2099746a005858cecc39d2a23>>
+ * @generated SignedSource<<ff12447635b4a42587b7d7de6ea1b4e1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,6 +9,7 @@
 // @ts-nocheck
 
 import { ReaderFragment } from 'relay-runtime';
+export type Role = "ADMIN" | "MEMBER" | "OWNER" | "VIEWER";
 export type UserAuthMethod = "PASSWORD" | "SAML";
 import { FragmentRefs } from "relay-runtime";
 export type MembersSettingsTabMembershipsFragment$data = {
@@ -22,7 +23,7 @@ export type MembersSettingsTabMembershipsFragment$data = {
         readonly emailAddress: string;
         readonly fullName: string;
         readonly id: string;
-        readonly role: string;
+        readonly role: Role;
       };
     }>;
     readonly totalCount: number;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched Relay-generated role fields from string to a typed Role enum in org invite and membership code to improve type safety and prevent invalid values.

- **Refactors**
  - Added Role union: "ADMIN" | "MEMBER" | "OWNER" | "VIEWER".
  - Updated role fields in InviteUserDialogMutation, MembersSettingsTabInvitationsFragment, and MembersSettingsTabMembershipsFragment to use Role.

<sup>Written for commit f803c647cff53f76959945ceccf68fc2c81d12c1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

