### PR TITLE
Add framework type to audit

### DIFF
--- a/apps/console/src/__generated__/core/AuditGraphCreateMutation.graphql.ts
+++ b/apps/console/src/__generated__/core/AuditGraphCreateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5da72785f4532d069a59c8bb5f12101d>>
+ * @generated SignedSource<<193e4008307c14b2a8a1d20e89f369dc>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,6 +13,7 @@ export type AuditState = "COMPLETED" | "IN_PROGRESS" | "NOT_STARTED" | "OUTDATED
 export type TrustCenterVisibility = "NONE" | "PRIVATE" | "PUBLIC";
 export type CreateAuditInput = {
   frameworkId: string;
+  frameworkType?: string | null | undefined;
   name?: string | null | undefined;
   organizationId: string;
   state?: AuditState | null | undefined;
@@ -35,6 +36,7 @@ export type AuditGraphCreateMutation$data = {
           readonly id: string;
           readonly name: string;
         };
+        readonly frameworkType: string | null | undefined;
         readonly id: string;
         readonly name: string | null | undefined;
         readonly report: {
@@ -103,6 +105,13 @@ v5 = {
       "selections": [
         (v3/*: any*/),
         (v4/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "frameworkType",
+          "storageKey": null
+        },
         {
           "alias": null,
           "args": null,
@@ -261,16 +270,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d5155df01b8fe2fb74b49b953d49aed7",
+    "cacheID": "5ed58efa45cf4db162320fba55568bc3",
     "id": null,
     "metadata": {},
     "name": "AuditGraphCreateMutation",
     "operationKind": "mutation",
-    "text": "mutation AuditGraphCreateMutation(\n  $input: CreateAuditInput!\n) {\n  createAudit(input: $input) {\n    auditEdge {\n      node {\n        id\n        name\n        validFrom\n        validUntil\n        report {\n          id\n          filename\n        }\n        state\n        framework {\n          id\n          name\n        }\n        createdAt\n        canUpdate: permission(action: \"core:audit:update\")\n        canDelete: permission(action: \"core:audit:delete\")\n      }\n    }\n  }\n}\n"
+    "text": "mutation AuditGraphCreateMutation(\n  $input: CreateAuditInput!\n) {\n  createAudit(input: $input) {\n    auditEdge {\n      node {\n        id\n        name\n        frameworkType\n        validFrom\n        validUntil\n        report {\n          id\n          filename\n        }\n        state\n        framework {\n          id\n          name\n        }\n        createdAt\n        canUpdate: permission(action: \"core:audit:update\")\n        canDelete: permission(action: \"core:audit:delete\")\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "dcca4ebf33522ad6ef45456612fad03f";
+(node as any).hash = "72361353e45565388bfdd22bac03ebb2";
 
 export default node;

--- a/apps/console/src/__generated__/core/AuditGraphListQuery.graphql.ts
+++ b/apps/console/src/__generated__/core/AuditGraphListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a866ac360421f2cca952ab1305c3de0b>>
+ * @generated SignedSource<<1880a0f57fad8f7fc1628a5a9657cfe6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -204,6 +204,13 @@ return {
                           {
                             "alias": null,
                             "args": null,
+                            "kind": "ScalarField",
+                            "name": "frameworkType",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
                             "concreteType": "Framework",
                             "kind": "LinkedField",
                             "name": "framework",
@@ -336,12 +343,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "441524ada7aa614fb611f3d64812314f",
+    "cacheID": "4ac0a27ee7916940d4d3efeca9936ebc",
     "id": null,
     "metadata": {},
     "name": "AuditGraphListQuery",
     "operationKind": "query",
-    "text": "query AuditGraphListQuery(\n  $organizationId: ID!\n) {\n  node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      canCreateAudit: permission(action: \"core:audit:create\")\n      ...AuditsPageFragment\n    }\n    id\n  }\n}\n\nfragment AuditsPageFragment on Organization {\n  audits(first: 10) {\n    edges {\n      node {\n        id\n        name\n        validFrom\n        validUntil\n        report {\n          id\n          filename\n        }\n        state\n        framework {\n          id\n          name\n        }\n        createdAt\n        canUpdate: permission(action: \"core:audit:update\")\n        canDelete: permission(action: \"core:audit:delete\")\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n"
+    "text": "query AuditGraphListQuery(\n  $organizationId: ID!\n) {\n  node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      canCreateAudit: permission(action: \"core:audit:create\")\n      ...AuditsPageFragment\n    }\n    id\n  }\n}\n\nfragment AuditsPageFragment on Organization {\n  audits(first: 10) {\n    edges {\n      node {\n        id\n        name\n        validFrom\n        validUntil\n        report {\n          id\n          filename\n        }\n        state\n        frameworkType\n        framework {\n          id\n          name\n        }\n        createdAt\n        canUpdate: permission(action: \"core:audit:update\")\n        canDelete: permission(action: \"core:audit:delete\")\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n"
   }
 };
 })();

--- a/apps/console/src/__generated__/core/AuditGraphNodeQuery.graphql.ts
+++ b/apps/console/src/__generated__/core/AuditGraphNodeQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8ce0dfdad4c98f5fa9fbbd2162a28778>>
+ * @generated SignedSource<<763afe06ed5166f208646c8ccc70c1ac>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -24,6 +24,7 @@ export type AuditGraphNodeQuery$data = {
       readonly lightLogoURL: string | null | undefined;
       readonly name: string;
     };
+    readonly frameworkType?: string | null | undefined;
     readonly id?: string;
     readonly name?: string | null | undefined;
     readonly organization?: {
@@ -83,24 +84,31 @@ v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "validFrom",
+  "name": "frameworkType",
   "storageKey": null
 },
 v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "validUntil",
+  "name": "validFrom",
   "storageKey": null
 },
 v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "createdAt",
+  "name": "validUntil",
   "storageKey": null
 },
 v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+},
+v8 = {
   "alias": null,
   "args": null,
   "concreteType": "Report",
@@ -137,25 +145,25 @@ v7 = {
       "name": "downloadUrl",
       "storageKey": null
     },
-    (v6/*: any*/)
+    (v7/*: any*/)
   ],
-  "storageKey": null
-},
-v8 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "reportUrl",
   "storageKey": null
 },
 v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "state",
+  "name": "reportUrl",
   "storageKey": null
 },
 v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "state",
+  "storageKey": null
+},
+v11 = {
   "alias": null,
   "args": null,
   "concreteType": "Framework",
@@ -182,7 +190,7 @@ v10 = {
   ],
   "storageKey": null
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "concreteType": "Organization",
@@ -195,14 +203,14 @@ v11 = {
   ],
   "storageKey": null
 },
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "updatedAt",
   "storageKey": null
 },
