### PR TITLE
Autosubmit mailing list confirmation

### DIFF
--- a/pkg/server/mailactions/confirm.go
+++ b/pkg/server/mailactions/confirm.go
@@ -42,14 +42,17 @@ func confirmGetHandler() http.HandlerFunc {
 		renderPage(
 			w,
 			http.StatusOK,
+			// The confirmation should happen too quickly for the user to notice.
+			// This content is only shown as a fallback.
 			page{
 				Title:   "Confirm subscription",
 				Heading: "Confirm your subscription",
-				Body:    "Click the button below to confirm that you want to receive updates.",
+				Body:    "Your confirmation should be processed automatically. If it isn’t, click the button below to confirm that you want to receive updates.",
 				Form: &form{
-					ActionURL: template.URL("?token=" + url.QueryEscape(token)),
-					Button:    "Confirm subscription",
-					Danger:    false,
+					ActionURL:  template.URL("?token=" + url.QueryEscape(token)),
+					Button:     "Confirm subscription",
+					AutoSubmit: true,
+					Danger:     false,
 				},
 			},
 		)

--- a/pkg/server/mailactions/render.go
+++ b/pkg/server/mailactions/render.go
@@ -24,9 +24,10 @@ import (
 var pageTmplHTML string
 
 type form struct {
-	ActionURL template.URL
-	Button    string
-	Danger    bool
+	ActionURL  template.URL
+	Button     string
+	Danger     bool
+	AutoSubmit bool
 }
 
 type page struct {

--- a/pkg/server/mailactions/templates/page.html.tmpl
+++ b/pkg/server/mailactions/templates/page.html.tmpl
@@ -88,11 +88,14 @@
       <h1>{{.Heading}}</h1>
       <p>{{.Body}}</p>
       {{- if .Form}}
-      <form method="POST" action="{{.Form.ActionURL}}">
+      <form id="action-form" method="POST" action="{{.Form.ActionURL}}">
         <button type="submit" class="{{if .Form.Danger}}danger{{else}}primary{{end}}">
           {{.Form.Button}}
         </button>
       </form>
+      {{- if .Form.AutoSubmit}}
+      <script>document.getElementById("action-form").submit();</script>
+      {{- end}}
       {{- end}}
     </div>
   </body>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Auto-confirms mailing list subscriptions by auto-submitting the confirmation form on page load. Keeps a clear fallback button and copy if auto-submit doesn’t run.

- **New Features**
  - Added `AutoSubmit` flag to the form and an inline script that submits `#action-form` on load.
  - Updated confirmation copy and template (form id and title/body) to reflect automatic processing while preserving a manual confirm button.

<sup>Written for commit 5ac6511f63ecdc2522754b3177666fe203491ab8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

