### PR TITLE
Add IDP initiated flow support

### DIFF
--- a/pkg/server/auth/saml_acs_handler.go
+++ b/pkg/server/auth/saml_acs_handler.go
@@ -60,10 +60,13 @@ func SAMLACSHandler(samlSvc *authsvc.SAMLService, authSvc *authsvc.Service, auth
 			return
 		}
 
-		if r.FormValue("RelayState") == "" {
-			logger.WarnCtx(ctx, "missing RelayState")
-			http.Error(w, "missing RelayState", http.StatusBadRequest)
-			return
+		relayState := r.FormValue("RelayState")
+		samlConfigID := r.URL.Query().Get("c")
+
+		if relayState != "" {
+			logger.InfoCtx(ctx, "processing SP-initiated SAML login", log.String("relay_state", relayState))
+		} else {
+			logger.InfoCtx(ctx, "processing IDP-initiated SAML login", log.String("config_id", samlConfigID))
 		}
 
 		userInfo, err := samlSvc.HandleSAMLAssertion(ctx, r)


### PR DESCRIPTION
close #520 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for IdP-initiated SAML login, enabling SSO without RelayState by using the ACS URL with a “c” query parameter for the SAML config ID. The ACS handler and assertion processing now work for both SP- and IdP-initiated flows with the same validation and replay protection.

- **New Features**
  - Accept ACS requests without RelayState and load context via the “c” query parameter.
  - Keep SP-initiated flow as-is; validate and clean up relay state and SAML request.
  - Use the loaded SAML configuration for assertion validation and replay protection.
  - Add logging to indicate SP vs IDP-initiated processing.

- **Migration**
  - For IdP-initiated SSO, configure the IdP to POST the SAMLResponse to the ACS endpoint with ?c=<SAML config ID>.

<sup>Written for commit edce70141d19e6fbfbdf9b53c1279784b7b573bd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

