### PR TITLE
Add compliance page newletter subscribers

### DIFF
--- a/apps/console/src/__generated__/core/CompliancePageNewsletterListDeleteMutation.graphql.ts
+++ b/apps/console/src/__generated__/core/CompliancePageNewsletterListDeleteMutation.graphql.ts
@@ -1,0 +1,132 @@
+/**
+ * @generated SignedSource<<d019db2bd3820f19cf30608260983723>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type DeleteNewsletterSubscriberInput = {
+  id: string;
+};
+export type CompliancePageNewsletterListDeleteMutation$variables = {
+  connections: ReadonlyArray<string>;
+  input: DeleteNewsletterSubscriberInput;
+};
+export type CompliancePageNewsletterListDeleteMutation$data = {
+  readonly deleteNewsletterSubscriber: {
+    readonly deletedNewsletterSubscriberId: string;
+  };
+};
+export type CompliancePageNewsletterListDeleteMutation = {
+  response: CompliancePageNewsletterListDeleteMutation$data;
+  variables: CompliancePageNewsletterListDeleteMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "input"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "deletedNewsletterSubscriberId",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "CompliancePageNewsletterListDeleteMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteNewsletterSubscriberPayload",
+        "kind": "LinkedField",
+        "name": "deleteNewsletterSubscriber",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "CompliancePageNewsletterListDeleteMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "DeleteNewsletterSubscriberPayload",
+        "kind": "LinkedField",
+        "name": "deleteNewsletterSubscriber",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "deleteEdge",
+            "key": "",
+            "kind": "ScalarHandle",
+            "name": "deletedNewsletterSubscriberId",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "c02f1499ae102eb3f2b95211cd3918ad",
+    "id": null,
+    "metadata": {},
+    "name": "CompliancePageNewsletterListDeleteMutation",
+    "operationKind": "mutation",
+    "text": "mutation CompliancePageNewsletterListDeleteMutation(\n  $input: DeleteNewsletterSubscriberInput!\n) {\n  deleteNewsletterSubscriber(input: $input) {\n    deletedNewsletterSubscriberId\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "2530fdc049352ab4d86e2bd7ee386da8";
+
+export default node;

--- a/apps/console/src/__generated__/core/CompliancePageNewsletterListFragment.graphql.ts
+++ b/apps/console/src/__generated__/core/CompliancePageNewsletterListFragment.graphql.ts
@@ -1,0 +1,201 @@
+/**
+ * @generated SignedSource<<c0f32bfebe7eb78a3735677b91a789c3>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type CompliancePageNewsletterListFragment$data = {
+  readonly id: string;
+  readonly newsletterSubscribers: {
+    readonly __id: string;
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly createdAt: string;
+        readonly email: string;
+        readonly id: string;
+      };
+    }>;
+    readonly pageInfo: {
+      readonly endCursor: string | null | undefined;
+      readonly hasNextPage: boolean;
+    };
+  };
+  readonly " $fragmentType": "CompliancePageNewsletterListFragment";
+};
+export type CompliancePageNewsletterListFragment$key = {
+  readonly " $data"?: CompliancePageNewsletterListFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"CompliancePageNewsletterListFragment">;
+};
+
+import CompliancePageNewsletterListQuery_graphql from './CompliancePageNewsletterListQuery.graphql';
+
+const node: ReaderFragment = (function(){
+var v0 = [
+  "newsletterSubscribers"
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "after"
+    },
+    {
+      "defaultValue": 20,
+      "kind": "LocalArgument",
+      "name": "first"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": {
+    "connection": [
+      {
+        "count": "first",
+        "cursor": "after",
+        "direction": "forward",
+        "path": (v0/*: any*/)
+      }
+    ],
+    "refetch": {
+      "connection": {
+        "forward": {
+          "count": "first",
+          "cursor": "after"
+        },
+        "backward": null,
+        "path": (v0/*: any*/)
+      },
+      "fragmentPathInResult": [
+        "node"
+      ],
+      "operation": CompliancePageNewsletterListQuery_graphql,
+      "identifierInfo": {
+        "identifierField": "id",
+        "identifierQueryVariableName": "id"
+      }
+    }
+  },
+  "name": "CompliancePageNewsletterListFragment",
+  "selections": [
+    {
+      "alias": "newsletterSubscribers",
+      "args": null,
+      "concreteType": "ComplianceNewsletterSubscriberConnection",
+      "kind": "LinkedField",
+      "name": "__CompliancePageNewsletterList_newsletterSubscribers_connection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "kind": "LinkedField",
+          "name": "pageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasNextPage",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "endCursor",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ComplianceNewsletterSubscriberEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "ComplianceNewsletterSubscriber",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                (v1/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "email",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "createdAt",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "__typename",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "cursor",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "kind": "ClientExtension",
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "__id",
+              "storageKey": null
+            }
+          ]
+        }
+      ],
+      "storageKey": null
+    },
+    (v1/*: any*/)
+  ],
+  "type": "TrustCenter",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "81139bd64601a67b66bd2bd67c7363d8";
+
+export default node;

--- a/apps/console/src/__generated__/core/CompliancePageNewsletterListQuery.graphql.ts
+++ b/apps/console/src/__generated__/core/CompliancePageNewsletterListQuery.graphql.ts
@@ -1,0 +1,249 @@
+/**
+ * @generated SignedSource<<61569ce567ad8bed7d4d391753bea3fa>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type CompliancePageNewsletterListQuery$variables = {
+  after?: string | null | undefined;
+  first?: number | null | undefined;
+  id: string;
+};
+export type CompliancePageNewsletterListQuery$data = {
+  readonly node: {
+    readonly " $fragmentSpreads": FragmentRefs<"CompliancePageNewsletterListFragment">;
+  };
+};
+export type CompliancePageNewsletterListQuery = {
+  response: CompliancePageNewsletterListQuery$data;
+  variables: CompliancePageNewsletterListQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "after"
+  },
+  {
+    "defaultValue": 20,
+    "kind": "LocalArgument",
+    "name": "first"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "after"
+  },
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "first"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "CompliancePageNewsletterListQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "args": (v2/*: any*/),
+            "kind": "FragmentSpread",
+            "name": "CompliancePageNewsletterListFragment"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "CompliancePageNewsletterListQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          (v4/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": (v2/*: any*/),
+                "concreteType": "ComplianceNewsletterSubscriberConnection",
+                "kind": "LinkedField",
+                "name": "newsletterSubscribers",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageInfo",
+                    "kind": "LinkedField",
+                    "name": "pageInfo",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "hasNextPage",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "endCursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "ComplianceNewsletterSubscriberEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ComplianceNewsletterSubscriber",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v4/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "email",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "createdAt",
+                            "storageKey": null
+                          },
+                          (v3/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "cursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "ClientExtension",
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "__id",
+                        "storageKey": null
+                      }
+                    ]
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": (v2/*: any*/),
+                "filters": null,
+                "handle": "connection",
+                "key": "CompliancePageNewsletterList_newsletterSubscribers",
+                "kind": "LinkedHandle",
+                "name": "newsletterSubscribers"
+              }
+            ],
+            "type": "TrustCenter",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "56bf51aaac6b44f03a352a4e0d4b9f97",
+    "id": null,
+    "metadata": {},
+    "name": "CompliancePageNewsletterListQuery",
+    "operationKind": "query",
+    "text": "query CompliancePageNewsletterListQuery(\n  $after: CursorKey = null\n  $first: Int = 20\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...CompliancePageNewsletterListFragment_2HEEH6\n    id\n  }\n}\n\nfragment CompliancePageNewsletterListFragment_2HEEH6 on TrustCenter {\n  newsletterSubscribers(first: $first, after: $after) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        email\n        createdAt\n        __typename\n      }\n      cursor\n    }\n  }\n  id\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "81139bd64601a67b66bd2bd67c7363d8";
+
+export default node;

