### PR TITLE
IAM set SAMLSubject on create

### DIFF
--- a/pkg/iam/saml/service.go
+++ b/pkg/iam/saml/service.go
@@ -261,6 +261,7 @@ func (s *Service) HandleAssertion(
 				*identity = coredata.Identity{
 					ID:                   gid.New(gid.NilTenant, coredata.IdentityEntityType),
 					EmailAddress:         email,
+					SAMLSubject:          &assertion.Subject.NameID.Value,
 					FullName:             fullname,
 					HashedPassword:       nil,
 					EmailAddressVerified: true,
@@ -275,7 +276,6 @@ func (s *Service) HandleAssertion(
 			} else if err != nil {
 				return fmt.Errorf("cannot load identity: %w", err)
 			} else {
-				identity.SAMLSubject = &assertion.Subject.NameID.Value
 				identity.EmailAddress = email
 				identity.FullName = fullname
 				identity.EmailAddressVerified = true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set SAMLSubject when creating a new identity from a SAML assertion, and stop updating it for existing identities to keep SSO links stable across logins.

<sup>Written for commit 063e1107eeaf3f8629237322e72b597d2a883306. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

