### PR TITLE
Fix compliance page bundle size

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
+  "sideEffects": false,
   "main": "src/index.ts",
   "scripts": {
     "lint": "eslint . --concurrency 2",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Mark `packages/ui` as side-effect free by setting `sideEffects: false` to enable tree-shaking and reduce the Compliance page bundle size. No runtime behavior changes.

<sup>Written for commit 019297103572104fd371c9eabd4965aa8af0cc24. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

