### PR TITLE
Remove useless encryption key injections

### DIFF
--- a/pkg/certmanager/acme_challenge_handler.go
+++ b/pkg/certmanager/acme_challenge_handler.go
@@ -22,24 +22,20 @@ import (
 	"go.gearno.de/kit/log"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/coredata"
-	"go.probo.inc/probo/pkg/crypto/cipher"
 )
 
 type ACMEChallengeHandler struct {
-	pg            *pg.Client
-	encryptionKey cipher.EncryptionKey
-	logger        *log.Logger
+	pg     *pg.Client
+	logger *log.Logger
 }
 
 func NewACMEChallengeHandler(
 	pg *pg.Client,
-	encryptionKey cipher.EncryptionKey,
 	logger *log.Logger,
 ) *ACMEChallengeHandler {
 	return &ACMEChallengeHandler{
-		pg:            pg,
-		encryptionKey: encryptionKey,
-		logger:        logger.Named("certmanager.acme-challenge-handler"),
+		pg:     pg,
+		logger: logger.Named("certmanager.acme-challenge-handler"),
 	}
 }
 
@@ -82,7 +78,7 @@ func (h *ACMEChallengeHandler) getKeyAuthForToken(ctx context.Context, token str
 		ctx,
 		func(conn pg.Conn) error {
 			domain := &coredata.CustomDomain{}
-			if err := domain.LoadByHTTPChallengeToken(ctx, conn, coredata.NewNoScope(), h.encryptionKey, token); err != nil {
+			if err := domain.LoadByHTTPChallengeToken(ctx, conn, coredata.NewNoScope(), token); err != nil {
 				return err
 			}
 

--- a/pkg/certmanager/cache_store.go
+++ b/pkg/certmanager/cache_store.go
@@ -53,7 +53,7 @@ func (w *CacheStore) WarmCache(ctx context.Context) error {
 		ctx,
 		func(conn pg.Conn) error {
 			domains := coredata.CustomDomains{}
-			if err := domains.LoadActiveCertificates(ctx, conn, coredata.NewNoScope(), w.encryptionKey); err != nil {
+			if err := domains.LoadActiveCertificates(ctx, conn, coredata.NewNoScope()); err != nil {
 				return fmt.Errorf("cannot load active certificates: %w", err)
 			}
 
@@ -95,7 +95,7 @@ func (w *CacheStore) WarmCache(ctx context.Context) error {
 
 func (w *CacheStore) warmDomain(ctx context.Context, conn pg.Conn, domain *coredata.CustomDomain) error {
 	var loadedDomain coredata.CustomDomain
-	if err := loadedDomain.LoadByID(ctx, conn, coredata.NewNoScope(), w.encryptionKey, domain.ID); err != nil {
+	if err := loadedDomain.LoadByID(ctx, conn, coredata.NewNoScope(), domain.ID); err != nil {
 		return fmt.Errorf("cannot load domain with decrypted values: %w", err)
 	}
 
@@ -162,7 +162,7 @@ func (w *CacheStore) WarmSingleDomain(ctx context.Context, domainName string) er
 		ctx,
 		func(conn pg.Conn) error {
 			var domain coredata.CustomDomain
-			if err := domain.LoadByDomain(ctx, conn, coredata.NewNoScope(), w.encryptionKey, domainName); err != nil {
+			if err := domain.LoadByDomain(ctx, conn, coredata.NewNoScope(), domainName); err != nil {
 				return fmt.Errorf("cannot load domain: %w", err)
 			}
 

--- a/pkg/certmanager/provisioner.go
+++ b/pkg/certmanager/provisioner.go
@@ -224,7 +224,7 @@ func (p *Provisioner) resetStaleDomain(
 	domain *coredata.CustomDomain,
 ) error {
 	fullDomain := &coredata.CustomDomain{}
-	if err := fullDomain.LoadByIDForUpdateSkipLocked(ctx, tx, coredata.NewNoScope(), p.encryptionKey, domain.ID); err != nil {
+	if err := fullDomain.LoadByIDForUpdateSkipLocked(ctx, tx, coredata.NewNoScope(), domain.ID); err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil
 		}
@@ -260,7 +260,7 @@ func (p *Provisioner) resetStaleDomain(
 		fullDomain.SSLLastAttemptAt = nil
 	}
 
-	if err := fullDomain.Update(ctx, tx, coredata.NewNoScope(), p.encryptionKey); err != nil {
+	if err := fullDomain.Update(ctx, tx, coredata.NewNoScope()); err != nil {
 		return fmt.Errorf("cannot update stale domain: %w", err)
 	}
 
@@ -273,7 +273,7 @@ func (p *Provisioner) provisionDomainCertificate(
 	domainID gid.GID,
 ) error {
 	domain := &coredata.CustomDomain{}
-	if err := domain.LoadByIDForUpdateSkipLocked(ctx, tx, coredata.NewNoScope(), p.encryptionKey, domainID); err != nil {
+	if err := domain.LoadByIDForUpdateSkipLocked(ctx, tx, coredata.NewNoScope(), domainID); err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil
 		}
@@ -312,7 +312,7 @@ func (p *Provisioner) provisionDomainCertificate(
 		domain.HTTPOrderURL = &challenge.OrderURL
 		domain.SSLStatus = coredata.CustomDomainSSLStatusProvisioning
 
-		if err := domain.Update(ctx, tx, coredata.NewNoScope(), p.encryptionKey); err != nil {
+		if err := domain.Update(ctx, tx, coredata.NewNoScope()); err != nil {
 			return fmt.Errorf("cannot update domain with challenge: %w", err)
 		}
 
@@ -362,7 +362,7 @@ func (p *Provisioner) provisionDomainCertificate(
 			domain.HTTPOrderURL = nil
 		}
 
-		if err := domain.Update(ctx, tx, coredata.NewNoScope(), p.encryptionKey); err != nil {
+		if err := domain.Update(ctx, tx, coredata.NewNoScope()); err != nil {
 			return fmt.Errorf("cannot update domain: %w", err)
 		}
 
@@ -393,7 +393,7 @@ func (p *Provisioner) provisionDomainCertificate(
 	domain.HTTPChallengeURL = nil
 	domain.HTTPOrderURL = nil
 
-	if err := domain.Update(ctx, tx, coredata.NewNoScope(), p.encryptionKey); err != nil {
+	if err := domain.Update(ctx, tx, coredata.NewNoScope()); err != nil {
 		return fmt.Errorf("cannot update domain: %w", err)
 	}
 

--- a/pkg/certmanager/renewer.go
+++ b/pkg/certmanager/renewer.go
@@ -130,7 +130,7 @@ func (r *Renewer) checkAndRenew(ctx context.Context) error {
 
 func (r *Renewer) renewDomain(ctx context.Context, tx pg.Conn, domainID gid.GID) error {
 	domain := &coredata.CustomDomain{}
-	if err := domain.LoadByIDForUpdateSkipLocked(ctx, tx, coredata.NewNoScope(), r.encryptionKey, domainID); err != nil {
+	if err := domain.LoadByIDForUpdateSkipLocked(ctx, tx, coredata.NewNoScope(), domainID); err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil
 		}
@@ -149,7 +149,7 @@ func (r *Renewer) renewDomain(ctx context.Context, tx pg.Conn, domainID gid.GID)
 	}
 
 	domain.SSLStatus = coredata.CustomDomainSSLStatusRenewing
-	if err := domain.Update(ctx, tx, coredata.NewNoScope(), r.encryptionKey); err != nil {
+	if err := domain.Update(ctx, tx, coredata.NewNoScope()); err != nil {
 		return fmt.Errorf("cannot update domain status: %w", err)
 	}
 

--- a/pkg/certmanager/selector.go
+++ b/pkg/certmanager/selector.go
@@ -116,7 +116,7 @@ func (s *Selector) loadFromDatabase(domain string) (*tls.Certificate, error) {
 
 func (s *Selector) rebuildCacheEntry(ctx context.Context, conn pg.Conn, domain string) error {
 	var customDomain coredata.CustomDomain
-	if err := customDomain.LoadByDomain(ctx, conn, coredata.NewNoScope(), s.encryptionKey, domain); err != nil {
+	if err := customDomain.LoadByDomain(ctx, conn, coredata.NewNoScope(), domain); err != nil {
 		return fmt.Errorf("cannot load domain: %w", err)
 	}
 

--- a/pkg/coredata/custom_domain.go
+++ b/pkg/coredata/custom_domain.go
@@ -153,7 +153,6 @@ func (cd *CustomDomain) LoadByID(
 	ctx context.Context,
 	conn pg.Conn,
 	scope Scoper,
-	encryptionKey cipher.EncryptionKey,
 	domainID gid.GID,
 ) error {
 	q := `
@@ -210,7 +209,6 @@ func (cd *CustomDomain) LoadByIDForUpdateSkipLocked(
 	ctx context.Context,
 	conn pg.Conn,
 	scope Scoper,
-	encryptionKey cipher.EncryptionKey,
 	domainID gid.GID,
 ) error {
 	q := `
@@ -267,7 +265,6 @@ func (cd *CustomDomain) LoadByDomain(
 	ctx context.Context,
 	conn pg.Conn,
 	scope Scoper,
-	encryptionKey cipher.EncryptionKey,
 	domain string,
 ) error {
 	q := `
@@ -324,7 +321,6 @@ func (cd *CustomDomain) LoadByOrganizationID(
 	ctx context.Context,
 	conn pg.Conn,
 	scope Scoper,
-	encryptionKey cipher.EncryptionKey,
 	organizationID gid.GID,
 ) error {
 	q := `
@@ -468,7 +464,6 @@ func (cd *CustomDomain) Update(
 	ctx context.Context,
 	conn pg.Conn,
 	scope Scoper,
-	encryptionKey cipher.EncryptionKey,
 ) error {
 	var encryptedKey []byte
 	if len(cd.EncryptedSSLPrivateKey) > 0 {
@@ -554,7 +549,6 @@ func (cd *CustomDomain) LoadByHTTPChallengeToken(
 	ctx context.Context,
 	conn pg.Conn,
 	scope Scoper,
-	encryptionKey cipher.EncryptionKey,
 	token string,
 ) error {
 	q := `
@@ -714,7 +708,6 @@ func (domains *CustomDomains) LoadActiveCertificates(
 	ctx context.Context,
 	conn pg.Conn,
 	scope Scoper,
-	encryptionKey cipher.EncryptionKey,
 ) error {
 	q := `
 SELECT

--- a/pkg/iam/compliance_page_service.go
+++ b/pkg/iam/compliance_page_service.go
@@ -114,7 +114,7 @@ func (s *CompliancePageService) EmailPresenterConfig(ctx context.Context, compli
 			}
 
 			customDomain = &coredata.CustomDomain{}
-			if err := customDomain.LoadByOrganizationID(ctx, conn, scope, s.encryptionKey, organization.ID); err != nil {
+			if err := customDomain.LoadByOrganizationID(ctx, conn, scope, organization.ID); err != nil {
 				if !errors.Is(err, coredata.ErrResourceNotFound) {
 					return fmt.Errorf("cannot load custom domain: %w", err)
 				}

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -1900,35 +1900,6 @@ func (s OrganizationService) GetSCIMBridgeByID(ctx context.Context, bridgeID gid
 	return bridge, nil
 }
 
-func (s OrganizationService) GetConnectorByID(ctx context.Context, connectorID gid.GID) (*coredata.Connector, error) {
-	var (
-		scope     = coredata.NewScopeFromObjectID(connectorID)
-		connector = &coredata.Connector{}
-	)
-
-	err := s.pg.WithConn(
-		ctx,
-		func(conn pg.Conn) error {
-			err := connector.LoadByID(ctx, conn, scope, connectorID, s.encryptionKey)
-			if err != nil {
-				if err == coredata.ErrResourceNotFound {
-					return NewConnectorNotFoundError(connectorID)
-				}
-
-				return fmt.Errorf("cannot load connector: %w", err)
-			}
-
-			return nil
-		},
-	)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return connector, nil
-}
-
 // GetConnectorMetadataByID returns connector metadata without decrypting the connection.
 // Use this when you only need provider, organization, or other metadata fields.
 func (s OrganizationService) GetConnectorMetadataByID(ctx context.Context, connectorID gid.GID) (*coredata.Connector, error) {

--- a/pkg/iam/saml/service.go
+++ b/pkg/iam/saml/service.go
@@ -31,18 +31,16 @@ import (
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/baseurl"
 	"go.probo.inc/probo/pkg/coredata"
-	"go.probo.inc/probo/pkg/crypto/cipher"
 	"go.probo.inc/probo/pkg/gid"
 )
 
 type (
 	Service struct {
-		pg            *pg.Client
-		encryptionKey cipher.EncryptionKey
-		baseURL       string
-		certificate   *x509.Certificate
-		privateKey    *rsa.PrivateKey
-		logger        *log.Logger
+		pg          *pg.Client
+		baseURL     string
+		certificate *x509.Certificate
+		privateKey  *rsa.PrivateKey
+		logger      *log.Logger
 	}
 
 	UserInfo struct {
@@ -57,19 +55,17 @@ type (
 
 func NewService(
 	pg *pg.Client,
-	encryptionKey cipher.EncryptionKey,
 	baseURL string,
 	certificate *x509.Certificate,
 	privateKey *rsa.PrivateKey,
 	logger *log.Logger,
 ) (*Service, error) {
 	return &Service{
-		pg:            pg,
-		encryptionKey: encryptionKey,
-		baseURL:       baseURL,
-		certificate:   certificate,
-		privateKey:    privateKey,
-		logger:        logger,
+		pg:          pg,
+		baseURL:     baseURL,
+		certificate: certificate,
+		privateKey:  privateKey,
+		logger:      logger,
 	}, nil
 }
 

--- a/pkg/iam/service.go
+++ b/pkg/iam/service.go
@@ -28,7 +28,6 @@ type (
 		pg                         *pg.Client
 		fm                         *filemanager.Service
 		hp                         *passwdhash.Profile
-		encryptionKey              cipher.EncryptionKey
 		baseURL                    string
 		tokenSecret                string
 		disableSignup              bool
@@ -127,7 +126,7 @@ func NewService(
 	svc.Authorizer = NewAuthorizer(pgClient)
 	svc.Authorizer.RegisterPolicySet(IAMPolicySet())
 
-	samlService, err := saml.NewService(svc.pg, svc.encryptionKey, svc.baseURL, svc.certificate, svc.privateKey, cfg.Logger)
+	samlService, err := saml.NewService(svc.pg, svc.baseURL, svc.certificate, svc.privateKey, cfg.Logger)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create SAML service: %w", err)
 	}

--- a/pkg/probo/custom_domain_service.go
+++ b/pkg/probo/custom_domain_service.go
@@ -122,7 +122,7 @@ func (s *CustomDomainService) DeleteCustomDomain(
 			}
 
 			domain := &coredata.CustomDomain{}
-			if err := domain.LoadByID(ctx, tx, s.svc.scope, s.encryptionKey, *org.CustomDomainID); err != nil {
+			if err := domain.LoadByID(ctx, tx, s.svc.scope, *org.CustomDomainID); err != nil {
 				return fmt.Errorf("cannot load domain: %w", err)
 			}
 
@@ -159,7 +159,7 @@ func (s *CustomDomainService) GetOrganizationCustomDomain(
 			}
 
 			domain = &coredata.CustomDomain{}
-			if err := domain.LoadByID(ctx, conn, s.svc.scope, s.encryptionKey, *org.CustomDomainID); err != nil {
+			if err := domain.LoadByID(ctx, conn, s.svc.scope, *org.CustomDomainID); err != nil {
 				return fmt.Errorf("cannot load custom domain: %w", err)
 			}
 

--- a/pkg/probo/service.go
+++ b/pkg/probo/service.go
@@ -399,7 +399,7 @@ func (s *Service) LoadOrganizationByDomain(ctx context.Context, domain string) (
 		ctx,
 		func(conn pg.Conn) error {
 			var customDomain coredata.CustomDomain
-			if err := customDomain.LoadByDomain(ctx, conn, coredata.NewNoScope(), s.encryptionKey, domain); err != nil {
+			if err := customDomain.LoadByDomain(ctx, conn, coredata.NewNoScope(), domain); err != nil {
 				return fmt.Errorf("cannot load custom domain: %w", err)
 			}
 

--- a/pkg/probo/trust_center_service.go
+++ b/pkg/probo/trust_center_service.go
@@ -617,7 +617,7 @@ func (s *TrustCenterService) EmailPresenterConfig(ctx context.Context, complianc
 			}
 
 			customDomain = &coredata.CustomDomain{}
-			if err := customDomain.LoadByOrganizationID(ctx, conn, scope, s.svc.encryptionKey, organization.ID); err != nil {
+			if err := customDomain.LoadByOrganizationID(ctx, conn, scope, organization.ID); err != nil {
 				if !errors.Is(err, coredata.ErrResourceNotFound) {
 					return fmt.Errorf("cannot load custom domain: %w", err)
 				}

--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -422,7 +422,6 @@ func (impl *Implm) Run(
 		pgClient,
 		impl.cfg.GetSlackSigningSecret(),
 		baseURL.String(),
-		encryptionKey,
 		impl.cfg.Auth.Cookie.Secret,
 		l.Named("slack"),
 	)
@@ -462,7 +461,6 @@ func (impl *Implm) Run(
 		s3Client,
 		impl.cfg.AWS.Bucket,
 		baseURL.String(),
-		encryptionKey,
 		impl.cfg.GetSlackSigningSecret(),
 		iamService,
 		esignService,
@@ -817,7 +815,6 @@ func (impl *Implm) runTrustCenterServer(
 
 	httpACMEHandler := certmanager.NewACMEChallengeHandler(
 		pgClient,
-		encryptionKey,
 		l.Named("http_acme_handler"),
 	)
 
@@ -863,7 +860,6 @@ func (impl *Implm) runTrustCenterServer(
 
 	acmeHandler := certmanager.NewACMEChallengeHandler(
 		pgClient,
-		encryptionKey,
 		l.Named("acme_handler"),
 	)
 

--- a/pkg/slack/service.go
+++ b/pkg/slack/service.go
@@ -7,7 +7,6 @@ import (
 	"go.gearno.de/kit/log"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/coredata"
-	"go.probo.inc/probo/pkg/crypto/cipher"
 	"go.probo.inc/probo/pkg/gid"
 )
 
@@ -16,7 +15,6 @@ type Service struct {
 	logger             *log.Logger
 	slackSigningSecret string
 	baseURL            string
-	encryptionKey      cipher.EncryptionKey
 	tokenSecret        string
 }
 
@@ -25,7 +23,6 @@ type TenantService struct {
 	scope         coredata.Scoper
 	logger        *log.Logger
 	baseURL       string
-	encryptionKey cipher.EncryptionKey
 	tokenSecret   string
 	SlackMessages *SlackMessageService
 }
@@ -34,7 +31,6 @@ func NewService(
 	pg *pg.Client,
 	slackSigningSecret string,
 	baseURL string,
-	encryptionKey cipher.EncryptionKey,
 	tokenSecret string,
 	logger *log.Logger,
 ) *Service {
@@ -43,19 +39,17 @@ func NewService(
 		logger:             logger,
 		slackSigningSecret: slackSigningSecret,
 		baseURL:            baseURL,
-		encryptionKey:      encryptionKey,
 		tokenSecret:        tokenSecret,
 	}
 }
 
 func (s *Service) WithTenant(tenantID gid.TenantID) *TenantService {
 	tenantService := &TenantService{
-		pg:            s.pg,
-		scope:         coredata.NewScope(tenantID),
-		logger:        s.logger,
-		baseURL:       s.baseURL,
-		encryptionKey: s.encryptionKey,
-		tokenSecret:   s.tokenSecret,
+		pg:          s.pg,
+		scope:       coredata.NewScope(tenantID),
+		logger:      s.logger,
+		baseURL:     s.baseURL,
+		tokenSecret: s.tokenSecret,
 	}
 	tenantService.SlackMessages = &SlackMessageService{svc: tenantService}
 

--- a/pkg/trust/organization_service.go
+++ b/pkg/trust/organization_service.go
@@ -79,7 +79,7 @@ func (s OrganizationService) GetOrganizationCustomDomain(
 			}
 
 			domain = &coredata.CustomDomain{}
-			if err := domain.LoadByID(ctx, conn, s.svc.scope, s.svc.encryptionKey, *org.CustomDomainID); err != nil {
+			if err := domain.LoadByID(ctx, conn, s.svc.scope, *org.CustomDomainID); err != nil {
 				return fmt.Errorf("cannot load custom domain: %w", err)
 			}
 

--- a/pkg/trust/service.go
+++ b/pkg/trust/service.go
@@ -24,7 +24,6 @@ import (
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/packages/emails"
 	"go.probo.inc/probo/pkg/coredata"
-	"go.probo.inc/probo/pkg/crypto/cipher"
 	"go.probo.inc/probo/pkg/esign"
 	"go.probo.inc/probo/pkg/filemanager"
 	"go.probo.inc/probo/pkg/gid"
@@ -40,7 +39,6 @@ type (
 		s3                 *s3.Client
 		bucket             string
 		proboSvc           *probo.Service
-		encryptionKey      cipher.EncryptionKey
 		slackSigningSecret string
 		baseURL            string
 		iam                *iam.Service
@@ -57,7 +55,6 @@ type (
 		bucket                string
 		scope                 coredata.Scoper
 		proboSvc              *probo.Service
-		encryptionKey         cipher.EncryptionKey
 		baseURL               string
 		iam                   *iam.Service
 		esign                 *esign.Service
@@ -84,7 +81,6 @@ func NewService(
 	s3Client *s3.Client,
 	bucket string,
 	baseURL string,
-	encryptionKey cipher.EncryptionKey,
 	slackSigningSecret string,
 	iam *iam.Service,
 	esignSvc *esign.Service,
@@ -97,7 +93,6 @@ func NewService(
 		pg:                 pgClient,
 		s3:                 s3Client,
 		bucket:             bucket,
-		encryptionKey:      encryptionKey,
 		slackSigningSecret: slackSigningSecret,
 		baseURL:            baseURL,
 		iam:                iam,
@@ -116,7 +111,6 @@ func (s *Service) WithTenant(tenantID gid.TenantID) *TenantService {
 		bucket:            s.bucket,
 		scope:             coredata.NewScope(tenantID),
 		proboSvc:          s.proboSvc,
-		encryptionKey:     s.encryptionKey,
 		baseURL:           s.baseURL,
 		iam:               s.iam,
 		esign:             s.esign,
@@ -204,7 +198,7 @@ func (s *Service) GetByDomainName(ctx context.Context, domain string) (*coredata
 		ctx,
 		func(conn pg.Conn) error {
 			var customDomain coredata.CustomDomain
-			if err := customDomain.LoadByDomain(ctx, conn, coredata.NewNoScope(), s.encryptionKey, domain); err != nil {
+			if err := customDomain.LoadByDomain(ctx, conn, coredata.NewNoScope(), domain); err != nil {
 				if errors.Is(err, coredata.ErrResourceNotFound) {
 					return ErrPageNotFound
 				}
@@ -247,7 +241,7 @@ func (s *Service) GetCustomDomainByOrganizationID(ctx context.Context, organizat
 	err := s.pg.WithConn(
 		ctx,
 		func(conn pg.Conn) error {
-			return customDomain.LoadByOrganizationID(ctx, conn, coredata.NewNoScope(), s.encryptionKey, organizationID)
+			return customDomain.LoadByOrganizationID(ctx, conn, coredata.NewNoScope(), organizationID)
 		},
 	)
 	if err != nil {

--- a/pkg/trust/trust_center_service.go
+++ b/pkg/trust/trust_center_service.go
@@ -274,7 +274,7 @@ func (s *TrustCenterService) EmailPresenterConfig(ctx context.Context, complianc
 			}
 
 			customDomain = &coredata.CustomDomain{}
-			if err := customDomain.LoadByOrganizationID(ctx, conn, scope, s.svc.encryptionKey, organization.ID); err != nil {
+			if err := customDomain.LoadByOrganizationID(ctx, conn, scope, organization.ID); err != nil {
 				if !errors.Is(err, coredata.ErrResourceNotFound) {
 					return fmt.Errorf("cannot load custom domain: %w", err)
 				}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed unnecessary `cipher.EncryptionKey` injections across services and `coredata.CustomDomain` APIs to simplify constructors and method signatures with no behavior change.

- **Refactors**
  - Removed `encryptionKey` param from `coredata.CustomDomain` loaders and `Update` (e.g., `LoadByID`, `LoadByDomain`, `LoadByOrganizationID`, `LoadByHTTPChallengeToken`, `LoadActiveCertificates`, `LoadByIDForUpdateSkipLocked`).
  - Updated `certmanager` (`ACMEChallengeHandler`, `CacheStore`, `Provisioner`, `Renewer`, `Selector`) for new `CustomDomain` signatures; `ACMEChallengeHandler` no longer takes an encryption key.
  - Simplified `saml.NewService`, `slack.NewService`, and `trust.NewService` constructors by dropping the encryption key arg; removed unused struct fields and wiring (including in `probod`).
  - Cleaned up `probo`, `trust`, and `iam` call sites; removed `GetConnectorByID` in `iam.OrganizationService` that relied on the old decryption path.

<sup>Written for commit 87415c032442b3e37cac5609b0df4042680ed721. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

