### PR TITLE
Add slack id to organizations

### DIFF
--- a/apps/console/src/hooks/graph/__generated__/OrganizationGraph_ViewQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/OrganizationGraph_ViewQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<11a62d34dafa502e3a464b91e12728ea>>
+ * @generated SignedSource<<2fddef55f50d256b153590f39128e26a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -269,6 +269,13 @@ return {
                 "args": null,
                 "kind": "ScalarField",
                 "name": "headquarterAddress",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "slackId",
                 "storageKey": null
               },
               (v6/*: any*/),
@@ -641,12 +648,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a44a7b84f5f4c569d028f1d88deadb99",
+    "cacheID": "94b51a33a118cedfc990b260620020f7",
     "id": null,
     "metadata": {},
     "name": "OrganizationGraph_ViewQuery",
     "operationKind": "query",
-    "text": "query OrganizationGraph_ViewQuery(\n  $organizationId: ID!\n) {\n  node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      id\n      name\n      ...SettingsPageFragment\n    }\n    id\n  }\n}\n\nfragment DomainSettingsTabFragment on Organization {\n  id\n  customDomain {\n    id\n    domain\n    sslStatus\n    dnsRecords {\n      type\n      name\n      value\n      ttl\n      purpose\n    }\n    createdAt\n    updatedAt\n    sslExpiresAt\n  }\n}\n\nfragment GeneralSettingsTabFragment on Organization {\n  id\n  name\n  logoUrl\n  horizontalLogoUrl\n  description\n  websiteUrl\n  email\n  headquarterAddress\n  createdAt\n  updatedAt\n}\n\nfragment MembersSettingsTabInvitationsFragment on Organization {\n  invitations(first: 20, orderBy: {direction: ASC, field: CREATED_AT}) {\n    totalCount\n    edges {\n      node {\n        id\n        fullName\n        email\n        role\n        status\n        createdAt\n        expiresAt\n        acceptedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n\nfragment MembersSettingsTabMembershipsFragment on Organization {\n  memberships(first: 20, orderBy: {direction: ASC, field: CREATED_AT}) {\n    totalCount\n    edges {\n      node {\n        id\n        fullName\n        emailAddress\n        role\n        authMethod\n        createdAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n\nfragment SAMLSettingsTabFragment on Organization {\n  id\n  name\n  samlConfigurations {\n    id\n    enabled\n    emailDomain\n    enforcementPolicy\n    domainVerified\n    domainVerificationToken\n    domainVerifiedAt\n    spEntityId\n    spAcsUrl\n    spMetadataUrl\n    testLoginUrl\n    idpEntityId\n    idpSsoUrl\n    idpCertificate\n    idpMetadataUrl\n    attributeEmail\n    attributeFirstname\n    attributeLastname\n    attributeRole\n    autoSignupEnabled\n  }\n}\n\nfragment SettingsPageFragment on Organization {\n  id\n  name\n  ...GeneralSettingsTabFragment\n  ...MembersSettingsTabMembershipsFragment\n  ...MembersSettingsTabInvitationsFragment\n  ...DomainSettingsTabFragment\n  ...SAMLSettingsTabFragment\n}\n"
+    "text": "query OrganizationGraph_ViewQuery(\n  $organizationId: ID!\n) {\n  node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      id\n      name\n      ...SettingsPageFragment\n    }\n    id\n  }\n}\n\nfragment DomainSettingsTabFragment on Organization {\n  id\n  customDomain {\n    id\n    domain\n    sslStatus\n    dnsRecords {\n      type\n      name\n      value\n      ttl\n      purpose\n    }\n    createdAt\n    updatedAt\n    sslExpiresAt\n  }\n}\n\nfragment GeneralSettingsTabFragment on Organization {\n  id\n  name\n  logoUrl\n  horizontalLogoUrl\n  description\n  websiteUrl\n  email\n  headquarterAddress\n  slackId\n  createdAt\n  updatedAt\n}\n\nfragment MembersSettingsTabInvitationsFragment on Organization {\n  invitations(first: 20, orderBy: {direction: ASC, field: CREATED_AT}) {\n    totalCount\n    edges {\n      node {\n        id\n        fullName\n        email\n        role\n        status\n        createdAt\n        expiresAt\n        acceptedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n\nfragment MembersSettingsTabMembershipsFragment on Organization {\n  memberships(first: 20, orderBy: {direction: ASC, field: CREATED_AT}) {\n    totalCount\n    edges {\n      node {\n        id\n        fullName\n        emailAddress\n        role\n        authMethod\n        createdAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n\nfragment SAMLSettingsTabFragment on Organization {\n  id\n  name\n  samlConfigurations {\n    id\n    enabled\n    emailDomain\n    enforcementPolicy\n    domainVerified\n    domainVerificationToken\n    domainVerifiedAt\n    spEntityId\n    spAcsUrl\n    spMetadataUrl\n    testLoginUrl\n    idpEntityId\n    idpSsoUrl\n    idpCertificate\n    idpMetadataUrl\n    attributeEmail\n    attributeFirstname\n    attributeLastname\n    attributeRole\n    autoSignupEnabled\n  }\n}\n\nfragment SettingsPageFragment on Organization {\n  id\n  name\n  ...GeneralSettingsTabFragment\n  ...MembersSettingsTabMembershipsFragment\n  ...MembersSettingsTabInvitationsFragment\n  ...DomainSettingsTabFragment\n  ...SAMLSettingsTabFragment\n}\n"
   }
 };
 })();

