### PR TITLE
Fix people deletion

### DIFF
--- a/apps/console/src/layouts/MainLayout.tsx
+++ b/apps/console/src/layouts/MainLayout.tsx
@@ -10,7 +10,7 @@ import {
   IconBank,
   IconBook,
   IconBox,
-  IconCalendar1,
+  IconCalendar2,
   IconCheckmark1,
   IconChevronGrabberVertical,
   IconCircleProgress,
@@ -122,7 +122,7 @@ function MainLayoutContent({
           {isAuthorized("Organization", "listMeetings") && (
             <SidebarItem
               label={__("Meetings")}
-              icon={IconCalendar1}
+              icon={IconCalendar2}
               to={`${prefix}/meetings`}
             />
           )}
@@ -441,7 +441,7 @@ function OrganizationSelector({
             {isLoading ? __("Loading...") : currentOrganization?.name || ""}
           </Button>
         }
-      >  
+      >
         <div className="px-3 py-2">
           <Input
             icon={IconMagnifyingGlass}
@@ -449,7 +449,7 @@ function OrganizationSelector({
             value={search}
             onValueChange={setSearch}
             onKeyDown={(e) => {
-                e.stopPropagation(); 
+                e.stopPropagation();
             }}
             autoFocus
           />

--- a/apps/console/src/pages/organizations/people/PeopleListPage.tsx
+++ b/apps/console/src/pages/organizations/people/PeopleListPage.tsx
@@ -11,6 +11,7 @@ import {
   ActionDropdown,
   DropdownItem,
   IconTrashCan,
+  IconCalendar2,
 } from "@probo/ui";
 import { useTranslate } from "@probo/i18n";
 import type { PeopleGraphPaginatedQuery } from "/hooks/graph/__generated__/PeopleGraphPaginatedQuery.graphql";
@@ -22,9 +23,10 @@ import type { NodeOf } from "/types";
 import { usePageTitle } from "@probo/hooks";
 import { getRole } from "@probo/helpers";
 import { CreatePeopleDialog } from "./dialogs/CreatePeopleDialog";
+import { SetEndOfContractDialog, type SetEndOfContractDialogRef } from "./dialogs/SetEndOfContractDialog";
 import { useOrganizationId } from "/hooks/useOrganizationId";
 import { PermissionsContext } from "/providers/PermissionsContext";
-import { use } from "react";
+import { use, useRef } from "react";
 
 type People = NodeOf<PeopleGraphPaginatedFragment$data["peoples"]>;
 
@@ -108,40 +110,56 @@ function PeopleRow({
   const deletePeople = useDeletePeople(people, connectionId);
   const contractEnded = isContractEnded(people);
   const { isAuthorized } = use(PermissionsContext);
+  const dialogRef = useRef<SetEndOfContractDialogRef>(null);
 
   return (
-    <Tr
-      to={`/organizations/${organizationId}/people/${people.id}/tasks`}
-      className={contractEnded ? "opacity-50" : ""}
-    >
-      <Td>
-        <div className="flex gap-3 items-center">
-          <Avatar name={people.fullName} />
-          <div>
-            <div className="text-sm">{people.fullName}</div>
-            <div className="text-xs text-txt-tertiary">
-              {people.primaryEmailAddress}
+    <>
+      <SetEndOfContractDialog
+        peopleId={people.id}
+        currentContractEndDate={people.contractEndDate}
+        ref={dialogRef}
+      />
+      <Tr
+        to={`/organizations/${organizationId}/people/${people.id}/profile`}
+        className={contractEnded ? "opacity-50" : ""}
+      >
+        <Td>
+          <div className="flex gap-3 items-center">
+            <Avatar name={people.fullName} />
+            <div>
+              <div className="text-sm">{people.fullName}</div>
+              <div className="text-xs text-txt-tertiary">
+                {people.primaryEmailAddress}
+              </div>
             </div>
           </div>
-        </div>
-      </Td>
-      <Td className="text-sm">{getRole(__, people.kind)}</Td>
-      <Td className="text-sm">{people.position}</Td>
-      {hasAnyAction && (
-        <Td noLink width={50} className="text-end">
-          <ActionDropdown>
-            {isAuthorized("People", "deletePeople") && (
-              <DropdownItem
-                icon={IconTrashCan}
-                variant="danger"
-                onClick={deletePeople}
-              >
-                {__("Delete")}
-              </DropdownItem>
-            )}
-          </ActionDropdown>
         </Td>
-      )}
-    </Tr>
+        <Td className="text-sm">{getRole(__, people.kind)}</Td>
+        <Td className="text-sm">{people.position}</Td>
+        {hasAnyAction && (
+          <Td noLink width={50} className="text-end">
+            <ActionDropdown>
+              {isAuthorized("People", "updatePeople") && (
+                <DropdownItem
+                  icon={IconCalendar2}
+                  onClick={() => dialogRef.current?.open()}
+                >
+                  {__("Set end of contract")}
+                </DropdownItem>
+              )}
+              {isAuthorized("People", "deletePeople") && (
+                <DropdownItem
+                  icon={IconTrashCan}
+                  variant="danger"
+                  onClick={deletePeople}
+                >
+                  {__("Delete")}
+                </DropdownItem>
+              )}
+            </ActionDropdown>
+          </Td>
+        )}
+      </Tr>
+    </>
   );
 }

--- a/apps/console/src/pages/organizations/people/dialogs/SetEndOfContractDialog.tsx
+++ b/apps/console/src/pages/organizations/people/dialogs/SetEndOfContractDialog.tsx
@@ -1,0 +1,107 @@
+import { useTranslate } from "@probo/i18n";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  Field,
+  Input,
+  Spinner,
+  useDialogRef,
+} from "@probo/ui";
+import { forwardRef, useImperativeHandle } from "react";
+import { z } from "zod";
+import { formatDatetime, toDateInput } from "@probo/helpers";
+import { useFormWithSchema } from "/hooks/useFormWithSchema";
+import { useMutationWithToasts } from "/hooks/useMutationWithToasts";
+import { updatePeopleMutation } from "/hooks/graph/PeopleGraph";
+
+const schema = z.object({
+  contractEndDate: z.string().optional(),
+});
+
+export type SetEndOfContractDialogRef = {
+  open: () => void;
+  close: () => void;
+};
+
+type Props = {
+  peopleId: string;
+  currentContractEndDate?: string | null;
+};
+
+export const SetEndOfContractDialog = forwardRef<SetEndOfContractDialogRef, Props>(function SetEndOfContractDialog(
+  {
+    peopleId,
+    currentContractEndDate,
+  },
+  ref
+) {
+  const { __ } = useTranslate();
+  const dialogRef = useDialogRef();
+
+  useImperativeHandle(ref, () => ({
+    open: () => dialogRef.current?.open(),
+    close: () => dialogRef.current?.close(),
+  }));
+
+  const {
+    register,
+    handleSubmit,
+    formState: { isSubmitting },
+    reset,
+  } = useFormWithSchema(schema, {
+    defaultValues: {
+      contractEndDate: toDateInput(currentContractEndDate),
+    },
+  });
+
+  const [mutate] = useMutationWithToasts(updatePeopleMutation, {
+    successMessage: __("End of contract updated successfully"),
+    errorMessage: __("Failed to update end of contract"),
+  });
+
+  const onSubmit = handleSubmit(async (data) => {
+    await mutate({
+      variables: {
+        input: {
+          id: peopleId,
+          contractEndDate: formatDatetime(data.contractEndDate),
+        },
+      },
+    });
+
+    dialogRef.current?.close();
+  });
+
+  const handleClose = () => {
+    reset();
+  };
+
+  return (
+    <Dialog
+      title={__("Set End of Contract")}
+      ref={dialogRef}
+      className="max-w-lg"
+      onClose={handleClose}
+    >
+      <form onSubmit={onSubmit}>
+        <DialogContent padded className="space-y-4">
+          <Field label={__("End of contract")}>
+            <Input {...register("contractEndDate")} type="date" />
+          </Field>
+        </DialogContent>
+
+        <DialogFooter>
+          <Button
+            type="submit"
+            disabled={isSubmitting}
+            icon={isSubmitting ? Spinner : undefined}
+          >
+            {__("Update")}
+          </Button>
+        </DialogFooter>
+      </form>
+    </Dialog>
+  );
+});

--- a/pkg/server/api/console/v1/v1_resolver.go
+++ b/pkg/server/api/console/v1/v1_resolver.go
@@ -2126,6 +2126,10 @@ func (r *mutationResolver) DeletePeople(ctx context.Context, input types.DeleteP
 
 	err := prb.Peoples.Delete(ctx, input.PeopleID)
 	if err != nil {
+		var errReferenced *coredata.ErrPeopleReferenced
+		if errors.As(err, &errReferenced) {
+			return nil, gqlutils.Conflict(errReferenced)
+		}
 		panic(fmt.Errorf("cannot delete people: %w", err))
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix people deletion by handling foreign key constraints and returning a 409 Conflict instead of crashing. Adds a “Set end of contract” dialog in People actions and updates the People row to link to the profile.

- **Bug Fixes**
  - Detect pg error code 23503 on delete and return ErrPeopleReferenced.
  - Map referenced deletion errors to GraphQL Conflict responses (no panic).

- **New Features**
  - Add “Set end of contract” dialog to People actions.
  - Update calendar icon usage to IconCalendar2 in sidebar and actions.
  - Change People row link to the Profile page.

<sup>Written for commit 233e197fdb5a42c015951de92da2b707ba2e88b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







