### PR TITLE
Fix: Add verifyDomain permission for SAMLConfiguration entity

### DIFF
--- a/pkg/authz/permissions.go
+++ b/pkg/authz/permissions.go
@@ -660,6 +660,7 @@ var Permissions = map[uint16]map[Action][]Role{
 		ActionDeleteSAMLConfiguration: {RoleOwner, RoleAdmin},
 		ActionEnableSAML:              {RoleOwner, RoleAdmin},
 		ActionDisableSAML:             {RoleOwner, RoleAdmin},
+		ActionVerifyDomain:            {RoleOwner},
 	},
 	coredata.FileEntityType: {
 		ActionGet:         AllRoles,


### PR DESCRIPTION
Added missing ActionVerifyDomain permission mapping for SAMLConfigurationEntityType to fix authorization error when verifying SAML domain. Fixes #539



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing verifyDomain permission to SAMLConfiguration, allowing only owners to verify SAML domains. Fixes the authorization error during domain verification.

<sup>Written for commit 1701ce79735e9798b13bfd2ccac52e658f2c2dcc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



