### PR TITLE
Add right requests

### DIFF
--- a/apps/console/src/hooks/graph/RightsRequestGraph.ts
+++ b/apps/console/src/hooks/graph/RightsRequestGraph.ts
@@ -1,0 +1,194 @@
+import { graphql } from "relay-runtime";
+import { useMutation } from "react-relay";
+import { useConfirm } from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { promisifyMutation, sprintf } from "@probo/helpers";
+import { useMutationWithToasts } from "../useMutationWithToasts";
+
+export const RightsRequestsConnectionKey = "RightsRequestsPage_rightsRequests";
+
+export const rightsRequestsQuery = graphql`
+  query RightsRequestGraphListQuery($organizationId: ID!) {
+    node(id: $organizationId) {
+      ... on Organization {
+        ...RightsRequestsPageFragment
+      }
+    }
+  }
+`;
+
+export const rightsRequestNodeQuery = graphql`
+  query RightsRequestGraphNodeQuery($rightsRequestId: ID!) {
+    node(id: $rightsRequestId) {
+      ... on RightsRequest {
+        id
+        requestType
+        requestState
+        dataSubject
+        contact
+        details
+        deadline
+        actionTaken
+        organization {
+          id
+          name
+        }
+        createdAt
+        updatedAt
+      }
+    }
+  }
+`;
+
+export const createRightsRequestMutation = graphql`
+  mutation RightsRequestGraphCreateMutation(
+    $input: CreateRightsRequestInput!
+    $connections: [ID!]!
+  ) {
+    createRightsRequest(input: $input) {
+      rightsRequestEdge @prependEdge(connections: $connections) {
+        node {
+          id
+          requestType
+          requestState
+          dataSubject
+          contact
+          details
+          deadline
+          actionTaken
+          createdAt
+        }
+      }
+    }
+  }
+`;
+
+export const updateRightsRequestMutation = graphql`
+  mutation RightsRequestGraphUpdateMutation($input: UpdateRightsRequestInput!) {
+    updateRightsRequest(input: $input) {
+      rightsRequest {
+        id
+        requestType
+        requestState
+        dataSubject
+        contact
+        details
+        deadline
+        actionTaken
+        updatedAt
+      }
+    }
+  }
+`;
+
+export const deleteRightsRequestMutation = graphql`
+  mutation RightsRequestGraphDeleteMutation(
+    $input: DeleteRightsRequestInput!
+    $connections: [ID!]!
+  ) {
+    deleteRightsRequest(input: $input) {
+      deletedRightsRequestId @deleteEdge(connections: $connections)
+    }
+  }
+`;
+
+export const useDeleteRightsRequest = (
+  request: { id: string },
+  connectionId: string
+) => {
+  const { __ } = useTranslate();
+  const [mutate] = useMutationWithToasts(deleteRightsRequestMutation, {
+    successMessage: __("Rights request deleted successfully"),
+    errorMessage: __("Failed to delete rights request"),
+  });
+  const confirm = useConfirm();
+
+  return () => {
+    confirm(
+      () =>
+        mutate({
+          variables: {
+            input: {
+              rightsRequestId: request.id,
+            },
+            connections: [connectionId],
+          },
+        }),
+      {
+        message: sprintf(
+          __(
+            "This will permanently delete the rights request. This action cannot be undone."
+          )
+        ),
+      }
+    );
+  };
+};
+
+export const useCreateRightsRequest = (connectionId: string) => {
+  const [mutate] = useMutation(createRightsRequestMutation);
+  const { __ } = useTranslate();
+
+  return (input: {
+    organizationId: string;
+    requestType: string;
+    requestState: string;
+    dataSubject?: string;
+    contact?: string;
+    details?: string;
+    deadline?: string;
+    actionTaken?: string;
+  }) => {
+    if (!input.organizationId) {
+      return alert(__("Failed to create rights request: organization is required"));
+    }
+    if (!input.requestType) {
+      return alert(__("Failed to create rights request: request type is required"));
+    }
+    if (!input.requestState) {
+      return alert(__("Failed to create rights request: request state is required"));
+    }
+
+    return promisifyMutation(mutate)({
+      variables: {
+        input: {
+          organizationId: input.organizationId,
+          requestType: input.requestType,
+          requestState: input.requestState,
+          dataSubject: input.dataSubject,
+          contact: input.contact,
+          details: input.details,
+          deadline: input.deadline,
+          actionTaken: input.actionTaken,
+        },
+        connections: [connectionId],
+      },
+    });
+  };
+};
+
+export const useUpdateRightsRequest = () => {
+  const [mutate] = useMutation(updateRightsRequestMutation);
+  const { __ } = useTranslate();
+
+  return (input: {
+    id: string;
+    requestType?: string;
+    requestState?: string;
+    dataSubject?: string;
+    contact?: string;
+    details?: string;
+    deadline?: string | null;
+    actionTaken?: string;
+  }) => {
+    if (!input.id) {
+      return alert(__("Failed to update rights request: ID is required"));
+    }
+
+    return promisifyMutation(mutate)({
+      variables: {
+        input,
+      },
+    });
+  };
+};

--- a/apps/console/src/hooks/graph/__generated__/RightsRequestGraphCreateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/RightsRequestGraphCreateMutation.graphql.ts
@@ -1,0 +1,231 @@
+/**
+ * @generated SignedSource<<630d2ddf409889a6c1632063d18a2545>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type RightsRequestState = "DONE" | "IN_PROGRESS" | "TODO";
+export type RightsRequestType = "ACCESS" | "DELETION" | "PORTABILITY";
+export type CreateRightsRequestInput = {
+  actionTaken?: string | null | undefined;
+  contact?: string | null | undefined;
+  dataSubject?: string | null | undefined;
+  deadline?: any | null | undefined;
+  details?: string | null | undefined;
+  organizationId: string;
+  requestState: RightsRequestState;
+  requestType: RightsRequestType;
+};
+export type RightsRequestGraphCreateMutation$variables = {
+  connections: ReadonlyArray<string>;
+  input: CreateRightsRequestInput;
+};
+export type RightsRequestGraphCreateMutation$data = {
+  readonly createRightsRequest: {
+    readonly rightsRequestEdge: {
+      readonly node: {
+        readonly actionTaken: string | null | undefined;
+        readonly contact: string | null | undefined;
+        readonly createdAt: any;
+        readonly dataSubject: string | null | undefined;
+        readonly deadline: any | null | undefined;
+        readonly details: string | null | undefined;
+        readonly id: string;
+        readonly requestState: RightsRequestState;
+        readonly requestType: RightsRequestType;
+      };
+    };
+  };
+};
+export type RightsRequestGraphCreateMutation = {
+  response: RightsRequestGraphCreateMutation$data;
+  variables: RightsRequestGraphCreateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "RightsRequestEdge",
+  "kind": "LinkedField",
+  "name": "rightsRequestEdge",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "RightsRequest",
+      "kind": "LinkedField",
+      "name": "node",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "id",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "requestType",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "requestState",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "dataSubject",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "contact",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "details",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "deadline",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "actionTaken",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "createdAt",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RightsRequestGraphCreateMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "CreateRightsRequestPayload",
+        "kind": "LinkedField",
+        "name": "createRightsRequest",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "RightsRequestGraphCreateMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "CreateRightsRequestPayload",
+        "kind": "LinkedField",
+        "name": "createRightsRequest",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "prependEdge",
+            "key": "",
+            "kind": "LinkedHandle",
+            "name": "rightsRequestEdge",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "2642d9a5f58aa90190df6ccf73e6e06f",
+    "id": null,
+    "metadata": {},
+    "name": "RightsRequestGraphCreateMutation",
+    "operationKind": "mutation",
+    "text": "mutation RightsRequestGraphCreateMutation(\n  $input: CreateRightsRequestInput!\n) {\n  createRightsRequest(input: $input) {\n    rightsRequestEdge {\n      node {\n        id\n        requestType\n        requestState\n        dataSubject\n        contact\n        details\n        deadline\n        actionTaken\n        createdAt\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "98fa74d3219cf56655e74441af4dc01d";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/RightsRequestGraphDeleteMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/RightsRequestGraphDeleteMutation.graphql.ts
@@ -1,0 +1,132 @@
+/**
+ * @generated SignedSource<<274e16758d468bf7fb911965acca3264>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type DeleteRightsRequestInput = {
+  rightsRequestId: string;
+};
+export type RightsRequestGraphDeleteMutation$variables = {
+  connections: ReadonlyArray<string>;
+  input: DeleteRightsRequestInput;
+};
+export type RightsRequestGraphDeleteMutation$data = {
+  readonly deleteRightsRequest: {
+    readonly deletedRightsRequestId: string;
+  };
+};
+export type RightsRequestGraphDeleteMutation = {
+  response: RightsRequestGraphDeleteMutation$data;
+  variables: RightsRequestGraphDeleteMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "deletedRightsRequestId",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RightsRequestGraphDeleteMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteRightsRequestPayload",
+        "kind": "LinkedField",
+        "name": "deleteRightsRequest",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "RightsRequestGraphDeleteMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteRightsRequestPayload",
+        "kind": "LinkedField",
+        "name": "deleteRightsRequest",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "deleteEdge",
+            "key": "",
+            "kind": "ScalarHandle",
+            "name": "deletedRightsRequestId",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "c81b44380a4647a241c72fe1ca359246",
+    "id": null,
+    "metadata": {},
+    "name": "RightsRequestGraphDeleteMutation",
+    "operationKind": "mutation",
+    "text": "mutation RightsRequestGraphDeleteMutation(\n  $input: DeleteRightsRequestInput!\n) {\n  deleteRightsRequest(input: $input) {\n    deletedRightsRequestId\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "e657b62ad808fa4fd5902cf4eea4ca3b";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/RightsRequestGraphListQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/RightsRequestGraphListQuery.graphql.ts
@@ -1,0 +1,295 @@
+/**
+ * @generated SignedSource<<22e08aea59fb3427d7770d89a44d6e9e>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type RightsRequestGraphListQuery$variables = {
+  organizationId: string;
+};
+export type RightsRequestGraphListQuery$data = {
+  readonly node: {
+    readonly " $fragmentSpreads": FragmentRefs<"RightsRequestsPageFragment">;
+  };
+};
+export type RightsRequestGraphListQuery = {
+  response: RightsRequestGraphListQuery$data;
+  variables: RightsRequestGraphListQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "organizationId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "organizationId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RightsRequestGraphListQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "RightsRequestsPageFragment"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "RightsRequestGraphListQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          (v3/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": (v4/*: any*/),
+                "concreteType": "RightsRequestConnection",
+                "kind": "LinkedField",
+                "name": "rightsRequests",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "totalCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "RightsRequestEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "RightsRequest",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v3/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "requestType",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "requestState",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "dataSubject",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "contact",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "details",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "deadline",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "actionTaken",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "createdAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "updatedAt",
+                            "storageKey": null
+                          },
+                          (v2/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "cursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageInfo",
+                    "kind": "LinkedField",
+                    "name": "pageInfo",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "hasNextPage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "endCursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ClientExtension",
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "__id",
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ],
+                "storageKey": "rightsRequests(first:10)"
+              },
+              {
+                "alias": null,
+                "args": (v4/*: any*/),
+                "filters": null,
+                "handle": "connection",
+                "key": "RightsRequestsPage_rightsRequests",
+                "kind": "LinkedHandle",
+                "name": "rightsRequests"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "77f124136a2da2eb84fb134e5d10396b",
+    "id": null,
+    "metadata": {},
+    "name": "RightsRequestGraphListQuery",
+    "operationKind": "query",
+    "text": "query RightsRequestGraphListQuery(\n  $organizationId: ID!\n) {\n  node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      ...RightsRequestsPageFragment\n    }\n    id\n  }\n}\n\nfragment RightsRequestsPageFragment on Organization {\n  id\n  rightsRequests(first: 10) {\n    totalCount\n    edges {\n      node {\n        id\n        requestType\n        requestState\n        dataSubject\n        contact\n        details\n        deadline\n        actionTaken\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "6ff83d9e0017a4fb245ad9f13106a439";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/RightsRequestGraphNodeQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/RightsRequestGraphNodeQuery.graphql.ts
@@ -1,0 +1,241 @@
+/**
+ * @generated SignedSource<<7314c67aea13775f772b81880c524a60>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type RightsRequestState = "DONE" | "IN_PROGRESS" | "TODO";
+export type RightsRequestType = "ACCESS" | "DELETION" | "PORTABILITY";
+export type RightsRequestGraphNodeQuery$variables = {
+  rightsRequestId: string;
+};
+export type RightsRequestGraphNodeQuery$data = {
+  readonly node: {
+    readonly actionTaken?: string | null | undefined;
+    readonly contact?: string | null | undefined;
+    readonly createdAt?: any;
+    readonly dataSubject?: string | null | undefined;
+    readonly deadline?: any | null | undefined;
+    readonly details?: string | null | undefined;
+    readonly id?: string;
+    readonly organization?: {
+      readonly id: string;
+      readonly name: string;
+    };
+    readonly requestState?: RightsRequestState;
+    readonly requestType?: RightsRequestType;
+    readonly updatedAt?: any;
+  };
+};
+export type RightsRequestGraphNodeQuery = {
+  response: RightsRequestGraphNodeQuery$data;
+  variables: RightsRequestGraphNodeQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "rightsRequestId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "rightsRequestId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "requestType",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "requestState",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "dataSubject",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "contact",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "details",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "deadline",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "actionTaken",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Organization",
+  "kind": "LinkedField",
+  "name": "organization",
+  "plural": false,
+  "selections": [
+    (v2/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "updatedAt",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RightsRequestGraphNodeQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/),
+              (v9/*: any*/),
+              (v10/*: any*/),
+              (v11/*: any*/),
+              (v12/*: any*/)
+            ],
+            "type": "RightsRequest",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "RightsRequestGraphNodeQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v3/*: any*/),
+              (v4/*: any*/),
+              (v5/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/),
+              (v9/*: any*/),
+              (v10/*: any*/),
+              (v11/*: any*/),
+              (v12/*: any*/)
+            ],
+            "type": "RightsRequest",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "93aa5fb44159c0ae2709c34f493bc69f",
+    "id": null,
+    "metadata": {},
+    "name": "RightsRequestGraphNodeQuery",
+    "operationKind": "query",
+    "text": "query RightsRequestGraphNodeQuery(\n  $rightsRequestId: ID!\n) {\n  node(id: $rightsRequestId) {\n    __typename\n    ... on RightsRequest {\n      id\n      requestType\n      requestState\n      dataSubject\n      contact\n      details\n      deadline\n      actionTaken\n      organization {\n        id\n        name\n      }\n      createdAt\n      updatedAt\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "9f7d09c59f937a8de6cfbc0354b42d1b";
+
+export default node;

