### PR TITLE
Suppress noisy TLS log

### DIFF
--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -773,7 +773,8 @@ func (impl *Implm) runTrustCenterServer(
 			strings.Contains(msg, "tls: client requested unsupported application protocols") ||
 			strings.Contains(msg, "read: connection reset by peer") ||
 			strings.Contains(msg, "tls: unsupported SSLv2 handshake received") ||
-			strings.Contains(msg, "tls: no cipher suite supported by both client and server")
+			strings.Contains(msg, "tls: no cipher suite supported by both client and server") ||
+			strings.Contains(msg, "tls: received record with version")
 	}
 	httpServerLogger := l.Named("", log.SkipMatch(ignoreTLSHandshakeErrors))
 	httpsServer := httpserver.NewServer(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Suppress the noisy TLS handshake log "tls: received record with version ..." by adding it to the ignore list in the Trust Center server logger. Reduces log spam from mismatched clients/port scans and aligns with Linear ENG-144.

<sup>Written for commit 99f1da15606855c6918fb5c72ed17febb05cc503. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

