### PR TITLE
Fix permissions

### DIFF
--- a/pkg/authz/permissions.go
+++ b/pkg/authz/permissions.go
@@ -47,6 +47,7 @@ const (
 	ActionGetDocument                   Action = "getDocument"
 	ActionGetReport                     Action = "getReport"
 	ActionGetFile                       Action = "getFile"
+	ActionGetAudit                      Action = "getAudit"
 	ActionGetFileUrl                    Action = "getFileUrl"
 	ActionGetFramework                  Action = "getFramework"
 	ActionGetHorizontalLogoUrl          Action = "getHorizontalLogoUrl"
@@ -557,8 +558,9 @@ var Permissions = map[uint16]map[Action][]Role{
 		ActionSignatures:               NonEmployeeRoles,
 		ActionExportDocumentVersionPDF: NonEmployeeRoles,
 
-		ActionUpdateDocumentVersion: EditRoles,
-		ActionRequestSignature:      EditRoles,
+		ActionUpdateDocumentVersion:      EditRoles,
+		ActionRequestSignature:           EditRoles,
+		ActionDeleteDraftDocumentVersion: EditRoles,
 	},
 	coredata.DocumentVersionSignatureEntityType: {
 		ActionGet:             NonEmployeeRoles,
@@ -619,6 +621,7 @@ var Permissions = map[uint16]map[Action][]Role{
 	},
 	coredata.ReportEntityType: {
 		ActionGet:             NonEmployeeRoles,
+		ActionGetAudit:        NonEmployeeRoles,
 		ActionGetFile:         NonEmployeeRoles,
 		ActionGetOrganization: NonEmployeeRoles,
 		ActionGetSnapshot:     NonEmployeeRoles,

--- a/pkg/server/api/console/v1/v1_resolver.go
+++ b/pkg/server/api/console/v1/v1_resolver.go
@@ -5827,14 +5827,14 @@ func (r *reportResolver) DownloadURL(ctx context.Context, obj *types.Report) (*s
 
 // Audit is the resolver for the audit field.
 func (r *reportResolver) Audit(ctx context.Context, obj *types.Report) (*types.Audit, error) {
+	r.MustBeAuthorized(ctx, obj.ID, authz.ActionGetAudit)
+
 	prb := r.ProboService(ctx, obj.ID.TenantID())
 
 	audit, err := prb.Audits.GetByReportID(ctx, obj.ID)
 	if err != nil {
 		panic(fmt.Errorf("cannot load audit for report: %w", err))
 	}
-
-	r.MustBeAuthorized(ctx, audit.OrganizationID, authz.ActionAudit)
 
 	return types.NewAudit(audit), nil
 }


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes incorrect permissions for report audit access and adds the missing permission to delete draft document versions.

- **Bug Fixes**
  - Added ActionGetAudit and enforced it in the report audit resolver at the report scope.
  - Allowed NonEmployeeRoles to access report audits.
  - Granted EditRoles permission to delete draft document versions.

<sup>Written for commit 8a817a70ecc0bb51ad77afa736db62c2c8d1e10e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



