### PR TITLE
Display control description

### DIFF
--- a/apps/console/src/pages/organizations/frameworks/FrameworkControlPage.tsx
+++ b/apps/console/src/pages/organizations/frameworks/FrameworkControlPage.tsx
@@ -352,7 +352,12 @@ export default function FrameworkControlPage({ queryRef }: Props) {
         </div>
       )}
       <div className={control.status === "EXCLUDED" ? "opacity-60" : ""}>
-        <div className="text-base mb-4">{control.name}</div>
+        <div className="text-base mb-1">{control.name}</div>
+        {control.description && (
+          <div className="text-sm text-txt-secondary mb-4 whitespace-pre-wrap">
+            {control.description}
+          </div>
+        )}
         <div className="mb-4">
           <LinkedMeasuresCard
             variant="card"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show control descriptions under the name on the Framework Control page for quick context. Renders only when present with secondary styling, tighter spacing, and preserved line breaks.

<sup>Written for commit 42189f3cc43f7a0c7202ce6ac1ab1aae77a85571. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

