### PR TITLE
Fix ACME renew infinit loop

### DIFF
--- a/pkg/coredata/custom_domain.go
+++ b/pkg/coredata/custom_domain.go
@@ -203,7 +203,7 @@ LIMIT 1
 	return nil
 }
 
-func (cd *CustomDomain) LoadByIDForUpdate(
+func (cd *CustomDomain) LoadByIDForUpdateSkipLocked(
 	ctx context.Context,
 	conn pg.Conn,
 	scope Scoper,
@@ -234,7 +234,7 @@ WHERE
 	%s
 	AND id = @id
 LIMIT 1
-FOR UPDATE
+FOR UPDATE SKIP LOCKED
 `
 	q = fmt.Sprintf(q, scope.SQLFragment())
 
@@ -565,7 +565,6 @@ FROM
 WHERE
 	%s
 	AND ssl_status = @status
-	AND ssl_expires_at IS NOT NULL
 	AND ssl_expires_at <= CURRENT_TIMESTAMP + INTERVAL '30 days'
 ORDER BY
 	ssl_expires_at ASC


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stops the infinite ACME renewal loop by shifting renewal to the provisioning flow and capping retries at 3. The renewer now only marks domains as renewing; the provisioner handles the challenge and certificate issuance.

- **Bug Fixes**
  - Removed ACME renew/obtain paths and the HTTP challenge error that caused repeated renew attempts.
  - Renewer sets SSLStatus to Renewing instead of trying to renew in-place, preventing loops.
  - Retry logic capped at 3; domain moves to Failed after exceeding retries.

- **Refactors**
  - Switched DB operations to transactions and use SkipLocked row updates to avoid contention and double-processing.
  - Provisioner now handles both Pending and Renewing statuses, updates status and challenge fields in one place, and maintains the certificate cache.

<sup>Written for commit 3a6295d80840284d6b0dd2d9c1088e579a749d9a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





