### PR TITLE
Fix vendor certifications dropdown

### DIFF
--- a/packages/ui/src/Molecules/Combobox/Combobox.tsx
+++ b/packages/ui/src/Molecules/Combobox/Combobox.tsx
@@ -49,7 +49,12 @@ export function Combobox({
                 className={input()}
             />
             {showDropdown && (
-                <ComboboxPopover gutter={4} sameWidth className={dropdown()}>
+                <ComboboxPopover
+                    gutter={4}
+                    sameWidth
+                    className={dropdown()}
+                    style={{ maxHeight: "var(--popover-available-height)" }}
+                >
                     {children}
                 </ComboboxPopover>
             )}


### PR DESCRIPTION
Fix https://github.com/getprobo/probo/issues/487






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set a max height on the Combobox popover to match the available viewport space, fixing the vendor certifications dropdown overflow. The dropdown now stays in view and scrolls when needed.

<sup>Written for commit 9e5a775f6605f2829f4423124dc3ee972dad2361. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







