### PR TITLE
Fix missing cache statichandler

### DIFF
--- a/pkg/server/statichandler/statichandler.go
+++ b/pkg/server/statichandler/statichandler.go
@@ -183,6 +183,13 @@ func (s *Server) ServeSPA(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "public, max-age=3600")
 	}
 
+	if matchETag := r.Header.Get("If-None-Match"); matchETag != "" {
+		if matchETag == quotedETag {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+	}
+
 	http.FileServer(s.spaFS).ServeHTTP(w, r)
 }
 


### PR DESCRIPTION
ENG-97



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes caching in the SPA static handler by quoting ETag values and reordering header logic. Ensures proper 304 responses and consistent Cache-Control headers; removes deprecated headers.

- **Bug Fixes**
  - Quote ETag and compare against If-None-Match; return 304 when it matches.
  - Set Cache-Control for assets before the ETag check so 304 responses include it.
  - Remove deprecated Pragma and Expires on the index; rely on Cache-Control.

<sup>Written for commit 0fb2d3c6c92927f0b75c8b93b2aa4361e284b082. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



