### PR TITLE
Add delete tasks to mcp

### DIFF
--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -1448,6 +1448,21 @@ func (r *Resolver) UnassignTaskTool(ctx context.Context, req *mcp.CallToolReques
 	}, nil
 }
 
+func (r *Resolver) DeleteTaskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteTaskInput) (*mcp.CallToolResult, types.DeleteTaskOutput, error) {
+	r.MustAuthorize(ctx, input.ID, probo.ActionTaskDelete)
+
+	svc := r.ProboService(ctx, input.ID)
+
+	err := svc.Tasks.Delete(ctx, input.ID)
+	if err != nil {
+		return nil, types.DeleteTaskOutput{}, fmt.Errorf("failed to delete task: %w", err)
+	}
+
+	return nil, types.DeleteTaskOutput{
+		DeletedTaskID: input.ID,
+	}, nil
+}
+
 func (r *Resolver) ListSnapshotsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListSnapshotsInput) (*mcp.CallToolResult, types.ListSnapshotsOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionSnapshotList)
 

--- a/pkg/server/api/mcp/v1/server/server.go
+++ b/pkg/server/api/mcp/v1/server/server.go
@@ -72,6 +72,7 @@ type ResolverInterface interface {
 	UpdateTaskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateTaskInput) (*mcp.CallToolResult, types.UpdateTaskOutput, error)
 	AssignTaskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AssignTaskInput) (*mcp.CallToolResult, types.AssignTaskOutput, error)
 	UnassignTaskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UnassignTaskInput) (*mcp.CallToolResult, types.UnassignTaskOutput, error)
+	DeleteTaskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteTaskInput) (*mcp.CallToolResult, types.DeleteTaskOutput, error)
 	ListSnapshotsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListSnapshotsInput) (*mcp.CallToolResult, types.ListSnapshotsOutput, error)
 	GetSnapshotTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetSnapshotInput) (*mcp.CallToolResult, types.GetSnapshotOutput, error)
 	TakeSnapshotTool(ctx context.Context, req *mcp.CallToolRequest, input *types.TakeSnapshotInput) (*mcp.CallToolResult, types.TakeSnapshotOutput, error)
@@ -841,6 +842,19 @@ func registerToolHandlers(server *mcp.Server, resolver ResolverInterface) {
 			OutputSchema: types.UnassignTaskToolOutputSchema,
 		},
 		resolver.UnassignTaskTool,
+	)
+	mcp.AddTool(
+		server,
+		&mcp.Tool{
+			Name:         "deleteTask",
+			Description:  "Delete a task",
+			InputSchema:  types.DeleteTaskToolInputSchema,
+			OutputSchema: types.DeleteTaskToolOutputSchema,
+			Annotations: &mcp.ToolAnnotations{
+				DestructiveHint: boolPtr(true),
+			},
+		},
+		resolver.DeleteTaskTool,
 	)
 	mcp.AddTool(
 		server,

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -3386,6 +3386,24 @@ components:
         task:
           $ref: "#/components/schemas/Task"
 
+    DeleteTaskInput:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+          description: Task ID
+
+    DeleteTaskOutput:
+      type: object
+      required:
+        - deleted_task_id
+      properties:
+        deleted_task_id:
+          $ref: "#/components/schemas/GID"
+          description: Deleted task ID
+
     SnapshotsType:
       type: string
       enum:
@@ -4898,6 +4916,15 @@ tools:
       $ref: "#/components/schemas/UnassignTaskInput"
     outputSchema:
       $ref: "#/components/schemas/UnassignTaskOutput"
+  - name: deleteTask
+    description: Delete a task
+    hints:
+      readonly: false
+      destructive: true
+    inputSchema:
+      $ref: "#/components/schemas/DeleteTaskInput"
+    outputSchema:
+      $ref: "#/components/schemas/DeleteTaskOutput"
   - name: listSnapshots
     description: List all snapshots for the organization
     hints:

--- a/pkg/server/api/mcp/v1/types/types.go
+++ b/pkg/server/api/mcp/v1/types/types.go
@@ -54,6 +54,8 @@ var (
 	DeleteDraftDocumentVersionToolInputSchema       = mcp.MustUnmarshalSchema(`{"type":"object","properties":{"document_version_id":{"type":"string","format":"string"}},"required":["document_version_id"]}`)
 	DeleteDraftDocumentVersionToolOutputSchema      = mcp.MustUnmarshalSchema(`{"type":"object","properties":{"deleted_document_version_id":{"type":"string","format":"string"}},"required":["deleted_document_version_id"]}`)
 	DeleteMeetingToolInputSchema                    = mcp.MustUnmarshalSchema(`{"type":"object","properties":{"id":{"type":"string","format":"string"}},"required":["id"]}`)
+	DeleteTaskToolInputSchema                      = mcp.MustUnmarshalSchema(`{"type":"object","properties":{"id":{"type":"string","format":"string"}},"required":["id"]}`)
+	DeleteTaskToolOutputSchema                     = mcp.MustUnmarshalSchema(`{"type":"object","properties":{"deleted_task_id":{"type":"string","format":"string"}},"required":["deleted_task_id"]}`)
 	DeleteMeetingToolOutputSchema                   = mcp.MustUnmarshalSchema(`{"type":"object","properties":{"deleted_meeting_id":{"type":"string","format":"string"}},"required":["deleted_meeting_id"]}`)
 	DeleteRiskToolInputSchema                       = mcp.MustUnmarshalSchema(`{"type":"object","properties":{"id":{"type":"string","format":"string"}},"required":["id"]}`)
 	DeleteRiskToolOutputSchema                      = mcp.MustUnmarshalSchema(`{"type":"object","properties":{"deleted_risk_id":{"type":"string","format":"string"}},"required":["deleted_risk_id"]}`)
@@ -2167,6 +2169,18 @@ type UnassignTaskInput struct {
 // UnassignTaskOutput represents the schema
 type UnassignTaskOutput struct {
 	Task *Task `json:"task"`
+}
+
+// DeleteTaskInput represents the schema
+type DeleteTaskInput struct {
+	// Task ID
+	ID gid.GID `json:"id"`
+}
+
+// DeleteTaskOutput represents the schema
+type DeleteTaskOutput struct {
+	// Deleted task ID
+	DeletedTaskID gid.GID `json:"deleted_task_id"`
 }
 
 // UnlinkControlAuditInput represents the schema


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new MCP tool to delete tasks and return the deleted task ID. This enables clients to remove tasks with proper authorization and a clear confirmation.

- **New Features**
  - Added deleteTask tool with destructive hint and input/output schemas (id → deleted_task_id).
  - Implemented DeleteTaskTool resolver: authorizes ActionTaskDelete, calls svc.Tasks.Delete, returns deleted_task_id.
  - Wired tool into server and ResolverInterface; no impact on existing tools.

<sup>Written for commit 90911a55f7b4f6723e69bffe081c806483ccc61b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

