### PR TITLE
Styles

### DIFF
--- a/e2e/internal/testutil/client.go
+++ b/e2e/internal/testutil/client.go
@@ -30,7 +30,7 @@ import (
 
 func generateUniqueID() string {
 	randomBytes := make([]byte, 4)
-	rand.Read(randomBytes)
+	_, _ = rand.Read(randomBytes)
 	return fmt.Sprintf("%d-%s", time.Now().UnixNano(), hex.EncodeToString(randomBytes))
 }
 

--- a/e2e/internal/testutil/graphql.go
+++ b/e2e/internal/testutil/graphql.go
@@ -89,7 +89,7 @@ func (c *Client) doWithEndpoint(endpoint string, query string, variables map[str
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -260,7 +260,7 @@ func (c *Client) executeMultipart(query string, variables map[string]any, files 
 	if err != nil {
 		return fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/e2e/internal/testutil/testutil.go
+++ b/e2e/internal/testutil/testutil.go
@@ -97,7 +97,7 @@ func Setup() {
 		defer cancel()
 		if err := waitForServer(ctx, testEnv.BaseURL, 30*time.Second); err != nil {
 			fmt.Fprintf(os.Stderr, "e2etest: server failed to start: %v\n", err)
-			testEnv.cmd.Process.Kill()
+			_ = testEnv.cmd.Process.Kill()
 			os.Exit(1)
 		}
 	})
@@ -121,7 +121,7 @@ func waitForServer(ctx context.Context, baseURL string, timeout time.Duration) e
 
 		resp, err := client.Do(req)
 		if err == nil {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			// Any response means server is up
 			return nil
 		}
@@ -138,12 +138,12 @@ func Teardown() {
 	}
 
 	if testEnv.cmd != nil && testEnv.cmd.Process != nil {
-		testEnv.cmd.Process.Signal(syscall.SIGTERM)
+		_ = testEnv.cmd.Process.Signal(syscall.SIGTERM)
 
 		select {
 		case <-testEnv.done:
 		case <-time.After(10 * time.Second):
-			testEnv.cmd.Process.Kill()
+			_ = testEnv.cmd.Process.Kill()
 			<-testEnv.done
 		}
 	}

--- a/pkg/certmanager/acme_challenge_handler.go
+++ b/pkg/certmanager/acme_challenge_handler.go
@@ -71,7 +71,7 @@ func (h *ACMEChallengeHandler) Handle(next http.Handler) http.Handler {
 
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(keyAuth))
+		_, _ = w.Write([]byte(keyAuth))
 	})
 }
 

--- a/pkg/connector/oauth2.go
+++ b/pkg/connector/oauth2.go
@@ -209,7 +209,7 @@ func (c *OAuth2Connector) CompleteWithState(ctx context.Context, r *http.Request
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot post token URL: %w", err)
 	}
-	defer tokenResp.Body.Close()
+	defer func() { _ = tokenResp.Body.Close() }()
 
 	if tokenResp.StatusCode != http.StatusOK {
 		return nil, nil, fmt.Errorf("token response status: %d", tokenResp.StatusCode)

--- a/pkg/connector/slack.go
+++ b/pkg/connector/slack.go
@@ -73,11 +73,11 @@ func (c SlackConnection) MarshalJSON() ([]byte, error) {
 		WebhookURL   string    `json:"webhook_url,omitempty"`
 	}{
 		Type:         string(ProtocolOAuth2),
-		AccessToken:  c.OAuth2Connection.AccessToken,
-		RefreshToken: c.OAuth2Connection.RefreshToken,
-		ExpiresAt:    c.OAuth2Connection.ExpiresAt,
-		TokenType:    c.OAuth2Connection.TokenType,
-		Scope:        c.OAuth2Connection.Scope,
+		AccessToken:  c.AccessToken,
+		RefreshToken: c.RefreshToken,
+		ExpiresAt:    c.ExpiresAt,
+		TokenType:    c.TokenType,
+		Scope:        c.Scope,
 		WebhookURL:   c.Settings.WebhookURL,
 	})
 }

--- a/pkg/docgen/generator.go
+++ b/pkg/docgen/generator.go
@@ -29,11 +29,6 @@ import (
 	"go.probo.inc/probo/pkg/coredata"
 )
 
