### PR TITLE
Fix compliance report

### DIFF
--- a/pkg/coredata/vendor_compliance_report.go
+++ b/pkg/coredata/vendor_compliance_report.go
@@ -80,6 +80,7 @@ func (vcs *VendorComplianceReports) LoadForVendorID(
 	q := `
 SELECT
 	id,
+	organization_id,
 	vendor_id,
 	report_date,
 	valid_until,
@@ -127,6 +128,7 @@ func (vcr *VendorComplianceReport) LoadByID(
 	q := `
 SELECT
 	id,
+	organization_id,
 	vendor_id,
 	report_date,
 	valid_until,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Include organization_id in compliance report queries so reports load with the correct org context. Fixes missing organization data when fetching reports by vendor or ID.

- **Bug Fixes**
  - Added organization_id to SELECT in LoadForVendorID and LoadByID queries to populate the field correctly.

<sup>Written for commit a3bb901d59c99893e34d67327f8904306d6e3474. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

