### PR TITLE
Allow svg for logo

### DIFF
--- a/apps/console/src/pages/organizations/settings/GeneralSettingsTab.tsx
+++ b/apps/console/src/pages/organizations/settings/GeneralSettingsTab.tsx
@@ -278,7 +278,7 @@ export default function GeneralSettingsTab() {
                   onChange={handleLogoChange}
                   variant="secondary"
                   className="ml-auto"
-                  accept="image/png,image/jpeg,image/jpg"
+                  accept="image/png,image/jpeg,image/jpg,image/svg+xml"
                 >
                   {isUpdatingOrganization
                     ? __("Uploading...")
@@ -313,7 +313,7 @@ export default function GeneralSettingsTab() {
                   disabled={formState.isSubmitting || isUpdatingOrganization}
                   onChange={handleHorizontalLogoChange}
                   variant="secondary"
-                  accept="image/png,image/jpeg,image/jpg"
+                  accept="image/png,image/jpeg,image/jpg,image/svg+xml"
                 >
                   {isUpdatingOrganization
                     ? __("Uploading...")


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow SVG logos for organization logo uploads in Settings. Updated both logo upload inputs to accept image/svg+xml alongside PNG and JPEG.

<sup>Written for commit 3bf3129debaa6966e21fb9d3135bbed8f82ff086. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



