### PR TITLE
Add api membership during organization creation

### DIFF
--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -1574,6 +1574,39 @@ func (s *Service) UpdateUserAPIKeyMemberships(
 	)
 }
 
+func (s *Service) AddAPIKeyMembershipToOrganization(
+	ctx context.Context,
+	tenantID gid.TenantID,
+	userAPIKeyID gid.GID,
+	membershipID gid.GID,
+	organizationID gid.GID,
+	role coredata.APIRole,
+) error {
+	scope := coredata.NewScope(tenantID)
+	now := time.Now()
+
+	return s.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			userAPIKeyMembership := &coredata.UserAPIKeyMembership{
+				ID:             gid.New(tenantID, coredata.UserAPIKeyMembershipEntityType),
+				UserAPIKeyID:   userAPIKeyID,
+				MembershipID:   membershipID,
+				Role:           role,
+				OrganizationID: organizationID,
+				CreatedAt:      now,
+				UpdatedAt:      now,
+			}
+
+			if err := userAPIKeyMembership.Insert(ctx, conn, scope); err != nil {
+				return fmt.Errorf("cannot insert user api key membership: %w", err)
+			}
+
+			return nil
+		},
+	)
+}
+
 func (s *Service) UpdateUserAPIKeyName(
 	ctx context.Context,
 	userAPIKeyID gid.GID,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Automatically link the current API key to a newly created organization by creating a full-access API key membership. This lets API calls work with the new org immediately after creation.

- **New Features**
  - Added Service.AddAPIKeyMembershipToOrganization to insert a UserAPIKeyMembership with APIRoleFull.
  - Updated createOrganization resolver to detect a current API key, fetch the user’s membership, and create the API key membership for the new org.

<sup>Written for commit 08c6cc8d09c9a9523048c331a698f95f91ac74ae. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

