### PR TITLE
Create slack message if necessary

### DIFF
--- a/pkg/probo/trust_center_access_service.go
+++ b/pkg/probo/trust_center_access_service.go
@@ -16,6 +16,7 @@ package probo
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"time"
@@ -26,6 +27,7 @@ import (
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/mail"
 	"go.probo.inc/probo/pkg/page"
+	"go.probo.inc/probo/pkg/slack"
 	"go.probo.inc/probo/pkg/statelesstoken"
 	"go.probo.inc/probo/pkg/validator"
 )
@@ -365,7 +367,10 @@ func (s TrustCenterAccessService) Update(
 
 	if shouldUpdateSlackMessage {
 		if err := s.svc.SlackMessages.QueueSlackNotification(ctx, access.Email, access.TrustCenterID); err != nil {
-			return nil, fmt.Errorf("cannot queue slack notification: %w", err)
+			var noConnectorErr slack.ErrNoSlackConnector
+			if !errors.Is(err, noConnectorErr) {
+				return nil, fmt.Errorf("cannot queue slack notification: %w", err)
+			}
 		}
 	}
 

--- a/pkg/slack/slack_message_service.go
+++ b/pkg/slack/slack_message_service.go
@@ -33,6 +33,12 @@ const (
 	slackMessageDeduplicationWindow = 7 * 24 * time.Hour
 )
 
+type ErrNoSlackConnector struct{}
+
+func (e ErrNoSlackConnector) Error() string {
+	return "no slack connector found for organization"
+}
+
 type (
 	SlackMessageService struct {
 		svc *TenantService
@@ -208,7 +214,7 @@ func (s *SlackMessageService) QueueSlackNotification(
 		}
 
 		if !hasSlackConnector {
-			return fmt.Errorf("no slack connector found for organization")
+			return ErrNoSlackConnector{}
 		}
 
 		documents, reports, files, err := s.loadDocumentsReportsAndFilesFromAccesses(ctx, tx, trustCenterAccess.ID)


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Queue Slack notifications for Trust Center access changes instead of updating existing Slack messages. Ignore “no Slack connector” errors so updates don’t fail when Slack isn’t configured.

- **Refactors**
  - Removed QueueSlackAccessMessageUpdate and its message update logic.
  - TrustCenterAccessService.Update now calls SlackMessages.QueueSlackNotification and ignores ErrNoSlackConnector; other errors are returned.

<sup>Written for commit 504d31af6c824d873d36aea6a07eba9f2de2611d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





