### PR TITLE
Upgrade to shipfox runners

### DIFF
--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   release-snapshot:
     name: "release-snapshot"
-    runs-on: "shipfox-16vcpu-ubuntu-2404"
+    runs-on: "shipfox-15vcpu-ubuntu-2404"
     permissions:
       contents: "read"
       packages: "write"
@@ -129,7 +129,7 @@ jobs:
 
   lint:
     name: "lint"
-    runs-on: "shipfox-16vcpu-ubuntu-2404"
+    runs-on: "shipfox-15vcpu-ubuntu-2404"
     permissions:
       contents: "read"
     steps:
@@ -154,7 +154,7 @@ jobs:
 
   test:
     name: "test"
-    runs-on: "shipfox-16vcpu-ubuntu-2404"
+    runs-on: "shipfox-15vcpu-ubuntu-2404"
     permissions:
       contents: "read"
     steps:
@@ -202,7 +202,7 @@ jobs:
 
   test-e2e:
     name: "test-e2e"
-    runs-on: "shipfox-16vcpu-ubuntu-2404"
+    runs-on: "shipfox-15vcpu-ubuntu-2404"
     permissions:
       contents: "read"
     steps:

--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   release-snapshot:
     name: "release-snapshot"
-    runs-on: "ubuntu-24.04"
+    runs-on: "shipfox-16vcpu-ubuntu-2404"
     permissions:
       contents: "read"
       packages: "write"
@@ -129,7 +129,7 @@ jobs:
 
   lint:
     name: "lint"
-    runs-on: "ubuntu-22.04"
+    runs-on: "shipfox-16vcpu-ubuntu-2404"
     permissions:
       contents: "read"
     steps:
@@ -154,7 +154,7 @@ jobs:
 
   test:
     name: "test"
-    runs-on: "ubuntu-22.04"
+    runs-on: "shipfox-16vcpu-ubuntu-2404"
     permissions:
       contents: "read"
     steps:
@@ -202,7 +202,7 @@ jobs:
 
   test-e2e:
     name: "test-e2e"
-    runs-on: "ubuntu-22.04"
+    runs-on: "shipfox-16vcpu-ubuntu-2404"
     permissions:
       contents: "read"
     steps:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched GitHub Actions jobs to Shipfox runners (shipfox-15vcpu-ubuntu-2404) to speed up CI and standardize on Ubuntu 24.04. Applies to release-snapshot, lint, test, and test-e2e.

<sup>Written for commit d9612ea551155c643df9786b68ce83bd57bcd1ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

