### PR TITLE
fix: select atom component relative style

### DIFF
--- a/packages/ui/src/Atoms/Select/Select.tsx
+++ b/packages/ui/src/Atoms/Select/Select.tsx
@@ -119,66 +119,70 @@ export function Select<T>({
     });
 
     return (
-        <Root
-            defaultOpen={defaultOpen}
-            open={open}
-            onOpenChange={onOpenChange}
-            onValueChange={onValueChange}
-            value={value as string}
-        >
-            <Trigger
-                {...props}
-                className={trigger({
-                    className: props.className,
-                    disabled: props.disabled,
-                })}
+        <div className="relative">
+            <Root
+                defaultOpen={defaultOpen}
+                open={open}
+                onOpenChange={onOpenChange}
+                onValueChange={onValueChange}
+                value={value as string}
             >
-                <Value placeholder={placeholder} />
-                <Icon className={icon()}>
-                    {loading ? (
-                        <Spinner size={16} />
-                    ) : (
-                        <IconChevronGrabberVertical size={16} />
-                    )}
-                </Icon>
-            </Trigger>
-            <Portal>
-                <Content
-                    position="popper"
-                    sideOffset={5}
-                    {...dropdownProps}
-                    style={{
-                        minWidth: "var(--radix-select-trigger-width)",
-                        maxHeight:
-                        "var(--radix-select-content-available-height)",
-                        ...dropdownProps?.style,
-                    }}
-                    className={content({ className: dropdownProps?.className })}
+                <Trigger
+                    {...props}
+                    className={trigger({
+                        className: props.className,
+                        disabled: props.disabled,
+                    })}
                 >
-                    {onSearch && (
-                        <Input
-                            // Prevent radix behaviour
-                            onBlurCapture={(e) => {
-                                e.stopPropagation();
-                                e.preventDefault();
-                            }}
-                            autoFocus
-                            icon={IconMagnifyingGlass}
-                            placeholder={searchPlaceholder}
-                            value={searchValue}
-                            onChange={(e) => onSearch(e.target.value)}
-                        />
-                    )}
-                    <ScrollArea.Root className="ScrollAreaRoot" type="auto">
-                        <Viewport asChild>
-                            <ScrollArea.Viewport className="ScrollAreaViewport">
-                                {children}
-                            </ScrollArea.Viewport>
-                        </Viewport>
-                    </ScrollArea.Root>
-                </Content>
-            </Portal>
-        </Root>
+                    <Value placeholder={placeholder} />
+                    <Icon className={icon()}>
+                        {loading ? (
+                            <Spinner size={16} />
+                        ) : (
+                            <IconChevronGrabberVertical size={16} />
+                        )}
+                    </Icon>
+                </Trigger>
+                <Portal>
+                    <Content
+                        position="popper"
+                        sideOffset={5}
+                        {...dropdownProps}
+                        style={{
+                            minWidth: "var(--radix-select-trigger-width)",
+                            maxHeight:
+                                "var(--radix-select-content-available-height)",
+                            ...dropdownProps?.style,
+                        }}
+                        className={content({
+                            className: dropdownProps?.className,
+                        })}
+                    >
+                        {onSearch && (
+                            <Input
+                                // Prevent radix behaviour
+                                onBlurCapture={(e) => {
+                                    e.stopPropagation();
+                                    e.preventDefault();
+                                }}
+                                autoFocus
+                                icon={IconMagnifyingGlass}
+                                placeholder={searchPlaceholder}
+                                value={searchValue}
+                                onChange={(e) => onSearch(e.target.value)}
+                            />
+                        )}
+                        <ScrollArea.Root className="ScrollAreaRoot" type="auto">
+                            <Viewport asChild>
+                                <ScrollArea.Viewport className="ScrollAreaViewport">
+                                    {children}
+                                </ScrollArea.Viewport>
+                            </Viewport>
+                        </ScrollArea.Root>
+                    </Content>
+                </Portal>
+            </Root>
+        </div>
     );
 }
 


### PR DESCRIPTION
Hi there! I’m new to the Project and I’m really impressed by the product and its structure. While exploring, I noticed a small UI bug in the select component.

**Problem:** Radix-ui select component uses absolute styles which means it styles itself relative to its parent component. This creates a distortion in the UI and results in empty white space on the pages. 
<img width="3566" height="2080" alt="image" src="https://github.com/user-attachments/assets/8f808a0d-3ca7-4cc9-a0a3-5320160ef8c5" />


**Fix:** I fixed this by wrapping the select component in a relative container.
<img width="3540" height="2082" alt="image" src="https://github.com/user-attachments/assets/b66f5269-513f-44b6-ae18-1d0ab2955c24" />

I’d love to hear your feedback on this change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wrapped the Select atom in a relative container so the Radix Select dropdown positions relative to its trigger, fixing the offset that caused empty white space and layout distortion. No API or behavior changes.

<sup>Written for commit 34a6390b8bbe709e0adaa1b33d7bf43c7a679001. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

