### PR TITLE
Fix trust center nil error

### DIFF
--- a/pkg/server/api/trust/v1/v1_resolver.go
+++ b/pkg/server/api/trust/v1/v1_resolver.go
@@ -425,7 +425,7 @@ func (r *mutationResolver) RequestReportAccess(ctx context.Context, input types.
 	email := input.Email
 	tokenData := TokenAccessFromContext(ctx)
 	if tokenData != nil {
-		*email = tokenData.Email
+		email = &tokenData.Email
 	}
 	if email == nil {
 		return nil, fmt.Errorf("email is required for unauthenticated users")
@@ -474,7 +474,7 @@ func (r *mutationResolver) RequestTrustCenterFileAccess(ctx context.Context, inp
 	email := input.Email
 	tokenData := TokenAccessFromContext(ctx)
 	if tokenData != nil {
-		*email = tokenData.Email
+		email = &tokenData.Email
 	}
 	if email == nil {
 		return nil, fmt.Errorf("email is required for unauthenticated users")


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix nil pointer dereference in trust center access resolvers by using the token email pointer when available. Prevents crashes when unauthenticated users don’t provide an email.

<sup>Written for commit 1b0923c6cce8c3631b587f618eacc46c628570a9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



