### PR TITLE
Fix probod baseurl and remove acme root-ca

### DIFF
--- a/cfg/dev.yaml
+++ b/cfg/dev.yaml
@@ -9,7 +9,7 @@ unit:
     max-queue-size: 2048
 
 probod:
-  base-url: "localhost:5173"
+  base-url: "http://localhost:5173"
   encryption-key: "thisisnotasecretAAAAAAAAAAAAAAAAAAAAAAAAAAA="
   chrome-dp-addr: "localhost:9222"
 


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated dev config to point probod base-url to localhost:5173 for local development and removed the ACME root-ca override to use defaults. This fixes misdirected requests to production and simplifies ACME setup in dev.

<sup>Written for commit 178674ff99aca324da72283394c712bdf73a690a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





