### PR TITLE
Make descriptions nullable

### DIFF
--- a/apps/console/src/components/risks/__generated__/LinkedRisksDialogQuery.graphql.ts
+++ b/apps/console/src/components/risks/__generated__/LinkedRisksDialogQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ac10f3fa76fc76951f4c08e38ef0a185>>
+ * @generated SignedSource<<b39754dc6d5d5f02e4310f0db334add3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -19,7 +19,7 @@ export type LinkedRisksDialogQuery$data = {
       readonly edges: ReadonlyArray<{
         readonly node: {
           readonly category: string;
-          readonly description: string;
+          readonly description: string | null | undefined;
           readonly id: string;
           readonly inherentRiskScore: number;
           readonly name: string;

--- a/apps/console/src/components/tasks/TaskFormDialog.tsx
+++ b/apps/console/src/components/tasks/TaskFormDialog.tsx
@@ -71,7 +71,7 @@ export const taskUpdateMutation = graphql`
 
 const createTaskSchema = z.object({
   name: z.string().min(1),
-  description: z.string(),
+  description: z.string().optional().nullable(),
   timeEstimate: z.string().optional().nullable(),
   assignedToId: z.preprocess(
     (val) => (val === "" || val == null ? undefined : val),
@@ -86,7 +86,7 @@ const createTaskSchema = z.object({
 
 const updateTaskSchema = z.object({
   name: z.string().min(1),
-  description: z.string(),
+  description: z.string().optional().nullable(),
   timeEstimate: z.string().optional().nullable(),
   assignedToId: z.string().optional(),
   measureId: z.string().optional(),
@@ -138,7 +138,7 @@ export default function TaskFormDialog(props: Props) {
           input: {
             taskId: task.id,
             name: data.name,
-            description: data.description,
+            description: data.description || null,
             timeEstimate: data.timeEstimate || null,
             deadline: formatDatetime(data.deadline) ?? null,
           },
@@ -150,7 +150,7 @@ export default function TaskFormDialog(props: Props) {
           input: {
             organizationId,
             name: data.name,
-            description: data.description,
+            description: data.description || null,
             timeEstimate: data.timeEstimate || null,
             deadline: formatDatetime(data.deadline) ?? null,
             assignedToId: data.assignedToId,

--- a/apps/console/src/components/tasks/TasksCard.tsx
+++ b/apps/console/src/components/tasks/TasksCard.tsx
@@ -38,7 +38,7 @@ type Props = {
     id: string;
     name: string;
     state: "TODO" | "DONE";
-    description: string;
+    description?: string | null;
     measure?: {
       id: string;
       name: string;

--- a/apps/console/src/components/tasks/__generated__/TaskFormDialogCreateMutation.graphql.ts
+++ b/apps/console/src/components/tasks/__generated__/TaskFormDialogCreateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<beed7398f44a7093301b72d7bceeeba1>>
+ * @generated SignedSource<<c196829e8365168f07614d741242296c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,7 +13,7 @@ import { FragmentRefs } from "relay-runtime";
 export type CreateTaskInput = {
   assignedToId?: string | null | undefined;
   deadline?: any | null | undefined;
-  description: string;
+  description?: string | null | undefined;
   measureId?: string | null | undefined;
   name: string;
   organizationId: string;

--- a/apps/console/src/components/tasks/__generated__/TaskFormDialogFragment.graphql.ts
+++ b/apps/console/src/components/tasks/__generated__/TaskFormDialogFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d6d04868c777f81982de3bffb9a7e73f>>
+ * @generated SignedSource<<1778d9b73cc75e2097e9c24fdfe83631>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,7 +16,7 @@ export type TaskFormDialogFragment$data = {
     readonly id: string;
   } | null | undefined;
   readonly deadline: any | null | undefined;
-  readonly description: string;
+  readonly description: string | null | undefined;
   readonly id: string;
   readonly measure: {
     readonly id: string;

--- a/apps/console/src/components/trustCenter/TrustCenterReferenceDialog.tsx
+++ b/apps/console/src/components/trustCenter/TrustCenterReferenceDialog.tsx
@@ -32,7 +32,7 @@ export type TrustCenterReferenceDialogRef = {
   openEdit: (reference: {
     id: string;
     name: string;
-    description: string;
+    description?: string | null;
     websiteUrl: string;
     rank: number;
   }) => void;
@@ -41,7 +41,7 @@ export type TrustCenterReferenceDialogRef = {
 type Reference = {
   id: string;
   name: string;
-  description: string;
+  description?: string | null;
   websiteUrl: string;
   rank: number;
 };
@@ -90,7 +90,7 @@ export const TrustCenterReferenceDialog = forwardRef<TrustCenterReferenceDialogR
         setUploadedFile(null);
         reset({
           name: reference.name,
-          description: reference.description,
+          description: reference.description ?? undefined,
           websiteUrl: reference.websiteUrl,
           rank: reference.rank,
         });
@@ -116,7 +116,7 @@ export const TrustCenterReferenceDialog = forwardRef<TrustCenterReferenceDialogR
             input: {
               trustCenterId,
               name: data.name,
-              description: data.description,
+              description: data.description || null,
               websiteUrl: data.websiteUrl,
               logoFile: null,
             },
@@ -135,14 +135,14 @@ export const TrustCenterReferenceDialog = forwardRef<TrustCenterReferenceDialogR
         const input: {
           id: string;
           name: string;
-          description: string;
+          description: string | null;
           websiteUrl: string;
           rank?: number;
           logoFile?: null;
         } = {
           id: editReference.id,
           name: data.name,
-          description: data.description,
+          description: data.description || null,
           websiteUrl: data.websiteUrl,
         };
 

--- a/apps/console/src/components/trustCenter/TrustCenterReferencesSection.tsx
+++ b/apps/console/src/components/trustCenter/TrustCenterReferencesSection.tsx
@@ -30,7 +30,7 @@ type Props = {
 type Reference = {
   id: string;
   name: string;
-  description: string;
+  description?: string | null;
   websiteUrl: string;
   logoUrl: string;
   rank: number;

--- a/apps/console/src/hooks/forms/__generated__/useRiskFormFragment.graphql.ts
+++ b/apps/console/src/hooks/forms/__generated__/useRiskFormFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<828d1e2364b7b8c540508d9fb7104b06>>
+ * @generated SignedSource<<759f9a511cc5c589b3ac366de83adbfe>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,7 +13,7 @@ export type RiskTreatment = "ACCEPTED" | "AVOIDED" | "MITIGATED" | "TRANSFERRED"
 import { FragmentRefs } from "relay-runtime";
 export type useRiskFormFragment$data = {
   readonly category: string;
-  readonly description: string;
+  readonly description: string | null | undefined;
   readonly id: string;
   readonly inherentImpact: number;
   readonly inherentLikelihood: number;

--- a/apps/console/src/hooks/forms/useRiskForm.tsx
+++ b/apps/console/src/hooks/forms/useRiskForm.tsx
@@ -34,7 +34,7 @@ export type RiskKey = useRiskFormFragment$key & { id: string };
 export const riskSchema = z.object({
   category: z.string().min(1, "Category is required"),
   name: z.string().min(1, "Name is required"),
-  description: z.string().min(1, "Description is required"),
+  description: z.string().optional().nullable(),
   ownerId: z.string().min(1, "Owner is required"),
   treatment: z.enum(["AVOIDED", "MITIGATED", "TRANSFERRED", "ACCEPTED"]),
   inherentLikelihood: z.number({ coerce: true }).min(1).max(5),
@@ -50,6 +50,7 @@ export const useRiskForm = (riskKey?: RiskKey) => {
     defaultValues: risk
       ? {
           ...risk,
+          description: risk.description ?? undefined,
           ownerId: risk.owner?.id,
         }
       : {

--- a/apps/console/src/hooks/forms/useVendorForm.tsx
+++ b/apps/console/src/hooks/forms/useVendorForm.tsx
@@ -9,7 +9,7 @@ import { useEffect, useMemo } from "react";
 
 const schema = z.object({
   name: z.string().min(1, "Name is required"),
-  description: z.string().min(1, "Description is required"),
+  description: z.string().optional().nullable(),
   category: z.string().nullish(),
   statusPageUrl: z.string().optional(),
   termsOfServiceUrl: z.string().optional(),
@@ -106,6 +106,7 @@ export function useVendorForm(vendorKey: useVendorFormFragment$key) {
         input: {
           id: vendor.id,
           ...data,
+          description: data.description || null,
         },
       },
     }).then(() => {

--- a/apps/console/src/hooks/graph/__generated__/FrameworkGraphControlNodeQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/FrameworkGraphControlNodeQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0e6281a892cbd711d75d22153d4710ea>>
+ * @generated SignedSource<<54b072cf5a78b17f86e5fc810cac517a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -25,7 +25,7 @@ export type FrameworkGraphControlNodeQuery$data = {
         };
       }>;
     };
-    readonly description?: string;
+    readonly description?: string | null | undefined;
     readonly documents?: {
       readonly __id: string;
       readonly edges: ReadonlyArray<{

--- a/apps/console/src/hooks/graph/__generated__/MeasureGraphNodeQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/MeasureGraphNodeQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1f413a42110dae78274cf3250fa4db4e>>
+ * @generated SignedSource<<02c0b1d637edafea060ddb9ee3b3f130>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -20,7 +20,7 @@ export type MeasureGraphNodeQuery$data = {
     readonly controlsInfos?: {
       readonly totalCount: number;
     };
-    readonly description?: string;
+    readonly description?: string | null | undefined;
     readonly evidencesInfos?: {
       readonly totalCount: number;
     };

--- a/apps/console/src/hooks/graph/__generated__/RiskGraphNodeQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/RiskGraphNodeQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f3eadb5ecfeb7b2304712f74b6ac8863>>
+ * @generated SignedSource<<36175d4a9f9c3b377ec502f518a47015>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -19,7 +19,7 @@ export type RiskGraphNodeQuery$data = {
     readonly controlsInfo?: {
       readonly totalCount: number;
     };
-    readonly description?: string;
+    readonly description?: string | null | undefined;
     readonly documentsInfo?: {
       readonly totalCount: number;
     };

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterGraphQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterGraphQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<285497dfb150c3f02c055a091769f301>>
+ * @generated SignedSource<<bfffdd69a2b1f565b60beee5e96d430a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -58,7 +58,7 @@ export type TrustCenterGraphQuery$data = {
         readonly edges: ReadonlyArray<{
           readonly node: {
             readonly createdAt: any;
-            readonly description: string;
+            readonly description: string | null | undefined;
             readonly id: string;
             readonly logoUrl: string;
             readonly name: string;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterReferenceGraphCreateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterReferenceGraphCreateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9d17f089c36e0567d217fe339b6382fd>>
+ * @generated SignedSource<<566b652d24d80b551827cb5d3bf5518c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,7 +10,7 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 export type CreateTrustCenterReferenceInput = {
-  description: string;
+  description?: string | null | undefined;
   logoFile: any;
   name: string;
   trustCenterId: string;
@@ -26,7 +26,7 @@ export type TrustCenterReferenceGraphCreateMutation$data = {
       readonly cursor: any;
       readonly node: {
         readonly createdAt: any;
-        readonly description: string;
+        readonly description: string | null | undefined;
         readonly id: string;
         readonly logoUrl: string;
         readonly name: string;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterReferenceGraphQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterReferenceGraphQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<85556d15b776b3e61e312057a994d482>>
+ * @generated SignedSource<<e7776b4ead5bff52ce340c208ec5bbc6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -21,7 +21,7 @@ export type TrustCenterReferenceGraphQuery$data = {
         readonly cursor: any;
         readonly node: {
           readonly createdAt: any;
-          readonly description: string;
+          readonly description: string | null | undefined;
           readonly id: string;
           readonly logoUrl: string;
           readonly name: string;

--- a/apps/console/src/hooks/graph/__generated__/TrustCenterReferenceGraphUpdateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/TrustCenterReferenceGraphUpdateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9f21158abea504110ef50d4e0114a56a>>
+ * @generated SignedSource<<2b51f7fdbc055d912be03031b258c042>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -24,7 +24,7 @@ export type TrustCenterReferenceGraphUpdateMutation$data = {
   readonly updateTrustCenterReference: {
     readonly trustCenterReference: {
       readonly createdAt: any;
-      readonly description: string;
+      readonly description: string | null | undefined;
       readonly id: string;
       readonly logoUrl: string;
       readonly name: string;

--- a/apps/console/src/hooks/graph/__generated__/usePaginatedMeasuresFragment.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/usePaginatedMeasuresFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4b559d5e004d1657ab8d52cf5770ac79>>
+ * @generated SignedSource<<53e0a105a9b28a70a1083500cd6b4577>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -17,7 +17,7 @@ export type usePaginatedMeasuresFragment$data = {
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly category: string;
-        readonly description: string;
+        readonly description: string | null | undefined;
         readonly id: string;
         readonly name: string;
         readonly state: MeasureState;

--- a/apps/console/src/pages/organizations/documents/__generated__/DocumentDetailPageRowFragment.graphql.ts
+++ b/apps/console/src/pages/organizations/documents/__generated__/DocumentDetailPageRowFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f6a6c2f623522098263a3b556d3c3658>>
+ * @generated SignedSource<<4a6e4730ab80df159c005156b71a7f3d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,7 +16,7 @@ export type DocumentVersionSignatureState = "REQUESTED" | "SIGNED";
 import { FragmentRefs } from "relay-runtime";
 export type DocumentDetailPageRowFragment$data = {
   readonly classification: DocumentClassification;
-  readonly description: string;
+  readonly description: string | null | undefined;
   readonly documentType: DocumentType;
   readonly id: string;
   readonly owner: {

--- a/apps/console/src/pages/organizations/documents/__generated__/DocumentsPageRowFragment.graphql.ts
+++ b/apps/console/src/pages/organizations/documents/__generated__/DocumentsPageRowFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e853bbeba41d33327ee6612c84e21297>>
+ * @generated SignedSource<<f772c53b0007859aecc59a9484b5b791>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,7 +16,7 @@ export type DocumentVersionSignatureState = "REQUESTED" | "SIGNED";
 import { FragmentRefs } from "relay-runtime";
 export type DocumentsPageRowFragment$data = {
   readonly classification: DocumentClassification;
-  readonly description: string;
+  readonly description: string | null | undefined;
   readonly documentType: DocumentType;
   readonly id: string;
   readonly owner: {

--- a/apps/console/src/pages/organizations/documents/dialogs/CreateDocumentDialog.tsx
+++ b/apps/console/src/pages/organizations/documents/dialogs/CreateDocumentDialog.tsx
@@ -98,8 +98,8 @@ export function CreateDocumentDialog({ trigger, connection }: Props) {
               id="content"
               variant="ghost"
               autogrow
-              placeholder={__("Add description")}
-              aria-label={__("Description")}
+              placeholder={__("Add content")}
+              aria-label={__("Content")}
               {...register("content")}
             />
           </div>

--- a/apps/console/src/pages/organizations/documents/dialogs/UpdateVersionDialog.tsx
+++ b/apps/console/src/pages/organizations/documents/dialogs/UpdateVersionDialog.tsx
@@ -175,8 +175,8 @@ export default function UpdateVersionDialog({
             variant="ghost"
             autogrow
             required
-            placeholder={__("Add description")}
-            aria-label={__("Description")}
+            placeholder={__("Add content")}
+            aria-label={__("Content")}
             className="p-6"
             {...register("content")}
           />

--- a/apps/console/src/pages/organizations/frameworks/__generated__/FrameworkDetailPageFragment.graphql.ts
+++ b/apps/console/src/pages/organizations/frameworks/__generated__/FrameworkDetailPageFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c6e55821a322dceae5408ac3898cfa48>>
+ * @generated SignedSource<<daf4012a65afffdedc10e4f5c7e2bc3c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -24,7 +24,7 @@ export type FrameworkDetailPageFragment$data = {
       };
     }>;
   };
-  readonly description: string;
+  readonly description: string | null | undefined;
   readonly id: string;
   readonly name: string;
   readonly organization: {

--- a/apps/console/src/pages/organizations/frameworks/__generated__/FrameworksPageCardFragment.graphql.ts
+++ b/apps/console/src/pages/organizations/frameworks/__generated__/FrameworksPageCardFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ec6bd0c6fff930b82216d940e83d8ef0>>
+ * @generated SignedSource<<9fdc712e118402371c9951169aac320a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,7 +11,7 @@
 import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type FrameworksPageCardFragment$data = {
-  readonly description: string;
+  readonly description: string | null | undefined;
   readonly id: string;
   readonly name: string;
   readonly " $fragmentType": "FrameworksPageCardFragment";

--- a/apps/console/src/pages/organizations/frameworks/dialogs/FrameworkControlDialog.tsx
+++ b/apps/console/src/pages/organizations/frameworks/dialogs/FrameworkControlDialog.tsx
@@ -65,7 +65,7 @@ const updateMutation = graphql`
 
 const schema = z.object({
   name: z.string(),
-  description: z.string(),
+  description: z.string().optional().nullable(),
   sectionTitle: z.string(),
   status: z.enum(["INCLUDED", "EXCLUDED"]),
   exclusionJustification: z.string().optional(),
@@ -120,7 +120,7 @@ export function FrameworkControlDialog(props: Props) {
           input: {
             id: frameworkControl.id,
             name: data.name,
-            description: data.description,
+            description: data.description || null,
             sectionTitle: data.sectionTitle,
             status: data.status,
             exclusionJustification: data.status === "EXCLUDED" ? data.exclusionJustification : null,
@@ -134,7 +134,7 @@ export function FrameworkControlDialog(props: Props) {
           input: {
             frameworkId: props.frameworkId,
             name: data.name,
-            description: data.description,
+            description: data.description || null,
             sectionTitle: data.sectionTitle,
             status: data.status,
             exclusionJustification: data.status === "EXCLUDED" ? data.exclusionJustification : null,

--- a/apps/console/src/pages/organizations/frameworks/dialogs/FrameworkFormDialog.tsx
+++ b/apps/console/src/pages/organizations/frameworks/dialogs/FrameworkFormDialog.tsx
@@ -49,7 +49,7 @@ type Props = {
   framework?: {
     id: string;
     name: string;
-    description: string;
+    description?: string | null;
   };
   ref?: DialogRef;
   children?: React.ReactNode;
@@ -57,7 +57,7 @@ type Props = {
 
 const schema = z.object({
   name: z.string().min(1).max(255),
-  description: z.string().max(255).optional(),
+  description: z.string().max(255).optional().nullable(),
 });
 
 /**
@@ -87,6 +87,7 @@ export function FrameworkFormDialog(props: Props) {
           input: {
             id: props.framework.id,
             ...data,
+            description: data.description || null,
           },
         },
       });
@@ -98,6 +99,7 @@ export function FrameworkFormDialog(props: Props) {
       variables: {
         input: {
           ...data,
+          description: data.description || null,
           organizationId: props.organizationId,
         },
         connections: [props.connectionId],

--- a/apps/console/src/pages/organizations/frameworks/dialogs/__generated__/FrameworkControlDialogCreateMutation.graphql.ts
+++ b/apps/console/src/pages/organizations/frameworks/dialogs/__generated__/FrameworkControlDialogCreateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<be64518840fd2564cffe1646a58c3762>>
+ * @generated SignedSource<<7985268ac23df51ae6187b72c4f33d83>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,7 +12,7 @@ import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type ControlStatus = "EXCLUDED" | "INCLUDED";
 export type CreateControlInput = {
-  description: string;
+  description?: string | null | undefined;
   exclusionJustification?: string | null | undefined;
   frameworkId: string;
   name: string;

--- a/apps/console/src/pages/organizations/frameworks/dialogs/__generated__/FrameworkControlDialogFragment.graphql.ts
+++ b/apps/console/src/pages/organizations/frameworks/dialogs/__generated__/FrameworkControlDialogFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8b52b1e3fd91d74821361d9ae652d9bd>>
+ * @generated SignedSource<<67703eb04d68c2798f5549ed6d948339>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,7 +12,7 @@ import { ReaderFragment } from 'relay-runtime';
 export type ControlStatus = "EXCLUDED" | "INCLUDED";
 import { FragmentRefs } from "relay-runtime";
 export type FrameworkControlDialogFragment$data = {
-  readonly description: string;
+  readonly description: string | null | undefined;
   readonly exclusionJustification: string | null | undefined;
   readonly id: string;
   readonly name: string;

--- a/apps/console/src/pages/organizations/frameworks/dialogs/__generated__/FrameworkFormDialogMutation.graphql.ts
+++ b/apps/console/src/pages/organizations/frameworks/dialogs/__generated__/FrameworkFormDialogMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fef15c2f99a731cf6c49a99487e37c59>>
+ * @generated SignedSource<<b8d5c939f1b3a4337be9a4ecc2e8fd98>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,7 +11,7 @@
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type CreateFrameworkInput = {
-  description: string;
+  description?: string | null | undefined;
   name: string;
   organizationId: string;
 };

--- a/apps/console/src/pages/organizations/frameworks/dialogs/__generated__/FrameworkFormDialogUpdateMutation.graphql.ts
+++ b/apps/console/src/pages/organizations/frameworks/dialogs/__generated__/FrameworkFormDialogUpdateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<530c955a326f52f3c668e9f43788a54f>>
+ * @generated SignedSource<<d60cc1832963c81fe19cfe8a71992273>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -20,7 +20,7 @@ export type FrameworkFormDialogUpdateMutation$variables = {
 export type FrameworkFormDialogUpdateMutation$data = {
   readonly updateFramework: {
     readonly framework: {
-      readonly description: string;
+      readonly description: string | null | undefined;
       readonly id: string;
       readonly name: string;
     };

--- a/apps/console/src/pages/organizations/measures/dialog/MeasureFormDialog.tsx
+++ b/apps/console/src/pages/organizations/measures/dialog/MeasureFormDialog.tsx
@@ -52,7 +52,7 @@ const measureCreateMutation = graphql`
 
 const measureSchema = z.object({
   name: z.string().min(1, "Name is required"),
-  description: z.string().min(1, "Description is required"),
+  description: z.string().optional().nullable(),
   category: z.string().min(1, "Category is required"),
   state: z.enum(measureStates),
 });
@@ -93,7 +93,7 @@ export default function MeasureFormDialog(props: Props) {
           input: {
             id: measure.id,
             name: data.name,
-            description: data.description,
+            description: data.description || null,
             category: data.category,
             state: data.state,
           },
@@ -105,7 +105,7 @@ export default function MeasureFormDialog(props: Props) {
           input: {
             organizationId,
             name: data.name,
-            description: data.description,
+            description: data.description || null,
             category: data.category,
           },
           connections: [props.connection!],
@@ -145,7 +145,6 @@ export default function MeasureFormDialog(props: Props) {
               label={__("Description")}
               placeholder={__("Add description")}
               type="textarea"
-              required
             />
           </div>
           {/* Properties form */}

--- a/apps/console/src/pages/organizations/measures/dialog/__generated__/MeasureFormDialogCreateMutation.graphql.ts
+++ b/apps/console/src/pages/organizations/measures/dialog/__generated__/MeasureFormDialogCreateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<09acdf5a03dd4ad1fab64c2c08564a2a>>
+ * @generated SignedSource<<a1cf7f654fe2f662c446e60ce82e3ae9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,7 +12,7 @@ import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type CreateMeasureInput = {
   category: string;
-  description: string;
+  description?: string | null | undefined;
   name: string;
   organizationId: string;
 };

--- a/apps/console/src/pages/organizations/measures/dialog/__generated__/MeasureFormDialogMeasureFragment.graphql.ts
+++ b/apps/console/src/pages/organizations/measures/dialog/__generated__/MeasureFormDialogMeasureFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ad3cb8a5e721cd1d83d80540320b8313>>
+ * @generated SignedSource<<d4866432b6b5c9e71e6e4893062c1809>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,7 +13,7 @@ export type MeasureState = "IMPLEMENTED" | "IN_PROGRESS" | "NOT_APPLICABLE" | "N
 import { FragmentRefs } from "relay-runtime";
 export type MeasureFormDialogMeasureFragment$data = {
   readonly category: string;
-  readonly description: string;
+  readonly description: string | null | undefined;
   readonly id: string;
   readonly name: string;
   readonly state: MeasureState;

--- a/apps/console/src/pages/organizations/measures/tabs/__generated__/MeasureTasksTabFragment.graphql.ts
+++ b/apps/console/src/pages/organizations/measures/tabs/__generated__/MeasureTasksTabFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<67fd0b26613189fa036f7873138787d7>>
+ * @generated SignedSource<<cfddd118e2b6db135ad87fe157c89151>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -20,7 +20,7 @@ export type MeasureTasksTabFragment$data = {
           readonly fullName: string;
           readonly id: string;
         } | null | undefined;
-        readonly description: string;
+        readonly description: string | null | undefined;
         readonly id: string;
         readonly name: string;
         readonly state: TaskState;

--- a/apps/console/src/pages/organizations/risks/FormRiskDialog.tsx
+++ b/apps/console/src/pages/organizations/risks/FormRiskDialog.tsx
@@ -110,6 +110,7 @@ export default function FormRiskDialog({
           input: {
             id: risk.id,
             ...data,
+            description: data.description || null,
           },
         },
         successMessage: __("Risk updated successfully."),
@@ -124,6 +125,7 @@ export default function FormRiskDialog({
       variables: {
         input: {
           ...data,
+          description: data.description || null,
           organizationId,
         },
         connections: [connection!],

--- a/apps/console/src/pages/organizations/risks/__generated__/FormRiskDialogMutation.graphql.ts
+++ b/apps/console/src/pages/organizations/risks/__generated__/FormRiskDialogMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<66f4e8603a811d1fb363ae88ea697b22>>
+ * @generated SignedSource<<dfc4b37cf499f7cb24c0b1bd1eec3b11>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,7 +13,7 @@ import { FragmentRefs } from "relay-runtime";
 export type RiskTreatment = "ACCEPTED" | "AVOIDED" | "MITIGATED" | "TRANSFERRED";
 export type CreateRiskInput = {
   category: string;
-  description: string;
+  description?: string | null | undefined;
   inherentImpact: number;
   inherentLikelihood: number;
   name: string;

--- a/apps/console/src/pages/organizations/tasks/__generated__/TasksPageFragment.graphql.ts
+++ b/apps/console/src/pages/organizations/tasks/__generated__/TasksPageFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0fbb86bdf90b3ec4e0ec6ea8253eef4c>>
+ * @generated SignedSource<<8bba8d318de0f4b0d28a8fba8b8e0bdf>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -21,7 +21,7 @@ export type TasksPageFragment$data = {
           readonly fullName: string;
           readonly id: string;
         } | null | undefined;
-        readonly description: string;
+        readonly description: string | null | undefined;
         readonly id: string;
         readonly measure: {
           readonly id: string;

--- a/packages/ui/src/Molecules/PageHeader/PageHeader.tsx
+++ b/packages/ui/src/Molecules/PageHeader/PageHeader.tsx
@@ -2,7 +2,7 @@ import type { PropsWithChildren, ReactNode } from "react";
 
 type Props = PropsWithChildren<{
     title: ReactNode;
-    description?: string;
+    description?: string | null;
 }>;
 
 export function PageHeader({ title, description, children }: Props) {

--- a/pkg/coredata/document.go
+++ b/pkg/coredata/document.go
@@ -21,10 +21,10 @@ import (
 	"maps"
 	"time"
 
-	"go.probo.inc/probo/pkg/gid"
-	"go.probo.inc/probo/pkg/page"
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/page"
 )
 
 type (

--- a/pkg/coredata/evidence.go
+++ b/pkg/coredata/evidence.go
@@ -21,11 +21,11 @@ import (
 	"maps"
 	"time"
 
-	"go.probo.inc/probo/pkg/gid"
-	"go.probo.inc/probo/pkg/page"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/page"
 )
 
 type (
@@ -38,7 +38,7 @@ type (
 		Type           EvidenceType  `db:"type"`
 		URL            string        `db:"url"`
 		EvidenceFileId *gid.GID      `db:"evidence_file_id"`
-		Description    string        `db:"description"`
+		Description    *string       `db:"description"`
 		CreatedAt      time.Time     `db:"created_at"`
 		UpdatedAt      time.Time     `db:"updated_at"`
 	}

--- a/pkg/coredata/framework.go
+++ b/pkg/coredata/framework.go
@@ -21,11 +21,11 @@ import (
 	"maps"
 	"time"
 
-	"go.probo.inc/probo/pkg/gid"
-	"go.probo.inc/probo/pkg/page"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/page"
 )
 
 type (
@@ -34,7 +34,7 @@ type (
 		OrganizationID gid.GID   `db:"organization_id"`
 		ReferenceID    string    `db:"reference_id"`
 		Name           string    `db:"name"`
-		Description    string    `db:"description"`
+		Description    *string   `db:"description"`
 		CreatedAt      time.Time `db:"created_at"`
 		UpdatedAt      time.Time `db:"updated_at"`
 	}

--- a/pkg/coredata/measure.go
+++ b/pkg/coredata/measure.go
@@ -21,10 +21,10 @@ import (
 	"maps"
 	"time"
 
-	"go.probo.inc/probo/pkg/gid"
-	"go.probo.inc/probo/pkg/page"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/page"
 
 	"go.gearno.de/kit/pg"
 )
@@ -35,7 +35,7 @@ type (
 		OrganizationID gid.GID      `db:"organization_id"`
 		Category       string       `db:"category"`
 		Name           string       `db:"name"`
-		Description    string       `db:"description"`
+		Description    *string      `db:"description"`
 		State          MeasureState `db:"state"`
 		ReferenceID    string       `db:"reference_id"`
 		CreatedAt      time.Time    `db:"created_at"`

--- a/pkg/coredata/migrations/20251105T145415Z.sql
+++ b/pkg/coredata/migrations/20251105T145415Z.sql
@@ -1,0 +1,8 @@
+ALTER TABLE controls ALTER COLUMN description DROP NOT NULL;
+ALTER TABLE documents ALTER COLUMN description DROP NOT NULL;
+ALTER TABLE documents ALTER COLUMN description DROP DEFAULT;
+ALTER TABLE evidences ALTER COLUMN description DROP NOT NULL;
+ALTER TABLE frameworks ALTER COLUMN description DROP NOT NULL;
+ALTER TABLE measures ALTER COLUMN description DROP NOT NULL;
+ALTER TABLE tasks ALTER COLUMN description DROP NOT NULL;
+ALTER TABLE trust_center_references ALTER COLUMN description DROP NOT NULL;

--- a/pkg/coredata/risk.go
+++ b/pkg/coredata/risk.go
@@ -21,10 +21,10 @@ import (
 	"maps"
 	"time"
 
-	"go.probo.inc/probo/pkg/gid"
-	"go.probo.inc/probo/pkg/page"
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/page"
 )
 
 type (
@@ -32,7 +32,7 @@ type (
 		ID                 gid.GID       `db:"id"`
 		OrganizationID     gid.GID       `db:"organization_id"`
 		Name               string        `db:"name"`
-		Description        string        `db:"description"`
+		Description        *string       `db:"description"`
 		Category           string        `db:"category"`
 		Treatment          RiskTreatment `db:"treatment"`
 		Note               string        `db:"note"`

--- a/pkg/coredata/task.go
+++ b/pkg/coredata/task.go
@@ -21,10 +21,10 @@ import (
 	"maps"
 	"time"
 
-	"go.probo.inc/probo/pkg/gid"
-	"go.probo.inc/probo/pkg/page"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/page"
 
 	"go.gearno.de/kit/pg"
 )
@@ -35,7 +35,7 @@ type (
 		OrganizationID gid.GID        `db:"organization_id"`
 		MeasureID      *gid.GID       `db:"measure_id"`
 		Name           string         `db:"name"`
-		Description    string         `db:"description"`
+		Description    *string        `db:"description"`
 		State          TaskState      `db:"state"`
 		ReferenceID    string         `db:"reference_id"`
 		TimeEstimate   *time.Duration `db:"time_estimate"`

--- a/pkg/coredata/trust_center_reference.go
+++ b/pkg/coredata/trust_center_reference.go
@@ -21,11 +21,11 @@ import (
 	"maps"
 	"time"
 
-	"go.probo.inc/probo/pkg/gid"
-	"go.probo.inc/probo/pkg/page"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/page"
 )
 
 type (
@@ -33,7 +33,7 @@ type (
 		ID            gid.GID   `db:"id"`
 		TrustCenterID gid.GID   `db:"trust_center_id"`
 		Name          string    `db:"name"`
-		Description   string    `db:"description"`
+		Description   *string   `db:"description"`
 		WebsiteURL    string    `db:"website_url"`
 		LogoFileID    gid.GID   `db:"logo_file_id"`
 		Rank          int       `db:"rank"`

--- a/pkg/probo/framework_service.go
+++ b/pkg/probo/framework_service.go
@@ -25,6 +25,9 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"go.gearno.de/crypto/uuid"
+	"go.gearno.de/kit/pg"
+	"go.gearno.de/x/ref"
 	"go.probo.inc/probo/packages/emails"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
@@ -32,9 +35,6 @@ import (
 	"go.probo.inc/probo/pkg/page"
 	"go.probo.inc/probo/pkg/slug"
 	"go.probo.inc/probo/pkg/soagen"
-	"go.gearno.de/crypto/uuid"
-	"go.gearno.de/kit/pg"
-	"go.gearno.de/x/ref"
 )
 
 const (
@@ -51,13 +51,13 @@ type (
 	CreateFrameworkRequest struct {
 		OrganizationID gid.GID
 		Name           string
-		Description    string
+		Description    *string
 	}
 
 	UpdateFrameworkRequest struct {
 		ID          gid.GID
 		Name        *string
-		Description *string
+		Description **string
 	}
 
 	ImportFrameworkRequest struct {
@@ -487,12 +487,13 @@ func (s FrameworkService) Import(
 			controlID := gid.New(organization.ID.TenantID(), coredata.ControlEntityType)
 
 			now := time.Now()
+			description := control.Description
 			control := &coredata.Control{
 				ID:           controlID,
 				FrameworkID:  frameworkID,
 				SectionTitle: control.ID,
 				Name:         control.Name,
-				Description:  control.Description,
+				Description:  &description,
 				Status:       coredata.ControlStatusIncluded,
 				CreatedAt:    now,
 				UpdatedAt:    now,

--- a/pkg/probo/measure_service.go
+++ b/pkg/probo/measure_service.go
@@ -19,11 +19,11 @@ import (
 	"fmt"
 	"time"
 
+	"go.gearno.de/crypto/uuid"
+	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/page"
-	"go.gearno.de/crypto/uuid"
-	"go.gearno.de/kit/pg"
 )
 
 type (
@@ -34,14 +34,14 @@ type (
 	CreateMeasureRequest struct {
 		OrganizationID gid.GID
 		Name           string
-		Description    string
+		Description    *string
 		Category       string
 	}
 
 	UpdateMeasureRequest struct {
 		ID          gid.GID
 		Name        *string
-		Description *string
+		Description **string
 		Category    *string
 		State       *coredata.MeasureState
 	}
@@ -296,7 +296,7 @@ func (s MeasureService) Import(
 					ID:             measureID,
 					OrganizationID: organization.ID,
 					Name:           req.Measures[i].Name,
-					Description:    "",
+					Description:    nil,
 					Category:       req.Measures[i].Category,
 					State:          coredata.MeasureStateNotStarted,
 					ReferenceID:    req.Measures[i].ReferenceID,
@@ -313,12 +313,13 @@ func (s MeasureService) Import(
 				for j := range req.Measures[i].Tasks {
 					taskID := gid.New(organization.ID.TenantID(), coredata.TaskEntityType)
 
+					taskDescription := req.Measures[i].Tasks[j].Description
 					task := &coredata.Task{
 						ID:             taskID,
 						OrganizationID: organizationID,
 						MeasureID:      &measure.ID,
 						Name:           req.Measures[i].Tasks[j].Name,
-						Description:    req.Measures[i].Tasks[j].Description,
+						Description:    &taskDescription,
 						ReferenceID:    req.Measures[i].Tasks[j].ReferenceID,
 						State:          coredata.TaskStateTodo,
 						CreatedAt:      now,
@@ -332,13 +333,14 @@ func (s MeasureService) Import(
 					for k := range req.Measures[i].Tasks[j].RequestedEvidences {
 						evidenceID := gid.New(organizationID.TenantID(), coredata.EvidenceEntityType)
 
+						evidenceDescription := req.Measures[i].Tasks[j].RequestedEvidences[k].Name
 						evidence := &coredata.Evidence{
 							State:       coredata.EvidenceStateRequested,
 							ID:          evidenceID,
 							TaskID:      &task.ID,
 							ReferenceID: req.Measures[i].Tasks[j].RequestedEvidences[k].ReferenceID,
 							Type:        req.Measures[i].Tasks[j].RequestedEvidences[k].Type,
-							Description: req.Measures[i].Tasks[j].RequestedEvidences[k].Name,
+							Description: &evidenceDescription,
 							CreatedAt:   now,
 							UpdatedAt:   now,
 						}

--- a/pkg/probo/risk_service.go
+++ b/pkg/probo/risk_service.go
@@ -19,10 +19,10 @@ import (
 	"fmt"
 	"time"
 
+	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/page"
-	"go.gearno.de/kit/pg"
 )
 
 type (
@@ -33,7 +33,7 @@ type (
 	CreateRiskRequest struct {
 		OrganizationID     gid.GID
 		Name               string
-		Description        string
+		Description        *string
 		Category           string
 		Treatment          coredata.RiskTreatment
 		OwnerID            *gid.GID
@@ -47,7 +47,7 @@ type (
 	UpdateRiskRequest struct {
 		ID                 gid.GID
 		Name               *string
-		Description        *string
+		Description        **string
 		Category           *string
 		Treatment          *coredata.RiskTreatment
 		OwnerID            **gid.GID

--- a/pkg/probo/task_service.go
+++ b/pkg/probo/task_service.go
@@ -19,11 +19,11 @@ import (
 	"fmt"
 	"time"
 
+	"go.gearno.de/crypto/uuid"
+	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/page"
-	"go.gearno.de/crypto/uuid"
-	"go.gearno.de/kit/pg"
 )
 
 type (
@@ -35,7 +35,7 @@ type (
 		OrganizationID gid.GID
 		MeasureID      *gid.GID
 		Name           string
-		Description    string
+		Description    *string
 		TimeEstimate   *time.Duration
 		AssignedToID   *gid.GID
 		Deadline       *time.Time
@@ -44,7 +44,7 @@ type (
 	UpdateTaskRequest struct {
 		TaskID       gid.GID
 		Name         *string
-		Description  *string
+		Description  **string
 		State        *coredata.TaskState
 		TimeEstimate **time.Duration
 		Deadline     **time.Time

--- a/pkg/probo/trust_center_reference_service.go
+++ b/pkg/probo/trust_center_reference_service.go
@@ -26,11 +26,11 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"go.gearno.de/crypto/uuid"
+	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/page"
-	"go.gearno.de/crypto/uuid"
-	"go.gearno.de/kit/pg"
 )
 
 type (
@@ -41,7 +41,7 @@ type (
 	CreateTrustCenterReferenceRequest struct {
 		TrustCenterID gid.GID
 		Name          string
-		Description   string
+		Description   *string
 		WebsiteURL    string
 		LogoFile      File
 	}
@@ -49,7 +49,7 @@ type (
 	UpdateTrustCenterReferenceRequest struct {
 		ID          gid.GID
 		Name        *string
-		Description *string
+		Description **string
 		WebsiteURL  *string
 		LogoFile    *File
 		Rank        *int

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -2020,7 +2020,7 @@ type VendorDataPrivacyAgreement implements Node {
 type Framework implements Node {
   id: ID!
   name: String!
-  description: String!
+  description: String
 
   organization: Organization! @goField(forceResolver: true)
 
@@ -2041,7 +2041,7 @@ type Control implements Node {
   id: ID!
   sectionTitle: String!
   name: String!
-  description: String!
+  description: String
   status: ControlStatus!
   exclusionJustification: String
 
@@ -2089,7 +2089,7 @@ type Measure implements Node {
   id: ID!
   category: String!
   name: String!
-  description: String!
+  description: String
   state: MeasureState!
 
   evidences(
@@ -2133,7 +2133,7 @@ type Measure implements Node {
 type Task implements Node {
   id: ID!
   name: String!
-  description: String!
+  description: String
   state: TaskState!
   timeEstimate: Duration
   deadline: Datetime
@@ -2161,7 +2161,7 @@ type Evidence implements Node {
   type: EvidenceType!
   file: File @goField(forceResolver: true)
   url: String
-  description: String!
+  description: String
 
   task: Task @goField(forceResolver: true)
   measure: Measure! @goField(forceResolver: true)
@@ -2173,7 +2173,7 @@ type Evidence implements Node {
 type Document implements Node {
   id: ID!
   title: String!
-  description: String!
+  description: String
   documentType: DocumentType!
   classification: DocumentClassification!
   currentPublishedVersion: Int
@@ -2207,7 +2207,7 @@ type Risk implements Node {
   id: ID!
   snapshotId: ID
   name: String!
-  description: String!
+  description: String
   category: String!
   treatment: RiskTreatment!
   inherentLikelihood: Int!
@@ -2498,7 +2498,7 @@ type TrustCenterAccessEdge {
 type TrustCenterReference implements Node {
   id: ID!
   name: String!
-  description: String!
+  description: String
   websiteUrl: String!
   logoUrl: String! @goField(forceResolver: true)
   rank: Int!
@@ -3303,7 +3303,7 @@ input DeleteTrustCenterAccessInput {
 input CreateTrustCenterReferenceInput {
   trustCenterId: ID!
   name: String!
-  description: String!
+  description: String
   websiteUrl: String!
   logoFile: Upload!
 }
@@ -3311,7 +3311,7 @@ input CreateTrustCenterReferenceInput {
 input UpdateTrustCenterReferenceInput {
   id: ID!
   name: String
-  description: String
+  description: String @goField(omittable: true)
   websiteUrl: String
   logoFile: Upload
   rank: Int
@@ -3464,13 +3464,13 @@ input DeletePeopleInput {
 input CreateFrameworkInput {
   organizationId: ID!
   name: String!
-  description: String!
+  description: String
 }
 
 input UpdateFrameworkInput {
   id: ID!
   name: String
-  description: String
+  description: String @goField(omittable: true)
 }
 
 input ImportFrameworkInput {
@@ -3489,14 +3489,14 @@ input ExportFrameworkInput {
 input CreateMeasureInput {
   organizationId: ID!
   name: String!
-  description: String!
+  description: String
   category: String!
 }
 
 input UpdateMeasureInput {
   id: ID!
   name: String
-  description: String
+  description: String @goField(omittable: true)
   category: String
   state: MeasureState
 }
@@ -3510,7 +3510,7 @@ input CreateTaskInput {
   organizationId: ID!
   measureId: ID
   name: String!
-  description: String!
+  description: String
   timeEstimate: Duration
   assignedToId: ID
   deadline: Datetime
@@ -3519,7 +3519,7 @@ input CreateTaskInput {
 input UpdateTaskInput {
   taskId: ID!
   name: String
-  description: String
+  description: String @goField(omittable: true)
   state: TaskState
   timeEstimate: Duration @goField(omittable: true)
   deadline: Datetime @goField(omittable: true)
@@ -3581,7 +3581,7 @@ input DeleteControlSnapshotMappingInput {
 input CreateRiskInput {
   organizationId: ID!
   name: String!
-  description: String!
+  description: String
   category: String!
   ownerId: ID
   treatment: RiskTreatment!
@@ -3595,7 +3595,7 @@ input CreateRiskInput {
 input UpdateRiskInput {
   id: ID!
   name: String
-  description: String
+  description: String @goField(omittable: true)
   category: String
   ownerId: ID @goField(omittable: true)
   treatment: RiskTreatment
@@ -3644,7 +3644,7 @@ input RequestEvidenceInput {
   taskId: ID!
   name: String!
   type: EvidenceType!
-  description: String!
+  description: String
 }
 
 input FulfillEvidenceInput {
@@ -3660,7 +3660,7 @@ input CreateEvidenceInput {
   type: EvidenceType!
   url: String
   file: Upload
-  description: String!
+  description: String
 }
 
 input DeleteEvidenceInput {
@@ -3774,7 +3774,7 @@ input CreateControlInput {
   frameworkId: ID!
   sectionTitle: String!
   name: String!
-  description: String!
+  description: String
   status: ControlStatus!
   exclusionJustification: String
 }
@@ -3783,7 +3783,7 @@ input UpdateControlInput {
   id: ID!
   sectionTitle: String
   name: String
-  description: String
+  description: String @goField(omittable: true)
   status: ControlStatus
   exclusionJustification: String
 }

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -11761,7 +11761,7 @@ type VendorDataPrivacyAgreement implements Node {
 type Framework implements Node {
   id: ID!
   name: String!
-  description: String!
+  description: String
 
   organization: Organization! @goField(forceResolver: true)
 
@@ -11782,7 +11782,7 @@ type Control implements Node {
   id: ID!
   sectionTitle: String!
   name: String!
-  description: String!
+  description: String
   status: ControlStatus!
   exclusionJustification: String
 
@@ -11830,7 +11830,7 @@ type Measure implements Node {
   id: ID!
   category: String!
   name: String!
-  description: String!
+  description: String
   state: MeasureState!
 
   evidences(
@@ -11874,7 +11874,7 @@ type Measure implements Node {
 type Task implements Node {
   id: ID!
   name: String!
-  description: String!
+  description: String
   state: TaskState!
   timeEstimate: Duration
   deadline: Datetime
@@ -11902,7 +11902,7 @@ type Evidence implements Node {
   type: EvidenceType!
   file: File @goField(forceResolver: true)
   url: String
-  description: String!
+  description: String
 
   task: Task @goField(forceResolver: true)
   measure: Measure! @goField(forceResolver: true)
@@ -11914,7 +11914,7 @@ type Evidence implements Node {
 type Document implements Node {
   id: ID!
   title: String!
-  description: String!
+  description: String
   documentType: DocumentType!
   classification: DocumentClassification!
   currentPublishedVersion: Int
@@ -11948,7 +11948,7 @@ type Risk implements Node {
   id: ID!
   snapshotId: ID
   name: String!
-  description: String!
+  description: String
   category: String!
   treatment: RiskTreatment!
   inherentLikelihood: Int!
@@ -12239,7 +12239,7 @@ type TrustCenterAccessEdge {
 type TrustCenterReference implements Node {
   id: ID!
   name: String!
-  description: String!
+  description: String
   websiteUrl: String!
   logoUrl: String! @goField(forceResolver: true)
   rank: Int!
@@ -13044,7 +13044,7 @@ input DeleteTrustCenterAccessInput {
 input CreateTrustCenterReferenceInput {
   trustCenterId: ID!
   name: String!
-  description: String!
+  description: String
   websiteUrl: String!
   logoFile: Upload!
 }
@@ -13052,7 +13052,7 @@ input CreateTrustCenterReferenceInput {
 input UpdateTrustCenterReferenceInput {
   id: ID!
   name: String
-  description: String
+  description: String @goField(omittable: true)
   websiteUrl: String
   logoFile: Upload
   rank: Int
@@ -13205,13 +13205,13 @@ input DeletePeopleInput {
 input CreateFrameworkInput {
   organizationId: ID!
   name: String!
-  description: String!
+  description: String
 }
 
 input UpdateFrameworkInput {
   id: ID!
   name: String
-  description: String
+  description: String @goField(omittable: true)
 }
 
 input ImportFrameworkInput {
@@ -13230,14 +13230,14 @@ input ExportFrameworkInput {
 input CreateMeasureInput {
   organizationId: ID!
   name: String!
-  description: String!
+  description: String
   category: String!
 }
 
 input UpdateMeasureInput {
   id: ID!
   name: String
-  description: String
+  description: String @goField(omittable: true)
   category: String
   state: MeasureState
 }
@@ -13251,7 +13251,7 @@ input CreateTaskInput {
   organizationId: ID!
   measureId: ID
   name: String!
-  description: String!
+  description: String
   timeEstimate: Duration
   assignedToId: ID
   deadline: Datetime
@@ -13260,7 +13260,7 @@ input CreateTaskInput {
 input UpdateTaskInput {
   taskId: ID!
   name: String
-  description: String
+  description: String @goField(omittable: true)
   state: TaskState
   timeEstimate: Duration @goField(omittable: true)
   deadline: Datetime @goField(omittable: true)
@@ -13322,7 +13322,7 @@ input DeleteControlSnapshotMappingInput {
 input CreateRiskInput {
   organizationId: ID!
   name: String!
-  description: String!
+  description: String
   category: String!
   ownerId: ID
   treatment: RiskTreatment!
@@ -13336,7 +13336,7 @@ input CreateRiskInput {
 input UpdateRiskInput {
   id: ID!
   name: String
-  description: String
+  description: String @goField(omittable: true)
   category: String
   ownerId: ID @goField(omittable: true)
   treatment: RiskTreatment
@@ -13385,7 +13385,7 @@ input RequestEvidenceInput {
   taskId: ID!
   name: String!
   type: EvidenceType!
-  description: String!
+  description: String
 }
 
 input FulfillEvidenceInput {
@@ -13401,7 +13401,7 @@ input CreateEvidenceInput {
   type: EvidenceType!
   url: String
   file: Upload
-  description: String!
+  description: String
 }
 
 input DeleteEvidenceInput {
@@ -13515,7 +13515,7 @@ input CreateControlInput {
   frameworkId: ID!
   sectionTitle: String!
   name: String!
-  description: String!
+  description: String
   status: ControlStatus!
   exclusionJustification: String
 }
@@ -13524,7 +13524,7 @@ input UpdateControlInput {
   id: ID!
   sectionTitle: String
   name: String
-  description: String
+  description: String @goField(omittable: true)
   status: ControlStatus
   exclusionJustification: String
 }
@@ -26564,14 +26564,11 @@ func (ec *executionContext) _Control_description(ctx context.Context, field grap
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Control_description(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -33282,14 +33279,11 @@ func (ec *executionContext) _Document_description(ctx context.Context, field gra
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Document_description(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -35984,14 +35978,11 @@ func (ec *executionContext) _Evidence_description(ctx context.Context, field gra
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Evidence_description(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -36995,14 +36986,11 @@ func (ec *executionContext) _Framework_description(ctx context.Context, field gr
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Framework_description(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -38889,14 +38877,11 @@ func (ec *executionContext) _Measure_description(ctx context.Context, field grap
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Measure_description(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -55403,14 +55388,11 @@ func (ec *executionContext) _Risk_description(ctx context.Context, field graphql
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Risk_description(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -58991,14 +58973,11 @@ func (ec *executionContext) _Task_description(ctx context.Context, field graphql
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Task_description(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -62523,14 +62502,11 @@ func (ec *executionContext) _TrustCenterReference_description(ctx context.Contex
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_TrustCenterReference_description(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -74042,7 +74018,7 @@ func (ec *executionContext) unmarshalInputCreateControlInput(ctx context.Context
 			it.Name = data
 		case "description":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -74371,7 +74347,7 @@ func (ec *executionContext) unmarshalInputCreateEvidenceInput(ctx context.Contex
 			it.File = data
 		case "description":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -74412,7 +74388,7 @@ func (ec *executionContext) unmarshalInputCreateFrameworkInput(ctx context.Conte
 			it.Name = data
 		case "description":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -74453,7 +74429,7 @@ func (ec *executionContext) unmarshalInputCreateMeasureInput(ctx context.Context
 			it.Name = data
 		case "description":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -74964,7 +74940,7 @@ func (ec *executionContext) unmarshalInputCreateRiskInput(ctx context.Context, o
 			it.Name = data
 		case "description":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -75309,7 +75285,7 @@ func (ec *executionContext) unmarshalInputCreateTaskInput(ctx context.Context, o
 			it.Name = data
 		case "description":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -75474,7 +75450,7 @@ func (ec *executionContext) unmarshalInputCreateTrustCenterReferenceInput(ctx co
 			it.Name = data
 		case "description":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -78219,7 +78195,7 @@ func (ec *executionContext) unmarshalInputRequestEvidenceInput(ctx context.Conte
 			it.Type = data
 		case "description":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -78838,7 +78814,7 @@ func (ec *executionContext) unmarshalInputUpdateControlInput(ctx context.Context
 			if err != nil {
 				return it, err
 			}
-			it.Description = data
+			it.Description = graphql.OmittableOf(data)
 		case "status":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("status"))
 			data, err := ec.unmarshalOControlStatus2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐControlStatus(ctx, v)
@@ -79051,7 +79027,7 @@ func (ec *executionContext) unmarshalInputUpdateFrameworkInput(ctx context.Conte
 			if err != nil {
 				return it, err
 			}
-			it.Description = data
+			it.Description = graphql.OmittableOf(data)
 		}
 	}
 
@@ -79092,7 +79068,7 @@ func (ec *executionContext) unmarshalInputUpdateMeasureInput(ctx context.Context
 			if err != nil {
 				return it, err
 			}
-			it.Description = data
+			it.Description = graphql.OmittableOf(data)
 		case "category":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("category"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
@@ -79625,7 +79601,7 @@ func (ec *executionContext) unmarshalInputUpdateRiskInput(ctx context.Context, o
 			if err != nil {
 				return it, err
 			}
-			it.Description = data
+			it.Description = graphql.OmittableOf(data)
 		case "category":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("category"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
@@ -79840,7 +79816,7 @@ func (ec *executionContext) unmarshalInputUpdateTaskInput(ctx context.Context, o
 			if err != nil {
 				return it, err
 			}
-			it.Description = data
+			it.Description = graphql.OmittableOf(data)
 		case "state":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("state"))
 			data, err := ec.unmarshalOTaskState2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐTaskState(ctx, v)
@@ -80046,7 +80022,7 @@ func (ec *executionContext) unmarshalInputUpdateTrustCenterReferenceInput(ctx co
 			if err != nil {
 				return it, err
 			}
-			it.Description = data
+			it.Description = graphql.OmittableOf(data)
 		case "websiteUrl":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("websiteUrl"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
@@ -82585,9 +82561,6 @@ func (ec *executionContext) _Control(ctx context.Context, sel ast.SelectionSet, 
 			}
 		case "description":
 			out.Values[i] = ec._Control_description(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
 		case "status":
 			out.Values[i] = ec._Control_status(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -86378,9 +86351,6 @@ func (ec *executionContext) _Document(ctx context.Context, sel ast.SelectionSet,
 			}
 		case "description":
 			out.Values[i] = ec._Document_description(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
 		case "documentType":
 			out.Values[i] = ec._Document_documentType(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -87304,9 +87274,6 @@ func (ec *executionContext) _Evidence(ctx context.Context, sel ast.SelectionSet,
 			out.Values[i] = ec._Evidence_url(ctx, field, obj)
 		case "description":
 			out.Values[i] = ec._Evidence_description(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
 		case "task":
 			field := field
 
@@ -87734,9 +87701,6 @@ func (ec *executionContext) _Framework(ctx context.Context, sel ast.SelectionSet
 			}
 		case "description":
 			out.Values[i] = ec._Framework_description(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
 		case "organization":
 			field := field
 
@@ -88542,9 +88506,6 @@ func (ec *executionContext) _Measure(ctx context.Context, sel ast.SelectionSet, 
 			}
 		case "description":
 			out.Values[i] = ec._Measure_description(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
 		case "state":
 			out.Values[i] = ec._Measure_state(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -92617,9 +92578,6 @@ func (ec *executionContext) _Risk(ctx context.Context, sel ast.SelectionSet, obj
 			}
 		case "description":
 			out.Values[i] = ec._Risk_description(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
 		case "category":
 			out.Values[i] = ec._Risk_category(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -93767,9 +93725,6 @@ func (ec *executionContext) _Task(ctx context.Context, sel ast.SelectionSet, obj
 			}
 		case "description":
 			out.Values[i] = ec._Task_description(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
 		case "state":
 			out.Values[i] = ec._Task_state(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -95176,9 +95131,6 @@ func (ec *executionContext) _TrustCenterReference(ctx context.Context, sel ast.S
 			}
 		case "description":
 			out.Values[i] = ec._TrustCenterReference_description(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
 		case "websiteUrl":
 			out.Values[i] = ec._TrustCenterReference_websiteUrl(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -178,7 +178,7 @@ type Control struct {
 	ID                     gid.GID                `json:"id"`
 	SectionTitle           string                 `json:"sectionTitle"`
 	Name                   string                 `json:"name"`
-	Description            string                 `json:"description"`
+	Description            *string                `json:"description,omitempty"`
 	Status                 coredata.ControlStatus `json:"status"`
 	ExclusionJustification *string                `json:"exclusionJustification,omitempty"`
 	Framework              *Framework             `json:"framework"`
@@ -269,7 +269,7 @@ type CreateControlInput struct {
 	FrameworkID            gid.GID                `json:"frameworkId"`
 	SectionTitle           string                 `json:"sectionTitle"`
 	Name                   string                 `json:"name"`
-	Description            string                 `json:"description"`
+	Description            *string                `json:"description,omitempty"`
 	Status                 coredata.ControlStatus `json:"status"`
 	ExclusionJustification *string                `json:"exclusionJustification,omitempty"`
 }
@@ -348,7 +348,7 @@ type CreateEvidenceInput struct {
 	Type        coredata.EvidenceType `json:"type"`
 	URL         *string               `json:"url,omitempty"`
 	File        *graphql.Upload       `json:"file,omitempty"`
-	Description string                `json:"description"`
+	Description *string               `json:"description,omitempty"`
 }
 
 type CreateEvidencePayload struct {
@@ -358,7 +358,7 @@ type CreateEvidencePayload struct {
 type CreateFrameworkInput struct {
 	OrganizationID gid.GID `json:"organizationId"`
 	Name           string  `json:"name"`
-	Description    string  `json:"description"`
+	Description    *string `json:"description,omitempty"`
 }
 
 type CreateFrameworkPayload struct {
@@ -368,7 +368,7 @@ type CreateFrameworkPayload struct {
 type CreateMeasureInput struct {
 	OrganizationID gid.GID `json:"organizationId"`
 	Name           string  `json:"name"`
-	Description    string  `json:"description"`
+	Description    *string `json:"description,omitempty"`
 	Category       string  `json:"category"`
 }
 
@@ -471,7 +471,7 @@ type CreateRiskDocumentMappingPayload struct {
 type CreateRiskInput struct {
 	OrganizationID     gid.GID                `json:"organizationId"`
 	Name               string                 `json:"name"`
-	Description        string                 `json:"description"`
+	Description        *string                `json:"description,omitempty"`
 	Category           string                 `json:"category"`
 	OwnerID            *gid.GID               `json:"ownerId,omitempty"`
 	Treatment          coredata.RiskTreatment `json:"treatment"`
@@ -543,7 +543,7 @@ type CreateTaskInput struct {
 	OrganizationID gid.GID        `json:"organizationId"`
 	MeasureID      *gid.GID       `json:"measureId,omitempty"`
 	Name           string         `json:"name"`
-	Description    string         `json:"description"`
+	Description    *string        `json:"description,omitempty"`
 	TimeEstimate   *time.Duration `json:"timeEstimate,omitempty"`
 	AssignedToID   *gid.GID       `json:"assignedToId,omitempty"`
 	Deadline       *time.Time     `json:"deadline,omitempty"`
@@ -579,7 +579,7 @@ type CreateTrustCenterFilePayload struct {
 type CreateTrustCenterReferenceInput struct {
 	TrustCenterID gid.GID        `json:"trustCenterId"`
 	Name          string         `json:"name"`
-	Description   string         `json:"description"`
+	Description   *string        `json:"description,omitempty"`
 	WebsiteURL    string         `json:"websiteUrl"`
 	LogoFile      graphql.Upload `json:"logoFile"`
 }
@@ -1042,7 +1042,7 @@ type DisableSAMLPayload struct {
 type Document struct {
 	ID                      gid.GID                         `json:"id"`
 	Title                   string                          `json:"title"`
-	Description             string                          `json:"description"`
+	Description             *string                         `json:"description,omitempty"`
 	DocumentType            coredata.DocumentType           `json:"documentType"`
 	Classification          coredata.DocumentClassification `json:"classification"`
 	CurrentPublishedVersion *int                            `json:"currentPublishedVersion,omitempty"`
@@ -1148,7 +1148,7 @@ type Evidence struct {
 	Type        coredata.EvidenceType  `json:"type"`
 	File        *File                  `json:"file,omitempty"`
 	URL         *string                `json:"url,omitempty"`
-	Description string                 `json:"description"`
+	Description *string                `json:"description,omitempty"`
 	Task        *Task                  `json:"task,omitempty"`
 	Measure     *Measure               `json:"measure"`
 	CreatedAt   time.Time              `json:"createdAt"`
@@ -1195,7 +1195,7 @@ type File struct {
 type Framework struct {
 	ID           gid.GID            `json:"id"`
 	Name         string             `json:"name"`
-	Description  string             `json:"description"`
+	Description  *string            `json:"description,omitempty"`
 	Organization *Organization      `json:"organization"`
 	Controls     *ControlConnection `json:"controls"`
 	CreatedAt    time.Time          `json:"createdAt"`
@@ -1317,7 +1317,7 @@ type Measure struct {
 	ID          gid.GID               `json:"id"`
 	Category    string                `json:"category"`
 	Name        string                `json:"name"`
-	Description string                `json:"description"`
+	Description *string               `json:"description,omitempty"`
 	State       coredata.MeasureState `json:"state"`
 	Evidences   *EvidenceConnection   `json:"evidences"`
 	Tasks       *TaskConnection       `json:"tasks"`
@@ -1587,7 +1587,7 @@ type RequestEvidenceInput struct {
 	TaskID      gid.GID               `json:"taskId"`
 	Name        string                `json:"name"`
 	Type        coredata.EvidenceType `json:"type"`
-	Description string                `json:"description"`
+	Description *string               `json:"description,omitempty"`
 }
 
 type RequestEvidencePayload struct {
@@ -1607,7 +1607,7 @@ type Risk struct {
 	ID                 gid.GID                `json:"id"`
 	SnapshotID         *gid.GID               `json:"snapshotId,omitempty"`
 	Name               string                 `json:"name"`
-	Description        string                 `json:"description"`
+	Description        *string                `json:"description,omitempty"`
 	Category           string                 `json:"category"`
 	Treatment          coredata.RiskTreatment `json:"treatment"`
 	InherentLikelihood int                    `json:"inherentLikelihood"`
@@ -1721,7 +1721,7 @@ type SnapshotEdge struct {
 type Task struct {
 	ID           gid.GID             `json:"id"`
 	Name         string              `json:"name"`
-	Description  string              `json:"description"`
+	Description  *string             `json:"description,omitempty"`
 	State        coredata.TaskState  `json:"state"`
 	TimeEstimate *time.Duration      `json:"timeEstimate,omitempty"`
 	Deadline     *time.Time          `json:"deadline,omitempty"`
@@ -1820,7 +1820,7 @@ type TrustCenterFileEdge struct {
 type TrustCenterReference struct {
 	ID          gid.GID   `json:"id"`
 	Name        string    `json:"name"`
-	Description string    `json:"description"`
+	Description *string   `json:"description,omitempty"`
 	WebsiteURL  string    `json:"websiteUrl"`
 	LogoURL     string    `json:"logoUrl"`
 	Rank        int       `json:"rank"`
@@ -1887,12 +1887,12 @@ type UpdateContinualImprovementPayload struct {
 }
 
 type UpdateControlInput struct {
-	ID                     gid.GID                 `json:"id"`
-	SectionTitle           *string                 `json:"sectionTitle,omitempty"`
-	Name                   *string                 `json:"name,omitempty"`
-	Description            *string                 `json:"description,omitempty"`
-	Status                 *coredata.ControlStatus `json:"status,omitempty"`
-	ExclusionJustification *string                 `json:"exclusionJustification,omitempty"`
+	ID                     gid.GID                    `json:"id"`
+	SectionTitle           *string                    `json:"sectionTitle,omitempty"`
+	Name                   *string                    `json:"name,omitempty"`
+	Description            graphql.Omittable[*string] `json:"description,omitempty"`
+	Status                 *coredata.ControlStatus    `json:"status,omitempty"`
+	ExclusionJustification *string                    `json:"exclusionJustification,omitempty"`
 }
 
 type UpdateControlPayload struct {
@@ -1935,9 +1935,9 @@ type UpdateDocumentVersionPayload struct {
 }
 
 type UpdateFrameworkInput struct {
-	ID          gid.GID `json:"id"`
-	Name        *string `json:"name,omitempty"`
-	Description *string `json:"description,omitempty"`
+	ID          gid.GID                    `json:"id"`
+	Name        *string                    `json:"name,omitempty"`
+	Description graphql.Omittable[*string] `json:"description,omitempty"`
 }
 
 type UpdateFrameworkPayload struct {
@@ -1945,11 +1945,11 @@ type UpdateFrameworkPayload struct {
 }
 
 type UpdateMeasureInput struct {
-	ID          gid.GID                `json:"id"`
-	Name        *string                `json:"name,omitempty"`
-	Description *string                `json:"description,omitempty"`
-	Category    *string                `json:"category,omitempty"`
-	State       *coredata.MeasureState `json:"state,omitempty"`
+	ID          gid.GID                    `json:"id"`
+	Name        *string                    `json:"name,omitempty"`
+	Description graphql.Omittable[*string] `json:"description,omitempty"`
+	Category    *string                    `json:"category,omitempty"`
+	State       *coredata.MeasureState     `json:"state,omitempty"`
 }
 
 type UpdateMeasurePayload struct {
@@ -2048,7 +2048,7 @@ type UpdateProcessingActivityPayload struct {
 type UpdateRiskInput struct {
 	ID                 gid.GID                     `json:"id"`
 	Name               *string                     `json:"name,omitempty"`
-	Description        *string                     `json:"description,omitempty"`
+	Description        graphql.Omittable[*string]  `json:"description,omitempty"`
 	Category           *string                     `json:"category,omitempty"`
 	OwnerID            graphql.Omittable[*gid.GID] `json:"ownerId,omitempty"`
 	Treatment          *coredata.RiskTreatment     `json:"treatment,omitempty"`
@@ -2087,7 +2087,7 @@ type UpdateSAMLConfigurationPayload struct {
 type UpdateTaskInput struct {
 	TaskID       gid.GID                           `json:"taskId"`
 	Name         *string                           `json:"name,omitempty"`
-	Description  *string                           `json:"description,omitempty"`
+	Description  graphql.Omittable[*string]        `json:"description,omitempty"`
 	State        *coredata.TaskState               `json:"state,omitempty"`
 	TimeEstimate graphql.Omittable[*time.Duration] `json:"timeEstimate,omitempty"`
 	Deadline     graphql.Omittable[*time.Time]     `json:"deadline,omitempty"`
@@ -2131,12 +2131,12 @@ type UpdateTrustCenterPayload struct {
 }
 
 type UpdateTrustCenterReferenceInput struct {
-	ID          gid.GID         `json:"id"`
-	Name        *string         `json:"name,omitempty"`
-	Description *string         `json:"description,omitempty"`
-	WebsiteURL  *string         `json:"websiteUrl,omitempty"`
-	LogoFile    *graphql.Upload `json:"logoFile,omitempty"`
-	Rank        *int            `json:"rank,omitempty"`
+	ID          gid.GID                    `json:"id"`
+	Name        *string                    `json:"name,omitempty"`
+	Description graphql.Omittable[*string] `json:"description,omitempty"`
+	WebsiteURL  *string                    `json:"websiteUrl,omitempty"`
+	LogoFile    *graphql.Upload            `json:"logoFile,omitempty"`
+	Rank        *int                       `json:"rank,omitempty"`
 }
 
 type UpdateTrustCenterReferencePayload struct {

--- a/pkg/server/api/console/v1/v1_resolver.go
+++ b/pkg/server/api/console/v1/v1_resolver.go
@@ -1487,7 +1487,7 @@ func (r *mutationResolver) UpdateTrustCenterReference(ctx context.Context, input
 	req := &probo.UpdateTrustCenterReferenceRequest{
 		ID:          input.ID,
 		Name:        input.Name,
-		Description: input.Description,
+		Description: UnwrapOmittable(input.Description),
 		WebsiteURL:  input.WebsiteURL,
 		Rank:        input.Rank,
 	}
@@ -1971,7 +1971,7 @@ func (r *mutationResolver) UpdateFramework(ctx context.Context, input types.Upda
 	framework, err := prb.Frameworks.Update(ctx, probo.UpdateFrameworkRequest{
 		ID:          input.ID,
 		Name:        input.Name,
-		Description: input.Description,
+		Description: UnwrapOmittable(input.Description),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("cannot update framework: %w", err)
@@ -2096,7 +2096,7 @@ func (r *mutationResolver) UpdateControl(ctx context.Context, input types.Update
 	control, err := prb.Controls.Update(ctx, probo.UpdateControlRequest{
 		ID:                     input.ID,
 		Name:                   input.Name,
-		Description:            input.Description,
+		Description:            UnwrapOmittable(input.Description),
 		SectionTitle:           input.SectionTitle,
 		Status:                 input.Status,
 		ExclusionJustification: input.ExclusionJustification,
@@ -2159,7 +2159,7 @@ func (r *mutationResolver) UpdateMeasure(ctx context.Context, input types.Update
 	measure, err := prb.Measures.Update(ctx, probo.UpdateMeasureRequest{
 		ID:          input.ID,
 		Name:        input.Name,
-		Description: input.Description,
+		Description: UnwrapOmittable(input.Description),
 		Category:    input.Category,
 		State:       input.State,
 	})
@@ -2366,7 +2366,7 @@ func (r *mutationResolver) UpdateTask(ctx context.Context, input types.UpdateTas
 	task, err := prb.Tasks.Update(ctx, probo.UpdateTaskRequest{
 		TaskID:       input.TaskID,
 		Name:         input.Name,
-		Description:  input.Description,
+		Description:  UnwrapOmittable(input.Description),
 		State:        input.State,
 		TimeEstimate: UnwrapOmittable(input.TimeEstimate),
 		Deadline:     UnwrapOmittable(input.Deadline),
@@ -2464,7 +2464,7 @@ func (r *mutationResolver) UpdateRisk(ctx context.Context, input types.UpdateRis
 		probo.UpdateRiskRequest{
 			ID:                 input.ID,
 			Name:               input.Name,
-			Description:        input.Description,
+			Description:        UnwrapOmittable(input.Description),
 			Category:           input.Category,
 			Treatment:          input.Treatment,
 			OwnerID:            UnwrapOmittable(input.OwnerID),

--- a/pkg/server/api/trust/v1/schema.graphql
+++ b/pkg/server/api/trust/v1/schema.graphql
@@ -461,7 +461,7 @@ type VendorEdge {
 type TrustCenterReference implements Node {
   id: ID!
   name: String!
-  description: String!
+  description: String
   websiteUrl: String!
   logoUrl: String! @goField(forceResolver: true)
 }

--- a/pkg/server/api/trust/v1/schema/schema.go
+++ b/pkg/server/api/trust/v1/schema/schema.go
@@ -1624,7 +1624,7 @@ type VendorEdge {
 type TrustCenterReference implements Node {
   id: ID!
   name: String!
-  description: String!
+  description: String
   websiteUrl: String!
   logoUrl: String! @goField(forceResolver: true)
 }
@@ -6809,14 +6809,11 @@ func (ec *executionContext) _TrustCenterReference_description(ctx context.Contex
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_TrustCenterReference_description(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -11683,9 +11680,6 @@ func (ec *executionContext) _TrustCenterReference(ctx context.Context, sel ast.S
 			}
 		case "description":
 			out.Values[i] = ec._TrustCenterReference_description(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
 		case "websiteUrl":
 			out.Values[i] = ec._TrustCenterReference_websiteUrl(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/pkg/server/api/trust/v1/types/types.go
+++ b/pkg/server/api/trust/v1/types/types.go
@@ -220,7 +220,7 @@ type TrustCenterFileEdge struct {
 type TrustCenterReference struct {
 	ID          gid.GID `json:"id"`
 	Name        string  `json:"name"`
-	Description string  `json:"description"`
+	Description *string `json:"description,omitempty"`
 	WebsiteURL  string  `json:"websiteUrl"`
 	LogoURL     string  `json:"logoUrl"`
 }


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make all entity descriptions optional across the app, API, and database. You can now create and update tasks, risks, measures, frameworks, controls, documents, evidences, and trust center references without a description.

- **Refactors**
  - GraphQL: description fields are nullable; create inputs accept optional description; update inputs use omittable description to distinguish “no change” vs “clear to null”.
  - Backend (Go): models switch description to *string; services and resolvers updated to unwrap omittable inputs and handle pointers.
  - Console: forms mark description as optional; Relay types use string | null; UI components accept nullable descriptions and default to undefined.

- **Migration**
  - Run migration 20251105T145415Z.sql to drop NOT NULL on description columns for controls, documents, evidences, frameworks, measures, tasks, and trust_center_references.
  - After deploy: omit description in create requests; to clear a description via update, send description: null; omit the field to leave it unchanged.

<sup>Written for commit 288c59a5f2e68ed30e87d19d2ce61f127bc7eb9d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