--- a/apps/console/src/pages/organizations/meetings/__generated__/MeetingsPage_UpdateSummaryMutation.graphql.ts
+++ b/apps/console/src/pages/organizations/meetings/__generated__/MeetingsPage_UpdateSummaryMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<60e0c9d7301cff5c1df299e76debb633>>
+ * @generated SignedSource<<1fff8c5cca1610284185c485630e84de>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -19,6 +19,7 @@ export type MeetingsPage_UpdateSummaryMutation$variables = {
 export type MeetingsPage_UpdateSummaryMutation$data = {
   readonly updateOrganizationContext: {
     readonly context: {
+      readonly organizationId: string;
       readonly summary: string | null | undefined;
     };
   };
@@ -63,6 +64,13 @@ v1 = [
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "organizationId",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "summary",
             "storageKey": null
           }
@@ -91,16 +99,16 @@ return {
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "e6bead1dde5239f3cfd2fa1440191454",
+    "cacheID": "cb37cdde6dc5ac655a7cefc63d9e72e7",
     "id": null,
     "metadata": {},
     "name": "MeetingsPage_UpdateSummaryMutation",
     "operationKind": "mutation",
-    "text": "mutation MeetingsPage_UpdateSummaryMutation(\n  $input: UpdateOrganizationContextInput!\n) {\n  updateOrganizationContext(input: $input) {\n    context {\n      summary\n    }\n  }\n}\n"
+    "text": "mutation MeetingsPage_UpdateSummaryMutation(\n  $input: UpdateOrganizationContextInput!\n) {\n  updateOrganizationContext(input: $input) {\n    context {\n      organizationId\n      summary\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "f354a34b18a449f02508c45d0e7d9dc5";
+(node as any).hash = "8bfa5b636dbc3535dbed22e1869bc941";
 
 export default node;

--- a/apps/console/src/pages/organizations/settings/GeneralSettingsTab.tsx
+++ b/apps/console/src/pages/organizations/settings/GeneralSettingsTab.tsx
@@ -34,6 +34,7 @@ const generalSettingsTabFragment = graphql`
     websiteUrl
     email
     headquarterAddress
+    slackId
     createdAt
     updatedAt
   }
@@ -51,6 +52,7 @@ const updateOrganizationMutation = graphql`
         websiteUrl
         email
         headquarterAddress
+        slackId
       }
     }
   }
@@ -75,6 +77,7 @@ const organizationSchema = z.object({
   websiteUrl: z.string().optional(),
   email: z.string().optional(),
   headquarterAddress: z.string().optional(),
+  slackId: z.string().optional(),
 });
 
 type OrganizationFormData = z.infer<typeof organizationSchema>;
@@ -119,6 +122,7 @@ export default function GeneralSettingsTab() {
         websiteUrl: organization.websiteUrl || "",
         email: organization.email || "",
         headquarterAddress: organization.headquarterAddress || "",
+        slackId: organization.slackId || "",
       },
     }
   );
