### PR TITLE
Remove people table

### DIFF
--- a/pkg/coredata/migrations/20260306T120000Z.sql
+++ b/pkg/coredata/migrations/20260306T120000Z.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS peoples;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Drop the unused peoples table to clean up the schema. Adds a safe migration (DROP TABLE IF EXISTS) to satisfy ENG-151.

<sup>Written for commit eca919b12ab1d34f1af7e7461b972172f3e05551. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

