### PR TITLE
Display empty state for soa control assessment

### DIFF
--- a/apps/console/src/pages/organizations/states-of-applicability/tabs/StateOfApplicabilityControlsTab.tsx
+++ b/apps/console/src/pages/organizations/states-of-applicability/tabs/StateOfApplicabilityControlsTab.tsx
@@ -294,66 +294,58 @@ export default function StateOfApplicabilityControlsTab({
                 </Td>
                 <Td>
                   <div className="flex justify-center">
-                    <Badge
-                      variant={
-                        control.regulatory
-                          ? "success"
-                          : "danger"
-                      }
-                      size="sm"
-                    >
-                      {control.regulatory
-                        ? __("Yes")
-                        : __("No")}
-                    </Badge>
+                    {control.applicability === false
+                      ? <span className="text-txt-tertiary">-</span>
+                      : (
+                          <Badge
+                            variant={control.regulatory ? "success" : "danger"}
+                            size="sm"
+                          >
+                            {control.regulatory ? __("Yes") : __("No")}
+                          </Badge>
+                        )}
                   </div>
                 </Td>
                 <Td>
                   <div className="flex justify-center">
-                    <Badge
-                      variant={
-                        control.contractual
-                          ? "success"
-                          : "danger"
-                      }
-                      size="sm"
-                    >
-                      {control.contractual
-                        ? __("Yes")
-                        : __("No")}
-                    </Badge>
+                    {control.applicability === false
+                      ? <span className="text-txt-tertiary">-</span>
+                      : (
+                          <Badge
+                            variant={control.contractual ? "success" : "danger"}
+                            size="sm"
+                          >
+                            {control.contractual ? __("Yes") : __("No")}
+                          </Badge>
+                        )}
                   </div>
                 </Td>
                 <Td>
                   <div className="flex justify-center">
-                    <Badge
-                      variant={
-                        control.bestPractice
-                          ? "success"
-                          : "danger"
-                      }
-                      size="sm"
-                    >
-                      {control.bestPractice
-                        ? __("Yes")
-                        : __("No")}
-                    </Badge>
+                    {control.applicability === false
+                      ? <span className="text-txt-tertiary">-</span>
+                      : (
+                          <Badge
+                            variant={control.bestPractice ? "success" : "danger"}
+                            size="sm"
+                          >
+                            {control.bestPractice ? __("Yes") : __("No")}
+                          </Badge>
+                        )}
                   </div>
                 </Td>
                 <Td>
                   <div className="flex justify-center">
-                    <Badge
-                      variant={
-                        control.riskAssessment
-                          ? "success"
-                          : "danger"
-                      }
-                      size="sm"
-                    >
-                      {control.riskAssessment
-                        ? __("Yes")
-                        : __("No")}
-                    </Badge>
+                    {control.applicability === false
+                      ? <span className="text-txt-tertiary">-</span>
+                      : (
+                          <Badge
+                            variant={control.riskAssessment ? "success" : "danger"}
+                            size="sm"
+                          >
+                            {control.riskAssessment ? __("Yes") : __("No")}
+                          </Badge>
+                        )}
                   </div>
                 </Td>
                 {(canUpdate || canDelete) && (

--- a/pkg/docgen/generator.go
+++ b/pkg/docgen/generator.go
@@ -306,7 +306,7 @@ type (
 		Name           string
 		Applicability  *bool
 		Justification  *string
-		BestPractice   bool
+		BestPractice   *bool
 		Regulatory     *bool
 		Contractual    *bool
 		RiskAssessment *bool

--- a/pkg/docgen/soa_template.html
+++ b/pkg/docgen/soa_template.html
@@ -333,19 +333,7 @@
                         </td>
                         <td>{{boolToYesNoDash .Regulatory}}</td>
                         <td>{{boolToYesNoDash .Contractual}}</td>
-                        <td>
-                            {{- if .Applicability}}
-                                {{- if and .Applicability .BestPractice}}
-                                Yes
-                                {{- else if .Applicability}}
-                                No
-                                {{- else}}
-                                -
-                                {{- end}}
-                            {{- else}}
-                            -
-                            {{- end}}
-                        </td>
+                        <td>{{boolToYesNoDash .BestPractice}}</td>
                         <td>{{boolToYesNoDash .RiskAssessment}}</td>
                     </tr>
                     {{- end}}

--- a/pkg/probo/state_of_applicability_service.go
+++ b/pkg/probo/state_of_applicability_service.go
@@ -543,6 +543,7 @@ func (s StateOfApplicabilityService) ExportPDF(
 
 				var regulatory *bool
 				var contractual *bool
+				var bestPractice *bool
 				var riskAssessment *bool
 
 				if stmt.Applicability {
@@ -562,6 +563,8 @@ func (s StateOfApplicabilityService) ExportPDF(
 					if hasRisk {
 						riskAssessment = &trueVal
 					}
+
+					bestPractice = &control.BestPractice
 				}
 
 				applicability := stmt.Applicability
@@ -574,7 +577,7 @@ func (s StateOfApplicabilityService) ExportPDF(
 						Name:           control.Name,
 						Applicability:  &applicability,
 						Justification:  stmt.Justification,
-						BestPractice:   control.BestPractice,
+						BestPractice:   bestPractice,
 						Regulatory:     regulatory,
 						Contractual:    contractual,
 						RiskAssessment: riskAssessment,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show an empty state for non-applicable controls in the SoA. The UI and PDF now display “-” for assessment fields when a control is excluded to avoid misleading Yes/No badges.

- **Bug Fixes**
  - Console: Show “-” in Regulatory, Contractual, Best practice, and Risk assessment columns when applicability is false; otherwise show Yes/No badges.
  - PDF export: Treat assessment flags (including BestPractice) as optional and only set them when applicable; simplify template to use boolToYesNoDash for consistent “-” rendering.

<sup>Written for commit e3c5a361fb72b75ff12921218d18d55d3d02f5c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

