### PR TITLE
Unify Typescript config across monorepo

### DIFF
--- a/apps/console/tsconfig.app.json
+++ b/apps/console/tsconfig.app.json
@@ -1,31 +1,11 @@
 {
+  "extends": "@probo/tsconfig/app.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "target": "ES2020",
-    "useDefineForClassFields": true,
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": false,
-    "verbatimModuleSyntax": true,
-    "moduleDetection": "force",
-    "noEmit": true,
-    "jsx": "react-jsx",
     "baseUrl": ".",
     "paths": {
       "#/*": ["src/*"]
-    },
-
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    }
   },
   "include": ["src"]
 }

--- a/apps/console/tsconfig.node.json
+++ b/apps/console/tsconfig.node.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@probo/tsconfig/node.json",
+  "extends": "@probo/tsconfig/node-esm.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "types": ["@probo/eslint-plugin-relay-types"]

--- a/apps/console/tsconfig.node.json
+++ b/apps/console/tsconfig.node.json
@@ -1,26 +1,7 @@
 {
+  "extends": "@probo/tsconfig/node.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-    "allowJs": true,
-    "target": "ES2022",
-    "lib": ["ES2023"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": false,
-    "verbatimModuleSyntax": true,
-    "moduleDetection": "force",
-    "noEmit": true,
-
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true,
     "types": ["@probo/eslint-plugin-relay-types"]
   },
   "include": ["vite.config.ts", "eslint.config.mjs"]

--- a/apps/trust/tsconfig.app.json
+++ b/apps/trust/tsconfig.app.json
@@ -1,31 +1,11 @@
 {
+  "extends": "@probo/tsconfig/app.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "target": "ES2020",
-    "useDefineForClassFields": true,
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": false,
-    "verbatimModuleSyntax": true,
-    "moduleDetection": "force",
-    "noEmit": true,
-    "jsx": "react-jsx",
     "baseUrl": ".",
     "paths": {
       "#/*": ["src/*"]
-    },
-
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    }
   },
   "include": ["src"]
 }

--- a/apps/trust/tsconfig.node.json
+++ b/apps/trust/tsconfig.node.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@probo/tsconfig/node.json",
+  "extends": "@probo/tsconfig/node-esm.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "types": ["@probo/eslint-plugin-relay-types"]

--- a/apps/trust/tsconfig.node.json
+++ b/apps/trust/tsconfig.node.json
@@ -1,26 +1,7 @@
 {
+  "extends": "@probo/tsconfig/node.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-    "allowJs": true,
-    "target": "ES2022",
-    "lib": ["ES2023"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": false,
-    "verbatimModuleSyntax": true,
-    "moduleDetection": "force",
-    "noEmit": true,
-
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true,
     "types": ["@probo/eslint-plugin-relay-types"]
   },
   "include": ["vite.config.ts", "eslint.config.mjs"]

--- a/packages/coredata/tsconfig.json
+++ b/packages/coredata/tsconfig.json
@@ -1,5 +1,6 @@
 {
+  "extends": "@probo/tsconfig/react.json",
   "compilerOptions": {
-    "lib": ["ES2021", "dom"],
+    "lib": ["ES2022", "DOM"]
   }
 }

--- a/packages/coredata/tsconfig.json
+++ b/packages/coredata/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "extends": "@probo/tsconfig/react.json",
-  "compilerOptions": {
-    "lib": ["ES2022", "DOM"]
-  }
+  "extends": "@probo/tsconfig/react.json"
 }

--- a/packages/eslint-config/tsconfig.json
+++ b/packages/eslint-config/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "@probo/tsconfig/node.json",
+  "extends": "@probo/tsconfig/base.json",
   "compilerOptions": {
-    "types": ["@probo/eslint-plugin-relay-types"]
+    "types": ["node", "@probo/eslint-plugin-relay-types"],
+    "noEmit": true
   },
   "include": ["src", "eslint.config.mjs"]
 }

