### PR TITLE
Fix n8n always in success mode

### DIFF
--- a/packages/n8n-node/nodes/Probo/GenericFunctions.ts
+++ b/packages/n8n-node/nodes/Probo/GenericFunctions.ts
@@ -34,7 +34,19 @@ export async function proboApiRequest(
 	};
 
 	try {
-		return await this.helpers.httpRequest(options);
+		const response = await this.helpers.httpRequest(options);
+
+		if (response.errors && Array.isArray(response.errors) && response.errors.length > 0) {
+			const errorMessages = response.errors.map((err: IDataObject) => 
+				err.message || JSON.stringify(err)
+			).join('; ');
+			throw new NodeApiError(this.getNode(), {
+				message: `GraphQL errors: ${errorMessages}`,
+				httpCode: '200',
+			} as JsonObject);
+		}
+		
+		return response;
 	} catch (error) {
 		throw new NodeApiError(this.getNode(), error as JsonObject);
 	}


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix the Probo n8n node always showing success. Detect GraphQL errors in HTTP 200 responses and throw a NodeApiError so the node fails when errors are present.

<sup>Written for commit 06098464b0965353ce0d386278e04328d2f60074. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