--- a/apps/console/src/__generated__/core/CompliancePageNewsletterPageQuery.graphql.ts
+++ b/apps/console/src/__generated__/core/CompliancePageNewsletterPageQuery.graphql.ts
@@ -1,0 +1,276 @@
+/**
+ * @generated SignedSource<<f659b2954af0c7c24c1fb9145c931cfb>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type CompliancePageNewsletterPageQuery$variables = {
+  organizationId: string;
+};
+export type CompliancePageNewsletterPageQuery$data = {
+  readonly organization: {
+    readonly __typename: "Organization";
+    readonly compliancePage: {
+      readonly id: string;
+      readonly " $fragmentSpreads": FragmentRefs<"CompliancePageNewsletterListFragment">;
+    };
+  } | {
+    // This will never be '%other', but we need some
+    // value in case none of the concrete values match.
+    readonly __typename: "%other";
+  };
+};
+export type CompliancePageNewsletterPageQuery = {
+  response: CompliancePageNewsletterPageQuery$data;
+  variables: CompliancePageNewsletterPageQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "organizationId"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "organizationId"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 20
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "CompliancePageNewsletterPageQuery",
+    "selections": [
+      {
+        "alias": "organization",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "kind": "RequiredField",
+                "field": {
+                  "alias": "compliancePage",
+                  "args": null,
+                  "concreteType": "TrustCenter",
+                  "kind": "LinkedField",
+                  "name": "trustCenter",
+                  "plural": false,
+                  "selections": [
+                    (v3/*: any*/),
+                    {
+                      "args": null,
+                      "kind": "FragmentSpread",
+                      "name": "CompliancePageNewsletterListFragment"
+                    }
+                  ],
+                  "storageKey": null
+                },
+                "action": "THROW"
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "CompliancePageNewsletterPageQuery",
+    "selections": [
+      {
+        "alias": "organization",
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": "compliancePage",
+                "args": null,
+                "concreteType": "TrustCenter",
+                "kind": "LinkedField",
+                "name": "trustCenter",
+                "plural": false,
+                "selections": [
+                  (v3/*: any*/),
+                  {
+                    "alias": null,
+                    "args": (v4/*: any*/),
+                    "concreteType": "ComplianceNewsletterSubscriberConnection",
+                    "kind": "LinkedField",
+                    "name": "newsletterSubscribers",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "PageInfo",
+                        "kind": "LinkedField",
+                        "name": "pageInfo",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "hasNextPage",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "endCursor",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ComplianceNewsletterSubscriberEdge",
+                        "kind": "LinkedField",
+                        "name": "edges",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ComplianceNewsletterSubscriber",
+                            "kind": "LinkedField",
+                            "name": "node",
+                            "plural": false,
+                            "selections": [
+                              (v3/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "email",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "createdAt",
+                                "storageKey": null
+                              },
+                              (v2/*: any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "cursor",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "ClientExtension",
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "__id",
+                            "storageKey": null
+                          }
+                        ]
+                      }
+                    ],
+                    "storageKey": "newsletterSubscribers(first:20)"
+                  },
+                  {
+                    "alias": null,
+                    "args": (v4/*: any*/),
+                    "filters": null,
+                    "handle": "connection",
+                    "key": "CompliancePageNewsletterList_newsletterSubscribers",
+                    "kind": "LinkedHandle",
+                    "name": "newsletterSubscribers"
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "type": "Organization",
+            "abstractKey": null
+          },
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "c10dc891075ed918e6cdf3b80150a505",
+    "id": null,
+    "metadata": {},
+    "name": "CompliancePageNewsletterPageQuery",
+    "operationKind": "query",
+    "text": "query CompliancePageNewsletterPageQuery(\n  $organizationId: ID!\n) {\n  organization: node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      compliancePage: trustCenter {\n        id\n        ...CompliancePageNewsletterListFragment\n      }\n    }\n    id\n  }\n}\n\nfragment CompliancePageNewsletterListFragment on TrustCenter {\n  newsletterSubscribers(first: 20) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        email\n        createdAt\n        __typename\n      }\n      cursor\n    }\n  }\n  id\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "2e7a0bcc107a2849d8c71483e9412c74";
+
+export default node;

--- a/apps/console/src/__generated__/core/WebhooksSettingsPageQuery.graphql.ts
+++ b/apps/console/src/__generated__/core/WebhooksSettingsPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<72029a8e627a0b60cb1e2c226af0d535>>
+ * @generated SignedSource<<754e567fe99c9c96b8d4e324ce5373b8>>
  * @lightSyntaxTransform
  * @nogrep
  */

--- a/apps/console/src/__generated__/core/WebhooksSettingsPage_createMutation.graphql.ts
+++ b/apps/console/src/__generated__/core/WebhooksSettingsPage_createMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<310671de1c8bca322875bfca9102fcbf>>
+ * @generated SignedSource<<876124efbbec99a5059c28550cb638c0>>
  * @lightSyntaxTransform
  * @nogrep
  */

--- a/apps/console/src/__generated__/core/WebhooksSettingsPage_updateMutation.graphql.ts
+++ b/apps/console/src/__generated__/core/WebhooksSettingsPage_updateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c58f6047e14212818972c5cf56162c1c>>
+ * @generated SignedSource<<ad43a2ccfc4f0bd38bf04b06ae2f8183>>
  * @lightSyntaxTransform
  * @nogrep
  */

--- a/apps/console/src/pages/organizations/compliance-page/CompliancePageLayout.tsx
+++ b/apps/console/src/pages/organizations/compliance-page/CompliancePageLayout.tsx
@@ -1,6 +1,6 @@
 import { usePageTitle } from "@probo/hooks";
 import { useTranslate } from "@probo/i18n";
-import { Badge, IconCheckmark1, IconFolder2, IconMedal, IconPageTextLine, IconPencil, IconPeopleAdd, IconSettingsGear2, IconStore, PageHeader, TabLink, Tabs } from "@probo/ui";
+import { Badge, IconBell2, IconCheckmark1, IconFolder2, IconMedal, IconPageTextLine, IconPencil, IconPeopleAdd, IconSettingsGear2, IconStore, PageHeader, TabLink, Tabs } from "@probo/ui";
 import { type PreloadedQuery, usePreloadedQuery } from "react-relay";
 import { Outlet } from "react-router";
 import { graphql } from "relay-runtime";
@@ -83,6 +83,10 @@ export function CompliancePageLayout(props: { queryRef: PreloadedQuery<Complianc
         <TabLink to={`/organizations/${organizationId}/compliance-page/access`}>
           <IconPeopleAdd className="size-4" />
           {__("Access")}
+        </TabLink>
+        <TabLink to={`/organizations/${organizationId}/compliance-page/newsletter`}>
+          <IconBell2 className="size-4" />
+          {__("Newsletter")}
         </TabLink>
       </Tabs>
 

--- a/apps/console/src/pages/organizations/compliance-page/newsletter/CompliancePageNewsletterPage.tsx
+++ b/apps/console/src/pages/organizations/compliance-page/newsletter/CompliancePageNewsletterPage.tsx
@@ -1,0 +1,49 @@
+import { useTranslate } from "@probo/i18n";
+import { type PreloadedQuery, usePreloadedQuery } from "react-relay";
+import { graphql } from "relay-runtime";
+
+import type { CompliancePageNewsletterPageQuery } from "#/__generated__/core/CompliancePageNewsletterPageQuery.graphql";
+
+import { CompliancePageNewsletterList } from "./_components/CompliancePageNewsletterList";
+
+export const compliancePageNewsletterPageQuery = graphql`
+  query CompliancePageNewsletterPageQuery($organizationId: ID!) {
+    organization: node(id: $organizationId) {
+      __typename
+      ... on Organization {
+        compliancePage: trustCenter @required(action: THROW) {
+          id
+          ...CompliancePageNewsletterListFragment
+        }
+      }
+    }
+  }
+`;
+
+export function CompliancePageNewsletterPage(props: {
+  queryRef: PreloadedQuery<CompliancePageNewsletterPageQuery>;
+}) {
+  const { queryRef } = props;
+  const { __ } = useTranslate();
+
+  const { organization } = usePreloadedQuery<CompliancePageNewsletterPageQuery>(
+    compliancePageNewsletterPageQuery,
+    queryRef,
+  );
+
+  if (organization.__typename !== "Organization") {
+    throw new Error("invalid type for node");
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-base font-medium">{__("Newsletter Subscribers")}</h3>
+        <p className="text-sm text-txt-tertiary">
+          {__("People subscribed to receive security and compliance updates")}
+        </p>
+      </div>
+      <CompliancePageNewsletterList fragmentRef={organization.compliancePage} />
+    </div>
+  );
+}

--- a/apps/console/src/pages/organizations/compliance-page/newsletter/CompliancePageNewsletterPageLoader.tsx
+++ b/apps/console/src/pages/organizations/compliance-page/newsletter/CompliancePageNewsletterPageLoader.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from "react";
+import { useQueryLoader } from "react-relay";
+
+import type { CompliancePageNewsletterPageQuery } from "#/__generated__/core/CompliancePageNewsletterPageQuery.graphql";
+import { LinkCardSkeleton } from "#/components/skeletons/LinkCardSkeleton";
+import { useOrganizationId } from "#/hooks/useOrganizationId";
+import { CoreRelayProvider } from "#/providers/CoreRelayProvider";
+
+import {
+  CompliancePageNewsletterPage,
+  compliancePageNewsletterPageQuery,
+} from "./CompliancePageNewsletterPage";
+
+function CompliancePageNewsletterPageQueryLoader() {
+  const organizationId = useOrganizationId();
+  const [queryRef, loadQuery] = useQueryLoader<CompliancePageNewsletterPageQuery>(
+    compliancePageNewsletterPageQuery,
+  );
+
+  useEffect(() => {
+    loadQuery({ organizationId });
+  }, [loadQuery, organizationId]);
+
+  if (!queryRef) return <LinkCardSkeleton />;
+
+  return <CompliancePageNewsletterPage queryRef={queryRef} />;
+}
+
+export default function CompliancePageNewsletterPageLoader() {
+  return (
+    <CoreRelayProvider>
+      <CompliancePageNewsletterPageQueryLoader />
+    </CoreRelayProvider>
+  );
+}

--- a/apps/console/src/pages/organizations/compliance-page/newsletter/_components/CompliancePageNewsletterList.tsx
+++ b/apps/console/src/pages/organizations/compliance-page/newsletter/_components/CompliancePageNewsletterList.tsx
@@ -1,0 +1,157 @@
+import { formatError } from "@probo/helpers";
+import { useTranslate } from "@probo/i18n";
+import { Button, IconChevronDown, IconTrashCan, Spinner, Table, Tbody, Td, Th, Thead, Tr, useToast } from "@probo/ui";
+import { useMutation, usePaginationFragment } from "react-relay";
+import { graphql } from "relay-runtime";
+
+import type { CompliancePageNewsletterListDeleteMutation } from "#/__generated__/core/CompliancePageNewsletterListDeleteMutation.graphql";
+import type { CompliancePageNewsletterListFragment$key } from "#/__generated__/core/CompliancePageNewsletterListFragment.graphql";
+import type { CompliancePageNewsletterListQuery } from "#/__generated__/core/CompliancePageNewsletterListQuery.graphql";
+
+const deleteMutation = graphql`
+  mutation CompliancePageNewsletterListDeleteMutation(
+    $input: DeleteNewsletterSubscriberInput!
+    $connections: [ID!]!
+  ) {
+    deleteNewsletterSubscriber(input: $input) {
+      deletedNewsletterSubscriberId @deleteEdge(connections: $connections)
+    }
+  }
+`;
+
+const fragment = graphql`
+  fragment CompliancePageNewsletterListFragment on TrustCenter
+  @argumentDefinitions(
+    first: { type: Int, defaultValue: 20 }
+    after: { type: CursorKey, defaultValue: null }
+  )
+  @refetchable(queryName: "CompliancePageNewsletterListQuery") {
+    newsletterSubscribers(
+      first: $first
+      after: $after
+    ) @connection(key: "CompliancePageNewsletterList_newsletterSubscribers") {
+      __id
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      edges {
+        node {
+          id
+          email
+          createdAt
+        }
+      }
+    }
+  }
+`;
+
+export function CompliancePageNewsletterList(props: {
+  fragmentRef: CompliancePageNewsletterListFragment$key;
+}) {
+  const { fragmentRef } = props;
+  const { __ } = useTranslate();
+  const { toast } = useToast();
+
+  const {
+    data: { newsletterSubscribers },
+    hasNext,
+    loadNext,
+    isLoadingNext,
+  } = usePaginationFragment<CompliancePageNewsletterListQuery, CompliancePageNewsletterListFragment$key>(
+    fragment,
+    fragmentRef,
+  );
+
+  const [deleteSubscriber, isDeleting] = useMutation<CompliancePageNewsletterListDeleteMutation>(deleteMutation);
+
+  const handleDelete = (id: string) => {
+    deleteSubscriber({
+      variables: {
+        input: { id },
+        connections: [newsletterSubscribers.__id],
+      },
+      onCompleted: (_, errors) => {
+        if (errors?.length) {
+          toast({
+            title: __("Error"),
+            description: formatError(__("Cannot delete subscriber"), errors),
+            variant: "error",
+          });
+          return;
+        }
+        toast({
+          title: __("Deleted"),
+          description: __("Subscriber removed successfully."),
+          variant: "success",
+        });
+      },
+      onError: (error) => {
+        toast({
+          title: __("Error"),
+          description: error.message ?? __("Cannot delete subscriber"),
+          variant: "error",
+        });
+      },
+    });
+  };
+
+  if (newsletterSubscribers.edges.length === 0) {
+    return (
+      <Table>
+        <Tbody>
+          <Tr>
+            <Td className="text-center text-txt-tertiary py-8">
+              {__("No newsletter subscribers yet")}
+            </Td>
+          </Tr>
+        </Tbody>
+      </Table>
+    );
+  }
+
+  return (
+    <>
+      <Table>
+        <Thead>
+          <Tr>
+            <Th>{__("Email")}</Th>
+            <Th>{__("Subscribed on")}</Th>
+            <Th />
+          </Tr>
+        </Thead>
+        <Tbody>
+          {newsletterSubscribers.edges.map(({ node: subscriber }) => (
+            <Tr key={subscriber.id}>
+              <Td>{subscriber.email}</Td>
+              <Td className="text-txt-tertiary text-sm">
+                {new Date(subscriber.createdAt).toLocaleDateString()}
+              </Td>
+              <Td className="w-10">
+                <Button
+                  variant="tertiary"
+                  icon={IconTrashCan}
+                  disabled={isDeleting}
+                  onClick={() => handleDelete(subscriber.id)}
+                  aria-label={__("Delete subscriber")}
+                />
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+      {hasNext && (
+        <Button
+          variant="tertiary"
+          onClick={() => loadNext(20)}
+          disabled={isLoadingNext}
+          className="mt-3 mx-auto"
+          icon={IconChevronDown}
+        >
+          {isLoadingNext && <Spinner />}
+          {__("Show More")}
+        </Button>
+      )}
+    </>
+  );
+}

--- a/apps/console/src/pages/organizations/compliance-page/routes.ts
+++ b/apps/console/src/pages/organizations/compliance-page/routes.ts
@@ -57,6 +57,11 @@ export const compliancePageRoutes = [
         Fallback: LinkCardSkeleton,
         Component: lazy(() => import("#/pages/organizations/compliance-page/access/CompliancePageAccessPageLoader")),
       },
+      {
+        path: "newsletter",
+        Fallback: LinkCardSkeleton,
+        Component: lazy(() => import("#/pages/organizations/compliance-page/newsletter/CompliancePageNewsletterPageLoader")),
+      },
     ],
   },
 ];

--- a/apps/trust/src/components/__generated__/OrganizationSidebar_subscribeToNewsletterMutation.graphql.ts
+++ b/apps/trust/src/components/__generated__/OrganizationSidebar_subscribeToNewsletterMutation.graphql.ts
@@ -1,0 +1,95 @@
+/**
+ * @generated SignedSource<<b2bd634aca663dc324e2e3990850e6df>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type OrganizationSidebar_subscribeToNewsletterMutation$variables = Record<PropertyKey, never>;
+export type OrganizationSidebar_subscribeToNewsletterMutation$data = {
+  readonly subscribeToNewsletter: {
+    readonly trustCenter: {
+      readonly id: string;
+      readonly isViewerSubscribedToNewsletter: boolean;
+    };
+  };
+};
+export type OrganizationSidebar_subscribeToNewsletterMutation = {
+  response: OrganizationSidebar_subscribeToNewsletterMutation$data;
+  variables: OrganizationSidebar_subscribeToNewsletterMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "SubscribeToNewsletterPayload",
+    "kind": "LinkedField",
+    "name": "subscribeToNewsletter",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "TrustCenter",
+        "kind": "LinkedField",
+        "name": "trustCenter",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isViewerSubscribedToNewsletter",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "OrganizationSidebar_subscribeToNewsletterMutation",
+    "selections": (v0/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "OrganizationSidebar_subscribeToNewsletterMutation",
+    "selections": (v0/*: any*/)
+  },
+  "params": {
+    "cacheID": "cf3287f9ae97a7def5aa3abee6ca84d9",
+    "id": null,
+    "metadata": {},
+    "name": "OrganizationSidebar_subscribeToNewsletterMutation",
+    "operationKind": "mutation",
+    "text": "mutation OrganizationSidebar_subscribeToNewsletterMutation {\n  subscribeToNewsletter {\n    trustCenter {\n      id\n      isViewerSubscribedToNewsletter\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "072a45581e8b7d92a61b6022f84841a4";
+
+export default node;

--- a/apps/trust/src/components/__generated__/OrganizationSidebar_unsubscribeFromNewsletterMutation.graphql.ts
+++ b/apps/trust/src/components/__generated__/OrganizationSidebar_unsubscribeFromNewsletterMutation.graphql.ts
@@ -1,0 +1,95 @@
+/**
+ * @generated SignedSource<<033e59bdf3d420b00f45cccf94f6155b>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type OrganizationSidebar_unsubscribeFromNewsletterMutation$variables = Record<PropertyKey, never>;
+export type OrganizationSidebar_unsubscribeFromNewsletterMutation$data = {
+  readonly unsubscribeFromNewsletter: {
+    readonly trustCenter: {
+      readonly id: string;
+      readonly isViewerSubscribedToNewsletter: boolean;
+    };
+  };
+};
+export type OrganizationSidebar_unsubscribeFromNewsletterMutation = {
+  response: OrganizationSidebar_unsubscribeFromNewsletterMutation$data;
+  variables: OrganizationSidebar_unsubscribeFromNewsletterMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "UnsubscribeFromNewsletterPayload",
+    "kind": "LinkedField",
+    "name": "unsubscribeFromNewsletter",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "TrustCenter",
+        "kind": "LinkedField",
+        "name": "trustCenter",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isViewerSubscribedToNewsletter",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "OrganizationSidebar_unsubscribeFromNewsletterMutation",
+    "selections": (v0/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "OrganizationSidebar_unsubscribeFromNewsletterMutation",
+    "selections": (v0/*: any*/)
+  },
+  "params": {
+    "cacheID": "4e11d3f1c4879997295a49c650cb5672",
+    "id": null,
+    "metadata": {},
+    "name": "OrganizationSidebar_unsubscribeFromNewsletterMutation",
+    "operationKind": "mutation",
+    "text": "mutation OrganizationSidebar_unsubscribeFromNewsletterMutation {\n  unsubscribeFromNewsletter {\n    trustCenter {\n      id\n      isViewerSubscribedToNewsletter\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "bcb94e4e8370c92d798da68dcbd695e6";
+
+export default node;

--- a/apps/trust/src/queries/TrustGraph.ts
+++ b/apps/trust/src/queries/TrustGraph.ts
@@ -11,6 +11,7 @@ export const currentTrustGraphQuery = graphql`
       id
       slug
       isViewerMember
+      isViewerSubscribedToNewsletter
       logoFileUrl
       darkLogoFileUrl
       nonDisclosureAgreement {

--- a/apps/trust/src/queries/__generated__/TrustGraphCurrentQuery.graphql.ts
+++ b/apps/trust/src/queries/__generated__/TrustGraphCurrentQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<663225cc4e0d94b50dc97084c3d51aae>>
+ * @generated SignedSource<<ea6ae786923583c3179cd025bccf93eb>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -25,6 +25,7 @@ export type TrustGraphCurrentQuery$data = {
     readonly darkLogoFileUrl: string | null | undefined;
     readonly id: string;
     readonly isViewerMember: boolean;
+    readonly isViewerSubscribedToNewsletter: boolean;
     readonly logoFileUrl: string | null | undefined;
     readonly nonDisclosureAgreement: {
       readonly fileName: string;
@@ -96,66 +97,73 @@ v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "logoFileUrl",
+  "name": "isViewerSubscribedToNewsletter",
   "storageKey": null
 },
 v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "darkLogoFileUrl",
+  "name": "logoFileUrl",
   "storageKey": null
 },
 v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "fileName",
+  "name": "darkLogoFileUrl",
   "storageKey": null
 },
 v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "fileUrl",
+  "name": "fileName",
   "storageKey": null
 },
 v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "status",
+  "name": "fileUrl",
   "storageKey": null
 },
 v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "status",
   "storageKey": null
 },
 v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "description",
+  "name": "name",
   "storageKey": null
 },
 v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "websiteUrl",
+  "name": "description",
   "storageKey": null
 },
 v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "headquarterAddress",
+  "name": "websiteUrl",
   "storageKey": null
 },
 v14 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "headquarterAddress",
+  "storageKey": null
+},
+v15 = {
   "alias": "vendorInfo",
   "args": [
     {
@@ -179,28 +187,28 @@ v14 = {
   ],
   "storageKey": "vendors(first:0)"
 },
-v15 = [
+v16 = [
   {
     "kind": "Literal",
     "name": "first",
     "value": 50
   }
 ],
-v16 = [
+v17 = [
   {
     "kind": "Literal",
     "name": "first",
     "value": 5
   }
 ],
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isUserAuthorized",
   "storageKey": null
 },
-v18 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -240,6 +248,7 @@ return {
           (v4/*: any*/),
           (v5/*: any*/),
           (v6/*: any*/),
+          (v7/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -248,8 +257,8 @@ return {
             "name": "nonDisclosureAgreement",
             "plural": false,
             "selections": [
-              (v7/*: any*/),
               (v8/*: any*/),
+              (v9/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -258,7 +267,7 @@ return {
                 "name": "viewerSignature",
                 "plural": false,
                 "selections": [
-                  (v9/*: any*/)
+                  (v10/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -273,11 +282,11 @@ return {
             "name": "organization",
             "plural": false,
             "selections": [
-              (v10/*: any*/),
               (v11/*: any*/),
               (v12/*: any*/),
+              (v13/*: any*/),
               (v0/*: any*/),
-              (v13/*: any*/)
+              (v14/*: any*/)
             ],
             "storageKey": null
           },
@@ -286,10 +295,10 @@ return {
             "kind": "FragmentSpread",
             "name": "OverviewPageFragment"
           },
-          (v14/*: any*/),
+          (v15/*: any*/),
           {
             "alias": null,
-            "args": (v15/*: any*/),
+            "args": (v16/*: any*/),
             "concreteType": "AuditConnection",
             "kind": "LinkedField",
             "name": "audits",
@@ -366,6 +375,7 @@ return {
           (v4/*: any*/),
           (v5/*: any*/),
           (v6/*: any*/),
+          (v7/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -374,8 +384,8 @@ return {
             "name": "nonDisclosureAgreement",
             "plural": false,
             "selections": [
-              (v7/*: any*/),
               (v8/*: any*/),
+              (v9/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -384,7 +394,7 @@ return {
                 "name": "viewerSignature",
                 "plural": false,
                 "selections": [
-                  (v9/*: any*/),
+                  (v10/*: any*/),
                   (v2/*: any*/)
                 ],
                 "storageKey": null
@@ -400,11 +410,11 @@ return {
             "name": "organization",
             "plural": false,
             "selections": [
-              (v10/*: any*/),
               (v11/*: any*/),
               (v12/*: any*/),
-              (v0/*: any*/),
               (v13/*: any*/),
+              (v0/*: any*/),
+              (v14/*: any*/),
               (v2/*: any*/)
             ],
             "storageKey": null
@@ -440,7 +450,7 @@ return {
                     "plural": false,
                     "selections": [
                       (v2/*: any*/),
-                      (v10/*: any*/),
+                      (v11/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -448,7 +458,7 @@ return {
                         "name": "logoUrl",
                         "storageKey": null
                       },
-                      (v12/*: any*/)
+                      (v13/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -496,9 +506,9 @@ return {
                         "name": "countries",
                         "storageKey": null
                       },
-                      (v10/*: any*/),
                       (v11/*: any*/),
-                      (v12/*: any*/)
+                      (v12/*: any*/),
+                      (v13/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -510,7 +520,7 @@ return {
           },
           {
             "alias": null,
-            "args": (v16/*: any*/),
+            "args": (v17/*: any*/),
             "concreteType": "DocumentConnection",
             "kind": "LinkedField",
             "name": "documents",
@@ -540,8 +550,8 @@ return {
                         "name": "title",
                         "storageKey": null
                       },
-                      (v17/*: any*/),
                       (v18/*: any*/),
+                      (v19/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -560,7 +570,7 @@ return {
           },
           {
             "alias": null,
-            "args": (v16/*: any*/),
+            "args": (v17/*: any*/),
             "concreteType": "TrustCenterFileConnection",
             "kind": "LinkedField",
             "name": "trustCenterFiles",
@@ -590,9 +600,9 @@ return {
                         "name": "category",
                         "storageKey": null
                       },
-                      (v10/*: any*/),
-                      (v17/*: any*/),
-                      (v18/*: any*/)
+                      (v11/*: any*/),
+                      (v18/*: any*/),
+                      (v19/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -602,10 +612,10 @@ return {
             ],
             "storageKey": "trustCenterFiles(first:5)"
           },
-          (v14/*: any*/),
+          (v15/*: any*/),
           {
             "alias": null,
-            "args": (v15/*: any*/),
+            "args": (v16/*: any*/),
             "concreteType": "AuditConnection",
             "kind": "LinkedField",
             "name": "audits",
@@ -628,7 +638,7 @@ return {
                     "plural": false,
                     "selections": [
                       (v2/*: any*/),
-                      (v10/*: any*/),
+                      (v11/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -645,8 +655,8 @@ return {
                             "name": "filename",
                             "storageKey": null
                           },
-                          (v17/*: any*/),
-                          (v18/*: any*/)
+                          (v18/*: any*/),
+                          (v19/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -659,7 +669,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v2/*: any*/),
-                          (v10/*: any*/),
+                          (v11/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -692,16 +702,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "fab59d135402a3b935f277a385d33b93",
+    "cacheID": "6b09aa7248857ca2e63c2630bfdd4824",
     "id": null,
     "metadata": {},
     "name": "TrustGraphCurrentQuery",
     "operationKind": "query",
-    "text": "query TrustGraphCurrentQuery {\n  viewer {\n    email\n    fullName\n    id\n  }\n  currentTrustCenter {\n    id\n    slug\n    isViewerMember\n    logoFileUrl\n    darkLogoFileUrl\n    nonDisclosureAgreement {\n      fileName\n      fileUrl\n      viewerSignature {\n        status\n        id\n      }\n    }\n    organization {\n      name\n      description\n      websiteUrl\n      email\n      headquarterAddress\n      id\n    }\n    ...OverviewPageFragment\n    vendorInfo: vendors(first: 0) {\n      totalCount\n    }\n    audits(first: 50) {\n      edges {\n        node {\n          id\n          ...AuditRowFragment\n        }\n      }\n    }\n  }\n}\n\nfragment AuditRowFragment on Audit {\n  name\n  report {\n    id\n    filename\n    isUserAuthorized\n    hasUserRequestedAccess\n  }\n  framework {\n    id\n    name\n    lightLogoURL\n    darkLogoURL\n  }\n}\n\nfragment DocumentRowFragment on Document {\n  id\n  title\n  isUserAuthorized\n  hasUserRequestedAccess\n}\n\nfragment OverviewPageFragment on TrustCenter {\n  references(first: 14) {\n    edges {\n      node {\n        id\n        name\n        logoUrl\n        websiteUrl\n      }\n    }\n  }\n  vendors(first: 3) {\n    edges {\n      node {\n        id\n        countries\n        ...VendorRowFragment\n      }\n    }\n  }\n  documents(first: 5) {\n    edges {\n      node {\n        id\n        ...DocumentRowFragment\n        documentType\n      }\n    }\n  }\n  trustCenterFiles(first: 5) {\n    edges {\n      node {\n        id\n        category\n        ...TrustCenterFileRowFragment\n      }\n    }\n  }\n}\n\nfragment TrustCenterFileRowFragment on TrustCenterFile {\n  id\n  name\n  isUserAuthorized\n  hasUserRequestedAccess\n}\n\nfragment VendorRowFragment on Vendor {\n  name\n  description\n  websiteUrl\n  countries\n}\n"
+    "text": "query TrustGraphCurrentQuery {\n  viewer {\n    email\n    fullName\n    id\n  }\n  currentTrustCenter {\n    id\n    slug\n    isViewerMember\n    isViewerSubscribedToNewsletter\n    logoFileUrl\n    darkLogoFileUrl\n    nonDisclosureAgreement {\n      fileName\n      fileUrl\n      viewerSignature {\n        status\n        id\n      }\n    }\n    organization {\n      name\n      description\n      websiteUrl\n      email\n      headquarterAddress\n      id\n    }\n    ...OverviewPageFragment\n    vendorInfo: vendors(first: 0) {\n      totalCount\n    }\n    audits(first: 50) {\n      edges {\n        node {\n          id\n          ...AuditRowFragment\n        }\n      }\n    }\n  }\n}\n\nfragment AuditRowFragment on Audit {\n  name\n  report {\n    id\n    filename\n    isUserAuthorized\n    hasUserRequestedAccess\n  }\n  framework {\n    id\n    name\n    lightLogoURL\n    darkLogoURL\n  }\n}\n\nfragment DocumentRowFragment on Document {\n  id\n  title\n  isUserAuthorized\n  hasUserRequestedAccess\n}\n\nfragment OverviewPageFragment on TrustCenter {\n  references(first: 14) {\n    edges {\n      node {\n        id\n        name\n        logoUrl\n        websiteUrl\n      }\n    }\n  }\n  vendors(first: 3) {\n    edges {\n      node {\n        id\n        countries\n        ...VendorRowFragment\n      }\n    }\n  }\n  documents(first: 5) {\n    edges {\n      node {\n        id\n        ...DocumentRowFragment\n        documentType\n      }\n    }\n  }\n  trustCenterFiles(first: 5) {\n    edges {\n      node {\n        id\n        category\n        ...TrustCenterFileRowFragment\n      }\n    }\n  }\n}\n\nfragment TrustCenterFileRowFragment on TrustCenterFile {\n  id\n  name\n  isUserAuthorized\n  hasUserRequestedAccess\n}\n\nfragment VendorRowFragment on Vendor {\n  name\n  description\n  websiteUrl\n  countries\n}\n"
   }
 };
 })();
 
-(node as any).hash = "6cbe676214b698d12e2cae08060a7285";
+(node as any).hash = "6de514b2cc62230e84d3015367de6886";
 
 export default node;

--- a/pkg/coredata/compliance_newsletter_subscriber.go
+++ b/pkg/coredata/compliance_newsletter_subscriber.go
@@ -1,0 +1,242 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/mail"
+	"go.probo.inc/probo/pkg/page"
+)
+
+type (
+	ComplianceNewsletterSubscriber struct {
+		ID             gid.GID      `db:"id"`
+		TenantID       gid.TenantID `db:"tenant_id"`
+		OrganizationID gid.GID      `db:"organization_id"`
+		TrustCenterID  gid.GID      `db:"trust_center_id"`
+		Email          mail.Addr    `db:"email"`
+		CreatedAt      time.Time    `db:"created_at"`
+		UpdatedAt      time.Time    `db:"updated_at"`
+	}
+
+	ComplianceNewsletterSubscribers []*ComplianceNewsletterSubscriber
+)
+
+func (cns *ComplianceNewsletterSubscriber) CursorKey(orderBy ComplianceNewsletterSubscriberOrderField) page.CursorKey {
+	switch orderBy {
+	case ComplianceNewsletterSubscriberOrderFieldCreatedAt:
+		return page.NewCursorKey(cns.ID, cns.CreatedAt)
+	}
+
+	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
+}
+
+func (cns *ComplianceNewsletterSubscriber) LoadByTrustCenterIDAndEmail(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	trustCenterID gid.GID,
+	email mail.Addr,
+) error {
+	q := `
+SELECT
+	id,
+	tenant_id,
+	organization_id,
+	trust_center_id,
+	email,
+	created_at,
+	updated_at
+FROM
+	compliance_newsletter_subscribers
+WHERE
+	%s
+	AND trust_center_id = @trust_center_id
+	AND email = @email
+LIMIT 1;
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"trust_center_id": trustCenterID,
+		"email":           email,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query compliance newsletter subscriber: %w", err)
+	}
+
+	subscriber, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[ComplianceNewsletterSubscriber])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrResourceNotFound
+		}
+
+		return fmt.Errorf("cannot collect compliance newsletter subscriber: %w", err)
+	}
+
+	*cns = subscriber
+
+	return nil
+}
+
+func (cns *ComplianceNewsletterSubscriber) Insert(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+INSERT INTO compliance_newsletter_subscribers (
+	id,
+	tenant_id,
+	organization_id,
+	trust_center_id,
+	email,
+	created_at,
+	updated_at
+)
+VALUES (
+	@id,
+	@tenant_id,
+	@organization_id,
+	@trust_center_id,
+	@email,
+	@created_at,
+	@updated_at
+)
+RETURNING
+	id,
+	tenant_id,
+	organization_id,
+	trust_center_id,
+	email,
+	created_at,
+	updated_at;
+`
+
+	args := pgx.StrictNamedArgs{
+		"id":              cns.ID,
+		"tenant_id":       scope.GetTenantID(),
+		"organization_id": cns.OrganizationID,
+		"trust_center_id": cns.TrustCenterID,
+		"email":           cns.Email,
+		"created_at":      cns.CreatedAt,
+		"updated_at":      cns.UpdatedAt,
+	}
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot insert compliance newsletter subscriber: %w", err)
+	}
+
+	subscriber, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[ComplianceNewsletterSubscriber])
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return ErrResourceAlreadyExists
+		}
+
+		return fmt.Errorf("cannot collect compliance newsletter subscriber: %w", err)
+	}
+
+	*cns = subscriber
+
+	return nil
+}
+
+func (cns *ComplianceNewsletterSubscriber) Delete(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+DELETE FROM
+	compliance_newsletter_subscribers
+WHERE
+	%s
+	AND id = @id;
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"id": cns.ID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete compliance newsletter subscriber: %w", err)
+	}
+
+	return nil
+}
+
+func (cnss *ComplianceNewsletterSubscribers) LoadByTrustCenterID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	trustCenterID gid.GID,
+	cursor *page.Cursor[ComplianceNewsletterSubscriberOrderField],
+) error {
+	q := `
+SELECT
+	id,
+	tenant_id,
+	organization_id,
+	trust_center_id,
+	email,
+	created_at,
+	updated_at
+FROM
+	compliance_newsletter_subscribers
+WHERE
+	%s
+	AND trust_center_id = @trust_center_id
+	AND %s
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"trust_center_id": trustCenterID,
+	}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, cursor.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query compliance newsletter subscribers: %w", err)
+	}
+
+	subscribers, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[ComplianceNewsletterSubscriber])
+	if err != nil {
+		return fmt.Errorf("cannot collect compliance newsletter subscribers: %w", err)
+	}
+
+	*cnss = subscribers
+
+	return nil
+}

