### PR TITLE
Add service to vendor on n8n

### DIFF
--- a/packages/n8n-node/nodes/Probo/actions/vendor/createService.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/vendor/createService.operation.ts
@@ -1,0 +1,87 @@
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { proboApiRequest } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Vendor ID',
+		name: 'vendorId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['vendor'],
+				operation: ['createService'],
+			},
+		},
+		default: '',
+		description: 'The ID of the vendor',
+		required: true,
+	},
+	{
+		displayName: 'Name',
+		name: 'name',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['vendor'],
+				operation: ['createService'],
+			},
+		},
+		default: '',
+		description: 'The name of the vendor service',
+		required: true,
+	},
+	{
+		displayName: 'Description',
+		name: 'description',
+		type: 'string',
+		typeOptions: {
+			rows: 4,
+		},
+		displayOptions: {
+			show: {
+				resource: ['vendor'],
+				operation: ['createService'],
+			},
+		},
+		default: '',
+		description: 'The description of the vendor service',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const vendorId = this.getNodeParameter('vendorId', itemIndex) as string;
+	const name = this.getNodeParameter('name', itemIndex) as string;
+	const description = this.getNodeParameter('description', itemIndex, '') as string;
+
+	const query = `
+		mutation CreateVendorService($input: CreateVendorServiceInput!) {
+			createVendorService(input: $input) {
+				vendorServiceEdge {
+					node {
+						id
+						name
+						description
+						createdAt
+						updatedAt
+					}
+				}
+			}
+		}
+	`;
+
+	const input: Record<string, unknown> = {
+		vendorId,
+		name,
+	};
+	if (description) input.description = description;
+
+	const responseData = await proboApiRequest.call(this, query, { input });
+
+	return {
+		json: responseData,
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/vendor/deleteService.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/vendor/deleteService.operation.ts
@@ -1,0 +1,41 @@
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { proboApiRequest } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Vendor Service ID',
+		name: 'vendorServiceId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['vendor'],
+				operation: ['deleteService'],
+			},
+		},
+		default: '',
+		description: 'The ID of the vendor service to delete',
+		required: true,
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const vendorServiceId = this.getNodeParameter('vendorServiceId', itemIndex) as string;
+
+	const query = `
+		mutation DeleteVendorService($input: DeleteVendorServiceInput!) {
+			deleteVendorService(input: $input) {
+				deletedVendorServiceId
+			}
+		}
+	`;
+
+	const responseData = await proboApiRequest.call(this, query, { input: { vendorServiceId } });
+
+	return {
+		json: responseData,
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/vendor/getAllServices.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/vendor/getAllServices.operation.ts
@@ -1,0 +1,133 @@
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
+import { proboApiRequestAllItems } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Vendor ID',
+		name: 'vendorId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['vendor'],
+				operation: ['getAllServices'],
+			},
+		},
+		default: '',
+		description: 'The ID of the vendor',
+		required: true,
+	},
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		displayOptions: {
+			show: {
+				resource: ['vendor'],
+				operation: ['getAllServices'],
+			},
+		},
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		displayOptions: {
+			show: {
+				resource: ['vendor'],
+				operation: ['getAllServices'],
+				returnAll: [false],
+			},
+		},
+		typeOptions: {
+			minValue: 1,
+		},
+		default: 50,
+		description: 'Max number of results to return',
+	},
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		placeholder: 'Add Option',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['vendor'],
+				operation: ['getAllServices'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Include Vendor',
+				name: 'includeVendor',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to include vendor in the response',
+			},
+		],
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const vendorId = this.getNodeParameter('vendorId', itemIndex) as string;
+	const returnAll = this.getNodeParameter('returnAll', itemIndex) as boolean;
+	const limit = this.getNodeParameter('limit', itemIndex, 50) as number;
+	const options = this.getNodeParameter('options', itemIndex, {}) as {
+		includeVendor?: boolean;
+	};
+
+	const vendorFragment = options.includeVendor
+		? `vendor {
+			id
+			name
+		}`
+		: '';
+
+	const query = `
+		query GetVendorServices($vendorId: ID!, $first: Int, $after: CursorKey) {
+			node(id: $vendorId) {
+				... on Vendor {
+					services(first: $first, after: $after) {
+						edges {
+							node {
+								id
+								name
+								description
+								${vendorFragment}
+								createdAt
+								updatedAt
+							}
+						}
+						pageInfo {
+							hasNextPage
+							endCursor
+						}
+					}
+				}
+			}
+		}
+	`;
+
+	const vendorServices = await proboApiRequestAllItems.call(
+		this,
+		query,
+		{ vendorId },
+		(response) => {
+			const data = response?.data as IDataObject | undefined;
+			const node = data?.node as IDataObject | undefined;
+			return node?.services as IDataObject | undefined;
+		},
+		returnAll,
+		limit,
+	);
+
+	return {
+		json: { vendorServices },
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/vendor/getService.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/vendor/getService.operation.ts
@@ -1,0 +1,84 @@
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { proboApiRequest } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Vendor Service ID',
+		name: 'vendorServiceId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['vendor'],
+				operation: ['getService'],
+			},
+		},
+		default: '',
+		description: 'The ID of the vendor service',
+		required: true,
+	},
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		placeholder: 'Add Option',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['vendor'],
+				operation: ['getService'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Include Vendor',
+				name: 'includeVendor',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to include vendor in the response',
+			},
+		],
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const vendorServiceId = this.getNodeParameter('vendorServiceId', itemIndex) as string;
+	const options = this.getNodeParameter('options', itemIndex, {}) as {
+		includeVendor?: boolean;
+	};
+
+	const vendorFragment = options.includeVendor
+		? `vendor {
+			id
+			name
+		}`
+		: '';
+
+	const query = `
+		query GetVendorService($vendorServiceId: ID!) {
+			node(id: $vendorServiceId) {
+				... on VendorService {
+					id
+					name
+					description
+					${vendorFragment}
+					createdAt
+					updatedAt
+				}
+			}
+		}
+	`;
+
+	const variables = {
+		vendorServiceId,
+	};
+
+	const responseData = await proboApiRequest.call(this, query, variables);
+
+	return {
+		json: responseData,
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/vendor/index.ts
+++ b/packages/n8n-node/nodes/Probo/actions/vendor/index.ts
@@ -4,6 +4,11 @@ import * as updateOp from './update.operation';
 import * as deleteOp from './delete.operation';
 import * as getOp from './get.operation';
 import * as getAllOp from './getAll.operation';
+import * as createServiceOp from './createService.operation';
+import * as updateServiceOp from './updateService.operation';
+import * as deleteServiceOp from './deleteService.operation';
+import * as getServiceOp from './getService.operation';
+import * as getAllServicesOp from './getAllServices.operation';
 
 export const description: INodeProperties[] = [
 	{
@@ -24,10 +29,22 @@ export const description: INodeProperties[] = [
 				action: 'Create a vendor',
 			},
 			{
+				name: 'Create Service',
+				value: 'createService',
+				description: 'Create a new vendor service',
+				action: 'Create a vendor service',
+			},
+			{
 				name: 'Delete',
 				value: 'delete',
 				description: 'Delete a vendor',
 				action: 'Delete a vendor',
+			},
+			{
+				name: 'Delete Service',
+				value: 'deleteService',
+				description: 'Delete a vendor service',
+				action: 'Delete a vendor service',
 			},
 			{
 				name: 'Get',
@@ -42,10 +59,28 @@ export const description: INodeProperties[] = [
 				action: 'Get many vendors',
 			},
 			{
+				name: 'Get Many Services',
+				value: 'getAllServices',
+				description: 'Get many vendor services',
+				action: 'Get many vendor services',
+			},
+			{
+				name: 'Get Service',
+				value: 'getService',
+				description: 'Get a vendor service',
+				action: 'Get a vendor service',
+			},
+			{
 				name: 'Update',
 				value: 'update',
 				description: 'Update an existing vendor',
 				action: 'Update a vendor',
+			},
+			{
+				name: 'Update Service',
+				value: 'updateService',
+				description: 'Update an existing vendor service',
+				action: 'Update a vendor service',
 			},
 		],
 		default: 'create',
@@ -55,7 +90,22 @@ export const description: INodeProperties[] = [
 	...deleteOp.description,
 	...getOp.description,
 	...getAllOp.description,
+	...createServiceOp.description,
+	...updateServiceOp.description,
+	...deleteServiceOp.description,
+	...getServiceOp.description,
+	...getAllServicesOp.description,
 ];
 
-export { createOp as create, updateOp as update, deleteOp as delete, getOp as get, getAllOp as getAll };
-
+export {
+	createOp as create,
+	updateOp as update,
+	deleteOp as delete,
+	getOp as get,
+	getAllOp as getAll,
+	createServiceOp as createService,
+	updateServiceOp as updateService,
+	deleteServiceOp as deleteService,
+	getServiceOp as getService,
+	getAllServicesOp as getAllServices,
+};

--- a/packages/n8n-node/nodes/Probo/actions/vendor/updateService.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/vendor/updateService.operation.ts
@@ -1,0 +1,82 @@
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { proboApiRequest } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Vendor Service ID',
+		name: 'vendorServiceId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['vendor'],
+				operation: ['updateService'],
+			},
+		},
+		default: '',
+		description: 'The ID of the vendor service to update',
+		required: true,
+	},
+	{
+		displayName: 'Name',
+		name: 'name',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['vendor'],
+				operation: ['updateService'],
+			},
+		},
+		default: '',
+		description: 'The name of the vendor service',
+	},
+	{
+		displayName: 'Description',
+		name: 'description',
+		type: 'string',
+		typeOptions: {
+			rows: 4,
+		},
+		displayOptions: {
+			show: {
+				resource: ['vendor'],
+				operation: ['updateService'],
+			},
+		},
+		default: '',
+		description: 'The description of the vendor service',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const vendorServiceId = this.getNodeParameter('vendorServiceId', itemIndex) as string;
+	const name = this.getNodeParameter('name', itemIndex, '') as string;
+	const description = this.getNodeParameter('description', itemIndex, '') as string;
+
+	const query = `
+		mutation UpdateVendorService($input: UpdateVendorServiceInput!) {
+			updateVendorService(input: $input) {
+				vendorService {
+					id
+					name
+					description
+					createdAt
+					updatedAt
+				}
+			}
+		}
+	`;
+
+	const input: Record<string, unknown> = { id: vendorServiceId };
+	if (name) input.name = name;
+	if (description !== undefined) input.description = description === '' ? null : description;
+
+	const responseData = await proboApiRequest.call(this, query, { input });
+
+	return {
+		json: responseData,
+		pairedItem: { item: itemIndex },
+	};
+}


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds vendor service actions to the Probo n8n node so you can create, read, update, delete, and list vendor services. Includes optional vendor details and pagination for listing.

- **New Features**
  - Added operations on vendor: createService, updateService, deleteService, getService, getAllServices.
  - createService: requires vendorId and name; optional description.
  - updateService: requires vendorServiceId; supports name and description (empty string clears description).
  - deleteService: requires vendorServiceId.
  - getService: requires vendorServiceId; options.includeVendor returns vendor id and name.
  - getAllServices: requires vendorId; supports returnAll or limit and options.includeVendor; uses cursor pagination.

<sup>Written for commit 88572b07da47dc635a210b0acfd39221f423e324. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





