### PR TITLE
Fix compliance update display

### DIFF
--- a/apps/trust/src/components/Skeletons/MainSkeleton.tsx
+++ b/apps/trust/src/components/Skeletons/MainSkeleton.tsx
@@ -16,6 +16,7 @@ export function MainSkeleton() {
           <TabLink to={getTrustCenterUrl("subprocessors")}>
             {__("Subprocessors")}
           </TabLink>
+          <TabLink to={getTrustCenterUrl("updates")}>{__("Updates")}</TabLink>
         </Tabs>
         <TabSkeleton />
       </main>

--- a/apps/trust/src/pages/UpdatesPage.tsx
+++ b/apps/trust/src/pages/UpdatesPage.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { type PreloadedQuery, usePreloadedQuery } from "react-relay";
 import { graphql } from "relay-runtime";
 
+import { Rows } from "#/components/Rows";
 import type { UpdatesPageQuery } from "#/pages/__generated__/UpdatesPageQuery.graphql";
 
 export const currentTrustUpdatesQuery = graphql`
@@ -41,14 +42,26 @@ export function UpdatesPage({ queryRef }: Props) {
   return (
     <div>
       <h2 className="font-medium mb-1">{__("Updates")}</h2>
-      <p className="text-sm text-txt-secondary mb-4">
-        {__("Latest compliance and security updates:")}
-      </p>
-      <div className="space-y-0">
-        {items.map(item => (
-          <UpdateItem key={item.id} item={item} />
-        ))}
-      </div>
+      {items.length === 0
+        ? (
+            <Rows>
+              <div className="text-sm text-txt-tertiary text-center py-5">
+                {__("No updates have been published yet.")}
+              </div>
+            </Rows>
+          )
+        : (
+            <>
+              <p className="text-sm text-txt-secondary mb-4">
+                {__("Latest compliance and security updates")}
+              </p>
+              <div className="space-y-0">
+                {items.map(item => (
+                  <UpdateItem key={item.id} item={item} />
+                ))}
+              </div>
+            </>
+          )}
     </div>
   );
 }


### PR DESCRIPTION

<img width="902" height="369" alt="Capture d’écran 2026-03-11 à 18 35 53" src="https://github.com/user-attachments/assets/de82cbe7-204f-43f0-8a9f-359db1ec8fd0" />




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the compliance updates display so the Updates tab is visible while loading and the page shows a clear empty state when no updates are published. Adds the tab to the main skeleton and updates the page to render a centered “No updates have been published yet” message with consistent layout.

<sup>Written for commit 5372404a1273f25637302dc5557b2fb971b56a4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



