### PR TITLE
Fix invitation delete permission

### DIFF
--- a/apps/console/src/pages/organizations/settings/MembersSettingsTab.tsx
+++ b/apps/console/src/pages/organizations/settings/MembersSettingsTab.tsx
@@ -376,7 +376,7 @@ function InvitationRow(props: {
           {isDeleting ? (
             <Spinner size={16} />
           ) : (
-            <Authorized entity="Organization" action="deleteInvitation">
+            <Authorized entity="Invitation" action="deleteInvitation">
               <Button
                 variant="danger"
                 onClick={onDelete}

--- a/pkg/authz/permissions.go
+++ b/pkg/authz/permissions.go
@@ -291,7 +291,6 @@ var Permissions = map[uint16]map[Action][]Role{
 		ActionDeleteOrganizationHorizontalLogo: EditRoles,
 		ActionCreateTrustCenter:                EditRoles,
 		ActionInviteUser:                       EditRoles,
-		ActionDeleteInvitation:                 EditRoles,
 		ActionUpdateMembership:                 EditRoles,
 		ActionCreatePeople:                     EditRoles,
 		ActionCreateVendor:                     EditRoles,
@@ -370,6 +369,8 @@ var Permissions = map[uint16]map[Action][]Role{
 	coredata.InvitationEntityType: {
 		ActionGet:             AllRoles,
 		ActionGetOrganization: AllRoles,
+
+		ActionDeleteInvitation: EditRoles,
 	},
 	coredata.PeopleEntityType: {
 		ActionGet: AllRoles,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes incorrect permission checks for deleting invitations. The delete action is now scoped to the Invitation entity and restricted to Edit roles, ensuring only authorized users can remove invites.

<sup>Written for commit 15d223a76107a3b3a127fbc6ddd90c8d4373046a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

