### PR TITLE
Fix SCIM disable all non SCIM managed members

### DIFF
--- a/pkg/coredata/membership_filter.go
+++ b/pkg/coredata/membership_filter.go
@@ -20,9 +20,10 @@ import (
 )
 
 type MembershipFilter struct {
-	email *mail.Addr
-	role  *MembershipRole
-	state *MembershipState
+	email  *mail.Addr
+	role   *MembershipRole
+	state  *MembershipState
+	source *MembershipSource
 }
 
 func NewMembershipFilter() *MembershipFilter {
@@ -56,11 +57,21 @@ func (f *MembershipFilter) State() *MembershipState {
 	return f.state
 }
 
+func (f *MembershipFilter) WithSource(source MembershipSource) *MembershipFilter {
+	f.source = &source
+	return f
+}
+
+func (f *MembershipFilter) Source() *MembershipSource {
+	return f.source
+}
+
 func (f *MembershipFilter) SQLArguments() pgx.StrictNamedArgs {
 	return pgx.StrictNamedArgs{
-		"filter_email": f.email,
-		"filter_role":  f.role,
-		"filter_state": f.state,
+		"filter_email":  f.email,
+		"filter_role":   f.role,
+		"filter_state":  f.state,
+		"filter_source": f.source,
 	}
 }
 
@@ -84,6 +95,13 @@ AND (
 	CASE
 		WHEN @filter_state::text IS NOT NULL THEN
 			m.state = @filter_state::membership_state
+		ELSE TRUE
+	END
+)
+AND (
+	CASE
+		WHEN @filter_source::text IS NOT NULL THEN
+			m.source = @filter_source::text
 		ELSE TRUE
 	END
 )`

--- a/pkg/iam/scim/service.go
+++ b/pkg/iam/scim/service.go
@@ -294,6 +294,13 @@ func (s *Service) ListUsers(
 		return nil, 0, err
 	}
 
+	// Only return SCIM-managed users. This ensures that:
+	// 1. Users created through other means (manual, SAML) are not deactivated
+	//    when they don't exist in the identity provider.
+	// 2. When a manual user exists in the identity provider but not in the
+	//    SCIM list, CreateUser is called which enrolls them into SCIM management.
+	filter.WithSource(coredata.MembershipSourceSCIM)
+
 	scope := coredata.NewScopeFromObjectID(config.OrganizationID)
 
 	var memberships coredata.Memberships


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restricts SCIM sync to SCIM-managed members so manual and SAML users aren’t disabled. Adds a membership source filter and applies it in SCIM ListUsers.

- **Bug Fixes**
  - Add source filter to MembershipFilter (field, getter/setter, SQL arg and WHERE clause).
  - Apply source=SCIM in SCIM ListUsers to return only SCIM-managed users, preventing accidental deactivation of non‑SCIM identities (ENG-111).

<sup>Written for commit 1bc5ebce2c690f25bea964b758f5ffafb6f189c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

