### PR TITLE
Fix permission trust center document access

### DIFF
--- a/pkg/authz/permissions.go
+++ b/pkg/authz/permissions.go
@@ -45,6 +45,7 @@ const (
 	ActionGetCustomDomain               Action = "getCustomDomain"
 	ActionGetDataPrivacyAgreement       Action = "getDataPrivacyAgreement"
 	ActionGetDocument                   Action = "getDocument"
+	ActionGetReport                     Action = "getReport"
 	ActionGetFile                       Action = "getFile"
 	ActionGetFileUrl                    Action = "getFileUrl"
 	ActionGetFramework                  Action = "getFramework"
@@ -351,6 +352,8 @@ var Permissions = map[uint16]map[Action][]Role{
 		ActionActiveCount:               NonEmployeeRoles,
 		ActionPendingRequestCount:       NonEmployeeRoles,
 		ActionAvailableDocumentAccesses: NonEmployeeRoles,
+		ActionGetTrustCenterFile:        NonEmployeeRoles,
+		ActionGetReport:                 NonEmployeeRoles,
 
 		ActionUpdateTrustCenterAccess: EditRoles,
 		ActionDeleteTrustCenterAccess: EditRoles,

--- a/pkg/server/api/console/v1/v1_resolver.go
+++ b/pkg/server/api/console/v1/v1_resolver.go
@@ -6516,7 +6516,7 @@ func (r *trustCenterDocumentAccessResolver) Document(ctx context.Context, obj *t
 
 // Report is the resolver for the report field.
 func (r *trustCenterDocumentAccessResolver) Report(ctx context.Context, obj *types.TrustCenterDocumentAccess) (*types.Report, error) {
-	r.MustBeAuthorized(ctx, obj.TrustCenterAccessID, authz.ActionReport)
+	r.MustBeAuthorized(ctx, obj.TrustCenterAccessID, authz.ActionGetReport)
 
 	if obj.ReportID == nil {
 		return nil, nil
@@ -6534,7 +6534,7 @@ func (r *trustCenterDocumentAccessResolver) Report(ctx context.Context, obj *typ
 
 // TrustCenterFile is the resolver for the trustCenterFile field.
 func (r *trustCenterDocumentAccessResolver) TrustCenterFile(ctx context.Context, obj *types.TrustCenterDocumentAccess) (*types.TrustCenterFile, error) {
-	r.MustBeAuthorized(ctx, obj.TrustCenterAccessID, authz.ActionTrustCenterFile)
+	r.MustBeAuthorized(ctx, obj.TrustCenterAccessID, authz.ActionGetTrustCenterFile)
 
 	if obj.TrustCenterFileID == nil {
 		return nil, nil


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix authorization checks in Trust Center document access resolver to use the document access ID. Define and use GetReport and GetTrustCenterFile actions with correct permissions for Report and TrustCenterFile queries.

<sup>Written for commit f0489f7d6ffeae38844ea8cecc86d0d0255e8264. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