@@ -129,6 +133,7 @@ export default function GeneralSettingsTab() {
     websiteUrl: organization.websiteUrl,
     email: organization.email,
     headquarterAddress: organization.headquarterAddress,
+    slackId: organization.slackId,
   });
 
   useEffect(() => {
@@ -139,6 +144,7 @@ export default function GeneralSettingsTab() {
       websiteUrl: organization.websiteUrl,
       email: organization.email,
       headquarterAddress: organization.headquarterAddress,
+      slackId: organization.slackId,
     };
 
     if (JSON.stringify(prevData) !== JSON.stringify(currentData)) {
@@ -148,6 +154,7 @@ export default function GeneralSettingsTab() {
         websiteUrl: organization.websiteUrl || "",
         email: organization.email || "",
         headquarterAddress: organization.headquarterAddress || "",
+        slackId: organization.slackId || "",
       });
       prevOrgDataRef.current = currentData;
     }
@@ -163,6 +170,7 @@ export default function GeneralSettingsTab() {
           websiteUrl: data.websiteUrl || null,
           email: data.email || null,
           headquarterAddress: data.headquarterAddress || null,
+          slackId: data.slackId || null,
         },
       },
     });
@@ -399,6 +407,16 @@ export default function GeneralSettingsTab() {
               name="headquarterAddress"
               placeholder={__("123 Main St, City, Country")}
             />
+          </div>
+          <div>
+            <Field
+              {...register("slackId")}
+              readOnly={formState.isSubmitting}
+              name="slackId"
+              type="text"
+              label={__("Slack ID")}
+              placeholder={__("C1234567890")}
+              />
           </div>
 
           {formState.isDirty && (

--- a/apps/console/src/pages/organizations/settings/__generated__/GeneralSettingsTabFragment.graphql.ts
+++ b/apps/console/src/pages/organizations/settings/__generated__/GeneralSettingsTabFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<02beba57812b8dd7c5c61fb10291de5a>>
+ * @generated SignedSource<<06d72f40fa4d7f96b4cad010ac8e6d30>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -19,6 +19,7 @@ export type GeneralSettingsTabFragment$data = {
   readonly id: string;
   readonly logoUrl: string | null | undefined;
   readonly name: string;
+  readonly slackId: string | null | undefined;
   readonly updatedAt: any;
   readonly websiteUrl: string | null | undefined;
   readonly " $fragmentType": "GeneralSettingsTabFragment";
@@ -94,6 +95,13 @@ const node: ReaderFragment = {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
+      "name": "slackId",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
       "name": "createdAt",
       "storageKey": null
     },
@@ -109,6 +117,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "f6552148ce1c0061c4f5cbef78d46c0e";
+(node as any).hash = "bebe816d2d14a8b07d94f48c360d12ee";
 
 export default node;

--- a/apps/console/src/pages/organizations/settings/__generated__/GeneralSettingsTab_UpdateMutation.graphql.ts
+++ b/apps/console/src/pages/organizations/settings/__generated__/GeneralSettingsTab_UpdateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<270832e99647c6636914a9644a65358c>>
+ * @generated SignedSource<<e83ac9ec44f74ec09b1b0273b398bb55>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -17,6 +17,7 @@ export type UpdateOrganizationInput = {
   logoFile?: any | null | undefined;
   name?: string | null | undefined;
   organizationId: string;
+  slackId?: string | null | undefined;
   websiteUrl?: string | null | undefined;
 };
 export type GeneralSettingsTab_UpdateMutation$variables = {
@@ -32,6 +33,7 @@ export type GeneralSettingsTab_UpdateMutation$data = {
       readonly id: string;
       readonly logoUrl: string | null | undefined;
       readonly name: string;
+      readonly slackId: string | null | undefined;
       readonly websiteUrl: string | null | undefined;
     };
   };
@@ -127,6 +129,13 @@ v1 = [
             "kind": "ScalarField",
             "name": "headquarterAddress",
             "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slackId",
+            "storageKey": null
           }
         ],
         "storageKey": null
@@ -153,16 +162,16 @@ return {
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "55c07b334317a5ca30023ef5354a6c45",
+    "cacheID": "b12144751666cdf149b9da0e5c2147e1",
     "id": null,
     "metadata": {},
     "name": "GeneralSettingsTab_UpdateMutation",
     "operationKind": "mutation",
-    "text": "mutation GeneralSettingsTab_UpdateMutation(\n  $input: UpdateOrganizationInput!\n) {\n  updateOrganization(input: $input) {\n    organization {\n      id\n      name\n      logoUrl\n      horizontalLogoUrl\n      description\n      websiteUrl\n      email\n      headquarterAddress\n    }\n  }\n}\n"
+    "text": "mutation GeneralSettingsTab_UpdateMutation(\n  $input: UpdateOrganizationInput!\n) {\n  updateOrganization(input: $input) {\n    organization {\n      id\n      name\n      logoUrl\n      horizontalLogoUrl\n      description\n      websiteUrl\n      email\n      headquarterAddress\n      slackId\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "f1731adcb4bf7b7214301a612f48567e";
+(node as any).hash = "0bb9e3923427f5830a034a023cffe07c";
 
 export default node;

--- a/pkg/coredata/migrations/20251113T123000Z.sql
+++ b/pkg/coredata/migrations/20251113T123000Z.sql
@@ -1,0 +1,1 @@
+ALTER TABLE organizations ADD COLUMN slack_id TEXT;

--- a/pkg/coredata/organization.go
+++ b/pkg/coredata/organization.go
@@ -38,6 +38,7 @@ type (
 		WebsiteURL           *string      `db:"website_url"`
 		Email                *string      `db:"email"`
 		HeadquarterAddress   *string      `db:"headquarter_address"`
+		SlackID              *string      `db:"slack_id"`
 		CustomDomainID       *gid.GID     `db:"custom_domain_id"`
 		CreatedAt            time.Time    `db:"created_at"`
 		UpdatedAt            time.Time    `db:"updated_at"`
@@ -92,6 +93,7 @@ SELECT
     website_url,
     email,
     headquarter_address,
+    slack_id,
     custom_domain_id,
     created_at,
     updated_at
@@ -153,6 +155,7 @@ SELECT
     website_url,
     email,
     headquarter_address,
+    slack_id,
     custom_domain_id,
     created_at,
     updated_at
@@ -207,6 +210,7 @@ SELECT
     website_url,
     email,
     headquarter_address,
+    slack_id,
     custom_domain_id,
     logo_file_id,
     horizontal_logo_file_id,
@@ -261,6 +265,7 @@ SELECT
     website_url,
     email,
     headquarter_address,
+    slack_id,
     custom_domain_id,
     logo_file_id,
     horizontal_logo_file_id,
@@ -306,10 +311,11 @@ INSERT INTO organizations (
     website_url,
     email,
     headquarter_address,
+    slack_id,
     custom_domain_id,
     created_at,
     updated_at
-) VALUES (@tenant_id, @id, @name, @logo_file_id, @horizontal_logo_file_id, @description, @website_url, @email, @headquarter_address, @custom_domain_id, @created_at, @updated_at)
+) VALUES (@tenant_id, @id, @name, @logo_file_id, @horizontal_logo_file_id, @description, @website_url, @email, @headquarter_address, @slack_id, @custom_domain_id, @created_at, @updated_at)
 `
 
 	args := pgx.StrictNamedArgs{
@@ -322,6 +328,7 @@ INSERT INTO organizations (
 		"website_url":             o.WebsiteURL,
 		"email":                   o.Email,
 		"headquarter_address":     o.HeadquarterAddress,
+		"slack_id":                o.SlackID,
 		"custom_domain_id":        o.CustomDomainID,
 		"created_at":              o.CreatedAt,
 		"updated_at":              o.UpdatedAt,
@@ -350,6 +357,7 @@ SET
     website_url = @website_url,
     email = @email,
     headquarter_address = @headquarter_address,
+    slack_id = @slack_id,
     custom_domain_id = @custom_domain_id,
     updated_at = @updated_at
 WHERE
@@ -368,6 +376,7 @@ WHERE
 		"website_url":             o.WebsiteURL,
 		"email":                   o.Email,
 		"headquarter_address":     o.HeadquarterAddress,
+		"slack_id":                o.SlackID,
 		"custom_domain_id":        o.CustomDomainID,
 		"updated_at":              o.UpdatedAt,
 	}
@@ -424,6 +433,7 @@ SELECT
     website_url,
     email,
     headquarter_address,
+    slack_id,
     custom_domain_id,
     created_at,
     updated_at
@@ -476,6 +486,7 @@ SELECT
     website_url,
     email,
     headquarter_address,
+    slack_id,
     custom_domain_id,
     created_at,
     updated_at

--- a/pkg/probo/organization_service.go
+++ b/pkg/probo/organization_service.go
@@ -72,6 +72,7 @@ type (
 		WebsiteURL         **string
 		Email              **string
 		HeadquarterAddress **string
+		SlackID            **string
 	}
 
 	UpdateOrganizationContextRequest struct {
@@ -97,6 +98,7 @@ func (uor *UpdateOrganizationRequest) Validate() error {
 	v.Check(uor.WebsiteURL, "website_url", validator.SafeText(2048))
 	v.Check(uor.Email, "email", validator.SafeText(255))
 	v.Check(uor.HeadquarterAddress, "headquarter_address", validator.SafeText(2048))
+	v.Check(uor.SlackID, "slack_id", validator.SafeTextNoNewLine(100))
 	v.Check(uor.File, "file", validator.NotEmpty())
 	v.Check(uor.HorizontalLogoFile, "horizontal_logo_file", validator.NotEmpty())
 
@@ -317,6 +319,10 @@ func (s OrganizationService) Update(
 
 			if req.HeadquarterAddress != nil {
 				organization.HeadquarterAddress = *req.HeadquarterAddress
+			}
+
+			if req.SlackID != nil {
+				organization.SlackID = *req.SlackID
 			}
 
 			if err := organization.Update(ctx, s.svc.scope, tx); err != nil {

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -1458,6 +1458,7 @@ type Organization implements Node {
   websiteUrl: String
   email: String
   headquarterAddress: String
+  slackId: String
   context: OrganizationContext @goField(forceResolver: true)
 
   memberships(
@@ -3103,6 +3104,7 @@ input UpdateOrganizationInput {
   websiteUrl: String @goField(omittable: true)
   email: String @goField(omittable: true)
   headquarterAddress: String @goField(omittable: true)
+  slackId: String @goField(omittable: true)
   logoFile: Upload
   horizontalLogoFile: Upload
 }

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -1115,6 +1115,7 @@ type ComplexityRoot struct {
 		Risks                 func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskOrderBy, filter *types.RiskFilter) int
 		SamlConfigurations    func(childComplexity int) int
 		SlackConnections      func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey) int
+		SlackID               func(childComplexity int) int
 		Snapshots             func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.SnapshotOrderBy) int
 		Tasks                 func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TaskOrderBy) int
 		TrustCenter           func(childComplexity int) int
@@ -6965,6 +6966,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Organization.SlackConnections(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey)), true
 
+	case "Organization.slackId":
+		if e.complexity.Organization.SlackID == nil {
+			break
+		}
+
+		return e.complexity.Organization.SlackID(childComplexity), true
+
 	case "Organization.snapshots":
 		if e.complexity.Organization.Snapshots == nil {
 			break
@@ -11468,6 +11476,7 @@ type Organization implements Node {
   websiteUrl: String
   email: String
   headquarterAddress: String
+  slackId: String
   context: OrganizationContext @goField(forceResolver: true)
 
   memberships(
@@ -13113,6 +13122,7 @@ input UpdateOrganizationInput {
   websiteUrl: String @goField(omittable: true)
   email: String @goField(omittable: true)
   headquarterAddress: String @goField(omittable: true)
+  slackId: String @goField(omittable: true)
   logoFile: Upload
   horizontalLogoFile: Upload
 }
@@ -24105,6 +24115,8 @@ func (ec *executionContext) fieldContext_Asset_organization(_ context.Context, f
 				return ec.fieldContext_Organization_email(ctx, field)
 			case "headquarterAddress":
 				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
+			case "slackId":
+				return ec.fieldContext_Organization_slackId(ctx, field)
 			case "context":
 				return ec.fieldContext_Organization_context(ctx, field)
 			case "memberships":
@@ -24724,6 +24736,8 @@ func (ec *executionContext) fieldContext_Audit_organization(_ context.Context, f
 				return ec.fieldContext_Organization_email(ctx, field)
 			case "headquarterAddress":
 				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
+			case "slackId":
+				return ec.fieldContext_Organization_slackId(ctx, field)
 			case "context":
 				return ec.fieldContext_Organization_context(ctx, field)
 			case "memberships":
@@ -26039,6 +26053,8 @@ func (ec *executionContext) fieldContext_ContinualImprovement_organization(_ con
 				return ec.fieldContext_Organization_email(ctx, field)
 			case "headquarterAddress":
 				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
+			case "slackId":
+				return ec.fieldContext_Organization_slackId(ctx, field)
 			case "context":
 				return ec.fieldContext_Organization_context(ctx, field)
 			case "memberships":
@@ -29998,6 +30014,8 @@ func (ec *executionContext) fieldContext_CustomDomain_organization(_ context.Con
 				return ec.fieldContext_Organization_email(ctx, field)
 			case "headquarterAddress":
 				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
+			case "slackId":
+				return ec.fieldContext_Organization_slackId(ctx, field)
 			case "context":
 				return ec.fieldContext_Organization_context(ctx, field)
 			case "memberships":
@@ -30909,6 +30927,8 @@ func (ec *executionContext) fieldContext_Datum_organization(_ context.Context, f
 				return ec.fieldContext_Organization_email(ctx, field)
 			case "headquarterAddress":
 				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
+			case "slackId":
+				return ec.fieldContext_Organization_slackId(ctx, field)
 			case "context":
 				return ec.fieldContext_Organization_context(ctx, field)
 			case "memberships":
@@ -32453,6 +32473,8 @@ func (ec *executionContext) fieldContext_DeleteOrganizationHorizontalLogoPayload
 				return ec.fieldContext_Organization_email(ctx, field)
 			case "headquarterAddress":
 				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
+			case "slackId":
+				return ec.fieldContext_Organization_slackId(ctx, field)
 			case "context":
 				return ec.fieldContext_Organization_context(ctx, field)
 			case "memberships":
@@ -34061,6 +34083,8 @@ func (ec *executionContext) fieldContext_Document_organization(_ context.Context
 				return ec.fieldContext_Organization_email(ctx, field)
 			case "headquarterAddress":
 				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
+			case "slackId":
+				return ec.fieldContext_Organization_slackId(ctx, field)
 			case "context":
 				return ec.fieldContext_Organization_context(ctx, field)
 			case "memberships":
@@ -37533,6 +37557,8 @@ func (ec *executionContext) fieldContext_Framework_organization(_ context.Contex
 				return ec.fieldContext_Organization_email(ctx, field)
 			case "headquarterAddress":
 				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
+			case "slackId":
+				return ec.fieldContext_Organization_slackId(ctx, field)
 			case "context":
 				return ec.fieldContext_Organization_context(ctx, field)
 			case "memberships":
@@ -38837,6 +38863,8 @@ func (ec *executionContext) fieldContext_Invitation_organization(_ context.Conte
 				return ec.fieldContext_Organization_email(ctx, field)
 			case "headquarterAddress":
 				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
+			case "slackId":
+				return ec.fieldContext_Organization_slackId(ctx, field)
 			case "context":
 				return ec.fieldContext_Organization_context(ctx, field)
 			case "memberships":
@@ -40315,6 +40343,8 @@ func (ec *executionContext) fieldContext_Meeting_organization(_ context.Context,
 				return ec.fieldContext_Organization_email(ctx, field)
 			case "headquarterAddress":
 				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
+			case "slackId":
+				return ec.fieldContext_Organization_slackId(ctx, field)
 			case "context":
 				return ec.fieldContext_Organization_context(ctx, field)
 			case "memberships":
@@ -49513,6 +49543,8 @@ func (ec *executionContext) fieldContext_Nonconformity_organization(_ context.Co
 				return ec.fieldContext_Organization_email(ctx, field)
 			case "headquarterAddress":
 				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
+			case "slackId":
+				return ec.fieldContext_Organization_slackId(ctx, field)
 			case "context":
 				return ec.fieldContext_Organization_context(ctx, field)
 			case "memberships":
@@ -50586,6 +50618,8 @@ func (ec *executionContext) fieldContext_Obligation_organization(_ context.Conte
 				return ec.fieldContext_Organization_email(ctx, field)
 			case "headquarterAddress":
 				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
+			case "slackId":
+				return ec.fieldContext_Organization_slackId(ctx, field)
 			case "context":
 				return ec.fieldContext_Organization_context(ctx, field)
 			case "memberships":
@@ -51722,6 +51756,47 @@ func (ec *executionContext) _Organization_headquarterAddress(ctx context.Context
 }
 
 func (ec *executionContext) fieldContext_Organization_headquarterAddress(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Organization",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Organization_slackId(ctx context.Context, field graphql.CollectedField, obj *types.Organization) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Organization_slackId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SlackID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Organization_slackId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Organization",
 		Field:      field,
@@ -53690,6 +53765,8 @@ func (ec *executionContext) fieldContext_OrganizationEdge_node(_ context.Context
 				return ec.fieldContext_Organization_email(ctx, field)
 			case "headquarterAddress":
 				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
+			case "slackId":
+				return ec.fieldContext_Organization_slackId(ctx, field)
 			case "context":
 				return ec.fieldContext_Organization_context(ctx, field)
 			case "memberships":
@@ -54791,6 +54868,8 @@ func (ec *executionContext) fieldContext_ProcessingActivity_organization(_ conte
 				return ec.fieldContext_Organization_email(ctx, field)
 			case "headquarterAddress":
 				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
+			case "slackId":
+				return ec.fieldContext_Organization_slackId(ctx, field)
 			case "context":
 				return ec.fieldContext_Organization_context(ctx, field)
 			case "memberships":
@@ -57546,6 +57625,8 @@ func (ec *executionContext) fieldContext_Risk_organization(_ context.Context, fi
 				return ec.fieldContext_Organization_email(ctx, field)
 			case "headquarterAddress":
 				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
+			case "slackId":
+				return ec.fieldContext_Organization_slackId(ctx, field)
 			case "context":
 				return ec.fieldContext_Organization_context(ctx, field)
 			case "memberships":
@@ -58326,6 +58407,8 @@ func (ec *executionContext) fieldContext_SAMLConfiguration_organization(_ contex
 				return ec.fieldContext_Organization_email(ctx, field)
 			case "headquarterAddress":
 				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
+			case "slackId":
+				return ec.fieldContext_Organization_slackId(ctx, field)
 			case "context":
 				return ec.fieldContext_Organization_context(ctx, field)
 			case "memberships":
@@ -59951,6 +60034,8 @@ func (ec *executionContext) fieldContext_Snapshot_organization(_ context.Context
 				return ec.fieldContext_Organization_email(ctx, field)
 			case "headquarterAddress":
 				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
+			case "slackId":
+				return ec.fieldContext_Organization_slackId(ctx, field)
 			case "context":
 				return ec.fieldContext_Organization_context(ctx, field)
 			case "memberships":
@@ -60873,6 +60958,8 @@ func (ec *executionContext) fieldContext_Task_organization(_ context.Context, fi
 				return ec.fieldContext_Organization_email(ctx, field)
 			case "headquarterAddress":
 				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
+			case "slackId":
+				return ec.fieldContext_Organization_slackId(ctx, field)
 			case "context":
 				return ec.fieldContext_Organization_context(ctx, field)
 			case "memberships":
@@ -61725,6 +61812,8 @@ func (ec *executionContext) fieldContext_TrustCenter_organization(_ context.Cont
 				return ec.fieldContext_Organization_email(ctx, field)
 			case "headquarterAddress":
 				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
+			case "slackId":
+				return ec.fieldContext_Organization_slackId(ctx, field)
 			case "context":
 				return ec.fieldContext_Organization_context(ctx, field)
 			case "memberships":
@@ -63726,6 +63815,8 @@ func (ec *executionContext) fieldContext_TrustCenterFile_organization(_ context.
 				return ec.fieldContext_Organization_email(ctx, field)
 			case "headquarterAddress":
 				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
+			case "slackId":
+				return ec.fieldContext_Organization_slackId(ctx, field)
 			case "context":
 				return ec.fieldContext_Organization_context(ctx, field)
 			case "memberships":
@@ -65653,6 +65744,8 @@ func (ec *executionContext) fieldContext_UpdateOrganizationPayload_organization(
 				return ec.fieldContext_Organization_email(ctx, field)
 			case "headquarterAddress":
 				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
+			case "slackId":
+				return ec.fieldContext_Organization_slackId(ctx, field)
 			case "context":
 				return ec.fieldContext_Organization_context(ctx, field)
 			case "memberships":
@@ -67833,6 +67926,8 @@ func (ec *executionContext) fieldContext_Vendor_organization(_ context.Context, 
 				return ec.fieldContext_Organization_email(ctx, field)
 			case "headquarterAddress":
 				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
+			case "slackId":
+				return ec.fieldContext_Organization_slackId(ctx, field)
 			case "context":
 				return ec.fieldContext_Organization_context(ctx, field)
 			case "memberships":
@@ -81256,7 +81351,7 @@ func (ec *executionContext) unmarshalInputUpdateOrganizationInput(ctx context.Co
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"organizationId", "name", "description", "websiteUrl", "email", "headquarterAddress", "logoFile", "horizontalLogoFile"}
+	fieldsInOrder := [...]string{"organizationId", "name", "description", "websiteUrl", "email", "headquarterAddress", "slackId", "logoFile", "horizontalLogoFile"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -81305,6 +81400,13 @@ func (ec *executionContext) unmarshalInputUpdateOrganizationInput(ctx context.Co
 				return it, err
 			}
 			it.HeadquarterAddress = graphql.OmittableOf(data)
+		case "slackId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("slackId"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SlackID = graphql.OmittableOf(data)
 		case "logoFile":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("logoFile"))
 			data, err := ec.unmarshalOUpload2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚐUpload(ctx, v)
@@ -93019,6 +93121,8 @@ func (ec *executionContext) _Organization(ctx context.Context, sel ast.Selection
 			out.Values[i] = ec._Organization_email(ctx, field, obj)
 		case "headquarterAddress":
 			out.Values[i] = ec._Organization_headquarterAddress(ctx, field, obj)
+		case "slackId":
+			out.Values[i] = ec._Organization_slackId(ctx, field, obj)
 		case "context":
 			field := field
 

--- a/pkg/server/api/console/v1/types/organization.go
+++ b/pkg/server/api/console/v1/types/organization.go
@@ -51,6 +51,7 @@ func NewOrganization(o *coredata.Organization) *Organization {
 		WebsiteURL:         o.WebsiteURL,
 		Email:              o.Email,
 		HeadquarterAddress: o.HeadquarterAddress,
+		SlackID:            o.SlackID,
 		CreatedAt:          o.CreatedAt,
 		UpdatedAt:          o.UpdatedAt,
 	}

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -1471,6 +1471,7 @@ type Organization struct {
 	WebsiteURL            *string                         `json:"websiteUrl,omitempty"`
 	Email                 *string                         `json:"email,omitempty"`
 	HeadquarterAddress    *string                         `json:"headquarterAddress,omitempty"`
+	SlackID               *string                         `json:"slackId,omitempty"`
 	Context               *OrganizationContext            `json:"context,omitempty"`
 	Memberships           *MembershipConnection           `json:"memberships"`
 	Invitations           *InvitationConnection           `json:"invitations"`
@@ -2065,6 +2066,7 @@ type UpdateOrganizationInput struct {
 	WebsiteURL         graphql.Omittable[*string] `json:"websiteUrl,omitempty"`
 	Email              graphql.Omittable[*string] `json:"email,omitempty"`
 	HeadquarterAddress graphql.Omittable[*string] `json:"headquarterAddress,omitempty"`
+	SlackID            graphql.Omittable[*string] `json:"slackId,omitempty"`
 	LogoFile           *graphql.Upload            `json:"logoFile,omitempty"`
 	HorizontalLogoFile *graphql.Upload            `json:"horizontalLogoFile,omitempty"`
 }

--- a/pkg/server/api/console/v1/v1_resolver.go
+++ b/pkg/server/api/console/v1/v1_resolver.go
@@ -1349,6 +1349,7 @@ func (r *mutationResolver) UpdateOrganization(ctx context.Context, input types.U
 		WebsiteURL:         UnwrapOmittable(input.WebsiteURL),
 		Email:              UnwrapOmittable(input.Email),
 		HeadquarterAddress: UnwrapOmittable(input.HeadquarterAddress),
+		SlackID:            UnwrapOmittable(input.SlackID),
 	}
 
 	if input.LogoFile != nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a Slack ID field to Organizations across the DB, API, and Console settings. This lets admins store a Slack channel/workspace ID for upcoming integrations.

- **New Features**
  - Database: added organizations.slack_id (nullable TEXT).
  - GraphQL: exposed Organization.slackId and UpdateOrganizationInput.slackId.
  - Backend: update flow validates and persists Slack ID.
  - Console: General Settings tab includes a “Slack ID” field; queries/mutations updated.

- **Migration**
  - Run migration 20251113T123000Z.sql.
  - No backfill needed; field is optional.
  - Regenerate client GraphQL types if applicable.

<sup>Written for commit 438faef202306b74a8769cc5080b517e25f6a898. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

