### PR TITLE
Fix MCP

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -60,6 +60,7 @@ type Server struct {
 	extraHeaderFields map[string]string
 	proboService      *probo.Service
 	trustService      *trust.Service
+	baseURL           *baseurl.BaseURL
 	logger            *log.Logger
 }
 
@@ -103,6 +104,7 @@ func NewServer(cfg Config) (*Server, error) {
 		extraHeaderFields: cfg.ExtraHeaderFields,
 		proboService:      cfg.Probo,
 		trustService:      cfg.Trust,
+		baseURL:           cfg.BaseURL,
 		logger:            cfg.Logger,
 	}
 
@@ -114,6 +116,14 @@ func NewServer(cfg Config) (*Server, error) {
 func (s *Server) setupRoutes() {
 	s.router.Mount("/api", http.StripPrefix("/api", s.apiServer))
 
+	// OAuth 2.0 Protected Resource Metadata (RFC 9728) for the MCP endpoint.
+	// MCP clients fetch this before connecting to discover auth requirements.
+	s.router.Get("/.well-known/oauth-protected-resource/api/mcp/v1", s.handleMCPOAuthProtectedResourceMetadata)
+
+	// OAuth 2.0 Authorization Server Metadata (RFC 8414).
+	// MCP clients fall back to this when the server URL itself is treated as the authorization server.
+	s.router.Get("/.well-known/oauth-authorization-server", s.handleOAuthAuthorizationServerMetadata)
+
 	s.router.Route("/trust/{slugOrId}", func(r chi.Router) {
 		r.Use(compliancepage.NewIDMiddleware(s.trustService))
 		r.Use(s.stripTrustPrefix)
@@ -121,6 +131,35 @@ func (s *Server) setupRoutes() {
 	})
 
 	s.router.Mount("/", s.consoleWebServer)
+}
+
+func (s *Server) handleMCPOAuthProtectedResourceMetadata(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	httpserver.RenderJSON(
+		w,
+		http.StatusOK,
+		map[string]any{
+			"resource":                 s.baseURL.WithPath("/api/mcp/v1").MustString(),
+			"bearer_methods_supported": []string{"header"},
+		},
+	)
+}
+
+func (s *Server) handleOAuthAuthorizationServerMetadata(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	httpserver.RenderJSON(
+		w,
+		http.StatusOK,
+		map[string]any{
+			"issuer":                   s.baseURL.String(),
+			"response_types_supported": []string{"token"},
+			"grant_types_supported":    []string{"client_credentials"},
+		},
+	)
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add OAuth 2.0 metadata endpoints for MCP so clients can discover auth and connect. Canonical resource and issuer URLs are built from Server.BaseURL.

- **New Features**
  - Exposes /.well-known/oauth-protected-resource/api/mcp/v1 → resource=<BaseURL>/api/mcp/v1, bearer_methods_supported=["header"].
  - Exposes /.well-known/oauth-authorization-server → issuer=<BaseURL>, response_types_supported=["token"], grant_types_supported=["client_credentials"].

- **Migration**
  - Set BaseURL in server config; Server stores cfg.BaseURL and handlers use it.

<sup>Written for commit 3048b99adba03d147c3cab1ddf60656026846aab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

