### PR TITLE
security: add ReadTimeout and WriteTimeout to API server

### DIFF
--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -681,6 +681,9 @@ func (impl *Implm) runApiServer(
 		httpserver.WithTracerProvider(tp),
 	)
 
+	apiServer.ReadTimeout = 30 * time.Second
+	apiServer.WriteTimeout = 30 * time.Second
+
 	l.Info("starting api server", log.String("addr", apiServer.Addr))
 	span.AddEvent("API server starting")
 


### PR DESCRIPTION
Found an inconsistency while reading the codebase.

The trust center HTTPS server has ReadTimeout and
WriteTimeout set to 30 seconds. The API server has
neither.

Same codebase. Same risk. Different treatment.

Without these, a slow client can trickle request body
data indefinitely — keeping connections open and quietly
exhausting server resources.

One-line fix. Two timeouts. Consistent behavior across
both servers.

  apiServer.ReadTimeout = 30 * time.Second
  apiServer.WriteTimeout = 30 * time.Second

Not glamorous. Just the kind of thing that matters before
a compliance platform goes to production.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set 30s ReadTimeout and WriteTimeout on the API server. This prevents slow clients from holding connections open and aligns with the trust center HTTPS server.

<sup>Written for commit 95c02788d1989fb57c9d868ade27f6f606d884b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

