### PR TITLE
Fix support PostgreSQL CA bundle in Helm charts with file path option

### DIFF
--- a/contrib/helm/charts/probo/README.md
+++ b/contrib/helm/charts/probo/README.md
@@ -155,6 +155,8 @@ The following parameters **must** be configured:
 | `postgresql.port`      | PostgreSQL port                 | `5432` |
 | `postgresql.database`  | Database name                   | `probod` |
 | `postgresql.username`  | Database user                   | `probod` |
+| `postgresql.caBundle`  | PostgreSQL TLS CA certificate bundle (inline) | `""` |
+| `postgresql.caBundlePath` | PostgreSQL TLS CA certificate bundle (file path) | `""` |
 | `s3.bucket`            | S3 bucket name                  | `probod` |
 | `s3.region`            | AWS region                      | `us-east-1` |
 | `s3.endpoint`          | S3 endpoint (for S3-compatible) | `""` |
@@ -182,6 +184,38 @@ The chart deploys the following:
 ### Migrations
 
 Database migrations run automatically when Probo starts. No manual intervention is required.
+
+### TLS/SSL Configuration
+
+For secure PostgreSQL connections, you can provide a CA certificate bundle in two ways:
+
+1. **Inline CA Bundle** (`postgresql.caBundle`): Provide the certificate content directly in values.yaml
+   ```yaml
+   postgresql:
+     caBundle: |
+       -----BEGIN CERTIFICATE-----
+       MIIEDzCCAvegAwIBAgIBADANBgkqhkiG9w0BAQUFADBoMQswCQYDVQQGEwJVUzEl
+       ...
+       -----END CERTIFICATE-----
+   ```
+
+2. **File Path** (`postgresql.caBundlePath`): Mount the CA bundle as a ConfigMap/Secret and reference the path
+   ```yaml
+   postgresql:
+     caBundlePath: /etc/ssl/certs/ca-certificates.crt
+
+   # Then mount your CA bundle using volumes/volumeMounts
+   volumes:
+     - name: ca-bundle
+       configMap:
+         name: postgres-ca-bundle
+   volumeMounts:
+     - name: ca-bundle
+       mountPath: /etc/ssl/certs
+       readOnly: true
+   ```
+
+**Note:** Using `caBundlePath` is recommended for large CA bundles (e.g., system CA bundles) as it avoids environment variable size limitations.
 
 ### Backup
 
@@ -232,6 +266,11 @@ Check the Probo logs for S3 connection errors when uploading files.
 postgresql:
   host: "mydb.abc123.us-east-1.rds.amazonaws.com"
   password: "<rds-password>"
+  # Optional: Add RDS CA bundle for TLS connections
+  # caBundle: |
+  #   -----BEGIN CERTIFICATE-----
+  #   ...RDS CA certificate...
+  #   -----END CERTIFICATE-----
 
 s3:
   region: "us-east-1"

--- a/contrib/helm/charts/probo/templates/deployment.yaml
+++ b/contrib/helm/charts/probo/templates/deployment.yaml
@@ -85,6 +85,16 @@ spec:
               value: {{ include "probo.postgresql.database" . | quote }}
             - name: PG_POOL_SIZE
               value: {{ .Values.postgresql.poolSize | default "100" | quote }}
+            {{- if .Values.postgresql.caBundle }}
+            - name: PG_CA_BUNDLE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "probo.fullname" . }}
+                  key: pg-ca-bundle
+            {{- else if .Values.postgresql.caBundlePath }}
+            - name: PG_CA_BUNDLE_PATH
+              value: {{ .Values.postgresql.caBundlePath | quote }}
+            {{- end }}
             # Authentication
             - name: AUTH_DISABLE_SIGNUP
               value: {{ .Values.probo.auth.disableSignup | quote }}

--- a/contrib/helm/charts/probo/templates/secret.yaml
+++ b/contrib/helm/charts/probo/templates/secret.yaml
@@ -8,6 +8,9 @@ type: Opaque
 stringData:
   # Database credentials
   db-password: {{ if .Values.postgresql.enabled }}{{ .Values.postgresql.auth.postgresPassword | quote }}{{ else }}{{ required "postgresql.password is required when postgresql.enabled=false" .Values.postgresql.password | quote }}{{ end }}
+  {{- if .Values.postgresql.caBundle }}
+  pg-ca-bundle: {{ .Values.postgresql.caBundle | quote }}
+  {{- end }}
 
   # S3 credentials
   s3-access-key: {{ include "probo.s3.accessKeyId" . | quote }}

--- a/contrib/helm/charts/probo/values.yaml
+++ b/contrib/helm/charts/probo/values.yaml
@@ -297,6 +297,13 @@ postgresql:
   password: ""  # REQUIRED when enabled=false: PostgreSQL password
   database: probod
   poolSize: 100
+  # PostgreSQL TLS/SSL configuration
+  # caBundle: |
+  #   -----BEGIN CERTIFICATE-----
+  #   ...certificate content...
+  #   -----END CERTIFICATE-----
+  # Or use caBundlePath to mount from a ConfigMap/Secret
+  # caBundlePath: /etc/ssl/certs/ca-certificates.crt
 
 # S3 storage configuration
 # For production: Use external S3 (AWS S3, GCS, etc.)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -325,6 +325,20 @@ Maximum number of database connections in the connection pool.
 
 PEM-encoded CA certificate bundle for TLS database connections. Required when connecting to databases with custom or self-signed certificates.
 
+**Environment Variable Options:**
+
+- `PG_CA_BUNDLE`: Provide the CA bundle content directly as an environment variable (suitable for smaller bundles)
+- `PG_CA_BUNDLE_PATH`: Provide a file path to the CA bundle (recommended for large CA bundles to avoid "Argument list too long" errors)
+
+**Example using file path:**
+```yaml
+# docker-compose.yml or Kubernetes deployment
+environment:
+  PG_CA_BUNDLE_PATH: /etc/ssl/certs/ca-certificates.crt
+```
+
+**Note:** When using `PG_CA_BUNDLE_PATH`, the file is read during configuration generation, avoiding environment size limitations. This is the recommended approach when using system CA bundles or large certificate collections.
+
 ### Authentication Configuration
 
 #### `auth.disable-signup` (boolean)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds file-path support for the PostgreSQL TLS CA bundle in Helm and entrypoint to avoid environment size limits. Fixes failures with large CA bundles and makes TLS setup more reliable.

- **Bug Fixes**
  - Helm: added postgresql.caBundlePath; still supports inline postgresql.caBundle.
  - Deployment: sets PG_CA_BUNDLE_PATH when using a file; keeps PG_CA_BUNDLE for inline.
  - Entrypoint: reads bundle from file (PG_CA_BUNDLE_PATH) without inlining content, preventing “Argument list too long”.
  - Docs: updated README, values.yaml, and CONFIGURATION with examples and guidance.

- **Migration**
  - For large bundles, mount the CA file into the pod and set postgresql.caBundlePath (e.g., /etc/ssl/certs/ca-certificates.crt).
  - No changes needed if you already use postgresql.caBundle inline.

<sup>Written for commit 6b05997aab6214f7e9e1f360d065a8da39ada544. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

