### PR TITLE
Fix tempo protocol in local stack

### DIFF
--- a/cmd/probod/main.go
+++ b/cmd/probod/main.go
@@ -17,13 +17,13 @@ package main
 import (
 	"context"
 
-	"go.probo.inc/probo/pkg/probod"
 	"go.gearno.de/kit/unit"
+	"go.probo.inc/probo/pkg/probod"
 )
 
 var (
 	version string = "unknown"
-	env     string = "unknow"
+	env     string = "unknown"
 )
 
 func main() {

--- a/compose/tempo/tempo.yaml
+++ b/compose/tempo/tempo.yaml
@@ -5,7 +5,7 @@ distributor:
   receivers:
     otlp:
       protocols:
-        grpc:
+        http:
           endpoint: "0.0.0.0:4317"
 
 ingester:
@@ -38,4 +38,3 @@ storage:
 
 usage_report:
   reporting_enabled: false
-


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes broken local tracing by switching Tempo’s OTLP receiver to HTTP in the docker-compose stack. Also corrects the default env string.

- **Bug Fixes**
  - Tempo: use OTLP HTTP at 0.0.0.0:4317 in compose/tempo/tempo.yaml to match local dev clients.
  - CLI: fix default env value from "unknow" to "unknown".

<sup>Written for commit 7aa02da555bb262747b5734e9016e90de20088a6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

