### PR TITLE
Add cache control headers to s3 presigned urls for assets

### DIFF
--- a/e2e/console/framework_test.go
+++ b/e2e/console/framework_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.probo.inc/probo/e2e/internal/factory"
 	"go.probo.inc/probo/e2e/internal/testutil"
-	"go.gearno.de/x/ref"
 )
 
 func TestFramework_Create(t *testing.T) {
@@ -720,7 +719,7 @@ func TestFramework_OmittableDescription(t *testing.T) {
 		{
 			name:            "update with new description",
 			input:           map[string]any{"description": "Updated description"},
-			wantDescription: ref.Ref("Updated description"),
+			wantDescription: new("Updated description"),
 		},
 		{
 			name:            "update with null description clears it",
@@ -730,12 +729,12 @@ func TestFramework_OmittableDescription(t *testing.T) {
 		{
 			name:            "set description again",
 			input:           map[string]any{"description": "Should persist"},
-			wantDescription: ref.Ref("Should persist"),
+			wantDescription: new("Should persist"),
 		},
 		{
 			name:            "update without description preserves it",
 			input:           map[string]any{"name": "Updated Name"},
-			wantDescription: ref.Ref("Should persist"),
+			wantDescription: new("Should persist"),
 		},
 	}
 

--- a/e2e/console/measure_test.go
+++ b/e2e/console/measure_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.probo.inc/probo/e2e/internal/factory"
 	"go.probo.inc/probo/e2e/internal/testutil"
-	"go.gearno.de/x/ref"
 )
 
 func TestMeasure_Create(t *testing.T) {
@@ -842,7 +841,7 @@ func TestMeasure_OmittableDescription(t *testing.T) {
 		{
 			name:            "update with new description",
 			input:           map[string]any{"description": "Updated description"},
-			wantDescription: ref.Ref("Updated description"),
+			wantDescription: new("Updated description"),
 		},
 		{
 			name:            "update with null description clears it",
@@ -852,12 +851,12 @@ func TestMeasure_OmittableDescription(t *testing.T) {
 		{
 			name:            "set description again",
 			input:           map[string]any{"description": "Should persist"},
-			wantDescription: ref.Ref("Should persist"),
+			wantDescription: new("Should persist"),
 		},
 		{
 			name:            "update without description preserves it",
 			input:           map[string]any{"name": "Updated Name"},
-			wantDescription: ref.Ref("Should persist"),
+			wantDescription: new("Should persist"),
 		},
 	}
 
@@ -2030,4 +2029,3 @@ func TestMeasure_Ordering(t *testing.T) {
 		testutil.AssertTimesOrderedDescending(t, times, "createdAt")
 	})
 }
-

--- a/packages/emails/emails.go
+++ b/packages/emails/emails.go
@@ -27,7 +27,6 @@ import (
 	texttemplate "text/template"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"go.probo.inc/probo/pkg/baseurl"
 	"go.probo.inc/probo/pkg/filemanager"
@@ -184,14 +183,14 @@ func UploadStaticAssets(ctx context.Context, s3Client *s3.Client, staticAssetsBu
 		_, err = s3Client.PutObject(
 			ctx,
 			&s3.PutObjectInput{
-				Bucket: aws.String(staticAssetsBucket),
-				Key:    aws.String(path),
+				Bucket: new(staticAssetsBucket),
+				Key:    new(path),
 				Body:   file,
 				Metadata: map[string]string{
 					"type": "static-email-asset",
 				},
-				ContentType:  aws.String(mimeType),
-				CacheControl: aws.String("max-age=3600, public"),
+				ContentType:  new(mimeType),
+				CacheControl: new("max-age=3600, public"),
 			},
 		)
 		if err != nil {

--- a/pkg/awsconfig/config.go
+++ b/pkg/awsconfig/config.go
@@ -108,7 +108,7 @@ func NewConfig(logger *log.Logger, httpClient *http.Client, opts Options) aws.Co
 	}
 
 	if opts.Endpoint != "" {
-		cfg.BaseEndpoint = aws.String(opts.Endpoint)
+		cfg.BaseEndpoint = new(opts.Endpoint)
 	}
 
 	return cfg.Copy()

--- a/pkg/certmanager/provisioner.go
+++ b/pkg/certmanager/provisioner.go
@@ -23,7 +23,6 @@ import (
 
 	"go.gearno.de/kit/log"
 	"go.gearno.de/kit/pg"
-	"go.gearno.de/x/ref"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/crypto/cipher"
 	"go.probo.inc/probo/pkg/gid"
@@ -346,7 +345,7 @@ func (p *Provisioner) provisionDomainCertificate(
 		)
 
 		domain.SSLRetryCount = domain.SSLRetryCount + 1
-		domain.SSLLastAttemptAt = ref.Ref(time.Now())
+		domain.SSLLastAttemptAt = new(time.Now())
 
 		if domain.SSLRetryCount >= maxRetries {
 			p.logger.ErrorCtx(

--- a/pkg/filemanager/service.go
+++ b/pkg/filemanager/service.go
@@ -22,7 +22,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
 
@@ -52,8 +51,8 @@ func (s *Service) GetFileBase64(
 	result, err := s.s3Client.GetObject(
 		ctx,
 		&s3.GetObjectInput{
-			Bucket: aws.String(file.GetBucketName()),
-			Key:    aws.String(file.GetObjectKey()),
+			Bucket: new(file.GetBucketName()),
+			Key:    new(file.GetObjectKey()),
 		},
 	)
 	if err != nil {
@@ -84,8 +83,8 @@ func (s *Service) GetFileBytes(
 	result, err := s.s3Client.GetObject(
 		ctx,
 		&s3.GetObjectInput{
-			Bucket: aws.String(file.GetBucketName()),
-			Key:    aws.String(file.GetObjectKey()),
+			Bucket: new(file.GetBucketName()),
+			Key:    new(file.GetObjectKey()),
 		},
 	)
 	if err != nil {
@@ -129,11 +128,11 @@ func (s *Service) PutFile(
 	_, err := s.s3Client.PutObject(
 		ctx,
 		&s3.PutObjectInput{
-			Bucket:       aws.String(file.GetBucketName()),
-			Key:          aws.String(file.GetObjectKey()),
+			Bucket:       new(file.GetBucketName()),
+			Key:          new(file.GetObjectKey()),
 			Body:         content,
-			ContentType:  aws.String(file.GetMimeType()),
-			CacheControl: aws.String("private, max-age=3600"),
+			ContentType:  new(file.GetMimeType()),
+			CacheControl: new("private, max-age=3600"),
 			Metadata:     metadata,
 		},
 	)
@@ -144,8 +143,8 @@ func (s *Service) PutFile(
 	headOutput, err := s.s3Client.HeadObject(
 		ctx,
 		&s3.HeadObjectInput{
-			Bucket: aws.String(file.GetBucketName()),
-			Key:    aws.String(file.GetObjectKey()),
+			Bucket: new(file.GetBucketName()),
+			Key:    new(file.GetObjectKey()),
 		},
 	)
 	if err != nil {
@@ -169,10 +168,10 @@ func (s *Service) GenerateFileUrl(
 	presignedReq, err := presignClient.PresignGetObject(
 		ctx,
 		&s3.GetObjectInput{
-			Bucket:                     aws.String(file.GetBucketName()),
-			Key:                        aws.String(file.GetObjectKey()),
-			ResponseCacheControl:       aws.String("max-age=3600, public"),
-			ResponseContentType:        aws.String(file.GetMimeType()),
+			Bucket:                     new(file.GetBucketName()),
+			Key:                        new(file.GetObjectKey()),
+			ResponseCacheControl:       new("max-age=3600, public"),
+			ResponseContentType:        new(file.GetMimeType()),
 			ResponseContentDisposition: &contentDisposition,
 		},
 		func(opts *s3.PresignOptions) {

--- a/pkg/iam/api_key.go
+++ b/pkg/iam/api_key.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"go.gearno.de/kit/pg"
-	"go.gearno.de/x/ref"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 )
@@ -55,7 +54,7 @@ func (s *APIKeyService) GetAPIKey(ctx context.Context, keyID gid.GID) (*coredata
 			}
 
 			if now.After(apiKey.ExpiresAt) {
-				apiKey.ExpireReason = ref.Ref(coredata.ExpireReasonIdleTimeout)
+				apiKey.ExpireReason = new(coredata.ExpireReasonIdleTimeout)
 				apiKey.ExpiresAt = now
 				apiKey.UpdatedAt = now
 

--- a/pkg/iam/session_service.go
+++ b/pkg/iam/session_service.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"go.gearno.de/kit/pg"
-	"go.gearno.de/x/ref"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/validator"
@@ -69,7 +68,7 @@ func (s SessionService) GetSession(ctx context.Context, sessionID gid.GID) (*cor
 			}
 
 			if now.After(session.ExpiredAt) {
-				session.ExpireReason = ref.Ref(coredata.ExpireReasonIdleTimeout)
+				session.ExpireReason = new(coredata.ExpireReasonIdleTimeout)
 				session.ExpiredAt = now
 				session.UpdatedAt = now
 				if err := session.Update(ctx, tx); err != nil {
@@ -107,7 +106,7 @@ func (s SessionService) CloseSession(ctx context.Context, sessionID gid.GID) err
 				return NewSessionExpiredError(sessionID)
 			}
 
-			session.ExpireReason = ref.Ref(coredata.ExpireReasonClosed)
+			session.ExpireReason = new(coredata.ExpireReasonClosed)
 			session.ExpiredAt = time.Now()
 			session.UpdatedAt = time.Now()
 			if err := session.Update(ctx, conn); err != nil {
@@ -158,7 +157,7 @@ func (s SessionService) RevokeSession(ctx context.Context, identityID gid.GID, s
 				return NewSessionExpiredError(sessionID)
 			}
 
-			session.ExpireReason = ref.Ref(coredata.ExpireReasonRevoked)
+			session.ExpireReason = new(coredata.ExpireReasonRevoked)
 			session.ExpiredAt = now
 			session.UpdatedAt = now
 			if err := session.Update(ctx, tx); err != nil {

--- a/pkg/probo/audit_service.go
+++ b/pkg/probo/audit_service.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"go.gearno.de/crypto/uuid"
 	"go.gearno.de/kit/pg"
@@ -347,11 +346,11 @@ func (s AuditService) UploadReport(
 			}
 
 			_, err = s.svc.s3.PutObject(ctx, &s3.PutObjectInput{
-				Bucket:       aws.String(s.svc.bucket),
-				Key:          aws.String(objectKey.String()),
+				Bucket:       new(s.svc.bucket),
+				Key:          new(objectKey.String()),
 				Body:         req.File.Content,
-				ContentType:  aws.String(req.File.ContentType),
-				CacheControl: aws.String("private, max-age=3600"),
+				ContentType:  new(req.File.ContentType),
+				CacheControl: new("private, max-age=3600"),
 				Metadata: map[string]string{
 					"type":            "report",
 					"report-id":       reportID.String(),

--- a/pkg/probo/document_service.go
+++ b/pkg/probo/document_service.go
@@ -16,7 +16,6 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/crypto/uuid"
 	"go.gearno.de/kit/pg"
-	"go.gearno.de/x/ref"
 	"go.probo.inc/probo/packages/emails"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/docgen"
@@ -1787,12 +1786,12 @@ func (s *DocumentService) BuildAndUploadExport(ctx context.Context, exportJobID 
 			_, err = s.svc.s3.PutObject(
 				ctx,
 				&s3.PutObjectInput{
-					Bucket:        ref.Ref(s.svc.bucket),
-					Key:           ref.Ref(uuid.String()),
+					Bucket:        new(s.svc.bucket),
+					Key:           new(uuid.String()),
 					Body:          tempFile,
-					ContentLength: ref.Ref(fileInfo.Size()),
-					ContentType:   ref.Ref("application/zip"),
-					CacheControl:  ref.Ref("private, max-age=3600"),
+					ContentLength: new(fileInfo.Size()),
+					ContentType:   new("application/zip"),
+					CacheControl:  new("private, max-age=3600"),
 					Metadata: map[string]string{
 						"type":            "document-export",
 						"export-job-id":   exportJob.ID.String(),
@@ -2087,11 +2086,11 @@ func (s *DocumentService) GenerateDocumentExportDownloadURL(
 	presignedReq, err := presignClient.PresignGetObject(
 		ctx,
 		&s3.GetObjectInput{
-			Bucket:                     ref.Ref(s.svc.bucket),
-			Key:                        ref.Ref(file.FileKey),
-			ResponseCacheControl:       ref.Ref("max-age=3600, public"),
-			ResponseContentType:        ref.Ref(file.MimeType),
-			ResponseContentDisposition: ref.Ref(fmt.Sprintf("attachment; filename=\"%s\"", file.FileName)),
+			Bucket:                     new(s.svc.bucket),
+			Key:                        new(file.FileKey),
+			ResponseCacheControl:       new("max-age=3600, public"),
+			ResponseContentType:        new(file.MimeType),
+			ResponseContentDisposition: new(fmt.Sprintf("attachment; filename=\"%s\"", file.FileName)),
 		},
 		func(opts *s3.PresignOptions) {
 			opts.Expires = documentExportEmailExpiresIn

--- a/pkg/probo/file_service.go
+++ b/pkg/probo/file_service.go
@@ -21,7 +21,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"go.gearno.de/crypto/uuid"
 	"go.gearno.de/kit/pg"
@@ -97,11 +96,11 @@ func (s FileService) UploadAndSaveFile(
 		ctx,
 		&s3.PutObjectInput{
 			Bucket:       &s.svc.bucket,
-			Key:          aws.String(objectKey.String()),
+			Key:          new(objectKey.String()),
 			Body:         req.Content,
 			Metadata:     s3Metadata,
-			ContentType:  aws.String(mimeType),
-			CacheControl: aws.String("private, max-age=3600"),
+			ContentType:  new(mimeType),
+			CacheControl: new("private, max-age=3600"),
 		},
 	)
 	if err != nil {
@@ -109,8 +108,8 @@ func (s FileService) UploadAndSaveFile(
 	}
 
 	headOutput, err := s.svc.s3.HeadObject(ctx, &s3.HeadObjectInput{
-		Bucket: aws.String(s.svc.bucket),
-		Key:    aws.String(objectKey.String()),
+		Bucket: new(s.svc.bucket),
+		Key:    new(objectKey.String()),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("cannot get object metadata: %w", err)
@@ -184,7 +183,7 @@ func (s FileService) GenerateFileTempURL(
 		&s3.GetObjectInput{
 			Bucket:                     &s.svc.bucket,
 			Key:                        &file.FileKey,
-			ResponseCacheControl:       aws.String("max-age=3600, public"),
+			ResponseCacheControl:       new("max-age=3600, public"),
 			ResponseContentType:        &file.MimeType,
 			ResponseContentDisposition: &contentDisposition,
 		},

--- a/pkg/probo/framework_service.go
+++ b/pkg/probo/framework_service.go
@@ -24,11 +24,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"go.gearno.de/crypto/uuid"
 	"go.gearno.de/kit/pg"
-	"go.gearno.de/x/ref"
 	"go.probo.inc/probo/packages/emails"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
@@ -255,8 +253,8 @@ func (s FrameworkService) Export(
 						object, err := s.svc.s3.GetObject(
 							ctx,
 							&s3.GetObjectInput{
-								Bucket: aws.String(s.svc.bucket),
-								Key:    aws.String(evidence_file.FileKey),
+								Bucket: new(s.svc.bucket),
+								Key:    new(evidence_file.FileKey),
 							},
 						)
 						if err != nil {
@@ -657,11 +655,11 @@ func (s FrameworkService) GenerateFrameworkExportDownloadURL(
 	presignedReq, err := presignClient.PresignGetObject(
 		ctx,
 		&s3.GetObjectInput{
-			Bucket:                     ref.Ref(s.svc.bucket),
-			Key:                        ref.Ref(file.FileKey),
-			ResponseCacheControl:       ref.Ref("max-age=3600, public"),
-			ResponseContentType:        ref.Ref(file.MimeType),
-			ResponseContentDisposition: ref.Ref(fmt.Sprintf("attachment; filename=\"%s\"", file.FileName)),
+			Bucket:                     new(s.svc.bucket),
+			Key:                        new(file.FileKey),
+			ResponseCacheControl:       new("max-age=3600, public"),
+			ResponseContentType:        new(file.MimeType),
+			ResponseContentDisposition: new(fmt.Sprintf("attachment; filename=\"%s\"", file.FileName)),
 		},
 		func(opts *s3.PresignOptions) {
 			opts.Expires = frameworkExportEmailExpiresIn
@@ -724,12 +722,12 @@ func (s *FrameworkService) BuildAndUploadExport(ctx context.Context, exportJobID
 			_, err = s.svc.s3.PutObject(
 				ctx,
 				&s3.PutObjectInput{
-					Bucket:        ref.Ref(s.svc.bucket),
-					Key:           ref.Ref(uuid.String()),
+					Bucket:        new(s.svc.bucket),
+					Key:           new(uuid.String()),
 					Body:          tempFile,
-					ContentLength: ref.Ref(fileInfo.Size()),
-					ContentType:   ref.Ref("application/zip"),
-					CacheControl:  ref.Ref("private, max-age=3600"),
+					ContentLength: new(fileInfo.Size()),
+					ContentType:   new("application/zip"),
+					CacheControl:  new("private, max-age=3600"),
 					Metadata: map[string]string{
 						"type":            "framework-export",
 						"export-job-id":   exportJob.ID.String(),

--- a/pkg/probo/report_service.go
+++ b/pkg/probo/report_service.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/coredata"
@@ -88,11 +87,11 @@ func (s ReportService) GenerateDownloadURL(
 	presignClient := s3.NewPresignClient(s.svc.s3)
 
 	presignedReq, err := presignClient.PresignGetObject(ctx, &s3.GetObjectInput{
-		Bucket:                     aws.String(s.svc.bucket),
-		Key:                        aws.String(report.ObjectKey),
-		ResponseCacheControl:       aws.String("max-age=3600, public"),
-		ResponseContentType:        aws.String(report.MimeType),
-		ResponseContentDisposition: aws.String(fmt.Sprintf("attachment; filename=\"%s\"", report.Filename)),
+		Bucket:                     new(s.svc.bucket),
+		Key:                        new(report.ObjectKey),
+		ResponseCacheControl:       new("max-age=3600, public"),
+		ResponseContentType:        new(report.MimeType),
+		ResponseContentDisposition: new(fmt.Sprintf("attachment; filename=\"%s\"", report.Filename)),
 	}, func(opts *s3.PresignOptions) {
 		opts.Expires = expiresIn
 	})

--- a/pkg/probo/service.go
+++ b/pkg/probo/service.go
@@ -22,7 +22,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"go.gearno.de/kit/log"
 	"go.gearno.de/kit/pg"
-	"go.gearno.de/x/ref"
 	"go.probo.inc/probo/pkg/agents"
 	"go.probo.inc/probo/pkg/certmanager"
 	"go.probo.inc/probo/pkg/coredata"
@@ -342,7 +341,7 @@ func (s *Service) lockExportJob(ctx context.Context) (*coredata.ExportJob, error
 			scope = coredata.NewScope(exportJob.ID.TenantID())
 
 			exportJob.Status = coredata.ExportJobStatusProcessing
-			exportJob.StartedAt = ref.Ref(time.Now())
+			exportJob.StartedAt = new(time.Now())
 			if err := exportJob.Update(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot update %s export job: %w", exportJob.Type, err)
 			}
@@ -358,7 +357,7 @@ func (s *Service) lockExportJob(ctx context.Context) (*coredata.ExportJob, error
 }
 
 func (s *Service) commitFailedExport(ctx context.Context, exportJob *coredata.ExportJob, failureErr error) error {
-	exportJob.CompletedAt = ref.Ref(time.Now())
+	exportJob.CompletedAt = new(time.Now())
 	exportJob.Status = coredata.ExportJobStatusFailed
 	errorMsg := failureErr.Error()
 	exportJob.Error = &errorMsg
@@ -377,7 +376,7 @@ func (s *Service) commitFailedExport(ctx context.Context, exportJob *coredata.Ex
 }
 
 func (s *Service) commitSuccessfulExport(ctx context.Context, exportJob *coredata.ExportJob) error {
-	exportJob.CompletedAt = ref.Ref(time.Now())
+	exportJob.CompletedAt = new(time.Now())
 	exportJob.Status = coredata.ExportJobStatusCompleted
 
 	return s.pg.WithConn(

--- a/pkg/probo/trust_center_file_service.go
+++ b/pkg/probo/trust_center_file_service.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"go.gearno.de/crypto/uuid"
 	"go.gearno.de/kit/pg"
@@ -375,11 +374,11 @@ func (s TrustCenterFileService) uploadFile(
 	}
 
 	_, err = s.svc.s3.PutObject(ctx, &s3.PutObjectInput{
-		Bucket:       aws.String(s.svc.bucket),
-		Key:          aws.String(objectKey.String()),
+		Bucket:       new(s.svc.bucket),
+		Key:          new(objectKey.String()),
 		Body:         fileContent,
-		ContentType:  aws.String(contentType),
-		CacheControl: aws.String("private, max-age=3600"),
+		ContentType:  new(contentType),
+		CacheControl: new("private, max-age=3600"),
 		Metadata: map[string]string{
 			"type":                 "trust-center-file",
 			"trust-center-file-id": trustCenterFileID.String(),
@@ -414,7 +413,7 @@ func (s TrustCenterFileService) cleanupS3Object(ctx context.Context, s3Key strin
 	}
 
 	_, _ = s.svc.s3.DeleteObject(ctx, &s3.DeleteObjectInput{
-		Bucket: aws.String(s.svc.bucket),
-		Key:    aws.String(s3Key),
+		Bucket: new(s.svc.bucket),
+		Key:    new(s3Key),
 	})
 }

--- a/pkg/probo/trust_center_reference_service.go
+++ b/pkg/probo/trust_center_reference_service.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"go.gearno.de/crypto/uuid"
 	"go.gearno.de/kit/pg"
@@ -321,10 +320,10 @@ func (s TrustCenterReferenceService) GenerateLogoURL(
 		encodedFilename, encodedFilename)
 
 	presignedReq, err := presignClient.PresignGetObject(ctx, &s3.GetObjectInput{
-		Bucket:                     aws.String(s.svc.bucket),
-		Key:                        aws.String(file.FileKey),
-		ResponseCacheControl:       aws.String("max-age=3600, public"),
-		ResponseContentDisposition: aws.String(contentDisposition),
+		Bucket:                     new(s.svc.bucket),
+		Key:                        new(file.FileKey),
+		ResponseCacheControl:       new("max-age=3600, public"),
+		ResponseContentDisposition: new(contentDisposition),
 	}, func(opts *s3.PresignOptions) {
 		opts.Expires = duration
 	})
@@ -395,11 +394,11 @@ func (s TrustCenterReferenceService) uploadLogoFile(
 	}
 
 	_, err = s.svc.s3.PutObject(ctx, &s3.PutObjectInput{
-		Bucket:       aws.String(s.svc.bucket),
-		Key:          aws.String(objectKey.String()),
+		Bucket:       new(s.svc.bucket),
+		Key:          new(objectKey.String()),
 		Body:         fileContent,
-		ContentType:  aws.String(contentType),
-		CacheControl: aws.String("max-age=3600, public"),
+		ContentType:  new(contentType),
+		CacheControl: new("max-age=3600, public"),
 		Metadata: map[string]string{
 			"type":                      "trust-center-reference-logo",
 			"trust-center-reference-id": referenceID.String(),
@@ -434,7 +433,7 @@ func (s TrustCenterReferenceService) cleanupS3Object(ctx context.Context, s3Key 
 	}
 
 	_, _ = s.svc.s3.DeleteObject(ctx, &s3.DeleteObjectInput{
-		Bucket: aws.String(s.svc.bucket),
-		Key:    aws.String(s3Key),
+		Bucket: new(s.svc.bucket),
+		Key:    new(s3Key),
 	})
 }

--- a/pkg/probo/trust_center_service.go
+++ b/pkg/probo/trust_center_service.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"go.gearno.de/crypto/uuid"
 	"go.gearno.de/kit/pg"
@@ -232,10 +231,10 @@ func (s TrustCenterService) UploadNDA(
 
 			_, err := s.svc.s3.PutObject(ctx, &s3.PutObjectInput{
 				Bucket:       &s.svc.bucket,
-				Key:          aws.String(objectKey.String()),
+				Key:          new(objectKey.String()),
 				Body:         req.File,
 				ContentType:  &mimeType,
-				CacheControl: aws.String("private, max-age=3600"),
+				CacheControl: new("private, max-age=3600"),
 				Metadata: map[string]string{
 					"type":            "trust-center-nda",
 					"trust-center-id": req.TrustCenterID.String(),
@@ -247,8 +246,8 @@ func (s TrustCenterService) UploadNDA(
 			}
 
 			headOutput, err := s.svc.s3.HeadObject(ctx, &s3.HeadObjectInput{
-				Bucket: aws.String(s.svc.bucket),
-				Key:    aws.String(objectKey.String()),
+				Bucket: new(s.svc.bucket),
+				Key:    new(objectKey.String()),
 			})
 			if err != nil {
 				return fmt.Errorf("cannot get object metadata: %w", err)
@@ -410,10 +409,10 @@ func (s TrustCenterService) uploadFile(
 
 	_, err = s.svc.s3.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:       &s.svc.bucket,
-		Key:          aws.String(objectKey.String()),
+		Key:          new(objectKey.String()),
 		Body:         fileUpload.Content,
 		ContentType:  &mimeType,
-		CacheControl: aws.String("max-age=3600, public"),
+		CacheControl: new("max-age=3600, public"),
 		Metadata: map[string]string{
 			"type":            fileType,
 			"trust-center-id": trustCenter.ID.String(),
@@ -425,8 +424,8 @@ func (s TrustCenterService) uploadFile(
 	}
 
 	headOutput, err := s.svc.s3.HeadObject(ctx, &s3.HeadObjectInput{
-		Bucket: aws.String(s.svc.bucket),
-		Key:    aws.String(objectKey.String()),
+		Bucket: new(s.svc.bucket),
+		Key:    new(objectKey.String()),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("cannot get object metadata: %w", err)

--- a/pkg/probo/vendor_business_associate_agreement_service.go
+++ b/pkg/probo/vendor_business_associate_agreement_service.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"go.gearno.de/crypto/uuid"
 	"go.gearno.de/kit/pg"
@@ -127,10 +126,10 @@ func (s VendorBusinessAssociateAgreementService) Upload(
 
 			_, err := s.svc.s3.PutObject(ctx, &s3.PutObjectInput{
 				Bucket:       &s.svc.bucket,
-				Key:          aws.String(objectKey.String()),
+				Key:          new(objectKey.String()),
 				Body:         req.File,
 				ContentType:  &mimeType,
-				CacheControl: aws.String("private, max-age=3600"),
+				CacheControl: new("private, max-age=3600"),
 				Metadata: map[string]string{
 					"type":            "vendor-business-associate-agreement",
 					"vendor-id":       vendorID.String(),
@@ -142,8 +141,8 @@ func (s VendorBusinessAssociateAgreementService) Upload(
 			}
 
 			headOutput, err := s.svc.s3.HeadObject(ctx, &s3.HeadObjectInput{
-				Bucket: aws.String(s.svc.bucket),
-				Key:    aws.String(objectKey.String()),
+				Bucket: new(s.svc.bucket),
+				Key:    new(objectKey.String()),
 			})
 			if err != nil {
 				return fmt.Errorf("cannot get object metadata: %w", err)
@@ -259,10 +258,10 @@ func (s VendorBusinessAssociateAgreementService) GenerateFileURL(
 		encodedFilename, encodedFilename)
 
 	presignedReq, err := presignClient.PresignGetObject(ctx, &s3.GetObjectInput{
-		Bucket:                     aws.String(s.svc.bucket),
-		Key:                        aws.String(file.FileKey),
-		ResponseCacheControl:       aws.String("max-age=3600, public"),
-		ResponseContentDisposition: aws.String(contentDisposition),
+		Bucket:                     new(s.svc.bucket),
+		Key:                        new(file.FileKey),
+		ResponseCacheControl:       new("max-age=3600, public"),
+		ResponseContentDisposition: new(contentDisposition),
 	}, func(opts *s3.PresignOptions) {
 		opts.Expires = expiresIn
 	})

--- a/pkg/probo/vendor_data_privacy_agreement_service.go
+++ b/pkg/probo/vendor_data_privacy_agreement_service.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"go.gearno.de/crypto/uuid"
 	"go.gearno.de/kit/pg"
@@ -127,10 +126,10 @@ func (s VendorDataPrivacyAgreementService) Upload(
 			mimeType := mime.TypeByExtension(filepath.Ext(req.FileName))
 			_, err := s.svc.s3.PutObject(ctx, &s3.PutObjectInput{
 				Bucket:       &s.svc.bucket,
-				Key:          aws.String(objectKey.String()),
+				Key:          new(objectKey.String()),
 				Body:         req.File,
 				ContentType:  &mimeType,
-				CacheControl: aws.String("private, max-age=3600"),
+				CacheControl: new("private, max-age=3600"),
 				Metadata: map[string]string{
 					"type":            "vendor-data-privacy-agreement",
 					"vendor-id":       vendorID.String(),
@@ -141,8 +140,8 @@ func (s VendorDataPrivacyAgreementService) Upload(
 				return fmt.Errorf("cannot upload file to S3: %w", err)
 			}
 			headOutput, err := s.svc.s3.HeadObject(ctx, &s3.HeadObjectInput{
-				Bucket: aws.String(s.svc.bucket),
-				Key:    aws.String(objectKey.String()),
+				Bucket: new(s.svc.bucket),
+				Key:    new(objectKey.String()),
 			})
 			if err != nil {
 				return fmt.Errorf("cannot get object metadata: %w", err)
@@ -257,10 +256,10 @@ func (s VendorDataPrivacyAgreementService) GenerateFileURL(
 		encodedFilename, encodedFilename)
 
 	presignedReq, err := presignClient.PresignGetObject(ctx, &s3.GetObjectInput{
-		Bucket:                     aws.String(s.svc.bucket),
-		Key:                        aws.String(file.FileKey),
-		ResponseCacheControl:       aws.String("max-age=3600, public"),
-		ResponseContentDisposition: aws.String(contentDisposition),
+		Bucket:                     new(s.svc.bucket),
+		Key:                        new(file.FileKey),
+		ResponseCacheControl:       new("max-age=3600, public"),
+		ResponseContentDisposition: new(contentDisposition),
 	}, func(opts *s3.PresignOptions) {
 		opts.Expires = expiresIn
 	})

--- a/pkg/server/api/mcp/v1/types/cursorkey.go
+++ b/pkg/server/api/mcp/v1/types/cursorkey.go
@@ -15,7 +15,6 @@
 package types
 
 import (
-	"go.gearno.de/x/ref"
 	"go.probo.inc/probo/pkg/page"
 	"go.probo.inc/probo/pkg/server/gqlutils/types/cursor"
 )
@@ -25,9 +24,9 @@ func NewCursor[O page.OrderField](
 	after *page.CursorKey,
 	orderBy page.OrderBy[O],
 ) *page.Cursor[O] {
-	firstValue := ref.Ref(100)
+	firstValue := new(100)
 	if first != nil {
-		firstValue = ref.Ref(int(*first))
+		firstValue = new(int(*first))
 	}
 
 	return cursor.NewCursor(firstValue, after, nil, nil, orderBy)

--- a/pkg/server/gqlutils/types/pageinfo/pageinfo.go
+++ b/pkg/server/gqlutils/types/pageinfo/pageinfo.go
@@ -15,7 +15,6 @@
 package pageinfo
 
 import (
-	"go.gearno.de/x/ref"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -33,8 +32,8 @@ func NewPageInfo[T page.Paginable[O], O page.OrderField](p *page.Page[T, O]) *Pa
 	)
 
 	if len(p.Data) > 0 {
-		startCursor = ref.Ref(p.First().CursorKey(p.Cursor.OrderBy.Field))
-		endCursor = ref.Ref(p.Last().CursorKey(p.Cursor.OrderBy.Field))
+		startCursor = new(p.First().CursorKey(p.Cursor.OrderBy.Field))
+		endCursor = new(p.Last().CursorKey(p.Cursor.OrderBy.Field))
 	}
 
 	return &PageInfo{

--- a/pkg/trust/organization_service.go
+++ b/pkg/trust/organization_service.go
@@ -20,7 +20,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/coredata"
@@ -127,10 +126,10 @@ func (s OrganizationService) GenerateLogoURL(
 		encodedFilename, encodedFilename)
 
 	presignedReq, err := presignClient.PresignGetObject(ctx, &s3.GetObjectInput{
-		Bucket:                     aws.String(s.svc.bucket),
-		Key:                        aws.String(file.FileKey),
-		ResponseCacheControl:       aws.String("max-age=3600, public"),
-		ResponseContentDisposition: aws.String(contentDisposition),
+		Bucket:                     new(s.svc.bucket),
+		Key:                        new(file.FileKey),
+		ResponseCacheControl:       new("max-age=3600, public"),
+		ResponseContentDisposition: new(contentDisposition),
 	}, func(opts *s3.PresignOptions) {
 		opts.Expires = expiresIn
 	})

--- a/pkg/trust/report_service.go
+++ b/pkg/trust/report_service.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/coredata"
@@ -71,11 +70,11 @@ func (s ReportService) GenerateDownloadURL(
 	presignClient := s3.NewPresignClient(s.svc.s3)
 
 	presignedReq, err := presignClient.PresignGetObject(ctx, &s3.GetObjectInput{
-		Bucket:                     aws.String(s.svc.bucket),
-		Key:                        aws.String(report.ObjectKey),
-		ResponseCacheControl:       aws.String("max-age=3600, public"),
-		ResponseContentType:        aws.String(report.MimeType),
-		ResponseContentDisposition: aws.String(fmt.Sprintf("attachment; filename=\"%s\"", report.Filename)),
+		Bucket:                     new(s.svc.bucket),
+		Key:                        new(report.ObjectKey),
+		ResponseCacheControl:       new("max-age=3600, public"),
+		ResponseContentType:        new(report.MimeType),
+		ResponseContentDisposition: new(fmt.Sprintf("attachment; filename=\"%s\"", report.Filename)),
 	}, func(opts *s3.PresignOptions) {
 		opts.Expires = expiresIn
 	})
@@ -121,8 +120,8 @@ func (s ReportService) exportPDFData(
 	}
 
 	result, err := s.svc.s3.GetObject(ctx, &s3.GetObjectInput{
-		Bucket: aws.String(s.svc.bucket),
-		Key:    aws.String(report.ObjectKey),
+		Bucket: new(s.svc.bucket),
+		Key:    new(report.ObjectKey),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("cannot download PDF from S3: %w", err)

--- a/pkg/trust/trust_center_file_service.go
+++ b/pkg/trust/trust_center_file_service.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/coredata"
@@ -135,8 +134,8 @@ func (s *TrustCenterFileService) exportFileData(
 	}
 
 	result, err := s.svc.s3.GetObject(ctx, &s3.GetObjectInput{
-		Bucket: aws.String(s.svc.bucket),
-		Key:    aws.String(file.FileKey),
+		Bucket: new(s.svc.bucket),
+		Key:    new(file.FileKey),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("cannot download file from S3: %w", err)

--- a/pkg/trust/trust_center_reference_service.go
+++ b/pkg/trust/trust_center_reference_service.go
@@ -20,7 +20,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/coredata"
@@ -87,10 +86,10 @@ func (s TrustCenterReferenceService) GenerateLogoURL(
 		encodedFilename, encodedFilename)
 
 	presignedReq, err := presignClient.PresignGetObject(ctx, &s3.GetObjectInput{
-		Bucket:                     aws.String(s.svc.bucket),
-		Key:                        aws.String(file.FileKey),
-		ResponseCacheControl:       aws.String("max-age=3600, public"),
-		ResponseContentDisposition: aws.String(contentDisposition),
+		Bucket:                     new(s.svc.bucket),
+		Key:                        new(file.FileKey),
+		ResponseCacheControl:       new("max-age=3600, public"),
+		ResponseContentDisposition: new(contentDisposition),
 	}, func(opts *s3.PresignOptions) {
 		opts.Expires = duration
 	})

--- a/pkg/validator/validation_test.go
+++ b/pkg/validator/validation_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"testing"
 
-	"go.gearno.de/x/ref"
 	"go.probo.inc/probo/pkg/mail"
 )
 
@@ -236,7 +235,7 @@ func TestRealWorldExample(t *testing.T) {
 		Email:    "",
 		Password: "123",
 		Age:      15,
-		Website:  ref.Ref("not-a-url"),
+		Website:  new("not-a-url"),
 		Address: Address{
 			City:    "",
 			ZipCode: "12345",

--- a/pkg/validator/validator_numeric_test.go
+++ b/pkg/validator/validator_numeric_test.go
@@ -16,8 +16,6 @@ package validator
 
 import (
 	"testing"
-
-	"go.gearno.de/x/ref"
 )
 
 func TestMin(t *testing.T) {
@@ -30,7 +28,7 @@ func TestMin(t *testing.T) {
 		{"valid int", 10, 5, false},
 		{"exact min", 5, 5, false},
 		{"below min", 3, 5, true},
-		{"valid int pointer", ref.Ref(10), 5, false},
+		{"valid int pointer", new(10), 5, false},
 		{"nil pointer", (*int)(nil), 5, false}, // Skip validation
 		{"non-numeric", "test", 5, true},
 	}
@@ -55,7 +53,7 @@ func TestMax(t *testing.T) {
 		{"valid int", 5, 10, false},
 		{"exact max", 10, 10, false},
 		{"above max", 15, 10, true},
-		{"valid int pointer", ref.Ref(5), 10, false},
+		{"valid int pointer", new(5), 10, false},
 		{"nil pointer", (*int)(nil), 10, false}, // Skip validation
 	}
 

--- a/pkg/validator/validator_string_test.go
+++ b/pkg/validator/validator_string_test.go
@@ -16,8 +16,6 @@ package validator
 
 import (
 	"testing"
-
-	"go.gearno.de/x/ref"
 )
 
 func TestMinLen(t *testing.T) {
@@ -31,7 +29,7 @@ func TestMinLen(t *testing.T) {
 		{"exact length", "hello", 5, false},
 		{"too short", "hi", 5, true},
 		{"nil pointer", (*string)(nil), 5, false}, // Skip validation
-		{"valid pointer", ref.Ref("hello"), 3, false},
+		{"valid pointer", new("hello"), 3, false},
 		{"non-string", 123, 5, true},
 	}
 
@@ -56,7 +54,7 @@ func TestMaxLen(t *testing.T) {
 		{"exact length", "hello", 5, false},
 		{"too long", "hello world", 5, true},
 		{"nil pointer", (*string)(nil), 5, false}, // Skip validation
-		{"valid pointer", ref.Ref("hi"), 5, false},
+		{"valid pointer", new("hi"), 5, false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Cache-Control headers to S3 uploads and presigned URLs to enable 1-hour caching and reduce repeated downloads. Addresses Linear ENG-99 by making asset downloads cacheable and faster.

- **New Features**
  - Set CacheControl on uploads: private assets use "private, max-age=3600"; public assets (logos, exports, email assets) use "max-age=3600, public".
  - Add ResponseCacheControl to presigned URLs so browsers cache downloads for 1 hour.

- **Refactors**
  - Replace aws.String and ref.Ref with concise pointer helpers across S3 calls.
  - Remove unused ref imports and update tests accordingly.

<sup>Written for commit d4b30254638c0b2e98d8e9802d78a535dc20335b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

