### PR TITLE
Fix noisy slack enqueue message

### DIFF
--- a/pkg/probo/trust_center_access_service.go
+++ b/pkg/probo/trust_center_access_service.go
@@ -365,8 +365,7 @@ func (s TrustCenterAccessService) Update(
 
 	if shouldUpdateSlackMessage {
 		if err := s.svc.SlackMessages.QueueSlackNotification(ctx, access.Email, access.TrustCenterID); err != nil {
-			var noConnectorErr slack.ErrNoSlackConnector
-			if !errors.Is(err, noConnectorErr) {
+			if !errors.Is(err, slack.ErrNoSlackConnector) {
 				return nil, fmt.Errorf("cannot queue slack notification: %w", err)
 			}
 		}

--- a/pkg/slack/slack_message_service.go
+++ b/pkg/slack/slack_message_service.go
@@ -33,11 +33,9 @@ const (
 	slackMessageDeduplicationWindow = 7 * 24 * time.Hour
 )
 
-type ErrNoSlackConnector struct{}
-
-func (e ErrNoSlackConnector) Error() string {
-	return "no slack connector found for organization"
-}
+var (
+	ErrNoSlackConnector = errors.New("no slack connector found for organization")
+)
 
 type (
 	SlackMessageService struct {
@@ -214,7 +212,7 @@ func (s *SlackMessageService) QueueSlackNotification(
 		}
 
 		if !hasSlackConnector {
-			return ErrNoSlackConnector{}
+			return ErrNoSlackConnector
 		}
 
 		documents, reports, files, err := s.loadDocumentsReportsAndFilesFromAccesses(ctx, tx, trustCenterAccess.ID)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Quietly skip Slack enqueue when no Slack connector is configured to remove noisy errors during access updates.

- **Bug Fixes**
  - Replace ErrNoSlackConnector type with a package-level sentinel error and use errors.Is for checks.
  - Update TrustCenterAccessService to ignore ErrNoSlackConnector when queueing Slack notifications.

<sup>Written for commit df56ae90e914d2d5cf2154a2169706470b783554. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

