### PR TITLE
Fix compose.prod.yaml

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -3,15 +3,15 @@ services:
     image: "ghcr.io/getprobo/probo:latest"
     environment:
       # Required secrets (use secure values in production)
-      PROBOD_ENCRYPTION_KEY: "thisisnotasecretAAAAAAAAAAAAAAAAAAAAAAAAAAA="
-      AUTH_COOKIE_SECRET: "this-is-a-secure-secret-for-cookie-signing-at-least-32-bytes"
-      AUTH_PASSWORD_PEPPER: "this-is-a-secure-pepper-for-password-hashing-at-least-32-bytes"
-      TRUST_AUTH_TOKEN_SECRET: "this-is-a-secure-secret-for-trust-token-signing-at-least-32-bytes"
+      PROBOD_ENCRYPTION_KEY: ${PROBOD_ENCRYPTION_KEY}
+      AUTH_COOKIE_SECRET: ${AUTH_COOKIE_SECRET}
+      AUTH_PASSWORD_PEPPER: ${AUTH_PASSWORD_PEPPER}
+      TRUST_AUTH_TOKEN_SECRET: ${TRUST_AUTH_TOKEN_SECRET}
 
       # Application settings
-      PROBOD_BASE_URL: "http://localhost:8080"
-      API_ADDR: "localhost:8080"
-      API_CORS_ALLOWED_ORIGINS: "http://localhost:8080"
+      PROBOD_BASE_URL: ${PROBOD_BASE_URL}
+      API_ADDR: ${API_ADDR}
+      API_CORS_ALLOWED_ORIGINS: ${API_CORS_ALLOWED_ORIGINS}
 
       # PostgreSQL database
       PG_ADDR: "postgres:5432"
@@ -26,6 +26,7 @@ services:
       AWS_ACCESS_KEY_ID: "probod"
       AWS_SECRET_ACCESS_KEY: "thisisnotasecret"
       AWS_ENDPOINT: "http://seaweedfs:8333"
+      AWS_USE_PATH_STYLE: "true"
 
       # Observability - Metrics & Tracing
       METRICS_ADDR: "probo:8081"


### PR DESCRIPTION
Fix https://github.com/getprobo/probo/issues/685

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update compose.prod.yaml to load secrets and app settings from environment variables, removing hardcoded placeholders. Set AWS_USE_PATH_STYLE=true to ensure SeaweedFS S3 path-style compatibility.

<sup>Written for commit 9b3c1b6428bd0d69de925dbc86a1879a1a26f717. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

