### PR TITLE
Remove FKs referencing peoples and table

### DIFF
--- a/pkg/coredata/migrations/20260311T164306Z.sql
+++ b/pkg/coredata/migrations/20260311T164306Z.sql
@@ -1,0 +1,44 @@
+ALTER TABLE
+    assets DROP COLUMN owner_id;
+
+ALTER TABLE
+    continual_improvements DROP COLUMN owner_id;
+
+ALTER TABLE
+    data DROP COLUMN owner_id;
+
+ALTER TABLE
+    document_versions DROP COLUMN owner_id;
+
+ALTER TABLE
+    meeting_attendees DROP COLUMN attendee_id;
+
+ALTER TABLE
+    nonconformities DROP COLUMN owner_id;
+
+ALTER TABLE
+    obligations DROP COLUMN owner_id;
+
+ALTER TABLE
+    documents DROP COLUMN owner_id;
+
+ALTER TABLE
+    document_version_signatures DROP COLUMN signed_by;
+
+ALTER TABLE
+    processing_activities DROP COLUMN data_protection_officer_id;
+
+ALTER TABLE
+    risks DROP COLUMN owner_id;
+
+ALTER TABLE
+    states_of_applicability DROP COLUMN owner_id;
+
+ALTER TABLE
+    tasks DROP COLUMN assigned_to;
+
+ALTER TABLE
+    vendors DROP COLUMN business_owner_id,
+    DROP COLUMN security_owner_id;
+
+DROP TABLE peoples;


### PR DESCRIPTION
Closes ENG-151

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed all columns that referenced the `peoples` table and dropped `peoples` to simplify the schema and remove unused relationships. This is a destructive migration that cleans up legacy FKs across multiple tables.

- **Migration**
  - Remove any app code that reads/writes the deleted columns (e.g., `owner_id`, `assigned_to`, `signed_by`).
  - Plan a maintenance window; this migration drops data in those columns and the `peoples` table.

<sup>Written for commit 87fcf96ff15c6f8b2d9a671cfbb1f7293fb85bfc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

