### PR TITLE
Add profile webhooks

### DIFF
--- a/apps/console/src/__generated__/core/WebhooksSettingsPageQuery.graphql.ts
+++ b/apps/console/src/__generated__/core/WebhooksSettingsPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<164efe490915ac140a48e42cbd17e915>>
+ * @generated SignedSource<<6cbb8778f87d89e33990a8d2f015f07c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,7 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type WebhookEventType = "MEETING_CREATED" | "MEETING_DELETED" | "MEETING_UPDATED" | "VENDOR_CREATED" | "VENDOR_DELETED" | "VENDOR_UPDATED";
+export type WebhookEventType = "MEETING_CREATED" | "MEETING_DELETED" | "MEETING_UPDATED" | "MEMBERSHIP_PROFILE_CREATED" | "MEMBERSHIP_PROFILE_DELETED" | "MEMBERSHIP_PROFILE_UPDATED" | "VENDOR_CREATED" | "VENDOR_DELETED" | "VENDOR_UPDATED";
 export type WebhooksSettingsPageQuery$variables = {
   organizationId: string;
 };

--- a/apps/console/src/__generated__/core/WebhooksSettingsPage_createMutation.graphql.ts
+++ b/apps/console/src/__generated__/core/WebhooksSettingsPage_createMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<240851e53a2871e13a6e19a5b327684c>>
+ * @generated SignedSource<<0d744fdb954b7d5cda77e7828f849b5c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,7 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type WebhookEventType = "MEETING_CREATED" | "MEETING_DELETED" | "MEETING_UPDATED" | "VENDOR_CREATED" | "VENDOR_DELETED" | "VENDOR_UPDATED";
+export type WebhookEventType = "MEETING_CREATED" | "MEETING_DELETED" | "MEETING_UPDATED" | "MEMBERSHIP_PROFILE_CREATED" | "MEMBERSHIP_PROFILE_DELETED" | "MEMBERSHIP_PROFILE_UPDATED" | "VENDOR_CREATED" | "VENDOR_DELETED" | "VENDOR_UPDATED";
 export type CreateWebhookSubscriptionInput = {
   endpointUrl: string;
   organizationId: string;

--- a/apps/console/src/__generated__/core/WebhooksSettingsPage_updateMutation.graphql.ts
+++ b/apps/console/src/__generated__/core/WebhooksSettingsPage_updateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<864603efd6135475b827a1234b128b7c>>
+ * @generated SignedSource<<b877b6877597e2843515beb1cbcfee07>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,7 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type WebhookEventType = "MEETING_CREATED" | "MEETING_DELETED" | "MEETING_UPDATED" | "VENDOR_CREATED" | "VENDOR_DELETED" | "VENDOR_UPDATED";
+export type WebhookEventType = "MEETING_CREATED" | "MEETING_DELETED" | "MEETING_UPDATED" | "MEMBERSHIP_PROFILE_CREATED" | "MEMBERSHIP_PROFILE_DELETED" | "MEMBERSHIP_PROFILE_UPDATED" | "VENDOR_CREATED" | "VENDOR_DELETED" | "VENDOR_UPDATED";
 export type UpdateWebhookSubscriptionInput = {
   endpointUrl?: string | null | undefined;
   id: string;

--- a/apps/console/src/pages/organizations/settings/WebhooksSettingsPage.tsx
+++ b/apps/console/src/pages/organizations/settings/WebhooksSettingsPage.tsx
@@ -147,6 +147,9 @@ const EVENT_TYPES = [
   { value: "VENDOR_CREATED", label: "vendor:created" },
   { value: "VENDOR_UPDATED", label: "vendor:updated" },
   { value: "VENDOR_DELETED", label: "vendor:deleted" },
+  { value: "MEMBERSHIP_PROFILE_CREATED", label: "membership_profile:created" },
+  { value: "MEMBERSHIP_PROFILE_UPDATED", label: "membership_profile:updated" },
+  { value: "MEMBERSHIP_PROFILE_DELETED", label: "membership_profile:deleted" },
 ] as const;
 
 type WebhookEventType = (typeof EVENT_TYPES)[number]["value"];

--- a/pkg/coredata/migrations/20260224T120000Z.sql
+++ b/pkg/coredata/migrations/20260224T120000Z.sql
@@ -1,0 +1,3 @@
+ALTER TYPE webhook_event_type ADD VALUE 'membership_profile:created';
+ALTER TYPE webhook_event_type ADD VALUE 'membership_profile:updated';
+ALTER TYPE webhook_event_type ADD VALUE 'membership_profile:deleted';

--- a/pkg/coredata/webhook_event_type.go
+++ b/pkg/coredata/webhook_event_type.go
@@ -23,12 +23,15 @@ import (
 type WebhookEventType string
 
 const (
-	WebhookEventTypeMeetingCreated WebhookEventType = "meeting:created"
-	WebhookEventTypeMeetingUpdated WebhookEventType = "meeting:updated"
-	WebhookEventTypeMeetingDeleted WebhookEventType = "meeting:deleted"
-	WebhookEventTypeVendorCreated  WebhookEventType = "vendor:created"
-	WebhookEventTypeVendorUpdated  WebhookEventType = "vendor:updated"
-	WebhookEventTypeVendorDeleted  WebhookEventType = "vendor:deleted"
+	WebhookEventTypeMeetingCreated        WebhookEventType = "meeting:created"
+	WebhookEventTypeMeetingUpdated        WebhookEventType = "meeting:updated"
+	WebhookEventTypeMeetingDeleted        WebhookEventType = "meeting:deleted"
+	WebhookEventTypeVendorCreated         WebhookEventType = "vendor:created"
+	WebhookEventTypeVendorUpdated         WebhookEventType = "vendor:updated"
+	WebhookEventTypeVendorDeleted         WebhookEventType = "vendor:deleted"
+	WebhookEventTypeMembershipProfileCreated WebhookEventType = "membership_profile:created"
+	WebhookEventTypeMembershipProfileUpdated WebhookEventType = "membership_profile:updated"
+	WebhookEventTypeMembershipProfileDeleted WebhookEventType = "membership_profile:deleted"
 )
 
 func (w WebhookEventType) String() string {
@@ -38,7 +41,8 @@ func (w WebhookEventType) String() string {
 func (w WebhookEventType) IsValid() bool {
 	switch w {
 	case WebhookEventTypeMeetingCreated, WebhookEventTypeMeetingUpdated, WebhookEventTypeMeetingDeleted,
-		WebhookEventTypeVendorCreated, WebhookEventTypeVendorUpdated, WebhookEventTypeVendorDeleted:
+		WebhookEventTypeVendorCreated, WebhookEventTypeVendorUpdated, WebhookEventTypeVendorDeleted,
+		WebhookEventTypeMembershipProfileCreated, WebhookEventTypeMembershipProfileUpdated, WebhookEventTypeMembershipProfileDeleted:
 		return true
 	}
 	return false

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -2282,6 +2282,12 @@ enum WebhookEventType
         @goEnum(value: "go.probo.inc/probo/pkg/coredata.WebhookEventTypeVendorUpdated")
     VENDOR_DELETED
         @goEnum(value: "go.probo.inc/probo/pkg/coredata.WebhookEventTypeVendorDeleted")
+    MEMBERSHIP_PROFILE_CREATED
+        @goEnum(value: "go.probo.inc/probo/pkg/coredata.WebhookEventTypeMembershipProfileCreated")
+    MEMBERSHIP_PROFILE_UPDATED
+        @goEnum(value: "go.probo.inc/probo/pkg/coredata.WebhookEventTypeMembershipProfileUpdated")
+    MEMBERSHIP_PROFILE_DELETED
+        @goEnum(value: "go.probo.inc/probo/pkg/coredata.WebhookEventTypeMembershipProfileDeleted")
 }
 
 type WebhookSubscription implements Node {

--- a/pkg/webhook/types/membership_profile.go
+++ b/pkg/webhook/types/membership_profile.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package types
+
+import (
+	"time"
+
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/mail"
+)
+
+type MembershipProfile struct {
+	ID                       gid.GID                        `json:"id"`
+	OrganizationID           gid.GID                        `json:"organizationId"`
+	EmailAddress             mail.Addr                      `json:"emailAddress"`
+	FullName                 string                         `json:"fullName"`
+	Kind                     coredata.MembershipProfileKind `json:"kind"`
+	Source                   coredata.ProfileSource         `json:"source"`
+	State                    coredata.ProfileState          `json:"state"`
+	AdditionalEmailAddresses mail.Addrs                     `json:"additionalEmailAddresses"`
+	Position                 *string                        `json:"position"`
+	ContractStartDate        *time.Time                     `json:"contractStartDate"`
+	ContractEndDate          *time.Time                     `json:"contractEndDate"`
+	CreatedAt                time.Time                      `json:"createdAt"`
+	UpdatedAt                time.Time                      `json:"updatedAt"`
+}
+
+func NewMembershipProfile(p *coredata.MembershipProfile) *MembershipProfile {
+	return &MembershipProfile{
+		ID:                       p.ID,
+		OrganizationID:           p.OrganizationID,
+		EmailAddress:             p.EmailAddress,
+		FullName:                 p.FullName,
+		Kind:                     p.Kind,
+		Source:                   p.Source,
+		State:                    p.State,
+		AdditionalEmailAddresses: p.AdditionalEmailAddresses,
+		Position:                 p.Position,
+		ContractStartDate:        p.ContractStartDate,
+		ContractEndDate:          p.ContractEndDate,
+		CreatedAt:                p.CreatedAt,
+		UpdatedAt:                p.UpdatedAt,
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add membership_profile webhook events (created, updated, deleted) to keep external systems in sync with user profile changes. Events fire from IAM and SCIM flows and are selectable in Console.

- **New Features**
  - Added event types: membership_profile:created, :updated, :deleted (DB enum, Go constants, GraphQL enum, Console UI).
  - New webhook payload: MembershipProfile (id, organizationId, emailAddress, additionalEmailAddresses, fullName, kind, source, state, position, contract dates, timestamps).
  - Emit events in IAM: CreateUser (created), UpdateUser (updated, now transactional), RemoveUser (deleted).
  - Emit events in SCIM: CreateUser (created or updated), UpdateUser (updated), DeleteUser (deleted).

- **Migration**
  - Run DB migration to add the new webhook_event_type enum values.
  - Update webhook subscriptions to include the new membership_profile events as needed.

<sup>Written for commit 655e6adaac732c8b6e3ec08bd88f2a0868af7d66. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

