### PR TITLE
Fix asset permissions

### DIFF
--- a/pkg/server/api/console/v1/v1_resolver.go
+++ b/pkg/server/api/console/v1/v1_resolver.go
@@ -3643,14 +3643,9 @@ func (r *mutationResolver) CreateAsset(ctx context.Context, input types.CreateAs
 
 // UpdateAsset is the resolver for the updateAsset field.
 func (r *mutationResolver) UpdateAsset(ctx context.Context, input types.UpdateAssetInput) (*types.UpdateAssetPayload, error) {
+	r.MustBeAuthorized(ctx, input.ID, authz.ActionUpdateAsset)
+
 	prb := r.ProboService(ctx, input.ID.TenantID())
-
-	existingAsset, err := prb.Assets.Get(ctx, input.ID)
-	if err != nil {
-		panic(fmt.Errorf("cannot get asset: %w", err))
-	}
-
-	r.MustBeAuthorized(ctx, existingAsset.OrganizationID, authz.ActionUpdateAsset)
 
 	asset, err := prb.Assets.Update(ctx, probo.UpdateAssetRequest{
 		ID:              input.ID,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed UpdateAsset authorization to validate permissions on the asset ID before updating, ensuring correct tenant-scoped access. Removed the asset pre-fetch and org-level check that could cause a panic and lead to incorrect permission checks.

<sup>Written for commit 41c0cf9daae113d3afe382fff144af38f0554a2f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