--- a/pkg/coredata/compliance_newsletter_subscriber_order_field.go
+++ b/pkg/coredata/compliance_newsletter_subscriber_order_field.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import "fmt"
+
+type ComplianceNewsletterSubscriberOrderField string
+
+const (
+	ComplianceNewsletterSubscriberOrderFieldCreatedAt ComplianceNewsletterSubscriberOrderField = "CREATED_AT"
+)
+
+func (f ComplianceNewsletterSubscriberOrderField) String() string {
+	return string(f)
+}
+
+func (f ComplianceNewsletterSubscriberOrderField) Column() string {
+	switch f {
+	case ComplianceNewsletterSubscriberOrderFieldCreatedAt:
+		return "created_at"
+	}
+
+	panic(fmt.Sprintf("unsupported order by: %s", f))
+}

--- a/pkg/coredata/entity_type_reg.go
+++ b/pkg/coredata/entity_type_reg.go
@@ -85,6 +85,7 @@ const (
 	ElectronicSignatureEntityType              uint16 = 59
 	ElectronicSignatureEventEntityType         uint16 = 60
 	EmailAttachmentEntityType                  uint16 = 61
+	ComplianceNewsletterSubscriberEntityType   uint16 = 62
 )
 
 func NewEntityFromID(id gid.GID) (any, bool) {
@@ -209,6 +210,8 @@ func NewEntityFromID(id gid.GID) (any, bool) {
 		return &ElectronicSignatureEvent{ID: id}, true
 	case EmailAttachmentEntityType:
 		return &EmailAttachment{ID: id}, true
+	case ComplianceNewsletterSubscriberEntityType:
+		return &ComplianceNewsletterSubscriber{ID: id}, true
 	default:
 		return nil, false
 	}

--- a/pkg/coredata/migrations/20260225T000000Z.sql
+++ b/pkg/coredata/migrations/20260225T000000Z.sql
@@ -1,0 +1,13 @@
+CREATE TABLE compliance_newsletter_subscribers (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    organization_id TEXT NOT NULL REFERENCES organizations(id) ON UPDATE CASCADE ON DELETE CASCADE,
+    trust_center_id TEXT NOT NULL REFERENCES trust_centers(id) ON UPDATE CASCADE ON DELETE CASCADE,
+    email TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    UNIQUE (trust_center_id, email)
+);
+
+CREATE INDEX compliance_newsletter_subscribers_trust_center_id_idx
+    ON compliance_newsletter_subscribers (trust_center_id);

--- a/pkg/probo/actions.go
+++ b/pkg/probo/actions.go
@@ -40,6 +40,10 @@ const (
 	ActionTrustCenterAccessUpdate = "core:trust-center-access:update"
 	ActionTrustCenterAccessDelete = "core:trust-center-access:delete"
 
+	// ComplianceNewsletterSubscriber actions
+	ActionComplianceNewsletterSubscriberList   = "core:compliance-newsletter-subscriber:list"
+	ActionComplianceNewsletterSubscriberDelete = "core:compliance-newsletter-subscriber:delete"
+
 	// TrustCenterReference actions
 	ActionTrustCenterReferenceList       = "core:trust-center-reference:list"
 	ActionTrustCenterReferenceGetLogoUrl = "core:trust-center-reference:get-logo-url"

--- a/pkg/probo/compliance_newsletter_subscriber_service.go
+++ b/pkg/probo/compliance_newsletter_subscriber_service.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package probo
+
+import (
+	"context"
+	"fmt"
+
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/page"
+)
+
+type ComplianceNewsletterSubscriberService struct {
+	svc *TenantService
+}
+
+func (s *ComplianceNewsletterSubscriberService) Delete(
+	ctx context.Context,
+	id gid.GID,
+) error {
+	return s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			subscriber := coredata.ComplianceNewsletterSubscriber{ID: id}
+			return subscriber.Delete(ctx, conn, s.svc.scope)
+		},
+	)
+}
+
+func (s *ComplianceNewsletterSubscriberService) List(
+	ctx context.Context,
+	trustCenterID gid.GID,
+	cursor *page.Cursor[coredata.ComplianceNewsletterSubscriberOrderField],
+) (*page.Page[*coredata.ComplianceNewsletterSubscriber, coredata.ComplianceNewsletterSubscriberOrderField], error) {
+	var subscribers coredata.ComplianceNewsletterSubscribers
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			return subscribers.LoadByTrustCenterID(ctx, conn, s.svc.scope, trustCenterID, cursor)
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot list compliance newsletter subscribers: %w", err)
+	}
+
+	return page.NewPage(subscribers, cursor), nil
+}

