### PR TITLE
Fix snapshots

### DIFF
--- a/pkg/coredata/asset_vendor.go
+++ b/pkg/coredata/asset_vendor.go
@@ -154,11 +154,12 @@ WITH
 		FROM asset_vendors
 		WHERE %s AND asset_id = ANY(SELECT id FROM source_assets) AND snapshot_id IS NULL
 	)
-INSERT INTO asset_vendors (tenant_id, asset_id, vendor_id, snapshot_id, created_at)
+INSERT INTO asset_vendors (tenant_id, asset_id, vendor_id, organization_id, snapshot_id, created_at)
 SELECT
 	@tenant_id,
 	sa.id,
 	sv.id,
+	@organization_id,
 	@snapshot_id,
 	av.created_at
 FROM source_asset_vendors av

--- a/pkg/coredata/datum_vendor.go
+++ b/pkg/coredata/datum_vendor.go
@@ -149,11 +149,12 @@ WITH
 		FROM data_vendors
 		WHERE %s AND datum_id = ANY(SELECT id FROM source_data)
 	)
-INSERT INTO data_vendors (tenant_id, datum_id, vendor_id, snapshot_id, created_at)
+INSERT INTO data_vendors (tenant_id, datum_id, vendor_id, organization_id, snapshot_id, created_at)
 SELECT
 	@tenant_id,
 	sd.id,
 	sv.id,
+	@organization_id,
 	@snapshot_id,
 	dv.created_at
 FROM source_data_vendors dv

--- a/pkg/probo/processing_activity_service.go
+++ b/pkg/probo/processing_activity_service.go
@@ -185,7 +185,7 @@ func (s *ProcessingActivityService) Create(
 			}
 
 			if len(req.VendorIDs) > 0 {
-				if err := processingActivityVendors.Insert(ctx, conn, s.svc.scope, processingActivity.ID, req.VendorIDs); err != nil {
+				if err := processingActivityVendors.Insert(ctx, conn, s.svc.scope, processingActivity.ID, req.OrganizationID, req.VendorIDs); err != nil {
 					return fmt.Errorf("cannot create processing activity vendors: %w", err)
 				}
 			}
@@ -268,7 +268,7 @@ func (s *ProcessingActivityService) Update(
 			}
 
 			if req.VendorIDs != nil {
-				if err := processingActivityVendors.Merge(ctx, conn, s.svc.scope, processingActivity.ID, *req.VendorIDs); err != nil {
+				if err := processingActivityVendors.Merge(ctx, conn, s.svc.scope, processingActivity.ID, processingActivity.OrganizationID, *req.VendorIDs); err != nil {
 					return fmt.Errorf("cannot update processing activity vendors: %w", err)
 				}
 			}


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes snapshot creation for vendor associations by persisting organization_id across asset, datum, and processing activity vendors. Snapshots now correctly capture organization context and avoid mismatched relations.

- **Bug Fixes**
  - Add organization_id to INSERT/MERGE for asset_vendors, data_vendors, and processing_activity_vendors, including snapshot copy queries.
  - Update ProcessingActivityVendors.Insert and Merge to accept organizationID and write it to the DB; service now passes organizationID on create/update.

<sup>Written for commit 70e00e2630bf5636eee313558ffbe6c363495892. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



