### PR TITLE
fix entrypoint to set email passwd/username

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -142,6 +142,8 @@ $(echo "${SAML_PRIVATE_KEY:-}" | sed 's/^/        /')
       sender-email: "${MAILER_SENDER_EMAIL:-no-reply@notification.getprobo.com}"
       smtp:
         addr: "${SMTP_ADDR:-localhost:1025}"
+        user: "${SMTP_USER:-}"
+        password: "${SMTP_PASSWORD:-}"
         tls-required: ${SMTP_TLS_REQUIRED:-false}
       mailer-interval: ${MAILER_INTERVAL:-60}
     slack:


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set SMTP user and password via environment variables (SMTP_USER, SMTP_PASSWORD) in entrypoint.sh to enable authenticated SMTP for outgoing emails.

<sup>Written for commit 2dca2099593bdf51f513182cd14d78e5cd7c9e9a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





