### PR TITLE
Add delete measure to mcp

### DIFF
--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -2040,3 +2040,18 @@ func (r *Resolver) ListMeetingAttendeesTool(ctx context.Context, req *mcp.CallTo
 		Attendees: profiles,
 	}, nil
 }
+
+func (r *Resolver) DeleteMeasureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteMeasureInput) (*mcp.CallToolResult, types.DeleteMeasureOutput, error) {
+	r.MustAuthorize(ctx, input.ID, probo.ActionMeasureDelete)
+
+	svc := r.ProboService(ctx, input.ID)
+
+	err := svc.Measures.Delete(ctx, input.ID)
+	if err != nil {
+		return nil, types.DeleteMeasureOutput{}, fmt.Errorf("failed to delete measure: %w", err)
+	}
+
+	return nil, types.DeleteMeasureOutput{
+		DeletedMeasureID: input.ID,
+	}, nil
+}

--- a/pkg/server/api/mcp/v1/server/server.go
+++ b/pkg/server/api/mcp/v1/server/server.go
@@ -26,6 +26,7 @@ type ResolverInterface interface {
 	GetMeasureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetMeasureInput) (*mcp.CallToolResult, types.GetMeasureOutput, error)
 	AddMeasureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddMeasureInput) (*mcp.CallToolResult, types.AddMeasureOutput, error)
 	UpdateMeasureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateMeasureInput) (*mcp.CallToolResult, types.UpdateMeasureOutput, error)
+	DeleteMeasureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteMeasureInput) (*mcp.CallToolResult, types.DeleteMeasureOutput, error)
 	ListFrameworksTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListFrameworksInput) (*mcp.CallToolResult, types.ListFrameworksOutput, error)
 	GetFrameworkTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetFrameworkInput) (*mcp.CallToolResult, types.GetFrameworkOutput, error)
 	AddFrameworkTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddFrameworkInput) (*mcp.CallToolResult, types.AddFrameworkOutput, error)
@@ -310,6 +311,19 @@ func registerToolHandlers(server *mcp.Server, resolver ResolverInterface) {
 			OutputSchema: types.UpdateMeasureToolOutputSchema,
 		},
 		resolver.UpdateMeasureTool,
+	)
+	mcp.AddTool(
+		server,
+		&mcp.Tool{
+			Name:         "deleteMeasure",
+			Description:  "Delete a measure",
+			InputSchema:  types.DeleteMeasureToolInputSchema,
+			OutputSchema: types.DeleteMeasureToolOutputSchema,
+			Annotations: &mcp.ToolAnnotations{
+				DestructiveHint: boolPtr(true),
+			},
+		},
+		resolver.DeleteMeasureTool,
 	)
 	mcp.AddTool(
 		server,

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -1137,6 +1137,24 @@ components:
         measure:
           $ref: "#/components/schemas/Measure"
 
+    DeleteMeasureInput:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+          description: Measure ID
+
+    DeleteMeasureOutput:
+      type: object
+      required:
+        - deleted_measure_id
+      properties:
+        deleted_measure_id:
+          $ref: "#/components/schemas/GID"
+          description: Deleted measure ID
+
     FrameworkOrderField:
       type: string
       enum:
@@ -4506,6 +4524,15 @@ tools:
       $ref: "#/components/schemas/UpdateMeasureInput"
     outputSchema:
       $ref: "#/components/schemas/UpdateMeasureOutput"
+  - name: deleteMeasure
+    description: Delete a measure
+    hints:
+      readonly: false
+      destructive: true
+    inputSchema:
+      $ref: "#/components/schemas/DeleteMeasureInput"
+    outputSchema:
+      $ref: "#/components/schemas/DeleteMeasureOutput"
   - name: listFrameworks
     description: List all frameworks for the organization
     hints:

--- a/pkg/server/api/mcp/v1/types/types.go
+++ b/pkg/server/api/mcp/v1/types/types.go
@@ -53,6 +53,8 @@ var (
 	DeleteDocumentToolOutputSchema                  = mcp.MustUnmarshalSchema(`{"type":"object","properties":{"deleted_document_id":{"type":"string","format":"string"}},"required":["deleted_document_id"]}`)
 	DeleteDraftDocumentVersionToolInputSchema       = mcp.MustUnmarshalSchema(`{"type":"object","properties":{"document_version_id":{"type":"string","format":"string"}},"required":["document_version_id"]}`)
 	DeleteDraftDocumentVersionToolOutputSchema      = mcp.MustUnmarshalSchema(`{"type":"object","properties":{"deleted_document_version_id":{"type":"string","format":"string"}},"required":["deleted_document_version_id"]}`)
+	DeleteMeasureToolInputSchema                    = mcp.MustUnmarshalSchema(`{"type":"object","properties":{"id":{"type":"string","format":"string"}},"required":["id"]}`)
+	DeleteMeasureToolOutputSchema                   = mcp.MustUnmarshalSchema(`{"type":"object","properties":{"deleted_measure_id":{"type":"string","format":"string"}},"required":["deleted_measure_id"]}`)
 	DeleteMeetingToolInputSchema                    = mcp.MustUnmarshalSchema(`{"type":"object","properties":{"id":{"type":"string","format":"string"}},"required":["id"]}`)
 	DeleteMeetingToolOutputSchema                   = mcp.MustUnmarshalSchema(`{"type":"object","properties":{"deleted_meeting_id":{"type":"string","format":"string"}},"required":["deleted_meeting_id"]}`)
 	DeleteRiskToolInputSchema                       = mcp.MustUnmarshalSchema(`{"type":"object","properties":{"id":{"type":"string","format":"string"}},"required":["id"]}`)
@@ -1054,6 +1056,18 @@ type DeleteDraftDocumentVersionInput struct {
 type DeleteDraftDocumentVersionOutput struct {
 	// Deleted document version ID
 	DeletedDocumentVersionID gid.GID `json:"deleted_document_version_id"`
+}
+
+// DeleteMeasureInput represents the schema
+type DeleteMeasureInput struct {
+	// Measure ID
+	ID gid.GID `json:"id"`
+}
+
+// DeleteMeasureOutput represents the schema
+type DeleteMeasureOutput struct {
+	// Deleted measure ID
+	DeletedMeasureID gid.GID `json:"deleted_measure_id"`
 }
 
 // DeleteMeetingInput represents the schema


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a deleteMeasure MCP tool to delete a measure by ID for authorized users. The tool returns deleted_measure_id and is marked as destructive.

- **New Features**
  - Added DeleteMeasureTool resolver with authorization (ActionMeasureDelete) and svc.Measures.Delete call.
  - Registered deleteMeasure tool in MCP server with destructive hint.
  - Introduced DeleteMeasureInput/Output schemas and Go types, plus JSON schema constants.

<sup>Written for commit 015b6bd6e78b630b40ff6cb5af35692a32e90c05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

