### PR TITLE
Upgrade to bigger github hosted runner

### DIFF
--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   release-snapshot:
     name: "release-snapshot"
-    runs-on: "ubuntu-24.04"
+    runs-on: "ubuntu-24.04-64cores"
     permissions:
       contents: "read"
       packages: "write"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   github-release:
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-24.04-64cores"
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
       image-digest: ${{ steps.image.outputs.digest }}
@@ -149,7 +149,7 @@ jobs:
           retention-days: 30
 
   npm-release:
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-24.04-64cores"
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgraded release workflows to use the ubuntu-24.04-64cores GitHub-hosted runner for more CPU and faster builds.
Updated release-snapshot, github-release, and npm-release jobs to this label.

<sup>Written for commit d2dbb6f7144abb2791d1042f4849b8577a53a262. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

