### PR TITLE
Fix create organization node

### DIFF
--- a/packages/n8n-node/nodes/Probo/actions/organization/create.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/organization/create.operation.ts
@@ -27,19 +27,17 @@ export async function execute(
 	const query = `
 		mutation CreateOrganization($input: CreateOrganizationInput!) {
 			createOrganization(input: $input) {
-				organizationEdge {
-					node {
-						id
-						name
-						description
-						websiteUrl
-						email
-						headquarterAddress
-						logoUrl
-						horizontalLogoUrl
-						createdAt
-						updatedAt
-					}
+				organization {
+					id
+					name
+					description
+					websiteUrl
+					email
+					headquarterAddress
+					logoUrl
+					horizontalLogoUrl
+					createdAt
+					updatedAt
 				}
 			}
 		}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed the Probo “Create Organization” n8n node by updating the GraphQL mutation to match the current API. The mutation now selects createOrganization.organization so creation works and fields are returned correctly.

- Bug Fixes
  - Switched from organizationEdge.node to organization in the selection set.
  - Prevents null output/errors caused by the outdated schema.

<sup>Written for commit 3ef541516c986c4696df18eb1a311c0628679f8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