--- a/packages/eslint-config/tsconfig.json
+++ b/packages/eslint-config/tsconfig.json
@@ -1,21 +1,7 @@
 {
+  "extends": "@probo/tsconfig/node.json",
   "compilerOptions": {
-    "lib": ["ES2023"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "module": "EsNext",
-    "moduleResolution": "Bundler",
-    "allowImportingTsExtensions": false,
-    "moduleDetection": "force",
-    "verbatimModuleSyntax": true,
-    "noEmit": true,
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true,
     "types": ["@probo/eslint-plugin-relay-types"]
   },
-  "include": ["src", "eslint.config.mjs"],
+  "include": ["src", "eslint.config.mjs"]
 }

--- a/packages/helpers/tsconfig.json
+++ b/packages/helpers/tsconfig.json
@@ -1,5 +1,6 @@
 {
+  "extends": "@probo/tsconfig/react.json",
   "compilerOptions": {
-    "lib": ["ES2021", "dom"]
+    "lib": ["ES2022", "DOM"]
   }
 }

--- a/packages/helpers/tsconfig.json
+++ b/packages/helpers/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "extends": "@probo/tsconfig/react.json",
-  "compilerOptions": {
-    "lib": ["ES2022", "DOM"]
-  }
+  "extends": "@probo/tsconfig/react.json"
 }

--- a/packages/hooks/tsconfig.json
+++ b/packages/hooks/tsconfig.json
@@ -1,5 +1,6 @@
 {
+  "extends": "@probo/tsconfig/react.json",
   "compilerOptions": {
-    "lib": ["ES2021", "dom"]
+    "lib": ["ES2022", "DOM"]
   }
 }

--- a/packages/hooks/tsconfig.json
+++ b/packages/hooks/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "extends": "@probo/tsconfig/react.json",
-  "compilerOptions": {
-    "lib": ["ES2022", "DOM"]
-  }
+  "extends": "@probo/tsconfig/react.json"
 }

--- a/packages/n8n-node/tsconfig.json
+++ b/packages/n8n-node/tsconfig.json
@@ -11,7 +11,8 @@
     "preserveConstEnums": true,
     "resolveJsonModule": true,
     "incremental": true,
-    "outDir": "./dist/"
+    "outDir": "./dist/",
+    "noEmit": false
   },
   "include": [
     "credentials/**/*",

--- a/packages/n8n-node/tsconfig.json
+++ b/packages/n8n-node/tsconfig.json
@@ -1,24 +1,16 @@
 {
+  "extends": "@probo/tsconfig/node.json",
   "compilerOptions": {
-    "strict": true,
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "target": "es2019",
-    "lib": ["es2019", "es2020", "es2022.error"],
+    "target": "ES2019",
+    "lib": ["ES2019", "ES2020", "ES2022.error"],
     "removeComments": true,
     "useUnknownInCatchVariables": false,
-    "forceConsistentCasingInFileNames": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,
-    "noUnusedLocals": true,
     "strictNullChecks": true,
     "preserveConstEnums": true,
-    "esModuleInterop": true,
     "resolveJsonModule": true,
     "incremental": true,
-    "declaration": true,
-    "sourceMap": true,
-    "skipLibCheck": true,
     "outDir": "./dist/"
   },
   "include": [

--- a/packages/react-lazy/tsconfig.json
+++ b/packages/react-lazy/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig/library.json",
+  "extends": "@probo/tsconfig/library.json",
   "include": ["src"],
   "exclude": ["node_modules", "dist"]
 } 

--- a/packages/relay/tsconfig.json
+++ b/packages/relay/tsconfig.json
@@ -1,6 +1,6 @@
 {
-    "compilerOptions": {
-      "lib": ["ES2021", "dom"],
-      "jsx": "react-jsx",
-    }
+  "extends": "@probo/tsconfig/react.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"]
   }
+}

--- a/packages/relay/tsconfig.json
+++ b/packages/relay/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "extends": "@probo/tsconfig/react.json",
-  "compilerOptions": {
-    "lib": ["ES2022", "DOM"]
-  }
+  "extends": "@probo/tsconfig/react.json"
 }

--- a/packages/routes/tsconfig.json
+++ b/packages/routes/tsconfig.json
@@ -1,6 +1,6 @@
 {
+  "extends": "@probo/tsconfig/react.json",
   "compilerOptions": {
-    "lib": ["ES2021", "dom"],
-    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM"]
   }
 }

--- a/packages/routes/tsconfig.json
+++ b/packages/routes/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "extends": "@probo/tsconfig/react.json",
-  "compilerOptions": {
-    "lib": ["ES2022", "DOM"]
-  }
+  "extends": "@probo/tsconfig/react.json"
 }

