### PR TITLE
Remove useless dependency to n8n

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11417,6 +11417,7 @@
       "version": "16.12.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
       "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -19355,9 +19356,6 @@
       "name": "@probo/n8n-nodes-probo",
       "version": "0.0.1",
       "license": "MIT",
-      "dependencies": {
-        "graphql": "^16.12.0"
-      },
       "devDependencies": {
         "@n8n/node-cli": "^0.17.0",
         "eslint": "9.32.0"

--- a/packages/n8n-node/package.json
+++ b/packages/n8n-node/package.json
@@ -53,9 +53,6 @@
   "peerDependencies": {
     "n8n-workflow": "*"
   },
-  "dependencies": {
-    "graphql": "^16.12.0"
-  },
   "devDependencies": {
     "@n8n/node-cli": "^0.17.0",
     "eslint": "9.32.0"


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the unused graphql runtime dependency from the n8n nodes package to reduce install size and avoid unnecessary production deps. graphql is now dev-only.

- **Dependencies**
  - Removed graphql from packages/n8n-node dependencies.
  - Marked graphql as dev-only in package-lock for @probo/n8n-nodes-probo.

<sup>Written for commit 8478006c30fdfbb70bb5f4741f49412fe72abdcd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



