### PR TITLE
API - Set profile email address on create

### DIFF
--- a/packages/n8n-node/nodes/Probo/actions/user/inviteUser.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/user/inviteUser.operation.ts
@@ -48,8 +48,6 @@ export async function execute(
 						expiresAt
 						status
 						createdAt
-						user { id fullName emailAddress }
-						organization { id name }
 					}
 				}
 			}

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -1163,45 +1163,6 @@ func (s *OrganizationService) GetOrganizationForMembership(ctx context.Context, 
 	return organization, nil
 }
 
-func (s *OrganizationService) GetOrganizationForInvitation(ctx context.Context, invitationID gid.GID) (*coredata.Organization, error) {
-	var (
-		scope        = coredata.NewScopeFromObjectID(invitationID)
-		organization = &coredata.Organization{}
-	)
-
-	err := s.pg.WithConn(
-		ctx,
-		func(conn pg.Conn) error {
-			invitation := &coredata.Invitation{}
-			err := invitation.LoadByID(ctx, conn, scope, invitationID)
-			if err != nil {
-				if err == coredata.ErrResourceNotFound {
-					return NewInvitationNotFoundError(invitationID)
-				}
-
-				return fmt.Errorf("cannot load invitation: %w", err)
-			}
-
-			err = organization.LoadByID(ctx, conn, scope, invitation.OrganizationID)
-			if err != nil {
-				if err == coredata.ErrResourceNotFound {
-					return NewOrganizationNotFoundError(invitation.OrganizationID)
-				}
-
-				return fmt.Errorf("cannot load organization: %w", err)
-			}
-
-			return nil
-		},
-	)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return organization, nil
-}
-
 func (s OrganizationService) GenerateLogoURL(
 	ctx context.Context,
 	organizationID gid.GID,

--- a/pkg/server/api/connect/v1/schema.graphql
+++ b/pkg/server/api/connect/v1/schema.graphql
@@ -291,9 +291,6 @@ type Invitation implements Node {
   createdAt: Datetime!
   status: InvitationStatus!
 
-  user: Profile @goField(forceResolver: true)
-  organization: Organization @goField(forceResolver: true)
-
   permission(action: String!): Boolean!
     @goField(forceResolver: true)
     @session(required: PRESENT)

--- a/pkg/server/api/connect/v1/schema/schema.go
+++ b/pkg/server/api/connect/v1/schema/schema.go
@@ -161,14 +161,12 @@ type ComplexityRoot struct {
 	}
 
 	Invitation struct {
-		AcceptedAt   func(childComplexity int) int
-		CreatedAt    func(childComplexity int) int
-		ExpiresAt    func(childComplexity int) int
-		ID           func(childComplexity int) int
-		Organization func(childComplexity int) int
-		Permission   func(childComplexity int, action string) int
-		Status       func(childComplexity int) int
-		User         func(childComplexity int) int
+		AcceptedAt func(childComplexity int) int
+		CreatedAt  func(childComplexity int) int
+		ExpiresAt  func(childComplexity int) int
+		ID         func(childComplexity int) int
+		Permission func(childComplexity int, action string) int
+		Status     func(childComplexity int) int
 	}
 
 	InvitationConnection struct {
@@ -502,8 +500,6 @@ type IdentityResolver interface {
 	Permission(ctx context.Context, obj *types.Identity, action string) (bool, error)
 }
 type InvitationResolver interface {
-	User(ctx context.Context, obj *types.Invitation) (*types.Profile, error)
-	Organization(ctx context.Context, obj *types.Invitation) (*types.Organization, error)
 	Permission(ctx context.Context, obj *types.Invitation, action string) (bool, error)
 }
 type MembershipResolver interface {
@@ -913,12 +909,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Invitation.ID(childComplexity), true
-	case "Invitation.organization":
-		if e.complexity.Invitation.Organization == nil {
-			break
-		}
-
-		return e.complexity.Invitation.Organization(childComplexity), true
 	case "Invitation.permission":
 		if e.complexity.Invitation.Permission == nil {
 			break
@@ -936,12 +926,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Invitation.Status(childComplexity), true
-	case "Invitation.user":
-		if e.complexity.Invitation.User == nil {
-			break
-		}
-
-		return e.complexity.Invitation.User(childComplexity), true
 
 	case "InvitationConnection.edges":
 		if e.complexity.InvitationConnection.Edges == nil {
@@ -2762,9 +2746,6 @@ type Invitation implements Node {
   acceptedAt: Datetime
   createdAt: Datetime!
   status: InvitationStatus!
-
-  user: Profile @goField(forceResolver: true)
-  organization: Organization @goField(forceResolver: true)
 
   permission(action: String!): Boolean!
     @goField(forceResolver: true)
@@ -5753,132 +5734,6 @@ func (ec *executionContext) fieldContext_Invitation_status(_ context.Context, fi
 	return fc, nil
 }
 
-func (ec *executionContext) _Invitation_user(ctx context.Context, field graphql.CollectedField, obj *types.Invitation) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		ec.fieldContext_Invitation_user,
-		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Invitation().User(ctx, obj)
-		},
-		nil,
-		ec.marshalOProfile2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconnectᚋv1ᚋtypesᚐProfile,
-		true,
-		false,
-	)
-}
-
-func (ec *executionContext) fieldContext_Invitation_user(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Invitation",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_Profile_id(ctx, field)
-			case "fullName":
-				return ec.fieldContext_Profile_fullName(ctx, field)
-			case "emailAddress":
-				return ec.fieldContext_Profile_emailAddress(ctx, field)
-			case "source":
-				return ec.fieldContext_Profile_source(ctx, field)
-			case "state":
-				return ec.fieldContext_Profile_state(ctx, field)
-			case "additionalEmailAddresses":
-				return ec.fieldContext_Profile_additionalEmailAddresses(ctx, field)
-			case "kind":
-				return ec.fieldContext_Profile_kind(ctx, field)
-			case "position":
-				return ec.fieldContext_Profile_position(ctx, field)
-			case "contractStartDate":
-				return ec.fieldContext_Profile_contractStartDate(ctx, field)
-			case "contractEndDate":
-				return ec.fieldContext_Profile_contractEndDate(ctx, field)
-			case "createdAt":
-				return ec.fieldContext_Profile_createdAt(ctx, field)
-			case "updatedAt":
-				return ec.fieldContext_Profile_updatedAt(ctx, field)
-			case "identity":
-				return ec.fieldContext_Profile_identity(ctx, field)
-			case "organization":
-				return ec.fieldContext_Profile_organization(ctx, field)
-			case "membership":
-				return ec.fieldContext_Profile_membership(ctx, field)
-			case "pendingInvitations":
-				return ec.fieldContext_Profile_pendingInvitations(ctx, field)
-			case "permission":
-				return ec.fieldContext_Profile_permission(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Profile", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Invitation_organization(ctx context.Context, field graphql.CollectedField, obj *types.Invitation) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		ec.fieldContext_Invitation_organization,
-		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Invitation().Organization(ctx, obj)
-		},
-		nil,
-		ec.marshalOOrganization2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconnectᚋv1ᚋtypesᚐOrganization,
-		true,
-		false,
-	)
-}
-
-func (ec *executionContext) fieldContext_Invitation_organization(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Invitation",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_Organization_id(ctx, field)
-			case "name":
-				return ec.fieldContext_Organization_name(ctx, field)
-			case "logoUrl":
-				return ec.fieldContext_Organization_logoUrl(ctx, field)
-			case "horizontalLogoUrl":
-				return ec.fieldContext_Organization_horizontalLogoUrl(ctx, field)
-			case "email":
-				return ec.fieldContext_Organization_email(ctx, field)
-			case "description":
-				return ec.fieldContext_Organization_description(ctx, field)
-			case "websiteUrl":
-				return ec.fieldContext_Organization_websiteUrl(ctx, field)
-			case "headquarterAddress":
-				return ec.fieldContext_Organization_headquarterAddress(ctx, field)
-			case "createdAt":
-				return ec.fieldContext_Organization_createdAt(ctx, field)
-			case "updatedAt":
-				return ec.fieldContext_Organization_updatedAt(ctx, field)
-			case "profiles":
-				return ec.fieldContext_Organization_profiles(ctx, field)
-			case "samlConfigurations":
-				return ec.fieldContext_Organization_samlConfigurations(ctx, field)
-			case "scimConfiguration":
-				return ec.fieldContext_Organization_scimConfiguration(ctx, field)
-			case "viewer":
-				return ec.fieldContext_Organization_viewer(ctx, field)
-			case "permission":
-				return ec.fieldContext_Organization_permission(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Organization", field.Name)
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _Invitation_permission(ctx context.Context, field graphql.CollectedField, obj *types.Invitation) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -6046,10 +5901,6 @@ func (ec *executionContext) fieldContext_InvitationEdge_node(_ context.Context, 
 				return ec.fieldContext_Invitation_createdAt(ctx, field)
 			case "status":
 				return ec.fieldContext_Invitation_status(ctx, field)
-			case "user":
-				return ec.fieldContext_Invitation_user(ctx, field)
-			case "organization":
-				return ec.fieldContext_Invitation_organization(ctx, field)
 			case "permission":
 				return ec.fieldContext_Invitation_permission(ctx, field)
 			}
@@ -17618,72 +17469,6 @@ func (ec *executionContext) _Invitation(ctx context.Context, sel ast.SelectionSe
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
-		case "user":
-			field := field
-
-			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Invitation_user(ctx, field, obj)
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-		case "organization":
-			field := field
-
-			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Invitation_organization(ctx, field, obj)
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "permission":
 			field := field
 

--- a/pkg/server/api/connect/v1/types/invitation.go
+++ b/pkg/server/api/connect/v1/types/invitation.go
@@ -68,11 +68,5 @@ func NewInvitation(invitation *coredata.Invitation) *Invitation {
 		AcceptedAt: invitation.AcceptedAt,
 		CreatedAt:  invitation.CreatedAt,
 		Status:     invitation.Status,
-		User: &Profile{
-			ID: invitation.UserID,
-		},
-		Organization: &Organization{
-			ID: invitation.OrganizationID,
-		},
 	}
 }

--- a/pkg/server/api/connect/v1/types/types.go
+++ b/pkg/server/api/connect/v1/types/types.go
@@ -208,14 +208,12 @@ func (Identity) IsNode()             {}
 func (this Identity) GetID() gid.GID { return this.ID }
 
 type Invitation struct {
-	ID           gid.GID                   `json:"id"`
-	ExpiresAt    time.Time                 `json:"expiresAt"`
-	AcceptedAt   *time.Time                `json:"acceptedAt,omitempty"`
-	CreatedAt    time.Time                 `json:"createdAt"`
-	Status       coredata.InvitationStatus `json:"status"`
-	User         *Profile                  `json:"user,omitempty"`
-	Organization *Organization             `json:"organization,omitempty"`
-	Permission   bool                      `json:"permission"`
+	ID         gid.GID                   `json:"id"`
+	ExpiresAt  time.Time                 `json:"expiresAt"`
+	AcceptedAt *time.Time                `json:"acceptedAt,omitempty"`
+	CreatedAt  time.Time                 `json:"createdAt"`
+	Status     coredata.InvitationStatus `json:"status"`
+	Permission bool                      `json:"permission"`
 }
 
 func (Invitation) IsNode()             {}

--- a/pkg/server/api/connect/v1/v1_resolver.go
+++ b/pkg/server/api/connect/v1/v1_resolver.go
@@ -189,32 +189,6 @@ func (r *identityResolver) Permission(ctx context.Context, obj *types.Identity, 
 	return r.Resolver.Permission(ctx, obj, action)
 }
 
-// User is the resolver for the user field.
-func (r *invitationResolver) User(ctx context.Context, obj *types.Invitation) (*types.Profile, error) {
-	panic(fmt.Errorf("not implemented: User - user"))
-}
-
-// Organization is the resolver for the organization field.
-func (r *invitationResolver) Organization(ctx context.Context, obj *types.Invitation) (*types.Organization, error) {
-	if err := r.authorize(ctx, obj.Organization.ID, iam.ActionOrganizationGet, authz.WithSkipAssumptionCheck()); err != nil {
-		return nil, err
-	}
-
-	if gqlutils.OnlyIDSelected(ctx) {
-		return &types.Organization{
-			ID: obj.Organization.ID,
-		}, nil
-	}
-
-	organization, err := r.iam.OrganizationService.GetOrganizationForInvitation(ctx, obj.ID)
-	if err != nil {
-		r.logger.ErrorCtx(ctx, "cannot get organization for invitation", log.Error(err))
-		return nil, gqlutils.Internal(ctx)
-	}
-
-	return types.NewOrganization(organization), nil
-}
-
 // Permission is the resolver for the permission field.
 func (r *invitationResolver) Permission(ctx context.Context, obj *types.Invitation, action string) (bool, error) {
 	return r.Resolver.Permission(ctx, obj, action)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set the profile EmailAddress in OrganizationService.CreateUser from req.EmailAddress so the create response includes the user’s email and avoids a follow-up fetch.
Removed unused Invitation.user and Invitation.organization GraphQL fields and resolvers, and updated the inviteUser query to stop requesting them.

<sup>Written for commit f75bde75f16460a7c0f3e738dc3b8cf420d22396. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

