### PR TITLE
Add missing validation on relation existence

### DIFF
--- a/pkg/probo/asset_service.go
+++ b/pkg/probo/asset_service.go
@@ -189,6 +189,10 @@ func (s AssetService) Update(
 			asset.Amount = *req.Amount
 		}
 		if req.OwnerID != nil {
+			people := &coredata.People{}
+			if err := people.LoadByID(ctx, conn, s.svc.scope, *req.OwnerID); err != nil {
+				return fmt.Errorf("cannot load owner: %w", err)
+			}
 			asset.OwnerID = *req.OwnerID
 		}
 		if req.AssetType != nil {
@@ -243,6 +247,11 @@ func (s AssetService) Create(
 	}
 
 	err := s.svc.pg.WithTx(ctx, func(conn pg.Conn) error {
+		people := &coredata.People{}
+		if err := people.LoadByID(ctx, conn, s.svc.scope, req.OwnerID); err != nil {
+			return fmt.Errorf("cannot load owner: %w", err)
+		}
+
 		if err := asset.Insert(ctx, conn, s.svc.scope); err != nil {
 			return fmt.Errorf("cannot insert asset: %w", err)
 		}

--- a/pkg/probo/datum_service.go
+++ b/pkg/probo/datum_service.go
@@ -196,6 +196,10 @@ func (s DatumService) Update(
 			datum.DataClassification = *req.DataClassification
 		}
 		if req.OwnerID != nil {
+			people := &coredata.People{}
+			if err := people.LoadByID(ctx, conn, s.svc.scope, *req.OwnerID); err != nil {
+				return fmt.Errorf("cannot load owner: %w", err)
+			}
 			datum.OwnerID = *req.OwnerID
 		}
 		datum.UpdatedAt = now
@@ -245,6 +249,11 @@ func (s DatumService) Create(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(conn pg.Conn) error {
+			people := &coredata.People{}
+			if err := people.LoadByID(ctx, conn, s.svc.scope, req.OwnerID); err != nil {
+				return fmt.Errorf("cannot load owner: %w", err)
+			}
+
 			if err := datum.Insert(ctx, conn, s.svc.scope); err != nil {
 				return fmt.Errorf("cannot insert datum: %w", err)
 			}

--- a/pkg/probo/nonconformity_service.go
+++ b/pkg/probo/nonconformity_service.go
@@ -209,9 +209,19 @@ func (s *NonconformityService) Update(
 				nonconformity.CorrectiveAction = *req.CorrectiveAction
 			}
 			if req.OwnerID != nil {
+				people := &coredata.People{}
+				if err := people.LoadByID(ctx, conn, s.svc.scope, *req.OwnerID); err != nil {
+					return fmt.Errorf("cannot load owner: %w", err)
+				}
 				nonconformity.OwnerID = *req.OwnerID
 			}
 			if req.AuditID != nil {
+				if *req.AuditID != nil {
+					audit := &coredata.Audit{}
+					if err := audit.LoadByID(ctx, conn, s.svc.scope, **req.AuditID); err != nil {
+						return fmt.Errorf("cannot load audit: %w", err)
+					}
+				}
 				nonconformity.AuditID = *req.AuditID
 			}
 			if req.DueDate != nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Validate related records before setting relationships in asset, datum, nonconformity, and task operations to prevent invalid references and improve data integrity.

- **Bug Fixes**
  - AssetService: verify OwnerID exists on create and update.
  - DatumService: verify OwnerID exists on create and update.
  - NonconformityService: verify OwnerID exists; if AuditID is provided, verify audit exists.
  - TaskService: on create, verify MeasureID and AssignedToID; on assign, verify assignee exists.

<sup>Written for commit d94d10148515f32b9de6c1c96af24b23bf87d631. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

