### PR TITLE
Fix azure storage

### DIFF
--- a/contrib/helm/README.md
+++ b/contrib/helm/README.md
@@ -29,7 +29,7 @@ export PASSWORD_PEPPER=$(openssl rand -base64 32)
 export TRUST_TOKEN_SECRET=$(openssl rand -base64 32)
 ```
 
-#### Download remote dependencies 
+#### Download remote dependencies
 
 ```bash
 helm dependency update ./charts/probo
@@ -225,7 +225,7 @@ helm install my-probo ././charts/probo \
 - Storage: Azure Blob Storage (with S3 compatibility)
 - Kubernetes: Azure Kubernetes Service (AKS)
 
-#### Exemple 
+#### Example
 
 
 ```bash
@@ -242,8 +242,11 @@ helm install my-probo ././charts/probo \
   --set s3.endpoint="https://<your-storage-account>.blob.core.windows.net" \
   --set s3.bucket="my-probo-bucket" \
   --set s3.accessKeyId="<azure-access-key>" \
-  --set s3.secretAccessKey="<azure-secret-key>"
+  --set s3.secretAccessKey="<azure-secret-key>" \
+  --set s3.usePathStyle=true
 ```
+
+> **Note:** Azure Blob Storage requires `s3.usePathStyle=true` to construct URLs correctly (path-style: `https://account.blob.core.windows.net/container/...` instead of virtual-hosted style: `https://bucket.account.blob.core.windows.net/...`).
 
 ### DigitalOcean
 - PostgreSQL: Managed PostgreSQL Database

--- a/contrib/helm/charts/probo/README.md
+++ b/contrib/helm/charts/probo/README.md
@@ -160,6 +160,7 @@ The following parameters **must** be configured:
 | `s3.bucket`            | S3 bucket name                  | `probod` |
 | `s3.region`            | AWS region                      | `us-east-1` |
 | `s3.endpoint`          | S3 endpoint (for S3-compatible) | `""` |
+| `s3.usePathStyle`      | Use path-style URLs (required for Azure Blob Storage) | `false` |
 | `chrome.enabled`       | Deploy Chrome                   | `true` |
 | `chrome.external.addr` | External Chrome (if disabled)   | `""` |
 | `ingress.enabled`      | Enable ingress                  | `false` |

--- a/contrib/helm/charts/probo/templates/deployment.yaml
+++ b/contrib/helm/charts/probo/templates/deployment.yaml
@@ -179,6 +179,10 @@ spec:
             - name: AWS_ENDPOINT
               value: {{ $s3Endpoint | quote }}
             {{- end }}
+            {{- if .Values.s3.usePathStyle }}
+            - name: AWS_USE_PATH_STYLE
+              value: "true"
+            {{- end }}
             # Email (SMTP)
             - name: MAILER_SENDER_NAME
               value: {{ .Values.probo.mailer.senderName | quote }}

--- a/contrib/helm/charts/probo/values-production.yaml.example
+++ b/contrib/helm/charts/probo/values-production.yaml.example
@@ -244,6 +244,14 @@ s3:
   # accessKeyId: "..." # Spaces access key
   # secretAccessKey: "..." # Spaces secret
 
+  # Azure Blob Storage example (uncomment and adjust):
+  # region: "eastus"
+  # bucket: "probo-container"
+  # endpoint: "https://mystorageaccount.blob.core.windows.net"
+  # accessKeyId: "mystorageaccount" # Storage account name
+  # secretAccessKey: "..." # Storage account access key
+  # usePathStyle: true  # Required for Azure Blob Storage
+
 # Chrome for PDF generation
 chrome:
   enabled: true

--- a/contrib/helm/charts/probo/values.yaml
+++ b/contrib/helm/charts/probo/values.yaml
@@ -317,6 +317,10 @@ s3:
   endpoint: ""
   accessKeyId: ""  # REQUIRED when minio.enabled=false: S3 access key
   secretAccessKey: ""  # REQUIRED when minio.enabled=false: S3 secret key
+  # Use path-style URLs (required for Azure Blob Storage and some S3-compatible services)
+  # When true: https://endpoint/bucket/key
+  # When false (default): https://bucket.endpoint/key
+  usePathStyle: false
 
 # MinIO configuration
 # Enable included MinIO for testing/development (NOT for production)

--- a/pkg/probod/aws_config.go
+++ b/pkg/probod/aws_config.go
@@ -21,5 +21,6 @@ type (
 		AccessKeyID     string `json:"access-key-id"`
 		SecretAccessKey string `json:"secret-access-key"`
 		Endpoint        string `json:"endpoint"`
+		UsePathStyle    bool   `json:"use-path-style"`
 	}
 )

--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -239,7 +239,9 @@ func (impl *Implm) Run(
 		html2pdf.WithTracerProvider(tp),
 	)
 
-	s3Client := s3.NewFromConfig(awsConfig)
+	s3Client := s3.NewFromConfig(awsConfig, func(o *s3.Options) {
+		o.UsePathStyle = impl.cfg.AWS.UsePathStyle
+	})
 
 	err = migrator.NewMigrator(pgClient, coredata.Migrations, l.Named("migrations")).Run(ctx, "migrations")
 	if err != nil {


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Azure Blob Storage compatibility by enabling path-style S3 requests. Adds a new config flag to switch URL style and updates Helm and docs so uploads work reliably on Azure.

- **Bug Fixes**
  - Go: Configure the S3 client with UsePathStyle based on AWS config.
  - Helm: Add s3.usePathStyle value and set AWS_USE_PATH_STYLE in the deployment when true.
  - Docs: Add Azure setup example and note that path-style is required; update values examples.

<sup>Written for commit d6abaec78682c21d0d2a8893461a10c3fc790f1a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



