### PR TITLE
Handle download in pdf preview

### DIFF
--- a/apps/console/src/components/documents/PDFPreview.tsx
+++ b/apps/console/src/components/documents/PDFPreview.tsx
@@ -71,6 +71,13 @@ export function PDFPreview({ src, name }: { src: string; name?: string }) {
     }
   };
 
+  const handleDownload = () => {
+    const link = document.createElement("a");
+    link.href = src;
+    link.download = name || "document.pdf";
+    link.click();
+  };
+
   return (
     <div className="grid grid-rows-[max-content_1fr] h-full bg-subtle">
       {/* Custom Zoom Controls */}
@@ -97,7 +104,7 @@ export function PDFPreview({ src, name }: { src: string; name?: string }) {
         <button onClick={zoomFactor(1.2)} className={btnClass}>
           <IconPlusLarge size={16} />
         </button>
-        <button onClick={zoomFactor(1.2)} className={btnClass}>
+        <button onClick={handleDownload} className={btnClass}>
           <IconArrowInbox size={16} />
         </button>
       </nav>

--- a/apps/trust/src/components/PDFPreview.tsx
+++ b/apps/trust/src/components/PDFPreview.tsx
@@ -71,6 +71,13 @@ export function PDFPreview({ src, name }: { src: string; name?: string }) {
     }
   };
 
+  const handleDownload = () => {
+    const link = document.createElement("a");
+    link.href = src;
+    link.download = name || "document.pdf";
+    link.click();
+  };
+
   return (
     <div className="grid grid-rows-[max-content_1fr] h-full bg-subtle">
       {/* Custom Zoom Controls */}
@@ -97,7 +104,7 @@ export function PDFPreview({ src, name }: { src: string; name?: string }) {
         <button onClick={zoomFactor(1.2)} className={btnClass}>
           <IconPlusLarge size={16} />
         </button>
-        <button onClick={zoomFactor(1.2)} className={btnClass}>
+        <button onClick={handleDownload} className={btnClass}>
           <IconArrowInbox size={16} />
         </button>
       </nav>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a proper download action to the PDF preview toolbar in Console and Trust. Clicking the inbox icon now downloads the PDF using the name prop (fallback: document.pdf) instead of zooming.

<sup>Written for commit 7da20b038ada219b3d29b8c60df9dda56c86f372. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

