### PR TITLE
Add proxy protocol support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.1.0
 	github.com/openai/openai-go v1.12.0
 	github.com/pdfcpu/pdfcpu v0.11.1
+	github.com/pires/go-proxyproto v0.8.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1
 	github.com/vektah/gqlparser/v2 v2.5.31

--- a/go.sum
+++ b/go.sum
@@ -164,6 +164,8 @@ github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde h1:x0TT0RDC7UhA
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/pdfcpu/pdfcpu v0.11.1 h1:htHBSkGH5jMKWC6e0sihBFbcKZ8vG1M67c8/dJxhjas=
 github.com/pdfcpu/pdfcpu v0.11.1/go.mod h1:pP3aGga7pRvwFWAm9WwFvo+V68DfANi9kxSQYioNYcw=
+github.com/pires/go-proxyproto v0.8.1 h1:9KEixbdJfhrbtjpz/ZwCdWDD2Xem0NZ38qMYaASJgp0=
+github.com/pires/go-proxyproto v0.8.1/go.mod h1:ZKAAyp3cgy5Y5Mo4n9AlScrkCZwUy0g3Jf+slqQVcuU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/pkg/probod/api_config.go
+++ b/pkg/probod/api_config.go
@@ -14,14 +14,23 @@
 
 package probod
 
+import (
+	"net"
+)
+
 type (
 	corsConfig struct {
 		AllowedOrigins []string `json:"allowed-origins"`
 	}
 
+	proxyProtocolConfig struct {
+		TrustedProxies []net.IP `json:"trusted-proxies"`
+	}
+
 	apiConfig struct {
-		Addr              string            `json:"addr"`
-		Cors              corsConfig        `json:"cors"`
-		ExtraHeaderFields map[string]string `json:"extra-header-fields"`
+		Addr              string              `json:"addr"`
+		ProxyProtocol     proxyProtocolConfig `json:"proxy-protocol"`
+		Cors              corsConfig          `json:"cors"`
+		ExtraHeaderFields map[string]string   `json:"extra-header-fields"`
 	}
 )


### PR DESCRIPTION
This is preparatory in order to change the load balancer configuration and keep the the end-user IP address available on the request (required to e-signature, cookie consent, etc.).

I've use the most maintain library. I'm not a big fan of the code of the lib tbh if we got issue with it I will write our own implementation. 