### PR TITLE
Fix profiles default filter

### DIFF
--- a/pkg/iam/scim/filter.go
+++ b/pkg/iam/scim/filter.go
@@ -25,7 +25,7 @@ import (
 )
 
 func ParseUserFilter(expr scimfilter.Expression) (*coredata.MembershipProfileFilter, error) {
-	filter := coredata.NewMembershipProfileFilter(nil)
+	filter := coredata.NewMembershipProfileFilter(nil).WithMembership()
 
 	if expr == nil {
 		return filter, nil

--- a/pkg/server/api/connect/v1/v1_resolver.go
+++ b/pkg/server/api/connect/v1/v1_resolver.go
@@ -38,9 +38,9 @@ func (r *identityResolver) Profiles(ctx context.Context, obj *types.Identity, fi
 		return nil, err
 	}
 
-	filters := coredata.NewMembershipProfileFilter(nil)
+	filters := coredata.NewMembershipProfileFilter(nil).WithMembership()
 	if filter != nil {
-		filters = coredata.NewMembershipProfileFilter(filter.ExcludeContractEnded)
+		filters = coredata.NewMembershipProfileFilter(filter.ExcludeContractEnded).WithMembership()
 		if filter.State != nil {
 			filters.WithState(*filter.State)
 		}
@@ -1184,8 +1184,7 @@ func (r *organizationResolver) Profiles(ctx context.Context, obj *types.Organiza
 		return nil, err
 	}
 
-	filter := coredata.NewMembershipProfileFilter(nil)
-	filter = filter.WithMembership()
+	filter := coredata.NewMembershipProfileFilter(nil).WithMembership()
 
 	if gqlutils.OnlyTotalCountSelected(ctx) {
 		return &types.ProfileConnection{

--- a/pkg/server/api/console/v1/v1_resolver.go
+++ b/pkg/server/api/console/v1/v1_resolver.go
@@ -5674,9 +5674,9 @@ func (r *organizationResolver) Profiles(ctx context.Context, obj *types.Organiza
 		}, nil
 	}
 
-	filters := coredata.NewMembershipProfileFilter(nil)
+	filters := coredata.NewMembershipProfileFilter(nil).WithMembership()
 	if filter != nil {
-		filters = coredata.NewMembershipProfileFilter(filter.ExcludeContractEnded)
+		filters = coredata.NewMembershipProfileFilter(filter.ExcludeContractEnded).WithMembership()
 	}
 
 	pageOrderBy := page.OrderBy[coredata.MembershipProfileOrderField]{

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -2754,9 +2754,9 @@ func (r *Resolver) ListUsersTool(ctx context.Context, req *mcp.CallToolRequest, 
 	}
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	filter := coredata.NewMembershipProfileFilter(nil)
+	filter := coredata.NewMembershipProfileFilter(nil).WithMembership()
 	if input.Filter != nil {
-		filter = coredata.NewMembershipProfileFilter(input.Filter.ExcludeContractEnded)
+		filter = coredata.NewMembershipProfileFilter(input.Filter.ExcludeContractEnded).WithMembership()
 	}
 
 	pageResult, err := r.iamSvc.OrganizationService.ListProfiles(ctx, input.OrganizationID, cursor, filter)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Defaulted profile queries to membership-scoped results by applying `.WithMembership()` to the filter when none is provided. This fixes incorrect or broad results across profile endpoints.

- **Bug Fixes**
  - Apply `.WithMembership()` by default in `connect` v1, `console` v1, and `mcp` v1 resolvers, and in SCIM `ParseUserFilter`.
  - Keep `ExcludeContractEnded` and `State` options when provided.
  - Ensures profile lists return membership-scoped results out of the box.

<sup>Written for commit 17c9f2eded8a6dde5090f6e6ce9ff7c0745390e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

