### PR TITLE
S3 Storage Path Style Fix

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -135,6 +135,7 @@ $(echo "${SAML_PRIVATE_KEY:-}" | sed 's/^/        /')
     access-key-id: "${AWS_ACCESS_KEY_ID:-}"
     secret-access-key: "${AWS_SECRET_ACCESS_KEY:-}"
     endpoint: "${AWS_ENDPOINT:-}"
+    use-path-style: ${AWS_USE_PATH_STYLE:-false}
 
   notifications:
     mailer:


### PR DESCRIPTION
AWS_USE_PATH_STYLE for docker had a code missing in entrypoint.sh which If not provided doesn't let us use minio or any other Storage with Probo Docker

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added AWS_USE_PATH_STYLE support in entrypoint.sh to set use-path-style for S3 storage. This enables path-style access needed for MinIO and other S3-compatible storage in Docker.

<sup>Written for commit aa19b59f99dd45386cc38d184aad3035f29ec9ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

