### PR TITLE
Fix person update

### DIFF
--- a/apps/console/src/pages/iam/organizations/people/_components/PersonForm.tsx
+++ b/apps/console/src/pages/iam/organizations/people/_components/PersonForm.tsx
@@ -124,10 +124,8 @@ export function PersonForm(props: {
     },
   );
   const handleSubmit = handleSubmitWrapper(async (data: z.infer<typeof schema>) => {
-    const input = {
+    const sharedInput = {
       fullName: data.fullName,
-      emailAddress: data.emailAddress,
-      role: data.role,
       additionalEmailAddresses: data.additionalEmailAddresses,
       kind: data.kind,
       position: data.position,
@@ -137,7 +135,7 @@ export function PersonForm(props: {
 
     if (id) {
       await updatePerson({
-        variables: { input: { ...input, id } },
+        variables: { input: { ...sharedInput, id } },
         onCompleted: () => {
           reset(data);
           onSubmit?.();
@@ -146,7 +144,12 @@ export function PersonForm(props: {
     } else {
       await createPerson({
         variables: {
-          input: { ...input, organizationId },
+          input: {
+            ...sharedInput,
+            emailAddress: data.emailAddress,
+            role: data.role,
+            organizationId,
+          },
           connections: [connectionId],
         },
         onCompleted: () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the person edit flow by excluding read-only fields from update requests and using a shared input for common fields. Create still includes required fields, so both paths work without errors.

- **Bug Fixes**
  - Use a shared input for common fields in `PersonForm`.
  - For updates: send only shared fields + `id` (exclude `emailAddress` and `role`).
  - For creates: include `emailAddress`, `role`, `organizationId`, and `connections`.

<sup>Written for commit 40e71489d8304c02a42ad2628232e8e9d601ffd4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

