### PR TITLE
Fix deletion freeze

### DIFF
--- a/packages/ui/src/Molecules/Dialog/ConfirmDialog.tsx
+++ b/packages/ui/src/Molecules/Dialog/ConfirmDialog.tsx
@@ -7,7 +7,7 @@ import {
     Description,
     Cancel,
 } from "@radix-ui/react-alert-dialog";
-import { useCallback, useState, type ComponentProps } from "react";
+import { useCallback, useState, useEffect, type ComponentProps } from "react";
 import { Button } from "../../Atoms/Button/Button";
 import { Root as Portal } from "@radix-ui/react-portal";
 import { dialog } from "./Dialog";
@@ -79,14 +79,21 @@ export function ConfirmDialog() {
         footer,
     } = dialog();
     const [loading, setLoading] = useState(false);
-    const handleConfirm = () => {
+
+    useEffect(() => {
+        if (!isOpen) {
+            setLoading(false);
+        }
+    }, [isOpen]);
+
+    const handleConfirm = useCallback(() => {
         setLoading(true);
         onConfirm()
             .finally(() => {
-                close();
                 setLoading(false);
+                close();
             });
-    };
+    }, [onConfirm, close]);
 
     return (
         <Root open={isOpen} onOpenChange={close}>

--- a/packages/ui/src/Molecules/Dialog/Dialog.tsx
+++ b/packages/ui/src/Molecules/Dialog/Dialog.tsx
@@ -14,6 +14,7 @@ import {
     isValidElement,
     useRef,
     useState,
+    useEffect,
     type ComponentProps,
     type CSSProperties,
     type HTMLAttributes,
@@ -70,16 +71,18 @@ export function Dialog({
     const { overlay, content, header, title: titleClassname } = dialog();
     const [open, setOpen] = useState(!!defaultOpen);
 
-    if (ref) {
-        ref.current = {
-            open() {
-                setOpen(true);
-            },
-            close() {
-                setOpen(false);
-            },
-        };
-    }
+    useEffect(() => {
+        if (ref) {
+            ref.current = {
+                open() {
+                    setOpen(true);
+                },
+                close() {
+                    setOpen(false);
+                },
+            };
+        }
+    }, [ref]);
 
     const onOpenChange = (open: boolean) => {
         if (!open && !closable) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a freeze when confirming deletions by properly resetting the loading state and stabilizing dialog ref behavior. The delete dialog now closes reliably without getting stuck on a spinner.

- **Bug Fixes**
  - ConfirmDialog: clear loading when the dialog closes and set loading to false before closing to avoid stuck states.
  - Dialog: move ref open/close assignments into useEffect to prevent stale refs during the delete flow.

<sup>Written for commit a120b756440b20de5909bdaf4f9475c870ee8eea. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

