### PR TITLE
Fix create meeting dialog

### DIFF
--- a/apps/console/src/pages/organizations/meetings/dialogs/CreateMeetingDialog.tsx
+++ b/apps/console/src/pages/organizations/meetings/dialogs/CreateMeetingDialog.tsx
@@ -82,7 +82,7 @@ export function CreateMeetingDialog({ children, connectionId }: Props) {
   return (
     <Dialog ref={dialogRef} trigger={children} title={__("Create meeting")}>
       <form onSubmit={onSubmit}>
-        <DialogContent>
+        <DialogContent padded className="space-y-4">
           <Field label={__("Meeting name")} required>
             <Input
               {...register("name")}


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the Create Meeting dialog layout by adding padding and vertical spacing to DialogContent. This prevents cramped fields and aligns the dialog with the rest of the UI.

<sup>Written for commit 6b1cdd7db87d50d94f25419830caf1cb8e0b3bf4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



