### PR TITLE
Fix cancel signature

### DIFF
--- a/pkg/authz/permissions.go
+++ b/pkg/authz/permissions.go
@@ -563,7 +563,6 @@ var Permissions = map[uint16]map[Action][]Role{
 		ActionRequestSignature:            EditRoles,
 		ActionBulkRequestSignatures:       EditRoles,
 		ActionSendSigningNotifications:    EditRoles,
-		ActionCancelSignatureRequest:      EditRoles,
 	},
 	coredata.DocumentVersionEntityType: {
 		ActionSignDocument: AllRoles,
@@ -586,6 +585,8 @@ var Permissions = map[uint16]map[Action][]Role{
 		ActionGet:             NonEmployeeRoles,
 		ActionDocumentVersion: NonEmployeeRoles,
 		ActionSignedBy:        NonEmployeeRoles,
+
+		ActionCancelSignatureRequest: EditRoles,
 	},
 	coredata.RiskEntityType: {
 		ActionGet:             NonEmployeeRoles,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed the cancel signature action by assigning ActionCancelSignatureRequest to DocumentVersion permissions instead of Document. This restores the cancel button visibility for users with the correct permission.

<sup>Written for commit 8b71d11bfc3d6f2ece191f66d2ba9a8ecb280768. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