--- a/apps/console/src/hooks/graph/__generated__/RightsRequestGraphUpdateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/RightsRequestGraphUpdateMutation.graphql.ts
@@ -1,0 +1,178 @@
+/**
+ * @generated SignedSource<<df8070312cba4b83a8f30231ac7b7fde>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type RightsRequestState = "DONE" | "IN_PROGRESS" | "TODO";
+export type RightsRequestType = "ACCESS" | "DELETION" | "PORTABILITY";
+export type UpdateRightsRequestInput = {
+  actionTaken?: string | null | undefined;
+  contact?: string | null | undefined;
+  dataSubject?: string | null | undefined;
+  deadline?: any | null | undefined;
+  details?: string | null | undefined;
+  id: string;
+  requestState?: RightsRequestState | null | undefined;
+  requestType?: RightsRequestType | null | undefined;
+};
+export type RightsRequestGraphUpdateMutation$variables = {
+  input: UpdateRightsRequestInput;
+};
+export type RightsRequestGraphUpdateMutation$data = {
+  readonly updateRightsRequest: {
+    readonly rightsRequest: {
+      readonly actionTaken: string | null | undefined;
+      readonly contact: string | null | undefined;
+      readonly dataSubject: string | null | undefined;
+      readonly deadline: any | null | undefined;
+      readonly details: string | null | undefined;
+      readonly id: string;
+      readonly requestState: RightsRequestState;
+      readonly requestType: RightsRequestType;
+      readonly updatedAt: any;
+    };
+  };
+};
+export type RightsRequestGraphUpdateMutation = {
+  response: RightsRequestGraphUpdateMutation$data;
+  variables: RightsRequestGraphUpdateMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "UpdateRightsRequestPayload",
+    "kind": "LinkedField",
+    "name": "updateRightsRequest",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "RightsRequest",
+        "kind": "LinkedField",
+        "name": "rightsRequest",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "requestType",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "requestState",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "dataSubject",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "contact",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "details",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "deadline",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "actionTaken",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "updatedAt",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RightsRequestGraphUpdateMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "RightsRequestGraphUpdateMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "4b06cb49236bb946cfa333e95b80f2a8",
+    "id": null,
+    "metadata": {},
+    "name": "RightsRequestGraphUpdateMutation",
+    "operationKind": "mutation",
+    "text": "mutation RightsRequestGraphUpdateMutation(\n  $input: UpdateRightsRequestInput!\n) {\n  updateRightsRequest(input: $input) {\n    rightsRequest {\n      id\n      requestType\n      requestState\n      dataSubject\n      contact\n      details\n      deadline\n      actionTaken\n      updatedAt\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "f2f42ebc57de95ec4a760e7d701f90fa";
+
+export default node;

--- a/apps/console/src/layouts/MainLayout.tsx
+++ b/apps/console/src/layouts/MainLayout.tsx
@@ -224,6 +224,13 @@ function MainLayoutContent({
               to={`${prefix}/processing-activities`}
             />
           )}
+          {isAuthorized("Organization", "listRightsRequests") && (
+            <SidebarItem
+              label={__("Rights Requests")}
+              icon={IconLock}
+              to={`${prefix}/rights-requests`}
+            />
+          )}
           {isAuthorized("Organization", "listSnapshots") && (
             <SidebarItem
               label={__("Snapshots")}

--- a/apps/console/src/pages/organizations/rightsRequests/RightsRequestDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/rightsRequests/RightsRequestDetailsPage.tsx
@@ -1,0 +1,279 @@
+import {
+  ConnectionHandler,
+  usePreloadedQuery,
+  type PreloadedQuery,
+} from "react-relay";
+import {
+  rightsRequestNodeQuery,
+  useDeleteRightsRequest,
+  useUpdateRightsRequest,
+  RightsRequestsConnectionKey,
+} from "../../../hooks/graph/RightsRequestGraph";
+import {
+  ActionDropdown,
+  Badge,
+  Breadcrumb,
+  Button,
+  DropdownItem,
+  Field,
+  Option,
+  Input,
+  Card,
+  Textarea,
+  useToast,
+  Select,
+  Label,
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { useOrganizationId } from "/hooks/useOrganizationId";
+import { useFormWithSchema } from "/hooks/useFormWithSchema";
+import { Controller } from "react-hook-form";
+import {
+  formatError,
+  type GraphQLError,
+  formatDatetime,
+  toDateInput,
+  getRightsRequestTypeLabel,
+  getRightsRequestTypeOptions,
+  getRightsRequestStateVariant,
+  getRightsRequestStateLabel,
+  getRightsRequestStateOptions,
+} from "@probo/helpers";
+import z from "zod";
+import type { RightsRequestGraphNodeQuery } from "/hooks/graph/__generated__/RightsRequestGraphNodeQuery.graphql";
+import { use } from "react";
+import { PermissionsContext } from "/providers/PermissionsContext";
+
+const updateRequestSchema = z.object({
+  requestType: z.enum(["ACCESS", "DELETION", "PORTABILITY"]),
+  requestState: z.enum(["TODO", "IN_PROGRESS", "DONE"]),
+  dataSubject: z.string().optional(),
+  contact: z.string().optional(),
+  details: z.string().optional(),
+  deadline: z.string().optional(),
+  actionTaken: z.string().optional(),
+});
+
+type Props = {
+  queryRef: PreloadedQuery<RightsRequestGraphNodeQuery>;
+};
+
+export default function RightsRequestDetailsPage(props: Props) {
+  const data = usePreloadedQuery<RightsRequestGraphNodeQuery>(rightsRequestNodeQuery, props.queryRef);
+  const request = data.node;
+  const { __ } = useTranslate();
+  const { toast } = useToast();
+  const organizationId = useOrganizationId();
+  const { isAuthorized } = use(PermissionsContext);
+
+  const updateRequest = useUpdateRightsRequest();
+
+  const connectionId = ConnectionHandler.getConnectionID(
+    organizationId,
+    RightsRequestsConnectionKey
+  );
+
+  const deleteRequest = useDeleteRightsRequest({ id: request.id! }, connectionId);
+
+  const { register, handleSubmit, formState, control } = useFormWithSchema(
+    updateRequestSchema,
+    {
+      defaultValues: {
+        requestType: request.requestType || "ACCESS",
+        requestState: request.requestState || "TODO",
+        dataSubject: request.dataSubject || "",
+        contact: request.contact || "",
+        details: request.details || "",
+        deadline: toDateInput(request.deadline),
+        actionTaken: request.actionTaken || "",
+      },
+    }
+  );
+
+  const onSubmit = handleSubmit(async (formData) => {
+    try {
+      await updateRequest({
+        id: request.id!,
+        requestType: formData.requestType,
+        requestState: formData.requestState,
+        dataSubject: formData.dataSubject || undefined,
+        contact: formData.contact || undefined,
+        details: formData.details || undefined,
+        deadline: formatDatetime(formData.deadline) ?? null,
+        actionTaken: formData.actionTaken || undefined,
+      });
+
+      toast({
+        title: __("Success"),
+        description: __("Rights request updated successfully"),
+        variant: "success",
+      });
+    } catch (error) {
+      toast({
+        title: __("Error"),
+        description: formatError(__("Failed to update rights request"), error as GraphQLError),
+        variant: "error",
+      });
+    }
+  });
+
+  const typeOptions = getRightsRequestTypeOptions(__);
+  const stateOptions = getRightsRequestStateOptions(__);
+
+  const breadcrumbRequestsUrl = `/organizations/${organizationId}/rights-requests`;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <Breadcrumb
+          items={[
+            { label: __("Rights Requests"), to: breadcrumbRequestsUrl },
+            { label: request.dataSubject || request.id! },
+          ]}
+        />
+        {isAuthorized("RightsRequest", "deleteRightsRequest") && (
+          <ActionDropdown>
+            <DropdownItem onClick={deleteRequest} variant="danger">
+              {__("Delete")}
+            </DropdownItem>
+          </ActionDropdown>
+        )}
+      </div>
+
+      <Card>
+        <div className="p-6">
+          <div className="mb-6">
+            <div className="flex items-center gap-4">
+              <h1 className="text-2xl font-bold">{getRightsRequestTypeLabel(__, request.requestType || "ACCESS")}</h1>
+              <Badge variant="neutral">{getRightsRequestTypeLabel(__, request.requestType || "ACCESS")}</Badge>
+              <Badge variant={getRightsRequestStateVariant(request.requestState || "TODO")}>
+                {getRightsRequestStateLabel(__, request.requestState || "TODO")}
+              </Badge>
+            </div>
+          </div>
+
+          <form onSubmit={onSubmit} className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <Controller
+                control={control}
+                name="requestType"
+                render={({ field }) => (
+                  <div>
+                    <Label>{__("Request Type")} *</Label>
+                    <Select
+                      value={field.value}
+                      onValueChange={field.onChange}
+                    >
+                      {typeOptions.map((option) => (
+                        <Option key={option.value} value={option.value}>
+                          {option.label}
+                        </Option>
+                      ))}
+                    </Select>
+                    {formState.errors.requestType?.message && (
+                      <div className="text-red-500 text-sm mt-1">
+                        {formState.errors.requestType.message}
+                      </div>
+                    )}
+                  </div>
+                )}
+              />
+
+              <Controller
+                control={control}
+                name="requestState"
+                render={({ field }) => (
+                  <div>
+                    <Label>{__("State")} *</Label>
+                    <Select
+                      value={field.value}
+                      onValueChange={field.onChange}
+                    >
+                      {stateOptions.map((option) => (
+                        <Option key={option.value} value={option.value}>
+                          {option.label}
+                        </Option>
+                      ))}
+                    </Select>
+                    {formState.errors.requestState?.message && (
+                      <div className="text-red-500 text-sm mt-1">
+                        {formState.errors.requestState.message}
+                      </div>
+                    )}
+                  </div>
+                )}
+              />
+            </div>
+
+            <Field
+              label={__("Data Subject")}
+              {...register("dataSubject")}
+              error={formState.errors.dataSubject?.message}
+            />
+
+            <Field
+              label={__("Contact")}
+              {...register("contact")}
+              error={formState.errors.contact?.message}
+            />
+
+            <div>
+              <Label>{__("Details")}</Label>
+              <Textarea
+                {...register("details")}
+                placeholder={__("Enter request details")}
+                rows={3}
+              />
+              {formState.errors.details?.message && (
+                <div className="text-red-500 text-sm mt-1">
+                  {formState.errors.details.message}
+                </div>
+              )}
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label>{__("Deadline")}</Label>
+                <Input
+                  type="date"
+                  {...register("deadline")}
+                />
+                {formState.errors.deadline?.message && (
+                  <div className="text-red-500 text-sm mt-1">
+                    {formState.errors.deadline.message}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div>
+              <Label>{__("Action Taken")}</Label>
+              <Textarea
+                {...register("actionTaken")}
+                placeholder={__("Enter action taken")}
+                rows={3}
+              />
+              {formState.errors.actionTaken?.message && (
+                <div className="text-red-500 text-sm mt-1">
+                  {formState.errors.actionTaken.message}
+                </div>
+              )}
+            </div>
+
+            <div className="flex justify-end pt-4">
+              {isAuthorized("RightsRequest", "updateRightsRequest") && (
+                <Button
+                  type="submit"
+                  variant="primary"
+                  disabled={formState.isSubmitting}
+                >
+                  {formState.isSubmitting ? __("Saving...") : __("Save Changes")}
+                </Button>
+              )}
+            </div>
+          </form>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/apps/console/src/pages/organizations/rightsRequests/RightsRequestsPage.tsx
+++ b/apps/console/src/pages/organizations/rightsRequests/RightsRequestsPage.tsx
@@ -1,0 +1,267 @@
+import {
+  Button,
+  IconPlusLarge,
+  PageHeader,
+  Card,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Badge,
+  ActionDropdown,
+  DropdownItem,
+  IconTrashCan,
+  Table,
+  useConfirm,
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { usePageTitle } from "@probo/hooks";
+import {
+  ConnectionHandler,
+  graphql,
+  usePaginationFragment,
+  usePreloadedQuery,
+  useMutation,
+  type PreloadedQuery,
+} from "react-relay";
+import { useOrganizationId } from "/hooks/useOrganizationId";
+import { CreateRightsRequestDialog } from "./dialogs/CreateRightsRequestDialog";
+import { deleteRightsRequestMutation, RightsRequestsConnectionKey, rightsRequestsQuery } from "../../../hooks/graph/RightsRequestGraph";
+import {
+  sprintf,
+  promisifyMutation,
+  formatDate,
+  getRightsRequestTypeLabel,
+  getRightsRequestStateVariant,
+  getRightsRequestStateLabel,
+} from "@probo/helpers";
+import type { NodeOf } from "/types";
+import type {
+  RightsRequestsPageFragment$key,
+  RightsRequestsPageFragment$data,
+} from "./__generated__/RightsRequestsPageFragment.graphql";
+import { use } from "react";
+import { PermissionsContext } from "/providers/PermissionsContext";
+import type { RightsRequestGraphListQuery } from "/hooks/graph/__generated__/RightsRequestGraphListQuery.graphql";
+
+interface RightsRequestsPageProps {
+  queryRef: PreloadedQuery<RightsRequestGraphListQuery>;
+}
+
+const rightsRequestsPageFragment = graphql`
+  fragment RightsRequestsPageFragment on Organization
+  @refetchable(queryName: "RightsRequestsPageRefetchQuery")
+  @argumentDefinitions(
+    first: { type: "Int", defaultValue: 10 }
+    after: { type: "CursorKey" }
+  ) {
+    id
+    rightsRequests(
+      first: $first
+      after: $after
+    )
+      @connection(key: "RightsRequestsPage_rightsRequests") {
+      __id
+      totalCount
+      edges {
+        node {
+          id
+          requestType
+          requestState
+          dataSubject
+          contact
+          details
+          deadline
+          actionTaken
+          createdAt
+          updatedAt
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+`;
+
+export default function RightsRequestsPage({ queryRef }: RightsRequestsPageProps) {
+  const { __ } = useTranslate();
+  const organizationId = useOrganizationId();
+  const { isAuthorized } = use(PermissionsContext);
+
+  usePageTitle(__("Rights Requests"));
+
+  const organization = usePreloadedQuery(
+    rightsRequestsQuery,
+    queryRef
+  );
+
+  const {
+    data,
+    loadNext,
+    hasNext,
+    isLoadingNext,
+  } = usePaginationFragment<
+    RightsRequestGraphListQuery,
+    RightsRequestsPageFragment$key
+  >(rightsRequestsPageFragment, organization.node);
+
+  const connectionId = ConnectionHandler.getConnectionID(
+    organizationId,
+    RightsRequestsConnectionKey
+  );
+  const requests = data?.rightsRequests?.edges?.map((edge) => edge.node) ?? [];
+
+  const hasAnyAction = (
+    isAuthorized("RightsRequest", "updateRightsRequest") ||
+    isAuthorized("RightsRequest", "deleteRightsRequest")
+  );
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title={__("Rights Requests")} description={__("Manage data subject rights requests.")}>
+        {isAuthorized("Organization", "createRightsRequest") && (
+          <CreateRightsRequestDialog
+            organizationId={organizationId}
+            connectionId={connectionId}
+          >
+            <Button icon={IconPlusLarge}>
+              {__("Add rights request")}
+            </Button>
+          </CreateRightsRequestDialog>
+        )}
+      </PageHeader>
+
+      {requests.length > 0 ? (
+        <Card>
+          <Table>
+            <Thead>
+              <Tr>
+                <Th>{__("Type")}</Th>
+                <Th>{__("State")}</Th>
+                <Th>{__("Data Subject")}</Th>
+                <Th>{__("Contact")}</Th>
+                <Th>{__("Deadline")}</Th>
+                {hasAnyAction && <Th>{__("Actions")}</Th>}
+              </Tr>
+            </Thead>
+            <Tbody>
+              {requests.map((request) => (
+                <RequestRow
+                  key={request.id}
+                  request={request}
+                  connectionId={connectionId}
+                  hasAnyAction={hasAnyAction}
+                />
+              ))}
+            </Tbody>
+          </Table>
+
+          {hasNext && (
+            <div className="p-4 border-t">
+              <Button
+                variant="secondary"
+                onClick={() => loadNext(10)}
+                disabled={isLoadingNext}
+              >
+                {isLoadingNext ? __("Loading...") : __("Load more")}
+              </Button>
+            </div>
+          )}
+        </Card>
+      ) : (
+        <Card padded>
+          <div className="text-center py-12">
+            <h3 className="text-lg font-semibold mb-2">
+              {__("No rights requests yet")}
+            </h3>
+            <p className="text-txt-tertiary mb-4">
+              {__("Create your first rights request to get started.")}
+            </p>
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function RequestRow({
+  request,
+  connectionId,
+  hasAnyAction,
+}: {
+  request: NodeOf<NonNullable<RightsRequestsPageFragment$data['rightsRequests']>>;
+  connectionId: string;
+  hasAnyAction: boolean;
+}) {
+  const organizationId = useOrganizationId();
+  const { __ } = useTranslate();
+  const [deleteRequest] = useMutation(deleteRightsRequestMutation);
+  const confirm = useConfirm();
+  const { isAuthorized } = use(PermissionsContext);
+
+  const handleDelete = () => {
+    confirm(
+      () =>
+        promisifyMutation(deleteRequest)({
+          variables: {
+            input: {
+              rightsRequestId: request.id,
+            },
+            connections: [connectionId],
+          },
+        }),
+      {
+        message: sprintf(
+          __(
+            "This will permanently delete the rights request. This action cannot be undone."
+          )
+        ),
+      }
+    );
+  };
+
+
+  const detailsUrl = `/organizations/${organizationId}/rights-requests/${request.id}`;
+
+  return (
+    <Tr to={detailsUrl}>
+      <Td>
+        <Badge variant="neutral">{getRightsRequestTypeLabel(__, request.requestType)}</Badge>
+      </Td>
+      <Td>
+        <Badge variant={getRightsRequestStateVariant(request.requestState)}>
+          {getRightsRequestStateLabel(__, request.requestState)}
+        </Badge>
+      </Td>
+      <Td>{request.dataSubject || "-"}</Td>
+      <Td>{request.contact || "-"}</Td>
+      <Td>
+        {request.deadline ? (
+          <time dateTime={request.deadline}>
+            {formatDate(request.deadline)}
+          </time>
+        ) : (
+          <span className="text-txt-tertiary">{__("No deadline")}</span>
+        )}
+      </Td>
+      {hasAnyAction && (
+        <Td noLink width={50} className="text-end">
+          <ActionDropdown>
+            {isAuthorized("RightsRequest", "deleteRightsRequest") && (
+              <DropdownItem
+                icon={IconTrashCan}
+                variant="danger"
+                onSelect={handleDelete}
+              >
+                {__("Delete")}
+              </DropdownItem>
+            )}
+          </ActionDropdown>
+        </Td>
+      )}
+    </Tr>
+  );
+}

--- a/apps/console/src/pages/organizations/rightsRequests/__generated__/RightsRequestsPageFragment.graphql.ts
+++ b/apps/console/src/pages/organizations/rightsRequests/__generated__/RightsRequestsPageFragment.graphql.ts
@@ -1,0 +1,267 @@
+/**
+ * @generated SignedSource<<4b94130573ce20c5879e717c00128fbb>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type RightsRequestState = "DONE" | "IN_PROGRESS" | "TODO";
+export type RightsRequestType = "ACCESS" | "DELETION" | "PORTABILITY";
+import { FragmentRefs } from "relay-runtime";
+export type RightsRequestsPageFragment$data = {
+  readonly id: string;
+  readonly rightsRequests: {
+    readonly __id: string;
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly actionTaken: string | null | undefined;
+        readonly contact: string | null | undefined;
+        readonly createdAt: any;
+        readonly dataSubject: string | null | undefined;
+        readonly deadline: any | null | undefined;
+        readonly details: string | null | undefined;
+        readonly id: string;
+        readonly requestState: RightsRequestState;
+        readonly requestType: RightsRequestType;
+        readonly updatedAt: any;
+      };
+    }>;
+    readonly pageInfo: {
+      readonly endCursor: any | null | undefined;
+      readonly hasNextPage: boolean;
+    };
+    readonly totalCount: number;
+  };
+  readonly " $fragmentType": "RightsRequestsPageFragment";
+};
+export type RightsRequestsPageFragment$key = {
+  readonly " $data"?: RightsRequestsPageFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"RightsRequestsPageFragment">;
+};
+
+import RightsRequestsPageRefetchQuery_graphql from './RightsRequestsPageRefetchQuery.graphql';
+
+const node: ReaderFragment = (function(){
+var v0 = [
+  "rightsRequests"
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "after"
+    },
+    {
+      "defaultValue": 10,
+      "kind": "LocalArgument",
+      "name": "first"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": {
+    "connection": [
+      {
+        "count": "first",
+        "cursor": "after",
+        "direction": "forward",
+        "path": (v0/*: any*/)
+      }
+    ],
+    "refetch": {
+      "connection": {
+        "forward": {
+          "count": "first",
+          "cursor": "after"
+        },
+        "backward": null,
+        "path": (v0/*: any*/)
+      },
+      "fragmentPathInResult": [
+        "node"
+      ],
+      "operation": RightsRequestsPageRefetchQuery_graphql,
+      "identifierInfo": {
+        "identifierField": "id",
+        "identifierQueryVariableName": "id"
+      }
+    }
+  },
+  "name": "RightsRequestsPageFragment",
+  "selections": [
+    (v1/*: any*/),
+    {
+      "alias": "rightsRequests",
+      "args": null,
+      "concreteType": "RightsRequestConnection",
+      "kind": "LinkedField",
+      "name": "__RightsRequestsPage_rightsRequests_connection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "totalCount",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "RightsRequestEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "RightsRequest",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                (v1/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "requestType",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "requestState",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "dataSubject",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "contact",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "details",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "deadline",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "actionTaken",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "createdAt",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "updatedAt",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "__typename",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "cursor",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "kind": "LinkedField",
+          "name": "pageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasNextPage",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "endCursor",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "kind": "ClientExtension",
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "__id",
+              "storageKey": null
+            }
+          ]
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Organization",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "3476c393dc97ae3d730ed5715922e987";
+
+export default node;

--- a/apps/console/src/pages/organizations/rightsRequests/__generated__/RightsRequestsPageRefetchQuery.graphql.ts
+++ b/apps/console/src/pages/organizations/rightsRequests/__generated__/RightsRequestsPageRefetchQuery.graphql.ts
@@ -1,0 +1,305 @@
+/**
+ * @generated SignedSource<<dddf70832ae8eecef831e8832a782f20>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type RightsRequestsPageRefetchQuery$variables = {
+  after?: any | null | undefined;
+  first?: number | null | undefined;
+  id: string;
+};
+export type RightsRequestsPageRefetchQuery$data = {
+  readonly node: {
+    readonly " $fragmentSpreads": FragmentRefs<"RightsRequestsPageFragment">;
+  };
+};
+export type RightsRequestsPageRefetchQuery = {
+  response: RightsRequestsPageRefetchQuery$data;
+  variables: RightsRequestsPageRefetchQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "after"
+  },
+  {
+    "defaultValue": 10,
+    "kind": "LocalArgument",
+    "name": "first"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "after"
+  },
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "first"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RightsRequestsPageRefetchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "args": (v2/*: any*/),
+            "kind": "FragmentSpread",
+            "name": "RightsRequestsPageFragment"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "RightsRequestsPageRefetchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          (v4/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": (v2/*: any*/),
+                "concreteType": "RightsRequestConnection",
+                "kind": "LinkedField",
+                "name": "rightsRequests",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "totalCount",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "RightsRequestEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "RightsRequest",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v4/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "requestType",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "requestState",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "dataSubject",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "contact",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "details",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "deadline",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "actionTaken",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "createdAt",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "updatedAt",
+                            "storageKey": null
+                          },
+                          (v3/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "cursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageInfo",
+                    "kind": "LinkedField",
+                    "name": "pageInfo",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "hasNextPage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "endCursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ClientExtension",
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "__id",
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": (v2/*: any*/),
+                "filters": null,
+                "handle": "connection",
+                "key": "RightsRequestsPage_rightsRequests",
+                "kind": "LinkedHandle",
+                "name": "rightsRequests"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "10c7e9a6f7813d150e34282befd799ff",
+    "id": null,
+    "metadata": {},
+    "name": "RightsRequestsPageRefetchQuery",
+    "operationKind": "query",
+    "text": "query RightsRequestsPageRefetchQuery(\n  $after: CursorKey\n  $first: Int = 10\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...RightsRequestsPageFragment_2HEEH6\n    id\n  }\n}\n\nfragment RightsRequestsPageFragment_2HEEH6 on Organization {\n  id\n  rightsRequests(first: $first, after: $after) {\n    totalCount\n    edges {\n      node {\n        id\n        requestType\n        requestState\n        dataSubject\n        contact\n        details\n        deadline\n        actionTaken\n        createdAt\n        updatedAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "3476c393dc97ae3d730ed5715922e987";
+
+export default node;

--- a/apps/console/src/pages/organizations/rightsRequests/dialogs/CreateRightsRequestDialog.tsx
+++ b/apps/console/src/pages/organizations/rightsRequests/dialogs/CreateRightsRequestDialog.tsx
@@ -1,0 +1,235 @@
+import { type ReactNode } from "react";
+import {
+  Button,
+  Field,
+  useToast,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  useDialogRef,
+  Textarea,
+  Breadcrumb,
+  Label,
+  Select,
+  Option,
+  Input,
+} from "@probo/ui";
+import { useTranslate } from "@probo/i18n";
+import { z } from "zod";
+import { useFormWithSchema } from "/hooks/useFormWithSchema";
+import { useCreateRightsRequest } from "../../../../hooks/graph/RightsRequestGraph";
+import { Controller } from "react-hook-form";
+import {
+  formatError,
+  type GraphQLError,
+  formatDatetime,
+  getRightsRequestTypeOptions,
+  getRightsRequestStateOptions,
+} from "@probo/helpers";
+
+const schema = z.object({
+  requestType: z.enum(["ACCESS", "DELETION", "PORTABILITY"]),
+  requestState: z.enum(["TODO", "IN_PROGRESS", "DONE"]),
+  dataSubject: z.string().optional(),
+  contact: z.string().optional(),
+  details: z.string().optional(),
+  deadline: z.string().optional(),
+  actionTaken: z.string().optional(),
+});
+
+type FormData = z.infer<typeof schema>;
+
+interface CreateRightsRequestDialogProps {
+  children: ReactNode;
+  organizationId: string;
+  connectionId?: string;
+}
+
+export function CreateRightsRequestDialog({
+  children,
+  organizationId,
+  connectionId,
+}: CreateRightsRequestDialogProps) {
+  const { __ } = useTranslate();
+  const { toast } = useToast();
+  const dialogRef = useDialogRef();
+
+  const createRequest = useCreateRightsRequest(connectionId || "");
+
+  const { register, handleSubmit, formState, reset, control } = useFormWithSchema(schema, {
+    defaultValues: {
+      requestType: "ACCESS" as const,
+      requestState: "TODO" as const,
+      dataSubject: "",
+      contact: "",
+      details: "",
+      deadline: "",
+      actionTaken: "",
+    },
+  });
+
+  const onSubmit = handleSubmit(async (formData: FormData) => {
+    try {
+      await createRequest({
+        organizationId,
+        requestType: formData.requestType,
+        requestState: formData.requestState,
+        dataSubject: formData.dataSubject || undefined,
+        contact: formData.contact || undefined,
+        details: formData.details || undefined,
+        deadline: formatDatetime(formData.deadline),
+        actionTaken: formData.actionTaken || undefined,
+      });
+
+      toast({
+        title: __("Success"),
+        description: __("Rights request created successfully"),
+        variant: "success",
+      });
+
+      reset();
+      dialogRef.current?.close();
+    } catch (error) {
+      toast({
+        title: __("Error"),
+        description: formatError(__("Failed to create rights request"), error as GraphQLError),
+        variant: "error",
+      });
+    }
+  });
+
+  const typeOptions = getRightsRequestTypeOptions(__);
+  const stateOptions = getRightsRequestStateOptions(__);
+
+  return (
+    <Dialog
+      ref={dialogRef}
+      trigger={children}
+      title={<Breadcrumb items={[__("Rights Requests"), __("Create Request")]} />}
+      className="max-w-2xl"
+    >
+      <form onSubmit={onSubmit}>
+        <DialogContent padded className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <Controller
+              control={control}
+              name="requestType"
+              render={({ field }) => (
+                <div>
+                  <Label>{__("Request Type")} *</Label>
+                  <Select
+                    value={field.value}
+                    onValueChange={field.onChange}
+                  >
+                    {typeOptions.map((option) => (
+                      <Option key={option.value} value={option.value}>
+                        {option.label}
+                      </Option>
+                    ))}
+                  </Select>
+                  {formState.errors.requestType?.message && (
+                    <div className="text-red-500 text-sm mt-1">
+                      {formState.errors.requestType.message}
+                    </div>
+                  )}
+                </div>
+              )}
+            />
+
+            <Controller
+              control={control}
+              name="requestState"
+              render={({ field }) => (
+                <div>
+                  <Label>{__("State")} *</Label>
+                  <Select
+                    value={field.value}
+                    onValueChange={field.onChange}
+                  >
+                    {stateOptions.map((option) => (
+                      <Option key={option.value} value={option.value}>
+                        {option.label}
+                      </Option>
+                    ))}
+                  </Select>
+                  {formState.errors.requestState?.message && (
+                    <div className="text-red-500 text-sm mt-1">
+                      {formState.errors.requestState.message}
+                    </div>
+                  )}
+                </div>
+              )}
+            />
+          </div>
+
+          <Field
+            label={__("Data Subject")}
+            {...register("dataSubject")}
+            placeholder={__("Enter data subject name")}
+            error={formState.errors.dataSubject?.message}
+          />
+
+          <Field
+            label={__("Contact")}
+            {...register("contact")}
+            placeholder={__("Enter contact information")}
+            error={formState.errors.contact?.message}
+          />
+
+          <div>
+            <Label>{__("Details")}</Label>
+            <Textarea
+              {...register("details")}
+              placeholder={__("Enter request details")}
+              rows={3}
+            />
+            {formState.errors.details?.message && (
+              <div className="text-red-500 text-sm mt-1">
+                {formState.errors.details.message}
+              </div>
+            )}
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label>{__("Deadline")}</Label>
+              <Input
+                type="date"
+                {...register("deadline")}
+              />
+              {formState.errors.deadline?.message && (
+                <div className="text-red-500 text-sm mt-1">
+                  {formState.errors.deadline.message}
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div>
+            <Label>{__("Action Taken")}</Label>
+            <Textarea
+              {...register("actionTaken")}
+              placeholder={__("Enter action taken")}
+              rows={3}
+            />
+            {formState.errors.actionTaken?.message && (
+              <div className="text-red-500 text-sm mt-1">
+                {formState.errors.actionTaken.message}
+              </div>
+            )}
+          </div>
+        </DialogContent>
+
+        <DialogFooter>
+          <Button
+            type="submit"
+            variant="primary"
+            disabled={formState.isSubmitting}
+          >
+            {formState.isSubmitting ? __("Creating...") : __("Create Request")}
+          </Button>
+        </DialogFooter>
+      </form>
+    </Dialog>
+  );
+}

--- a/apps/console/src/routes.tsx
+++ b/apps/console/src/routes.tsx
@@ -33,6 +33,7 @@ import { nonconformityRoutes } from "./routes/nonconformityRoutes.ts";
 import { obligationRoutes } from "./routes/obligationRoutes.ts";
 import { snapshotsRoutes } from "./routes/snapshotsRoutes.ts";
 import { continualImprovementRoutes } from "./routes/continualImprovementRoutes.ts";
+import { rightsRequestRoutes } from "./routes/rightsRequestRoutes.ts";
 import { processingActivityRoutes } from "./routes/processingActivityRoutes.ts";
 import { lazy } from "@probo/react-lazy";
 import { loaderFromQueryLoader, routeFromAppRoute, withQueryRef, type AppRoute } from "@probo/routes";
@@ -224,6 +225,7 @@ const routes = [
       ...nonconformityRoutes,
       ...obligationRoutes,
       ...continualImprovementRoutes,
+      ...rightsRequestRoutes,
       ...processingActivityRoutes,
       ...snapshotsRoutes,
       ...trustCenterRoutes,

--- a/apps/console/src/routes/rightsRequestRoutes.ts
+++ b/apps/console/src/routes/rightsRequestRoutes.ts
@@ -1,0 +1,35 @@
+import { loadQuery } from "react-relay";
+import { relayEnvironment } from "/providers/RelayProviders";
+import { PageSkeleton } from "/components/skeletons/PageSkeleton";
+import { lazy } from "@probo/react-lazy";
+import { rightsRequestsQuery, rightsRequestNodeQuery } from "/hooks/graph/RightsRequestGraph";
+import type { RightsRequestGraphListQuery } from "/hooks/graph/__generated__/RightsRequestGraphListQuery.graphql";
+import type { RightsRequestGraphNodeQuery } from "/hooks/graph/__generated__/RightsRequestGraphNodeQuery.graphql";
+import { loaderFromQueryLoader, withQueryRef, type AppRoute } from "@probo/routes";
+
+export const rightsRequestRoutes = [
+  {
+    path: "rights-requests",
+    Fallback: PageSkeleton,
+    loader: loaderFromQueryLoader(({ organizationId }) =>
+      loadQuery<RightsRequestGraphListQuery>(relayEnvironment, rightsRequestsQuery, {
+        organizationId,
+      }),
+    ),
+    Component: withQueryRef(lazy(
+      () => import("/pages/organizations/rightsRequests/RightsRequestsPage")
+    )),
+  },
+  {
+    path: "rights-requests/:requestId",
+    Fallback: PageSkeleton,
+    loader: loaderFromQueryLoader(({ requestId }) =>
+      loadQuery<RightsRequestGraphNodeQuery>(relayEnvironment, rightsRequestNodeQuery, {
+        rightsRequestId: requestId!,
+      }),
+    ),
+    Component: withQueryRef(lazy(
+      () => import("/pages/organizations/rightsRequests/RightsRequestDetailsPage")
+    )),
+  },
+] satisfies AppRoute[];

--- a/e2e/console/rights_request_test.go
+++ b/e2e/console/rights_request_test.go
@@ -1,0 +1,394 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package console_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/e2e/internal/testutil"
+)
+
+func TestRightsRequest_Create(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+
+	query := `
+		mutation CreateRightsRequest($input: CreateRightsRequestInput!) {
+			createRightsRequest(input: $input) {
+				rightsRequestEdge {
+					node {
+						id
+						requestType
+						requestState
+						dataSubject
+						contact
+						details
+						actionTaken
+					}
+				}
+			}
+		}
+	`
+
+	var result struct {
+		CreateRightsRequest struct {
+			RightsRequestEdge struct {
+				Node struct {
+					ID           string `json:"id"`
+					RequestType  string `json:"requestType"`
+					RequestState string `json:"requestState"`
+					DataSubject  string `json:"dataSubject"`
+					Contact      string `json:"contact"`
+					Details      string `json:"details"`
+					ActionTaken  string `json:"actionTaken"`
+				} `json:"node"`
+			} `json:"rightsRequestEdge"`
+		} `json:"createRightsRequest"`
+	}
+
+	err := owner.Execute(query, map[string]any{
+		"input": map[string]any{
+			"organizationId": owner.GetOrganizationID().String(),
+			"requestType":    "ACCESS",
+			"requestState":   "TODO",
+			"dataSubject":    "John Doe",
+			"contact":        "john.doe@example.com",
+			"details":        "Request access to personal data",
+			"actionTaken":    "Initial review completed",
+		},
+	}, &result)
+	require.NoError(t, err)
+
+	rr := result.CreateRightsRequest.RightsRequestEdge.Node
+	assert.NotEmpty(t, rr.ID)
+	assert.Equal(t, "ACCESS", rr.RequestType)
+	assert.Equal(t, "TODO", rr.RequestState)
+	assert.Equal(t, "John Doe", rr.DataSubject)
+	assert.Equal(t, "john.doe@example.com", rr.Contact)
+	assert.Equal(t, "Request access to personal data", rr.Details)
+	assert.Equal(t, "Initial review completed", rr.ActionTaken)
+}
+
+func TestRightsRequest_Update(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+
+	createQuery := `
+		mutation CreateRightsRequest($input: CreateRightsRequestInput!) {
+			createRightsRequest(input: $input) {
+				rightsRequestEdge {
+					node {
+						id
+					}
+				}
+			}
+		}
+	`
+
+	var createResult struct {
+		CreateRightsRequest struct {
+			RightsRequestEdge struct {
+				Node struct {
+					ID string `json:"id"`
+				} `json:"node"`
+			} `json:"rightsRequestEdge"`
+		} `json:"createRightsRequest"`
+	}
+
+	err := owner.Execute(createQuery, map[string]any{
+		"input": map[string]any{
+			"organizationId": owner.GetOrganizationID().String(),
+			"requestType":    "ACCESS",
+			"requestState":   "TODO",
+			"dataSubject":    "Original Subject",
+			"contact":        "original@example.com",
+		},
+	}, &createResult)
+	require.NoError(t, err)
+	rrID := createResult.CreateRightsRequest.RightsRequestEdge.Node.ID
+
+	query := `
+		mutation UpdateRightsRequest($input: UpdateRightsRequestInput!) {
+			updateRightsRequest(input: $input) {
+				rightsRequest {
+					id
+					requestType
+					requestState
+					dataSubject
+					contact
+					details
+					actionTaken
+				}
+			}
+		}
+	`
+
+	var result struct {
+		UpdateRightsRequest struct {
+			RightsRequest struct {
+				ID           string `json:"id"`
+				RequestType  string `json:"requestType"`
+				RequestState string `json:"requestState"`
+				DataSubject  string `json:"dataSubject"`
+				Contact      string `json:"contact"`
+				Details      string `json:"details"`
+				ActionTaken  string `json:"actionTaken"`
+			} `json:"rightsRequest"`
+		} `json:"updateRightsRequest"`
+	}
+
+	err = owner.Execute(query, map[string]any{
+		"input": map[string]any{
+			"id":           rrID,
+			"requestType":  "DELETION",
+			"requestState": "IN_PROGRESS",
+			"dataSubject":  "Updated Subject",
+			"contact":      "updated@example.com",
+			"details":      "Updated details",
+			"actionTaken":  "Processing deletion request",
+		},
+	}, &result)
+	require.NoError(t, err)
+
+	assert.Equal(t, rrID, result.UpdateRightsRequest.RightsRequest.ID)
+	assert.Equal(t, "DELETION", result.UpdateRightsRequest.RightsRequest.RequestType)
+	assert.Equal(t, "IN_PROGRESS", result.UpdateRightsRequest.RightsRequest.RequestState)
+	assert.Equal(t, "Updated Subject", result.UpdateRightsRequest.RightsRequest.DataSubject)
+	assert.Equal(t, "updated@example.com", result.UpdateRightsRequest.RightsRequest.Contact)
+	assert.Equal(t, "Updated details", result.UpdateRightsRequest.RightsRequest.Details)
+	assert.Equal(t, "Processing deletion request", result.UpdateRightsRequest.RightsRequest.ActionTaken)
+}
+
+func TestRightsRequest_Delete(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+
+	createQuery := `
+		mutation CreateRightsRequest($input: CreateRightsRequestInput!) {
+			createRightsRequest(input: $input) {
+				rightsRequestEdge {
+					node {
+						id
+					}
+				}
+			}
+		}
+	`
+
+	var createResult struct {
+		CreateRightsRequest struct {
+			RightsRequestEdge struct {
+				Node struct {
+					ID string `json:"id"`
+				} `json:"node"`
+			} `json:"rightsRequestEdge"`
+		} `json:"createRightsRequest"`
+	}
+
+	err := owner.Execute(createQuery, map[string]any{
+		"input": map[string]any{
+			"organizationId": owner.GetOrganizationID().String(),
+			"requestType":    "ACCESS",
+			"requestState":   "TODO",
+		},
+	}, &createResult)
+	require.NoError(t, err)
+	rrID := createResult.CreateRightsRequest.RightsRequestEdge.Node.ID
+
+	query := `
+		mutation DeleteRightsRequest($input: DeleteRightsRequestInput!) {
+			deleteRightsRequest(input: $input) {
+				deletedRightsRequestId
+			}
+		}
+	`
+
+	var result struct {
+		DeleteRightsRequest struct {
+			DeletedRightsRequestID string `json:"deletedRightsRequestId"`
+		} `json:"deleteRightsRequest"`
+	}
+
+	err = owner.Execute(query, map[string]any{
+		"input": map[string]any{
+			"rightsRequestId": rrID,
+		},
+	}, &result)
+	require.NoError(t, err)
+	assert.Equal(t, rrID, result.DeleteRightsRequest.DeletedRightsRequestID)
+}
+
+func TestRightsRequest_List(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+
+	createQuery := `
+		mutation CreateRightsRequest($input: CreateRightsRequestInput!) {
+			createRightsRequest(input: $input) {
+				rightsRequestEdge {
+					node {
+						id
+					}
+				}
+			}
+		}
+	`
+
+	for i := 0; i < 3; i++ {
+		_, err := owner.Do(createQuery, map[string]any{
+			"input": map[string]any{
+				"organizationId": owner.GetOrganizationID().String(),
+				"requestType":    "ACCESS",
+				"requestState":   "TODO",
+				"dataSubject":    fmt.Sprintf("Subject %d", i),
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	query := `
+		query GetRightsRequests($id: ID!) {
+			node(id: $id) {
+				... on Organization {
+					rightsRequests(first: 10) {
+						edges {
+							node {
+								id
+								requestType
+								requestState
+								dataSubject
+							}
+						}
+						totalCount
+					}
+				}
+			}
+		}
+	`
+
+	var result struct {
+		Node struct {
+			RightsRequests struct {
+				Edges []struct {
+					Node struct {
+						ID           string `json:"id"`
+						RequestType  string `json:"requestType"`
+						RequestState string `json:"requestState"`
+						DataSubject  string `json:"dataSubject"`
+					} `json:"node"`
+				} `json:"edges"`
+				TotalCount int `json:"totalCount"`
+			} `json:"rightsRequests"`
+		} `json:"node"`
+	}
+
+	err := owner.Execute(query, map[string]any{
+		"id": owner.GetOrganizationID().String(),
+	}, &result)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, result.Node.RightsRequests.TotalCount, 3)
+}
+
+func TestRightsRequest_TypeAndStateValues(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+
+	t.Run("request type values", func(t *testing.T) {
+		types := []string{"ACCESS", "DELETION", "PORTABILITY"}
+
+		for _, requestType := range types {
+			t.Run(requestType, func(t *testing.T) {
+				query := `
+					mutation CreateRightsRequest($input: CreateRightsRequestInput!) {
+						createRightsRequest(input: $input) {
+							rightsRequestEdge {
+								node {
+									id
+									requestType
+								}
+							}
+						}
+					}
+				`
+
+				var result struct {
+					CreateRightsRequest struct {
+						RightsRequestEdge struct {
+							Node struct {
+								ID          string `json:"id"`
+								RequestType string `json:"requestType"`
+							} `json:"node"`
+						} `json:"rightsRequestEdge"`
+					} `json:"createRightsRequest"`
+				}
+
+				err := owner.Execute(query, map[string]any{
+					"input": map[string]any{
+						"organizationId": owner.GetOrganizationID().String(),
+						"requestType":    requestType,
+						"requestState":   "TODO",
+					},
+				}, &result)
+				require.NoError(t, err)
+				assert.Equal(t, requestType, result.CreateRightsRequest.RightsRequestEdge.Node.RequestType)
+			})
+		}
+	})
+
+	t.Run("request state values", func(t *testing.T) {
+		states := []string{"TODO", "IN_PROGRESS", "DONE"}
+
+		for _, requestState := range states {
+			t.Run(requestState, func(t *testing.T) {
+				query := `
+					mutation CreateRightsRequest($input: CreateRightsRequestInput!) {
+						createRightsRequest(input: $input) {
+							rightsRequestEdge {
+								node {
+									id
+									requestState
+								}
+							}
+						}
+					}
+				`
+
+				var result struct {
+					CreateRightsRequest struct {
+						RightsRequestEdge struct {
+							Node struct {
+								ID           string `json:"id"`
+								RequestState string `json:"requestState"`
+							} `json:"node"`
+						} `json:"rightsRequestEdge"`
+					} `json:"createRightsRequest"`
+				}
+
+				err := owner.Execute(query, map[string]any{
+					"input": map[string]any{
+						"organizationId": owner.GetOrganizationID().String(),
+						"requestType":    "ACCESS",
+						"requestState":   requestState,
+					},
+				}, &result)
+				require.NoError(t, err)
+				assert.Equal(t, requestState, result.CreateRightsRequest.RightsRequestEdge.Node.RequestState)
+			})
+		}
+	})
+}

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -71,3 +71,14 @@ export {
     getTrustCenterDocumentAccessStatusLabel,
     type TrustCenterDocumentAccessInfo,
 } from "./trustCenterDocumentAccess";
+export {
+    getRightsRequestTypeLabel,
+    getRightsRequestTypeOptions,
+    getRightsRequestStateVariant,
+    getRightsRequestStateLabel,
+    getRightsRequestStateOptions,
+    rightsRequestTypes,
+    rightsRequestStates,
+    type RightsRequestType,
+    type RightsRequestState,
+} from "./rightsRequest";

--- a/packages/helpers/src/rightsRequest.ts
+++ b/packages/helpers/src/rightsRequest.ts
@@ -1,0 +1,80 @@
+type Translator = (s: string) => string;
+
+export type RightsRequestType = "ACCESS" | "DELETION" | "PORTABILITY";
+
+export const rightsRequestTypes = [
+  "ACCESS",
+  "DELETION",
+  "PORTABILITY",
+] as const;
+
+export type RightsRequestState = "TODO" | "IN_PROGRESS" | "DONE";
+
+export const rightsRequestStates = [
+  "TODO",
+  "IN_PROGRESS",
+  "DONE",
+] as const;
+
+export function getRightsRequestTypeLabel(__: Translator, type: RightsRequestType) {
+  switch (type) {
+    case "ACCESS":
+      return __("Access");
+    case "DELETION":
+      return __("Deletion");
+    case "PORTABILITY":
+      return __("Portability");
+    default:
+      return type;
+  }
+}
+
+export function getRightsRequestTypeOptions(__: Translator) {
+  return rightsRequestTypes.map((type) => ({
+    value: type,
+    label: __({
+      "ACCESS": "Access",
+      "DELETION": "Deletion",
+      "PORTABILITY": "Portability",
+    }[type]),
+  }));
+}
+
+export const getRightsRequestStateVariant = (
+  state: RightsRequestState
+): "danger" | "warning" | "success" | "neutral" | "info" | "outline" | "highlight" => {
+  switch (state) {
+    case "TODO":
+      return "warning" as const;
+    case "IN_PROGRESS":
+      return "info" as const;
+    case "DONE":
+      return "success" as const;
+    default:
+      return "neutral" as const;
+  }
+};
+
+export function getRightsRequestStateLabel(__: Translator, state: RightsRequestState) {
+  switch (state) {
+    case "TODO":
+      return __("To Do");
+    case "IN_PROGRESS":
+      return __("In Progress");
+    case "DONE":
+      return __("Done");
+    default:
+      return state;
+  }
+}
+
+export function getRightsRequestStateOptions(__: Translator) {
+  return rightsRequestStates.map((state) => ({
+    value: state,
+    label: __({
+      "TODO": "To Do",
+      "IN_PROGRESS": "In Progress",
+      "DONE": "Done",
+    }[state]),
+  }));
+}

--- a/pkg/authz/permissions.go
+++ b/pkg/authz/permissions.go
@@ -92,6 +92,7 @@ const (
 	ActionListComplianceReports       Action = "listComplianceReports"
 	ActionListContacts                Action = "listContacts"
 	ActionListContinualImprovements   Action = "listContinualImprovements"
+	ActionListRightsRequests           Action = "listRightsRequests"
 	ActionListControls                Action = "listControls"
 	ActionListData                    Action = "listData"
 	ActionListDocuments               Action = "listDocuments"
@@ -122,6 +123,7 @@ const (
 	ActionCreateAsset                          Action = "createAsset"
 	ActionCreateAudit                          Action = "createAudit"
 	ActionCreateContinualImprovement           Action = "createContinualImprovement"
+	ActionCreateRightsRequest                  Action = "createRightsRequest"
 	ActionCreateControl                        Action = "createControl"
 	ActionCreateControlAuditMapping            Action = "createControlAuditMapping"
 	ActionCreateControlDocumentMapping         Action = "createControlDocumentMapping"
@@ -159,6 +161,7 @@ const (
 	ActionUpdateAsset                            Action = "updateAsset"
 	ActionUpdateAudit                            Action = "updateAudit"
 	ActionUpdateContinualImprovement             Action = "updateContinualImprovement"
+	ActionUpdateRightsRequest                    Action = "updateRightsRequest"
 	ActionUpdateControl                          Action = "updateControl"
 	ActionUpdateDatum                            Action = "updateDatum"
 	ActionUpdateDocument                         Action = "updateDocument"
@@ -191,6 +194,7 @@ const (
 	ActionDeleteAudit                            Action = "deleteAudit"
 	ActionDeleteAuditReport                      Action = "deleteAuditReport"
 	ActionDeleteContinualImprovement             Action = "deleteContinualImprovement"
+	ActionDeleteRightsRequest                    Action = "deleteRightsRequest"
 	ActionDeleteControl                          Action = "deleteControl"
 	ActionDeleteControlAuditMapping              Action = "deleteControlAuditMapping"
 	ActionDeleteControlDocumentMapping           Action = "deleteControlDocumentMapping"
@@ -299,6 +303,7 @@ var Permissions = map[uint16]map[Action][]Role{
 		ActionListNonconformities:       NonEmployeeRoles,
 		ActionListObligations:           NonEmployeeRoles,
 		ActionListContinualImprovements: NonEmployeeRoles,
+		ActionListRightsRequests:         NonEmployeeRoles,
 		ActionListProcessingActivities:  NonEmployeeRoles,
 		ActionListSnapshots:             NonEmployeeRoles,
 		ActionConfirmEmail:              NonEmployeeRoles,
@@ -337,6 +342,7 @@ var Permissions = map[uint16]map[Action][]Role{
 		ActionCreateNonconformity:              EditRoles,
 		ActionCreateObligation:                 EditRoles,
 		ActionCreateContinualImprovement:       EditRoles,
+		ActionCreateRightsRequest:              EditRoles,
 		ActionCreateProcessingActivity:         EditRoles,
 		ActionCreateSnapshot:                   EditRoles,
 		ActionCreateTrustCenterFile:            EditRoles,
@@ -673,6 +679,13 @@ var Permissions = map[uint16]map[Action][]Role{
 
 		ActionUpdateContinualImprovement: EditRoles,
 		ActionDeleteContinualImprovement: EditRoles,
+	},
+	coredata.RightsRequestEntityType: {
+		ActionGet:             NonEmployeeRoles,
+		ActionGetOrganization: NonEmployeeRoles,
+
+		ActionUpdateRightsRequest: EditRoles,
+		ActionDeleteRightsRequest: EditRoles,
 	},
 	coredata.ProcessingActivityEntityType: {
 		ActionGet:                               NonEmployeeRoles,

--- a/pkg/coredata/entity_type_reg.go
+++ b/pkg/coredata/entity_type_reg.go
@@ -69,6 +69,7 @@ const (
 	MeetingEntityType                          uint16 = 45
 	DataProtectionImpactAssessmentEntityType   uint16 = 46
 	TransferImpactAssessmentEntityType         uint16 = 47
+	RightsRequestEntityType                    uint16 = 48
 )
 
 type EntityInfo struct {
@@ -268,6 +269,10 @@ var entityRegistry = map[uint16]EntityInfo{
 	TransferImpactAssessmentEntityType: {
 		Model: "TransferImpactAssessment",
 		Table: "processing_activity_transfer_impact_assessments",
+	},
+	RightsRequestEntityType: {
+		Model: "RightsRequest",
+		Table: "rights_requests",
 	},
 }
 

--- a/pkg/coredata/migrations/20251226T130238Z.sql
+++ b/pkg/coredata/migrations/20251226T130238Z.sql
@@ -1,0 +1,37 @@
+CREATE TYPE rights_request_type AS ENUM (
+    'ACCESS',
+    'DELETION',
+    'PORTABILITY'
+);
+
+CREATE TYPE rights_request_state AS ENUM (
+    'TODO',
+    'IN_PROGRESS',
+    'DONE'
+);
+
+CREATE TABLE rights_requests (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    organization_id TEXT NOT NULL,
+
+    request_type rights_request_type NOT NULL,
+    request_state rights_request_state NOT NULL,
+
+    data_subject TEXT,
+    contact TEXT,
+    details TEXT,
+
+    deadline DATE,
+
+    action_taken TEXT,
+
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+
+    CONSTRAINT rights_requests_organization_id_fkey
+        FOREIGN KEY (organization_id)
+        REFERENCES organizations(id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+);

--- a/pkg/coredata/rights_request_order_field.go
+++ b/pkg/coredata/rights_request_order_field.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+type RightsRequestOrderField string
+
+const (
+	RightsRequestOrderFieldCreatedAt RightsRequestOrderField = "CREATED_AT"
+	RightsRequestOrderFieldDeadline  RightsRequestOrderField = "DEADLINE"
+	RightsRequestOrderFieldState     RightsRequestOrderField = "STATE"
+	RightsRequestOrderFieldType      RightsRequestOrderField = "TYPE"
+)
+
+func (p RightsRequestOrderField) Column() string {
+	return string(p)
+}
+
+func (p RightsRequestOrderField) String() string {
+	return string(p)
+}
+
+func (p RightsRequestOrderField) MarshalText() ([]byte, error) {
+	return []byte(p.String()), nil
+}
+
+func (p *RightsRequestOrderField) UnmarshalText(text []byte) error {
+	*p = RightsRequestOrderField(text)
+	return nil
+}

--- a/pkg/coredata/rights_request_state.go
+++ b/pkg/coredata/rights_request_state.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+type RightsRequestState string
+
+const (
+	RightsRequestStateTodo       RightsRequestState = "TODO"
+	RightsRequestStateInProgress RightsRequestState = "IN_PROGRESS"
+	RightsRequestStateDone       RightsRequestState = "DONE"
+)
+
+func RightsRequestStates() []RightsRequestState {
+	return []RightsRequestState{
+		RightsRequestStateTodo,
+		RightsRequestStateInProgress,
+		RightsRequestStateDone,
+	}
+}
+
+func (rrs RightsRequestState) String() string {
+	return string(rrs)
+}
+
+func (rrs *RightsRequestState) Scan(value any) error {
+	var s string
+	switch v := value.(type) {
+	case string:
+		s = v
+	case []byte:
+		s = string(v)
+	default:
+		return fmt.Errorf("unsupported type for RightsRequestState: %T", value)
+	}
+
+	switch s {
+	case "TODO":
+		*rrs = RightsRequestStateTodo
+	case "IN_PROGRESS":
+		*rrs = RightsRequestStateInProgress
+	case "DONE":
+		*rrs = RightsRequestStateDone
+	default:
+		return fmt.Errorf("invalid RightsRequestState value: %q", s)
+	}
+	return nil
+}
+
+func (rrs RightsRequestState) Value() (driver.Value, error) {
+	return string(rrs), nil
+}

--- a/pkg/coredata/rights_request_type.go
+++ b/pkg/coredata/rights_request_type.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+type RightsRequestType string
+
+const (
+	RightsRequestTypeAccess     RightsRequestType = "ACCESS"
+	RightsRequestTypeDeletion   RightsRequestType = "DELETION"
+	RightsRequestTypePortability RightsRequestType = "PORTABILITY"
+)
+
+func RightsRequestTypes() []RightsRequestType {
+	return []RightsRequestType{
+		RightsRequestTypeAccess,
+		RightsRequestTypeDeletion,
+		RightsRequestTypePortability,
+	}
+}
+
+func (rrt RightsRequestType) String() string {
+	return string(rrt)
+}
+
+func (rrt *RightsRequestType) Scan(value any) error {
+	var s string
+	switch v := value.(type) {
+	case string:
+		s = v
+	case []byte:
+		s = string(v)
+	default:
+		return fmt.Errorf("unsupported type for RightsRequestType: %T", value)
+	}
+
+	switch s {
+	case "ACCESS":
+		*rrt = RightsRequestTypeAccess
+	case "DELETION":
+		*rrt = RightsRequestTypeDeletion
+	case "PORTABILITY":
+		*rrt = RightsRequestTypePortability
+	default:
+		return fmt.Errorf("invalid RightsRequestType value: %q", s)
+	}
+	return nil
+}
+
+func (rrt RightsRequestType) Value() (driver.Value, error) {
+	return string(rrt), nil
+}

--- a/pkg/coredata/rights_requests.go
+++ b/pkg/coredata/rights_requests.go
@@ -1,0 +1,327 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/page"
+)
+
+type (
+	ErrRightsRequestNotFound struct {
+		Identifier string
+	}
+
+	RightsRequest struct {
+		ID             gid.GID            `db:"id"`
+		OrganizationID gid.GID            `db:"organization_id"`
+		RequestType    RightsRequestType  `db:"request_type"`
+		RequestState   RightsRequestState `db:"request_state"`
+		DataSubject    *string            `db:"data_subject"`
+		Contact        *string            `db:"contact"`
+		Details        *string            `db:"details"`
+		Deadline       *time.Time         `db:"deadline"`
+		ActionTaken    *string            `db:"action_taken"`
+		CreatedAt      time.Time          `db:"created_at"`
+		UpdatedAt      time.Time          `db:"updated_at"`
+	}
+
+	RightsRequests []*RightsRequest
+)
+
+func (e ErrRightsRequestNotFound) Error() string {
+	return fmt.Sprintf("rights request not found: %q", e.Identifier)
+}
+
+func (rr *RightsRequest) CursorKey(field RightsRequestOrderField) page.CursorKey {
+	switch field {
+	case RightsRequestOrderFieldCreatedAt:
+		return page.NewCursorKey(rr.ID, rr.CreatedAt)
+	case RightsRequestOrderFieldDeadline:
+		return page.NewCursorKey(rr.ID, rr.Deadline)
+	case RightsRequestOrderFieldState:
+		return page.NewCursorKey(rr.ID, rr.RequestState)
+	case RightsRequestOrderFieldType:
+		return page.NewCursorKey(rr.ID, rr.RequestType)
+	}
+
+	panic(fmt.Sprintf("unsupported order by: %s", field))
+}
+
+func (rr *RightsRequest) LoadByID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	rightsRequestID gid.GID,
+) error {
+	q := `
+SELECT
+	id,
+	organization_id,
+	request_type,
+	request_state,
+	data_subject,
+	contact,
+	details,
+	deadline,
+	action_taken,
+	created_at,
+	updated_at
+FROM
+	rights_requests
+WHERE
+	%s
+	AND id = @rights_request_id
+LIMIT 1;
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"rights_request_id": rightsRequestID}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query rights request: %w", err)
+	}
+
+	request, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[RightsRequest])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return &ErrRightsRequestNotFound{Identifier: rightsRequestID.String()}
+		}
+
+		return fmt.Errorf("cannot collect rights request: %w", err)
+	}
+
+	*rr = request
+
+	return nil
+}
+
+func (rrs *RightsRequests) CountByOrganizationID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	organizationID gid.GID,
+) (int, error) {
+	q := `
+SELECT
+	COUNT(id)
+FROM
+	rights_requests
+WHERE
+	%s
+	AND organization_id = @organization_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	row := conn.QueryRow(ctx, q, args)
+
+	var count int
+	err := row.Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("cannot count rights requests: %w", err)
+	}
+
+	return count, nil
+}
+
+func (rrs *RightsRequests) LoadByOrganizationID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	organizationID gid.GID,
+	cursor *page.Cursor[RightsRequestOrderField],
+) error {
+	q := `
+SELECT
+	id,
+	organization_id,
+	request_type,
+	request_state,
+	data_subject,
+	contact,
+	details,
+	deadline,
+	action_taken,
+	created_at,
+	updated_at
+FROM
+	rights_requests
+WHERE
+	%s
+	AND organization_id = @organization_id
+	AND %s
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, cursor.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query rights requests: %w", err)
+	}
+
+	requests, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[RightsRequest])
+	if err != nil {
+		return fmt.Errorf("cannot collect rights requests: %w", err)
+	}
+
+	*rrs = requests
+
+	return nil
+}
+
+func (rr *RightsRequest) Insert(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+INSERT INTO rights_requests (
+	id,
+	tenant_id,
+	organization_id,
+	request_type,
+	request_state,
+	data_subject,
+	contact,
+	details,
+	deadline,
+	action_taken,
+	created_at,
+	updated_at
+) VALUES (
+	@id,
+	@tenant_id,
+	@organization_id,
+	@request_type,
+	@request_state,
+	@data_subject,
+	@contact,
+	@details,
+	@deadline,
+	@action_taken,
+	@created_at,
+	@updated_at
+)
+`
+
+	args := pgx.StrictNamedArgs{
+		"id":              rr.ID,
+		"tenant_id":       scope.GetTenantID(),
+		"organization_id": rr.OrganizationID,
+		"request_type":    rr.RequestType,
+		"request_state":   rr.RequestState,
+		"data_subject":    rr.DataSubject,
+		"contact":         rr.Contact,
+		"details":         rr.Details,
+		"deadline":        rr.Deadline,
+		"action_taken":    rr.ActionTaken,
+		"created_at":      rr.CreatedAt,
+		"updated_at":      rr.UpdatedAt,
+	}
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot insert rights request: %w", err)
+	}
+
+	return nil
+}
+
+func (rr *RightsRequest) Update(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+UPDATE rights_requests SET
+	request_type = @request_type,
+	request_state = @request_state,
+	data_subject = @data_subject,
+	contact = @contact,
+	details = @details,
+	deadline = @deadline,
+	action_taken = @action_taken,
+	updated_at = @updated_at
+WHERE
+	%s
+	AND id = @id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"id":            rr.ID,
+		"request_type":  rr.RequestType,
+		"request_state": rr.RequestState,
+		"data_subject":  rr.DataSubject,
+		"contact":       rr.Contact,
+		"details":       rr.Details,
+		"deadline":      rr.Deadline,
+		"action_taken":  rr.ActionTaken,
+		"updated_at":    rr.UpdatedAt,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot update rights request: %w", err)
+	}
+
+	return nil
+}
+
+func (rr *RightsRequest) Delete(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+DELETE FROM rights_requests
+WHERE
+	%s
+	AND id = @id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"id": rr.ID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete rights request: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/probo/rights_request_service.go
+++ b/pkg/probo/rights_request_service.go
@@ -1,0 +1,291 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package probo
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/page"
+	"go.probo.inc/probo/pkg/validator"
+)
+
+type RightsRequestService struct {
+	svc *TenantService
+}
+
+type (
+	CreateRightsRequestRequest struct {
+		OrganizationID gid.GID
+		RequestType    *coredata.RightsRequestType
+		RequestState   *coredata.RightsRequestState
+		DataSubject    *string
+		Contact        *string
+		Details        *string
+		Deadline       *time.Time
+		ActionTaken    *string
+	}
+
+	UpdateRightsRequestRequest struct {
+		ID           gid.GID
+		RequestType  *coredata.RightsRequestType
+		RequestState *coredata.RightsRequestState
+		DataSubject  **string
+		Contact      **string
+		Details      **string
+		Deadline     **time.Time
+		ActionTaken  **string
+	}
+)
+
+func (crrr *CreateRightsRequestRequest) Validate() error {
+	v := validator.New()
+
+	v.Check(crrr.OrganizationID, "organization_id", validator.Required(), validator.GID(coredata.OrganizationEntityType))
+	v.Check(crrr.RequestType, "request_type", validator.Required(), validator.OneOfSlice(coredata.RightsRequestTypes()))
+	v.Check(crrr.RequestState, "request_state", validator.Required(), validator.OneOfSlice(coredata.RightsRequestStates()))
+	v.Check(crrr.DataSubject, "data_subject", validator.SafeText(ContentMaxLength))
+	v.Check(crrr.Contact, "contact", validator.SafeText(ContentMaxLength))
+	v.Check(crrr.Details, "details", validator.SafeText(ContentMaxLength))
+	v.Check(crrr.ActionTaken, "action_taken", validator.SafeText(ContentMaxLength))
+
+	return v.Error()
+}
+
+func (urrr *UpdateRightsRequestRequest) Validate() error {
+	v := validator.New()
+
+	v.Check(urrr.ID, "id", validator.Required(), validator.GID(coredata.RightsRequestEntityType))
+	v.Check(urrr.RequestType, "request_type", validator.OneOfSlice(coredata.RightsRequestTypes()))
+	v.Check(urrr.RequestState, "request_state", validator.OneOfSlice(coredata.RightsRequestStates()))
+	v.Check(urrr.DataSubject, "data_subject", validator.SafeText(ContentMaxLength))
+	v.Check(urrr.Contact, "contact", validator.SafeText(ContentMaxLength))
+	v.Check(urrr.Details, "details", validator.SafeText(ContentMaxLength))
+	v.Check(urrr.ActionTaken, "action_taken", validator.SafeText(ContentMaxLength))
+
+	return v.Error()
+}
+
+func (s RightsRequestService) Get(
+	ctx context.Context,
+	rightsRequestID gid.GID,
+) (*coredata.RightsRequest, error) {
+	request := &coredata.RightsRequest{}
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			if err := request.LoadByID(ctx, conn, s.svc.scope, rightsRequestID); err != nil {
+				return fmt.Errorf("cannot load rights request: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return request, nil
+}
+
+func (s *RightsRequestService) Create(
+	ctx context.Context,
+	req *CreateRightsRequestRequest,
+) (*coredata.RightsRequest, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+
+	request := &coredata.RightsRequest{
+		ID:             gid.New(s.svc.scope.GetTenantID(), coredata.RightsRequestEntityType),
+		OrganizationID: req.OrganizationID,
+		RequestType:    *req.RequestType,
+		RequestState:   *req.RequestState,
+		DataSubject:    req.DataSubject,
+		Contact:        req.Contact,
+		Details:        req.Details,
+		Deadline:       req.Deadline,
+		ActionTaken:    req.ActionTaken,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	err := s.svc.pg.WithTx(
+		ctx,
+		func(conn pg.Conn) error {
+			organization := &coredata.Organization{}
+			if err := organization.LoadByID(ctx, conn, s.svc.scope, req.OrganizationID); err != nil {
+				return fmt.Errorf("cannot load organization: %w", err)
+			}
+
+			if err := request.Insert(ctx, conn, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot insert rights request: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return request, nil
+}
+
+func (s *RightsRequestService) Update(
+	ctx context.Context,
+	req *UpdateRightsRequestRequest,
+) (*coredata.RightsRequest, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	request := &coredata.RightsRequest{}
+
+	err := s.svc.pg.WithTx(
+		ctx,
+		func(conn pg.Conn) error {
+			if err := request.LoadByID(ctx, conn, s.svc.scope, req.ID); err != nil {
+				return fmt.Errorf("cannot load rights request: %w", err)
+			}
+
+			if req.RequestType != nil {
+				request.RequestType = *req.RequestType
+			}
+
+			if req.RequestState != nil {
+				request.RequestState = *req.RequestState
+			}
+
+			if req.DataSubject != nil {
+				request.DataSubject = *req.DataSubject
+			}
+
+			if req.Contact != nil {
+				request.Contact = *req.Contact
+			}
+
+			if req.Details != nil {
+				request.Details = *req.Details
+			}
+
+			if req.Deadline != nil {
+				request.Deadline = *req.Deadline
+			}
+
+			if req.ActionTaken != nil {
+				request.ActionTaken = *req.ActionTaken
+			}
+
+			request.UpdatedAt = time.Now()
+
+			if err := request.Update(ctx, conn, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot update rights request: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return request, nil
+}
+
+func (s *RightsRequestService) Delete(
+	ctx context.Context,
+	rightsRequestID gid.GID,
+) error {
+	err := s.svc.pg.WithTx(
+		ctx,
+		func(conn pg.Conn) error {
+			request := &coredata.RightsRequest{}
+			if err := request.LoadByID(ctx, conn, s.svc.scope, rightsRequestID); err != nil {
+				return fmt.Errorf("cannot load rights request: %w", err)
+			}
+
+			if err := request.Delete(ctx, conn, s.svc.scope); err != nil {
+				return fmt.Errorf("cannot delete rights request: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	return err
+}
+
+func (s RightsRequestService) CountByOrganizationID(
+	ctx context.Context,
+	organizationID gid.GID,
+) (int, error) {
+	var count int
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) (err error) {
+			requests := coredata.RightsRequests{}
+			count, err = requests.CountByOrganizationID(ctx, conn, s.svc.scope, organizationID)
+			if err != nil {
+				return fmt.Errorf("cannot count rights requests: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+func (s RightsRequestService) ListForOrganizationID(
+	ctx context.Context,
+	organizationID gid.GID,
+	cursor *page.Cursor[coredata.RightsRequestOrderField],
+) (*page.Page[*coredata.RightsRequest, coredata.RightsRequestOrderField], error) {
+	var requests coredata.RightsRequests
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			err := requests.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID, cursor)
+			if err != nil {
+				return fmt.Errorf("cannot load rights requests: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return page.NewPage(requests, cursor), nil
+}

--- a/pkg/probo/service.go
+++ b/pkg/probo/service.go
@@ -113,6 +113,7 @@ type (
 		Obligations                       *ObligationService
 		Snapshots                         *SnapshotService
 		ContinualImprovements             *ContinualImprovementService
+		RightsRequests                    *RightsRequestService
 		ProcessingActivities              *ProcessingActivityService
 		DataProtectionImpactAssessments   *DataProtectionImpactAssessmentService
 		TransferImpactAssessments         *TransferImpactAssessmentService
@@ -250,6 +251,7 @@ func (s *Service) WithTenant(tenantID gid.TenantID) *TenantService {
 	tenantService.Obligations = &ObligationService{svc: tenantService}
 	tenantService.Snapshots = &SnapshotService{svc: tenantService}
 	tenantService.ContinualImprovements = &ContinualImprovementService{svc: tenantService}
+	tenantService.RightsRequests = &RightsRequestService{svc: tenantService}
 	tenantService.ProcessingActivities = &ProcessingActivityService{svc: tenantService}
 	tenantService.DataProtectionImpactAssessments = &DataProtectionImpactAssessmentService{svc: tenantService}
 	tenantService.TransferImpactAssessments = &TransferImpactAssessmentService{svc: tenantService}

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -260,6 +260,42 @@ enum ContinualImprovementPriority
     )
 }
 
+enum RightsRequestType
+  @goModel(
+    model: "go.probo.inc/probo/pkg/coredata.RightsRequestType"
+  ) {
+  ACCESS
+    @goEnum(
+      value: "go.probo.inc/probo/pkg/coredata.RightsRequestTypeAccess"
+    )
+  DELETION
+    @goEnum(
+      value: "go.probo.inc/probo/pkg/coredata.RightsRequestTypeDeletion"
+    )
+  PORTABILITY
+    @goEnum(
+      value: "go.probo.inc/probo/pkg/coredata.RightsRequestTypePortability"
+    )
+}
+
+enum RightsRequestState
+  @goModel(
+    model: "go.probo.inc/probo/pkg/coredata.RightsRequestState"
+  ) {
+  TODO
+    @goEnum(
+      value: "go.probo.inc/probo/pkg/coredata.RightsRequestStateTodo"
+    )
+  IN_PROGRESS
+    @goEnum(
+      value: "go.probo.inc/probo/pkg/coredata.RightsRequestStateInProgress"
+    )
+  DONE
+    @goEnum(
+      value: "go.probo.inc/probo/pkg/coredata.RightsRequestStateDone"
+    )
+}
+
 enum ProcessingActivitySpecialOrCriminalDatum
   @goModel(
     model: "go.probo.inc/probo/pkg/coredata.ProcessingActivitySpecialOrCriminalDatum"
@@ -1065,6 +1101,28 @@ enum ContinualImprovementOrderField
     )
 }
 
+enum RightsRequestOrderField
+  @goModel(
+    model: "go.probo.inc/probo/pkg/coredata.RightsRequestOrderField"
+  ) {
+  CREATED_AT
+    @goEnum(
+      value: "go.probo.inc/probo/pkg/coredata.RightsRequestOrderFieldCreatedAt"
+    )
+  DEADLINE
+    @goEnum(
+      value: "go.probo.inc/probo/pkg/coredata.RightsRequestOrderFieldDeadline"
+    )
+  STATE
+    @goEnum(
+      value: "go.probo.inc/probo/pkg/coredata.RightsRequestOrderFieldState"
+    )
+  TYPE
+    @goEnum(
+      value: "go.probo.inc/probo/pkg/coredata.RightsRequestOrderFieldType"
+    )
+}
+
 enum ProcessingActivityOrderField
   @goModel(
     model: "go.probo.inc/probo/pkg/coredata.ProcessingActivityOrderField"
@@ -1344,6 +1402,14 @@ input ContinualImprovementOrder
   field: ContinualImprovementOrderField!
 }
 
+input RightsRequestOrder
+  @goModel(
+    model: "go.probo.inc/probo/pkg/server/api/console/v1/types.RightsRequestOrderBy"
+  ) {
+  direction: OrderDirection!
+  field: RightsRequestOrderField!
+}
+
 input ProcessingActivityOrder
   @goModel(
     model: "go.probo.inc/probo/pkg/server/api/console/v1/types.ProcessingActivityOrderBy"
@@ -1512,6 +1578,7 @@ input ObligationFilter {
 input ContinualImprovementFilter {
   snapshotId: ID
 }
+
 
 input ProcessingActivityFilter {
   snapshotId: ID
@@ -1726,6 +1793,14 @@ type Organization implements Node {
     orderBy: ContinualImprovementOrder
     filter: ContinualImprovementFilter = { snapshotId: null }
   ): ContinualImprovementConnection! @goField(forceResolver: true)
+
+  rightsRequests(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+    orderBy: RightsRequestOrder
+  ): RightsRequestConnection! @goField(forceResolver: true)
 
   processingActivities(
     first: Int
@@ -2326,6 +2401,20 @@ type ContinualImprovement implements Node {
   updatedAt: Datetime!
 }
 
+type RightsRequest implements Node {
+  id: ID!
+  organization: Organization! @goField(forceResolver: true)
+  requestType: RightsRequestType!
+  requestState: RightsRequestState!
+  dataSubject: String
+  contact: String
+  details: String
+  deadline: Datetime
+  actionTaken: String
+  createdAt: Datetime!
+  updatedAt: Datetime!
+}
+
 type ProcessingActivity implements Node {
   id: ID!
   snapshotId: ID
@@ -2879,6 +2968,20 @@ type ContinualImprovementEdge {
   node: ContinualImprovement!
 }
 
+type RightsRequestConnection
+  @goModel(
+    model: "go.probo.inc/probo/pkg/server/api/console/v1/types.RightsRequestConnection"
+  ) {
+  totalCount: Int! @goField(forceResolver: true)
+  edges: [RightsRequestEdge!]!
+  pageInfo: PageInfo!
+}
+
+type RightsRequestEdge {
+  cursor: CursorKey!
+  node: RightsRequest!
+}
+
 type ProcessingActivityConnection
   @goModel(
     model: "go.probo.inc/probo/pkg/server/api/console/v1/types.ProcessingActivityConnection"
@@ -3246,6 +3349,20 @@ type Mutation {
   deleteContinualImprovement(
     input: DeleteContinualImprovementInput!
   ): DeleteContinualImprovementPayload!
+
+  # Rights Request mutations
+  createRightsRequest(
+    input: CreateRightsRequestInput!
+  ): CreateRightsRequestPayload!
+
+  updateRightsRequest(
+    input: UpdateRightsRequestInput!
+  ): UpdateRightsRequestPayload!
+
+  deleteRightsRequest(
+    input: DeleteRightsRequestInput!
+  ): DeleteRightsRequestPayload!
+
   # Processing Activity mutations
   createProcessingActivity(
     input: CreateProcessingActivityInput!
@@ -4020,6 +4137,32 @@ input UpdateContinualImprovementInput {
 
 input DeleteContinualImprovementInput {
   continualImprovementId: ID!
+}
+
+input CreateRightsRequestInput {
+  organizationId: ID!
+  requestType: RightsRequestType!
+  requestState: RightsRequestState!
+  dataSubject: String
+  contact: String
+  details: String
+  deadline: Datetime
+  actionTaken: String
+}
+
+input UpdateRightsRequestInput {
+  id: ID!
+  requestType: RightsRequestType
+  requestState: RightsRequestState
+  dataSubject: String @goField(omittable: true)
+  contact: String @goField(omittable: true)
+  details: String @goField(omittable: true)
+  deadline: Datetime @goField(omittable: true)
+  actionTaken: String @goField(omittable: true)
+}
+
+input DeleteRightsRequestInput {
+  rightsRequestId: ID!
 }
 
 input CreateProcessingActivityInput {
@@ -4962,6 +5105,18 @@ type UpdateContinualImprovementPayload {
 
 type DeleteContinualImprovementPayload {
   deletedContinualImprovementId: ID!
+}
+
+type CreateRightsRequestPayload {
+  rightsRequestEdge: RightsRequestEdge!
+}
+
+type UpdateRightsRequestPayload {
+  rightsRequest: RightsRequest!
+}
+
+type DeleteRightsRequestPayload {
+  deletedRightsRequestId: ID!
 }
 
 type CreateProcessingActivityPayload {

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -87,6 +87,8 @@ type ResolverRoot interface {
 	ProcessingActivityConnection() ProcessingActivityConnectionResolver
 	Query() QueryResolver
 	Report() ReportResolver
+	RightsRequest() RightsRequestResolver
+	RightsRequestConnection() RightsRequestConnectionResolver
 	Risk() RiskResolver
 	RiskConnection() RiskConnectionResolver
 	SAMLConfiguration() SAMLConfigurationResolver
@@ -353,6 +355,10 @@ type ComplexityRoot struct {
 		ProcessingActivityEdge func(childComplexity int) int
 	}
 
+	CreateRightsRequestPayload struct {
+		RightsRequestEdge func(childComplexity int) int
+	}
+
 	CreateRiskDocumentMappingPayload struct {
 		DocumentEdge func(childComplexity int) int
 		RiskEdge     func(childComplexity int) int
@@ -584,6 +590,10 @@ type ComplexityRoot struct {
 
 	DeleteProcessingActivityPayload struct {
 		DeletedProcessingActivityID func(childComplexity int) int
+	}
+
+	DeleteRightsRequestPayload struct {
+		DeletedRightsRequestID func(childComplexity int) int
 	}
 
 	DeleteRiskDocumentMappingPayload struct {
@@ -970,6 +980,7 @@ type ComplexityRoot struct {
 		CreateOrganization                     func(childComplexity int, input types.CreateOrganizationInput) int
 		CreatePeople                           func(childComplexity int, input types.CreatePeopleInput) int
 		CreateProcessingActivity               func(childComplexity int, input types.CreateProcessingActivityInput) int
+		CreateRightsRequest                    func(childComplexity int, input types.CreateRightsRequestInput) int
 		CreateRisk                             func(childComplexity int, input types.CreateRiskInput) int
 		CreateRiskDocumentMapping              func(childComplexity int, input types.CreateRiskDocumentMappingInput) int
 		CreateRiskMeasureMapping               func(childComplexity int, input types.CreateRiskMeasureMappingInput) int
@@ -1010,6 +1021,7 @@ type ComplexityRoot struct {
 		DeleteOrganizationHorizontalLogo       func(childComplexity int, input types.DeleteOrganizationHorizontalLogoInput) int
 		DeletePeople                           func(childComplexity int, input types.DeletePeopleInput) int
 		DeleteProcessingActivity               func(childComplexity int, input types.DeleteProcessingActivityInput) int
+		DeleteRightsRequest                    func(childComplexity int, input types.DeleteRightsRequestInput) int
 		DeleteRisk                             func(childComplexity int, input types.DeleteRiskInput) int
 		DeleteRiskDocumentMapping              func(childComplexity int, input types.DeleteRiskDocumentMappingInput) int
 		DeleteRiskMeasureMapping               func(childComplexity int, input types.DeleteRiskMeasureMappingInput) int
@@ -1063,6 +1075,7 @@ type ComplexityRoot struct {
 		UpdateOrganizationContext              func(childComplexity int, input types.UpdateOrganizationContextInput) int
 		UpdatePeople                           func(childComplexity int, input types.UpdatePeopleInput) int
 		UpdateProcessingActivity               func(childComplexity int, input types.UpdateProcessingActivityInput) int
+		UpdateRightsRequest                    func(childComplexity int, input types.UpdateRightsRequestInput) int
 		UpdateRisk                             func(childComplexity int, input types.UpdateRiskInput) int
 		UpdateSAMLConfiguration                func(childComplexity int, input types.UpdateSAMLConfigurationInput) int
 		UpdateTask                             func(childComplexity int, input types.UpdateTaskInput) int
@@ -1170,6 +1183,7 @@ type ComplexityRoot struct {
 		Obligations                     func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ObligationOrderBy, filter *types.ObligationFilter) int
 		Peoples                         func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.PeopleOrderBy, filter *types.PeopleFilter) int
 		ProcessingActivities            func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ProcessingActivityOrderBy, filter *types.ProcessingActivityFilter) int
+		RightsRequests                  func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RightsRequestOrderBy) int
 		Risks                           func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskOrderBy, filter *types.RiskFilter) int
 		SamlConfigurations              func(childComplexity int) int
 		SlackConnections                func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey) int
@@ -1303,6 +1317,31 @@ type ComplexityRoot struct {
 
 	RequestSignaturePayload struct {
 		DocumentVersionSignatureEdge func(childComplexity int) int
+	}
+
+	RightsRequest struct {
+		ActionTaken  func(childComplexity int) int
+		Contact      func(childComplexity int) int
+		CreatedAt    func(childComplexity int) int
+		DataSubject  func(childComplexity int) int
+		Deadline     func(childComplexity int) int
+		Details      func(childComplexity int) int
+		ID           func(childComplexity int) int
+		Organization func(childComplexity int) int
+		RequestState func(childComplexity int) int
+		RequestType  func(childComplexity int) int
+		UpdatedAt    func(childComplexity int) int
+	}
+
+	RightsRequestConnection struct {
+		Edges      func(childComplexity int) int
+		PageInfo   func(childComplexity int) int
+		TotalCount func(childComplexity int) int
+	}
+
+	RightsRequestEdge struct {
+		Cursor func(childComplexity int) int
+		Node   func(childComplexity int) int
 	}
 
 	Risk struct {
@@ -1669,6 +1708,10 @@ type ComplexityRoot struct {
 
 	UpdateProcessingActivityPayload struct {
 		ProcessingActivity func(childComplexity int) int
+	}
+
+	UpdateRightsRequestPayload struct {
+		RightsRequest func(childComplexity int) int
 	}
 
 	UpdateRiskPayload struct {
@@ -2179,6 +2222,9 @@ type MutationResolver interface {
 	CreateContinualImprovement(ctx context.Context, input types.CreateContinualImprovementInput) (*types.CreateContinualImprovementPayload, error)
 	UpdateContinualImprovement(ctx context.Context, input types.UpdateContinualImprovementInput) (*types.UpdateContinualImprovementPayload, error)
 	DeleteContinualImprovement(ctx context.Context, input types.DeleteContinualImprovementInput) (*types.DeleteContinualImprovementPayload, error)
+	CreateRightsRequest(ctx context.Context, input types.CreateRightsRequestInput) (*types.CreateRightsRequestPayload, error)
+	UpdateRightsRequest(ctx context.Context, input types.UpdateRightsRequestInput) (*types.UpdateRightsRequestPayload, error)
+	DeleteRightsRequest(ctx context.Context, input types.DeleteRightsRequestInput) (*types.DeleteRightsRequestPayload, error)
 	CreateProcessingActivity(ctx context.Context, input types.CreateProcessingActivityInput) (*types.CreateProcessingActivityPayload, error)
 	UpdateProcessingActivity(ctx context.Context, input types.UpdateProcessingActivityInput) (*types.UpdateProcessingActivityPayload, error)
 	DeleteProcessingActivity(ctx context.Context, input types.DeleteProcessingActivityInput) (*types.DeleteProcessingActivityPayload, error)
@@ -2241,6 +2287,7 @@ type OrganizationResolver interface {
 	Nonconformities(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.NonconformityOrderBy, filter *types.NonconformityFilter) (*types.NonconformityConnection, error)
 	Obligations(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ObligationOrderBy, filter *types.ObligationFilter) (*types.ObligationConnection, error)
 	ContinualImprovements(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ContinualImprovementOrderBy, filter *types.ContinualImprovementFilter) (*types.ContinualImprovementConnection, error)
+	RightsRequests(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RightsRequestOrderBy) (*types.RightsRequestConnection, error)
 	ProcessingActivities(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ProcessingActivityOrderBy, filter *types.ProcessingActivityFilter) (*types.ProcessingActivityConnection, error)
 	DataProtectionImpactAssessments(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DataProtectionImpactAssessmentOrderBy, filter *types.DataProtectionImpactAssessmentFilter) (*types.DataProtectionImpactAssessmentConnection, error)
 	TransferImpactAssessments(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TransferImpactAssessmentOrderBy, filter *types.TransferImpactAssessmentFilter) (*types.TransferImpactAssessmentConnection, error)
@@ -2272,6 +2319,12 @@ type ReportResolver interface {
 	DownloadURL(ctx context.Context, obj *types.Report) (*string, error)
 
 	Audit(ctx context.Context, obj *types.Report) (*types.Audit, error)
+}
+type RightsRequestResolver interface {
+	Organization(ctx context.Context, obj *types.RightsRequest) (*types.Organization, error)
+}
+type RightsRequestConnectionResolver interface {
+	TotalCount(ctx context.Context, obj *types.RightsRequestConnection) (int, error)
 }
 type RiskResolver interface {
 	Owner(ctx context.Context, obj *types.Risk) (*types.People, error)
@@ -3127,6 +3180,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.CreateProcessingActivityPayload.ProcessingActivityEdge(childComplexity), true
 
+	case "CreateRightsRequestPayload.rightsRequestEdge":
+		if e.complexity.CreateRightsRequestPayload.RightsRequestEdge == nil {
+			break
+		}
+
+		return e.complexity.CreateRightsRequestPayload.RightsRequestEdge(childComplexity), true
+
 	case "CreateRiskDocumentMappingPayload.documentEdge":
 		if e.complexity.CreateRiskDocumentMappingPayload.DocumentEdge == nil {
 			break
@@ -3713,6 +3773,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.DeleteProcessingActivityPayload.DeletedProcessingActivityID(childComplexity), true
+
+	case "DeleteRightsRequestPayload.deletedRightsRequestId":
+		if e.complexity.DeleteRightsRequestPayload.DeletedRightsRequestID == nil {
+			break
+		}
+
+		return e.complexity.DeleteRightsRequestPayload.DeletedRightsRequestID(childComplexity), true
 
 	case "DeleteRiskDocumentMappingPayload.deletedDocumentId":
 		if e.complexity.DeleteRiskDocumentMappingPayload.DeletedDocumentID == nil {
@@ -5194,6 +5261,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.CreateProcessingActivity(childComplexity, args["input"].(types.CreateProcessingActivityInput)), true
+	case "Mutation.createRightsRequest":
+		if e.complexity.Mutation.CreateRightsRequest == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_createRightsRequest_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreateRightsRequest(childComplexity, args["input"].(types.CreateRightsRequestInput)), true
 	case "Mutation.createRisk":
 		if e.complexity.Mutation.CreateRisk == nil {
 			break
@@ -5634,6 +5712,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.DeleteProcessingActivity(childComplexity, args["input"].(types.DeleteProcessingActivityInput)), true
+	case "Mutation.deleteRightsRequest":
+		if e.complexity.Mutation.DeleteRightsRequest == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_deleteRightsRequest_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteRightsRequest(childComplexity, args["input"].(types.DeleteRightsRequestInput)), true
 	case "Mutation.deleteRisk":
 		if e.complexity.Mutation.DeleteRisk == nil {
 			break
@@ -6217,6 +6306,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.UpdateProcessingActivity(childComplexity, args["input"].(types.UpdateProcessingActivityInput)), true
+	case "Mutation.updateRightsRequest":
+		if e.complexity.Mutation.UpdateRightsRequest == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_updateRightsRequest_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UpdateRightsRequest(childComplexity, args["input"].(types.UpdateRightsRequestInput)), true
 	case "Mutation.updateRisk":
 		if e.complexity.Mutation.UpdateRisk == nil {
 			break
@@ -6920,6 +7020,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Organization.ProcessingActivities(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.ProcessingActivityOrderBy), args["filter"].(*types.ProcessingActivityFilter)), true
+	case "Organization.rightsRequests":
+		if e.complexity.Organization.RightsRequests == nil {
+			break
+		}
+
+		args, err := ec.field_Organization_rightsRequests_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.RightsRequests(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey), args["orderBy"].(*types.RightsRequestOrderBy)), true
 	case "Organization.risks":
 		if e.complexity.Organization.Risks == nil {
 			break
@@ -7491,6 +7602,105 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.RequestSignaturePayload.DocumentVersionSignatureEdge(childComplexity), true
+
+	case "RightsRequest.actionTaken":
+		if e.complexity.RightsRequest.ActionTaken == nil {
+			break
+		}
+
+		return e.complexity.RightsRequest.ActionTaken(childComplexity), true
+	case "RightsRequest.contact":
+		if e.complexity.RightsRequest.Contact == nil {
+			break
+		}
+
+		return e.complexity.RightsRequest.Contact(childComplexity), true
+	case "RightsRequest.createdAt":
+		if e.complexity.RightsRequest.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.RightsRequest.CreatedAt(childComplexity), true
+	case "RightsRequest.dataSubject":
+		if e.complexity.RightsRequest.DataSubject == nil {
+			break
+		}
+
+		return e.complexity.RightsRequest.DataSubject(childComplexity), true
+	case "RightsRequest.deadline":
+		if e.complexity.RightsRequest.Deadline == nil {
+			break
+		}
+
+		return e.complexity.RightsRequest.Deadline(childComplexity), true
+	case "RightsRequest.details":
+		if e.complexity.RightsRequest.Details == nil {
+			break
+		}
+
+		return e.complexity.RightsRequest.Details(childComplexity), true
+	case "RightsRequest.id":
+		if e.complexity.RightsRequest.ID == nil {
+			break
+		}
+
+		return e.complexity.RightsRequest.ID(childComplexity), true
+	case "RightsRequest.organization":
+		if e.complexity.RightsRequest.Organization == nil {
+			break
+		}
+
+		return e.complexity.RightsRequest.Organization(childComplexity), true
+	case "RightsRequest.requestState":
+		if e.complexity.RightsRequest.RequestState == nil {
+			break
+		}
+
+		return e.complexity.RightsRequest.RequestState(childComplexity), true
+	case "RightsRequest.requestType":
+		if e.complexity.RightsRequest.RequestType == nil {
+			break
+		}
+
+		return e.complexity.RightsRequest.RequestType(childComplexity), true
+	case "RightsRequest.updatedAt":
+		if e.complexity.RightsRequest.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.RightsRequest.UpdatedAt(childComplexity), true
+
+	case "RightsRequestConnection.edges":
+		if e.complexity.RightsRequestConnection.Edges == nil {
+			break
+		}
+
+		return e.complexity.RightsRequestConnection.Edges(childComplexity), true
+	case "RightsRequestConnection.pageInfo":
+		if e.complexity.RightsRequestConnection.PageInfo == nil {
+			break
+		}
+
+		return e.complexity.RightsRequestConnection.PageInfo(childComplexity), true
+	case "RightsRequestConnection.totalCount":
+		if e.complexity.RightsRequestConnection.TotalCount == nil {
+			break
+		}
+
+		return e.complexity.RightsRequestConnection.TotalCount(childComplexity), true
+
+	case "RightsRequestEdge.cursor":
+		if e.complexity.RightsRequestEdge.Cursor == nil {
+			break
+		}
+
+		return e.complexity.RightsRequestEdge.Cursor(childComplexity), true
+	case "RightsRequestEdge.node":
+		if e.complexity.RightsRequestEdge.Node == nil {
+			break
+		}
+
+		return e.complexity.RightsRequestEdge.Node(childComplexity), true
 
 	case "Risk.category":
 		if e.complexity.Risk.Category == nil {
@@ -8803,6 +9013,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.UpdateProcessingActivityPayload.ProcessingActivity(childComplexity), true
 
+	case "UpdateRightsRequestPayload.rightsRequest":
+		if e.complexity.UpdateRightsRequestPayload.RightsRequest == nil {
+			break
+		}
+
+		return e.complexity.UpdateRightsRequestPayload.RightsRequest(childComplexity), true
+
 	case "UpdateRiskPayload.risk":
 		if e.complexity.UpdateRiskPayload.Risk == nil {
 			break
@@ -9740,6 +9957,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputCreateOrganizationInput,
 		ec.unmarshalInputCreatePeopleInput,
 		ec.unmarshalInputCreateProcessingActivityInput,
+		ec.unmarshalInputCreateRightsRequestInput,
 		ec.unmarshalInputCreateRiskDocumentMappingInput,
 		ec.unmarshalInputCreateRiskInput,
 		ec.unmarshalInputCreateRiskMeasureMappingInput,
@@ -9784,6 +10002,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputDeleteOrganizationInput,
 		ec.unmarshalInputDeletePeopleInput,
 		ec.unmarshalInputDeleteProcessingActivityInput,
+		ec.unmarshalInputDeleteRightsRequestInput,
 		ec.unmarshalInputDeleteRiskDocumentMappingInput,
 		ec.unmarshalInputDeleteRiskInput,
 		ec.unmarshalInputDeleteRiskMeasureMappingInput,
@@ -9842,6 +10061,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputRemoveMemberInput,
 		ec.unmarshalInputRequestEvidenceInput,
 		ec.unmarshalInputRequestSignatureInput,
+		ec.unmarshalInputRightsRequestOrder,
 		ec.unmarshalInputRiskFilter,
 		ec.unmarshalInputRiskOrder,
 		ec.unmarshalInputSendSigningNotificationsInput,
@@ -9873,6 +10093,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputUpdateOrganizationInput,
 		ec.unmarshalInputUpdatePeopleInput,
 		ec.unmarshalInputUpdateProcessingActivityInput,
+		ec.unmarshalInputUpdateRightsRequestInput,
 		ec.unmarshalInputUpdateRiskInput,
 		ec.unmarshalInputUpdateSAMLConfigurationInput,
 		ec.unmarshalInputUpdateTaskInput,
@@ -10256,6 +10477,42 @@ enum ContinualImprovementPriority
   HIGH
     @goEnum(
       value: "go.probo.inc/probo/pkg/coredata.ContinualImprovementPriorityHigh"
+    )
+}
+
+enum RightsRequestType
+  @goModel(
+    model: "go.probo.inc/probo/pkg/coredata.RightsRequestType"
+  ) {
+  ACCESS
+    @goEnum(
+      value: "go.probo.inc/probo/pkg/coredata.RightsRequestTypeAccess"
+    )
+  DELETION
+    @goEnum(
+      value: "go.probo.inc/probo/pkg/coredata.RightsRequestTypeDeletion"
+    )
+  PORTABILITY
+    @goEnum(
+      value: "go.probo.inc/probo/pkg/coredata.RightsRequestTypePortability"
+    )
+}
+
+enum RightsRequestState
+  @goModel(
+    model: "go.probo.inc/probo/pkg/coredata.RightsRequestState"
+  ) {
+  TODO
+    @goEnum(
+      value: "go.probo.inc/probo/pkg/coredata.RightsRequestStateTodo"
+    )
+  IN_PROGRESS
+    @goEnum(
+      value: "go.probo.inc/probo/pkg/coredata.RightsRequestStateInProgress"
+    )
+  DONE
+    @goEnum(
+      value: "go.probo.inc/probo/pkg/coredata.RightsRequestStateDone"
     )
 }
 
@@ -11064,6 +11321,28 @@ enum ContinualImprovementOrderField
     )
 }
 
+enum RightsRequestOrderField
+  @goModel(
+    model: "go.probo.inc/probo/pkg/coredata.RightsRequestOrderField"
+  ) {
+  CREATED_AT
+    @goEnum(
+      value: "go.probo.inc/probo/pkg/coredata.RightsRequestOrderFieldCreatedAt"
+    )
+  DEADLINE
+    @goEnum(
+      value: "go.probo.inc/probo/pkg/coredata.RightsRequestOrderFieldDeadline"
+    )
+  STATE
+    @goEnum(
+      value: "go.probo.inc/probo/pkg/coredata.RightsRequestOrderFieldState"
+    )
+  TYPE
+    @goEnum(
+      value: "go.probo.inc/probo/pkg/coredata.RightsRequestOrderFieldType"
+    )
+}
+
 enum ProcessingActivityOrderField
   @goModel(
     model: "go.probo.inc/probo/pkg/coredata.ProcessingActivityOrderField"
@@ -11343,6 +11622,14 @@ input ContinualImprovementOrder
   field: ContinualImprovementOrderField!
 }
 
+input RightsRequestOrder
+  @goModel(
+    model: "go.probo.inc/probo/pkg/server/api/console/v1/types.RightsRequestOrderBy"
+  ) {
+  direction: OrderDirection!
+  field: RightsRequestOrderField!
+}
+
 input ProcessingActivityOrder
   @goModel(
     model: "go.probo.inc/probo/pkg/server/api/console/v1/types.ProcessingActivityOrderBy"
@@ -11511,6 +11798,7 @@ input ObligationFilter {
 input ContinualImprovementFilter {
   snapshotId: ID
 }
+
 
 input ProcessingActivityFilter {
   snapshotId: ID
@@ -11725,6 +12013,14 @@ type Organization implements Node {
     orderBy: ContinualImprovementOrder
     filter: ContinualImprovementFilter = { snapshotId: null }
   ): ContinualImprovementConnection! @goField(forceResolver: true)
+
+  rightsRequests(
+    first: Int
+    after: CursorKey
+    last: Int
+    before: CursorKey
+    orderBy: RightsRequestOrder
+  ): RightsRequestConnection! @goField(forceResolver: true)
 
   processingActivities(
     first: Int
@@ -12325,6 +12621,20 @@ type ContinualImprovement implements Node {
   updatedAt: Datetime!
 }
 
+type RightsRequest implements Node {
+  id: ID!
+  organization: Organization! @goField(forceResolver: true)
+  requestType: RightsRequestType!
+  requestState: RightsRequestState!
+  dataSubject: String
+  contact: String
+  details: String
+  deadline: Datetime
+  actionTaken: String
+  createdAt: Datetime!
+  updatedAt: Datetime!
+}
+
 type ProcessingActivity implements Node {
   id: ID!
   snapshotId: ID
@@ -12878,6 +13188,20 @@ type ContinualImprovementEdge {
   node: ContinualImprovement!
 }
 
+type RightsRequestConnection
+  @goModel(
+    model: "go.probo.inc/probo/pkg/server/api/console/v1/types.RightsRequestConnection"
+  ) {
+  totalCount: Int! @goField(forceResolver: true)
+  edges: [RightsRequestEdge!]!
+  pageInfo: PageInfo!
+}
+
+type RightsRequestEdge {
+  cursor: CursorKey!
+  node: RightsRequest!
+}
+
 type ProcessingActivityConnection
   @goModel(
     model: "go.probo.inc/probo/pkg/server/api/console/v1/types.ProcessingActivityConnection"
@@ -13245,6 +13569,20 @@ type Mutation {
   deleteContinualImprovement(
     input: DeleteContinualImprovementInput!
   ): DeleteContinualImprovementPayload!
+
+  # Rights Request mutations
+  createRightsRequest(
+    input: CreateRightsRequestInput!
+  ): CreateRightsRequestPayload!
+
+  updateRightsRequest(
+    input: UpdateRightsRequestInput!
+  ): UpdateRightsRequestPayload!
+
+  deleteRightsRequest(
+    input: DeleteRightsRequestInput!
+  ): DeleteRightsRequestPayload!
+
   # Processing Activity mutations
   createProcessingActivity(
     input: CreateProcessingActivityInput!
@@ -14019,6 +14357,32 @@ input UpdateContinualImprovementInput {
 
 input DeleteContinualImprovementInput {
   continualImprovementId: ID!
+}
+
+input CreateRightsRequestInput {
+  organizationId: ID!
+  requestType: RightsRequestType!
+  requestState: RightsRequestState!
+  dataSubject: String
+  contact: String
+  details: String
+  deadline: Datetime
+  actionTaken: String
+}
+
+input UpdateRightsRequestInput {
+  id: ID!
+  requestType: RightsRequestType
+  requestState: RightsRequestState
+  dataSubject: String @goField(omittable: true)
+  contact: String @goField(omittable: true)
+  details: String @goField(omittable: true)
+  deadline: Datetime @goField(omittable: true)
+  actionTaken: String @goField(omittable: true)
+}
+
+input DeleteRightsRequestInput {
+  rightsRequestId: ID!
 }
 
 input CreateProcessingActivityInput {
@@ -14961,6 +15325,18 @@ type UpdateContinualImprovementPayload {
 
 type DeleteContinualImprovementPayload {
   deletedContinualImprovementId: ID!
+}
+
+type CreateRightsRequestPayload {
+  rightsRequestEdge: RightsRequestEdge!
+}
+
+type UpdateRightsRequestPayload {
+  rightsRequest: RightsRequest!
+}
+
+type DeleteRightsRequestPayload {
+  deletedRightsRequestId: ID!
 }
 
 type CreateProcessingActivityPayload {
@@ -16066,6 +16442,17 @@ func (ec *executionContext) field_Mutation_createProcessingActivity_args(ctx con
 	return args, nil
 }
 
+func (ec *executionContext) field_Mutation_createRightsRequest_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "input", ec.unmarshalNCreateRightsRequestInput2goᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateRightsRequestInput)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
 func (ec *executionContext) field_Mutation_createRiskDocumentMapping_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -16499,6 +16886,17 @@ func (ec *executionContext) field_Mutation_deleteProcessingActivity_args(ctx con
 	var err error
 	args := map[string]any{}
 	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "input", ec.unmarshalNDeleteProcessingActivityInput2goᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteProcessingActivityInput)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_deleteRightsRequest_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "input", ec.unmarshalNDeleteRightsRequestInput2goᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteRightsRequestInput)
 	if err != nil {
 		return nil, err
 	}
@@ -17082,6 +17480,17 @@ func (ec *executionContext) field_Mutation_updateProcessingActivity_args(ctx con
 	var err error
 	args := map[string]any{}
 	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "input", ec.unmarshalNUpdateProcessingActivityInput2goᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateProcessingActivityInput)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_updateRightsRequest_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "input", ec.unmarshalNUpdateRightsRequestInput2goᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateRightsRequestInput)
 	if err != nil {
 		return nil, err
 	}
@@ -17862,6 +18271,37 @@ func (ec *executionContext) field_Organization_processingActivities_args(ctx con
 		return nil, err
 	}
 	args["filter"] = arg5
+	return args, nil
+}
+
+func (ec *executionContext) field_Organization_rightsRequests_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "first", ec.unmarshalOInt2ᚖint)
+	if err != nil {
+		return nil, err
+	}
+	args["first"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "after", ec.unmarshalOCursorKey2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋpageᚐCursorKey)
+	if err != nil {
+		return nil, err
+	}
+	args["after"] = arg1
+	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "last", ec.unmarshalOInt2ᚖint)
+	if err != nil {
+		return nil, err
+	}
+	args["last"] = arg2
+	arg3, err := graphql.ProcessArgField(ctx, rawArgs, "before", ec.unmarshalOCursorKey2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋpageᚐCursorKey)
+	if err != nil {
+		return nil, err
+	}
+	args["before"] = arg3
+	arg4, err := graphql.ProcessArgField(ctx, rawArgs, "orderBy", ec.unmarshalORightsRequestOrder2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐRightsRequestOrderBy)
+	if err != nil {
+		return nil, err
+	}
+	args["orderBy"] = arg4
 	return args, nil
 }
 
@@ -19233,6 +19673,8 @@ func (ec *executionContext) fieldContext_Asset_organization(_ context.Context, f
 				return ec.fieldContext_Organization_obligations(ctx, field)
 			case "continualImprovements":
 				return ec.fieldContext_Organization_continualImprovements(ctx, field)
+			case "rightsRequests":
+				return ec.fieldContext_Organization_rightsRequests(ctx, field)
 			case "processingActivities":
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "dataProtectionImpactAssessments":
@@ -19639,6 +20081,8 @@ func (ec *executionContext) fieldContext_Audit_organization(_ context.Context, f
 				return ec.fieldContext_Organization_obligations(ctx, field)
 			case "continualImprovements":
 				return ec.fieldContext_Organization_continualImprovements(ctx, field)
+			case "rightsRequests":
+				return ec.fieldContext_Organization_rightsRequests(ctx, field)
 			case "processingActivities":
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "dataProtectionImpactAssessments":
@@ -20591,6 +21035,8 @@ func (ec *executionContext) fieldContext_ContinualImprovement_organization(_ con
 				return ec.fieldContext_Organization_obligations(ctx, field)
 			case "continualImprovements":
 				return ec.fieldContext_Organization_continualImprovements(ctx, field)
+			case "rightsRequests":
+				return ec.fieldContext_Organization_rightsRequests(ctx, field)
 			case "processingActivities":
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "dataProtectionImpactAssessments":
@@ -22729,6 +23175,41 @@ func (ec *executionContext) fieldContext_CreateProcessingActivityPayload_process
 	return fc, nil
 }
 
+func (ec *executionContext) _CreateRightsRequestPayload_rightsRequestEdge(ctx context.Context, field graphql.CollectedField, obj *types.CreateRightsRequestPayload) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_CreateRightsRequestPayload_rightsRequestEdge,
+		func(ctx context.Context) (any, error) {
+			return obj.RightsRequestEdge, nil
+		},
+		nil,
+		ec.marshalNRightsRequestEdge2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐRightsRequestEdge,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_CreateRightsRequestPayload_rightsRequestEdge(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CreateRightsRequestPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "cursor":
+				return ec.fieldContext_RightsRequestEdge_cursor(ctx, field)
+			case "node":
+				return ec.fieldContext_RightsRequestEdge_node(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type RightsRequestEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _CreateRiskDocumentMappingPayload_riskEdge(ctx context.Context, field graphql.CollectedField, obj *types.CreateRiskDocumentMappingPayload) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -23524,6 +24005,8 @@ func (ec *executionContext) fieldContext_CustomDomain_organization(_ context.Con
 				return ec.fieldContext_Organization_obligations(ctx, field)
 			case "continualImprovements":
 				return ec.fieldContext_Organization_continualImprovements(ctx, field)
+			case "rightsRequests":
+				return ec.fieldContext_Organization_rightsRequests(ctx, field)
 			case "processingActivities":
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "dataProtectionImpactAssessments":
@@ -24076,6 +24559,8 @@ func (ec *executionContext) fieldContext_DataProtectionImpactAssessment_organiza
 				return ec.fieldContext_Organization_obligations(ctx, field)
 			case "continualImprovements":
 				return ec.fieldContext_Organization_continualImprovements(ctx, field)
+			case "rightsRequests":
+				return ec.fieldContext_Organization_rightsRequests(ctx, field)
 			case "processingActivities":
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "dataProtectionImpactAssessments":
@@ -24783,6 +25268,8 @@ func (ec *executionContext) fieldContext_Datum_organization(_ context.Context, f
 				return ec.fieldContext_Organization_obligations(ctx, field)
 			case "continualImprovements":
 				return ec.fieldContext_Organization_continualImprovements(ctx, field)
+			case "rightsRequests":
+				return ec.fieldContext_Organization_rightsRequests(ctx, field)
 			case "processingActivities":
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "dataProtectionImpactAssessments":
@@ -25880,6 +26367,8 @@ func (ec *executionContext) fieldContext_DeleteOrganizationHorizontalLogoPayload
 				return ec.fieldContext_Organization_obligations(ctx, field)
 			case "continualImprovements":
 				return ec.fieldContext_Organization_continualImprovements(ctx, field)
+			case "rightsRequests":
+				return ec.fieldContext_Organization_rightsRequests(ctx, field)
 			case "processingActivities":
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "dataProtectionImpactAssessments":
@@ -25984,6 +26473,35 @@ func (ec *executionContext) _DeleteProcessingActivityPayload_deletedProcessingAc
 func (ec *executionContext) fieldContext_DeleteProcessingActivityPayload_deletedProcessingActivityId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "DeleteProcessingActivityPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DeleteRightsRequestPayload_deletedRightsRequestId(ctx context.Context, field graphql.CollectedField, obj *types.DeleteRightsRequestPayload) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_DeleteRightsRequestPayload_deletedRightsRequestId,
+		func(ctx context.Context) (any, error) {
+			return obj.DeletedRightsRequestID, nil
+		},
+		nil,
+		ec.marshalNID2goᚗproboᚗincᚋproboᚋpkgᚋgidᚐGID,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_DeleteRightsRequestPayload_deletedRightsRequestId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DeleteRightsRequestPayload",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -27032,6 +27550,8 @@ func (ec *executionContext) fieldContext_Document_organization(_ context.Context
 				return ec.fieldContext_Organization_obligations(ctx, field)
 			case "continualImprovements":
 				return ec.fieldContext_Organization_continualImprovements(ctx, field)
+			case "rightsRequests":
+				return ec.fieldContext_Organization_rightsRequests(ctx, field)
 			case "processingActivities":
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "dataProtectionImpactAssessments":
@@ -29574,6 +30094,8 @@ func (ec *executionContext) fieldContext_Framework_organization(_ context.Contex
 				return ec.fieldContext_Organization_obligations(ctx, field)
 			case "continualImprovements":
 				return ec.fieldContext_Organization_continualImprovements(ctx, field)
+			case "rightsRequests":
+				return ec.fieldContext_Organization_rightsRequests(ctx, field)
 			case "processingActivities":
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "dataProtectionImpactAssessments":
@@ -30573,6 +31095,8 @@ func (ec *executionContext) fieldContext_Invitation_organization(_ context.Conte
 				return ec.fieldContext_Organization_obligations(ctx, field)
 			case "continualImprovements":
 				return ec.fieldContext_Organization_continualImprovements(ctx, field)
+			case "rightsRequests":
+				return ec.fieldContext_Organization_rightsRequests(ctx, field)
 			case "processingActivities":
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "dataProtectionImpactAssessments":
@@ -31645,6 +32169,8 @@ func (ec *executionContext) fieldContext_Meeting_organization(_ context.Context,
 				return ec.fieldContext_Organization_obligations(ctx, field)
 			case "continualImprovements":
 				return ec.fieldContext_Organization_continualImprovements(ctx, field)
+			case "rightsRequests":
+				return ec.fieldContext_Organization_rightsRequests(ctx, field)
 			case "processingActivities":
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "dataProtectionImpactAssessments":
@@ -37875,6 +38401,141 @@ func (ec *executionContext) fieldContext_Mutation_deleteContinualImprovement(ctx
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_createRightsRequest(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Mutation_createRightsRequest,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.resolvers.Mutation().CreateRightsRequest(ctx, fc.Args["input"].(types.CreateRightsRequestInput))
+		},
+		nil,
+		ec.marshalNCreateRightsRequestPayload2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateRightsRequestPayload,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Mutation_createRightsRequest(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "rightsRequestEdge":
+				return ec.fieldContext_CreateRightsRequestPayload_rightsRequestEdge(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CreateRightsRequestPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_createRightsRequest_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_updateRightsRequest(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Mutation_updateRightsRequest,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.resolvers.Mutation().UpdateRightsRequest(ctx, fc.Args["input"].(types.UpdateRightsRequestInput))
+		},
+		nil,
+		ec.marshalNUpdateRightsRequestPayload2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateRightsRequestPayload,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Mutation_updateRightsRequest(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "rightsRequest":
+				return ec.fieldContext_UpdateRightsRequestPayload_rightsRequest(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UpdateRightsRequestPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_updateRightsRequest_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_deleteRightsRequest(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Mutation_deleteRightsRequest,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.resolvers.Mutation().DeleteRightsRequest(ctx, fc.Args["input"].(types.DeleteRightsRequestInput))
+		},
+		nil,
+		ec.marshalNDeleteRightsRequestPayload2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteRightsRequestPayload,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Mutation_deleteRightsRequest(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "deletedRightsRequestId":
+				return ec.fieldContext_DeleteRightsRequestPayload_deletedRightsRequestId(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DeleteRightsRequestPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_deleteRightsRequest_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation_createProcessingActivity(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -38915,6 +39576,8 @@ func (ec *executionContext) fieldContext_Nonconformity_organization(_ context.Co
 				return ec.fieldContext_Organization_obligations(ctx, field)
 			case "continualImprovements":
 				return ec.fieldContext_Organization_continualImprovements(ctx, field)
+			case "rightsRequests":
+				return ec.fieldContext_Organization_rightsRequests(ctx, field)
 			case "processingActivities":
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "dataProtectionImpactAssessments":
@@ -39698,6 +40361,8 @@ func (ec *executionContext) fieldContext_Obligation_organization(_ context.Conte
 				return ec.fieldContext_Organization_obligations(ctx, field)
 			case "continualImprovements":
 				return ec.fieldContext_Organization_continualImprovements(ctx, field)
+			case "rightsRequests":
+				return ec.fieldContext_Organization_rightsRequests(ctx, field)
 			case "processingActivities":
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "dataProtectionImpactAssessments":
@@ -41406,6 +42071,55 @@ func (ec *executionContext) fieldContext_Organization_continualImprovements(ctx 
 	return fc, nil
 }
 
+func (ec *executionContext) _Organization_rightsRequests(ctx context.Context, field graphql.CollectedField, obj *types.Organization) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Organization_rightsRequests,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.resolvers.Organization().RightsRequests(ctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey), fc.Args["orderBy"].(*types.RightsRequestOrderBy))
+		},
+		nil,
+		ec.marshalNRightsRequestConnection2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐRightsRequestConnection,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Organization_rightsRequests(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Organization",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "totalCount":
+				return ec.fieldContext_RightsRequestConnection_totalCount(ctx, field)
+			case "edges":
+				return ec.fieldContext_RightsRequestConnection_edges(ctx, field)
+			case "pageInfo":
+				return ec.fieldContext_RightsRequestConnection_pageInfo(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type RightsRequestConnection", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Organization_rightsRequests_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Organization_processingActivities(ctx context.Context, field graphql.CollectedField, obj *types.Organization) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -42121,6 +42835,8 @@ func (ec *executionContext) fieldContext_OrganizationEdge_node(_ context.Context
 				return ec.fieldContext_Organization_obligations(ctx, field)
 			case "continualImprovements":
 				return ec.fieldContext_Organization_continualImprovements(ctx, field)
+			case "rightsRequests":
+				return ec.fieldContext_Organization_rightsRequests(ctx, field)
 			case "processingActivities":
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "dataProtectionImpactAssessments":
@@ -42902,6 +43618,8 @@ func (ec *executionContext) fieldContext_ProcessingActivity_organization(_ conte
 				return ec.fieldContext_Organization_obligations(ctx, field)
 			case "continualImprovements":
 				return ec.fieldContext_Organization_continualImprovements(ctx, field)
+			case "rightsRequests":
+				return ec.fieldContext_Organization_rightsRequests(ctx, field)
 			case "processingActivities":
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "dataProtectionImpactAssessments":
@@ -44624,6 +45342,588 @@ func (ec *executionContext) fieldContext_RequestSignaturePayload_documentVersion
 	return fc, nil
 }
 
+func (ec *executionContext) _RightsRequest_id(ctx context.Context, field graphql.CollectedField, obj *types.RightsRequest) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RightsRequest_id,
+		func(ctx context.Context) (any, error) {
+			return obj.ID, nil
+		},
+		nil,
+		ec.marshalNID2goᚗproboᚗincᚋproboᚋpkgᚋgidᚐGID,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_RightsRequest_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RightsRequest",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RightsRequest_organization(ctx context.Context, field graphql.CollectedField, obj *types.RightsRequest) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RightsRequest_organization,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.RightsRequest().Organization(ctx, obj)
+		},
+		nil,
+		ec.marshalNOrganization2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐOrganization,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_RightsRequest_organization(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RightsRequest",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Organization_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Organization_name(ctx, field)
+			case "logoUrl":
+				return ec.fieldContext_Organization_logoUrl(ctx, field)
+			case "horizontalLogoUrl":
+				return ec.fieldContext_Organization_horizontalLogoUrl(ctx, field)
+			case "description":
+				return ec.fieldContext_Organization_description(ctx, field)
+			case "websiteUrl":
+				return ec.fieldContext_Organization_websiteUrl(ctx, field)
+			case "email":
+				return ec.fieldContext_Organization_email(ctx, field)
+			case "headquarterAddress":
+				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
+			case "context":
+				return ec.fieldContext_Organization_context(ctx, field)
+			case "memberships":
+				return ec.fieldContext_Organization_memberships(ctx, field)
+			case "invitations":
+				return ec.fieldContext_Organization_invitations(ctx, field)
+			case "slackConnections":
+				return ec.fieldContext_Organization_slackConnections(ctx, field)
+			case "frameworks":
+				return ec.fieldContext_Organization_frameworks(ctx, field)
+			case "controls":
+				return ec.fieldContext_Organization_controls(ctx, field)
+			case "vendors":
+				return ec.fieldContext_Organization_vendors(ctx, field)
+			case "peoples":
+				return ec.fieldContext_Organization_peoples(ctx, field)
+			case "documents":
+				return ec.fieldContext_Organization_documents(ctx, field)
+			case "meetings":
+				return ec.fieldContext_Organization_meetings(ctx, field)
+			case "measures":
+				return ec.fieldContext_Organization_measures(ctx, field)
+			case "risks":
+				return ec.fieldContext_Organization_risks(ctx, field)
+			case "tasks":
+				return ec.fieldContext_Organization_tasks(ctx, field)
+			case "assets":
+				return ec.fieldContext_Organization_assets(ctx, field)
+			case "data":
+				return ec.fieldContext_Organization_data(ctx, field)
+			case "audits":
+				return ec.fieldContext_Organization_audits(ctx, field)
+			case "nonconformities":
+				return ec.fieldContext_Organization_nonconformities(ctx, field)
+			case "obligations":
+				return ec.fieldContext_Organization_obligations(ctx, field)
+			case "continualImprovements":
+				return ec.fieldContext_Organization_continualImprovements(ctx, field)
+			case "rightsRequests":
+				return ec.fieldContext_Organization_rightsRequests(ctx, field)
+			case "processingActivities":
+				return ec.fieldContext_Organization_processingActivities(ctx, field)
+			case "dataProtectionImpactAssessments":
+				return ec.fieldContext_Organization_dataProtectionImpactAssessments(ctx, field)
+			case "transferImpactAssessments":
+				return ec.fieldContext_Organization_transferImpactAssessments(ctx, field)
+			case "snapshots":
+				return ec.fieldContext_Organization_snapshots(ctx, field)
+			case "trustCenterFiles":
+				return ec.fieldContext_Organization_trustCenterFiles(ctx, field)
+			case "trustCenter":
+				return ec.fieldContext_Organization_trustCenter(ctx, field)
+			case "customDomain":
+				return ec.fieldContext_Organization_customDomain(ctx, field)
+			case "samlConfigurations":
+				return ec.fieldContext_Organization_samlConfigurations(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Organization_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Organization_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Organization", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RightsRequest_requestType(ctx context.Context, field graphql.CollectedField, obj *types.RightsRequest) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RightsRequest_requestType,
+		func(ctx context.Context) (any, error) {
+			return obj.RequestType, nil
+		},
+		nil,
+		ec.marshalNRightsRequestType2goᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestType,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_RightsRequest_requestType(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RightsRequest",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type RightsRequestType does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RightsRequest_requestState(ctx context.Context, field graphql.CollectedField, obj *types.RightsRequest) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RightsRequest_requestState,
+		func(ctx context.Context) (any, error) {
+			return obj.RequestState, nil
+		},
+		nil,
+		ec.marshalNRightsRequestState2goᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestState,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_RightsRequest_requestState(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RightsRequest",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type RightsRequestState does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RightsRequest_dataSubject(ctx context.Context, field graphql.CollectedField, obj *types.RightsRequest) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RightsRequest_dataSubject,
+		func(ctx context.Context) (any, error) {
+			return obj.DataSubject, nil
+		},
+		nil,
+		ec.marshalOString2ᚖstring,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_RightsRequest_dataSubject(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RightsRequest",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RightsRequest_contact(ctx context.Context, field graphql.CollectedField, obj *types.RightsRequest) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RightsRequest_contact,
+		func(ctx context.Context) (any, error) {
+			return obj.Contact, nil
+		},
+		nil,
+		ec.marshalOString2ᚖstring,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_RightsRequest_contact(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RightsRequest",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RightsRequest_details(ctx context.Context, field graphql.CollectedField, obj *types.RightsRequest) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RightsRequest_details,
+		func(ctx context.Context) (any, error) {
+			return obj.Details, nil
+		},
+		nil,
+		ec.marshalOString2ᚖstring,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_RightsRequest_details(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RightsRequest",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RightsRequest_deadline(ctx context.Context, field graphql.CollectedField, obj *types.RightsRequest) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RightsRequest_deadline,
+		func(ctx context.Context) (any, error) {
+			return obj.Deadline, nil
+		},
+		nil,
+		ec.marshalODatetime2ᚖtimeᚐTime,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_RightsRequest_deadline(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RightsRequest",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RightsRequest_actionTaken(ctx context.Context, field graphql.CollectedField, obj *types.RightsRequest) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RightsRequest_actionTaken,
+		func(ctx context.Context) (any, error) {
+			return obj.ActionTaken, nil
+		},
+		nil,
+		ec.marshalOString2ᚖstring,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_RightsRequest_actionTaken(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RightsRequest",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RightsRequest_createdAt(ctx context.Context, field graphql.CollectedField, obj *types.RightsRequest) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RightsRequest_createdAt,
+		func(ctx context.Context) (any, error) {
+			return obj.CreatedAt, nil
+		},
+		nil,
+		ec.marshalNDatetime2timeᚐTime,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_RightsRequest_createdAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RightsRequest",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RightsRequest_updatedAt(ctx context.Context, field graphql.CollectedField, obj *types.RightsRequest) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RightsRequest_updatedAt,
+		func(ctx context.Context) (any, error) {
+			return obj.UpdatedAt, nil
+		},
+		nil,
+		ec.marshalNDatetime2timeᚐTime,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_RightsRequest_updatedAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RightsRequest",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RightsRequestConnection_totalCount(ctx context.Context, field graphql.CollectedField, obj *types.RightsRequestConnection) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RightsRequestConnection_totalCount,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.RightsRequestConnection().TotalCount(ctx, obj)
+		},
+		nil,
+		ec.marshalNInt2int,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_RightsRequestConnection_totalCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RightsRequestConnection",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RightsRequestConnection_edges(ctx context.Context, field graphql.CollectedField, obj *types.RightsRequestConnection) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RightsRequestConnection_edges,
+		func(ctx context.Context) (any, error) {
+			return obj.Edges, nil
+		},
+		nil,
+		ec.marshalNRightsRequestEdge2ᚕᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐRightsRequestEdgeᚄ,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_RightsRequestConnection_edges(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RightsRequestConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "cursor":
+				return ec.fieldContext_RightsRequestEdge_cursor(ctx, field)
+			case "node":
+				return ec.fieldContext_RightsRequestEdge_node(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type RightsRequestEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RightsRequestConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *types.RightsRequestConnection) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RightsRequestConnection_pageInfo,
+		func(ctx context.Context) (any, error) {
+			return obj.PageInfo, nil
+		},
+		nil,
+		ec.marshalNPageInfo2goᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐPageInfo,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_RightsRequestConnection_pageInfo(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RightsRequestConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "hasNextPage":
+				return ec.fieldContext_PageInfo_hasNextPage(ctx, field)
+			case "hasPreviousPage":
+				return ec.fieldContext_PageInfo_hasPreviousPage(ctx, field)
+			case "startCursor":
+				return ec.fieldContext_PageInfo_startCursor(ctx, field)
+			case "endCursor":
+				return ec.fieldContext_PageInfo_endCursor(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RightsRequestEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *types.RightsRequestEdge) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RightsRequestEdge_cursor,
+		func(ctx context.Context) (any, error) {
+			return obj.Cursor, nil
+		},
+		nil,
+		ec.marshalNCursorKey2goᚗproboᚗincᚋproboᚋpkgᚋpageᚐCursorKey,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_RightsRequestEdge_cursor(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RightsRequestEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type CursorKey does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RightsRequestEdge_node(ctx context.Context, field graphql.CollectedField, obj *types.RightsRequestEdge) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RightsRequestEdge_node,
+		func(ctx context.Context) (any, error) {
+			return obj.Node, nil
+		},
+		nil,
+		ec.marshalNRightsRequest2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐRightsRequest,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_RightsRequestEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RightsRequestEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_RightsRequest_id(ctx, field)
+			case "organization":
+				return ec.fieldContext_RightsRequest_organization(ctx, field)
+			case "requestType":
+				return ec.fieldContext_RightsRequest_requestType(ctx, field)
+			case "requestState":
+				return ec.fieldContext_RightsRequest_requestState(ctx, field)
+			case "dataSubject":
+				return ec.fieldContext_RightsRequest_dataSubject(ctx, field)
+			case "contact":
+				return ec.fieldContext_RightsRequest_contact(ctx, field)
+			case "details":
+				return ec.fieldContext_RightsRequest_details(ctx, field)
+			case "deadline":
+				return ec.fieldContext_RightsRequest_deadline(ctx, field)
+			case "actionTaken":
+				return ec.fieldContext_RightsRequest_actionTaken(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_RightsRequest_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_RightsRequest_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type RightsRequest", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Risk_id(ctx context.Context, field graphql.CollectedField, obj *types.Risk) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -45130,6 +46430,8 @@ func (ec *executionContext) fieldContext_Risk_organization(_ context.Context, fi
 				return ec.fieldContext_Organization_obligations(ctx, field)
 			case "continualImprovements":
 				return ec.fieldContext_Organization_continualImprovements(ctx, field)
+			case "rightsRequests":
+				return ec.fieldContext_Organization_rightsRequests(ctx, field)
 			case "processingActivities":
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "dataProtectionImpactAssessments":
@@ -45723,6 +47025,8 @@ func (ec *executionContext) fieldContext_SAMLConfiguration_organization(_ contex
 				return ec.fieldContext_Organization_obligations(ctx, field)
 			case "continualImprovements":
 				return ec.fieldContext_Organization_continualImprovements(ctx, field)
+			case "rightsRequests":
+				return ec.fieldContext_Organization_rightsRequests(ctx, field)
 			case "processingActivities":
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "dataProtectionImpactAssessments":
@@ -47320,6 +48624,8 @@ func (ec *executionContext) fieldContext_Snapshot_organization(_ context.Context
 				return ec.fieldContext_Organization_obligations(ctx, field)
 			case "continualImprovements":
 				return ec.fieldContext_Organization_continualImprovements(ctx, field)
+			case "rightsRequests":
+				return ec.fieldContext_Organization_rightsRequests(ctx, field)
 			case "processingActivities":
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "dataProtectionImpactAssessments":
@@ -47992,6 +49298,8 @@ func (ec *executionContext) fieldContext_Task_organization(_ context.Context, fi
 				return ec.fieldContext_Organization_obligations(ctx, field)
 			case "continualImprovements":
 				return ec.fieldContext_Organization_continualImprovements(ctx, field)
+			case "rightsRequests":
+				return ec.fieldContext_Organization_rightsRequests(ctx, field)
 			case "processingActivities":
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "dataProtectionImpactAssessments":
@@ -48560,6 +49868,8 @@ func (ec *executionContext) fieldContext_TransferImpactAssessment_organization(_
 				return ec.fieldContext_Organization_obligations(ctx, field)
 			case "continualImprovements":
 				return ec.fieldContext_Organization_continualImprovements(ctx, field)
+			case "rightsRequests":
+				return ec.fieldContext_Organization_rightsRequests(ctx, field)
 			case "processingActivities":
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "dataProtectionImpactAssessments":
@@ -49225,6 +50535,8 @@ func (ec *executionContext) fieldContext_TrustCenter_organization(_ context.Cont
 				return ec.fieldContext_Organization_obligations(ctx, field)
 			case "continualImprovements":
 				return ec.fieldContext_Organization_continualImprovements(ctx, field)
+			case "rightsRequests":
+				return ec.fieldContext_Organization_rightsRequests(ctx, field)
 			case "processingActivities":
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "dataProtectionImpactAssessments":
@@ -50660,6 +51972,8 @@ func (ec *executionContext) fieldContext_TrustCenterFile_organization(_ context.
 				return ec.fieldContext_Organization_obligations(ctx, field)
 			case "continualImprovements":
 				return ec.fieldContext_Organization_continualImprovements(ctx, field)
+			case "rightsRequests":
+				return ec.fieldContext_Organization_rightsRequests(ctx, field)
 			case "processingActivities":
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "dataProtectionImpactAssessments":
@@ -52150,6 +53464,8 @@ func (ec *executionContext) fieldContext_UpdateOrganizationPayload_organization(
 				return ec.fieldContext_Organization_obligations(ctx, field)
 			case "continualImprovements":
 				return ec.fieldContext_Organization_continualImprovements(ctx, field)
+			case "rightsRequests":
+				return ec.fieldContext_Organization_rightsRequests(ctx, field)
 			case "processingActivities":
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "dataProtectionImpactAssessments":
@@ -52310,6 +53626,59 @@ func (ec *executionContext) fieldContext_UpdateProcessingActivityPayload_process
 				return ec.fieldContext_ProcessingActivity_updatedAt(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ProcessingActivity", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UpdateRightsRequestPayload_rightsRequest(ctx context.Context, field graphql.CollectedField, obj *types.UpdateRightsRequestPayload) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_UpdateRightsRequestPayload_rightsRequest,
+		func(ctx context.Context) (any, error) {
+			return obj.RightsRequest, nil
+		},
+		nil,
+		ec.marshalNRightsRequest2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐRightsRequest,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_UpdateRightsRequestPayload_rightsRequest(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UpdateRightsRequestPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_RightsRequest_id(ctx, field)
+			case "organization":
+				return ec.fieldContext_RightsRequest_organization(ctx, field)
+			case "requestType":
+				return ec.fieldContext_RightsRequest_requestType(ctx, field)
+			case "requestState":
+				return ec.fieldContext_RightsRequest_requestState(ctx, field)
+			case "dataSubject":
+				return ec.fieldContext_RightsRequest_dataSubject(ctx, field)
+			case "contact":
+				return ec.fieldContext_RightsRequest_contact(ctx, field)
+			case "details":
+				return ec.fieldContext_RightsRequest_details(ctx, field)
+			case "deadline":
+				return ec.fieldContext_RightsRequest_deadline(ctx, field)
+			case "actionTaken":
+				return ec.fieldContext_RightsRequest_actionTaken(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_RightsRequest_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_RightsRequest_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type RightsRequest", field.Name)
 		},
 	}
 	return fc, nil
@@ -53863,6 +55232,8 @@ func (ec *executionContext) fieldContext_Vendor_organization(_ context.Context, 
 				return ec.fieldContext_Organization_obligations(ctx, field)
 			case "continualImprovements":
 				return ec.fieldContext_Organization_continualImprovements(ctx, field)
+			case "rightsRequests":
+				return ec.fieldContext_Organization_rightsRequests(ctx, field)
 			case "processingActivities":
 				return ec.fieldContext_Organization_processingActivities(ctx, field)
 			case "dataProtectionImpactAssessments":
@@ -60958,6 +62329,82 @@ func (ec *executionContext) unmarshalInputCreateProcessingActivityInput(ctx cont
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputCreateRightsRequestInput(ctx context.Context, obj any) (types.CreateRightsRequestInput, error) {
+	var it types.CreateRightsRequestInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"organizationId", "requestType", "requestState", "dataSubject", "contact", "details", "deadline", "actionTaken"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "organizationId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("organizationId"))
+			data, err := ec.unmarshalNID2goᚗproboᚗincᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OrganizationID = data
+		case "requestType":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("requestType"))
+			data, err := ec.unmarshalNRightsRequestType2goᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestType(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.RequestType = data
+		case "requestState":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("requestState"))
+			data, err := ec.unmarshalNRightsRequestState2goᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestState(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.RequestState = data
+		case "dataSubject":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("dataSubject"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DataSubject = data
+		case "contact":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("contact"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Contact = data
+		case "details":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("details"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Details = data
+		case "deadline":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deadline"))
+			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Deadline = data
+		case "actionTaken":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("actionTaken"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ActionTaken = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputCreateRiskDocumentMappingInput(ctx context.Context, obj any) (types.CreateRiskDocumentMappingInput, error) {
 	var it types.CreateRiskDocumentMappingInput
 	asMap := map[string]any{}
@@ -62763,6 +64210,33 @@ func (ec *executionContext) unmarshalInputDeleteProcessingActivityInput(ctx cont
 				return it, err
 			}
 			it.ProcessingActivityID = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputDeleteRightsRequestInput(ctx context.Context, obj any) (types.DeleteRightsRequestInput, error) {
+	var it types.DeleteRightsRequestInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"rightsRequestId"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "rightsRequestId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rightsRequestId"))
+			data, err := ec.unmarshalNID2goᚗproboᚗincᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.RightsRequestID = data
 		}
 	}
 
@@ -64594,6 +66068,40 @@ func (ec *executionContext) unmarshalInputRequestSignatureInput(ctx context.Cont
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputRightsRequestOrder(ctx context.Context, obj any) (types.RightsRequestOrderBy, error) {
+	var it types.RightsRequestOrderBy
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"direction", "field"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "direction":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("direction"))
+			data, err := ec.unmarshalNOrderDirection2goᚗproboᚗincᚋproboᚋpkgᚋpageᚐOrderDirection(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Direction = data
+		case "field":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("field"))
+			data, err := ec.unmarshalNRightsRequestOrderField2goᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestOrderField(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Field = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputRiskFilter(ctx context.Context, obj any) (types.RiskFilter, error) {
 	var it types.RiskFilter
 	asMap := map[string]any{}
@@ -66236,6 +67744,82 @@ func (ec *executionContext) unmarshalInputUpdateProcessingActivityInput(ctx cont
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputUpdateRightsRequestInput(ctx context.Context, obj any) (types.UpdateRightsRequestInput, error) {
+	var it types.UpdateRightsRequestInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id", "requestType", "requestState", "dataSubject", "contact", "details", "deadline", "actionTaken"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			data, err := ec.unmarshalNID2goᚗproboᚗincᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ID = data
+		case "requestType":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("requestType"))
+			data, err := ec.unmarshalORightsRequestType2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestType(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.RequestType = data
+		case "requestState":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("requestState"))
+			data, err := ec.unmarshalORightsRequestState2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestState(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.RequestState = data
+		case "dataSubject":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("dataSubject"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DataSubject = graphql.OmittableOf(data)
+		case "contact":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("contact"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Contact = graphql.OmittableOf(data)
+		case "details":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("details"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Details = graphql.OmittableOf(data)
+		case "deadline":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deadline"))
+			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Deadline = graphql.OmittableOf(data)
+		case "actionTaken":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("actionTaken"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ActionTaken = graphql.OmittableOf(data)
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputUpdateRiskInput(ctx context.Context, obj any) (types.UpdateRiskInput, error) {
 	var it types.UpdateRiskInput
 	asMap := map[string]any{}
@@ -67799,6 +69383,13 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._Risk(ctx, sel, obj)
+	case types.RightsRequest:
+		return ec._RightsRequest(ctx, sel, &obj)
+	case *types.RightsRequest:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._RightsRequest(ctx, sel, obj)
 	case types.Report:
 		return ec._Report(ctx, sel, &obj)
 	case *types.Report:
@@ -70501,6 +72092,45 @@ func (ec *executionContext) _CreateProcessingActivityPayload(ctx context.Context
 	return out
 }
 
+var createRightsRequestPayloadImplementors = []string{"CreateRightsRequestPayload"}
+
+func (ec *executionContext) _CreateRightsRequestPayload(ctx context.Context, sel ast.SelectionSet, obj *types.CreateRightsRequestPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, createRightsRequestPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CreateRightsRequestPayload")
+		case "rightsRequestEdge":
+			out.Values[i] = ec._CreateRightsRequestPayload_rightsRequestEdge(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var createRiskDocumentMappingPayloadImplementors = []string{"CreateRiskDocumentMappingPayload"}
 
 func (ec *executionContext) _CreateRiskDocumentMappingPayload(ctx context.Context, sel ast.SelectionSet, obj *types.CreateRiskDocumentMappingPayload) graphql.Marshaler {
@@ -72748,6 +74378,45 @@ func (ec *executionContext) _DeleteProcessingActivityPayload(ctx context.Context
 			out.Values[i] = graphql.MarshalString("DeleteProcessingActivityPayload")
 		case "deletedProcessingActivityId":
 			out.Values[i] = ec._DeleteProcessingActivityPayload_deletedProcessingActivityId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var deleteRightsRequestPayloadImplementors = []string{"DeleteRightsRequestPayload"}
+
+func (ec *executionContext) _DeleteRightsRequestPayload(ctx context.Context, sel ast.SelectionSet, obj *types.DeleteRightsRequestPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, deleteRightsRequestPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("DeleteRightsRequestPayload")
+		case "deletedRightsRequestId":
+			out.Values[i] = ec._DeleteRightsRequestPayload_deletedRightsRequestId(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -77519,6 +79188,27 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "createRightsRequest":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_createRightsRequest(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "updateRightsRequest":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_updateRightsRequest(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "deleteRightsRequest":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_deleteRightsRequest(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "createProcessingActivity":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_createProcessingActivity(ctx, field)
@@ -79031,6 +80721,42 @@ func (ec *executionContext) _Organization(ctx context.Context, sel ast.Selection
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "rightsRequests":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Organization_rightsRequests(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "processingActivities":
 			field := field
 
@@ -80491,6 +82217,235 @@ func (ec *executionContext) _RequestSignaturePayload(ctx context.Context, sel as
 			out.Values[i] = graphql.MarshalString("RequestSignaturePayload")
 		case "documentVersionSignatureEdge":
 			out.Values[i] = ec._RequestSignaturePayload_documentVersionSignatureEdge(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var rightsRequestImplementors = []string{"RightsRequest", "Node"}
+
+func (ec *executionContext) _RightsRequest(ctx context.Context, sel ast.SelectionSet, obj *types.RightsRequest) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, rightsRequestImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("RightsRequest")
+		case "id":
+			out.Values[i] = ec._RightsRequest_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "organization":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._RightsRequest_organization(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "requestType":
+			out.Values[i] = ec._RightsRequest_requestType(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "requestState":
+			out.Values[i] = ec._RightsRequest_requestState(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "dataSubject":
+			out.Values[i] = ec._RightsRequest_dataSubject(ctx, field, obj)
+		case "contact":
+			out.Values[i] = ec._RightsRequest_contact(ctx, field, obj)
+		case "details":
+			out.Values[i] = ec._RightsRequest_details(ctx, field, obj)
+		case "deadline":
+			out.Values[i] = ec._RightsRequest_deadline(ctx, field, obj)
+		case "actionTaken":
+			out.Values[i] = ec._RightsRequest_actionTaken(ctx, field, obj)
+		case "createdAt":
+			out.Values[i] = ec._RightsRequest_createdAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "updatedAt":
+			out.Values[i] = ec._RightsRequest_updatedAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var rightsRequestConnectionImplementors = []string{"RightsRequestConnection"}
+
+func (ec *executionContext) _RightsRequestConnection(ctx context.Context, sel ast.SelectionSet, obj *types.RightsRequestConnection) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, rightsRequestConnectionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("RightsRequestConnection")
+		case "totalCount":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._RightsRequestConnection_totalCount(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "edges":
+			out.Values[i] = ec._RightsRequestConnection_edges(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "pageInfo":
+			out.Values[i] = ec._RightsRequestConnection_pageInfo(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var rightsRequestEdgeImplementors = []string{"RightsRequestEdge"}
+
+func (ec *executionContext) _RightsRequestEdge(ctx context.Context, sel ast.SelectionSet, obj *types.RightsRequestEdge) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, rightsRequestEdgeImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("RightsRequestEdge")
+		case "cursor":
+			out.Values[i] = ec._RightsRequestEdge_cursor(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "node":
+			out.Values[i] = ec._RightsRequestEdge_node(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -84494,6 +86449,45 @@ func (ec *executionContext) _UpdateProcessingActivityPayload(ctx context.Context
 			out.Values[i] = graphql.MarshalString("UpdateProcessingActivityPayload")
 		case "processingActivity":
 			out.Values[i] = ec._UpdateProcessingActivityPayload_processingActivity(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var updateRightsRequestPayloadImplementors = []string{"UpdateRightsRequestPayload"}
+
+func (ec *executionContext) _UpdateRightsRequestPayload(ctx context.Context, sel ast.SelectionSet, obj *types.UpdateRightsRequestPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, updateRightsRequestPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("UpdateRightsRequestPayload")
+		case "rightsRequest":
+			out.Values[i] = ec._UpdateRightsRequestPayload_rightsRequest(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -89329,6 +91323,25 @@ func (ec *executionContext) marshalNCreateProcessingActivityPayload2ᚖgoᚗprob
 	return ec._CreateProcessingActivityPayload(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNCreateRightsRequestInput2goᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateRightsRequestInput(ctx context.Context, v any) (types.CreateRightsRequestInput, error) {
+	res, err := ec.unmarshalInputCreateRightsRequestInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNCreateRightsRequestPayload2goᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateRightsRequestPayload(ctx context.Context, sel ast.SelectionSet, v types.CreateRightsRequestPayload) graphql.Marshaler {
+	return ec._CreateRightsRequestPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNCreateRightsRequestPayload2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateRightsRequestPayload(ctx context.Context, sel ast.SelectionSet, v *types.CreateRightsRequestPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._CreateRightsRequestPayload(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNCreateRiskDocumentMappingInput2goᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐCreateRiskDocumentMappingInput(ctx context.Context, v any) (types.CreateRiskDocumentMappingInput, error) {
 	res, err := ec.unmarshalInputCreateRiskDocumentMappingInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -90461,6 +92474,25 @@ func (ec *executionContext) marshalNDeleteProcessingActivityPayload2ᚖgoᚗprob
 		return graphql.Null
 	}
 	return ec._DeleteProcessingActivityPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNDeleteRightsRequestInput2goᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteRightsRequestInput(ctx context.Context, v any) (types.DeleteRightsRequestInput, error) {
+	res, err := ec.unmarshalInputDeleteRightsRequestInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNDeleteRightsRequestPayload2goᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteRightsRequestPayload(ctx context.Context, sel ast.SelectionSet, v types.DeleteRightsRequestPayload) graphql.Marshaler {
+	return ec._DeleteRightsRequestPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNDeleteRightsRequestPayload2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteRightsRequestPayload(ctx context.Context, sel ast.SelectionSet, v *types.DeleteRightsRequestPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._DeleteRightsRequestPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNDeleteRiskDocumentMappingInput2goᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteRiskDocumentMappingInput(ctx context.Context, v any) (types.DeleteRiskDocumentMappingInput, error) {
@@ -93343,6 +95375,176 @@ func (ec *executionContext) marshalNRequestSignaturePayload2ᚖgoᚗproboᚗinc�
 	return ec._RequestSignaturePayload(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNRightsRequest2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐRightsRequest(ctx context.Context, sel ast.SelectionSet, v *types.RightsRequest) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._RightsRequest(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNRightsRequestConnection2goᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐRightsRequestConnection(ctx context.Context, sel ast.SelectionSet, v types.RightsRequestConnection) graphql.Marshaler {
+	return ec._RightsRequestConnection(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNRightsRequestConnection2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐRightsRequestConnection(ctx context.Context, sel ast.SelectionSet, v *types.RightsRequestConnection) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._RightsRequestConnection(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNRightsRequestEdge2ᚕᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐRightsRequestEdgeᚄ(ctx context.Context, sel ast.SelectionSet, v []*types.RightsRequestEdge) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNRightsRequestEdge2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐRightsRequestEdge(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNRightsRequestEdge2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐRightsRequestEdge(ctx context.Context, sel ast.SelectionSet, v *types.RightsRequestEdge) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._RightsRequestEdge(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNRightsRequestOrderField2goᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestOrderField(ctx context.Context, v any) (coredata.RightsRequestOrderField, error) {
+	tmp, err := graphql.UnmarshalString(v)
+	res := unmarshalNRightsRequestOrderField2goᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestOrderField[tmp]
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNRightsRequestOrderField2goᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestOrderField(ctx context.Context, sel ast.SelectionSet, v coredata.RightsRequestOrderField) graphql.Marshaler {
+	_ = sel
+	res := graphql.MarshalString(marshalNRightsRequestOrderField2goᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestOrderField[v])
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+var (
+	unmarshalNRightsRequestOrderField2goᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestOrderField = map[string]coredata.RightsRequestOrderField{
+		"CREATED_AT": coredata.RightsRequestOrderFieldCreatedAt,
+		"DEADLINE":   coredata.RightsRequestOrderFieldDeadline,
+		"STATE":      coredata.RightsRequestOrderFieldState,
+		"TYPE":       coredata.RightsRequestOrderFieldType,
+	}
+	marshalNRightsRequestOrderField2goᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestOrderField = map[coredata.RightsRequestOrderField]string{
+		coredata.RightsRequestOrderFieldCreatedAt: "CREATED_AT",
+		coredata.RightsRequestOrderFieldDeadline:  "DEADLINE",
+		coredata.RightsRequestOrderFieldState:     "STATE",
+		coredata.RightsRequestOrderFieldType:      "TYPE",
+	}
+)
+
+func (ec *executionContext) unmarshalNRightsRequestState2goᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestState(ctx context.Context, v any) (coredata.RightsRequestState, error) {
+	tmp, err := graphql.UnmarshalString(v)
+	res := unmarshalNRightsRequestState2goᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestState[tmp]
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNRightsRequestState2goᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestState(ctx context.Context, sel ast.SelectionSet, v coredata.RightsRequestState) graphql.Marshaler {
+	_ = sel
+	res := graphql.MarshalString(marshalNRightsRequestState2goᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestState[v])
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+var (
+	unmarshalNRightsRequestState2goᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestState = map[string]coredata.RightsRequestState{
+		"TODO":        coredata.RightsRequestStateTodo,
+		"IN_PROGRESS": coredata.RightsRequestStateInProgress,
+		"DONE":        coredata.RightsRequestStateDone,
+	}
+	marshalNRightsRequestState2goᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestState = map[coredata.RightsRequestState]string{
+		coredata.RightsRequestStateTodo:       "TODO",
+		coredata.RightsRequestStateInProgress: "IN_PROGRESS",
+		coredata.RightsRequestStateDone:       "DONE",
+	}
+)
+
+func (ec *executionContext) unmarshalNRightsRequestType2goᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestType(ctx context.Context, v any) (coredata.RightsRequestType, error) {
+	tmp, err := graphql.UnmarshalString(v)
+	res := unmarshalNRightsRequestType2goᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestType[tmp]
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNRightsRequestType2goᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestType(ctx context.Context, sel ast.SelectionSet, v coredata.RightsRequestType) graphql.Marshaler {
+	_ = sel
+	res := graphql.MarshalString(marshalNRightsRequestType2goᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestType[v])
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+var (
+	unmarshalNRightsRequestType2goᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestType = map[string]coredata.RightsRequestType{
+		"ACCESS":      coredata.RightsRequestTypeAccess,
+		"DELETION":    coredata.RightsRequestTypeDeletion,
+		"PORTABILITY": coredata.RightsRequestTypePortability,
+	}
+	marshalNRightsRequestType2goᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestType = map[coredata.RightsRequestType]string{
+		coredata.RightsRequestTypeAccess:      "ACCESS",
+		coredata.RightsRequestTypeDeletion:    "DELETION",
+		coredata.RightsRequestTypePortability: "PORTABILITY",
+	}
+)
+
 func (ec *executionContext) marshalNRisk2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐRisk(ctx context.Context, sel ast.SelectionSet, v *types.Risk) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -95125,6 +97327,25 @@ func (ec *executionContext) marshalNUpdateProcessingActivityPayload2ᚖgoᚗprob
 		return graphql.Null
 	}
 	return ec._UpdateProcessingActivityPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNUpdateRightsRequestInput2goᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateRightsRequestInput(ctx context.Context, v any) (types.UpdateRightsRequestInput, error) {
+	res, err := ec.unmarshalInputUpdateRightsRequestInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNUpdateRightsRequestPayload2goᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateRightsRequestPayload(ctx context.Context, sel ast.SelectionSet, v types.UpdateRightsRequestPayload) graphql.Marshaler {
+	return ec._UpdateRightsRequestPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNUpdateRightsRequestPayload2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateRightsRequestPayload(ctx context.Context, sel ast.SelectionSet, v *types.UpdateRightsRequestPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._UpdateRightsRequestPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNUpdateRiskInput2goᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐUpdateRiskInput(ctx context.Context, v any) (types.UpdateRiskInput, error) {
@@ -97925,6 +100146,78 @@ func (ec *executionContext) marshalOReport2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋs
 	}
 	return ec._Report(ctx, sel, v)
 }
+
+func (ec *executionContext) unmarshalORightsRequestOrder2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐRightsRequestOrderBy(ctx context.Context, v any) (*types.RightsRequestOrderBy, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputRightsRequestOrder(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalORightsRequestState2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestState(ctx context.Context, v any) (*coredata.RightsRequestState, error) {
+	if v == nil {
+		return nil, nil
+	}
+	tmp, err := graphql.UnmarshalString(v)
+	res := unmarshalORightsRequestState2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestState[tmp]
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalORightsRequestState2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestState(ctx context.Context, sel ast.SelectionSet, v *coredata.RightsRequestState) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	_ = sel
+	_ = ctx
+	res := graphql.MarshalString(marshalORightsRequestState2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestState[*v])
+	return res
+}
+
+var (
+	unmarshalORightsRequestState2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestState = map[string]coredata.RightsRequestState{
+		"TODO":        coredata.RightsRequestStateTodo,
+		"IN_PROGRESS": coredata.RightsRequestStateInProgress,
+		"DONE":        coredata.RightsRequestStateDone,
+	}
+	marshalORightsRequestState2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestState = map[coredata.RightsRequestState]string{
+		coredata.RightsRequestStateTodo:       "TODO",
+		coredata.RightsRequestStateInProgress: "IN_PROGRESS",
+		coredata.RightsRequestStateDone:       "DONE",
+	}
+)
+
+func (ec *executionContext) unmarshalORightsRequestType2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestType(ctx context.Context, v any) (*coredata.RightsRequestType, error) {
+	if v == nil {
+		return nil, nil
+	}
+	tmp, err := graphql.UnmarshalString(v)
+	res := unmarshalORightsRequestType2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestType[tmp]
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalORightsRequestType2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestType(ctx context.Context, sel ast.SelectionSet, v *coredata.RightsRequestType) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	_ = sel
+	_ = ctx
+	res := graphql.MarshalString(marshalORightsRequestType2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestType[*v])
+	return res
+}
+
+var (
+	unmarshalORightsRequestType2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestType = map[string]coredata.RightsRequestType{
+		"ACCESS":      coredata.RightsRequestTypeAccess,
+		"DELETION":    coredata.RightsRequestTypeDeletion,
+		"PORTABILITY": coredata.RightsRequestTypePortability,
+	}
+	marshalORightsRequestType2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐRightsRequestType = map[coredata.RightsRequestType]string{
+		coredata.RightsRequestTypeAccess:      "ACCESS",
+		coredata.RightsRequestTypeDeletion:    "DELETION",
+		coredata.RightsRequestTypePortability: "PORTABILITY",
+	}
+)
 
 func (ec *executionContext) unmarshalORiskFilter2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐRiskFilter(ctx context.Context, v any) (*types.RiskFilter, error) {
 	if v == nil {

--- a/pkg/server/api/console/v1/types/rights_request.go
+++ b/pkg/server/api/console/v1/types/rights_request.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package types
+
+import (
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/page"
+)
+
+type (
+	RightsRequestOrderBy OrderBy[coredata.RightsRequestOrderField]
+
+	RightsRequestConnection struct {
+		TotalCount int
+		Edges      []*RightsRequestEdge
+		PageInfo   PageInfo
+
+		Resolver any
+		ParentID gid.GID
+	}
+)
+
+func NewRightsRequestConnection(
+	p *page.Page[*coredata.RightsRequest, coredata.RightsRequestOrderField],
+	parentType any,
+	parentID gid.GID,
+) *RightsRequestConnection {
+	edges := make([]*RightsRequestEdge, len(p.Data))
+	for i, request := range p.Data {
+		edges[i] = NewRightsRequestEdge(request, p.Cursor.OrderBy.Field)
+	}
+
+	return &RightsRequestConnection{
+		Edges:    edges,
+		PageInfo: *NewPageInfo(p),
+
+		Resolver: parentType,
+		ParentID: parentID,
+	}
+}
+
+func NewRightsRequest(rr *coredata.RightsRequest) *RightsRequest {
+	return &RightsRequest{
+		ID:           rr.ID,
+		RequestType:  rr.RequestType,
+		RequestState: rr.RequestState,
+		DataSubject:  rr.DataSubject,
+		Contact:      rr.Contact,
+		Details:      rr.Details,
+		Deadline:     rr.Deadline,
+		ActionTaken:  rr.ActionTaken,
+		CreatedAt:    rr.CreatedAt,
+		UpdatedAt:    rr.UpdatedAt,
+	}
+}
+
+func NewRightsRequestEdge(rr *coredata.RightsRequest, orderField coredata.RightsRequestOrderField) *RightsRequestEdge {
+	return &RightsRequestEdge{
+		Node:   NewRightsRequest(rr),
+		Cursor: rr.CursorKey(orderField),
+	}
+}

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -464,6 +464,21 @@ type CreateProcessingActivityPayload struct {
 	ProcessingActivityEdge *ProcessingActivityEdge `json:"processingActivityEdge"`
 }
 
+type CreateRightsRequestInput struct {
+	OrganizationID gid.GID                     `json:"organizationId"`
+	RequestType    coredata.RightsRequestType  `json:"requestType"`
+	RequestState   coredata.RightsRequestState `json:"requestState"`
+	DataSubject    *string                     `json:"dataSubject,omitempty"`
+	Contact        *string                     `json:"contact,omitempty"`
+	Details        *string                     `json:"details,omitempty"`
+	Deadline       *time.Time                  `json:"deadline,omitempty"`
+	ActionTaken    *string                     `json:"actionTaken,omitempty"`
+}
+
+type CreateRightsRequestPayload struct {
+	RightsRequestEdge *RightsRequestEdge `json:"rightsRequestEdge"`
+}
+
 type CreateRiskDocumentMappingInput struct {
 	RiskID     gid.GID `json:"riskId"`
 	DocumentID gid.GID `json:"documentId"`
@@ -932,6 +947,14 @@ type DeleteProcessingActivityInput struct {
 
 type DeleteProcessingActivityPayload struct {
 	DeletedProcessingActivityID gid.GID `json:"deletedProcessingActivityId"`
+}
+
+type DeleteRightsRequestInput struct {
+	RightsRequestID gid.GID `json:"rightsRequestId"`
+}
+
+type DeleteRightsRequestPayload struct {
+	DeletedRightsRequestID gid.GID `json:"deletedRightsRequestId"`
 }
 
 type DeleteRiskDocumentMappingInput struct {
@@ -1515,6 +1538,7 @@ type Organization struct {
 	Nonconformities                 *NonconformityConnection                  `json:"nonconformities"`
 	Obligations                     *ObligationConnection                     `json:"obligations"`
 	ContinualImprovements           *ContinualImprovementConnection           `json:"continualImprovements"`
+	RightsRequests                  *RightsRequestConnection                  `json:"rightsRequests"`
 	ProcessingActivities            *ProcessingActivityConnection             `json:"processingActivities"`
 	DataProtectionImpactAssessments *DataProtectionImpactAssessmentConnection `json:"dataProtectionImpactAssessments"`
 	TransferImpactAssessments       *TransferImpactAssessmentConnection       `json:"transferImpactAssessments"`
@@ -1680,6 +1704,28 @@ type RequestSignatureInput struct {
 
 type RequestSignaturePayload struct {
 	DocumentVersionSignatureEdge *DocumentVersionSignatureEdge `json:"documentVersionSignatureEdge"`
+}
+
+type RightsRequest struct {
+	ID           gid.GID                     `json:"id"`
+	Organization *Organization               `json:"organization"`
+	RequestType  coredata.RightsRequestType  `json:"requestType"`
+	RequestState coredata.RightsRequestState `json:"requestState"`
+	DataSubject  *string                     `json:"dataSubject,omitempty"`
+	Contact      *string                     `json:"contact,omitempty"`
+	Details      *string                     `json:"details,omitempty"`
+	Deadline     *time.Time                  `json:"deadline,omitempty"`
+	ActionTaken  *string                     `json:"actionTaken,omitempty"`
+	CreatedAt    time.Time                   `json:"createdAt"`
+	UpdatedAt    time.Time                   `json:"updatedAt"`
+}
+
+func (RightsRequest) IsNode()             {}
+func (this RightsRequest) GetID() gid.GID { return this.ID }
+
+type RightsRequestEdge struct {
+	Cursor page.CursorKey `json:"cursor"`
+	Node   *RightsRequest `json:"node"`
 }
 
 type Risk struct {
@@ -2197,6 +2243,21 @@ type UpdateProcessingActivityInput struct {
 
 type UpdateProcessingActivityPayload struct {
 	ProcessingActivity *ProcessingActivity `json:"processingActivity"`
+}
+
+type UpdateRightsRequestInput struct {
+	ID           gid.GID                       `json:"id"`
+	RequestType  *coredata.RightsRequestType   `json:"requestType,omitempty"`
+	RequestState *coredata.RightsRequestState  `json:"requestState,omitempty"`
+	DataSubject  graphql.Omittable[*string]    `json:"dataSubject,omitempty"`
+	Contact      graphql.Omittable[*string]    `json:"contact,omitempty"`
+	Details      graphql.Omittable[*string]    `json:"details,omitempty"`
+	Deadline     graphql.Omittable[*time.Time] `json:"deadline,omitempty"`
+	ActionTaken  graphql.Omittable[*string]    `json:"actionTaken,omitempty"`
+}
+
+type UpdateRightsRequestPayload struct {
+	RightsRequest *RightsRequest `json:"rightsRequest"`
 }
 
 type UpdateRiskInput struct {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add “Rights Requests” to the Console so organizations can track and manage data subject rights (access, deletion, portability). Includes UI pages, GraphQL API, backend service, and a new database table.

- **New Features**
  - Console pages: list and details, plus a create dialog; sidebar entry gated by permissions.
  - CRUD: create, update, delete via Relay mutations with toasts and pagination.
  - Permissions: added listRightsRequests and createRightsRequest checks.
  - Helpers: labels/options for request types and states, badge variants.
  - API & DB: GraphQL enums/types/resolvers, service layer, and rights_requests table with enums.
  - Tests: e2e coverage for rights requests flows.

- **Migration**
  - Run migration 20251226T130238Z.sql to create rights_requests and enums.
  - Grant roles the listRightsRequests and createRightsRequest permissions to enable access.

<sup>Written for commit 9626e243706161d67eea479a83a71724cf2169c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