-v13 = {
+v14 = {
   "alias": "canUpdate",
   "args": [
     {
@@ -215,7 +223,7 @@ v13 = {
   "name": "permission",
   "storageKey": "permission(action:\"core:audit:update\")"
 },
-v14 = {
+v15 = {
   "alias": "canDelete",
   "args": [
     {
@@ -250,15 +258,16 @@ return {
               (v3/*: any*/),
               (v4/*: any*/),
               (v5/*: any*/),
-              (v7/*: any*/),
+              (v6/*: any*/),
               (v8/*: any*/),
               (v9/*: any*/),
               (v10/*: any*/),
               (v11/*: any*/),
-              (v6/*: any*/),
               (v12/*: any*/),
+              (v7/*: any*/),
               (v13/*: any*/),
-              (v14/*: any*/)
+              (v14/*: any*/),
+              (v15/*: any*/)
             ],
             "type": "Audit",
             "abstractKey": null
@@ -298,15 +307,16 @@ return {
               (v3/*: any*/),
               (v4/*: any*/),
               (v5/*: any*/),
-              (v7/*: any*/),
+              (v6/*: any*/),
               (v8/*: any*/),
               (v9/*: any*/),
               (v10/*: any*/),
               (v11/*: any*/),
-              (v6/*: any*/),
               (v12/*: any*/),
+              (v7/*: any*/),
               (v13/*: any*/),
-              (v14/*: any*/)
+              (v14/*: any*/),
+              (v15/*: any*/)
             ],
             "type": "Audit",
             "abstractKey": null
@@ -317,16 +327,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c9d41c45b625f17ccf291ae2c027a027",
+    "cacheID": "7db49ce707dc3447233e2d0d33363626",
     "id": null,
     "metadata": {},
     "name": "AuditGraphNodeQuery",
     "operationKind": "query",
-    "text": "query AuditGraphNodeQuery(\n  $auditId: ID!\n) {\n  node(id: $auditId) {\n    __typename\n    ... on Audit {\n      id\n      name\n      validFrom\n      validUntil\n      report {\n        id\n        filename\n        mimeType\n        size\n        downloadUrl\n        createdAt\n      }\n      reportUrl\n      state\n      framework {\n        id\n        name\n        lightLogoURL\n        darkLogoURL\n      }\n      organization {\n        id\n        name\n      }\n      createdAt\n      updatedAt\n      canUpdate: permission(action: \"core:audit:update\")\n      canDelete: permission(action: \"core:audit:delete\")\n    }\n    id\n  }\n}\n"
+    "text": "query AuditGraphNodeQuery(\n  $auditId: ID!\n) {\n  node(id: $auditId) {\n    __typename\n    ... on Audit {\n      id\n      name\n      frameworkType\n      validFrom\n      validUntil\n      report {\n        id\n        filename\n        mimeType\n        size\n        downloadUrl\n        createdAt\n      }\n      reportUrl\n      state\n      framework {\n        id\n        name\n        lightLogoURL\n        darkLogoURL\n      }\n      organization {\n        id\n        name\n      }\n      createdAt\n      updatedAt\n      canUpdate: permission(action: \"core:audit:update\")\n      canDelete: permission(action: \"core:audit:delete\")\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "3195b5564b2cf8a21536ebf89f0f5c82";
+(node as any).hash = "9a82086c685f3f7d7014a9442c1cf8e6";
 
 export default node;

--- a/apps/console/src/__generated__/core/AuditGraphUpdateMutation.graphql.ts
+++ b/apps/console/src/__generated__/core/AuditGraphUpdateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1b9fd2fad98545d0e1ca4440a6a8936a>>
+ * @generated SignedSource<<78e0001b78b4c12614cf1bb03b2d7e80>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,7 @@ import { ConcreteRequest } from 'relay-runtime';
 export type AuditState = "COMPLETED" | "IN_PROGRESS" | "NOT_STARTED" | "OUTDATED" | "REJECTED";
 export type TrustCenterVisibility = "NONE" | "PRIVATE" | "PUBLIC";
 export type UpdateAuditInput = {
+  frameworkType?: string | null | undefined;
   id: string;
   name?: string | null | undefined;
   state?: AuditState | null | undefined;
@@ -29,6 +30,7 @@ export type AuditGraphUpdateMutation$data = {
         readonly id: string;
         readonly name: string;
       };
+      readonly frameworkType: string | null | undefined;
       readonly id: string;
       readonly name: string | null | undefined;
       readonly report: {
@@ -94,6 +96,13 @@ v3 = [
         "selections": [
           (v1/*: any*/),
           (v2/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "frameworkType",
+            "storageKey": null
+          },
           {
             "alias": null,
             "args": null,
@@ -179,16 +188,16 @@ return {
     "selections": (v3/*: any*/)
   },
   "params": {
-    "cacheID": "7257cd170b7441f3ce85966556e00ac3",
+    "cacheID": "90d3d14a9c4eca844eeb32b2711cc4d2",
     "id": null,
     "metadata": {},
     "name": "AuditGraphUpdateMutation",
     "operationKind": "mutation",
-    "text": "mutation AuditGraphUpdateMutation(\n  $input: UpdateAuditInput!\n) {\n  updateAudit(input: $input) {\n    audit {\n      id\n      name\n      validFrom\n      validUntil\n      report {\n        id\n        filename\n      }\n      state\n      framework {\n        id\n        name\n      }\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation AuditGraphUpdateMutation(\n  $input: UpdateAuditInput!\n) {\n  updateAudit(input: $input) {\n    audit {\n      id\n      name\n      frameworkType\n      validFrom\n      validUntil\n      report {\n        id\n        filename\n      }\n      state\n      framework {\n        id\n        name\n      }\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "7fb5d28c8c5fdffddb1c8926e66965ec";
+(node as any).hash = "3389bd0155f2ef74996dca505277e3ea";
 
 export default node;

--- a/apps/console/src/__generated__/core/AuditsListQuery.graphql.ts
+++ b/apps/console/src/__generated__/core/AuditsListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4cd493e5c45c274b8d7aabdac8c62f95>>
+ * @generated SignedSource<<a1ccde2e9d81f01e2cac208a82a993ee>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -249,6 +249,13 @@ return {
                           {
                             "alias": null,
                             "args": null,
+                            "kind": "ScalarField",
+                            "name": "frameworkType",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
                             "concreteType": "Framework",
                             "kind": "LinkedField",
                             "name": "framework",
@@ -381,16 +388,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "7804de168f5c2484d6beb2f4d19287b0",
+    "cacheID": "3eea5e685f4d6c517053c9ce0d5b7c8c",
     "id": null,
     "metadata": {},
     "name": "AuditsListQuery",
     "operationKind": "query",
-    "text": "query AuditsListQuery(\n  $after: CursorKey = null\n  $before: CursorKey = null\n  $first: Int = 10\n  $last: Int = null\n  $orderBy: AuditOrder = null\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...AuditsPageFragment_sdb03\n    id\n  }\n}\n\nfragment AuditsPageFragment_sdb03 on Organization {\n  audits(first: $first, after: $after, last: $last, before: $before, orderBy: $orderBy) {\n    edges {\n      node {\n        id\n        name\n        validFrom\n        validUntil\n        report {\n          id\n          filename\n        }\n        state\n        framework {\n          id\n          name\n        }\n        createdAt\n        canUpdate: permission(action: \"core:audit:update\")\n        canDelete: permission(action: \"core:audit:delete\")\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n"
+    "text": "query AuditsListQuery(\n  $after: CursorKey = null\n  $before: CursorKey = null\n  $first: Int = 10\n  $last: Int = null\n  $orderBy: AuditOrder = null\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...AuditsPageFragment_sdb03\n    id\n  }\n}\n\nfragment AuditsPageFragment_sdb03 on Organization {\n  audits(first: $first, after: $after, last: $last, before: $before, orderBy: $orderBy) {\n    edges {\n      node {\n        id\n        name\n        validFrom\n        validUntil\n        report {\n          id\n          filename\n        }\n        state\n        frameworkType\n        framework {\n          id\n          name\n        }\n        createdAt\n        canUpdate: permission(action: \"core:audit:update\")\n        canDelete: permission(action: \"core:audit:delete\")\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "4013ec4e657ef7fb9d13afbd572ea9e5";
+(node as any).hash = "cc001b29e19c6d20a50095490da54c1a";
 
 export default node;

--- a/apps/console/src/__generated__/core/AuditsPageFragment.graphql.ts
+++ b/apps/console/src/__generated__/core/AuditsPageFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<eb5012ba560d977fd2d9c44a5e567c7c>>
+ * @generated SignedSource<<154ebe7d39ff639b7e275e8d2a0064dd>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -23,6 +23,7 @@ export type AuditsPageFragment$data = {
           readonly id: string;
           readonly name: string;
         };
+        readonly frameworkType: string | null | undefined;
         readonly id: string;
         readonly name: string | null | undefined;
         readonly report: {
@@ -200,6 +201,13 @@ return {
                 {
                   "alias": null,
                   "args": null,
+                  "kind": "ScalarField",
+                  "name": "frameworkType",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
                   "concreteType": "Framework",
                   "kind": "LinkedField",
                   "name": "framework",
@@ -324,6 +332,6 @@ return {
 };
 })();
 
-(node as any).hash = "4013ec4e657ef7fb9d13afbd572ea9e5";
+(node as any).hash = "cc001b29e19c6d20a50095490da54c1a";
 
 export default node;

--- a/apps/console/src/__generated__/core/CompliancePageAuditListItem_auditFragment.graphql.ts
+++ b/apps/console/src/__generated__/core/CompliancePageAuditListItem_auditFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7de15e098b76ab6e91a10160c60c6c69>>
+ * @generated SignedSource<<6201aa75d6361fd302caba39179ebe6e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,6 +16,7 @@ export type CompliancePageAuditListItem_auditFragment$data = {
   readonly framework: {
     readonly name: string;
   };
+  readonly frameworkType: string | null | undefined;
   readonly id: string;
   readonly name: string | null | undefined;
   readonly state: AuditState;
@@ -50,6 +51,13 @@ return {
       "storageKey": null
     },
     (v0/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "frameworkType",
+      "storageKey": null
+    },
     {
       "alias": null,
       "args": null,
@@ -89,6 +97,6 @@ return {
 };
 })();
 
-(node as any).hash = "495e75c50400e856ba08ed9f5840da67";
+(node as any).hash = "8c20a1fd2221e4813c60d4f8c81dc016";
 
 export default node;

--- a/apps/console/src/__generated__/core/CompliancePageAuditListItem_updateAuditVisibilityMutation.graphql.ts
+++ b/apps/console/src/__generated__/core/CompliancePageAuditListItem_updateAuditVisibilityMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4286fb5d45f1d4d8dba035c29219ab34>>
+ * @generated SignedSource<<6b973ad40bd4ce5cc9e31e4e6fdb20c0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,6 +13,7 @@ import { FragmentRefs } from "relay-runtime";
 export type AuditState = "COMPLETED" | "IN_PROGRESS" | "NOT_STARTED" | "OUTDATED" | "REJECTED";
 export type TrustCenterVisibility = "NONE" | "PRIVATE" | "PUBLIC";
 export type UpdateAuditInput = {
+  frameworkType?: string | null | undefined;
   id: string;
   name?: string | null | undefined;
   state?: AuditState | null | undefined;
@@ -129,6 +130,13 @@ return {
               {
                 "alias": null,
                 "args": null,
+                "kind": "ScalarField",
+                "name": "frameworkType",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
                 "concreteType": "Framework",
                 "kind": "LinkedField",
                 "name": "framework",
@@ -169,12 +177,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4363d4bbf56cf55359dc0a1ff19e1dbf",
+    "cacheID": "a8e7107515ca00dd33cb60783b25853f",
     "id": null,
     "metadata": {},
     "name": "CompliancePageAuditListItem_updateAuditVisibilityMutation",
     "operationKind": "mutation",
-    "text": "mutation CompliancePageAuditListItem_updateAuditVisibilityMutation(\n  $input: UpdateAuditInput!\n) {\n  updateAudit(input: $input) {\n    audit {\n      ...CompliancePageAuditListItem_auditFragment\n      id\n    }\n  }\n}\n\nfragment CompliancePageAuditListItem_auditFragment on Audit {\n  id\n  name\n  framework {\n    name\n    id\n  }\n  validUntil\n  state\n  trustCenterVisibility\n}\n"
+    "text": "mutation CompliancePageAuditListItem_updateAuditVisibilityMutation(\n  $input: UpdateAuditInput!\n) {\n  updateAudit(input: $input) {\n    audit {\n      ...CompliancePageAuditListItem_auditFragment\n      id\n    }\n  }\n}\n\nfragment CompliancePageAuditListItem_auditFragment on Audit {\n  id\n  name\n  frameworkType\n  framework {\n    name\n    id\n  }\n  validUntil\n  state\n  trustCenterVisibility\n}\n"
   }
 };
 })();

--- a/apps/console/src/__generated__/core/CompliancePageAuditsPageQuery.graphql.ts
+++ b/apps/console/src/__generated__/core/CompliancePageAuditsPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<109bdc23095ddd764ac63f68d9185ab1>>
+ * @generated SignedSource<<47428164724cb0c4855b0f74be3ff615>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -163,6 +163,13 @@ return {
                           {
                             "alias": null,
                             "args": null,
+                            "kind": "ScalarField",
+                            "name": "frameworkType",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
                             "concreteType": "Framework",
                             "kind": "LinkedField",
                             "name": "framework",
@@ -214,12 +221,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ebb26dedba5dbbae4d46bcd3a41b201d",
+    "cacheID": "4c6de76d85294acf385c6170508b9206",
     "id": null,
     "metadata": {},
     "name": "CompliancePageAuditsPageQuery",
     "operationKind": "query",
-    "text": "query CompliancePageAuditsPageQuery(\n  $organizationId: ID!\n) {\n  organization: node(id: $organizationId) {\n    __typename\n    ...CompliancePageAuditListFragment\n    id\n  }\n}\n\nfragment CompliancePageAuditListFragment on Organization {\n  compliancePage: trustCenter {\n    ...CompliancePageAuditListItem_compliancePageFragment\n    id\n  }\n  audits(first: 100) {\n    edges {\n      node {\n        id\n        ...CompliancePageAuditListItem_auditFragment\n      }\n    }\n  }\n}\n\nfragment CompliancePageAuditListItem_auditFragment on Audit {\n  id\n  name\n  framework {\n    name\n    id\n  }\n  validUntil\n  state\n  trustCenterVisibility\n}\n\nfragment CompliancePageAuditListItem_compliancePageFragment on TrustCenter {\n  canUpdate: permission(action: \"core:trust-center:update\")\n}\n"
+    "text": "query CompliancePageAuditsPageQuery(\n  $organizationId: ID!\n) {\n  organization: node(id: $organizationId) {\n    __typename\n    ...CompliancePageAuditListFragment\n    id\n  }\n}\n\nfragment CompliancePageAuditListFragment on Organization {\n  compliancePage: trustCenter {\n    ...CompliancePageAuditListItem_compliancePageFragment\n    id\n  }\n  audits(first: 100) {\n    edges {\n      node {\n        id\n        ...CompliancePageAuditListItem_auditFragment\n      }\n    }\n  }\n}\n\nfragment CompliancePageAuditListItem_auditFragment on Audit {\n  id\n  name\n  frameworkType\n  framework {\n    name\n    id\n  }\n  validUntil\n  state\n  trustCenterVisibility\n}\n\nfragment CompliancePageAuditListItem_compliancePageFragment on TrustCenter {\n  canUpdate: permission(action: \"core:trust-center:update\")\n}\n"
   }
 };
 })();

--- a/apps/console/src/hooks/graph/AuditGraph.ts
+++ b/apps/console/src/hooks/graph/AuditGraph.ts
@@ -23,6 +23,7 @@ export const auditNodeQuery = graphql`
       ... on Audit {
         id
         name
+        frameworkType
         validFrom
         validUntil
         report {
@@ -64,6 +65,7 @@ export const createAuditMutation = graphql`
         node {
           id
           name
+          frameworkType
           validFrom
           validUntil
           report {
@@ -90,6 +92,7 @@ export const updateAuditMutation = graphql`
       audit {
         id
         name
+        frameworkType
         validFrom
         validUntil
         report {
@@ -163,6 +166,7 @@ export const useCreateAudit = (connectionId: string) => {
     organizationId: string;
     frameworkId: string;
     name?: string | null;
+    frameworkType?: string | null;
     validFrom?: string;
     validUntil?: string;
     reportKey?: string;
@@ -181,6 +185,7 @@ export const useCreateAudit = (connectionId: string) => {
           organizationId: input.organizationId,
           frameworkId: input.frameworkId,
           name: input.name,
+          frameworkType: input.frameworkType,
           validFrom: input.validFrom,
           validUntil: input.validUntil,
           reportKey: input.reportKey,
@@ -199,6 +204,7 @@ export const useUpdateAudit = () => {
   return (input: {
     id: string;
     name?: string | null;
+    frameworkType?: string | null;
     validFrom?: string | null;
     validUntil?: string | null;
     state?: string;

--- a/apps/console/src/pages/organizations/audits/AuditDetailsPage.tsx
+++ b/apps/console/src/pages/organizations/audits/AuditDetailsPage.tsx
@@ -50,6 +50,7 @@ import {
 
 const updateAuditSchema = z.object({
   name: z.string().nullable().optional(),
+  frameworkType: z.string().nullable().optional(),
   validFrom: z.string().optional(),
   validUntil: z.string().optional(),
   state: z.enum([
@@ -85,6 +86,7 @@ export default function AuditDetailsPage(props: Props) {
     = useFormWithSchema(updateAuditSchema, {
       defaultValues: {
         name: auditEntry.name || null,
+        frameworkType: auditEntry.frameworkType || null,
         validFrom: auditEntry.validFrom?.split("T")[0] || "",
         validUntil: auditEntry.validUntil?.split("T")[0] || "",
         state: auditEntry.state || "NOT_STARTED",
@@ -104,6 +106,7 @@ export default function AuditDetailsPage(props: Props) {
       await updateAudit({
         id: auditEntry.id,
         name: formData.name || null,
+        frameworkType: formData.frameworkType || null,
         validFrom: formatDatetime(formData.validFrom) ?? null,
         validUntil: formatDatetime(formData.validUntil) ?? null,
         state: formData.state,
@@ -203,6 +206,13 @@ export default function AuditDetailsPage(props: Props) {
         <form onSubmit={e => void onSubmit(e)} className="space-y-6">
           <Field label={__("Name")}>
             <Input {...register("name")} placeholder={__("Audit name")} />
+          </Field>
+
+          <Field label={__("Framework Type")}>
+            <Input
+              {...register("frameworkType")}
+              placeholder={__("e.g. Type I, Type II")}
+            />
           </Field>
 
           <ControlledField

--- a/apps/console/src/pages/organizations/audits/AuditsPage.tsx
+++ b/apps/console/src/pages/organizations/audits/AuditsPage.tsx
@@ -68,6 +68,7 @@ const paginatedAuditsFragment = graphql`
             filename
           }
           state
+          frameworkType
           framework {
             id
             name
@@ -165,7 +166,9 @@ function AuditRow({
   return (
     <Tr to={`/organizations/${organizationId}/audits/${entry.id}`}>
       <Td>{entry.name || __("Untitled")}</Td>
-      <Td>{entry.framework?.name ?? __("Unknown Framework")}</Td>
+      <Td>
+        {[entry.framework?.name, entry.frameworkType].filter(Boolean).join(" ") || __("Unknown Framework")}
+      </Td>
       <Td>
         <Badge variant={getAuditStateVariant(entry.state)}>
           {getAuditStateLabel(__, entry.state)}

--- a/apps/console/src/pages/organizations/audits/dialogs/CreateAuditDialog.tsx
+++ b/apps/console/src/pages/organizations/audits/dialogs/CreateAuditDialog.tsx
@@ -50,6 +50,7 @@ const frameworksQuery = graphql`
 const schema = z.object({
   frameworkId: z.string().min(1, "Framework is required"),
   name: z.string().optional(),
+  frameworkType: z.string().optional(),
   validFrom: z.string().optional(),
   validUntil: z.string().optional(),
   state: z.enum([
@@ -79,6 +80,7 @@ export function CreateAuditDialog({
       defaultValues: {
         frameworkId: "",
         name: "",
+        frameworkType: "",
         validFrom: "",
         validUntil: "",
         state: "NOT_STARTED",
@@ -93,6 +95,7 @@ export function CreateAuditDialog({
         organizationId,
         frameworkId: data.frameworkId,
         name: data.name || null,
+        frameworkType: data.frameworkType || null,
         validFrom: formatDatetime(data.validFrom),
         validUntil: formatDatetime(data.validUntil),
         state: data.state,
@@ -140,6 +143,13 @@ export function CreateAuditDialog({
 
           <Field label={__("Name")}>
             <Input {...register("name")} placeholder={__("Audit name")} />
+          </Field>
+
+          <Field label={__("Framework Type")}>
+            <Input
+              {...register("frameworkType")}
+              placeholder={__("e.g. Type I, Type II")}
+            />
           </Field>
 
           <ControlledField

--- a/apps/console/src/pages/organizations/compliance-page/audits/_components/CompliancePageAuditListItem.tsx
+++ b/apps/console/src/pages/organizations/compliance-page/audits/_components/CompliancePageAuditListItem.tsx
@@ -21,6 +21,7 @@ const auditFragment = graphql`
   fragment CompliancePageAuditListItem_auditFragment on Audit {
     id
     name
+    frameworkType
     framework {
       name
     }
@@ -88,7 +89,9 @@ export function CompliancePageAuditListItem(props: {
   return (
     <Tr to={`/organizations/${organizationId}/audits/${audit.id}`}>
       <Td>
-        <div className="flex gap-4 items-center">{audit.framework.name}</div>
+        <div className="flex gap-4 items-center">
+          {[audit.framework.name, audit.frameworkType].filter(Boolean).join(" ")}
+        </div>
       </Td>
       <Td>{audit.name || __("Untitled")}</Td>
       <Td>{validUntilFormatted}</Td>

--- a/apps/trust/src/components/AuditRow.tsx
+++ b/apps/trust/src/components/AuditRow.tsx
@@ -45,6 +45,7 @@ const downloadMutation = graphql`
 
 const auditRowFragment = graphql`
   fragment AuditRowFragment on Audit {
+    frameworkType
     report {
       id
       filename
@@ -129,6 +130,9 @@ export function AuditRow(props: { audit: AuditRowFragment$key }) {
       <div className="flex items-center gap-2">
         <IconMedal size={16} className="flex-none text-txt-tertiary" />
         {audit.framework.name}
+        {audit.frameworkType && (
+          <em className="not-italic italic text-txt-secondary">{audit.frameworkType}</em>
+        )}
       </div>
       {audit.report && audit.report.isUserAuthorized
         ? (
@@ -185,8 +189,14 @@ export function AuditRowAvatar(props: { audit: AuditRowFragment$key }) {
               darkLogoURL={audit.framework.darkLogoURL}
               name={audit.framework.name}
             />
-            <div className="txt-primary text-sm max-w-19 overflow-hidden min-w-0 whitespace-nowrap text-ellipsis">
+            <div className="txt-primary text-sm max-w-19 overflow-hidden min-w-0 whitespace-nowrap text-ellipsis text-center">
               {audit.framework.name}
+              {audit.frameworkType && (
+                <>
+                  {" "}
+                  <em className="italic text-txt-secondary">{audit.frameworkType}</em>
+                </>
+              )}
             </div>
           </div>
         </button>
@@ -224,7 +234,15 @@ function AuditDialog(
           darkLogoURL={audit.framework.darkLogoURL}
           name={audit.framework.name}
         />
-        <h2 className="text-xl font-semibold mb-1">{audit.framework.name}</h2>
+        <h2 className="text-xl font-semibold mb-1">
+          {audit.framework.name}
+          {audit.frameworkType && (
+            <>
+              {" "}
+              <em className="italic font-normal text-txt-secondary">{audit.frameworkType}</em>
+            </>
+          )}
+        </h2>
         <Table>
           <AuditRow audit={props.audit} />
         </Table>

--- a/apps/trust/src/components/__generated__/AuditRowFragment.graphql.ts
+++ b/apps/trust/src/components/__generated__/AuditRowFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3265a0991323eee4011c668b68d1b365>>
+ * @generated SignedSource<<c63d7bc0fa167d1b49395e577dab8460>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -17,6 +17,7 @@ export type AuditRowFragment$data = {
     readonly lightLogoURL: string | null | undefined;
     readonly name: string;
   };
+  readonly frameworkType: string | null | undefined;
   readonly report: {
     readonly filename: string;
     readonly hasUserRequestedAccess: boolean;
@@ -44,6 +45,13 @@ return {
   "metadata": null,
   "name": "AuditRowFragment",
   "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "frameworkType",
+      "storageKey": null
+    },
     {
       "alias": null,
       "args": null,
@@ -116,6 +124,6 @@ return {
 };
 })();
 
-(node as any).hash = "417e65b500df4b4cff874dab2bea90ee";
+(node as any).hash = "8a1dfb613b9e7ef70dad429f05038730";
 
 export default node;

--- a/apps/trust/src/queries/__generated__/TrustGraphCurrentQuery.graphql.ts
+++ b/apps/trust/src/queries/__generated__/TrustGraphCurrentQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c89278f85dedf2e3c5d8dbd77cd19222>>
+ * @generated SignedSource<<ecffb2003dfe42df34f456d33b13b5b8>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -631,6 +631,13 @@ return {
                       {
                         "alias": null,
                         "args": null,
+                        "kind": "ScalarField",
+                        "name": "frameworkType",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
                         "concreteType": "Report",
                         "kind": "LinkedField",
                         "name": "report",
@@ -691,12 +698,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "011070e93164ecde082cc2e74651ef2e",
+    "cacheID": "a3bf445aac88e26751987a8d223d8e02",
     "id": null,
     "metadata": {},
     "name": "TrustGraphCurrentQuery",
     "operationKind": "query",
-    "text": "query TrustGraphCurrentQuery {\n  viewer {\n    email\n    fullName\n    id\n  }\n  currentTrustCenter {\n    id\n    slug\n    isViewerMember\n    logoFileUrl\n    darkLogoFileUrl\n    nonDisclosureAgreement {\n      fileName\n      fileUrl\n      viewerSignature {\n        status\n        id\n      }\n    }\n    organization {\n      name\n      description\n      websiteUrl\n      email\n      headquarterAddress\n      id\n    }\n    ...OverviewPageFragment\n    vendorInfo: vendors(first: 0) {\n      totalCount\n    }\n    audits(first: 50) {\n      edges {\n        node {\n          id\n          ...AuditRowFragment\n        }\n      }\n    }\n  }\n}\n\nfragment AuditRowFragment on Audit {\n  report {\n    id\n    filename\n    isUserAuthorized\n    hasUserRequestedAccess\n  }\n  framework {\n    id\n    name\n    lightLogoURL\n    darkLogoURL\n  }\n}\n\nfragment DocumentRowFragment on Document {\n  id\n  title\n  isUserAuthorized\n  hasUserRequestedAccess\n}\n\nfragment OverviewPageFragment on TrustCenter {\n  references(first: 14) {\n    edges {\n      node {\n        id\n        name\n        logoUrl\n        websiteUrl\n      }\n    }\n  }\n  vendors(first: 3) {\n    edges {\n      node {\n        id\n        countries\n        ...VendorRowFragment\n      }\n    }\n  }\n  documents(first: 5) {\n    edges {\n      node {\n        id\n        ...DocumentRowFragment\n        documentType\n      }\n    }\n  }\n  trustCenterFiles(first: 5) {\n    edges {\n      node {\n        id\n        category\n        ...TrustCenterFileRowFragment\n      }\n    }\n  }\n}\n\nfragment TrustCenterFileRowFragment on TrustCenterFile {\n  id\n  name\n  isUserAuthorized\n  hasUserRequestedAccess\n}\n\nfragment VendorRowFragment on Vendor {\n  name\n  description\n  websiteUrl\n  countries\n}\n"
+    "text": "query TrustGraphCurrentQuery {\n  viewer {\n    email\n    fullName\n    id\n  }\n  currentTrustCenter {\n    id\n    slug\n    isViewerMember\n    logoFileUrl\n    darkLogoFileUrl\n    nonDisclosureAgreement {\n      fileName\n      fileUrl\n      viewerSignature {\n        status\n        id\n      }\n    }\n    organization {\n      name\n      description\n      websiteUrl\n      email\n      headquarterAddress\n      id\n    }\n    ...OverviewPageFragment\n    vendorInfo: vendors(first: 0) {\n      totalCount\n    }\n    audits(first: 50) {\n      edges {\n        node {\n          id\n          ...AuditRowFragment\n        }\n      }\n    }\n  }\n}\n\nfragment AuditRowFragment on Audit {\n  frameworkType\n  report {\n    id\n    filename\n    isUserAuthorized\n    hasUserRequestedAccess\n  }\n  framework {\n    id\n    name\n    lightLogoURL\n    darkLogoURL\n  }\n}\n\nfragment DocumentRowFragment on Document {\n  id\n  title\n  isUserAuthorized\n  hasUserRequestedAccess\n}\n\nfragment OverviewPageFragment on TrustCenter {\n  references(first: 14) {\n    edges {\n      node {\n        id\n        name\n        logoUrl\n        websiteUrl\n      }\n    }\n  }\n  vendors(first: 3) {\n    edges {\n      node {\n        id\n        countries\n        ...VendorRowFragment\n      }\n    }\n  }\n  documents(first: 5) {\n    edges {\n      node {\n        id\n        ...DocumentRowFragment\n        documentType\n      }\n    }\n  }\n  trustCenterFiles(first: 5) {\n    edges {\n      node {\n        id\n        category\n        ...TrustCenterFileRowFragment\n      }\n    }\n  }\n}\n\nfragment TrustCenterFileRowFragment on TrustCenterFile {\n  id\n  name\n  isUserAuthorized\n  hasUserRequestedAccess\n}\n\nfragment VendorRowFragment on Vendor {\n  name\n  description\n  websiteUrl\n  countries\n}\n"
   }
 };
 })();

--- a/pkg/coredata/audit.go
+++ b/pkg/coredata/audit.go
@@ -33,6 +33,7 @@ type (
 		Name                  *string               `db:"name"`
 		OrganizationID        gid.GID               `db:"organization_id"`
 		FrameworkID           gid.GID               `db:"framework_id"`
+		FrameworkType         *string               `db:"framework_type"`
 		ReportID              *gid.GID              `db:"report_id"`
 		ValidFrom             *time.Time            `db:"valid_from"`
 		ValidUntil            *time.Time            `db:"valid_until"`
@@ -87,6 +88,7 @@ SELECT
 	name,
 	organization_id,
 	framework_id,
+	framework_type,
 	report_id,
 	valid_from,
 	valid_until,
@@ -172,6 +174,7 @@ SELECT
 	name,
 	organization_id,
 	framework_id,
+	framework_type,
 	report_id,
 	valid_from,
 	valid_until,
@@ -223,6 +226,7 @@ SELECT
 	name,
 	organization_id,
 	framework_id,
+	framework_type,
 	report_id,
 	valid_from,
 	valid_until,
@@ -272,6 +276,7 @@ INSERT INTO audits (
 	tenant_id,
 	organization_id,
 	framework_id,
+	framework_type,
 	report_id,
 	valid_from,
 	valid_until,
@@ -285,6 +290,7 @@ INSERT INTO audits (
 	@tenant_id,
 	@organization_id,
 	@framework_id,
+	@framework_type,
 	@report_id,
 	@valid_from,
 	@valid_until,
@@ -301,6 +307,7 @@ INSERT INTO audits (
 		"tenant_id":               scope.GetTenantID(),
 		"organization_id":         a.OrganizationID,
 		"framework_id":            a.FrameworkID,
+		"framework_type":          a.FrameworkType,
 		"report_id":               a.ReportID,
 		"valid_from":              a.ValidFrom,
 		"valid_until":             a.ValidUntil,
@@ -327,6 +334,7 @@ func (a *Audit) Update(
 UPDATE audits
 SET
 	name = @name,
+	framework_type = @framework_type,
 	report_id = @report_id,
 	valid_from = @valid_from,
 	valid_until = @valid_until,
@@ -343,6 +351,7 @@ WHERE
 	args := pgx.StrictNamedArgs{
 		"id":                      a.ID,
 		"name":                    a.Name,
+		"framework_type":          a.FrameworkType,
 		"report_id":               a.ReportID,
 		"valid_from":              a.ValidFrom,
 		"valid_until":             a.ValidUntil,
@@ -439,6 +448,7 @@ WITH audits_by_control AS (
 		a.name,
 		a.organization_id,
 		a.framework_id,
+		a.framework_type,
 		a.report_id,
 		a.valid_from,
 		a.valid_until,
@@ -458,6 +468,7 @@ SELECT
 	name,
 	organization_id,
 	framework_id,
+	framework_type,
 	report_id,
 	valid_from,
 	valid_until,
@@ -503,6 +514,7 @@ SELECT
 	name,
 	organization_id,
 	framework_id,
+	framework_type,
 	report_id,
 	valid_from,
 	valid_until,

--- a/pkg/coredata/migrations/20260227T120000Z.sql
+++ b/pkg/coredata/migrations/20260227T120000Z.sql
@@ -1,0 +1,1 @@
+ALTER TABLE audits ADD COLUMN framework_type TEXT;

--- a/pkg/probo/audit_service.go
+++ b/pkg/probo/audit_service.go
@@ -39,6 +39,7 @@ type (
 		OrganizationID        gid.GID
 		FrameworkID           gid.GID
 		Name                  *string
+		FrameworkType         *string
 		ValidFrom             *time.Time
 		ValidUntil            *time.Time
 		State                 *coredata.AuditState
@@ -48,6 +49,7 @@ type (
 	UpdateAuditRequest struct {
 		ID                    gid.GID
 		Name                  **string
+		FrameworkType         **string
 		ValidFrom             *time.Time
 		ValidUntil            *time.Time
 		State                 *coredata.AuditState
@@ -66,6 +68,7 @@ func (car *CreateAuditRequest) Validate() error {
 	v.Check(car.OrganizationID, "organization_id", validator.Required(), validator.GID(coredata.OrganizationEntityType))
 	v.Check(car.FrameworkID, "framework_id", validator.Required(), validator.GID(coredata.FrameworkEntityType))
 	v.Check(car.Name, "name", validator.SafeTextNoNewLine(TitleMaxLength))
+	v.Check(car.FrameworkType, "framework_type", validator.SafeTextNoNewLine(TitleMaxLength))
 	v.Check(car.ValidUntil, "valid_until", validator.After(car.ValidFrom))
 	v.Check(car.State, "state", validator.OneOfSlice(coredata.AuditStates()))
 	v.Check(car.TrustCenterVisibility, "trust_center_visibility", validator.OneOfSlice(coredata.TrustCenterVisibilities()))
@@ -78,6 +81,7 @@ func (uar *UpdateAuditRequest) Validate() error {
 
 	v.Check(uar.ID, "id", validator.Required(), validator.GID(coredata.AuditEntityType))
 	v.Check(uar.Name, "name", validator.SafeTextNoNewLine(TitleMaxLength))
+	v.Check(uar.FrameworkType, "framework_type", validator.SafeTextNoNewLine(TitleMaxLength))
 	v.Check(uar.ValidUntil, "valid_until", validator.After(uar.ValidFrom))
 	v.Check(uar.State, "state", validator.OneOfSlice(coredata.AuditStates()))
 	v.Check(uar.TrustCenterVisibility, "trust_center_visibility", validator.OneOfSlice(coredata.TrustCenterVisibilities()))
@@ -158,6 +162,7 @@ func (s *AuditService) Create(
 		Name:                  req.Name,
 		OrganizationID:        req.OrganizationID,
 		FrameworkID:           req.FrameworkID,
+		FrameworkType:         req.FrameworkType,
 		ValidFrom:             req.ValidFrom,
 		ValidUntil:            req.ValidUntil,
 		State:                 coredata.AuditStateNotStarted,
@@ -220,6 +225,9 @@ func (s *AuditService) Update(
 
 			if req.Name != nil {
 				audit.Name = *req.Name
+			}
+			if req.FrameworkType != nil {
+				audit.FrameworkType = *req.FrameworkType
 			}
 			if req.ValidFrom != nil {
 				audit.ValidFrom = req.ValidFrom

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -2484,6 +2484,7 @@ type Risk implements Node {
 type Audit implements Node {
     id: ID!
     name: String
+    frameworkType: String
     organization: Organization! @goField(forceResolver: true)
     framework: Framework! @goField(forceResolver: true)
     validFrom: Datetime
@@ -4152,6 +4153,7 @@ input CreateAuditInput {
     organizationId: ID!
     frameworkId: ID!
     name: String
+    frameworkType: String
     validFrom: Datetime
     validUntil: Datetime
     state: AuditState
@@ -4161,6 +4163,7 @@ input CreateAuditInput {
 input UpdateAuditInput {
     id: ID!
     name: String @goField(omittable: true)
+    frameworkType: String @goField(omittable: true)
     validFrom: Datetime
     validUntil: Datetime
     state: AuditState

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -185,6 +185,7 @@ type ComplexityRoot struct {
 		Controls              func(childComplexity int, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ControlOrderBy, filter *types.ControlFilter) int
 		CreatedAt             func(childComplexity int) int
 		Framework             func(childComplexity int) int
+		FrameworkType         func(childComplexity int) int
 		ID                    func(childComplexity int) int
 		Name                  func(childComplexity int) int
 		Organization          func(childComplexity int) int
@@ -2815,6 +2816,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Audit.Framework(childComplexity), true
+	case "Audit.frameworkType":
+		if e.complexity.Audit.FrameworkType == nil {
+			break
+		}
+
+		return e.complexity.Audit.FrameworkType(childComplexity), true
 	case "Audit.id":
 		if e.complexity.Audit.ID == nil {
 			break
@@ -12988,6 +12995,12 @@ enum WebhookEventType
         @goEnum(value: "go.probo.inc/probo/pkg/coredata.WebhookEventTypeVendorUpdated")
     VENDOR_DELETED
         @goEnum(value: "go.probo.inc/probo/pkg/coredata.WebhookEventTypeVendorDeleted")
+    USER_CREATED
+        @goEnum(value: "go.probo.inc/probo/pkg/coredata.WebhookEventTypeUserCreated")
+    USER_UPDATED
+        @goEnum(value: "go.probo.inc/probo/pkg/coredata.WebhookEventTypeUserUpdated")
+    USER_DELETED
+        @goEnum(value: "go.probo.inc/probo/pkg/coredata.WebhookEventTypeUserDeleted")
 }
 
 type WebhookSubscription implements Node {
@@ -13184,6 +13197,7 @@ type Risk implements Node {
 type Audit implements Node {
     id: ID!
     name: String
+    frameworkType: String
     organization: Organization! @goField(forceResolver: true)
     framework: Framework! @goField(forceResolver: true)
     validFrom: Datetime
@@ -14852,6 +14866,7 @@ input CreateAuditInput {
     organizationId: ID!
     frameworkId: ID!
     name: String
+    frameworkType: String
     validFrom: Datetime
     validUntil: Datetime
     state: AuditState
@@ -14861,6 +14876,7 @@ input CreateAuditInput {
 input UpdateAuditInput {
     id: ID!
     name: String @goField(omittable: true)
+    frameworkType: String @goField(omittable: true)
     validFrom: Datetime
     validUntil: Datetime
     state: AuditState
@@ -21622,6 +21638,35 @@ func (ec *executionContext) fieldContext_Audit_name(_ context.Context, field gra
 	return fc, nil
 }
 
+func (ec *executionContext) _Audit_frameworkType(ctx context.Context, field graphql.CollectedField, obj *types.Audit) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Audit_frameworkType,
+		func(ctx context.Context) (any, error) {
+			return obj.FrameworkType, nil
+		},
+		nil,
+		ec.marshalOString2ᚖstring,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_Audit_frameworkType(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Audit",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Audit_organization(ctx context.Context, field graphql.CollectedField, obj *types.Audit) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -22284,6 +22329,8 @@ func (ec *executionContext) fieldContext_AuditEdge_node(_ context.Context, field
 				return ec.fieldContext_Audit_id(ctx, field)
 			case "name":
 				return ec.fieldContext_Audit_name(ctx, field)
+			case "frameworkType":
+				return ec.fieldContext_Audit_frameworkType(ctx, field)
 			case "organization":
 				return ec.fieldContext_Audit_organization(ctx, field)
 			case "framework":
@@ -27730,6 +27777,8 @@ func (ec *executionContext) fieldContext_DeleteAuditReportPayload_audit(_ contex
 				return ec.fieldContext_Audit_id(ctx, field)
 			case "name":
 				return ec.fieldContext_Audit_name(ctx, field)
+			case "frameworkType":
+				return ec.fieldContext_Audit_frameworkType(ctx, field)
 			case "organization":
 				return ec.fieldContext_Audit_organization(ctx, field)
 			case "framework":
@@ -41183,6 +41232,8 @@ func (ec *executionContext) fieldContext_Nonconformity_audit(_ context.Context, 
 				return ec.fieldContext_Audit_id(ctx, field)
 			case "name":
 				return ec.fieldContext_Audit_name(ctx, field)
+			case "frameworkType":
+				return ec.fieldContext_Audit_frameworkType(ctx, field)
 			case "organization":
 				return ec.fieldContext_Audit_organization(ctx, field)
 			case "framework":
@@ -46683,6 +46734,8 @@ func (ec *executionContext) fieldContext_Report_audit(_ context.Context, field g
 				return ec.fieldContext_Audit_id(ctx, field)
 			case "name":
 				return ec.fieldContext_Audit_name(ctx, field)
+			case "frameworkType":
+				return ec.fieldContext_Audit_frameworkType(ctx, field)
 			case "organization":
 				return ec.fieldContext_Audit_organization(ctx, field)
 			case "framework":
@@ -54493,6 +54546,8 @@ func (ec *executionContext) fieldContext_UpdateAuditPayload_audit(_ context.Cont
 				return ec.fieldContext_Audit_id(ctx, field)
 			case "name":
 				return ec.fieldContext_Audit_name(ctx, field)
+			case "frameworkType":
+				return ec.fieldContext_Audit_frameworkType(ctx, field)
 			case "organization":
 				return ec.fieldContext_Audit_organization(ctx, field)
 			case "framework":
@@ -56205,6 +56260,8 @@ func (ec *executionContext) fieldContext_UploadAuditReportPayload_audit(_ contex
 				return ec.fieldContext_Audit_id(ctx, field)
 			case "name":
 				return ec.fieldContext_Audit_name(ctx, field)
+			case "frameworkType":
+				return ec.fieldContext_Audit_frameworkType(ctx, field)
 			case "organization":
 				return ec.fieldContext_Audit_organization(ctx, field)
 			case "framework":
@@ -63599,7 +63656,7 @@ func (ec *executionContext) unmarshalInputCreateAuditInput(ctx context.Context, 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"organizationId", "frameworkId", "name", "validFrom", "validUntil", "state", "trustCenterVisibility"}
+	fieldsInOrder := [...]string{"organizationId", "frameworkId", "name", "frameworkType", "validFrom", "validUntil", "state", "trustCenterVisibility"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -63627,6 +63684,13 @@ func (ec *executionContext) unmarshalInputCreateAuditInput(ctx context.Context, 
 				return it, err
 			}
 			it.Name = data
+		case "frameworkType":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("frameworkType"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.FrameworkType = data
 		case "validFrom":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("validFrom"))
 			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)
@@ -68723,7 +68787,7 @@ func (ec *executionContext) unmarshalInputUpdateAuditInput(ctx context.Context, 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "name", "validFrom", "validUntil", "state", "trustCenterVisibility"}
+	fieldsInOrder := [...]string{"id", "name", "frameworkType", "validFrom", "validUntil", "state", "trustCenterVisibility"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -68744,6 +68808,13 @@ func (ec *executionContext) unmarshalInputUpdateAuditInput(ctx context.Context, 
 				return it, err
 			}
 			it.Name = graphql.OmittableOf(data)
+		case "frameworkType":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("frameworkType"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.FrameworkType = graphql.OmittableOf(data)
 		case "validFrom":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("validFrom"))
 			data, err := ec.unmarshalODatetime2ᚖtimeᚐTime(ctx, v)
@@ -72208,6 +72279,8 @@ func (ec *executionContext) _Audit(ctx context.Context, sel ast.SelectionSet, ob
 			}
 		case "name":
 			out.Values[i] = ec._Audit_name(ctx, field, obj)
+		case "frameworkType":
+			out.Values[i] = ec._Audit_frameworkType(ctx, field, obj)
 		case "organization":
 			field := field
 
@@ -101902,6 +101975,9 @@ var (
 		"VENDOR_CREATED":  coredata.WebhookEventTypeVendorCreated,
 		"VENDOR_UPDATED":  coredata.WebhookEventTypeVendorUpdated,
 		"VENDOR_DELETED":  coredata.WebhookEventTypeVendorDeleted,
+		"USER_CREATED":    coredata.WebhookEventTypeUserCreated,
+		"USER_UPDATED":    coredata.WebhookEventTypeUserUpdated,
+		"USER_DELETED":    coredata.WebhookEventTypeUserDeleted,
 	}
 	marshalNWebhookEventType2goᚗproboᚗincᚋproboᚋpkgᚋcoredataᚐWebhookEventType = map[coredata.WebhookEventType]string{
 		coredata.WebhookEventTypeMeetingCreated: "MEETING_CREATED",
@@ -101910,6 +101986,9 @@ var (
 		coredata.WebhookEventTypeVendorCreated:  "VENDOR_CREATED",
 		coredata.WebhookEventTypeVendorUpdated:  "VENDOR_UPDATED",
 		coredata.WebhookEventTypeVendorDeleted:  "VENDOR_DELETED",
+		coredata.WebhookEventTypeUserCreated:    "USER_CREATED",
+		coredata.WebhookEventTypeUserUpdated:    "USER_UPDATED",
+		coredata.WebhookEventTypeUserDeleted:    "USER_DELETED",
 	}
 )
 

--- a/pkg/server/api/console/v1/types/audit.go
+++ b/pkg/server/api/console/v1/types/audit.go
@@ -72,6 +72,7 @@ func NewAudit(a *coredata.Audit) *Audit {
 		ValidUntil:            a.ValidUntil,
 		State:                 a.State,
 		Name:                  a.Name,
+		FrameworkType:         a.FrameworkType,
 		TrustCenterVisibility: a.TrustCenterVisibility,
 		CreatedAt:             a.CreatedAt,
 		UpdatedAt:             a.UpdatedAt,

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -81,6 +81,7 @@ type AssetFilter struct {
 type Audit struct {
 	ID                    gid.GID                        `json:"id"`
 	Name                  *string                        `json:"name,omitempty"`
+	FrameworkType         *string                        `json:"frameworkType,omitempty"`
 	Organization          *Organization                  `json:"organization"`
 	Framework             *Framework                     `json:"framework"`
 	ValidFrom             *time.Time                     `json:"validFrom,omitempty"`
@@ -240,6 +241,7 @@ type CreateAuditInput struct {
 	OrganizationID        gid.GID                         `json:"organizationId"`
 	FrameworkID           gid.GID                         `json:"frameworkId"`
 	Name                  *string                         `json:"name,omitempty"`
+	FrameworkType         *string                         `json:"frameworkType,omitempty"`
 	ValidFrom             *time.Time                      `json:"validFrom,omitempty"`
 	ValidUntil            *time.Time                      `json:"validUntil,omitempty"`
 	State                 *coredata.AuditState            `json:"state,omitempty"`
@@ -1984,6 +1986,7 @@ type UpdateAssetPayload struct {
 type UpdateAuditInput struct {
 	ID                    gid.GID                         `json:"id"`
 	Name                  graphql.Omittable[*string]      `json:"name,omitempty"`
+	FrameworkType         graphql.Omittable[*string]      `json:"frameworkType,omitempty"`
 	ValidFrom             *time.Time                      `json:"validFrom,omitempty"`
 	ValidUntil            *time.Time                      `json:"validUntil,omitempty"`
 	State                 *coredata.AuditState            `json:"state,omitempty"`

--- a/pkg/server/api/console/v1/v1_resolver.go
+++ b/pkg/server/api/console/v1/v1_resolver.go
@@ -4591,6 +4591,7 @@ func (r *mutationResolver) CreateAudit(ctx context.Context, input types.CreateAu
 		OrganizationID:        input.OrganizationID,
 		FrameworkID:           input.FrameworkID,
 		Name:                  input.Name,
+		FrameworkType:         input.FrameworkType,
 		ValidFrom:             input.ValidFrom,
 		ValidUntil:            input.ValidUntil,
 		State:                 input.State,
@@ -4619,6 +4620,7 @@ func (r *mutationResolver) UpdateAudit(ctx context.Context, input types.UpdateAu
 	req := probo.UpdateAuditRequest{
 		ID:                    input.ID,
 		Name:                  gqlutils.UnwrapOmittable(input.Name),
+		FrameworkType:         gqlutils.UnwrapOmittable(input.FrameworkType),
 		ValidFrom:             input.ValidFrom,
 		ValidUntil:            input.ValidUntil,
 		State:                 input.State,

--- a/pkg/server/api/trust/v1/helpers.go
+++ b/pkg/server/api/trust/v1/helpers.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package trust_v1
+
+import (
+	"context"
+
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/server/gqlutils"
+)
+
+func (r *Resolver) checkNDASignature(
+	ctx context.Context,
+	trustCenter *coredata.TrustCenter,
+	identity *coredata.Identity,
+) error {
+	if trustCenter.NonDisclosureAgreementFileID == nil {
+		return nil
+	}
+
+	trustService := r.TrustService(ctx, trustCenter.ID.TenantID())
+
+	access, err := trustService.TrustCenterAccesses.GetAccess(ctx, trustCenter.ID, identity.EmailAddress)
+	if err != nil {
+		return gqlutils.Forbiddenf(ctx, "user has not signed the NDA")
+	}
+
+	if access.ElectronicSignatureID == nil {
+		return nil
+	}
+
+	sig, err := r.esign.GetSignatureByID(ctx, *access.ElectronicSignatureID)
+	if err != nil {
+		return gqlutils.Forbiddenf(ctx, "user has not signed the NDA")
+	}
+
+	switch sig.Status {
+	case coredata.ElectronicSignatureStatusAccepted,
+		coredata.ElectronicSignatureStatusProcessing,
+		coredata.ElectronicSignatureStatusCompleted:
+		return nil
+	default:
+		return gqlutils.Forbiddenf(ctx, "user has not signed the NDA")
+	}
+}

--- a/pkg/server/api/trust/v1/schema.graphql
+++ b/pkg/server/api/trust/v1/schema.graphql
@@ -90,6 +90,7 @@ type Report implements Node {
 
 type Audit implements Node {
   id: ID!
+  frameworkType: String
   framework: Framework! @goField(forceResolver: true)
   report: Report @goField(forceResolver: true)
 }

--- a/pkg/server/api/trust/v1/schema/schema.go
+++ b/pkg/server/api/trust/v1/schema/schema.go
@@ -71,9 +71,10 @@ type ComplexityRoot struct {
 	}
 
 	Audit struct {
-		Framework func(childComplexity int) int
-		ID        func(childComplexity int) int
-		Report    func(childComplexity int) int
+		Framework     func(childComplexity int) int
+		FrameworkType func(childComplexity int) int
+		ID            func(childComplexity int) int
+		Report        func(childComplexity int) int
 	}
 
 	AuditConnection struct {
@@ -387,6 +388,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Audit.Framework(childComplexity), true
+	case "Audit.frameworkType":
+		if e.complexity.Audit.FrameworkType == nil {
+			break
+		}
+
+		return e.complexity.Audit.FrameworkType(childComplexity), true
 	case "Audit.id":
 		if e.complexity.Audit.ID == nil {
 			break
@@ -1427,6 +1434,7 @@ type Report implements Node {
 
 type Audit implements Node {
   id: ID!
+  frameworkType: String
   framework: Framework! @goField(forceResolver: true)
   report: Report @goField(forceResolver: true)
 }
@@ -2572,6 +2580,35 @@ func (ec *executionContext) fieldContext_Audit_id(_ context.Context, field graph
 	return fc, nil
 }
 
+func (ec *executionContext) _Audit_frameworkType(ctx context.Context, field graphql.CollectedField, obj *types.Audit) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Audit_frameworkType,
+		func(ctx context.Context) (any, error) {
+			return obj.FrameworkType, nil
+		},
+		nil,
+		ec.marshalOString2ᚖstring,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_Audit_frameworkType(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Audit",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Audit_framework(ctx context.Context, field graphql.CollectedField, obj *types.Audit) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -2779,6 +2816,8 @@ func (ec *executionContext) fieldContext_AuditEdge_node(_ context.Context, field
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_Audit_id(ctx, field)
+			case "frameworkType":
+				return ec.fieldContext_Audit_frameworkType(ctx, field)
 			case "framework":
 				return ec.fieldContext_Audit_framework(ctx, field)
 			case "report":
@@ -8772,6 +8811,8 @@ func (ec *executionContext) _Audit(ctx context.Context, sel ast.SelectionSet, ob
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "frameworkType":
+			out.Values[i] = ec._Audit_frameworkType(ctx, field, obj)
 		case "framework":
 			field := field
 

--- a/pkg/server/api/trust/v1/types/audit.go
+++ b/pkg/server/api/trust/v1/types/audit.go
@@ -35,7 +35,8 @@ func NewAuditConnection(
 
 func NewAudit(a *coredata.Audit) *Audit {
 	return &Audit{
-		ID: a.ID,
+		ID:            a.ID,
+		FrameworkType: a.FrameworkType,
 	}
 }
 

--- a/pkg/server/api/trust/v1/types/types.go
+++ b/pkg/server/api/trust/v1/types/types.go
@@ -26,9 +26,10 @@ type AcceptElectronicSignaturePayload struct {
 }
 
 type Audit struct {
-	ID        gid.GID    `json:"id"`
-	Framework *Framework `json:"framework"`
-	Report    *Report    `json:"report,omitempty"`
+	ID            gid.GID    `json:"id"`
+	FrameworkType *string    `json:"frameworkType,omitempty"`
+	Framework     *Framework `json:"framework"`
+	Report        *Report    `json:"report,omitempty"`
 }
 
 func (Audit) IsNode()             {}

--- a/pkg/server/api/trust/v1/v1_resolver.go
+++ b/pkg/server/api/trust/v1/v1_resolver.go
@@ -236,41 +236,6 @@ func (r *mutationResolver) RequestAllAccesses(ctx context.Context) (*types.Reque
 	}, nil
 }
 
-func (r *mutationResolver) checkNDASignature(
-	ctx context.Context,
-	trustCenter *coredata.TrustCenter,
-	identity *coredata.Identity,
-) error {
-	if trustCenter.NonDisclosureAgreementFileID == nil {
-		return nil
-	}
-
-	trustService := r.TrustService(ctx, trustCenter.ID.TenantID())
-
-	access, err := trustService.TrustCenterAccesses.GetAccess(ctx, trustCenter.ID, identity.EmailAddress)
-	if err != nil {
-		return gqlutils.Forbiddenf(ctx, "user has not signed the NDA")
-	}
-
-	if access.ElectronicSignatureID == nil {
-		return nil
-	}
-
-	sig, err := r.esign.GetSignatureByID(ctx, *access.ElectronicSignatureID)
-	if err != nil {
-		return gqlutils.Forbiddenf(ctx, "user has not signed the NDA")
-	}
-
-	switch sig.Status {
-	case coredata.ElectronicSignatureStatusAccepted,
-		coredata.ElectronicSignatureStatusProcessing,
-		coredata.ElectronicSignatureStatusCompleted:
-		return nil
-	default:
-		return gqlutils.Forbiddenf(ctx, "user has not signed the NDA")
-	}
-}
-
 // ExportDocumentPDF is the resolver for the exportDocumentPDF field.
 func (r *mutationResolver) ExportDocumentPDF(ctx context.Context, input types.ExportDocumentPDFInput) (*types.ExportDocumentPDFPayload, error) {
 	trustService := r.TrustService(ctx, input.DocumentID.TenantID())


### PR DESCRIPTION

<img width="881" height="236" alt="Capture d’écran 2026-02-27 à 16 40 39" src="https://github.com/user-attachments/assets/c532dcf7-ed8b-48fa-ab8d-fd96083984b3" />


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds frameworkType to Audit to capture and display the framework subtype (e.g., Type I/Type II). Stored in the database, editable on create/update, and shown across Console and Trust Center.

- **New Features**
  - Persist frameworkType on audits and expose it in console/trust GraphQL schemas, queries, and mutations.
  - Add “Framework Type” field to Create Audit and Audit Details; display alongside framework name in Console audit lists and Trust Center (AuditRow, avatar, dialog).

- **Migration**
  - Run migration to add framework_type column to audits (pkg/coredata/migrations/20260227T120000Z.sql).

<sup>Written for commit 42e133052893c28e7be3a4228f6551aecb935e90. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

