### PR TITLE
Add access to SOA for auditor

### DIFF
--- a/pkg/probo/policies.go
+++ b/pkg/probo/policies.go
@@ -142,11 +142,17 @@ var AuditorPolicy = policy.NewPolicy(
 		ActionSnapshotGet, ActionSnapshotList,
 		ActionMeetingGet, ActionMeetingList,
 		ActionFileGet, ActionFileDownloadUrl,
+		ActionStateOfApplicabilityGet, ActionStateOfApplicabilityList,
+		ActionApplicabilityStatementGet, ActionApplicabilityStatementList,
 	).WithSID("entity-read-access").When(organizationCondition),
 
 	policy.Allow(
 		ActionDocumentVersionExportPDF, ActionDocumentVersionExportSignable, ActionDocumentVersionSign,
 	).WithSID("document-signing").When(organizationCondition),
+
+	policy.Allow(
+		ActionStateOfApplicabilityExport,
+	).WithSID("soa-export").When(organizationCondition),
 ).WithDescription("Read-only probo access for auditors (excludes internal/employee content)")
 
 // EmployeePolicy defines permissions for employee role.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Grant auditors org-scoped read access to the State of Applicability (SoA) and Applicability Statements, and enable SoA export in the read-only auditor policy.

<sup>Written for commit 858c02a6bbbcb87d224ef1e456709384a67e977d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

