### PR TITLE
Fix organization creation

### DIFF
--- a/pkg/server/api/console/v1/v1_resolver.go
+++ b/pkg/server/api/console/v1/v1_resolver.go
@@ -1119,7 +1119,7 @@ func (r *mutationResolver) CreateOrganization(ctx context.Context, input types.C
 		return nil, fmt.Errorf("cannot create organization: %w", err)
 	}
 
-	authz.AddUserToOrganization(
+	err = authz.AddUserToOrganization(
 		ctx,
 		currentUser.ID,
 		organization.ID,
@@ -1145,8 +1145,10 @@ func (r *mutationResolver) CreateOrganization(ctx context.Context, input types.C
 	}
 
 	// Append tenant to allowed one
-	tenantIDs, _ := ctx.Value(userTenantContextKey).(*[]gid.TenantID)
-	*tenantIDs = append(*tenantIDs, organization.ID.TenantID())
+	access, _ := ctx.Value(userTenantContextKey).(*userTenantAccess)
+	if access != nil {
+		access.tenantIDs = append(access.tenantIDs, organization.ID.TenantID())
+	}
 
 	return &types.CreateOrganizationPayload{
 		OrganizationEdge: types.NewOrganizationEdge(organization, coredata.OrganizationOrderFieldCreatedAt),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes organization creation by properly handling the add-member step and safely updating tenant access in the request context. This prevents nil panics and ensures the creator immediately has access to the new org.

- **Bug Fixes**
  - Capture the error from authz.AddUserToOrganization so failures surface.
  - Read userTenantAccess from context and append the new tenant ID only when present, avoiding nil dereferences and keeping access in sync.

<sup>Written for commit a22c06002780a6e9d6eabdb8512b819cc6fd3c2b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

