### PR TITLE
Make employee role assignable

### DIFF
--- a/apps/console/src/components/organizations/InviteUserDialog.tsx
+++ b/apps/console/src/components/organizations/InviteUserDialog.tsx
@@ -45,7 +45,7 @@ const inviteMutation = graphql`
 const schema = z.object({
   email: z.string().email(),
   fullName: z.string(),
-  role: z.enum(["OWNER", "ADMIN", "FULL", "VIEWER"]).default("VIEWER"),
+  role: z.enum(["OWNER", "ADMIN", "FULL", "VIEWER", "EMPLOYEE"]).default("VIEWER"),
   createPeople: z.boolean().default(false),
 });
 
@@ -126,6 +126,7 @@ function InviteUserDialogContent({ children, connectionId, onRefetch }: Props) {
                     {assignableRoles.includes("OWNER") && <Option value="OWNER">{__("Owner")}</Option>}
                     {assignableRoles.includes("ADMIN") && <Option value="ADMIN">{__("Admin")}</Option>}
                     {assignableRoles.includes("VIEWER") && <Option value="VIEWER">{__("Viewer")}</Option>}
+                    {assignableRoles.includes("EMPLOYEE") && <Option value="EMPLOYEE">{__("Employee")}</Option>}
                   </Select>
                   <div className="mt-2 text-sm text-txt-tertiary">
                     {field.value === "OWNER" && (
@@ -136,6 +137,9 @@ function InviteUserDialogContent({ children, connectionId, onRefetch }: Props) {
                     )}
                     {field.value === "VIEWER" && (
                       <p>{__("Read-only access")}</p>
+                    )}
+                    {field.value === "EMPLOYEE" && (
+                      <p>{__("Access to employee page")}</p>
                     )}
                   </div>
                 </>

--- a/apps/console/src/pages/organizations/settings/MembersSettingsTab.tsx
+++ b/apps/console/src/pages/organizations/settings/MembersSettingsTab.tsx
@@ -535,6 +535,7 @@ function MembershipRowContent(props: {
                   {availableRoles.includes("OWNER") && <Option value="OWNER">{__("Owner")}</Option>}
                   {availableRoles.includes("ADMIN") && <Option value="ADMIN">{__("Admin")}</Option>}
                   {availableRoles.includes("VIEWER") && <Option value="VIEWER">{__("Viewer")}</Option>}
+                  {availableRoles.includes("EMPLOYEE") && <Option value="EMPLOYEE">{__("Employee")}</Option>}
                 </Select>
               </Field>
 
@@ -547,6 +548,9 @@ function MembershipRowContent(props: {
                 )}
                 {selectedRole === "VIEWER" && (
                   <p>{__("Read-only access")}</p>
+                )}
+                {selectedRole === "EMPLOYEE" && (
+                  <p>{__("Access to employee page")}</p>
                 )}
               </div>
             </div>

--- a/packages/helpers/src/roles.ts
+++ b/packages/helpers/src/roles.ts
@@ -9,11 +9,11 @@ export type Role = (typeof Role)[keyof typeof Role];
 
 export function getAssignableRoles(currentRole: Role): Role[] {
   if (currentRole === Role.OWNER) {
-    return [Role.OWNER, Role.ADMIN, Role.VIEWER];
+    return [Role.OWNER, Role.ADMIN, Role.VIEWER, Role.EMPLOYEE];
   }
 
   if (currentRole === Role.ADMIN) {
-    return [Role.ADMIN, Role.VIEWER];
+    return [Role.ADMIN, Role.VIEWER, Role.EMPLOYEE];
   }
 
   return [];


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable assigning the Employee role to organization members. Updated role enum and getAssignableRoles, and added “Employee” to Invite User and Members settings with help text (“Access to employee page”).

<sup>Written for commit c355f1c307f1a56b797f54d13eee82b8af7db098. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