--- a/pkg/probo/service.go
+++ b/pkg/probo/service.go
@@ -101,6 +101,7 @@ type (
 		TrustCenterAccesses               *TrustCenterAccessService
 		TrustCenterReferences             *TrustCenterReferenceService
 		TrustCenterFiles                  *TrustCenterFileService
+		ComplianceNewsletterSubscribers   *ComplianceNewsletterSubscriberService
 		Nonconformities                   *NonconformityService
 		Obligations                       *ObligationService
 		Snapshots                         *SnapshotService
@@ -225,6 +226,7 @@ func (s *Service) WithTenant(tenantID gid.TenantID) *TenantService {
 	tenantService.TrustCenters = &TrustCenterService{svc: tenantService}
 	tenantService.TrustCenterAccesses = &TrustCenterAccessService{svc: tenantService}
 	tenantService.TrustCenterReferences = &TrustCenterReferenceService{svc: tenantService}
+	tenantService.ComplianceNewsletterSubscribers = &ComplianceNewsletterSubscriberService{svc: tenantService}
 	tenantService.TrustCenterFiles = &TrustCenterFileService{
 		svc: tenantService,
 		fileValidator: filevalidation.NewValidator(

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -1614,7 +1614,32 @@ type TrustCenter implements Node {
         orderBy: TrustCenterReferenceOrder
     ): TrustCenterReferenceConnection! @goField(forceResolver: true)
 
+    newsletterSubscribers(
+        first: Int
+        after: CursorKey
+        last: Int
+        before: CursorKey
+    ): ComplianceNewsletterSubscriberConnection! @goField(forceResolver: true)
+
     permission(action: String!): Boolean! @goField(forceResolver: true)
+}
+
+type ComplianceNewsletterSubscriber implements Node {
+    id: ID!
+    email: EmailAddr!
+    createdAt: Datetime!
+    updatedAt: Datetime!
+}
+
+type ComplianceNewsletterSubscriberConnection {
+    edges: [ComplianceNewsletterSubscriberEdge!]!
+    pageInfo: PageInfo!
+    totalCount: Int! @goField(forceResolver: true)
+}
+
+type ComplianceNewsletterSubscriberEdge {
+    cursor: CursorKey!
+    node: ComplianceNewsletterSubscriber!
 }
 
 type Organization implements Node {
@@ -3237,6 +3262,10 @@ type Mutation {
     deleteTrustCenterAccess(
         input: DeleteTrustCenterAccessInput!
     ): DeleteTrustCenterAccessPayload!
+    # Newsletter Subscriber mutations
+    deleteNewsletterSubscriber(
+        input: DeleteNewsletterSubscriberInput!
+    ): DeleteNewsletterSubscriberPayload!
     # Trust Center Reference mutations
     createTrustCenterReference(
         input: CreateTrustCenterReferenceInput!
@@ -3623,6 +3652,10 @@ input UpdateTrustCenterAccessInput {
 }
 
 input DeleteTrustCenterAccessInput {
+    id: ID!
+}
+
+input DeleteNewsletterSubscriberInput {
     id: ID!
 }
 
@@ -4448,6 +4481,10 @@ type UpdateTrustCenterAccessPayload {
 
 type DeleteTrustCenterAccessPayload {
     deletedTrustCenterAccessId: ID!
+}
+
+type DeleteNewsletterSubscriberPayload {
+    deletedNewsletterSubscriberId: ID!
 }
 
 type CreateTrustCenterReferencePayload {

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -53,6 +53,7 @@ type ResolverRoot interface {
 	AssetConnection() AssetConnectionResolver
 	Audit() AuditResolver
 	AuditConnection() AuditConnectionResolver
+	ComplianceNewsletterSubscriberConnection() ComplianceNewsletterSubscriberConnectionResolver
 	ContinualImprovement() ContinualImprovementResolver
 	ContinualImprovementConnection() ContinualImprovementConnectionResolver
 	Control() ControlResolver
@@ -228,6 +229,24 @@ type ComplexityRoot struct {
 
 	CancelSignatureRequestPayload struct {
 		DeletedDocumentVersionSignatureID func(childComplexity int) int
+	}
+
+	ComplianceNewsletterSubscriber struct {
+		CreatedAt func(childComplexity int) int
+		Email     func(childComplexity int) int
+		ID        func(childComplexity int) int
+		UpdatedAt func(childComplexity int) int
+	}
+
+	ComplianceNewsletterSubscriberConnection struct {
+		Edges      func(childComplexity int) int
+		PageInfo   func(childComplexity int) int
+		TotalCount func(childComplexity int) int
+	}
+
+	ComplianceNewsletterSubscriberEdge struct {
+		Cursor func(childComplexity int) int
+		Node   func(childComplexity int) int
 	}
 
 	ContinualImprovement struct {
@@ -603,6 +622,10 @@ type ComplexityRoot struct {
 
 	DeleteMeetingPayload struct {
 		DeletedMeetingID func(childComplexity int) int
+	}
+
+	DeleteNewsletterSubscriberPayload struct {
+		DeletedNewsletterSubscriberID func(childComplexity int) int
 	}
 
 	DeleteNonconformityPayload struct {
@@ -1022,6 +1045,7 @@ type ComplexityRoot struct {
 		DeleteFramework                          func(childComplexity int, input types.DeleteFrameworkInput) int
 		DeleteMeasure                            func(childComplexity int, input types.DeleteMeasureInput) int
 		DeleteMeeting                            func(childComplexity int, input types.DeleteMeetingInput) int
+		DeleteNewsletterSubscriber               func(childComplexity int, input types.DeleteNewsletterSubscriberInput) int
 		DeleteNonconformity                      func(childComplexity int, input types.DeleteNonconformityInput) int
 		DeleteObligation                         func(childComplexity int, input types.DeleteObligationInput) int
 		DeleteProcessingActivity                 func(childComplexity int, input types.DeleteProcessingActivityInput) int
@@ -1518,18 +1542,19 @@ type ComplexityRoot struct {
 	}
 
 	TrustCenter struct {
-		Accesses        func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.OrderBy[coredata.TrustCenterAccessOrderField]) int
-		Active          func(childComplexity int) int
-		CreatedAt       func(childComplexity int) int
-		DarkLogoFileURL func(childComplexity int) int
-		ID              func(childComplexity int) int
-		LogoFileURL     func(childComplexity int) int
-		NdaFileName     func(childComplexity int) int
-		NdaFileURL      func(childComplexity int) int
-		Organization    func(childComplexity int) int
-		Permission      func(childComplexity int, action string) int
-		References      func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.OrderBy[coredata.TrustCenterReferenceOrderField]) int
-		UpdatedAt       func(childComplexity int) int
+		Accesses              func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.OrderBy[coredata.TrustCenterAccessOrderField]) int
+		Active                func(childComplexity int) int
+		CreatedAt             func(childComplexity int) int
+		DarkLogoFileURL       func(childComplexity int) int
+		ID                    func(childComplexity int) int
+		LogoFileURL           func(childComplexity int) int
+		NdaFileName           func(childComplexity int) int
+		NdaFileURL            func(childComplexity int) int
+		NewsletterSubscribers func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey) int
+		Organization          func(childComplexity int) int
+		Permission            func(childComplexity int, action string) int
+		References            func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.OrderBy[coredata.TrustCenterReferenceOrderField]) int
+		UpdatedAt             func(childComplexity int) int
 	}
 
 	TrustCenterAccess struct {
@@ -2026,6 +2051,9 @@ type AuditResolver interface {
 type AuditConnectionResolver interface {
 	TotalCount(ctx context.Context, obj *types.AuditConnection) (int, error)
 }
+type ComplianceNewsletterSubscriberConnectionResolver interface {
+	TotalCount(ctx context.Context, obj *types.ComplianceNewsletterSubscriberConnection) (int, error)
+}
 type ContinualImprovementResolver interface {
 	Organization(ctx context.Context, obj *types.ContinualImprovement) (*types.Organization, error)
 
@@ -2167,6 +2195,7 @@ type MutationResolver interface {
 	CreateTrustCenterAccess(ctx context.Context, input types.CreateTrustCenterAccessInput) (*types.CreateTrustCenterAccessPayload, error)
 	UpdateTrustCenterAccess(ctx context.Context, input types.UpdateTrustCenterAccessInput) (*types.UpdateTrustCenterAccessPayload, error)
 	DeleteTrustCenterAccess(ctx context.Context, input types.DeleteTrustCenterAccessInput) (*types.DeleteTrustCenterAccessPayload, error)
+	DeleteNewsletterSubscriber(ctx context.Context, input types.DeleteNewsletterSubscriberInput) (*types.DeleteNewsletterSubscriberPayload, error)
 	CreateTrustCenterReference(ctx context.Context, input types.CreateTrustCenterReferenceInput) (*types.CreateTrustCenterReferencePayload, error)
 	UpdateTrustCenterReference(ctx context.Context, input types.UpdateTrustCenterReferenceInput) (*types.UpdateTrustCenterReferencePayload, error)
 	DeleteTrustCenterReference(ctx context.Context, input types.DeleteTrustCenterReferenceInput) (*types.DeleteTrustCenterReferencePayload, error)
@@ -2459,6 +2488,7 @@ type TrustCenterResolver interface {
 	Organization(ctx context.Context, obj *types.TrustCenter) (*types.Organization, error)
 	Accesses(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.OrderBy[coredata.TrustCenterAccessOrderField]) (*types.TrustCenterAccessConnection, error)
 	References(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.OrderBy[coredata.TrustCenterReferenceOrderField]) (*types.TrustCenterReferenceConnection, error)
+	NewsletterSubscribers(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.ComplianceNewsletterSubscriberConnection, error)
 	Permission(ctx context.Context, obj *types.TrustCenter, action string) (bool, error)
 }
 type TrustCenterAccessResolver interface {
@@ -2959,6 +2989,63 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.CancelSignatureRequestPayload.DeletedDocumentVersionSignatureID(childComplexity), true
+
+	case "ComplianceNewsletterSubscriber.createdAt":
+		if e.complexity.ComplianceNewsletterSubscriber.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.ComplianceNewsletterSubscriber.CreatedAt(childComplexity), true
+	case "ComplianceNewsletterSubscriber.email":
+		if e.complexity.ComplianceNewsletterSubscriber.Email == nil {
+			break
+		}
+
+		return e.complexity.ComplianceNewsletterSubscriber.Email(childComplexity), true
+	case "ComplianceNewsletterSubscriber.id":
+		if e.complexity.ComplianceNewsletterSubscriber.ID == nil {
+			break
+		}
+
+		return e.complexity.ComplianceNewsletterSubscriber.ID(childComplexity), true
+	case "ComplianceNewsletterSubscriber.updatedAt":
+		if e.complexity.ComplianceNewsletterSubscriber.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.ComplianceNewsletterSubscriber.UpdatedAt(childComplexity), true
+
+	case "ComplianceNewsletterSubscriberConnection.edges":
+		if e.complexity.ComplianceNewsletterSubscriberConnection.Edges == nil {
+			break
+		}
+
+		return e.complexity.ComplianceNewsletterSubscriberConnection.Edges(childComplexity), true
+	case "ComplianceNewsletterSubscriberConnection.pageInfo":
+		if e.complexity.ComplianceNewsletterSubscriberConnection.PageInfo == nil {
+			break
+		}
+
+		return e.complexity.ComplianceNewsletterSubscriberConnection.PageInfo(childComplexity), true
+	case "ComplianceNewsletterSubscriberConnection.totalCount":
+		if e.complexity.ComplianceNewsletterSubscriberConnection.TotalCount == nil {
+			break
+		}
+
+		return e.complexity.ComplianceNewsletterSubscriberConnection.TotalCount(childComplexity), true
+
+	case "ComplianceNewsletterSubscriberEdge.cursor":
+		if e.complexity.ComplianceNewsletterSubscriberEdge.Cursor == nil {
+			break
+		}
+
+		return e.complexity.ComplianceNewsletterSubscriberEdge.Cursor(childComplexity), true
+	case "ComplianceNewsletterSubscriberEdge.node":
+		if e.complexity.ComplianceNewsletterSubscriberEdge.Node == nil {
+			break
+		}
+
+		return e.complexity.ComplianceNewsletterSubscriberEdge.Node(childComplexity), true
 
 	case "ContinualImprovement.createdAt":
 		if e.complexity.ContinualImprovement.CreatedAt == nil {
@@ -4040,6 +4127,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.DeleteMeetingPayload.DeletedMeetingID(childComplexity), true
+
+	case "DeleteNewsletterSubscriberPayload.deletedNewsletterSubscriberId":
+		if e.complexity.DeleteNewsletterSubscriberPayload.DeletedNewsletterSubscriberID == nil {
+			break
+		}
+
+		return e.complexity.DeleteNewsletterSubscriberPayload.DeletedNewsletterSubscriberID(childComplexity), true
 
 	case "DeleteNonconformityPayload.deletedNonconformityId":
 		if e.complexity.DeleteNonconformityPayload.DeletedNonconformityID == nil {
@@ -5956,6 +6050,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.DeleteMeeting(childComplexity, args["input"].(types.DeleteMeetingInput)), true
+	case "Mutation.deleteNewsletterSubscriber":
+		if e.complexity.Mutation.DeleteNewsletterSubscriber == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_deleteNewsletterSubscriber_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteNewsletterSubscriber(childComplexity, args["input"].(types.DeleteNewsletterSubscriberInput)), true
 	case "Mutation.deleteNonconformity":
 		if e.complexity.Mutation.DeleteNonconformity == nil {
 			break
@@ -8813,6 +8918,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.TrustCenter.NdaFileURL(childComplexity), true
+	case "TrustCenter.newsletterSubscribers":
+		if e.complexity.TrustCenter.NewsletterSubscribers == nil {
+			break
+		}
+
+		args, err := ec.field_TrustCenter_newsletterSubscribers_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.TrustCenter.NewsletterSubscribers(childComplexity, args["first"].(*int), args["after"].(*page.CursorKey), args["last"].(*int), args["before"].(*page.CursorKey)), true
 	case "TrustCenter.organization":
 		if e.complexity.TrustCenter.Organization == nil {
 			break
@@ -10490,6 +10606,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputDeleteFrameworkInput,
 		ec.unmarshalInputDeleteMeasureInput,
 		ec.unmarshalInputDeleteMeetingInput,
+		ec.unmarshalInputDeleteNewsletterSubscriberInput,
 		ec.unmarshalInputDeleteNonconformityInput,
 		ec.unmarshalInputDeleteObligationInput,
 		ec.unmarshalInputDeleteProcessingActivityInput,
@@ -12320,7 +12437,32 @@ type TrustCenter implements Node {
         orderBy: TrustCenterReferenceOrder
     ): TrustCenterReferenceConnection! @goField(forceResolver: true)
 
+    newsletterSubscribers(
+        first: Int
+        after: CursorKey
+        last: Int
+        before: CursorKey
+    ): ComplianceNewsletterSubscriberConnection! @goField(forceResolver: true)
+
     permission(action: String!): Boolean! @goField(forceResolver: true)
+}
+
+type ComplianceNewsletterSubscriber implements Node {
+    id: ID!
+    email: EmailAddr!
+    createdAt: Datetime!
+    updatedAt: Datetime!
+}
+
+type ComplianceNewsletterSubscriberConnection {
+    edges: [ComplianceNewsletterSubscriberEdge!]!
+    pageInfo: PageInfo!
+    totalCount: Int! @goField(forceResolver: true)
+}
+
+type ComplianceNewsletterSubscriberEdge {
+    cursor: CursorKey!
+    node: ComplianceNewsletterSubscriber!
 }
 
 type Organization implements Node {
@@ -13943,6 +14085,10 @@ type Mutation {
     deleteTrustCenterAccess(
         input: DeleteTrustCenterAccessInput!
     ): DeleteTrustCenterAccessPayload!
+    # Newsletter Subscriber mutations
+    deleteNewsletterSubscriber(
+        input: DeleteNewsletterSubscriberInput!
+    ): DeleteNewsletterSubscriberPayload!
     # Trust Center Reference mutations
     createTrustCenterReference(
         input: CreateTrustCenterReferenceInput!
@@ -14329,6 +14475,10 @@ input UpdateTrustCenterAccessInput {
 }
 
 input DeleteTrustCenterAccessInput {
+    id: ID!
+}
+
+input DeleteNewsletterSubscriberInput {
     id: ID!
 }
 
@@ -15154,6 +15304,10 @@ type UpdateTrustCenterAccessPayload {
 
 type DeleteTrustCenterAccessPayload {
     deletedTrustCenterAccessId: ID!
+}
+
+type DeleteNewsletterSubscriberPayload {
+    deletedNewsletterSubscriberId: ID!
 }
 
 type CreateTrustCenterReferencePayload {
@@ -17737,6 +17891,17 @@ func (ec *executionContext) field_Mutation_deleteMeeting_args(ctx context.Contex
 	return args, nil
 }
 
+func (ec *executionContext) field_Mutation_deleteNewsletterSubscriber_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "input", ec.unmarshalNDeleteNewsletterSubscriberInput2goᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteNewsletterSubscriberInput)
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
 func (ec *executionContext) field_Mutation_deleteNonconformity_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -19942,6 +20107,32 @@ func (ec *executionContext) field_TrustCenter_accesses_args(ctx context.Context,
 		return nil, err
 	}
 	args["orderBy"] = arg4
+	return args, nil
+}
+
+func (ec *executionContext) field_TrustCenter_newsletterSubscribers_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "first", ec.unmarshalOInt2ᚖint)
+	if err != nil {
+		return nil, err
+	}
+	args["first"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "after", ec.unmarshalOCursorKey2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋpageᚐCursorKey)
+	if err != nil {
+		return nil, err
+	}
+	args["after"] = arg1
+	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "last", ec.unmarshalOInt2ᚖint)
+	if err != nil {
+		return nil, err
+	}
+	args["last"] = arg2
+	arg3, err := graphql.ProcessArgField(ctx, rawArgs, "before", ec.unmarshalOCursorKey2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋpageᚐCursorKey)
+	if err != nil {
+		return nil, err
+	}
+	args["before"] = arg3
 	return args, nil
 }
 
@@ -22514,6 +22705,293 @@ func (ec *executionContext) fieldContext_CancelSignatureRequestPayload_deletedDo
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceNewsletterSubscriber_id(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceNewsletterSubscriber) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ComplianceNewsletterSubscriber_id,
+		func(ctx context.Context) (any, error) {
+			return obj.ID, nil
+		},
+		nil,
+		ec.marshalNID2goᚗproboᚗincᚋproboᚋpkgᚋgidᚐGID,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_ComplianceNewsletterSubscriber_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceNewsletterSubscriber",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceNewsletterSubscriber_email(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceNewsletterSubscriber) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ComplianceNewsletterSubscriber_email,
+		func(ctx context.Context) (any, error) {
+			return obj.Email, nil
+		},
+		nil,
+		ec.marshalNEmailAddr2goᚗproboᚗincᚋproboᚋpkgᚋmailᚐAddr,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_ComplianceNewsletterSubscriber_email(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceNewsletterSubscriber",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type EmailAddr does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceNewsletterSubscriber_createdAt(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceNewsletterSubscriber) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ComplianceNewsletterSubscriber_createdAt,
+		func(ctx context.Context) (any, error) {
+			return obj.CreatedAt, nil
+		},
+		nil,
+		ec.marshalNDatetime2timeᚐTime,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_ComplianceNewsletterSubscriber_createdAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceNewsletterSubscriber",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceNewsletterSubscriber_updatedAt(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceNewsletterSubscriber) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ComplianceNewsletterSubscriber_updatedAt,
+		func(ctx context.Context) (any, error) {
+			return obj.UpdatedAt, nil
+		},
+		nil,
+		ec.marshalNDatetime2timeᚐTime,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_ComplianceNewsletterSubscriber_updatedAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceNewsletterSubscriber",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Datetime does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceNewsletterSubscriberConnection_edges(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceNewsletterSubscriberConnection) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ComplianceNewsletterSubscriberConnection_edges,
+		func(ctx context.Context) (any, error) {
+			return obj.Edges, nil
+		},
+		nil,
+		ec.marshalNComplianceNewsletterSubscriberEdge2ᚕᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐComplianceNewsletterSubscriberEdgeᚄ,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_ComplianceNewsletterSubscriberConnection_edges(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceNewsletterSubscriberConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "cursor":
+				return ec.fieldContext_ComplianceNewsletterSubscriberEdge_cursor(ctx, field)
+			case "node":
+				return ec.fieldContext_ComplianceNewsletterSubscriberEdge_node(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ComplianceNewsletterSubscriberEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceNewsletterSubscriberConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceNewsletterSubscriberConnection) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ComplianceNewsletterSubscriberConnection_pageInfo,
+		func(ctx context.Context) (any, error) {
+			return obj.PageInfo, nil
+		},
+		nil,
+		ec.marshalNPageInfo2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐPageInfo,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_ComplianceNewsletterSubscriberConnection_pageInfo(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceNewsletterSubscriberConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "hasNextPage":
+				return ec.fieldContext_PageInfo_hasNextPage(ctx, field)
+			case "hasPreviousPage":
+				return ec.fieldContext_PageInfo_hasPreviousPage(ctx, field)
+			case "startCursor":
+				return ec.fieldContext_PageInfo_startCursor(ctx, field)
+			case "endCursor":
+				return ec.fieldContext_PageInfo_endCursor(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceNewsletterSubscriberConnection_totalCount(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceNewsletterSubscriberConnection) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ComplianceNewsletterSubscriberConnection_totalCount,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.ComplianceNewsletterSubscriberConnection().TotalCount(ctx, obj)
+		},
+		nil,
+		ec.marshalNInt2int,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_ComplianceNewsletterSubscriberConnection_totalCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceNewsletterSubscriberConnection",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceNewsletterSubscriberEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceNewsletterSubscriberEdge) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ComplianceNewsletterSubscriberEdge_cursor,
+		func(ctx context.Context) (any, error) {
+			return obj.Cursor, nil
+		},
+		nil,
+		ec.marshalNCursorKey2goᚗproboᚗincᚋproboᚋpkgᚋpageᚐCursorKey,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_ComplianceNewsletterSubscriberEdge_cursor(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceNewsletterSubscriberEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type CursorKey does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ComplianceNewsletterSubscriberEdge_node(ctx context.Context, field graphql.CollectedField, obj *types.ComplianceNewsletterSubscriberEdge) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ComplianceNewsletterSubscriberEdge_node,
+		func(ctx context.Context) (any, error) {
+			return obj.Node, nil
+		},
+		nil,
+		ec.marshalNComplianceNewsletterSubscriber2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐComplianceNewsletterSubscriber,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_ComplianceNewsletterSubscriberEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ComplianceNewsletterSubscriberEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_ComplianceNewsletterSubscriber_id(ctx, field)
+			case "email":
+				return ec.fieldContext_ComplianceNewsletterSubscriber_email(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_ComplianceNewsletterSubscriber_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_ComplianceNewsletterSubscriber_updatedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ComplianceNewsletterSubscriber", field.Name)
 		},
 	}
 	return fc, nil
@@ -28382,6 +28860,35 @@ func (ec *executionContext) fieldContext_DeleteMeetingPayload_deletedMeetingId(_
 	return fc, nil
 }
 
+func (ec *executionContext) _DeleteNewsletterSubscriberPayload_deletedNewsletterSubscriberId(ctx context.Context, field graphql.CollectedField, obj *types.DeleteNewsletterSubscriberPayload) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_DeleteNewsletterSubscriberPayload_deletedNewsletterSubscriberId,
+		func(ctx context.Context) (any, error) {
+			return obj.DeletedNewsletterSubscriberID, nil
+		},
+		nil,
+		ec.marshalNID2goᚗproboᚗincᚋproboᚋpkgᚋgidᚐGID,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_DeleteNewsletterSubscriberPayload_deletedNewsletterSubscriberId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DeleteNewsletterSubscriberPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _DeleteNonconformityPayload_deletedNonconformityId(ctx context.Context, field graphql.CollectedField, obj *types.DeleteNonconformityPayload) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -28921,6 +29428,8 @@ func (ec *executionContext) fieldContext_DeleteTrustCenterNDAPayload_trustCenter
 				return ec.fieldContext_TrustCenter_accesses(ctx, field)
 			case "references":
 				return ec.fieldContext_TrustCenter_references(ctx, field)
+			case "newsletterSubscribers":
+				return ec.fieldContext_TrustCenter_newsletterSubscribers(ctx, field)
 			case "permission":
 				return ec.fieldContext_TrustCenter_permission(ctx, field)
 			}
@@ -34960,6 +35469,51 @@ func (ec *executionContext) fieldContext_Mutation_deleteTrustCenterAccess(ctx co
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_deleteTrustCenterAccess_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_deleteNewsletterSubscriber(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Mutation_deleteNewsletterSubscriber,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.resolvers.Mutation().DeleteNewsletterSubscriber(ctx, fc.Args["input"].(types.DeleteNewsletterSubscriberInput))
+		},
+		nil,
+		ec.marshalNDeleteNewsletterSubscriberPayload2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteNewsletterSubscriberPayload,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Mutation_deleteNewsletterSubscriber(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "deletedNewsletterSubscriberId":
+				return ec.fieldContext_DeleteNewsletterSubscriberPayload_deletedNewsletterSubscriberId(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DeleteNewsletterSubscriberPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_deleteNewsletterSubscriber_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -43989,6 +44543,8 @@ func (ec *executionContext) fieldContext_Organization_trustCenter(_ context.Cont
 				return ec.fieldContext_TrustCenter_accesses(ctx, field)
 			case "references":
 				return ec.fieldContext_TrustCenter_references(ctx, field)
+			case "newsletterSubscribers":
+				return ec.fieldContext_TrustCenter_newsletterSubscribers(ctx, field)
 			case "permission":
 				return ec.fieldContext_TrustCenter_permission(ctx, field)
 			}
@@ -52209,6 +52765,55 @@ func (ec *executionContext) fieldContext_TrustCenter_references(ctx context.Cont
 	return fc, nil
 }
 
+func (ec *executionContext) _TrustCenter_newsletterSubscribers(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenter) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TrustCenter_newsletterSubscribers,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.resolvers.TrustCenter().NewsletterSubscribers(ctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey))
+		},
+		nil,
+		ec.marshalNComplianceNewsletterSubscriberConnection2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐComplianceNewsletterSubscriberConnection,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_TrustCenter_newsletterSubscribers(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenter",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "edges":
+				return ec.fieldContext_ComplianceNewsletterSubscriberConnection_edges(ctx, field)
+			case "pageInfo":
+				return ec.fieldContext_ComplianceNewsletterSubscriberConnection_pageInfo(ctx, field)
+			case "totalCount":
+				return ec.fieldContext_ComplianceNewsletterSubscriberConnection_totalCount(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ComplianceNewsletterSubscriberConnection", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_TrustCenter_newsletterSubscribers_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _TrustCenter_permission(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenter) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -53380,6 +53985,8 @@ func (ec *executionContext) fieldContext_TrustCenterEdge_node(_ context.Context,
 				return ec.fieldContext_TrustCenter_accesses(ctx, field)
 			case "references":
 				return ec.fieldContext_TrustCenter_references(ctx, field)
+			case "newsletterSubscribers":
+				return ec.fieldContext_TrustCenter_newsletterSubscribers(ctx, field)
 			case "permission":
 				return ec.fieldContext_TrustCenter_permission(ctx, field)
 			}
@@ -55687,6 +56294,8 @@ func (ec *executionContext) fieldContext_UpdateTrustCenterBrandPayload_trustCent
 				return ec.fieldContext_TrustCenter_accesses(ctx, field)
 			case "references":
 				return ec.fieldContext_TrustCenter_references(ctx, field)
+			case "newsletterSubscribers":
+				return ec.fieldContext_TrustCenter_newsletterSubscribers(ctx, field)
 			case "permission":
 				return ec.fieldContext_TrustCenter_permission(ctx, field)
 			}
@@ -55791,6 +56400,8 @@ func (ec *executionContext) fieldContext_UpdateTrustCenterPayload_trustCenter(_ 
 				return ec.fieldContext_TrustCenter_accesses(ctx, field)
 			case "references":
 				return ec.fieldContext_TrustCenter_references(ctx, field)
+			case "newsletterSubscribers":
+				return ec.fieldContext_TrustCenter_newsletterSubscribers(ctx, field)
 			case "permission":
 				return ec.fieldContext_TrustCenter_permission(ctx, field)
 			}
@@ -56329,6 +56940,8 @@ func (ec *executionContext) fieldContext_UploadTrustCenterNDAPayload_trustCenter
 				return ec.fieldContext_TrustCenter_accesses(ctx, field)
 			case "references":
 				return ec.fieldContext_TrustCenter_references(ctx, field)
+			case "newsletterSubscribers":
+				return ec.fieldContext_TrustCenter_newsletterSubscribers(ctx, field)
 			case "permission":
 				return ec.fieldContext_TrustCenter_permission(ctx, field)
 			}
@@ -66435,6 +67048,33 @@ func (ec *executionContext) unmarshalInputDeleteMeetingInput(ctx context.Context
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputDeleteNewsletterSubscriberInput(ctx context.Context, obj any) (types.DeleteNewsletterSubscriberInput, error) {
+	var it types.DeleteNewsletterSubscriberInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			data, err := ec.unmarshalNID2goᚗproboᚗincᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ID = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputDeleteNonconformityInput(ctx context.Context, obj any) (types.DeleteNonconformityInput, error) {
 	var it types.DeleteNonconformityInput
 	asMap := map[string]any{}
@@ -71499,6 +72139,13 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._ContinualImprovement(ctx, sel, obj)
+	case types.ComplianceNewsletterSubscriber:
+		return ec._ComplianceNewsletterSubscriber(ctx, sel, &obj)
+	case *types.ComplianceNewsletterSubscriber:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._ComplianceNewsletterSubscriber(ctx, sel, obj)
 	case types.Audit:
 		return ec._Audit(ctx, sel, &obj)
 	case *types.Audit:
@@ -72775,6 +73422,184 @@ func (ec *executionContext) _CancelSignatureRequestPayload(ctx context.Context, 
 			out.Values[i] = graphql.MarshalString("CancelSignatureRequestPayload")
 		case "deletedDocumentVersionSignatureId":
 			out.Values[i] = ec._CancelSignatureRequestPayload_deletedDocumentVersionSignatureId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var complianceNewsletterSubscriberImplementors = []string{"ComplianceNewsletterSubscriber", "Node"}
+
+func (ec *executionContext) _ComplianceNewsletterSubscriber(ctx context.Context, sel ast.SelectionSet, obj *types.ComplianceNewsletterSubscriber) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, complianceNewsletterSubscriberImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ComplianceNewsletterSubscriber")
+		case "id":
+			out.Values[i] = ec._ComplianceNewsletterSubscriber_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "email":
+			out.Values[i] = ec._ComplianceNewsletterSubscriber_email(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "createdAt":
+			out.Values[i] = ec._ComplianceNewsletterSubscriber_createdAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "updatedAt":
+			out.Values[i] = ec._ComplianceNewsletterSubscriber_updatedAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var complianceNewsletterSubscriberConnectionImplementors = []string{"ComplianceNewsletterSubscriberConnection"}
+
+func (ec *executionContext) _ComplianceNewsletterSubscriberConnection(ctx context.Context, sel ast.SelectionSet, obj *types.ComplianceNewsletterSubscriberConnection) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, complianceNewsletterSubscriberConnectionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ComplianceNewsletterSubscriberConnection")
+		case "edges":
+			out.Values[i] = ec._ComplianceNewsletterSubscriberConnection_edges(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "pageInfo":
+			out.Values[i] = ec._ComplianceNewsletterSubscriberConnection_pageInfo(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "totalCount":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._ComplianceNewsletterSubscriberConnection_totalCount(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var complianceNewsletterSubscriberEdgeImplementors = []string{"ComplianceNewsletterSubscriberEdge"}
+
+func (ec *executionContext) _ComplianceNewsletterSubscriberEdge(ctx context.Context, sel ast.SelectionSet, obj *types.ComplianceNewsletterSubscriberEdge) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, complianceNewsletterSubscriberEdgeImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ComplianceNewsletterSubscriberEdge")
+		case "cursor":
+			out.Values[i] = ec._ComplianceNewsletterSubscriberEdge_cursor(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "node":
+			out.Values[i] = ec._ComplianceNewsletterSubscriberEdge_node(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -76782,6 +77607,45 @@ func (ec *executionContext) _DeleteMeetingPayload(ctx context.Context, sel ast.S
 			out.Values[i] = graphql.MarshalString("DeleteMeetingPayload")
 		case "deletedMeetingId":
 			out.Values[i] = ec._DeleteMeetingPayload_deletedMeetingId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var deleteNewsletterSubscriberPayloadImplementors = []string{"DeleteNewsletterSubscriberPayload"}
+
+func (ec *executionContext) _DeleteNewsletterSubscriberPayload(ctx context.Context, sel ast.SelectionSet, obj *types.DeleteNewsletterSubscriberPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, deleteNewsletterSubscriberPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("DeleteNewsletterSubscriberPayload")
+		case "deletedNewsletterSubscriberId":
+			out.Values[i] = ec._DeleteNewsletterSubscriberPayload_deletedNewsletterSubscriberId(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -80933,6 +81797,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "deleteTrustCenterAccess":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_deleteTrustCenterAccess(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "deleteNewsletterSubscriber":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_deleteNewsletterSubscriber(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
@@ -87465,6 +88336,42 @@ func (ec *executionContext) _TrustCenter(ctx context.Context, sel ast.SelectionS
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "newsletterSubscribers":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TrustCenter_newsletterSubscribers(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "permission":
 			field := field
 
@@ -93593,6 +94500,84 @@ func (ec *executionContext) marshalNCancelSignatureRequestPayload2ᚖgoᚗprobo�
 	return ec._CancelSignatureRequestPayload(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNComplianceNewsletterSubscriber2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐComplianceNewsletterSubscriber(ctx context.Context, sel ast.SelectionSet, v *types.ComplianceNewsletterSubscriber) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ComplianceNewsletterSubscriber(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNComplianceNewsletterSubscriberConnection2goᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐComplianceNewsletterSubscriberConnection(ctx context.Context, sel ast.SelectionSet, v types.ComplianceNewsletterSubscriberConnection) graphql.Marshaler {
+	return ec._ComplianceNewsletterSubscriberConnection(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNComplianceNewsletterSubscriberConnection2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐComplianceNewsletterSubscriberConnection(ctx context.Context, sel ast.SelectionSet, v *types.ComplianceNewsletterSubscriberConnection) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ComplianceNewsletterSubscriberConnection(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNComplianceNewsletterSubscriberEdge2ᚕᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐComplianceNewsletterSubscriberEdgeᚄ(ctx context.Context, sel ast.SelectionSet, v []*types.ComplianceNewsletterSubscriberEdge) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNComplianceNewsletterSubscriberEdge2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐComplianceNewsletterSubscriberEdge(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNComplianceNewsletterSubscriberEdge2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐComplianceNewsletterSubscriberEdge(ctx context.Context, sel ast.SelectionSet, v *types.ComplianceNewsletterSubscriberEdge) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ComplianceNewsletterSubscriberEdge(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalNContinualImprovement2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐContinualImprovement(ctx context.Context, sel ast.SelectionSet, v *types.ContinualImprovement) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -95930,6 +96915,25 @@ func (ec *executionContext) marshalNDeleteMeetingPayload2ᚖgoᚗproboᚗincᚋp
 		return graphql.Null
 	}
 	return ec._DeleteMeetingPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNDeleteNewsletterSubscriberInput2goᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteNewsletterSubscriberInput(ctx context.Context, v any) (types.DeleteNewsletterSubscriberInput, error) {
+	res, err := ec.unmarshalInputDeleteNewsletterSubscriberInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNDeleteNewsletterSubscriberPayload2goᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteNewsletterSubscriberPayload(ctx context.Context, sel ast.SelectionSet, v types.DeleteNewsletterSubscriberPayload) graphql.Marshaler {
+	return ec._DeleteNewsletterSubscriberPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNDeleteNewsletterSubscriberPayload2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteNewsletterSubscriberPayload(ctx context.Context, sel ast.SelectionSet, v *types.DeleteNewsletterSubscriberPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._DeleteNewsletterSubscriberPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNDeleteNonconformityInput2goᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐDeleteNonconformityInput(ctx context.Context, v any) (types.DeleteNonconformityInput, error) {

--- a/pkg/server/api/console/v1/types/compliance_newsletter_subscriber.go
+++ b/pkg/server/api/console/v1/types/compliance_newsletter_subscriber.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package types
+
+import (
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/page"
+)
+
+func EmptyComplianceNewsletterSubscriberConnection() *ComplianceNewsletterSubscriberConnection {
+	return &ComplianceNewsletterSubscriberConnection{
+		Edges:    []*ComplianceNewsletterSubscriberEdge{},
+		PageInfo: &PageInfo{},
+	}
+}
+
+func NewComplianceNewsletterSubscriberConnection(
+	p *page.Page[*coredata.ComplianceNewsletterSubscriber, coredata.ComplianceNewsletterSubscriberOrderField],
+) *ComplianceNewsletterSubscriberConnection {
+	edges := make([]*ComplianceNewsletterSubscriberEdge, len(p.Data))
+
+	for i, subscriber := range p.Data {
+		edges[i] = &ComplianceNewsletterSubscriberEdge{
+			Cursor: subscriber.CursorKey(p.Cursor.OrderBy.Field),
+			Node: &ComplianceNewsletterSubscriber{
+				ID:        subscriber.ID,
+				Email:     subscriber.Email,
+				CreatedAt: subscriber.CreatedAt,
+				UpdatedAt: subscriber.UpdatedAt,
+			},
+		}
+	}
+
+	return &ComplianceNewsletterSubscriberConnection{
+		Edges:    edges,
+		PageInfo: NewPageInfo(p),
+	}
+}

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -149,6 +149,27 @@ type CancelSignatureRequestPayload struct {
 	DeletedDocumentVersionSignatureID gid.GID `json:"deletedDocumentVersionSignatureId"`
 }
 
+type ComplianceNewsletterSubscriber struct {
+	ID        gid.GID   `json:"id"`
+	Email     mail.Addr `json:"email"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+func (ComplianceNewsletterSubscriber) IsNode()             {}
+func (this ComplianceNewsletterSubscriber) GetID() gid.GID { return this.ID }
+
+type ComplianceNewsletterSubscriberConnection struct {
+	Edges      []*ComplianceNewsletterSubscriberEdge `json:"edges"`
+	PageInfo   *PageInfo                             `json:"pageInfo"`
+	TotalCount int                                   `json:"totalCount"`
+}
+
+type ComplianceNewsletterSubscriberEdge struct {
+	Cursor page.CursorKey                  `json:"cursor"`
+	Node   *ComplianceNewsletterSubscriber `json:"node"`
+}
+
 type ContinualImprovement struct {
 	ID           gid.GID                               `json:"id"`
 	SnapshotID   *gid.GID                              `json:"snapshotId,omitempty"`
@@ -925,6 +946,14 @@ type DeleteMeetingInput struct {
 
 type DeleteMeetingPayload struct {
 	DeletedMeetingID gid.GID `json:"deletedMeetingId"`
+}
+
+type DeleteNewsletterSubscriberInput struct {
+	ID gid.GID `json:"id"`
+}
+
+type DeleteNewsletterSubscriberPayload struct {
+	DeletedNewsletterSubscriberID gid.GID `json:"deletedNewsletterSubscriberId"`
 }
 
 type DeleteNonconformityInput struct {
@@ -1851,18 +1880,19 @@ type TransferImpactAssessmentFilter struct {
 }
 
 type TrustCenter struct {
-	ID              gid.GID                         `json:"id"`
-	Active          bool                            `json:"active"`
-	LogoFileURL     *string                         `json:"logoFileUrl,omitempty"`
-	DarkLogoFileURL *string                         `json:"darkLogoFileUrl,omitempty"`
-	NdaFileName     *string                         `json:"ndaFileName,omitempty"`
-	NdaFileURL      *string                         `json:"ndaFileUrl,omitempty"`
-	CreatedAt       time.Time                       `json:"createdAt"`
-	UpdatedAt       time.Time                       `json:"updatedAt"`
-	Organization    *Organization                   `json:"organization"`
-	Accesses        *TrustCenterAccessConnection    `json:"accesses"`
-	References      *TrustCenterReferenceConnection `json:"references"`
-	Permission      bool                            `json:"permission"`
+	ID                    gid.GID                                   `json:"id"`
+	Active                bool                                      `json:"active"`
+	LogoFileURL           *string                                   `json:"logoFileUrl,omitempty"`
+	DarkLogoFileURL       *string                                   `json:"darkLogoFileUrl,omitempty"`
+	NdaFileName           *string                                   `json:"ndaFileName,omitempty"`
+	NdaFileURL            *string                                   `json:"ndaFileUrl,omitempty"`
+	CreatedAt             time.Time                                 `json:"createdAt"`
+	UpdatedAt             time.Time                                 `json:"updatedAt"`
+	Organization          *Organization                             `json:"organization"`
+	Accesses              *TrustCenterAccessConnection              `json:"accesses"`
+	References            *TrustCenterReferenceConnection           `json:"references"`
+	NewsletterSubscribers *ComplianceNewsletterSubscriberConnection `json:"newsletterSubscribers"`
+	Permission            bool                                      `json:"permission"`
 }
 
 func (TrustCenter) IsNode()             {}

--- a/pkg/server/api/trust/v1/schema.graphql
+++ b/pkg/server/api/trust/v1/schema.graphql
@@ -505,6 +505,7 @@ type TrustCenter implements Node {
   nonDisclosureAgreement: NonDisclosureAgreement @goField(forceResolver: true)
 
   isViewerMember: Boolean! @goField(forceResolver: true)
+  isViewerSubscribedToNewsletter: Boolean! @goField(forceResolver: true)
   organization: Organization! @goField(forceResolver: true)
 
   documents(
@@ -787,4 +788,17 @@ type Mutation {
   recordSigningEvent(
     input: RecordSigningEventInput!
   ): RecordSigningEventPayload @session(required: PRESENT)
+
+  subscribeToNewsletter: SubscribeToNewsletterPayload! @session(required: PRESENT)
+  unsubscribeFromNewsletter: UnsubscribeFromNewsletterPayload! @session(required: PRESENT)
+}
+
+type SubscribeToNewsletterPayload {
+  success: Boolean!
+  trustCenter: TrustCenter!
+}
+
+type UnsubscribeFromNewsletterPayload {
+  success: Boolean!
+  trustCenter: TrustCenter!
 }

--- a/pkg/server/api/trust/v1/schema/schema.go
+++ b/pkg/server/api/trust/v1/schema/schema.go
@@ -155,6 +155,8 @@ type ComplexityRoot struct {
 		RequestReportAccess          func(childComplexity int, input types.RequestReportAccessInput) int
 		RequestTrustCenterFileAccess func(childComplexity int, input types.RequestTrustCenterFileAccessInput) int
 		SendMagicLink                func(childComplexity int, input types.SendMagicLinkInput) int
+		SubscribeToNewsletter        func(childComplexity int) int
+		UnsubscribeFromNewsletter    func(childComplexity int) int
 		VerifyMagicLink              func(childComplexity int, input types.VerifyMagicLinkInput) int
 	}
 
@@ -206,20 +208,26 @@ type ComplexityRoot struct {
 		Success func(childComplexity int) int
 	}
 
+	SubscribeToNewsletterPayload struct {
+		Success     func(childComplexity int) int
+		TrustCenter func(childComplexity int) int
+	}
+
 	TrustCenter struct {
-		Active                 func(childComplexity int) int
-		Audits                 func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey) int
-		DarkLogoFileURL        func(childComplexity int) int
-		Documents              func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey) int
-		ID                     func(childComplexity int) int
-		IsViewerMember         func(childComplexity int) int
-		LogoFileURL            func(childComplexity int) int
-		NonDisclosureAgreement func(childComplexity int) int
-		Organization           func(childComplexity int) int
-		References             func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey) int
-		Slug                   func(childComplexity int) int
-		TrustCenterFiles       func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey) int
-		Vendors                func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey) int
+		Active                         func(childComplexity int) int
+		Audits                         func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey) int
+		DarkLogoFileURL                func(childComplexity int) int
+		Documents                      func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey) int
+		ID                             func(childComplexity int) int
+		IsViewerMember                 func(childComplexity int) int
+		IsViewerSubscribedToNewsletter func(childComplexity int) int
+		LogoFileURL                    func(childComplexity int) int
+		NonDisclosureAgreement         func(childComplexity int) int
+		Organization                   func(childComplexity int) int
+		References                     func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey) int
+		Slug                           func(childComplexity int) int
+		TrustCenterFiles               func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey) int
+		Vendors                        func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey) int
 	}
 
 	TrustCenterAccess struct {
@@ -264,6 +272,11 @@ type ComplexityRoot struct {
 	TrustCenterReferenceEdge struct {
 		Cursor func(childComplexity int) int
 		Node   func(childComplexity int) int
+	}
+
+	UnsubscribeFromNewsletterPayload struct {
+		Success     func(childComplexity int) int
+		TrustCenter func(childComplexity int) int
 	}
 
 	Vendor struct {
@@ -316,6 +329,8 @@ type MutationResolver interface {
 	RequestTrustCenterFileAccess(ctx context.Context, input types.RequestTrustCenterFileAccessInput) (*types.RequestAccessesPayload, error)
 	AcceptElectronicSignature(ctx context.Context, input types.AcceptElectronicSignatureInput) (*types.AcceptElectronicSignaturePayload, error)
 	RecordSigningEvent(ctx context.Context, input types.RecordSigningEventInput) (*types.RecordSigningEventPayload, error)
+	SubscribeToNewsletter(ctx context.Context) (*types.SubscribeToNewsletterPayload, error)
+	UnsubscribeFromNewsletter(ctx context.Context) (*types.UnsubscribeFromNewsletterPayload, error)
 }
 type NonDisclosureAgreementResolver interface {
 	FileURL(ctx context.Context, obj *types.NonDisclosureAgreement) (string, error)
@@ -338,6 +353,7 @@ type TrustCenterResolver interface {
 	DarkLogoFileURL(ctx context.Context, obj *types.TrustCenter) (*string, error)
 	NonDisclosureAgreement(ctx context.Context, obj *types.TrustCenter) (*types.NonDisclosureAgreement, error)
 	IsViewerMember(ctx context.Context, obj *types.TrustCenter) (bool, error)
+	IsViewerSubscribedToNewsletter(ctx context.Context, obj *types.TrustCenter) (bool, error)
 	Organization(ctx context.Context, obj *types.TrustCenter) (*types.Organization, error)
 	Documents(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.DocumentConnection, error)
 	Audits(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.AuditConnection, error)
@@ -727,6 +743,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.SendMagicLink(childComplexity, args["input"].(types.SendMagicLinkInput)), true
+	case "Mutation.subscribeToNewsletter":
+		if e.complexity.Mutation.SubscribeToNewsletter == nil {
+			break
+		}
+
+		return e.complexity.Mutation.SubscribeToNewsletter(childComplexity), true
+	case "Mutation.unsubscribeFromNewsletter":
+		if e.complexity.Mutation.UnsubscribeFromNewsletter == nil {
+			break
+		}
+
+		return e.complexity.Mutation.UnsubscribeFromNewsletter(childComplexity), true
 	case "Mutation.verifyMagicLink":
 		if e.complexity.Mutation.VerifyMagicLink == nil {
 			break
@@ -896,6 +924,19 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.SendMagicLinkPayload.Success(childComplexity), true
 
+	case "SubscribeToNewsletterPayload.success":
+		if e.complexity.SubscribeToNewsletterPayload.Success == nil {
+			break
+		}
+
+		return e.complexity.SubscribeToNewsletterPayload.Success(childComplexity), true
+	case "SubscribeToNewsletterPayload.trustCenter":
+		if e.complexity.SubscribeToNewsletterPayload.TrustCenter == nil {
+			break
+		}
+
+		return e.complexity.SubscribeToNewsletterPayload.TrustCenter(childComplexity), true
+
 	case "TrustCenter.active":
 		if e.complexity.TrustCenter.Active == nil {
 			break
@@ -942,6 +983,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.TrustCenter.IsViewerMember(childComplexity), true
+	case "TrustCenter.isViewerSubscribedToNewsletter":
+		if e.complexity.TrustCenter.IsViewerSubscribedToNewsletter == nil {
+			break
+		}
+
+		return e.complexity.TrustCenter.IsViewerSubscribedToNewsletter(childComplexity), true
 	case "TrustCenter.logoFileUrl":
 		if e.complexity.TrustCenter.LogoFileURL == nil {
 			break
@@ -1144,6 +1191,19 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.TrustCenterReferenceEdge.Node(childComplexity), true
+
+	case "UnsubscribeFromNewsletterPayload.success":
+		if e.complexity.UnsubscribeFromNewsletterPayload.Success == nil {
+			break
+		}
+
+		return e.complexity.UnsubscribeFromNewsletterPayload.Success(childComplexity), true
+	case "UnsubscribeFromNewsletterPayload.trustCenter":
+		if e.complexity.UnsubscribeFromNewsletterPayload.TrustCenter == nil {
+			break
+		}
+
+		return e.complexity.UnsubscribeFromNewsletterPayload.TrustCenter(childComplexity), true
 
 	case "Vendor.category":
 		if e.complexity.Vendor.Category == nil {
@@ -1849,6 +1909,7 @@ type TrustCenter implements Node {
   nonDisclosureAgreement: NonDisclosureAgreement @goField(forceResolver: true)
 
   isViewerMember: Boolean! @goField(forceResolver: true)
+  isViewerSubscribedToNewsletter: Boolean! @goField(forceResolver: true)
   organization: Organization! @goField(forceResolver: true)
 
   documents(
@@ -2131,6 +2192,19 @@ type Mutation {
   recordSigningEvent(
     input: RecordSigningEventInput!
   ): RecordSigningEventPayload @session(required: PRESENT)
+
+  subscribeToNewsletter: SubscribeToNewsletterPayload! @session(required: PRESENT)
+  unsubscribeFromNewsletter: UnsubscribeFromNewsletterPayload! @session(required: PRESENT)
+}
+
+type SubscribeToNewsletterPayload {
+  success: Boolean!
+  trustCenter: TrustCenter!
+}
+
+type UnsubscribeFromNewsletterPayload {
+  success: Boolean!
+  trustCenter: TrustCenter!
 }
 `, BuiltIn: false},
 	{Name: "../../../../gqlutils/directives/session/schema.graphql", Input: `# Session directive for GraphQL APIs
@@ -4408,6 +4482,112 @@ func (ec *executionContext) fieldContext_Mutation_recordSigningEvent(ctx context
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_subscribeToNewsletter(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Mutation_subscribeToNewsletter,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.Mutation().SubscribeToNewsletter(ctx)
+		},
+		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
+			directive0 := next
+
+			directive1 := func(ctx context.Context) (any, error) {
+				required, err := ec.unmarshalNSessionRequirement2goᚗproboᚗincᚋproboᚋpkgᚋserverᚋgqlutilsᚋdirectivesᚋsessionᚐSessionRequirement(ctx, "PRESENT")
+				if err != nil {
+					var zeroVal *types.SubscribeToNewsletterPayload
+					return zeroVal, err
+				}
+				if ec.directives.Session == nil {
+					var zeroVal *types.SubscribeToNewsletterPayload
+					return zeroVal, errors.New("directive session is not implemented")
+				}
+				return ec.directives.Session(ctx, nil, directive0, required)
+			}
+
+			next = directive1
+			return next
+		},
+		ec.marshalNSubscribeToNewsletterPayload2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐSubscribeToNewsletterPayload,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Mutation_subscribeToNewsletter(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "success":
+				return ec.fieldContext_SubscribeToNewsletterPayload_success(ctx, field)
+			case "trustCenter":
+				return ec.fieldContext_SubscribeToNewsletterPayload_trustCenter(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SubscribeToNewsletterPayload", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_unsubscribeFromNewsletter(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Mutation_unsubscribeFromNewsletter,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.Mutation().UnsubscribeFromNewsletter(ctx)
+		},
+		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
+			directive0 := next
+
+			directive1 := func(ctx context.Context) (any, error) {
+				required, err := ec.unmarshalNSessionRequirement2goᚗproboᚗincᚋproboᚋpkgᚋserverᚋgqlutilsᚋdirectivesᚋsessionᚐSessionRequirement(ctx, "PRESENT")
+				if err != nil {
+					var zeroVal *types.UnsubscribeFromNewsletterPayload
+					return zeroVal, err
+				}
+				if ec.directives.Session == nil {
+					var zeroVal *types.UnsubscribeFromNewsletterPayload
+					return zeroVal, errors.New("directive session is not implemented")
+				}
+				return ec.directives.Session(ctx, nil, directive0, required)
+			}
+
+			next = directive1
+			return next
+		},
+		ec.marshalNUnsubscribeFromNewsletterPayload2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐUnsubscribeFromNewsletterPayload,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Mutation_unsubscribeFromNewsletter(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "success":
+				return ec.fieldContext_UnsubscribeFromNewsletterPayload_success(ctx, field)
+			case "trustCenter":
+				return ec.fieldContext_UnsubscribeFromNewsletterPayload_trustCenter(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UnsubscribeFromNewsletterPayload", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _NonDisclosureAgreement_fileName(ctx context.Context, field graphql.CollectedField, obj *types.NonDisclosureAgreement) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -4954,6 +5134,8 @@ func (ec *executionContext) fieldContext_Query_currentTrustCenter(_ context.Cont
 				return ec.fieldContext_TrustCenter_nonDisclosureAgreement(ctx, field)
 			case "isViewerMember":
 				return ec.fieldContext_TrustCenter_isViewerMember(ctx, field)
+			case "isViewerSubscribedToNewsletter":
+				return ec.fieldContext_TrustCenter_isViewerSubscribedToNewsletter(ctx, field)
 			case "organization":
 				return ec.fieldContext_TrustCenter_organization(ctx, field)
 			case "documents":
@@ -5296,6 +5478,94 @@ func (ec *executionContext) fieldContext_SendMagicLinkPayload_success(_ context.
 	return fc, nil
 }
 
+func (ec *executionContext) _SubscribeToNewsletterPayload_success(ctx context.Context, field graphql.CollectedField, obj *types.SubscribeToNewsletterPayload) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_SubscribeToNewsletterPayload_success,
+		func(ctx context.Context) (any, error) {
+			return obj.Success, nil
+		},
+		nil,
+		ec.marshalNBoolean2bool,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_SubscribeToNewsletterPayload_success(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SubscribeToNewsletterPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SubscribeToNewsletterPayload_trustCenter(ctx context.Context, field graphql.CollectedField, obj *types.SubscribeToNewsletterPayload) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_SubscribeToNewsletterPayload_trustCenter,
+		func(ctx context.Context) (any, error) {
+			return obj.TrustCenter, nil
+		},
+		nil,
+		ec.marshalNTrustCenter2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐTrustCenter,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_SubscribeToNewsletterPayload_trustCenter(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SubscribeToNewsletterPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TrustCenter_id(ctx, field)
+			case "active":
+				return ec.fieldContext_TrustCenter_active(ctx, field)
+			case "slug":
+				return ec.fieldContext_TrustCenter_slug(ctx, field)
+			case "logoFileUrl":
+				return ec.fieldContext_TrustCenter_logoFileUrl(ctx, field)
+			case "darkLogoFileUrl":
+				return ec.fieldContext_TrustCenter_darkLogoFileUrl(ctx, field)
+			case "nonDisclosureAgreement":
+				return ec.fieldContext_TrustCenter_nonDisclosureAgreement(ctx, field)
+			case "isViewerMember":
+				return ec.fieldContext_TrustCenter_isViewerMember(ctx, field)
+			case "isViewerSubscribedToNewsletter":
+				return ec.fieldContext_TrustCenter_isViewerSubscribedToNewsletter(ctx, field)
+			case "organization":
+				return ec.fieldContext_TrustCenter_organization(ctx, field)
+			case "documents":
+				return ec.fieldContext_TrustCenter_documents(ctx, field)
+			case "audits":
+				return ec.fieldContext_TrustCenter_audits(ctx, field)
+			case "vendors":
+				return ec.fieldContext_TrustCenter_vendors(ctx, field)
+			case "references":
+				return ec.fieldContext_TrustCenter_references(ctx, field)
+			case "trustCenterFiles":
+				return ec.fieldContext_TrustCenter_trustCenterFiles(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustCenter", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _TrustCenter_id(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenter) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -5495,6 +5765,35 @@ func (ec *executionContext) _TrustCenter_isViewerMember(ctx context.Context, fie
 }
 
 func (ec *executionContext) fieldContext_TrustCenter_isViewerMember(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TrustCenter",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TrustCenter_isViewerSubscribedToNewsletter(ctx context.Context, field graphql.CollectedField, obj *types.TrustCenter) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TrustCenter_isViewerSubscribedToNewsletter,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.TrustCenter().IsViewerSubscribedToNewsletter(ctx, obj)
+		},
+		nil,
+		ec.marshalNBoolean2bool,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_TrustCenter_isViewerSubscribedToNewsletter(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "TrustCenter",
 		Field:      field,
@@ -6507,6 +6806,94 @@ func (ec *executionContext) fieldContext_TrustCenterReferenceEdge_node(_ context
 				return ec.fieldContext_TrustCenterReference_logoUrl(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TrustCenterReference", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UnsubscribeFromNewsletterPayload_success(ctx context.Context, field graphql.CollectedField, obj *types.UnsubscribeFromNewsletterPayload) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_UnsubscribeFromNewsletterPayload_success,
+		func(ctx context.Context) (any, error) {
+			return obj.Success, nil
+		},
+		nil,
+		ec.marshalNBoolean2bool,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_UnsubscribeFromNewsletterPayload_success(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UnsubscribeFromNewsletterPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UnsubscribeFromNewsletterPayload_trustCenter(ctx context.Context, field graphql.CollectedField, obj *types.UnsubscribeFromNewsletterPayload) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_UnsubscribeFromNewsletterPayload_trustCenter,
+		func(ctx context.Context) (any, error) {
+			return obj.TrustCenter, nil
+		},
+		nil,
+		ec.marshalNTrustCenter2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐTrustCenter,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_UnsubscribeFromNewsletterPayload_trustCenter(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UnsubscribeFromNewsletterPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TrustCenter_id(ctx, field)
+			case "active":
+				return ec.fieldContext_TrustCenter_active(ctx, field)
+			case "slug":
+				return ec.fieldContext_TrustCenter_slug(ctx, field)
+			case "logoFileUrl":
+				return ec.fieldContext_TrustCenter_logoFileUrl(ctx, field)
+			case "darkLogoFileUrl":
+				return ec.fieldContext_TrustCenter_darkLogoFileUrl(ctx, field)
+			case "nonDisclosureAgreement":
+				return ec.fieldContext_TrustCenter_nonDisclosureAgreement(ctx, field)
+			case "isViewerMember":
+				return ec.fieldContext_TrustCenter_isViewerMember(ctx, field)
+			case "isViewerSubscribedToNewsletter":
+				return ec.fieldContext_TrustCenter_isViewerSubscribedToNewsletter(ctx, field)
+			case "organization":
+				return ec.fieldContext_TrustCenter_organization(ctx, field)
+			case "documents":
+				return ec.fieldContext_TrustCenter_documents(ctx, field)
+			case "audits":
+				return ec.fieldContext_TrustCenter_audits(ctx, field)
+			case "vendors":
+				return ec.fieldContext_TrustCenter_vendors(ctx, field)
+			case "references":
+				return ec.fieldContext_TrustCenter_references(ctx, field)
+			case "trustCenterFiles":
+				return ec.fieldContext_TrustCenter_trustCenterFiles(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TrustCenter", field.Name)
 		},
 	}
 	return fc, nil
@@ -9645,6 +10032,20 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_recordSigningEvent(ctx, field)
 			})
+		case "subscribeToNewsletter":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_subscribeToNewsletter(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "unsubscribeFromNewsletter":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_unsubscribeFromNewsletter(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -10252,6 +10653,50 @@ func (ec *executionContext) _SendMagicLinkPayload(ctx context.Context, sel ast.S
 	return out
 }
 
+var subscribeToNewsletterPayloadImplementors = []string{"SubscribeToNewsletterPayload"}
+
+func (ec *executionContext) _SubscribeToNewsletterPayload(ctx context.Context, sel ast.SelectionSet, obj *types.SubscribeToNewsletterPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, subscribeToNewsletterPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("SubscribeToNewsletterPayload")
+		case "success":
+			out.Values[i] = ec._SubscribeToNewsletterPayload_success(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "trustCenter":
+			out.Values[i] = ec._SubscribeToNewsletterPayload_trustCenter(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var trustCenterImplementors = []string{"TrustCenter", "Node"}
 
 func (ec *executionContext) _TrustCenter(ctx context.Context, sel ast.SelectionSet, obj *types.TrustCenter) graphql.Marshaler {
@@ -10387,6 +10832,42 @@ func (ec *executionContext) _TrustCenter(ctx context.Context, sel ast.SelectionS
 					}
 				}()
 				res = ec._TrustCenter_isViewerMember(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "isViewerSubscribedToNewsletter":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TrustCenter_isViewerSubscribedToNewsletter(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -11069,6 +11550,50 @@ func (ec *executionContext) _TrustCenterReferenceEdge(ctx context.Context, sel a
 			}
 		case "node":
 			out.Values[i] = ec._TrustCenterReferenceEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var unsubscribeFromNewsletterPayloadImplementors = []string{"UnsubscribeFromNewsletterPayload"}
+
+func (ec *executionContext) _UnsubscribeFromNewsletterPayload(ctx context.Context, sel ast.SelectionSet, obj *types.UnsubscribeFromNewsletterPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, unsubscribeFromNewsletterPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("UnsubscribeFromNewsletterPayload")
+		case "success":
+			out.Values[i] = ec._UnsubscribeFromNewsletterPayload_success(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "trustCenter":
+			out.Values[i] = ec._UnsubscribeFromNewsletterPayload_trustCenter(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -12843,6 +13368,30 @@ func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.S
 	return res
 }
 
+func (ec *executionContext) marshalNSubscribeToNewsletterPayload2goᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐSubscribeToNewsletterPayload(ctx context.Context, sel ast.SelectionSet, v types.SubscribeToNewsletterPayload) graphql.Marshaler {
+	return ec._SubscribeToNewsletterPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNSubscribeToNewsletterPayload2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐSubscribeToNewsletterPayload(ctx context.Context, sel ast.SelectionSet, v *types.SubscribeToNewsletterPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._SubscribeToNewsletterPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNTrustCenter2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐTrustCenter(ctx context.Context, sel ast.SelectionSet, v *types.TrustCenter) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TrustCenter(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalNTrustCenterAccess2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐTrustCenterAccess(ctx context.Context, sel ast.SelectionSet, v *types.TrustCenterAccess) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -13007,6 +13556,20 @@ func (ec *executionContext) marshalNTrustCenterReferenceEdge2ᚖgoᚗproboᚗinc
 		return graphql.Null
 	}
 	return ec._TrustCenterReferenceEdge(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNUnsubscribeFromNewsletterPayload2goᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐUnsubscribeFromNewsletterPayload(ctx context.Context, sel ast.SelectionSet, v types.UnsubscribeFromNewsletterPayload) graphql.Marshaler {
+	return ec._UnsubscribeFromNewsletterPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNUnsubscribeFromNewsletterPayload2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐUnsubscribeFromNewsletterPayload(ctx context.Context, sel ast.SelectionSet, v *types.UnsubscribeFromNewsletterPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._UnsubscribeFromNewsletterPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNVendor2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐVendor(ctx context.Context, sel ast.SelectionSet, v *types.Vendor) graphql.Marshaler {

--- a/pkg/server/api/trust/v1/types/types.go
+++ b/pkg/server/api/trust/v1/types/types.go
@@ -201,20 +201,26 @@ type SendMagicLinkPayload struct {
 	Success bool `json:"success"`
 }
 
+type SubscribeToNewsletterPayload struct {
+	Success     bool         `json:"success"`
+	TrustCenter *TrustCenter `json:"trustCenter"`
+}
+
 type TrustCenter struct {
-	ID                     gid.GID                         `json:"id"`
-	Active                 bool                            `json:"active"`
-	Slug                   string                          `json:"slug"`
-	LogoFileURL            *string                         `json:"logoFileUrl,omitempty"`
-	DarkLogoFileURL        *string                         `json:"darkLogoFileUrl,omitempty"`
-	NonDisclosureAgreement *NonDisclosureAgreement         `json:"nonDisclosureAgreement,omitempty"`
-	IsViewerMember         bool                            `json:"isViewerMember"`
-	Organization           *Organization                   `json:"organization"`
-	Documents              *DocumentConnection             `json:"documents"`
-	Audits                 *AuditConnection                `json:"audits"`
-	Vendors                *VendorConnection               `json:"vendors"`
-	References             *TrustCenterReferenceConnection `json:"references"`
-	TrustCenterFiles       *TrustCenterFileConnection      `json:"trustCenterFiles"`
+	ID                             gid.GID                         `json:"id"`
+	Active                         bool                            `json:"active"`
+	Slug                           string                          `json:"slug"`
+	LogoFileURL                    *string                         `json:"logoFileUrl,omitempty"`
+	DarkLogoFileURL                *string                         `json:"darkLogoFileUrl,omitempty"`
+	NonDisclosureAgreement         *NonDisclosureAgreement         `json:"nonDisclosureAgreement,omitempty"`
+	IsViewerMember                 bool                            `json:"isViewerMember"`
+	IsViewerSubscribedToNewsletter bool                            `json:"isViewerSubscribedToNewsletter"`
+	Organization                   *Organization                   `json:"organization"`
+	Documents                      *DocumentConnection             `json:"documents"`
+	Audits                         *AuditConnection                `json:"audits"`
+	Vendors                        *VendorConnection               `json:"vendors"`
+	References                     *TrustCenterReferenceConnection `json:"references"`
+	TrustCenterFiles               *TrustCenterFileConnection      `json:"trustCenterFiles"`
 }
 
 func (TrustCenter) IsNode()             {}
@@ -271,6 +277,11 @@ type TrustCenterReferenceConnection struct {
 type TrustCenterReferenceEdge struct {
 	Cursor page.CursorKey        `json:"cursor"`
 	Node   *TrustCenterReference `json:"node"`
+}
+
+type UnsubscribeFromNewsletterPayload struct {
+	Success     bool         `json:"success"`
+	TrustCenter *TrustCenter `json:"trustCenter"`
 }
 
 type Vendor struct {

--- a/pkg/server/api/trust/v1/v1_resolver.go
+++ b/pkg/server/api/trust/v1/v1_resolver.go
@@ -628,6 +628,48 @@ func (r *mutationResolver) RecordSigningEvent(ctx context.Context, input types.R
 	return &types.RecordSigningEventPayload{Success: true}, nil
 }
 
+// SubscribeToNewsletter is the resolver for the subscribeToNewsletter field.
+func (r *mutationResolver) SubscribeToNewsletter(ctx context.Context) (*types.SubscribeToNewsletterPayload, error) {
+	trustCenter := compliancepage.CompliancePageFromContext(ctx)
+	trustService := r.TrustService(ctx, trustCenter.ID.TenantID())
+
+	identity := authn.IdentityFromContext(ctx)
+	if identity == nil {
+		return nil, gqlutils.Unauthenticated(ctx, errors.New("unauthenticated"))
+	}
+
+	if _, err := trustService.ComplianceNewsletterSubscribers.Subscribe(ctx, trustCenter.ID, identity.EmailAddress); err != nil {
+		r.logger.ErrorCtx(ctx, "cannot subscribe to newsletter", log.Error(err))
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	return &types.SubscribeToNewsletterPayload{
+		Success:     true,
+		TrustCenter: types.NewTrustCenter(trustCenter),
+	}, nil
+}
+
+// UnsubscribeFromNewsletter is the resolver for the unsubscribeFromNewsletter field.
+func (r *mutationResolver) UnsubscribeFromNewsletter(ctx context.Context) (*types.UnsubscribeFromNewsletterPayload, error) {
+	trustCenter := compliancepage.CompliancePageFromContext(ctx)
+	trustService := r.TrustService(ctx, trustCenter.ID.TenantID())
+
+	identity := authn.IdentityFromContext(ctx)
+	if identity == nil {
+		return nil, gqlutils.Unauthenticated(ctx, errors.New("unauthenticated"))
+	}
+
+	if err := trustService.ComplianceNewsletterSubscribers.Unsubscribe(ctx, trustCenter.ID, identity.EmailAddress); err != nil {
+		r.logger.ErrorCtx(ctx, "cannot unsubscribe from newsletter", log.Error(err))
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	return &types.UnsubscribeFromNewsletterPayload{
+		Success:     true,
+		TrustCenter: types.NewTrustCenter(trustCenter),
+	}, nil
+}
+
 // FileURL is the resolver for the fileUrl field.
 func (r *nonDisclosureAgreementResolver) FileURL(ctx context.Context, obj *types.NonDisclosureAgreement) (string, error) {
 	trustCenter := compliancepage.CompliancePageFromContext(ctx)
@@ -914,6 +956,24 @@ func (r *trustCenterResolver) IsViewerMember(ctx context.Context, obj *types.Tru
 	membership := compliancepage.ComplianceMembershipFromContext(ctx)
 
 	return membership != nil, nil
+}
+
+// IsViewerSubscribedToNewsletter is the resolver for the isViewerSubscribedToNewsletter field.
+func (r *trustCenterResolver) IsViewerSubscribedToNewsletter(ctx context.Context, obj *types.TrustCenter) (bool, error) {
+	identity := authn.IdentityFromContext(ctx)
+	if identity == nil {
+		return false, nil
+	}
+
+	trustService := r.TrustService(ctx, obj.ID.TenantID())
+
+	isSubscribed, err := trustService.ComplianceNewsletterSubscribers.IsSubscribed(ctx, obj.ID, identity.EmailAddress)
+	if err != nil {
+		r.logger.ErrorCtx(ctx, "cannot check newsletter subscription", log.Error(err))
+		return false, gqlutils.Internal(ctx)
+	}
+
+	return isSubscribed, nil
 }
 
 // Organization is the resolver for the organization field.

--- a/pkg/trust/compliance_newsletter_subscriber_service.go
+++ b/pkg/trust/compliance_newsletter_subscriber_service.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package trust
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/mail"
+)
+
+type ComplianceNewsletterSubscriberService struct {
+	svc *TenantService
+}
+
+func (s *ComplianceNewsletterSubscriberService) IsSubscribed(
+	ctx context.Context,
+	trustCenterID gid.GID,
+	email mail.Addr,
+) (bool, error) {
+	var subscriber coredata.ComplianceNewsletterSubscriber
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			return subscriber.LoadByTrustCenterIDAndEmail(ctx, conn, s.svc.scope, trustCenterID, email)
+		},
+	)
+	if err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("cannot check newsletter subscription: %w", err)
+	}
+
+	return true, nil
+}
+
+func (s *ComplianceNewsletterSubscriberService) Subscribe(
+	ctx context.Context,
+	trustCenterID gid.GID,
+	email mail.Addr,
+) (*coredata.ComplianceNewsletterSubscriber, error) {
+	now := time.Now()
+
+	trustCenter := &coredata.TrustCenter{}
+	var subscriber coredata.ComplianceNewsletterSubscriber
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			if err := trustCenter.LoadByID(ctx, conn, s.svc.scope, trustCenterID); err != nil {
+				return fmt.Errorf("cannot load trust center: %w", err)
+			}
+
+			existing := &coredata.ComplianceNewsletterSubscriber{}
+			err := existing.LoadByTrustCenterIDAndEmail(ctx, conn, s.svc.scope, trustCenterID, email)
+			if err == nil {
+				subscriber = *existing
+				return nil
+			}
+
+			if !errors.Is(err, coredata.ErrResourceNotFound) {
+				return fmt.Errorf("cannot check existing subscription: %w", err)
+			}
+
+			subscriber = coredata.ComplianceNewsletterSubscriber{
+				ID:             gid.New(trustCenter.TenantID, coredata.ComplianceNewsletterSubscriberEntityType),
+				TenantID:       trustCenter.TenantID,
+				OrganizationID: trustCenter.OrganizationID,
+				TrustCenterID:  trustCenterID,
+				Email:          email,
+				CreatedAt:      now,
+				UpdatedAt:      now,
+			}
+
+			return subscriber.Insert(ctx, conn, s.svc.scope)
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot subscribe to newsletter: %w", err)
+	}
+
+	return &subscriber, nil
+}
+
+func (s *ComplianceNewsletterSubscriberService) Unsubscribe(
+	ctx context.Context,
+	trustCenterID gid.GID,
+	email mail.Addr,
+) error {
+	return s.svc.pg.WithConn(
+		ctx,
+		func(conn pg.Conn) error {
+			subscriber := &coredata.ComplianceNewsletterSubscriber{}
+
+			if err := subscriber.LoadByTrustCenterIDAndEmail(ctx, conn, s.svc.scope, trustCenterID, email); err != nil {
+				if errors.Is(err, coredata.ErrResourceNotFound) {
+					return nil
+				}
+
+				return fmt.Errorf("cannot load subscription: %w", err)
+			}
+
+			return subscriber.Delete(ctx, conn, s.svc.scope)
+		},
+	)
+}

--- a/pkg/trust/service.go
+++ b/pkg/trust/service.go
@@ -53,29 +53,30 @@ type (
 	}
 
 	TenantService struct {
-		pg                    *pg.Client
-		s3                    *s3.Client
-		bucket                string
-		scope                 coredata.Scoper
-		proboSvc              *probo.Service
-		encryptionKey         cipher.EncryptionKey
-		baseURL               string
-		iam                   *iam.Service
-		esign                 *esign.Service
-		html2pdfConverter     *html2pdf.Converter
-		fileManager           *filemanager.Service
-		logger                *log.Logger
-		TrustCenters          *TrustCenterService
-		Documents             *DocumentService
-		Audits                *AuditService
-		Vendors               *VendorService
-		Frameworks            *FrameworkService
-		TrustCenterAccesses   *TrustCenterAccessService
-		TrustCenterReferences *TrustCenterReferenceService
-		TrustCenterFiles      *TrustCenterFileService
-		Reports               *ReportService
-		Organizations         *OrganizationService
-		SlackMessages         *slack.SlackMessageService
+		pg                              *pg.Client
+		s3                              *s3.Client
+		bucket                          string
+		scope                           coredata.Scoper
+		proboSvc                        *probo.Service
+		encryptionKey                   cipher.EncryptionKey
+		baseURL                         string
+		iam                             *iam.Service
+		esign                           *esign.Service
+		html2pdfConverter               *html2pdf.Converter
+		fileManager                     *filemanager.Service
+		logger                          *log.Logger
+		TrustCenters                    *TrustCenterService
+		Documents                       *DocumentService
+		Audits                          *AuditService
+		Vendors                         *VendorService
+		Frameworks                      *FrameworkService
+		TrustCenterAccesses             *TrustCenterAccessService
+		TrustCenterReferences           *TrustCenterReferenceService
+		TrustCenterFiles                *TrustCenterFileService
+		ComplianceNewsletterSubscribers *ComplianceNewsletterSubscriberService
+		Reports                         *ReportService
+		Organizations                   *OrganizationService
+		SlackMessages                   *slack.SlackMessageService
 	}
 )
 
@@ -133,6 +134,7 @@ func (s *Service) WithTenant(tenantID gid.TenantID) *TenantService {
 	tenantService.TrustCenterAccesses = &TrustCenterAccessService{svc: tenantService, iamSvc: s.iam, logger: s.logger}
 	tenantService.TrustCenterReferences = &TrustCenterReferenceService{svc: tenantService}
 	tenantService.TrustCenterFiles = &TrustCenterFileService{svc: tenantService}
+	tenantService.ComplianceNewsletterSubscribers = &ComplianceNewsletterSubscriberService{svc: tenantService}
 	tenantService.Reports = &ReportService{svc: tenantService}
 	tenantService.Organizations = &OrganizationService{svc: tenantService}
 	tenantService.SlackMessages = s.slack.WithTenant(tenantID).SlackMessages


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds newsletter subscriptions to the Compliance Page and Trust Center. Admins can list/delete subscribers; visitors can subscribe or unsubscribe from the Trust sidebar.

- **New Features**
  - Console: Newsletter tab with a paginated subscriber list, delete, and totalCount.
  - Trust: Sidebar bell toggle to subscribe/unsubscribe; state via isViewerSubscribedToNewsletter.
  - GraphQL: Console ComplianceNewsletterSubscriber type and connection, deleteNewsletterSubscriber. Trust subscribeToNewsletter/unsubscribeFromNewsletter and isViewerSubscribedToNewsletter.
  - Permissions: New actions to list and delete newsletter subscribers.

- **Migration**
  - Run DB migration to create compliance_newsletter_subscribers (unique per trust_center_id, email).

<sup>Written for commit 1027039bcccf96119d2dfdf4340760cd29ce85ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

