### PR TITLE
Change button text while loading

### DIFF
--- a/apps/trust/src/components/AuditRow.tsx
+++ b/apps/trust/src/components/AuditRow.tsx
@@ -139,7 +139,7 @@ export function AuditRow(props: { audit: AuditRowFragment$key }) {
               icon={downloading ? Spinner : IconArrowInbox}
               onClick={() => void handleDownload()}
             >
-              {__("Download")}
+              {downloading ? __("Downloading") : __("Download")}
             </Button>
           )
         : viewer

--- a/apps/trust/src/components/DocumentRow.tsx
+++ b/apps/trust/src/components/DocumentRow.tsx
@@ -124,7 +124,7 @@ export function DocumentRow(props: { document: DocumentRowFragment$key }) {
               icon={downloading ? Spinner : IconArrowInbox}
               onClick={() => void handleDownload()}
             >
-              {__("Download")}
+              {downloading ? __("Downloading") : __("Download")}
             </Button>
           )
         : viewer

--- a/apps/trust/src/components/TrustCenterFileRow.tsx
+++ b/apps/trust/src/components/TrustCenterFileRow.tsx
@@ -128,7 +128,7 @@ export function TrustCenterFileRow(props: {
               icon={downloading ? Spinner : IconArrowInbox}
               onClick={() => void handleDownload()}
             >
-              {__("Download")}
+              {downloading ? __("Downloading") : __("Download")}
             </Button>
           )
         : viewer


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show “Downloading” on the download button while a file is in progress, giving clearer feedback to users. Applied to AuditRow, DocumentRow, and TrustCenterFileRow.

<sup>Written for commit 27ad068c6349afe2c81034e48a66d1bec16d7ef1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

