### PR TITLE
Return proper error not found during deletion

### DIFF
--- a/pkg/server/api/authz/authorization.go
+++ b/pkg/server/api/authz/authorization.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 
 	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/iam"
 	"go.probo.inc/probo/pkg/server/api/authn"
@@ -80,6 +81,10 @@ func NewAuthorizeFunc(
 			var errInsufficientPermissions *iam.ErrInsufficientPermissions
 			if errors.As(err, &errInsufficientPermissions) {
 				return gqlutils.Forbidden(ctx, err)
+			}
+
+			if errors.Is(err, coredata.ErrResourceNotFound) {
+				return gqlutils.NotFoundf(ctx, "resource not found")
 			}
 
 			logger.ErrorCtx(ctx, "cannot authorize", log.Error(err))


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Return 404 Not Found when a resource is missing during authorization, including delete operations. Replaces 500/403 with a clear Not Found error.

- **Bug Fixes**
  - Map coredata.ErrResourceNotFound to gqlutils.NotFoundf(ctx, "resource not found") in the authorization handler.
  - Avoid 500s and misleading 403s; clients now consistently receive 404 for missing resources.

<sup>Written for commit 4d882e37b0935c06f0f96a8bb227b8833af9c7a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

