### PR TITLE
Automatically initialize and clone submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Probo is designed to be accessible, transparent, and community-driven.
 1. Clone the repository:
 
    ```bash
-   git clone https://github.com/getprobo/probo.git
+   git clone --recurse-submodules https://github.com/getprobo/probo.git
    cd probo
    ```
 


### PR DESCRIPTION
Use --recurse-submodules option in initial git clone to let Git automatically initialize and clone any submodules that are part of the repository.

In that case: the submodule 'pkg/validator/data/disposable-email-domains' (https://github.com/disposable-email-domains/disposable-email-domains.git) 

This submodule was introduced 3 weeks ago in https://github.com/getprobo/probo/pull/593

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update README to use git clone --recurse-submodules so submodules are initialized automatically. This ensures pkg/validator/data/disposable-email-domains is cloned during setup.

<sup>Written for commit 16a0d90005357dfcdec0e02a894a901d7dbbfd6f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

