### PR TITLE
Fix output and sarif upload trivy

### DIFF
--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
       - uses: "actions/setup-go@v5"
         with:
-          go-version: "1.25"
+          go-version: "1.25.5"
       - uses: "actions/setup-node@v4"
         with:
           node-version-file: ".nvmrc"
@@ -85,7 +85,7 @@ jobs:
       - uses: "actions/checkout@v4"
       - uses: "actions/setup-go@v5"
         with:
-          go-version: "1.25"
+          go-version: "1.25.5"
       - uses: "actions/setup-node@v4"
         with:
           node-version-file: ".nvmrc"
@@ -111,7 +111,7 @@ jobs:
       - uses: "actions/checkout@v4"
       - uses: "actions/setup-go@v5"
         with:
-          go-version: "1.25"
+          go-version: "1.25.5"
       - uses: "actions/setup-node@v4"
         with:
           node-version-file: ".nvmrc"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.25.5"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.probo.inc/probo
 
-go 1.25.3
+go 1.25.5
 
 require (
 	github.com/99designs/gqlgen v0.17.83


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix Trivy scan output and SARIF uploads in CI so results reliably appear in the GitHub Security tab, with branch-aware behavior to avoid noisy failures.

- **Bug Fixes**
  - make.yaml: On main, run Trivy with SARIF and upload; on other branches, use table output and fail on findings.
  - release.yaml: Add security-events permission, scan the release image tag with SARIF, and always upload results.
  - Move SBOM generation and Anchore scan from the test job to the build/release stage; fail builds on critical findings.

- **Dependencies**
  - Upgrade Go to 1.25.5 in go.mod and GitHub Actions.

<sup>Written for commit 9bbea1d15e4bdc9f789cef4c1628bd05d8751525. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



