### PR TITLE
Invitation not deleted when delete organization

### DIFF
--- a/pkg/coredata/migrations/20251205T154956Z.sql
+++ b/pkg/coredata/migrations/20251205T154956Z.sql
@@ -1,5 +1,11 @@
 DELETE FROM authz_invitations 
 WHERE organization_id NOT IN (SELECT id FROM organizations);
 
+DELETE FROM authz_memberships 
+WHERE organization_id NOT IN (SELECT id FROM organizations);
+
 ALTER TABLE authz_invitations ADD CONSTRAINT authz_invitations_organization_id_fkey
+FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE;
+
+ALTER TABLE authz_memberships ADD CONSTRAINT authz_memberships_organization_id_fkey
 FOREIGN KEY (organization_id) REFERENCES organizations(id) ON DELETE CASCADE;


### PR DESCRIPTION
fixes: #563 

cascade authz_invitations and authz_memberships on organization delete

[delete invitation.webm](https://github.com/user-attachments/assets/6eda4ff0-b5cd-4d14-a435-ee0a01a6bb24)








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delete invitations and memberships automatically when an organization is removed. Adds cascade constraints and cleans up existing orphaned records.

- **Migration**
  - Delete invitations and memberships with non-existent organizations.
  - Add FKs on authz_invitations.organization_id and authz_memberships.organization_id referencing organizations(id) with ON DELETE CASCADE.

<sup>Written for commit 4dfe61ba0bbb4793a635807ce49303ceadfb0612. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







