### PR TITLE
fix: addPeople tool call

### DIFF
--- a/pkg/server/api/mcp/v1/types/people.go
+++ b/pkg/server/api/mcp/v1/types/people.go
@@ -15,17 +15,22 @@ package types
 
 import (
 	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/mail"
 	"go.probo.inc/probo/pkg/page"
 )
 
 func NewPeople(p *coredata.People) *People {
+	additionalEmails := p.AdditionalEmailAddresses
+	if additionalEmails == nil {
+		additionalEmails = []mail.Addr{}
+	}
 	return &People{
 		FullName:                 p.FullName,
 		ID:                       p.ID,
 		OrganizationID:           p.OrganizationID,
 		Kind:                     p.Kind,
 		PrimaryEmailAddress:      p.PrimaryEmailAddress,
-		AdditionalEmailAddresses: p.AdditionalEmailAddresses,
+		AdditionalEmailAddresses: additionalEmails,
 		Position:                 p.Position,
 		ContractStartDate:        p.ContractStartDate,
 		ContractEndDate:          p.ContractEndDate,


### PR DESCRIPTION
fixes #631 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the addPeople tool call by ensuring AdditionalEmailAddresses defaults to an empty slice when missing. Prevents errors when iterating or encoding emails and keeps person creation stable.

<sup>Written for commit 31cc3694f6812f4a43e10af670f3d92dad721402. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

