### PR TITLE
Change audit name display on compliance

### DIFF
--- a/apps/trust/src/components/AuditRow.tsx
+++ b/apps/trust/src/components/AuditRow.tsx
@@ -129,13 +129,7 @@ export function AuditRow(props: { audit: AuditRowFragment$key }) {
     <div className="text-sm border border-border-solid -mt-px flex gap-3 flex-col md:flex-row md:justify-between px-6 py-3">
       <div className="flex items-center gap-2">
         <IconMedal size={16} className="flex-none text-txt-tertiary" />
-        {audit.framework.name}
-        {audit.name && (
-          <>
-            {" "}
-            <em>{audit.name}</em>
-          </>
-        )}
+        {audit.name ?? audit.framework.name}
       </div>
       {audit.report && audit.report.isUserAuthorized
         ? (


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
On the Compliance page, display a single audit label: audit.name when present, otherwise audit.framework.name. Replaces the previous “framework + italicized audit name” pattern to avoid duplicate labels.

<sup>Written for commit 3c760bfc513113662d0ccd02e0d5e713ca24efeb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

