### PR TITLE
Allow more permissive bracket validations

### DIFF
--- a/e2e/console/audit_test.go
+++ b/e2e/console/audit_test.go
@@ -183,13 +183,6 @@ func TestAudit_Create_Validation(t *testing.T) {
 			wantErrorContains: "HTML",
 		},
 		{
-			name: "name with angle brackets",
-			input: map[string]any{
-				"name": "Test < Audit",
-			},
-			wantErrorContains: "angle brackets",
-		},
-		{
 			name: "name with newline",
 			input: map[string]any{
 				"name": "Test\nAudit",
@@ -424,14 +417,6 @@ func TestAudit_Update_Validation(t *testing.T) {
 				return map[string]any{"id": id, "name": "<script>alert('xss')</script>"}
 			},
 			wantErrorContains: "HTML",
-		},
-		{
-			name:  "name with angle brackets",
-			setup: func() string { return baseAuditID },
-			input: func(id string) map[string]any {
-				return map[string]any{"id": id, "name": "Test < Audit"}
-			},
-			wantErrorContains: "angle brackets",
 		},
 		{
 			name:  "name with newline",

--- a/e2e/console/datum_test.go
+++ b/e2e/console/datum_test.go
@@ -175,14 +175,6 @@ func TestDatum_Create_Validation(t *testing.T) {
 			wantErrorContains: "HTML",
 		},
 		{
-			name: "name with angle brackets",
-			input: map[string]any{
-				"name":               "Test < Datum",
-				"dataClassification": "INTERNAL",
-			},
-			wantErrorContains: "angle brackets",
-		},
-		{
 			name: "name with newline",
 			input: map[string]any{
 				"name":               "Test\nDatum",
@@ -396,14 +388,6 @@ func TestDatum_Update_Validation(t *testing.T) {
 				return map[string]any{"id": id, "name": "<script>alert('xss')</script>"}
 			},
 			wantErrorContains: "HTML",
-		},
-		{
-			name:  "name with angle brackets",
-			setup: func() string { return baseDatumID },
-			input: func(id string) map[string]any {
-				return map[string]any{"id": id, "name": "Test < Datum"}
-			},
-			wantErrorContains: "angle brackets",
 		},
 		{
 			name:  "name with newline",

--- a/e2e/console/document_test.go
+++ b/e2e/console/document_test.go
@@ -193,16 +193,6 @@ func TestDocument_Create_Validation(t *testing.T) {
 			wantErrorContains: "HTML",
 		},
 		{
-			name: "title with angle brackets",
-			input: map[string]any{
-				"title":          "Test < Document",
-				"content":        "Test content",
-				"documentType":   "POLICY",
-				"classification": "INTERNAL",
-			},
-			wantErrorContains: "angle brackets",
-		},
-		{
 			name: "title with newline",
 			input: map[string]any{
 				"title":          "Test\nDocument",
@@ -417,14 +407,6 @@ func TestDocument_Update_Validation(t *testing.T) {
 				return map[string]any{"id": id, "title": "<script>alert('xss')</script>"}
 			},
 			wantErrorContains: "HTML",
-		},
-		{
-			name:  "title with angle brackets",
-			setup: func() string { return baseDocumentID },
-			input: func(id string) map[string]any {
-				return map[string]any{"id": id, "title": "Test < Document"}
-			},
-			wantErrorContains: "angle brackets",
 		},
 		{
 			name:  "title with newline",

--- a/e2e/console/framework_test.go
+++ b/e2e/console/framework_test.go
@@ -144,13 +144,6 @@ func TestFramework_Create_Validation(t *testing.T) {
 			},
 			wantErrorContains: "HTML",
 		},
-		{
-			name: "name with angle brackets",
-			input: map[string]any{
-				"name": "Test < Framework",
-			},
-			wantErrorContains: "angle brackets",
-		},
 		// Newline validation
 		{
 			name: "name with newline",
@@ -358,14 +351,6 @@ func TestFramework_Update_Validation(t *testing.T) {
 				return map[string]any{"id": id, "name": "<script>alert('xss')</script>"}
 			},
 			wantErrorContains: "HTML",
-		},
-		{
-			name:  "name with angle brackets",
-			setup: func() string { return baseFrameworkID },
-			input: func(id string) map[string]any {
-				return map[string]any{"id": id, "name": "Test < Framework"}
-			},
-			wantErrorContains: "angle brackets",
 		},
 		{
 			name:  "description with HTML tags",

--- a/e2e/console/measure_test.go
+++ b/e2e/console/measure_test.go
@@ -206,14 +206,6 @@ func TestMeasure_Create_Validation(t *testing.T) {
 			wantErrorContains: "HTML",
 		},
 		{
-			name: "name with angle brackets",
-			input: map[string]any{
-				"name":     "Test < Measure",
-				"category": "POLICY",
-			},
-			wantErrorContains: "angle brackets",
-		},
-		{
 			name: "description with HTML tags",
 			input: map[string]any{
 				"name":        "Test Measure",
@@ -472,14 +464,6 @@ func TestMeasure_Update_Validation(t *testing.T) {
 				return map[string]any{"id": id, "name": "<script>alert('xss')</script>"}
 			},
 			wantErrorContains: "HTML",
-		},
-		{
-			name:  "name with angle brackets",
-			setup: func() string { return baseMeasureID },
-			input: func(id string) map[string]any {
-				return map[string]any{"id": id, "name": "Test < Measure"}
-			},
-			wantErrorContains: "angle brackets",
 		},
 		{
 			name:  "description with HTML tags",

--- a/e2e/console/meeting_test.go
+++ b/e2e/console/meeting_test.go
@@ -136,14 +136,6 @@ func TestMeeting_Create_Validation(t *testing.T) {
 			wantErrorContains: "HTML",
 		},
 		{
-			name: "name with angle brackets",
-			input: map[string]any{
-				"name": "Test < Meeting",
-				"date": time.Now().Format(time.RFC3339Nano),
-			},
-			wantErrorContains: "angle brackets",
-		},
-		{
 			name: "name with newline",
 			input: map[string]any{
 				"name": "Test\nMeeting",
@@ -342,14 +334,6 @@ func TestMeeting_Update_Validation(t *testing.T) {
 				return map[string]any{"meetingId": id, "name": "<script>alert('xss')</script>"}
 			},
 			wantErrorContains: "HTML",
-		},
-		{
-			name:  "name with angle brackets",
-			setup: func() string { return baseMeetingID },
-			input: func(id string) map[string]any {
-				return map[string]any{"meetingId": id, "name": "Test < Meeting"}
-			},
-			wantErrorContains: "angle brackets",
 		},
 		{
 			name:  "name with newline",

--- a/pkg/validator/validator_security.go
+++ b/pkg/validator/validator_security.go
@@ -17,18 +17,17 @@ package validator
 import (
 	"fmt"
 	"regexp"
-	"strings"
 )
 
 var (
-	htmlTagRegex = regexp.MustCompile(`<[^>]*>`)
+	htmlTagRegex = regexp.MustCompile(`</?[a-zA-Z][^>]*>|<![^>]*>`)
 )
 
-// NoHTML validates that a string does not contain HTML tags or angle brackets.
+// NoHTML validates that a string does not contain HTML tags.
 // It rejects:
 // - HTML tags (e.g., <script>, <b>, <div>, etc.)
-// - Angle brackets (< and >) even when not part of complete tags
 //
+// Plain angle brackets used outside of HTML tags (e.g., "5 < 10") are allowed.
 // This helps prevent XSS attacks and ensures user input doesn't contain HTML markup.
 // Combine with PrintableText() for comprehensive text field validation.
 func NoHTML() ValidatorFunc {
@@ -47,14 +46,8 @@ func NoHTML() ValidatorFunc {
 			return nil
 		}
 
-		// Check for HTML tags first (more specific error message)
 		if htmlTagRegex.MatchString(str) {
 			return newValidationError(ErrorCodeInvalidFormat, "must not contain HTML tags")
-		}
-
-		// Check for angle brackets (even without complete tags)
-		if strings.ContainsAny(str, "<>") {
-			return newValidationError(ErrorCodeInvalidFormat, "must not contain angle brackets")
 		}
 
 		return nil


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Loosened NoHTML and SafeText to allow plain angle brackets (math and arrows) while still blocking real HTML tags, comments, and DOCTYPEs. This removes false positives without reducing XSS protection.

- **Bug Fixes**
  - Replaced the “contains < or >” check with a tag-only regex that matches start/end tags and <!…> blocks.
  - Do not flag incomplete fragments like "<incomplete".
  - Expanded validator tests for XSS vectors (svg/iframe/style/meta, attribute newlines) and positive cases; removed e2e tests that expected angle-bracket errors.

<sup>Written for commit 06aa781bb2faee521fd9b6c5ca6326c17b920f58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

