### PR TITLE
Activate pg debug via config

### DIFF
--- a/pkg/probod/pg_config.go
+++ b/pkg/probod/pg_config.go
@@ -29,6 +29,7 @@ type (
 		Database     string `json:"database"`
 		PoolSize     int32  `json:"pool-size"`
 		CACertBundle string `json:"ca-cert-bundle"`
+		Debug        bool   `json:"debug"`
 	}
 )
 
@@ -39,6 +40,10 @@ func (cfg pgConfig) Options(options ...pg.Option) []pg.Option {
 		pg.WithPassword(cfg.Password),
 		pg.WithDatabase(cfg.Database),
 		pg.WithPoolSize(cfg.PoolSize),
+	}
+
+	if cfg.Debug {
+		opts = append(opts, pg.WithDebug())
 	}
 
 	if cfg.CACertBundle != "" {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a debug flag to the Postgres config to enable driver debug logging via configuration. When debug is true, Options appends pg.WithDebug(); otherwise behavior is unchanged.

<sup>Written for commit 03404e5d635615b567fc9b08e9ca78e64a9ff41f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

