### PR TITLE
Add connect API to n8n execute

### DIFF
--- a/packages/n8n-node/nodes/Probo/actions/execute/execute.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/execute/execute.operation.ts
@@ -1,7 +1,32 @@
 import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
-import { proboApiRequest } from '../../GenericFunctions';
+import { proboApiRequest, proboConnectApiRequest } from '../../GenericFunctions';
 
 export const description: INodeProperties[] = [
+	{
+		displayName: 'API',
+		name: 'api',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['execute'],
+			},
+		},
+		options: [
+			{
+				name: 'Console API',
+				value: 'console',
+				description: 'Call the Console GraphQL API (/api/console/v1/graphql)',
+			},
+			{
+				name: 'Connect API',
+				value: 'connect',
+				description: 'Call the Connect GraphQL API (/api/connect/v1/graphql)',
+			},
+		],
+		default: 'console',
+		description: 'Which Probo API to call',
+	},
 	{
 		displayName: 'Query',
 		name: 'query',
@@ -36,6 +61,7 @@ export async function execute(
 	this: IExecuteFunctions,
 	itemIndex: number,
 ): Promise<INodeExecutionData> {
+	const api = this.getNodeParameter('api', itemIndex, 'console') as string;
 	const query = this.getNodeParameter('query', itemIndex) as string;
 	const variablesParam = this.getNodeParameter('variables', itemIndex) as string;
 
@@ -63,7 +89,8 @@ export async function execute(
 		}
 	}
 
-	const responseData = await proboApiRequest.call(this, query, variables);
+	const requestFn = api === 'connect' ? proboConnectApiRequest : proboApiRequest;
+	const responseData = await requestFn.call(this, query, variables);
 
 	return {
 		json: responseData,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an API selector to the Probo execute node so workflows can call either the Console or Connect GraphQL API. This lets you run queries against both Probo services from the same node.

- **New Features**
  - Added an "API" option (Console or Connect), defaulting to Console.
  - Routes requests to proboConnectApiRequest for Connect (/api/connect/v1/graphql) and proboApiRequest for Console (/api/console/v1/graphql).

<sup>Written for commit 9dd626ff2d0914f1a41a04707513fa5baf68ddbe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

