### PR TITLE
Add delete vendor tool on mcp

### DIFF
--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -3192,3 +3192,18 @@ func (r *Resolver) AddVendorRiskAssessmentTool(ctx context.Context, req *mcp.Cal
 
 	return nil, types.NewAddVendorRiskAssessmentOutput(assessment), nil
 }
+
+func (r *Resolver) DeleteVendorTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteVendorInput) (*mcp.CallToolResult, types.DeleteVendorOutput, error) {
+	r.MustAuthorize(ctx, input.ID, probo.ActionVendorDelete)
+
+	svc := r.ProboService(ctx, input.ID)
+
+	err := svc.Vendors.Delete(ctx, input.ID)
+	if err != nil {
+		return nil, types.DeleteVendorOutput{}, fmt.Errorf("failed to delete vendor: %w", err)
+	}
+
+	return nil, types.DeleteVendorOutput{
+		DeletedVendorID: input.ID,
+	}, nil
+}

--- a/pkg/server/api/mcp/v1/server/server.go
+++ b/pkg/server/api/mcp/v1/server/server.go
@@ -23,6 +23,7 @@ type ResolverInterface interface {
 	UpdateVendorTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateVendorInput) (*mcp.CallToolResult, types.UpdateVendorOutput, error)
 	ListVendorRiskAssessmentsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListVendorRiskAssessmentsInput) (*mcp.CallToolResult, types.ListVendorRiskAssessmentsOutput, error)
 	AddVendorRiskAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddVendorRiskAssessmentInput) (*mcp.CallToolResult, types.AddVendorRiskAssessmentOutput, error)
+	DeleteVendorTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteVendorInput) (*mcp.CallToolResult, types.DeleteVendorOutput, error)
 	ListRisksTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListRisksInput) (*mcp.CallToolResult, types.ListRisksOutput, error)
 	GetRiskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetRiskInput) (*mcp.CallToolResult, types.GetRiskOutput, error)
 	AddRiskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddRiskInput) (*mcp.CallToolResult, types.AddRiskOutput, error)
@@ -306,6 +307,19 @@ func registerToolHandlers(server *mcp.Server, resolver ResolverInterface) {
 			OutputSchema: types.AddVendorRiskAssessmentToolOutputSchema,
 		},
 		resolver.AddVendorRiskAssessmentTool,
+	)
+	mcp.AddTool(
+		server,
+		&mcp.Tool{
+			Name:         "deleteVendor",
+			Description:  "Delete a vendor",
+			InputSchema:  types.DeleteVendorToolInputSchema,
+			OutputSchema: types.DeleteVendorToolOutputSchema,
+			Annotations: &mcp.ToolAnnotations{
+				DestructiveHint: boolPtr(true),
+			},
+		},
+		resolver.DeleteVendorTool,
 	)
 	mcp.AddTool(
 		server,

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -766,6 +766,24 @@ components:
         vendor:
           $ref: "#/components/schemas/Vendor"
 
+    DeleteVendorInput:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+          description: Vendor ID
+
+    DeleteVendorOutput:
+      type: object
+      required:
+        - deleted_vendor_id
+      properties:
+        deleted_vendor_id:
+          $ref: "#/components/schemas/GID"
+          description: Deleted vendor ID
+
     GetUserInput:
       type: object
       required:
@@ -6394,6 +6412,15 @@ tools:
       $ref: "#/components/schemas/AddVendorRiskAssessmentInput"
     outputSchema:
       $ref: "#/components/schemas/AddVendorRiskAssessmentOutput"
+  - name: deleteVendor
+    description: Delete a vendor
+    hints:
+      readonly: false
+      destructive: true
+    inputSchema:
+      $ref: "#/components/schemas/DeleteVendorInput"
+    outputSchema:
+      $ref: "#/components/schemas/DeleteVendorOutput"
   - name: listRisks
     description: List all risks for the organization
     hints:

--- a/pkg/server/api/mcp/v1/types/types.go
+++ b/pkg/server/api/mcp/v1/types/types.go
@@ -85,6 +85,8 @@ var (
 	DeleteTaskToolOutputSchema                           = mcp.MustUnmarshalSchema(`{"type":"object","properties":{"deleted_task_id":{"type":"string","format":"string"}},"required":["deleted_task_id"]}`)
 	DeleteTransferImpactAssessmentToolInputSchema        = mcp.MustUnmarshalSchema(`{"type":"object","properties":{"id":{"type":"string","format":"string"}},"required":["id"]}`)
 	DeleteTransferImpactAssessmentToolOutputSchema       = mcp.MustUnmarshalSchema(`{"type":"object","properties":{"deleted_transfer_impact_assessment_id":{"type":"string","format":"string"}},"required":["deleted_transfer_impact_assessment_id"]}`)
+	DeleteVendorToolInputSchema                          = mcp.MustUnmarshalSchema(`{"type":"object","properties":{"id":{"type":"string","format":"string"}},"required":["id"]}`)
+	DeleteVendorToolOutputSchema                         = mcp.MustUnmarshalSchema(`{"type":"object","properties":{"deleted_vendor_id":{"type":"string","format":"string"}},"required":["deleted_vendor_id"]}`)
 	ExportStateOfApplicabilityPDFToolInputSchema         = mcp.MustUnmarshalSchema(`{"type":"object","properties":{"id":{"type":"string","format":"string"}},"required":["id"]}`)
 	ExportStateOfApplicabilityPDFToolOutputSchema        = mcp.MustUnmarshalSchema(`{"type":"object","properties":{"filename":{"type":"string","description":"Suggested filename for the PDF"},"pdf_base64":{"type":"string","description":"Base64-encoded PDF content"}},"required":["pdf_base64","filename"]}`)
 	GetApplicabilityStatementToolInputSchema             = mcp.MustUnmarshalSchema(`{"type":"object","properties":{"id":{"type":"string","format":"string"}},"required":["id"]}`)
@@ -1529,6 +1531,18 @@ type DeleteTransferImpactAssessmentInput struct {
 // DeleteTransferImpactAssessmentOutput represents the schema
 type DeleteTransferImpactAssessmentOutput struct {
 	DeletedTransferImpactAssessmentID gid.GID `json:"deleted_transfer_impact_assessment_id"`
+}
+
+// DeleteVendorInput represents the schema
+type DeleteVendorInput struct {
+	// Vendor ID
+	ID gid.GID `json:"id"`
+}
+
+// DeleteVendorOutput represents the schema
+type DeleteVendorOutput struct {
+	// Deleted vendor ID
+	DeletedVendorID gid.GID `json:"deleted_vendor_id"`
 }
 
 // Document represents the schema


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new deleteVendor MCP tool to delete vendors by ID. The tool is marked destructive, enforces authorization, and returns the deleted vendor ID.

- **New Features**
  - Registers deleteVendor with input id and output deleted_vendor_id schemas; sets destructive hint.
  - Adds DeleteVendorTool resolver that authorizes, calls Vendors.Delete, and returns the deleted ID.
  - Updates MCP specification and types with DeleteVendorInput/DeleteVendorOutput.

<sup>Written for commit e0de1548d63bfe112941121d1883fc0a7ee1752b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

