### PR TITLE
Fix vendor snapshot

### DIFF
--- a/pkg/coredata/vendor_service.go
+++ b/pkg/coredata/vendor_service.go
@@ -289,6 +289,7 @@ WITH
 INSERT INTO vendor_services (
 	tenant_id,
 	id,
+	organization_id,
 	snapshot_id,
 	source_id,
 	vendor_id,
@@ -300,6 +301,7 @@ INSERT INTO vendor_services (
 SELECT
 	@tenant_id,
 	generate_gid(decode_base64_unpadded(@tenant_id), @vendor_service_entity_type),
+	@organization_id,
 	@snapshot_id,
 	vs.id,
 	sv.id,


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Include organization_id when inserting vendor_services during snapshot creation. This correctly associates snapshot records with the organization and prevents orphaned entries.

<sup>Written for commit 55eb8a6c06b6d3a2604f8d1d0600df26f5d9baba. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



