### PR TITLE
Fix: Correct SAML config path in entrypoint script

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -111,6 +111,13 @@ EOF
     password:
       pepper: "${AUTH_PASSWORD_PEPPER:?AUTH_PASSWORD_PEPPER is required}"
       iterations: ${AUTH_PASSWORD_ITERATIONS:-1000000}
+    saml:
+      session-duration: ${SAML_SESSION_DURATION:-604800}
+      cleanup-interval-seconds: ${SAML_CLEANUP_INTERVAL_SECONDS:-0}
+      certificate: |
+$(echo "${SAML_CERTIFICATE:-}" | sed 's/^/        /')
+      private-key: |
+$(echo "${SAML_PRIVATE_KEY:-}" | sed 's/^/        /')
 
   trust-auth:
     cookie-name: "${TRUST_AUTH_COOKIE_NAME:-TCT}"
@@ -177,18 +184,6 @@ EOF
         signing-secret: "${CONNECTOR_SLACK_SIGNING_SECRET:?CONNECTOR_SLACK_SIGNING_SECRET is required when CONNECTOR_SLACK_CLIENT_ID is set}"
 EOF
   fi
-
-  # Add SAML config if any SAML variable is configured
-    cat >> "$CONFIG_FILE" <<EOF
-
-saml:
-  session-duration: ${SAML_SESSION_DURATION:-604800}
-  cleanup-interval-seconds: ${SAML_CLEANUP_INTERVAL_SECONDS:-0}
-  certificate: |
-$(echo "${SAML_CERTIFICATE:-}" | sed 's/^/    /')
-  private-key: |
-$(echo "${SAML_PRIVATE_KEY:-}" | sed 's/^/    /')
-EOF
 
   echo "Configuration file generated at: $CONFIG_FILE"
 fi


### PR DESCRIPTION
Fix entrypoint.sh to place SAML config under auth.saml instead of root level, resolving "SP certificate and private key are not configured" error

Fixes #541



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the SAML config path in entrypoint.sh by nesting it under auth.saml, resolving the “SP certificate and private key are not configured” error. SAML settings now load correctly from environment variables.

- **Bug Fixes**
  - Moved saml config under auth.saml in the generated YAML.
  - Correctly indented certificate and private-key values.
  - Removed the incorrect root-level saml block.

<sup>Written for commit 8714a5902b1fe3383289add0b5a3020d05aff477. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