-const (
-	firstPageTOCItems = 21
-	otherPageTOCItems = 28
-)
-
 var (
 	//go:embed template.html
 	htmlTemplateContent string

--- a/pkg/filemanager/service.go
+++ b/pkg/filemanager/service.go
@@ -51,7 +51,7 @@ func (s *Service) GetFileBase64(
 	if err != nil {
 		return "", "", fmt.Errorf("cannot get file from S3: %w", err)
 	}
-	defer result.Body.Close()
+	defer func() { _ = result.Body.Close() }()
 
 	fileData, err := io.ReadAll(result.Body)
 	if err != nil {

--- a/pkg/iam/auth_service.go
+++ b/pkg/iam/auth_service.go
@@ -499,7 +499,7 @@ func (s AuthService) OpenSessionWithPassword(ctx context.Context, email mail.Add
 			// Perform a password comparison even when the identity does not exist to mitigate timing attacks
 			// and prevent revealing account existence.
 			if identity.ID == gid.Nil {
-				s.hp.ComparePasswordAndHash([]byte(password+"qwertyuiop1234567890"), []byte("qwertyuiop1234567890"))
+				_, _ = s.hp.ComparePasswordAndHash([]byte(password+"qwertyuiop1234567890"), []byte("qwertyuiop1234567890"))
 				return NewInvalidCredentialsError("invalid email or password")
 			}
 

--- a/pkg/iam/saml/attributes.go
+++ b/pkg/iam/saml/attributes.go
@@ -111,44 +111,6 @@ func extractAttributeValue(assertion *saml.Assertion, attributeName string) (str
 	return "", fmt.Errorf("attribute %q not found in assertion", attributeName)
 }
 
-func extractEmailFromAssertion(assertion *saml.Assertion) (string, error) {
-	commonEmailAttributes := []string{
-		"email",
-		"Email",
-		"emailAddress",
-		"mail",
-		"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
-		"http://schemas.xmlsoap.org/claims/EmailAddress",
-	}
-
-	for _, attrName := range commonEmailAttributes {
-		email, err := extractAttributeValue(assertion, attrName)
-		if err == nil && email != "" {
-			return email, nil
-		}
-	}
-
-	if assertion.Subject != nil && assertion.Subject.NameID != nil && assertion.Subject.NameID.Value != "" {
-		return assertion.Subject.NameID.Value, nil
-	}
-
-	return "", fmt.Errorf("could not extract email from assertion")
-}
-
-func extractEmailDomain(email string) (string, error) {
-	parts := strings.Split(email, "@")
-	if len(parts) != 2 {
-		return "", fmt.Errorf("invalid email address: %s", email)
-	}
-
-	domain := strings.ToLower(strings.TrimSpace(parts[1]))
-	if domain == "" {
-		return "", fmt.Errorf("empty domain in email address: %s", email)
-	}
-
-	return domain, nil
-}
-
 func mapSAMLRoleToSystemRole(samlRole string) *coredata.MembershipRole {
 	if samlRole != "" && isValidRole(samlRole) {
 		role := coredata.MembershipRole(samlRole)

--- a/pkg/iam/scim/bridge/client/client.go
+++ b/pkg/iam/scim/bridge/client/client.go
@@ -97,7 +97,7 @@ func (c *Client) listUsersPage(ctx context.Context, startIndex, count int) (User
 	if err != nil {
 		return nil, 0, fmt.Errorf("cannot fetch users: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -150,7 +150,7 @@ func (c *Client) CreateUser(ctx context.Context, user *User) error {
 	if err != nil {
 		return fmt.Errorf("cannot create user: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
@@ -198,7 +198,7 @@ func (c *Client) UpdateUser(ctx context.Context, userID string, user *User) erro
 	if err != nil {
 		return fmt.Errorf("cannot update user: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
@@ -238,7 +238,7 @@ func (c *Client) DeactivateUser(ctx context.Context, userID string) error {
 	if err != nil {
 		return fmt.Errorf("cannot deactivate user: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		respBody, _ := io.ReadAll(resp.Body)

--- a/pkg/mailer/mailer.go
+++ b/pkg/mailer/mailer.go
@@ -92,13 +92,13 @@ func (m *Mailer) sendMailWithTimeout(ctx context.Context, to []string, msg []byt
 	if err != nil {
 		return fmt.Errorf("connection error: %w", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	c, err := smtp.NewClient(conn, host)
 	if err != nil {
 		return fmt.Errorf("SMTP client creation error: %w", err)
 	}
-	defer c.Quit()
+	defer func() { _ = c.Quit() }()
 
 	if m.cfg.TLSRequired {
 		if err := c.StartTLS(&tls.Config{ServerName: host}); err != nil {

--- a/pkg/probo/document_service.go
+++ b/pkg/probo/document_service.go
@@ -1541,8 +1541,8 @@ func (s *DocumentService) BuildAndUploadExport(ctx context.Context, exportJobID 
 			if err != nil {
 				return fmt.Errorf("cannot create temp file: %w", err)
 			}
-			defer tempFile.Close()
-			defer os.Remove(tempFile.Name())
+			defer func() { _ = tempFile.Close() }()
+			defer func() { _ = os.Remove(tempFile.Name()) }()
 
 			exportArgs, err := exportJob.GetDocumentExportArguments()
 			if err != nil {

--- a/pkg/probo/trust_center_file_service.go
+++ b/pkg/probo/trust_center_file_service.go
@@ -412,7 +412,7 @@ func (s TrustCenterFileService) cleanupS3Object(ctx context.Context, s3Key strin
 		return
 	}
 
-	s.svc.s3.DeleteObject(ctx, &s3.DeleteObjectInput{
+	_, _ = s.svc.s3.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: aws.String(s.svc.bucket),
 		Key:    aws.String(s3Key),
 	})

--- a/pkg/probo/trust_center_reference_service.go
+++ b/pkg/probo/trust_center_reference_service.go
@@ -432,7 +432,7 @@ func (s TrustCenterReferenceService) cleanupS3Object(ctx context.Context, s3Key 
 		return
 	}
 
-	s.svc.s3.DeleteObject(ctx, &s3.DeleteObjectInput{
+	_, _ = s.svc.s3.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: aws.String(s.svc.bucket),
 		Key:    aws.String(s3Key),
 	})

--- a/pkg/probod/auth_config.go
+++ b/pkg/probod/auth_config.go
@@ -30,17 +30,6 @@ type (
 		SAML                                samlConfig     `json:"saml"`
 	}
 
-	trustAuthConfig struct {
-		CookieName        string `json:"cookie-name"`
-		CookieDomain      string `json:"cookie-domain"`
-		CookieDuration    int    `json:"cookie-duration"`
-		TokenDuration     int    `json:"token-duration"`
-		ReportURLDuration int    `json:"report-url-duration"`
-		TokenSecret       string `json:"token-secret"`
-		Scope             string `json:"scope"`
-		TokenType         string `json:"token-type"`
-	}
-
 	cookieConfig struct {
 		Domain   string `json:"domain"`
 		Secret   string `json:"secret"`
@@ -91,23 +80,4 @@ func (c authConfig) GetCookieSecretBytes() ([]byte, error) {
 	}
 
 	return []byte(c.Cookie.Secret), nil
-}
-
-func (c trustAuthConfig) GetTokenSecretBytes() ([]byte, error) {
-	if c.TokenSecret == "" {
-		return nil, fmt.Errorf("token secret cannot be empty")
-	}
-
-	if decoded, err := base64.StdEncoding.DecodeString(c.TokenSecret); err == nil {
-		if len(decoded) < 32 {
-			return nil, fmt.Errorf("decoded token secret must be at least 32 bytes long")
-		}
-		return decoded, nil
-	}
-
-	if len(c.TokenSecret) < 32 {
-		return nil, fmt.Errorf("token secret must be at least 32 bytes long")
-	}
-
-	return []byte(c.TokenSecret), nil
 }

--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -573,7 +573,7 @@ func (impl *Implm) runApiServer(
 
 		l.Info("using proxy protocol", log.Any("trusted-proxies", impl.cfg.Api.ProxyProtocol.TrustedProxies))
 	}
-	defer listener.Close()
+	defer func() { _ = listener.Close() }()
 
 	serverErrCh := make(chan error, 1)
 	go func() {
@@ -725,7 +725,7 @@ func (impl *Implm) runTrustCenterServer(
 			if err != nil {
 				return fmt.Errorf("cannot listen on %q: %w", httpServer.Addr, err)
 			}
-			defer listener.Close()
+			defer func() { _ = listener.Close() }()
 
 			if len(impl.cfg.TrustCenter.ProxyProtocol.TrustedProxies) > 0 {
 				policy := proxyproto.TrustProxyHeaderFrom(impl.cfg.TrustCenter.ProxyProtocol.TrustedProxies...)
@@ -807,7 +807,7 @@ func (impl *Implm) runTrustCenterServer(
 			if err != nil {
 				return fmt.Errorf("cannot listen on %q: %w", httpsServer.Addr, err)
 			}
-			defer listener.Close()
+			defer func() { _ = listener.Close() }()
 
 			if len(impl.cfg.TrustCenter.ProxyProtocol.TrustedProxies) > 0 {
 				policy := proxyproto.TrustProxyHeaderFrom(impl.cfg.TrustCenter.ProxyProtocol.TrustedProxies...)

--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -75,7 +75,7 @@ var (
 )
 
 func methodNotAllowed(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	httpserver.RenderJSON(
 		w,
@@ -87,7 +87,7 @@ func methodNotAllowed(w http.ResponseWriter, r *http.Request) {
 }
 
 func notFound(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
+	defer func() { _ = r.Body.Close() }()
 
 	httpserver.RenderJSON(
 		w,

--- a/pkg/server/api/console/v1/types/datum.go
+++ b/pkg/server/api/console/v1/types/datum.go
@@ -35,8 +35,8 @@ type Datum struct {
 	UpdatedAt          time.Time                   `json:"updatedAt"`
 }
 
-func (Datum) IsNode()             {}
-func (this Datum) GetID() gid.GID { return this.ID }
+func (Datum) IsNode()          {}
+func (d Datum) GetID() gid.GID { return d.ID }
 
 type (
 	DatumOrderBy OrderBy[coredata.DatumOrderField]

--- a/pkg/server/api/console/v1/types/signable_document.go
+++ b/pkg/server/api/console/v1/types/signable_document.go
@@ -44,8 +44,8 @@ type (
 	}
 )
 
-func (SignableDocument) IsNode()             {}
-func (this SignableDocument) GetID() gid.GID { return this.ID }
+func (SignableDocument) IsNode()          {}
+func (d SignableDocument) GetID() gid.GID { return d.ID }
 
 func NewSignableDocumentConnection(
 	p *page.Page[*SignableDocument, coredata.DocumentOrderField],

--- a/pkg/server/api/console/v1/v1_resolver.go
+++ b/pkg/server/api/console/v1/v1_resolver.go
@@ -2612,7 +2612,7 @@ func (r *mutationResolver) ExportFramework(ctx context.Context, input types.Expo
 	prb := r.ProboService(ctx, input.FrameworkID.TenantID())
 	identity := authn.IdentityFromContext(ctx)
 
-	exportErr, exportJobID := prb.Frameworks.RequestExport(
+	exportJob, exportErr := prb.Frameworks.RequestExport(
 		ctx,
 		input.FrameworkID,
 		identity.EmailAddress,
@@ -2624,7 +2624,7 @@ func (r *mutationResolver) ExportFramework(ctx context.Context, input types.Expo
 	}
 
 	return &types.ExportFrameworkPayload{
-		ExportJobID: exportJobID.ID,
+		ExportJobID: exportJob.ID,
 	}, nil
 }
 

--- a/pkg/server/gqlutils/directives/session/session.go
+++ b/pkg/server/gqlutils/directives/session/session.go
@@ -66,7 +66,7 @@ func (e *SessionRequirement) UnmarshalGQL(v any) error {
 }
 
 func (e SessionRequirement) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
+	_, _ = fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
 func (e *SessionRequirement) UnmarshalJSON(b []byte) error {

--- a/pkg/server/gqlutils/types/bigint/bigint.go
+++ b/pkg/server/gqlutils/types/bigint/bigint.go
@@ -26,7 +26,7 @@ type BigIntScalar = int64
 
 func MarshalBigIntScalar(i int64) graphql.Marshaler {
 	return graphql.WriterFunc(func(w io.Writer) {
-		w.Write([]byte(strconv.FormatInt(i, 10)))
+		_, _ = w.Write([]byte(strconv.FormatInt(i, 10)))
 	})
 }
 

--- a/pkg/server/gqlutils/types/gid/gid.go
+++ b/pkg/server/gqlutils/types/gid/gid.go
@@ -26,9 +26,11 @@ import (
 type GIDScalar = gid.GID
 
 func MarshalGIDScalar(id gid.GID) graphql.Marshaler {
-	return graphql.WriterFunc(func(w io.Writer) {
-		w.Write([]byte(strconv.Quote(id.String())))
-	})
+	return graphql.WriterFunc(
+		func(w io.Writer) {
+			_, _ = w.Write([]byte(strconv.Quote(id.String())))
+		},
+	)
 }
 
 func UnmarshalGIDScalar(v interface{}) (gid.GID, error) {

--- a/pkg/server/gqlutils/types/mail/addr.go
+++ b/pkg/server/gqlutils/types/mail/addr.go
@@ -26,9 +26,11 @@ import (
 type AddrScalar = mail.Addr
 
 func MarshalAddrScalar(a mail.Addr) graphql.Marshaler {
-	return graphql.WriterFunc(func(w io.Writer) {
-		w.Write([]byte(strconv.Quote(a.String())))
-	})
+	return graphql.WriterFunc(
+		func(w io.Writer) {
+			_, _ = w.Write([]byte(strconv.Quote(a.String())))
+		},
+	)
 }
 
 func UnmarshalAddrScalar(v interface{}) (mail.Addr, error) {

--- a/pkg/server/statichandler/statichandler.go
+++ b/pkg/server/statichandler/statichandler.go
@@ -77,7 +77,7 @@ func NewServer(staticFiles fs.FS, distPath string, gzipOptions GzipOptions) (*Se
 			if err != nil {
 				return err
 			}
-			defer file.Close()
+			defer func() { _ = file.Close() }()
 
 			_, err = file.Read(content)
 			if err != nil {
@@ -136,11 +136,11 @@ func (s *Server) ServeSPA(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 
 		w.WriteHeader(http.StatusOK)
-		w.Write(s.indexContent)
+		_, _ = w.Write(s.indexContent)
 		return
 	}
 
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	info, err := f.Stat()
 	if err != nil {
@@ -162,7 +162,7 @@ func (s *Server) ServeSPA(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Expires", "0")
 
 		w.WriteHeader(http.StatusOK)
-		w.Write(s.indexContent)
+		_, _ = w.Write(s.indexContent)
 		return
 	}
 
@@ -225,7 +225,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.shouldCompressWithGzip(r) {
 		w.Header().Set("Content-Encoding", "gzip")
 		gz := gzip.NewWriter(w)
-		defer gz.Close()
+		defer func() { _ = gz.Close() }()
 
 		gzw := gzipResponseWriter{Writer: gz, ResponseWriter: w}
 		s.ServeSPA(gzw, r)

--- a/pkg/slack/client.go
+++ b/pkg/slack/client.go
@@ -87,7 +87,7 @@ func (c *Client) CreateMessage(ctx context.Context, accessToken string, channelI
 	if err != nil {
 		return nil, fmt.Errorf("cannot send request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -105,7 +105,7 @@ func (c *Client) CreateMessage(ctx context.Context, accessToken string, channelI
 	}
 
 	if !slackResponse.OK {
-		return nil, fmt.Errorf("Slack API error: %s (channel: %s, response: %s)", slackResponse.Error, channelID, string(responseBody))
+		return nil, fmt.Errorf("slack API error: %s (channel: %s, response: %s)", slackResponse.Error, channelID, string(responseBody))
 	}
 
 	return &slackResponse, nil
@@ -138,7 +138,7 @@ func (c *Client) UpdateInteractiveMessage(ctx context.Context, responseURL strin
 	if err != nil {
 		return fmt.Errorf("cannot send interactive message update request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -161,7 +161,7 @@ func (c *Client) UpdateInteractiveMessage(ctx context.Context, responseURL strin
 			return nil
 		}
 		if slackResponse.Error != "" {
-			return fmt.Errorf("Slack error: %s", slackResponse.Error)
+			return fmt.Errorf("slack error: %s", slackResponse.Error)
 		}
 	}
 
@@ -193,7 +193,7 @@ func (c *Client) UpdateMessage(ctx context.Context, accessToken string, channelI
 	if err != nil {
 		return fmt.Errorf("cannot send request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -210,7 +210,7 @@ func (c *Client) UpdateMessage(ctx context.Context, accessToken string, channelI
 	}
 
 	if !slackResponse.OK {
-		return fmt.Errorf("Slack API error: %s", slackResponse.Error)
+		return fmt.Errorf("slack API error: %s", slackResponse.Error)
 	}
 
 	return nil
@@ -238,7 +238,7 @@ func (c *Client) JoinChannel(ctx context.Context, accessToken string, channelID 
 	if err != nil {
 		return fmt.Errorf("cannot send request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -264,7 +264,7 @@ func (c *Client) JoinChannel(ctx context.Context, accessToken string, channelID 
 			return fmt.Errorf("cannot join private channel - bot must be invited manually")
 		}
 
-		return fmt.Errorf("Slack API error: %s", slackResponse.Error)
+		return fmt.Errorf("slack API error: %s", slackResponse.Error)
 	}
 
 	return nil

--- a/pkg/soagen/generator.go
+++ b/pkg/soagen/generator.go
@@ -23,7 +23,7 @@ import (
 
 func GenerateSOAExcel(data SOAData) ([]byte, error) {
 	f := excelize.NewFile()
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	sheetName := "State of Applicability"
 	_, err := f.NewSheet(sheetName)
@@ -155,8 +155,8 @@ func applySOAAutoFilter(f *excelize.File, sheetName string, filterColumns []stri
 func applySOAFinalFormatting(f *excelize.File, sheetName string, dataRowCount int) error {
 	if dataRowCount > 0 {
 		headerRowHeight := 30.0
-		f.SetRowHeight(sheetName, 6, headerRowHeight)
-		f.SetRowHeight(sheetName, 7, headerRowHeight)
+		_ = f.SetRowHeight(sheetName, 6, headerRowHeight)
+		_ = f.SetRowHeight(sheetName, 7, headerRowHeight)
 
 		return f.SetPanes(sheetName, &excelize.Panes{
 			Freeze:      true,
@@ -296,8 +296,8 @@ func writeSingleColumnField(f *excelize.File, sheetName string, row int, excelVa
 	col := colDef.Columns[0]
 	cellRef := fmt.Sprintf("%s%d", col, row)
 
-	f.SetCellValue(sheetName, cellRef, excelValue.Value)
-	f.SetCellStyle(sheetName, cellRef, cellRef, styleID)
+	_ = f.SetCellValue(sheetName, cellRef, excelValue.Value)
+	_ = f.SetCellStyle(sheetName, cellRef, cellRef, styleID)
 
 	if isFirstRow {
 		if err := applyDataValidation(f, sheetName, col, row, excelValue.Validation); err != nil {

--- a/pkg/soagen/styles.go
+++ b/pkg/soagen/styles.go
@@ -76,7 +76,7 @@ func applyDataValidation(f *excelize.File, sheetName, col string, row int, valid
 
 	dv := excelize.NewDataValidation(true)
 	dv.Sqref = fmt.Sprintf("%s%d:%s1000", col, row, col) // Apply to reasonable range
-	dv.SetDropList(validation)
+	_ = dv.SetDropList(validation)
 	dv.SetError(excelize.DataValidationErrorStyleStop, "Invalid Input", "Please select from the dropdown list.")
 	if err := f.AddDataValidation(sheetName, dv); err != nil {
 		return fmt.Errorf("cannot add data validation: %w", err)

--- a/pkg/trust/report_service.go
+++ b/pkg/trust/report_service.go
@@ -127,7 +127,7 @@ func (s ReportService) exportPDFData(
 	if err != nil {
 		return nil, fmt.Errorf("cannot download PDF from S3: %w", err)
 	}
-	defer result.Body.Close()
+	defer func() { _ = result.Body.Close() }()
 
 	pdfData, err := io.ReadAll(result.Body)
 	if err != nil {

--- a/pkg/trust/service.go
+++ b/pkg/trust/service.go
@@ -40,7 +40,6 @@ type (
 		bucket             string
 		proboSvc           *probo.Service
 		encryptionKey      cipher.EncryptionKey
-		tokenSecret        string
 		slackSigningSecret string
 		baseURL            string
 		iam                *iam.Service

--- a/pkg/trust/trust_center_file_service.go
+++ b/pkg/trust/trust_center_file_service.go
@@ -141,7 +141,7 @@ func (s *TrustCenterFileService) exportFileData(
 	if err != nil {
 		return nil, fmt.Errorf("cannot download file from S3: %w", err)
 	}
-	defer result.Body.Close()
+	defer func() { _ = result.Body.Close() }()
 
 	fileData, err := io.ReadAll(result.Body)
 	if err != nil {

--- a/pkg/validator/validation_test.go
+++ b/pkg/validator/validation_test.go
@@ -153,7 +153,7 @@ func TestValidationErrors_Methods(t *testing.T) {
 	t.Run("First", func(t *testing.T) {
 		first := errors.First()
 		if first == nil {
-			t.Error("expected first error")
+			t.Fatal("expected first error")
 		}
 		if first.Field != "email" {
 			t.Errorf("expected first field to be 'email', got '%s'", first.Field)

--- a/pkg/validator/validator_collection_test.go
+++ b/pkg/validator/validator_collection_test.go
@@ -39,7 +39,7 @@ func TestMinItems(t *testing.T) {
 		items := []string{"a"}
 		err := MinItems(2)(&items)
 		if err == nil {
-			t.Error("expected validation error")
+			t.Fatal("expected validation error")
 		}
 		if err.Code != ErrorCodeOutOfRange {
 			t.Errorf("expected error code %s, got %s", ErrorCodeOutOfRange, err.Code)
@@ -84,7 +84,7 @@ func TestMaxItems(t *testing.T) {
 		items := []string{"a", "b", "c", "d"}
 		err := MaxItems(2)(&items)
 		if err == nil {
-			t.Error("expected validation error")
+			t.Fatal("expected validation error")
 		}
 		if err.Code != ErrorCodeOutOfRange {
 			t.Errorf("expected error code %s, got %s", ErrorCodeOutOfRange, err.Code)
@@ -113,7 +113,7 @@ func TestUniqueItems(t *testing.T) {
 		items := []string{"a", "b", "a"}
 		err := UniqueItems()(&items)
 		if err == nil {
-			t.Error("expected validation error")
+			t.Fatal("expected validation error")
 		}
 		if err.Code != ErrorCodeInvalidFormat {
 			t.Errorf("expected error code %s, got %s", ErrorCodeInvalidFormat, err.Code)
@@ -156,7 +156,7 @@ func TestUniqueItems(t *testing.T) {
 		items := [][]int{{1, 2}, {3, 4}}
 		err := UniqueItems()(&items)
 		if err == nil {
-			t.Error("expected validation error for non-comparable type")
+			t.Fatal("expected validation error for non-comparable type")
 		}
 		if err.Code != ErrorCodeInvalidFormat {
 			t.Errorf("expected error code %s, got %s", ErrorCodeInvalidFormat, err.Code)
@@ -170,7 +170,7 @@ func TestUniqueItems(t *testing.T) {
 		items := []map[string]int{{"a": 1}, {"b": 2}}
 		err := UniqueItems()(&items)
 		if err == nil {
-			t.Error("expected validation error for non-comparable type")
+			t.Fatal("expected validation error for non-comparable type")
 		}
 		if err.Code != ErrorCodeInvalidFormat {
 			t.Errorf("expected error code %s, got %s", ErrorCodeInvalidFormat, err.Code)
@@ -184,7 +184,7 @@ func TestUniqueItems(t *testing.T) {
 		items := []NonComparable{{Items: []int{1, 2}}, {Items: []int{3, 4}}}
 		err := UniqueItems()(&items)
 		if err == nil {
-			t.Error("expected validation error for non-comparable type")
+			t.Fatal("expected validation error for non-comparable type")
 		}
 		if err.Code != ErrorCodeInvalidFormat {
 			t.Errorf("expected error code %s, got %s", ErrorCodeInvalidFormat, err.Code)
@@ -211,7 +211,7 @@ func TestUniqueItems(t *testing.T) {
 		items := []ComparableStruct{{ID: 1, Name: "a"}, {ID: 2, Name: "b"}, {ID: 1, Name: "a"}}
 		err := UniqueItems()(&items)
 		if err == nil {
-			t.Error("expected validation error for duplicate comparable structs")
+			t.Fatal("expected validation error for duplicate comparable structs")
 		}
 		if err.Code != ErrorCodeInvalidFormat {
 			t.Errorf("expected error code %s, got %s", ErrorCodeInvalidFormat, err.Code)

--- a/pkg/validator/validator_common_test.go
+++ b/pkg/validator/validator_common_test.go
@@ -102,7 +102,7 @@ func TestRequired(t *testing.T) {
 		str := ""
 		err := Required()(&str)
 		if err == nil {
-			t.Error("expected validation error")
+			t.Fatal("expected validation error")
 		}
 		if err.Code != ErrorCodeRequired {
 			t.Errorf("expected error code %s, got %s", ErrorCodeRequired, err.Code)
@@ -192,7 +192,7 @@ func TestRequired(t *testing.T) {
 		slice := []string{}
 		err := Required()(slice)
 		if err == nil {
-			t.Error("expected validation error for empty []string slice")
+			t.Fatal("expected validation error for empty []string slice")
 		}
 		if err.Code != ErrorCodeRequired {
 			t.Errorf("expected error code %s, got %s", ErrorCodeRequired, err.Code)
@@ -211,7 +211,7 @@ func TestRequired(t *testing.T) {
 		slice := []int{}
 		err := Required()(slice)
 		if err == nil {
-			t.Error("expected validation error for empty []int slice")
+			t.Fatal("expected validation error for empty []int slice")
 		}
 		if err.Code != ErrorCodeRequired {
 			t.Errorf("expected error code %s, got %s", ErrorCodeRequired, err.Code)
@@ -233,7 +233,7 @@ func TestRequired(t *testing.T) {
 		slice := []CustomType{}
 		err := Required()(slice)
 		if err == nil {
-			t.Error("expected validation error for empty custom type slice")
+			t.Fatal("expected validation error for empty custom type slice")
 		}
 		if err.Code != ErrorCodeRequired {
 			t.Errorf("expected error code %s, got %s", ErrorCodeRequired, err.Code)

--- a/pkg/validator/validator_format_test.go
+++ b/pkg/validator/validator_format_test.go
@@ -80,7 +80,7 @@ func TestHTTPUrl(t *testing.T) {
 		str := "https://example.com"
 		err := HTTPUrl()(&str)
 		if err == nil {
-			t.Error("expected validation error for https")
+			t.Fatal("expected validation error for https")
 		}
 		if err.Message != "URL must use http scheme" {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -149,7 +149,7 @@ func TestHTTPSUrl(t *testing.T) {
 		str := "http://example.com"
 		err := HTTPSUrl()(&str)
 		if err == nil {
-			t.Error("expected validation error for http")
+			t.Fatal("expected validation error for http")
 		}
 		if err.Message != "URL must use https scheme" {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -282,7 +282,7 @@ func TestDomain(t *testing.T) {
 		str := strings.Repeat("a", 254)
 		err := Domain()(&str)
 		if err == nil {
-			t.Error("expected validation error for domain too long")
+			t.Fatal("expected validation error for domain too long")
 		}
 		if err.Message != "domain name too long (max 253 characters)" {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -335,7 +335,7 @@ func TestGID(t *testing.T) {
 	t.Run("invalid - wrong entity type", func(t *testing.T) {
 		err := GID(200)(validGID)
 		if err == nil {
-			t.Error("expected validation error for wrong entity type")
+			t.Fatal("expected validation error for wrong entity type")
 		}
 		if err.Code != ErrorCodeInvalidGID {
 			t.Errorf("expected error code %s, got %s", ErrorCodeInvalidGID, err.Code)
@@ -384,7 +384,7 @@ func TestGID(t *testing.T) {
 	t.Run("non-GID type", func(t *testing.T) {
 		err := GID()(123)
 		if err == nil {
-			t.Error("expected validation error for non-GID type")
+			t.Fatal("expected validation error for non-GID type")
 		}
 		if err.Message != "value must be a GID" {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -394,7 +394,7 @@ func TestGID(t *testing.T) {
 	t.Run("string type not supported", func(t *testing.T) {
 		err := GID()("some-string")
 		if err == nil {
-			t.Error("expected validation error for string type")
+			t.Fatal("expected validation error for string type")
 		}
 		if err.Message != "value must be a GID" {
 			t.Errorf("unexpected error message: %s", err.Message)

--- a/pkg/validator/validator_security_test.go
+++ b/pkg/validator/validator_security_test.go
@@ -56,7 +56,7 @@ func TestNoHTML(t *testing.T) {
 		str := "<script>alert('xss')</script>"
 		err := NoHTML()(&str)
 		if err == nil {
-			t.Error("expected validation error for script tag")
+			t.Fatal("expected validation error for script tag")
 		}
 		if !strings.Contains(err.Message, "HTML tags") {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -67,7 +67,7 @@ func TestNoHTML(t *testing.T) {
 		str := "Hello <b>World</b>"
 		err := NoHTML()(&str)
 		if err == nil {
-			t.Error("expected validation error for bold tag")
+			t.Fatal("expected validation error for bold tag")
 		}
 		if !strings.Contains(err.Message, "HTML tags") {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -110,7 +110,7 @@ func TestNoHTML(t *testing.T) {
 		str := "5 < 10"
 		err := NoHTML()(&str)
 		if err == nil {
-			t.Error("expected validation error for angle bracket")
+			t.Fatal("expected validation error for angle bracket")
 		}
 		if !strings.Contains(err.Message, "angle brackets") {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -169,7 +169,7 @@ func TestNoHTML(t *testing.T) {
 		num := 123
 		err := NoHTML()(&num)
 		if err == nil {
-			t.Error("expected validation error for non-string")
+			t.Fatal("expected validation error for non-string")
 		}
 		if !strings.Contains(err.Message, "must be a string") {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -312,7 +312,7 @@ func TestPrintableText(t *testing.T) {
 		str := "test\u202Eexe.txt"
 		err := PrintableText()(&str)
 		if err == nil {
-			t.Error("expected validation error for RLO character")
+			t.Fatal("expected validation error for RLO character")
 		}
 		if !strings.Contains(err.Message, "bidirectional override") {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -331,7 +331,7 @@ func TestPrintableText(t *testing.T) {
 		str := "test\u200Btext"
 		err := PrintableText()(&str)
 		if err == nil {
-			t.Error("expected validation error for zero-width space")
+			t.Fatal("expected validation error for zero-width space")
 		}
 		if !strings.Contains(err.Message, "zero-width") {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -366,7 +366,7 @@ func TestPrintableText(t *testing.T) {
 		str := "test\x00text"
 		err := PrintableText()(&str)
 		if err == nil {
-			t.Error("expected validation error for null byte")
+			t.Fatal("expected validation error for null byte")
 		}
 		if !strings.Contains(err.Message, "control character") {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -409,7 +409,7 @@ func TestPrintableText(t *testing.T) {
 		str := "test\u00ADtext"
 		err := PrintableText()(&str)
 		if err == nil {
-			t.Error("expected validation error for soft hyphen")
+			t.Fatal("expected validation error for soft hyphen")
 		}
 		if !strings.Contains(err.Message, "invisible formatting") {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -428,7 +428,7 @@ func TestPrintableText(t *testing.T) {
 		str := "test\uE000text"
 		err := PrintableText()(&str)
 		if err == nil {
-			t.Error("expected validation error for private use area")
+			t.Fatal("expected validation error for private use area")
 		}
 		if !strings.Contains(err.Message, "private use") {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -439,7 +439,7 @@ func TestPrintableText(t *testing.T) {
 		str := "test\uFFFDtext"
 		err := PrintableText()(&str)
 		if err == nil {
-			t.Error("expected validation error for replacement character")
+			t.Fatal("expected validation error for replacement character")
 		}
 		if !strings.Contains(err.Message, "replacement character") {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -506,7 +506,7 @@ func TestPrintableText(t *testing.T) {
 		num := 123
 		err := PrintableText()(&num)
 		if err == nil {
-			t.Error("expected validation error for non-string")
+			t.Fatal("expected validation error for non-string")
 		}
 		if !strings.Contains(err.Message, "must be a string") {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -527,7 +527,7 @@ func TestPrintableText(t *testing.T) {
 		str := "abc\x00def"
 		err := PrintableText()(&str)
 		if err == nil {
-			t.Error("expected validation error")
+			t.Fatal("expected validation error")
 		}
 		if !strings.Contains(err.Message, "position 3") {
 			t.Errorf("expected position 3 in error message, got: %s", err.Message)
@@ -540,7 +540,7 @@ func TestPrintableText(t *testing.T) {
 		str := "abc\x00"
 		err := PrintableText()(&str)
 		if err == nil {
-			t.Error("expected validation error")
+			t.Fatal("expected validation error")
 		}
 		// The null byte is at rune position 3 (after 'a', 'b', 'c')
 		if !strings.Contains(err.Message, "position 3") {
@@ -586,7 +586,7 @@ func TestSafeText(t *testing.T) {
 		str := ""
 		err := SafeText(100)(&str)
 		if err == nil {
-			t.Error("expected validation error for empty string")
+			t.Fatal("expected validation error for empty string")
 		}
 		if !strings.Contains(err.Message, "empty") && !strings.Contains(err.Message, "required") {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -597,7 +597,7 @@ func TestSafeText(t *testing.T) {
 		str := "This is a very long string that exceeds the maximum length"
 		err := SafeText(10)(&str)
 		if err == nil {
-			t.Error("expected validation error for exceeding max length")
+			t.Fatal("expected validation error for exceeding max length")
 		}
 		if !strings.Contains(err.Message, "at most") {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -608,7 +608,7 @@ func TestSafeText(t *testing.T) {
 		str := "Hello <b>World</b>"
 		err := SafeText(100)(&str)
 		if err == nil {
-			t.Error("expected validation error for HTML tags")
+			t.Fatal("expected validation error for HTML tags")
 		}
 		if !strings.Contains(err.Message, "HTML tags") {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -627,7 +627,7 @@ func TestSafeText(t *testing.T) {
 		str := "5 < 10"
 		err := SafeText(100)(&str)
 		if err == nil {
-			t.Error("expected validation error for angle brackets")
+			t.Fatal("expected validation error for angle brackets")
 		}
 		if !strings.Contains(err.Message, "angle brackets") {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -638,7 +638,7 @@ func TestSafeText(t *testing.T) {
 		str := "test\x00text"
 		err := SafeText(100)(&str)
 		if err == nil {
-			t.Error("expected validation error for null byte")
+			t.Fatal("expected validation error for null byte")
 		}
 		if !strings.Contains(err.Message, "control character") {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -673,7 +673,7 @@ func TestSafeText(t *testing.T) {
 		str := "test\u200Btext"
 		err := SafeText(100)(&str)
 		if err == nil {
-			t.Error("expected validation error for zero-width space")
+			t.Fatal("expected validation error for zero-width space")
 		}
 		if !strings.Contains(err.Message, "zero-width") {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -684,7 +684,7 @@ func TestSafeText(t *testing.T) {
 		str := "test\u202Eexe.txt"
 		err := SafeText(100)(&str)
 		if err == nil {
-			t.Error("expected validation error for RLO character")
+			t.Fatal("expected validation error for RLO character")
 		}
 		if !strings.Contains(err.Message, "bidirectional override") {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -695,7 +695,7 @@ func TestSafeText(t *testing.T) {
 		str := "test\uE000text"
 		err := SafeText(100)(&str)
 		if err == nil {
-			t.Error("expected validation error for private use area")
+			t.Fatal("expected validation error for private use area")
 		}
 		if !strings.Contains(err.Message, "private use") {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -714,7 +714,7 @@ func TestSafeText(t *testing.T) {
 		num := 123
 		err := SafeText(100)(&num)
 		if err == nil {
-			t.Error("expected validation error for non-string")
+			t.Fatal("expected validation error for non-string")
 		}
 		if !strings.Contains(err.Message, "must be a string") {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -783,7 +783,7 @@ func TestNoNewLine(t *testing.T) {
 		str := "Line 1\nLine 2"
 		err := NoNewLine()(&str)
 		if err == nil {
-			t.Error("expected validation error for newline")
+			t.Fatal("expected validation error for newline")
 		}
 		if !strings.Contains(err.Message, "newline") {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -794,7 +794,7 @@ func TestNoNewLine(t *testing.T) {
 		str := "Line 1\rLine 2"
 		err := NoNewLine()(&str)
 		if err == nil {
-			t.Error("expected validation error for carriage return")
+			t.Fatal("expected validation error for carriage return")
 		}
 		if !strings.Contains(err.Message, "carriage return") {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -847,7 +847,7 @@ func TestSafeTextNoNewLine(t *testing.T) {
 		str := "Line 1\nLine 2"
 		err := SafeTextNoNewLine(100)(&str)
 		if err == nil {
-			t.Error("expected validation error for newline")
+			t.Fatal("expected validation error for newline")
 		}
 		if !strings.Contains(err.Message, "newline") {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -858,7 +858,7 @@ func TestSafeTextNoNewLine(t *testing.T) {
 		str := "Line 1\rLine 2"
 		err := SafeTextNoNewLine(100)(&str)
 		if err == nil {
-			t.Error("expected validation error for carriage return")
+			t.Fatal("expected validation error for carriage return")
 		}
 		if !strings.Contains(err.Message, "carriage return") {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -869,7 +869,7 @@ func TestSafeTextNoNewLine(t *testing.T) {
 		str := ""
 		err := SafeTextNoNewLine(100)(&str)
 		if err == nil {
-			t.Error("expected validation error for empty string")
+			t.Fatal("expected validation error for empty string")
 		}
 		if !strings.Contains(err.Message, "empty") && !strings.Contains(err.Message, "required") {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -880,7 +880,7 @@ func TestSafeTextNoNewLine(t *testing.T) {
 		str := "This is a very long string that exceeds the maximum length"
 		err := SafeTextNoNewLine(10)(&str)
 		if err == nil {
-			t.Error("expected validation error for exceeding max length")
+			t.Fatal("expected validation error for exceeding max length")
 		}
 		if !strings.Contains(err.Message, "at most") {
 			t.Errorf("unexpected error message: %s", err.Message)
@@ -891,7 +891,7 @@ func TestSafeTextNoNewLine(t *testing.T) {
 		str := "Hello <b>World</b>"
 		err := SafeTextNoNewLine(100)(&str)
 		if err == nil {
-			t.Error("expected validation error for HTML tags")
+			t.Fatal("expected validation error for HTML tags")
 		}
 		if !strings.Contains(err.Message, "HTML tags") {
 			t.Errorf("unexpected error message: %s", err.Message)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Broad lint cleanup to satisfy errcheck and go vet, plus a small API polish. Standardized defers/writes across the codebase, removed dead code, and updated FrameworkService.RequestExport to return (*ExportJob, error).

- **Refactors**
  - Made Close/Write/Body.Close calls explicit with ignored errors using _, _ or defer func() { _ = ... } across HTTP, S3, zip, SMTP, gzip, and Excel handlers.
  - Switched FrameworkService.RequestExport to return (*coredata.ExportJob, error); updated the GraphQL resolver accordingly.
  - Simplified SlackConnection.MarshalJSON to read fields directly; normalized Slack error messages to sentence case.
  - Removed unused SAML attribute helpers and unused/duplicate auth and docgen constants/structs.
  - Minor API/typing cleanups: receiver variable names, JSON/GQL marshalers use WriterFunc with ignored write errors, and tests use t.Fatal where errors must abort.

- **Migration**
  - Update call sites to the new signature: job, err := Frameworks.RequestExport(ctx, frameworkID, email, name).

<sup>Written for commit 68661d9198ad1b1876cbd6619445d697a58e2d0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

