### PR TITLE
fix: add trust-center config section to entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -164,6 +164,10 @@ $(echo "${SAML_PRIVATE_KEY:-}" | sed 's/^/        /')
       email: "${ACME_EMAIL:-admin@getprobo.com}"
       key-type: "${ACME_KEY_TYPE:-EC256}"
       root-ca: "${ACME_ROOT_CA:-}"
+
+  trust-center:
+    http-addr: "${TRUST_CENTER_HTTP_ADDR:-:80}"
+    https-addr: "${TRUST_CENTER_HTTPS_ADDR:-:443}"
 EOF
 
   # Add connectors if configured


### PR DESCRIPTION
## Summary

- Add `trust-center:` section to the generated config in `entrypoint.sh` with two new environment variables:
  - `TRUST_CENTER_HTTP_ADDR` (default `:80`)
  - `TRUST_CENTER_HTTPS_ADDR` (default `:443`)
- Fixes startup panic on container runtimes that drop `CAP_NET_BIND_SERVICE` (Azure Container Apps, AWS ECS Fargate, GKE Autopilot)
- Backward compatible — defaults match existing Go hardcoded values

## Test plan
- [x] Verified generated YAML includes `trust-center:` section with correct defaults
- [x] Verified custom env var values are picked up correctly
- [x] Verified generated YAML is valid (parsed with Python yaml module)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a trust-center config section to entrypoint.sh to make HTTP/HTTPS bind addresses configurable via TRUST_CENTER_HTTP_ADDR and TRUST_CENTER_HTTPS_ADDR (defaults :80 and :443). This prevents startup panics on runtimes that drop CAP_NET_BIND_SERVICE and keeps behavior backward-compatible.

<sup>Written for commit 7f4a8c4f8665bda7b929e15c209aaff26a491d3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

