### PR TITLE
Compliance updates should be public

### DIFF
--- a/apps/trust/src/layouts/MainLayout.tsx
+++ b/apps/trust/src/layouts/MainLayout.tsx
@@ -39,8 +39,7 @@ export function MainLayout(props: Props) {
             <TabLink to="/documents">{__("Documents")}</TabLink>
             {trustCenter.vendorInfo.totalCount > 0
               && <TabLink to="/subprocessors">{__("Subprocessors")}</TabLink>}
-            {isAuthenticated
-              && <TabLink to="/updates">{__("Updates")}</TabLink>}
+            <TabLink to="/updates">{__("Updates")}</TabLink>
           </Tabs>
           <Outlet context={{ trustCenter }} />
         </main>

--- a/pkg/server/api/trust/v1/schema.graphql
+++ b/pkg/server/api/trust/v1/schema.graphql
@@ -131,19 +131,19 @@ type ComplianceFrameworkEdge
   node: ComplianceFramework!
 }
 
-type MailingListUpdate implements Node @nda {
+type MailingListUpdate implements Node {
   id: ID!
   title: String!
   body: String!
   updatedAt: Datetime!
 }
 
-type MailingListUpdateConnection @nda {
+type MailingListUpdateConnection {
   edges: [MailingListUpdateEdge!]!
   pageInfo: PageInfo!
 }
 
-type MailingListUpdateEdge @nda {
+type MailingListUpdateEdge {
   cursor: CursorKey!
   node: MailingListUpdate!
 }

--- a/pkg/server/api/trust/v1/schema/schema.go
+++ b/pkg/server/api/trust/v1/schema/schema.go
@@ -1832,19 +1832,19 @@ type ComplianceFrameworkEdge
   node: ComplianceFramework!
 }
 
-type MailingListUpdate implements Node @nda {
+type MailingListUpdate implements Node {
   id: ID!
   title: String!
   body: String!
   updatedAt: Datetime!
 }
 
-type MailingListUpdateConnection @nda {
+type MailingListUpdateConnection {
   edges: [MailingListUpdateEdge!]!
   pageInfo: PageInfo!
 }
 
-type MailingListUpdateEdge @nda {
+type MailingListUpdateEdge {
   cursor: CursorKey!
   node: MailingListUpdate!
 }
@@ -5259,20 +5259,7 @@ func (ec *executionContext) _MailingListUpdateConnection_edges(ctx context.Conte
 		func(ctx context.Context) (any, error) {
 			return obj.Edges, nil
 		},
-		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
-			directive0 := next
-
-			directive1 := func(ctx context.Context) (any, error) {
-				if ec.Directives.Nda == nil {
-					var zeroVal []*types.MailingListUpdateEdge
-					return zeroVal, errors.New("directive nda is not implemented")
-				}
-				return ec.Directives.Nda(ctx, obj, directive0)
-			}
-
-			next = directive1
-			return next
-		},
+		nil,
 		ec.marshalNMailingListUpdateEdge2ᚕᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐMailingListUpdateEdgeᚄ,
 		true,
 		true,
@@ -5375,20 +5362,7 @@ func (ec *executionContext) _MailingListUpdateEdge_node(ctx context.Context, fie
 		func(ctx context.Context) (any, error) {
 			return obj.Node, nil
 		},
-		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
-			directive0 := next
-
-			directive1 := func(ctx context.Context) (any, error) {
-				if ec.Directives.Nda == nil {
-					var zeroVal *types.MailingListUpdate
-					return zeroVal, errors.New("directive nda is not implemented")
-				}
-				return ec.Directives.Nda(ctx, obj, directive0)
-			}
-
-			next = directive1
-			return next
-		},
+		nil,
 		ec.marshalNMailingListUpdate2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐMailingListUpdate,
 		true,
 		true,
@@ -8092,20 +8066,7 @@ func (ec *executionContext) _TrustCenter_updates(ctx context.Context, field grap
 			fc := graphql.GetFieldContext(ctx)
 			return ec.Resolvers.TrustCenter().Updates(ctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*page.CursorKey), fc.Args["last"].(*int), fc.Args["before"].(*page.CursorKey))
 		},
-		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
-			directive0 := next
-
-			directive1 := func(ctx context.Context) (any, error) {
-				if ec.Directives.Nda == nil {
-					var zeroVal *types.MailingListUpdateConnection
-					return zeroVal, errors.New("directive nda is not implemented")
-				}
-				return ec.Directives.Nda(ctx, obj, directive0)
-			}
-
-			next = directive1
-			return next
-		},
+		nil,
 		ec.marshalNMailingListUpdateConnection2ᚖgoᚗproboᚗincᚋproboᚋpkgᚋserverᚋapiᚋtrustᚋv1ᚋtypesᚐMailingListUpdateConnection,
 		true,
 		true,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make Compliance Updates public in the Trust Center. The Updates tab is now visible to everyone, and the API exposes `MailingListUpdate` without `@nda` gating.

- **New Features**
  - UI: Always show the "Updates" tab in `MainLayout`.
  - API: Removed `@nda` from `MailingListUpdate`, `MailingListUpdateConnection`, and `MailingListUpdateEdge` and stripped related resolvers so updates are publicly queryable.

<sup>Written for commit b8ba213fcb9d57daad0f9f3a1257f10be4fe1fc4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