--- a/packages/tsconfig/app.json
+++ b/packages/tsconfig/app.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig",
+    "display": "App",
+    "extends": "./react.json",
+    "compilerOptions": {
+        "lib": [
+            "ES2022",
+            "DOM",
+            "DOM.Iterable"
+        ],
+        "noEmit": true
+    }
+}

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -2,6 +2,21 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Default",
   "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": false,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
     "composite": false,
     "declaration": true,
     "declarationMap": true,
@@ -9,14 +24,7 @@
     "forceConsistentCasingInFileNames": true,
     "inlineSources": false,
     "isolatedModules": true,
-    "moduleResolution": "bundler",
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "preserveWatchOutput": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "target": "ES2020",
-    "module": "ESNext"
+    "preserveWatchOutput": true
   },
   "exclude": ["node_modules"]
 }

--- a/packages/tsconfig/library.json
+++ b/packages/tsconfig/library.json
@@ -8,6 +8,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "rootDir": "./src",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "noEmit": false
   }
 }

--- a/packages/tsconfig/node-esm.json
+++ b/packages/tsconfig/node-esm.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Node ESM",
+  "extends": "./base.json",
+  "compilerOptions": {
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "noEmit": true
+  }
+}

--- a/packages/tsconfig/node.json
+++ b/packages/tsconfig/node.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig",
+    "display": "Node",
+    "extends": "./base.json",
+    "compilerOptions": {
+        "lib": [
+            "ES2023"
+        ],
+        "module": "CommonJS",
+        "moduleResolution": "node",
+        "allowJs": true,
+        "types": [
+            "node"
+        ],
+        "noEmit": true
+    }
+}

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -8,7 +8,9 @@
   "files": [
     "base.json",
     "react.json",
-    "library.json"
+    "library.json",
+    "node.json",
+    "app.json"
   ],
   "license": "MIT"
 }

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -10,6 +10,7 @@
     "react.json",
     "library.json",
     "node.json",
+    "node-esm.json",
     "app.json"
   ],
   "license": "MIT"

--- a/packages/tsconfig/react.json
+++ b/packages/tsconfig/react.json
@@ -4,9 +4,7 @@
   "extends": "./base.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "module": "ESNext",
-    "target": "ESNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "noEmit": true
   }
 }

--- a/packages/ui/tsconfig.app.json
+++ b/packages/ui/tsconfig.app.json
@@ -1,27 +1,7 @@
 {
+  "extends": "@probo/tsconfig/app.json",
   "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "target": "ES2020",
-    "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": false,
-    "verbatimModuleSyntax": true,
-    "moduleDetection": "force",
-    "noEmit": true,
-    "jsx": "react-jsx",
-
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo"
   },
-  "include": ["src", ".storybook/**/*"],
+  "include": ["src", ".storybook/**/*"]
 }

--- a/packages/ui/tsconfig.node.json
+++ b/packages/ui/tsconfig.node.json
@@ -1,26 +1,7 @@
 {
+  "extends": "@probo/tsconfig/node.json",
   "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-    "allowJs": true,
-    "target": "ES2022",
-    "lib": ["ES2023"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": false,
-    "verbatimModuleSyntax": true,
-    "moduleDetection": "force",
-    "noEmit": true,
-
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo"
   },
   "include": ["vite.config.ts", "eslint.config.mjs", "tailwind.config.js"]
 }

--- a/packages/ui/tsconfig.node.json
+++ b/packages/ui/tsconfig.node.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@probo/tsconfig/node.json",
+  "extends": "@probo/tsconfig/node-esm.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo"
   },


### PR DESCRIPTION
Fixes #616 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies TypeScript config across the monorepo using shared @probo/tsconfig presets. Removes duplication, enforces strict settings, and clarifies build behavior for apps vs libraries.

- **Refactors**
  - Added and published presets: base, react, app, library, node (CJS), and node-esm (packages/tsconfig).
  - Tightened defaults in base (ES2022 target/libs, bundler resolution, strict/unused checks); React uses ES2022 + DOM libs; Library preset enables emit to dist.
  - Updated apps (console, trust, ui) to extend app/node-esm; updated packages (coredata, helpers, hooks, relay, routes, eslint-config, react-lazy) to extend react/library or base; eslint-config now includes node types; react-lazy references the published library preset.
  - n8n-node now extends the Node preset and emits build output to dist by overriding noEmit.

<sup>Written for commit 2fb3f133a4ba5d2f289261f0369226b28f026fe9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

