### PR TITLE
Fix slack connection empty case

### DIFF
--- a/apps/console/src/pages/organizations/compliance-page/overview/_components/CompliancePageSlackSection.tsx
+++ b/apps/console/src/pages/organizations/compliance-page/overview/_components/CompliancePageSlackSection.tsx
@@ -44,46 +44,49 @@ export function CompliancePageSlackSection(props: { fragmentRef: CompliancePageS
               className="flex items-center gap-3"
             >
               <div>
-                <img src={`/${slackConnection.id.toLowerCase()}.png`} alt="" />
+                <img src="/slack.png" alt="" />
               </div>
               <div className="mr-auto">
                 <h3 className="text-base font-semibold">Slack</h3>
                 <p className="text-sm text-txt-tertiary">
-                  {slackConnection.createdAt
-                    ? (
-                        <>
-                          {sprintf(
-                            __("Connected on %s"),
-                            dateTimeFormat(slackConnection.createdAt),
-                          )}
-                          {slackConnection.channel && (
-                            <>
-                              {" • "}
-                              {sprintf(__("Channel: %s"), slackConnection.channel)}
-                            </>
-                          )}
-                        </>
-                      )
-                    : __("Manage your compliance page access with slack")}
+                  {sprintf(
+                    __("Connected on %s"),
+                    dateTimeFormat(slackConnection.createdAt),
+                  )}
+                  {slackConnection.channel && (
+                    <>
+                      {" • "}
+                      {sprintf(__("Channel: %s"), slackConnection.channel)}
+                    </>
+                  )}
                 </p>
               </div>
-              {slackConnection.createdAt
-                ? (
-                    <div>
-                      <Badge variant="success" size="md">
-                        {__("Connected")}
-                      </Badge>
-                    </div>
-                  )
-                : (
-                    organization.compliancePage?.canUpdate && (
-                      <Button variant="secondary" asChild>
-                        <a href={getSlackConnectionUrl(organizationId)}>{__("Connect")}</a>
-                      </Button>
-                    )
-                  )}
+              <div>
+                <Badge variant="success" size="md">
+                  {__("Connected")}
+                </Badge>
+              </div>
             </Card>
           ))}
+          {organization.compliancePage?.canUpdate && organization.slackConnections.edges.length === 0 && (
+            <Card
+              padded
+              className="flex items-center gap-3"
+            >
+              <div>
+                <img src="/slack.png" alt="" />
+              </div>
+              <div className="mr-auto">
+                <h3 className="text-base font-semibold">Slack</h3>
+                <p className="text-sm text-txt-tertiary">
+                  {__("Manage your compliance page access with slack")}
+                </p>
+              </div>
+              <Button variant="secondary" asChild>
+                <a href={getSlackConnectionUrl(organizationId)}>{__("Connect")}</a>
+              </Button>
+            </Card>
+          )}
         </div>
       </Card>
     </div>


### PR DESCRIPTION
Fixes ENG-95

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ENG-95: Corrects the Slack connection empty state on the compliance page. When no Slack connections exist, show a Connect card (if the user can update); existing connections always show a Connected badge.

- **Bug Fixes**
  - Display the Connect button only when the org has zero Slack connections and can update.
  - Remove the per-connection Connect button; always show Connected for existing connections.

<sup>Written for commit 7f71124b5ad7554199d68b4de07ebb463b9485db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

