### PR TITLE
Fix deletion freeze

### DIFF
--- a/apps/console/src/hooks/useMutationWithToasts.ts
+++ b/apps/console/src/hooks/useMutationWithToasts.ts
@@ -68,7 +68,7 @@ export function useMutationWithToasts<T extends MutationParameters>(
         })
       );
     },
-    [mutate]
+    [mutate, toast, __]
   );
 
   return [mutateWithToast, isLoading] as const;

--- a/packages/ui/src/Molecules/Dialog/ConfirmDialog.tsx
+++ b/packages/ui/src/Molecules/Dialog/ConfirmDialog.tsx
@@ -79,13 +79,14 @@ export function ConfirmDialog() {
         footer,
     } = dialog();
     const [loading, setLoading] = useState(false);
-    const handleConfirm = () => {
+    const handleConfirm = async () => {
         setLoading(true);
-        onConfirm()
-            .finally(() => {
-                close();
-                setLoading(false);
-            });
+        try {
+            await onConfirm();
+        } finally {
+            close();
+            setLoading(false);
+        }
     };
 
     return (


### PR DESCRIPTION










<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the deletion dialog freeze by awaiting the async confirm action and resetting the loading state. The dialog now closes after the confirm finishes, even on errors, to prevent hangs.

<sup>Written for commit b25d30d3c700ed1436aa03b6b91dca2a5efca9d4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









