### PR TITLE
Clean up database

### DIFF
--- a/pkg/coredata/migrations/20260213T120000Z.sql
+++ b/pkg/coredata/migrations/20260213T120000Z.sql
@@ -39,5 +39,3 @@ WHERE approver_profile_id IS NOT NULL;
 
 -- Allow NULL on old columns now that data is in the join tables
 ALTER TABLE document_versions ALTER COLUMN approver_profile_id DROP NOT NULL;
-
--- TODO: Drop the old columns

--- a/pkg/coredata/migrations/20260217T120000Z.sql
+++ b/pkg/coredata/migrations/20260217T120000Z.sql
@@ -1,6 +1,1 @@
 ALTER TABLE controls ALTER COLUMN status DROP NOT NULL;
-
--- TODO: drop columns and type once all code references are fully removed
--- ALTER TABLE controls DROP COLUMN status;
--- ALTER TABLE controls DROP COLUMN exclusion_justification;
--- DROP TYPE control_status;

--- a/pkg/coredata/migrations/20260217T130000Z.sql
+++ b/pkg/coredata/migrations/20260217T130000Z.sql
@@ -1,0 +1,6 @@
+ALTER TABLE documents DROP COLUMN approver_profile_id;
+ALTER TABLE document_versions DROP COLUMN approver_profile_id;
+
+ALTER TABLE controls DROP COLUMN status;
+ALTER TABLE controls DROP COLUMN exclusion_justification;
+DROP TYPE control_status;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Finalizes the approvals and controls schema cleanup by dropping deprecated columns and the control_status enum. Removes approver_profile_id from documents and document_versions, and drops controls.status and controls.exclusion_justification.

- **Migration**
  - Apply the migration; it is destructive.
  - Confirm no code references remain; approvals data lives in join tables from prior migrations.

<sup>Written for commit b2785dba59f21779dfc6f5cf7d9754ed9c86982e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

