### PR TITLE
Fix wrong error type

### DIFF
--- a/pkg/certmanager/provisioner.go
+++ b/pkg/certmanager/provisioner.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/log"
 	"go.gearno.de/kit/pg"
 	"go.gearno.de/x/ref"
@@ -227,7 +226,7 @@ func (p *Provisioner) resetStaleDomain(
 ) error {
 	fullDomain := &coredata.CustomDomain{}
 	if err := fullDomain.LoadByIDForUpdateSkipLocked(ctx, tx, coredata.NewNoScope(), p.encryptionKey, domain.ID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil
 		}
 
@@ -276,7 +275,7 @@ func (p *Provisioner) provisionDomainCertificate(
 ) error {
 	domain := &coredata.CustomDomain{}
 	if err := domain.LoadByIDForUpdateSkipLocked(ctx, tx, coredata.NewNoScope(), p.encryptionKey, domainID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil
 		}
 

--- a/pkg/certmanager/renewer.go
+++ b/pkg/certmanager/renewer.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/log"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/coredata"
@@ -132,7 +131,7 @@ func (r *Renewer) checkAndRenew(ctx context.Context) error {
 func (r *Renewer) renewDomain(ctx context.Context, tx pg.Conn, domainID gid.GID) error {
 	domain := &coredata.CustomDomain{}
 	if err := domain.LoadByIDForUpdateSkipLocked(ctx, tx, coredata.NewNoScope(), r.encryptionKey, domainID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil
 		}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use coredata.ErrResourceNotFound instead of pgx.ErrNoRows when loading domains in the provisioner and renewer, so missing records are treated as no-ops instead of errors. Also removes the now-unused pgx import.

<sup>Written for commit a9a2e75c599398f7239bfb42d3d71df9b2e9ed70. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

