### PR TITLE
Run go fmt/fix

### DIFF
--- a/e2e/console/asset_test.go
+++ b/e2e/console/asset_test.go
@@ -237,7 +237,7 @@ func TestAsset_List(t *testing.T) {
 	profileID := factory.CreateUser(owner)
 
 	// Create multiple assets
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		const query = `
 			mutation($input: CreateAssetInput!) {
 				createAsset(input: $input) {

--- a/e2e/console/audit_test.go
+++ b/e2e/console/audit_test.go
@@ -16,6 +16,7 @@ package console_test
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 	"testing"
 	"time"
@@ -114,9 +115,7 @@ func TestAudit_Create(t *testing.T) {
 				"organizationId": owner.GetOrganizationID().String(),
 				"frameworkId":    frameworkID,
 			}
-			for k, v := range tt.input {
-				input[k] = v
-			}
+			maps.Copy(input, tt.input)
 
 			var result struct {
 				CreateAudit struct {
@@ -254,9 +253,7 @@ func TestAudit_Create_Validation(t *testing.T) {
 			if !tt.skipFramework {
 				input["frameworkId"] = frameworkID
 			}
-			for k, v := range tt.input {
-				input[k] = v
-			}
+			maps.Copy(input, tt.input)
 
 			_, err := owner.Do(query, map[string]any{"input": input})
 			require.Error(t, err)
@@ -1132,7 +1129,7 @@ func TestAudit_Pagination(t *testing.T) {
 
 	frameworkID := factory.NewFramework(owner).WithName("Framework for Pagination").Create()
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		factory.NewAudit(owner, frameworkID).
 			WithName(fmt.Sprintf("Pagination Audit %d", i)).
 			Create()

--- a/e2e/console/continual_improvement_test.go
+++ b/e2e/console/continual_improvement_test.go
@@ -242,7 +242,7 @@ func TestContinualImprovement_List(t *testing.T) {
 		}
 	`
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		_, err := owner.Do(createQuery, map[string]any{
 			"input": map[string]any{
 				"organizationId": owner.GetOrganizationID().String(),

--- a/e2e/console/datum_test.go
+++ b/e2e/console/datum_test.go
@@ -16,6 +16,7 @@ package console_test
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 	"testing"
 	"time"
@@ -104,9 +105,7 @@ func TestDatum_Create(t *testing.T) {
 				"organizationId": owner.GetOrganizationID().String(),
 				"ownerId":        profileID,
 			}
-			for k, v := range tt.input {
-				input[k] = v
-			}
+			maps.Copy(input, tt.input)
 
 			var result struct {
 				CreateDatum struct {
@@ -253,9 +252,7 @@ func TestDatum_Create_Validation(t *testing.T) {
 			if !tt.skipOwner {
 				input["ownerId"] = profileID
 			}
-			for k, v := range tt.input {
-				input[k] = v
-			}
+			maps.Copy(input, tt.input)
 
 			_, err := owner.Do(query, map[string]any{"input": input})
 			require.Error(t, err)
@@ -1103,7 +1100,7 @@ func TestDatum_Pagination(t *testing.T) {
 	owner := testutil.NewClient(t, testutil.RoleOwner)
 	profileID := factory.CreateUser(owner)
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		factory.NewDatum(owner, profileID).
 			WithName(fmt.Sprintf("Pagination Datum %d", i)).
 			Create()

--- a/e2e/console/document_test.go
+++ b/e2e/console/document_test.go
@@ -16,6 +16,7 @@ package console_test
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 	"testing"
 	"time"
@@ -115,9 +116,7 @@ func TestDocument_Create(t *testing.T) {
 				"organizationId": owner.GetOrganizationID().String(),
 				"approverIds":    []string{approverProfileID},
 			}
-			for k, v := range tt.input {
-				input[k] = v
-			}
+			maps.Copy(input, tt.input)
 
 			var result struct {
 				CreateDocument struct {
@@ -285,9 +284,7 @@ func TestDocument_Create_Validation(t *testing.T) {
 			if !tt.skipApprover {
 				input["approverIds"] = []string{approverProfileID}
 			}
-			for k, v := range tt.input {
-				input[k] = v
-			}
+			maps.Copy(input, tt.input)
 
 			_, err := owner.Do(query, map[string]any{"input": input})
 			require.Error(t, err)
@@ -1120,7 +1117,7 @@ func TestDocument_Pagination(t *testing.T) {
 	owner := testutil.NewClient(t, testutil.RoleOwner)
 	approverProfileID := factory.CreateUser(owner)
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		factory.NewDocument(owner, approverProfileID).
 			WithTitle(fmt.Sprintf("Pagination Document %d", i)).
 			Create()

--- a/e2e/console/framework_test.go
+++ b/e2e/console/framework_test.go
@@ -16,6 +16,7 @@ package console_test
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 	"testing"
 	"time"
@@ -74,9 +75,7 @@ func TestFramework_Create(t *testing.T) {
 			input := map[string]any{
 				"organizationId": owner.GetOrganizationID().String(),
 			}
-			for k, v := range tt.input {
-				input[k] = v
-			}
+			maps.Copy(input, tt.input)
 
 			var result struct {
 				CreateFramework struct {
@@ -216,9 +215,7 @@ func TestFramework_Create_Validation(t *testing.T) {
 			if !tt.skipOrganization {
 				input["organizationId"] = owner.GetOrganizationID().String()
 			}
-			for k, v := range tt.input {
-				input[k] = v
-			}
+			maps.Copy(input, tt.input)
 
 			_, err := owner.Do(query, map[string]any{"input": input})
 			require.Error(t, err)
@@ -753,9 +750,7 @@ func TestFramework_OmittableDescription(t *testing.T) {
 			`
 
 			input := map[string]any{"id": frameworkID}
-			for k, v := range tt.input {
-				input[k] = v
-			}
+			maps.Copy(input, tt.input)
 
 			var result struct {
 				UpdateFramework struct {
@@ -1121,9 +1116,7 @@ func TestFramework_MaxLength_Validation(t *testing.T) {
 				input := map[string]any{
 					"organizationId": owner.GetOrganizationID().String(),
 				}
-				for k, v := range tt.input {
-					input[k] = v
-				}
+				maps.Copy(input, tt.input)
 
 				_, err := owner.Do(query, map[string]any{"input": input})
 				require.Error(t, err)
@@ -1163,9 +1156,7 @@ func TestFramework_MaxLength_Validation(t *testing.T) {
 				`
 
 				input := map[string]any{"id": frameworkID}
-				for k, v := range tt.input {
-					input[k] = v
-				}
+				maps.Copy(input, tt.input)
 
 				_, err := owner.Do(query, map[string]any{"input": input})
 				require.Error(t, err)
@@ -1236,7 +1227,7 @@ func TestFramework_Pagination(t *testing.T) {
 	owner := testutil.NewClient(t, testutil.RoleOwner)
 
 	// Create exactly 5 frameworks for pagination testing
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		factory.NewFramework(owner).
 			WithName(fmt.Sprintf("Pagination Framework %d", i)).
 			Create()

--- a/e2e/console/measure_test.go
+++ b/e2e/console/measure_test.go
@@ -16,6 +16,7 @@ package console_test
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 	"testing"
 	"time"
@@ -113,9 +114,7 @@ func TestMeasure_Create(t *testing.T) {
 			input := map[string]any{
 				"organizationId": owner.GetOrganizationID().String(),
 			}
-			for k, v := range tt.input {
-				input[k] = v
-			}
+			maps.Copy(input, tt.input)
 
 			var result struct {
 				CreateMeasure struct {
@@ -301,9 +300,7 @@ func TestMeasure_Create_Validation(t *testing.T) {
 			if !tt.skipOrganization {
 				input["organizationId"] = owner.GetOrganizationID().String()
 			}
-			for k, v := range tt.input {
-				input[k] = v
-			}
+			maps.Copy(input, tt.input)
 
 			_, err := owner.Do(query, map[string]any{"input": input})
 			require.Error(t, err)
@@ -875,9 +872,7 @@ func TestMeasure_OmittableDescription(t *testing.T) {
 			`
 
 			input := map[string]any{"id": measureID}
-			for k, v := range tt.input {
-				input[k] = v
-			}
+			maps.Copy(input, tt.input)
 
 			var result struct {
 				UpdateMeasure struct {
@@ -1246,9 +1241,7 @@ func TestMeasure_MaxLength_Validation(t *testing.T) {
 				input := map[string]any{
 					"organizationId": owner.GetOrganizationID().String(),
 				}
-				for k, v := range tt.input {
-					input[k] = v
-				}
+				maps.Copy(input, tt.input)
 
 				_, err := owner.Do(query, map[string]any{"input": input})
 				require.Error(t, err)
@@ -1293,9 +1286,7 @@ func TestMeasure_MaxLength_Validation(t *testing.T) {
 				`
 
 				input := map[string]any{"id": measureID}
-				for k, v := range tt.input {
-					input[k] = v
-				}
+				maps.Copy(input, tt.input)
 
 				_, err := owner.Do(query, map[string]any{"input": input})
 				require.Error(t, err)
@@ -1496,7 +1487,7 @@ func TestMeasure_Pagination(t *testing.T) {
 
 	// Create multiple measures for pagination testing
 	measureIDs := make([]string, 5)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		measureIDs[i] = factory.NewMeasure(owner).
 			WithName(fmt.Sprintf("Pagination Measure %d", i)).
 			Create()

--- a/e2e/console/meeting_test.go
+++ b/e2e/console/meeting_test.go
@@ -16,6 +16,7 @@ package console_test
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 	"testing"
 	"time"
@@ -77,9 +78,7 @@ func TestMeeting_Create(t *testing.T) {
 			input := map[string]any{
 				"organizationId": owner.GetOrganizationID().String(),
 			}
-			for k, v := range tt.input {
-				input[k] = v
-			}
+			maps.Copy(input, tt.input)
 
 			var result struct {
 				CreateMeeting struct {
@@ -211,9 +210,7 @@ func TestMeeting_Create_Validation(t *testing.T) {
 			if !tt.skipOrganization {
 				input["organizationId"] = owner.GetOrganizationID().String()
 			}
-			for k, v := range tt.input {
-				input[k] = v
-			}
+			maps.Copy(input, tt.input)
 
 			_, err := owner.Do(query, map[string]any{"input": input})
 			require.Error(t, err)
@@ -1023,7 +1020,7 @@ func TestMeeting_Pagination(t *testing.T) {
 	t.Parallel()
 	owner := testutil.NewClient(t, testutil.RoleOwner)
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		factory.NewMeeting(owner).
 			WithName(fmt.Sprintf("Pagination Meeting %d", i)).
 			Create()

--- a/e2e/console/nonconformity_test.go
+++ b/e2e/console/nonconformity_test.go
@@ -323,7 +323,7 @@ func TestNonconformity_List(t *testing.T) {
 		}
 	`
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		var createResult struct {
 			CreateNonconformity struct {
 				NonconformityEdge struct {

--- a/e2e/console/processing_activity_test.go
+++ b/e2e/console/processing_activity_test.go
@@ -16,6 +16,7 @@ package console_test
 
 import (
 	"fmt"
+	"maps"
 	"testing"
 	"time"
 
@@ -114,9 +115,7 @@ func TestProcessingActivity_Create(t *testing.T) {
 			input := map[string]any{
 				"organizationId": owner.GetOrganizationID().String(),
 			}
-			for k, v := range tt.input {
-				input[k] = v
-			}
+			maps.Copy(input, tt.input)
 
 			var result struct {
 				CreateProcessingActivity struct {
@@ -193,9 +192,7 @@ func TestProcessingActivity_Create_Validation(t *testing.T) {
 			if !tt.skipOrganization {
 				input["organizationId"] = owner.GetOrganizationID().String()
 			}
-			for k, v := range tt.input {
-				input[k] = v
-			}
+			maps.Copy(input, tt.input)
 
 			_, err := owner.Do(query, map[string]any{"input": input})
 			require.Error(t, err)
@@ -898,7 +895,7 @@ func TestProcessingActivity_Pagination(t *testing.T) {
 	t.Parallel()
 	owner := testutil.NewClient(t, testutil.RoleOwner)
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		factory.NewProcessingActivity(owner).
 			WithName(fmt.Sprintf("Pagination PA %d", i)).
 			Create()

--- a/e2e/console/rights_request_test.go
+++ b/e2e/console/rights_request_test.go
@@ -249,7 +249,7 @@ func TestRightsRequest_List(t *testing.T) {
 		}
 	`
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		_, err := owner.Do(createQuery, map[string]any{
 			"input": map[string]any{
 				"organizationId": owner.GetOrganizationID().String(),

--- a/e2e/console/risk_test.go
+++ b/e2e/console/risk_test.go
@@ -15,6 +15,7 @@
 package console_test
 
 import (
+	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -401,9 +402,7 @@ func TestRisk_RequiredFields(t *testing.T) {
 			if !tt.skipOrganization {
 				input["organizationId"] = owner.GetOrganizationID().String()
 			}
-			for k, v := range tt.input {
-				input[k] = v
-			}
+			maps.Copy(input, tt.input)
 
 			_, err := owner.Do(query, map[string]any{"input": input})
 			require.Error(t, err)

--- a/e2e/console/vendor_contact_test.go
+++ b/e2e/console/vendor_contact_test.go
@@ -230,7 +230,7 @@ func TestVendorContact_List(t *testing.T) {
 	vendorID := factory.NewVendor(owner).WithName("List Contacts Vendor").Create()
 
 	// Create multiple contacts
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		query := `
 			mutation CreateVendorContact($input: CreateVendorContactInput!) {
 				createVendorContact(input: $input) {

--- a/e2e/console/vendor_test.go
+++ b/e2e/console/vendor_test.go
@@ -15,6 +15,7 @@
 package console_test
 
 import (
+	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -340,9 +341,7 @@ func TestVendor_RequiredFields(t *testing.T) {
 			if !tt.skipOrganization {
 				input["organizationId"] = owner.GetOrganizationID().String()
 			}
-			for k, v := range tt.input {
-				input[k] = v
-			}
+			maps.Copy(input, tt.input)
 
 			_, err := owner.Do(query, map[string]any{"input": input})
 			require.Error(t, err)

--- a/pkg/bootstrap/builder.go
+++ b/pkg/bootstrap/builder.go
@@ -193,7 +193,7 @@ func (b *Builder) Build() (*probod.FullConfig, error) {
 					TokenURL:     b.getEnvOrDefault("CONNECTOR_SLACK_TOKEN_URL", "https://slack.com/api/oauth.v2.access"),
 					Scopes:       []string{"chat:write", "channels:join", "incoming-webhook"},
 				},
-				RawSettings: map[string]interface{}{
+				RawSettings: map[string]any{
 					"signing-secret": b.getEnv("CONNECTOR_SLACK_SIGNING_SECRET"),
 				},
 			},
@@ -311,7 +311,7 @@ func (b *Builder) parseOriginsList(s string) []string {
 	}
 
 	var result []string
-	for _, part := range strings.Split(s, ",") {
+	for part := range strings.SplitSeq(s, ",") {
 		part = strings.TrimSpace(part)
 		part = strings.Trim(part, "\"")
 		if part != "" {

--- a/pkg/bootstrap/builder_test.go
+++ b/pkg/bootstrap/builder_test.go
@@ -329,7 +329,7 @@ func TestBuilder_Build_SlackConnector(t *testing.T) {
 	assert.Equal(t, "https://slack.com/oauth/v2/authorize", rawConfig.AuthURL)
 	assert.Equal(t, "https://slack.com/api/oauth.v2.access", rawConfig.TokenURL)
 	assert.Equal(t, []string{"chat:write", "channels:join", "incoming-webhook"}, rawConfig.Scopes)
-	rawSettings := connector.RawSettings.(map[string]interface{})
+	rawSettings := connector.RawSettings.(map[string]any)
 	assert.Equal(t, "slack-signing-secret", rawSettings["signing-secret"])
 }
 

--- a/pkg/bootstrap/write_test.go
+++ b/pkg/bootstrap/write_test.go
@@ -126,7 +126,7 @@ func TestWriteConfig_CompleteConfig(t *testing.T) {
 						ClientSecret: "client-secret",
 						Scopes:       []string{"chat:write"},
 					},
-					RawSettings: map[string]interface{}{
+					RawSettings: map[string]any{
 						"signing-secret": "secret",
 					},
 				},

--- a/pkg/coredata/business_impact.go
+++ b/pkg/coredata/business_impact.go
@@ -42,7 +42,7 @@ func (i BusinessImpact) String() string {
 	return string(i)
 }
 
-func (i *BusinessImpact) Scan(value interface{}) error {
+func (i *BusinessImpact) Scan(value any) error {
 	switch v := value.(type) {
 	case string:
 		switch v {

--- a/pkg/coredata/data_sensitivity.go
+++ b/pkg/coredata/data_sensitivity.go
@@ -44,7 +44,7 @@ func (i DataSensitivity) String() string {
 	return string(i)
 }
 
-func (i *DataSensitivity) Scan(value interface{}) error {
+func (i *DataSensitivity) Scan(value any) error {
 	switch v := value.(type) {
 	case string:
 		switch v {

--- a/pkg/coredata/document_classification.go
+++ b/pkg/coredata/document_classification.go
@@ -38,7 +38,7 @@ func (dc DocumentClassification) String() string {
 }
 
 // Scan implements the sql.Scanner interface for database deserialization.
-func (dc *DocumentClassification) Scan(value interface{}) error {
+func (dc *DocumentClassification) Scan(value any) error {
 	if value == nil {
 		return nil
 	}

--- a/pkg/coredata/membership_profile.go
+++ b/pkg/coredata/membership_profile.go
@@ -31,40 +31,40 @@ import (
 
 type (
 	MembershipProfile struct {
-		ID                       gid.GID                `db:"id"`
-		IdentityID               gid.GID                `db:"identity_id"`
-		OrganizationID           gid.GID                `db:"organization_id"`
-		EmailAddress             mail.Addr              `db:"email_address"`
-		Source                   ProfileSource          `db:"source"`
-		State                    ProfileState           `db:"state"`
-		FullName                 string                 `db:"full_name"`
-		Kind                     *string                `db:"kind"`
-		AdditionalEmailAddresses mail.Addrs             `db:"additional_email_addresses"`
-		Position                 *string                `db:"position"`
-		ContractStartDate        *time.Time             `db:"contract_start_date"`
-		ContractEndDate          *time.Time             `db:"contract_end_date"`
-		OrganizationName         string                 `db:"organization_name"`
-		UserName                 *string                `db:"user_name"`
-		ExternalID               *string                `db:"external_id"`
-		Nickname                 *string                `db:"nickname"`
-		Locale                   *string                `db:"locale"`
-		Timezone                 *string                `db:"timezone"`
-		ProfileUrl               *string                `db:"profile_url"`
-		PreferredLanguage        *string                `db:"preferred_language"`
-		GivenName                *string                `db:"given_name"`
-		FamilyName               *string                `db:"family_name"`
-		FormattedName            *string                `db:"formatted_name"`
-		MiddleName               *string                `db:"middle_name"`
-		HonorificPrefix          *string                `db:"honorific_prefix"`
-		HonorificSuffix          *string                `db:"honorific_suffix"`
-		EmployeeNumber           *string                `db:"employee_number"`
-		Department               *string                `db:"department"`
-		CostCenter               *string                `db:"cost_center"`
-		EnterpriseOrganization   *string                `db:"enterprise_organization"`
-		Division                 *string                `db:"division"`
-		ManagerValue             *string                `db:"manager_value"`
-		CreatedAt                time.Time              `db:"created_at"`
-		UpdatedAt                time.Time              `db:"updated_at"`
+		ID                       gid.GID       `db:"id"`
+		IdentityID               gid.GID       `db:"identity_id"`
+		OrganizationID           gid.GID       `db:"organization_id"`
+		EmailAddress             mail.Addr     `db:"email_address"`
+		Source                   ProfileSource `db:"source"`
+		State                    ProfileState  `db:"state"`
+		FullName                 string        `db:"full_name"`
+		Kind                     *string       `db:"kind"`
+		AdditionalEmailAddresses mail.Addrs    `db:"additional_email_addresses"`
+		Position                 *string       `db:"position"`
+		ContractStartDate        *time.Time    `db:"contract_start_date"`
+		ContractEndDate          *time.Time    `db:"contract_end_date"`
+		OrganizationName         string        `db:"organization_name"`
+		UserName                 *string       `db:"user_name"`
+		ExternalID               *string       `db:"external_id"`
+		Nickname                 *string       `db:"nickname"`
+		Locale                   *string       `db:"locale"`
+		Timezone                 *string       `db:"timezone"`
+		ProfileUrl               *string       `db:"profile_url"`
+		PreferredLanguage        *string       `db:"preferred_language"`
+		GivenName                *string       `db:"given_name"`
+		FamilyName               *string       `db:"family_name"`
+		FormattedName            *string       `db:"formatted_name"`
+		MiddleName               *string       `db:"middle_name"`
+		HonorificPrefix          *string       `db:"honorific_prefix"`
+		HonorificSuffix          *string       `db:"honorific_suffix"`
+		EmployeeNumber           *string       `db:"employee_number"`
+		Department               *string       `db:"department"`
+		CostCenter               *string       `db:"cost_center"`
+		EnterpriseOrganization   *string       `db:"enterprise_organization"`
+		Division                 *string       `db:"division"`
+		ManagerValue             *string       `db:"manager_value"`
+		CreatedAt                time.Time     `db:"created_at"`
+		UpdatedAt                time.Time     `db:"updated_at"`
 	}
 
 	MembershipProfiles []*MembershipProfile
@@ -1240,7 +1240,7 @@ VALUES (
 		"contract_end_date":          p.ContractEndDate,
 		"user_name":                  p.UserName,
 		"external_id":                p.ExternalID,
-		"nickname":                  p.Nickname,
+		"nickname":                   p.Nickname,
 		"locale":                     p.Locale,
 		"timezone":                   p.Timezone,
 		"profile_url":                p.ProfileUrl,
@@ -1330,7 +1330,7 @@ WHERE
 		"contract_end_date":          p.ContractEndDate,
 		"user_name":                  p.UserName,
 		"external_id":                p.ExternalID,
-		"nickname":                  p.Nickname,
+		"nickname":                   p.Nickname,
 		"locale":                     p.Locale,
 		"timezone":                   p.Timezone,
 		"profile_url":                p.ProfileUrl,

--- a/pkg/coredata/vendor_category.go
+++ b/pkg/coredata/vendor_category.go
@@ -78,7 +78,7 @@ func (i VendorCategory) String() string {
 	return string(i)
 }
 
-func (i *VendorCategory) Scan(value interface{}) error {
+func (i *VendorCategory) Scan(value any) error {
 	switch v := value.(type) {
 	case string:
 		switch v {

--- a/pkg/crypto/keys/keys_test.go
+++ b/pkg/crypto/keys/keys_test.go
@@ -30,13 +30,13 @@ func TestGenerate(t *testing.T) {
 	tests := []struct {
 		name        string
 		keyType     keys.Type
-		checkFunc   func(t *testing.T, key interface{})
+		checkFunc   func(t *testing.T, key any)
 		expectError bool
 	}{
 		{
 			name:    "EC256",
 			keyType: keys.TypeEC256,
-			checkFunc: func(t *testing.T, key interface{}) {
+			checkFunc: func(t *testing.T, key any) {
 				ecKey, ok := key.(*ecdsa.PrivateKey)
 				require.True(t, ok, "expected *ecdsa.PrivateKey, got %T", key)
 				assert.Equal(t, elliptic.P256(), ecKey.Curve, "expected P256 curve")
@@ -45,7 +45,7 @@ func TestGenerate(t *testing.T) {
 		{
 			name:    "EC384",
 			keyType: keys.TypeEC384,
-			checkFunc: func(t *testing.T, key interface{}) {
+			checkFunc: func(t *testing.T, key any) {
 				ecKey, ok := key.(*ecdsa.PrivateKey)
 				require.True(t, ok, "expected *ecdsa.PrivateKey, got %T", key)
 				assert.Equal(t, elliptic.P384(), ecKey.Curve, "expected P384 curve")
@@ -54,7 +54,7 @@ func TestGenerate(t *testing.T) {
 		{
 			name:    "RSA2048",
 			keyType: keys.TypeRSA2048,
-			checkFunc: func(t *testing.T, key interface{}) {
+			checkFunc: func(t *testing.T, key any) {
 				rsaKey, ok := key.(*rsa.PrivateKey)
 				require.True(t, ok, "expected *rsa.PrivateKey, got %T", key)
 				bitSize := rsaKey.N.BitLen()
@@ -65,7 +65,7 @@ func TestGenerate(t *testing.T) {
 		{
 			name:    "RSA4096",
 			keyType: keys.TypeRSA4096,
-			checkFunc: func(t *testing.T, key interface{}) {
+			checkFunc: func(t *testing.T, key any) {
 				rsaKey, ok := key.(*rsa.PrivateKey)
 				require.True(t, ok, "expected *rsa.PrivateKey, got %T", key)
 				bitSize := rsaKey.N.BitLen()
@@ -118,7 +118,7 @@ func TestGenerateConcurrency(t *testing.T) {
 			const numGoroutines = 10
 			errorsChan := make(chan error, numGoroutines)
 
-			for i := 0; i < numGoroutines; i++ {
+			for range numGoroutines {
 				go func() {
 					key, err := keys.Generate(keyType)
 					if err != nil {
@@ -133,7 +133,7 @@ func TestGenerateConcurrency(t *testing.T) {
 				}()
 			}
 
-			for i := 0; i < numGoroutines; i++ {
+			for range numGoroutines {
 				err := <-errorsChan
 				assert.NoError(t, err, "concurrent generation failed")
 			}

--- a/pkg/docgen/generator_test.go
+++ b/pkg/docgen/generator_test.go
@@ -359,7 +359,7 @@ func TestDocumentVersionSignatureStates(t *testing.T) {
 func TestLargeContent(t *testing.T) {
 	// Create a large markdown content
 	var largeContent strings.Builder
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		largeContent.WriteString("# Section ")
 		largeContent.WriteString(string(rune('A' + i%26)))
 		largeContent.WriteString("\n\nThis is a paragraph with **bold** and *italic* text.\n\n")

--- a/pkg/gid/gid.go
+++ b/pkg/gid/gid.go
@@ -95,7 +95,7 @@ func (gid GID) Timestamp() time.Time {
 }
 
 // Scan implements the database/sql/driver.Scanner interface
-func (gid *GID) Scan(value interface{}) error {
+func (gid *GID) Scan(value any) error {
 	var str string
 	switch v := value.(type) {
 	case string:

--- a/pkg/gid/tenant_id.go
+++ b/pkg/gid/tenant_id.go
@@ -103,7 +103,7 @@ func (id TenantID) Value() (driver.Value, error) {
 }
 
 // Scan implements the database/sql.Scanner interface
-func (id *TenantID) Scan(value interface{}) error {
+func (id *TenantID) Scan(value any) error {
 	switch v := value.(type) {
 	case string:
 		decoded, err := base64.RawURLEncoding.DecodeString(v)

--- a/pkg/html2pdf/margin.go
+++ b/pkg/html2pdf/margin.go
@@ -70,20 +70,20 @@ func ParseMargin(margin string) Margin {
 	margin = strings.TrimSpace(margin)
 
 	// Handle different units
-	if strings.HasSuffix(margin, "in") {
-		if val, err := strconv.ParseFloat(strings.TrimSuffix(margin, "in"), 64); err == nil {
+	if before, ok := strings.CutSuffix(margin, "in"); ok {
+		if val, err := strconv.ParseFloat(before, 64); err == nil {
 			return NewMarginInches(val)
 		}
-	} else if strings.HasSuffix(margin, "mm") {
-		if val, err := strconv.ParseFloat(strings.TrimSuffix(margin, "mm"), 64); err == nil {
+	} else if before, ok := strings.CutSuffix(margin, "mm"); ok {
+		if val, err := strconv.ParseFloat(before, 64); err == nil {
 			return NewMarginMillimeters(val)
 		}
-	} else if strings.HasSuffix(margin, "cm") {
-		if val, err := strconv.ParseFloat(strings.TrimSuffix(margin, "cm"), 64); err == nil {
+	} else if before, ok := strings.CutSuffix(margin, "cm"); ok {
+		if val, err := strconv.ParseFloat(before, 64); err == nil {
 			return NewMarginCentimeters(val)
 		}
-	} else if strings.HasSuffix(margin, "pt") {
-		if val, err := strconv.ParseFloat(strings.TrimSuffix(margin, "pt"), 64); err == nil {
+	} else if before, ok := strings.CutSuffix(margin, "pt"); ok {
+		if val, err := strconv.ParseFloat(before, 64); err == nil {
 			return NewMarginPoints(val)
 		}
 	} else {

--- a/pkg/iam/policy/authorizer.go
+++ b/pkg/iam/policy/authorizer.go
@@ -17,6 +17,7 @@ package policy
 import (
 	"errors"
 	"fmt"
+	"maps"
 
 	"go.probo.inc/probo/pkg/gid"
 )
@@ -108,9 +109,7 @@ func (a *Authorizer) Authorize(params AuthorizeParams) error {
 	}
 
 	// Add resource attributes to context
-	for k, v := range params.ResourceAttributes {
-		conditionCtx.Resource[k] = v
-	}
+	maps.Copy(conditionCtx.Resource, params.ResourceAttributes)
 
 	// Build authorization request
 	req := AuthorizationRequest{

--- a/pkg/iam/policy/statement.go
+++ b/pkg/iam/policy/statement.go
@@ -148,7 +148,7 @@ func (c Condition) Evaluate(ctx ConditionContext) bool {
 			// Support a comma-separated "set" value, e.g.
 			// principal.organization_ids = "org_1,org_2"
 			if strings.Contains(resolved, ",") {
-				for _, item := range strings.Split(resolved, ",") {
+				for item := range strings.SplitSeq(resolved, ",") {
 					if value == strings.TrimSpace(item) {
 						return true
 					}
@@ -170,7 +170,7 @@ func (c Condition) Evaluate(ctx ConditionContext) bool {
 			}
 
 			if strings.Contains(resolved, ",") {
-				for _, item := range strings.Split(resolved, ",") {
+				for item := range strings.SplitSeq(resolved, ",") {
 					if value == strings.TrimSpace(item) {
 						return false
 					}

--- a/pkg/iam/scim/bridge/provider/googleworkspace/provider.go
+++ b/pkg/iam/scim/bridge/provider/googleworkspace/provider.go
@@ -109,7 +109,7 @@ func (p *Provider) ListUsers(ctx context.Context) (scimclient.Users, error) {
 	return allUsers, nil
 }
 
-func (p *Provider) extractOrganizationFields(raw interface{}, user *scimclient.User) {
+func (p *Provider) extractOrganizationFields(raw any, user *scimclient.User) {
 	if raw == nil {
 		return
 	}
@@ -151,7 +151,7 @@ func (p *Provider) extractOrganizationFields(raw interface{}, user *scimclient.U
 	user.UserType = org.Description
 }
 
-func (p *Provider) extractEmployeeNumber(raw interface{}, user *scimclient.User) {
+func (p *Provider) extractEmployeeNumber(raw any, user *scimclient.User) {
 	if raw == nil {
 		return
 	}
@@ -178,7 +178,7 @@ func (p *Provider) extractEmployeeNumber(raw interface{}, user *scimclient.User)
 	}
 }
 
-func (p *Provider) extractRelations(raw interface{}, user *scimclient.User) {
+func (p *Provider) extractRelations(raw any, user *scimclient.User) {
 	if raw == nil {
 		return
 	}
@@ -201,7 +201,7 @@ func (p *Provider) extractRelations(raw interface{}, user *scimclient.User) {
 	}
 }
 
-func (p *Provider) extractPreferredLanguage(raw interface{}, user *scimclient.User) {
+func (p *Provider) extractPreferredLanguage(raw any, user *scimclient.User) {
 	if raw == nil {
 		return
 	}

--- a/pkg/iam/scim/bridge_runner_backoff.go
+++ b/pkg/iam/scim/bridge_runner_backoff.go
@@ -37,10 +37,7 @@ func (r *BridgeRunner) calculateBackoff(consecutiveFailures int) time.Duration {
 	// Cap the shift exponent to prevent integer overflow from the shift itself.
 	// Bit 63 is the sign bit, so shifting by 63+ produces negative or zero values.
 	const maxShift = 62
-	shiftAmount := consecutiveFailures
-	if shiftAmount > maxShift {
-		shiftAmount = maxShift
-	}
+	shiftAmount := min(consecutiveFailures, maxShift)
 
 	backoff := r.cfg.Interval * time.Duration(1<<shiftAmount)
 

--- a/pkg/iam/scim/service.go
+++ b/pkg/iam/scim/service.go
@@ -223,12 +223,12 @@ func (s *Service) CreateUser(
 					CreatedAt:              now,
 					UpdatedAt:              now,
 				}
-			if attrs.UserType != "" {
-				kind := attrs.UserType
-				profile.Kind = &kind
-			}
+				if attrs.UserType != "" {
+					kind := attrs.UserType
+					profile.Kind = &kind
+				}
 
-			err = profile.Insert(ctx, tx)
+				err = profile.Insert(ctx, tx)
 				if err != nil {
 					if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 						return scimerrors.ScimErrorUniqueness
@@ -268,11 +268,11 @@ func (s *Service) CreateUser(
 			profile.Division = ref.RefOrNil(attrs.Division)
 			profile.ManagerValue = ref.RefOrNil(attrs.ManagerValue)
 			profile.UpdatedAt = now
-		if attrs.UserType != "" {
-			kind := attrs.UserType
-			profile.Kind = &kind
-		}
-		if err := profile.Update(ctx, tx, scope); err != nil {
+			if attrs.UserType != "" {
+				kind := attrs.UserType
+				profile.Kind = &kind
+			}
+			if err := profile.Update(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot update profile: %w", err)
 			}
 		}
@@ -501,189 +501,189 @@ func (s *Service) updateUser(
 				profile.UpdatedAt = now
 			}
 
-		if attrs.Title != nil {
-			if *attrs.Title == "" {
-				profile.Position = nil
-			} else {
-				profile.Position = attrs.Title
+			if attrs.Title != nil {
+				if *attrs.Title == "" {
+					profile.Position = nil
+				} else {
+					profile.Position = attrs.Title
+				}
 			}
-		}
 
 			if attrs.UserName != nil {
 				profile.UserName = attrs.UserName
 				profile.UpdatedAt = now
 			}
 
-		if attrs.ExternalID != nil {
-			if *attrs.ExternalID == "" {
-				profile.ExternalID = nil
-			} else {
-				profile.ExternalID = attrs.ExternalID
+			if attrs.ExternalID != nil {
+				if *attrs.ExternalID == "" {
+					profile.ExternalID = nil
+				} else {
+					profile.ExternalID = attrs.ExternalID
+				}
+				profile.UpdatedAt = now
 			}
-			profile.UpdatedAt = now
-		}
 
-		if attrs.UserType != nil {
-		if *attrs.UserType == "" {
-			profile.Kind = nil
-		} else {
-			profile.Kind = attrs.UserType
-		}
-		profile.UpdatedAt = now
-	}
-
-		if attrs.Nickname != nil {
-			if *attrs.Nickname == "" {
-				profile.Nickname = nil
-			} else {
-				profile.Nickname = attrs.Nickname
+			if attrs.UserType != nil {
+				if *attrs.UserType == "" {
+					profile.Kind = nil
+				} else {
+					profile.Kind = attrs.UserType
+				}
+				profile.UpdatedAt = now
 			}
-			profile.UpdatedAt = now
-		}
 
-		if attrs.Locale != nil {
-			if *attrs.Locale == "" {
-				profile.Locale = nil
-			} else {
-				profile.Locale = attrs.Locale
+			if attrs.Nickname != nil {
+				if *attrs.Nickname == "" {
+					profile.Nickname = nil
+				} else {
+					profile.Nickname = attrs.Nickname
+				}
+				profile.UpdatedAt = now
 			}
-			profile.UpdatedAt = now
-		}
 
-		if attrs.Timezone != nil {
-			if *attrs.Timezone == "" {
-				profile.Timezone = nil
-			} else {
-				profile.Timezone = attrs.Timezone
+			if attrs.Locale != nil {
+				if *attrs.Locale == "" {
+					profile.Locale = nil
+				} else {
+					profile.Locale = attrs.Locale
+				}
+				profile.UpdatedAt = now
 			}
-			profile.UpdatedAt = now
-		}
 
-	if attrs.ProfileUrl != nil {
-		if *attrs.ProfileUrl == "" {
-			profile.ProfileUrl = nil
-		} else {
-			profile.ProfileUrl = attrs.ProfileUrl
-		}
-		profile.UpdatedAt = now
-	}
+			if attrs.Timezone != nil {
+				if *attrs.Timezone == "" {
+					profile.Timezone = nil
+				} else {
+					profile.Timezone = attrs.Timezone
+				}
+				profile.UpdatedAt = now
+			}
 
-	if attrs.PreferredLanguage != nil {
-		if *attrs.PreferredLanguage == "" {
-			profile.PreferredLanguage = nil
-		} else {
-			profile.PreferredLanguage = attrs.PreferredLanguage
-		}
-		profile.UpdatedAt = now
-	}
+			if attrs.ProfileUrl != nil {
+				if *attrs.ProfileUrl == "" {
+					profile.ProfileUrl = nil
+				} else {
+					profile.ProfileUrl = attrs.ProfileUrl
+				}
+				profile.UpdatedAt = now
+			}
 
-	if attrs.GivenName != nil {
-		if *attrs.GivenName == "" {
-			profile.GivenName = nil
-		} else {
-			profile.GivenName = attrs.GivenName
-		}
-		profile.UpdatedAt = now
-	}
+			if attrs.PreferredLanguage != nil {
+				if *attrs.PreferredLanguage == "" {
+					profile.PreferredLanguage = nil
+				} else {
+					profile.PreferredLanguage = attrs.PreferredLanguage
+				}
+				profile.UpdatedAt = now
+			}
 
-	if attrs.FamilyName != nil {
-		if *attrs.FamilyName == "" {
-			profile.FamilyName = nil
-		} else {
-			profile.FamilyName = attrs.FamilyName
-		}
-		profile.UpdatedAt = now
-	}
+			if attrs.GivenName != nil {
+				if *attrs.GivenName == "" {
+					profile.GivenName = nil
+				} else {
+					profile.GivenName = attrs.GivenName
+				}
+				profile.UpdatedAt = now
+			}
 
-	if attrs.FormattedName != nil {
-		if *attrs.FormattedName == "" {
-			profile.FormattedName = nil
-		} else {
-			profile.FormattedName = attrs.FormattedName
-		}
-		profile.UpdatedAt = now
-	}
+			if attrs.FamilyName != nil {
+				if *attrs.FamilyName == "" {
+					profile.FamilyName = nil
+				} else {
+					profile.FamilyName = attrs.FamilyName
+				}
+				profile.UpdatedAt = now
+			}
 
-	if attrs.MiddleName != nil {
-		if *attrs.MiddleName == "" {
-			profile.MiddleName = nil
-		} else {
-			profile.MiddleName = attrs.MiddleName
-		}
-		profile.UpdatedAt = now
-	}
+			if attrs.FormattedName != nil {
+				if *attrs.FormattedName == "" {
+					profile.FormattedName = nil
+				} else {
+					profile.FormattedName = attrs.FormattedName
+				}
+				profile.UpdatedAt = now
+			}
 
-	if attrs.HonorificPrefix != nil {
-		if *attrs.HonorificPrefix == "" {
-			profile.HonorificPrefix = nil
-		} else {
-			profile.HonorificPrefix = attrs.HonorificPrefix
-		}
-		profile.UpdatedAt = now
-	}
+			if attrs.MiddleName != nil {
+				if *attrs.MiddleName == "" {
+					profile.MiddleName = nil
+				} else {
+					profile.MiddleName = attrs.MiddleName
+				}
+				profile.UpdatedAt = now
+			}
 
-	if attrs.HonorificSuffix != nil {
-		if *attrs.HonorificSuffix == "" {
-			profile.HonorificSuffix = nil
-		} else {
-			profile.HonorificSuffix = attrs.HonorificSuffix
-		}
-		profile.UpdatedAt = now
-	}
+			if attrs.HonorificPrefix != nil {
+				if *attrs.HonorificPrefix == "" {
+					profile.HonorificPrefix = nil
+				} else {
+					profile.HonorificPrefix = attrs.HonorificPrefix
+				}
+				profile.UpdatedAt = now
+			}
 
-	if attrs.EmployeeNumber != nil {
-		if *attrs.EmployeeNumber == "" {
-			profile.EmployeeNumber = nil
-		} else {
-			profile.EmployeeNumber = attrs.EmployeeNumber
-		}
-		profile.UpdatedAt = now
-	}
+			if attrs.HonorificSuffix != nil {
+				if *attrs.HonorificSuffix == "" {
+					profile.HonorificSuffix = nil
+				} else {
+					profile.HonorificSuffix = attrs.HonorificSuffix
+				}
+				profile.UpdatedAt = now
+			}
 
-	if attrs.Department != nil {
-		if *attrs.Department == "" {
-			profile.Department = nil
-		} else {
-			profile.Department = attrs.Department
-		}
-		profile.UpdatedAt = now
-	}
+			if attrs.EmployeeNumber != nil {
+				if *attrs.EmployeeNumber == "" {
+					profile.EmployeeNumber = nil
+				} else {
+					profile.EmployeeNumber = attrs.EmployeeNumber
+				}
+				profile.UpdatedAt = now
+			}
 
-	if attrs.CostCenter != nil {
-		if *attrs.CostCenter == "" {
-			profile.CostCenter = nil
-		} else {
-			profile.CostCenter = attrs.CostCenter
-		}
-		profile.UpdatedAt = now
-	}
+			if attrs.Department != nil {
+				if *attrs.Department == "" {
+					profile.Department = nil
+				} else {
+					profile.Department = attrs.Department
+				}
+				profile.UpdatedAt = now
+			}
 
-	if attrs.EnterpriseOrganization != nil {
-		if *attrs.EnterpriseOrganization == "" {
-			profile.EnterpriseOrganization = nil
-		} else {
-			profile.EnterpriseOrganization = attrs.EnterpriseOrganization
-		}
-		profile.UpdatedAt = now
-	}
+			if attrs.CostCenter != nil {
+				if *attrs.CostCenter == "" {
+					profile.CostCenter = nil
+				} else {
+					profile.CostCenter = attrs.CostCenter
+				}
+				profile.UpdatedAt = now
+			}
 
-	if attrs.Division != nil {
-		if *attrs.Division == "" {
-			profile.Division = nil
-		} else {
-			profile.Division = attrs.Division
-		}
-		profile.UpdatedAt = now
-	}
+			if attrs.EnterpriseOrganization != nil {
+				if *attrs.EnterpriseOrganization == "" {
+					profile.EnterpriseOrganization = nil
+				} else {
+					profile.EnterpriseOrganization = attrs.EnterpriseOrganization
+				}
+				profile.UpdatedAt = now
+			}
 
-	if attrs.ManagerValue != nil {
-		if *attrs.ManagerValue == "" {
-			profile.ManagerValue = nil
-		} else {
-			profile.ManagerValue = attrs.ManagerValue
-		}
-		profile.UpdatedAt = now
-	}
+			if attrs.Division != nil {
+				if *attrs.Division == "" {
+					profile.Division = nil
+				} else {
+					profile.Division = attrs.Division
+				}
+				profile.UpdatedAt = now
+			}
+
+			if attrs.ManagerValue != nil {
+				if *attrs.ManagerValue == "" {
+					profile.ManagerValue = nil
+				} else {
+					profile.ManagerValue = attrs.ManagerValue
+				}
+				profile.UpdatedAt = now
+			}
 
 			if shouldReactivate {
 				profile.State = coredata.ProfileStateActive

--- a/pkg/server/api/console/v1/resolver.go
+++ b/pkg/server/api/console/v1/resolver.go
@@ -202,7 +202,6 @@ func (r *Resolver) ProboService(ctx context.Context, tenantID gid.TenantID) *pro
 	return r.probo.WithTenant(tenantID)
 }
 
-
 func (r *Resolver) Permission(ctx context.Context, obj types.Node, action string) (bool, error) {
 	return r.authorize(ctx, obj.GetID(), action) == nil, nil
 }

--- a/pkg/server/api/console/v1/types/trust_center.go
+++ b/pkg/server/api/console/v1/types/trust_center.go
@@ -22,17 +22,17 @@ import (
 )
 
 type TrustCenter struct {
-	ID                   gid.GID                         `json:"id"`
-	Active               bool                            `json:"active"`
-	LogoFileURL          *string                         `json:"logoFileUrl,omitempty"`
-	DarkLogoFileURL      *string                         `json:"darkLogoFileUrl,omitempty"`
-	NdaFileName          *string                         `json:"ndaFileName,omitempty"`
-	NdaFileURL           *string                         `json:"ndaFileUrl,omitempty"`
-	CreatedAt            time.Time                       `json:"createdAt"`
-	UpdatedAt            time.Time                       `json:"updatedAt"`
-	Organization         *Organization                   `json:"organization"`
-	Accesses             *TrustCenterAccessConnection    `json:"accesses"`
-	References           *TrustCenterReferenceConnection `json:"references"`
+	ID                   gid.GID                          `json:"id"`
+	Active               bool                             `json:"active"`
+	LogoFileURL          *string                          `json:"logoFileUrl,omitempty"`
+	DarkLogoFileURL      *string                          `json:"darkLogoFileUrl,omitempty"`
+	NdaFileName          *string                          `json:"ndaFileName,omitempty"`
+	NdaFileURL           *string                          `json:"ndaFileUrl,omitempty"`
+	CreatedAt            time.Time                        `json:"createdAt"`
+	UpdatedAt            time.Time                        `json:"updatedAt"`
+	Organization         *Organization                    `json:"organization"`
+	Accesses             *TrustCenterAccessConnection     `json:"accesses"`
+	References           *TrustCenterReferenceConnection  `json:"references"`
 	ComplianceFrameworks *ComplianceFrameworkConnection   `json:"complianceFrameworks"`
 	ExternalUrls         *ComplianceExternalURLConnection `json:"externalUrls"`
 	MailingList          *MailingList                     `json:"mailingList,omitempty"`

--- a/pkg/server/api/trust/v1/types/compliance_framework.go
+++ b/pkg/server/api/trust/v1/types/compliance_framework.go
@@ -26,7 +26,7 @@ type ComplianceFramework struct {
 	FrameworkID gid.GID    `json:"-"`
 }
 
-func (ComplianceFramework) IsNode()             {}
+func (ComplianceFramework) IsNode()           {}
 func (cf ComplianceFramework) GetID() gid.GID { return cf.ID }
 
 type ComplianceFrameworkConnection struct {

--- a/pkg/server/gqlutils/tracing.go
+++ b/pkg/server/gqlutils/tracing.go
@@ -42,7 +42,7 @@ func (t TracingExtension) Validate(schema graphql.ExecutableSchema) error {
 	return nil
 }
 
-func (t TracingExtension) InterceptField(ctx context.Context, next graphql.Resolver) (interface{}, error) {
+func (t TracingExtension) InterceptField(ctx context.Context, next graphql.Resolver) (any, error) {
 	rootSpan := trace.SpanFromContext(ctx)
 
 	if rootSpan.IsRecording() {

--- a/pkg/server/gqlutils/types/cursor/cursorkey.go
+++ b/pkg/server/gqlutils/types/cursor/cursorkey.go
@@ -57,7 +57,7 @@ func MarshalCursorKeyScalar(ck page.CursorKey) graphql.Marshaler {
 	})
 }
 
-func UnmarshalCursorKeyScalar(v interface{}) (page.CursorKey, error) {
+func UnmarshalCursorKeyScalar(v any) (page.CursorKey, error) {
 	s, ok := v.(string)
 	if !ok {
 		return page.CursorKeyNil, errors.New("must be a string")

--- a/pkg/server/gqlutils/types/gid/gid.go
+++ b/pkg/server/gqlutils/types/gid/gid.go
@@ -33,7 +33,7 @@ func MarshalGIDScalar(id gid.GID) graphql.Marshaler {
 	)
 }
 
-func UnmarshalGIDScalar(v interface{}) (gid.GID, error) {
+func UnmarshalGIDScalar(v any) (gid.GID, error) {
 	s, ok := v.(string)
 	if !ok {
 		return gid.Nil, errors.New("must be a string")

--- a/pkg/server/gqlutils/types/mail/addr.go
+++ b/pkg/server/gqlutils/types/mail/addr.go
@@ -33,7 +33,7 @@ func MarshalAddrScalar(a mail.Addr) graphql.Marshaler {
 	)
 }
 
-func UnmarshalAddrScalar(v interface{}) (mail.Addr, error) {
+func UnmarshalAddrScalar(v any) (mail.Addr, error) {
 	s, ok := v.(string)
 	if !ok {
 		return mail.Nil, errors.New("must be a string")

--- a/pkg/validator/validation.go
+++ b/pkg/validator/validation.go
@@ -39,12 +39,12 @@ func (v *Validator) Check(value any, field string, validators ...ValidatorFunc) 
 	if value != nil {
 		val := reflect.ValueOf(value)
 		// Dereference all pointer levels
-		for val.Kind() == reflect.Ptr && !val.IsNil() {
+		for val.Kind() == reflect.Pointer && !val.IsNil() {
 			val = val.Elem()
 			actualValue = val.Interface()
 		}
 		// If we ended up with a nil pointer at any level, set actualValue to nil
-		if val.Kind() == reflect.Ptr && val.IsNil() {
+		if val.Kind() == reflect.Pointer && val.IsNil() {
 			actualValue = nil
 		}
 	}
@@ -75,7 +75,7 @@ func (v *Validator) CheckEach(items any, field string, fn func(index int, item a
 
 	val := reflect.ValueOf(items)
 	// Dereference pointer levels to get to the actual slice
-	for val.Kind() == reflect.Ptr {
+	for val.Kind() == reflect.Pointer {
 		if val.IsNil() {
 			return
 		}
@@ -138,7 +138,7 @@ func dereferenceValue(value any) (any, bool) {
 
 	val := reflect.ValueOf(value)
 	// Dereference all pointer levels
-	for val.Kind() == reflect.Ptr {
+	for val.Kind() == reflect.Pointer {
 		if val.IsNil() {
 			return nil, true
 		}

--- a/pkg/validator/validator_collection.go
+++ b/pkg/validator/validator_collection.go
@@ -23,7 +23,7 @@ import (
 func MinItems(min int) ValidatorFunc {
 	return func(value any) *ValidationError {
 		v := reflect.ValueOf(value)
-		if v.Kind() == reflect.Ptr {
+		if v.Kind() == reflect.Pointer {
 			if v.IsNil() {
 				return nil
 			}
@@ -49,7 +49,7 @@ func MinItems(min int) ValidatorFunc {
 func MaxItems(max int) ValidatorFunc {
 	return func(value any) *ValidationError {
 		v := reflect.ValueOf(value)
-		if v.Kind() == reflect.Ptr {
+		if v.Kind() == reflect.Pointer {
 			if v.IsNil() {
 				return nil
 			}
@@ -75,7 +75,7 @@ func MaxItems(max int) ValidatorFunc {
 func UniqueItems() ValidatorFunc {
 	return func(value any) *ValidationError {
 		v := reflect.ValueOf(value)
-		if v.Kind() == reflect.Ptr {
+		if v.Kind() == reflect.Pointer {
 			if v.IsNil() {
 				return nil
 			}

--- a/pkg/validator/validator_format.go
+++ b/pkg/validator/validator_format.go
@@ -17,6 +17,7 @@ package validator
 import (
 	"net/url"
 	"regexp"
+	"slices"
 
 	"go.probo.inc/probo/pkg/gid"
 )
@@ -182,13 +183,7 @@ func GID(entityTypes ...uint16) ValidatorFunc {
 
 		if len(entityTypes) > 0 {
 			parsedEntityType := gidValue.EntityType()
-			valid := false
-			for _, expected := range entityTypes {
-				if parsedEntityType == expected {
-					valid = true
-					break
-				}
-			}
+			valid := slices.Contains(entityTypes, parsedEntityType)
 			if !valid {
 				return newValidationError(ErrorCodeInvalidGID, "GID has invalid entity type")
 			}

--- a/pkg/validator/validator_string.go
+++ b/pkg/validator/validator_string.go
@@ -197,7 +197,7 @@ func OneOfSlice[T any](allowed []T) ValidatorFunc {
 		// Dereference all pointer levels
 		actualValue := value
 		val := reflect.ValueOf(value)
-		for val.Kind() == reflect.Ptr {
+		for val.Kind() == reflect.Pointer {
 			if val.IsNil() {
 				return nil
 			}
@@ -247,7 +247,7 @@ func NotOneOfSlice[T any](disallowed []T) ValidatorFunc {
 		// Dereference all pointer levels
 		actualValue := value
 		val := reflect.ValueOf(value)
-		for val.Kind() == reflect.Ptr {
+		for val.Kind() == reflect.Pointer {
 			if val.IsNil() {
 				return nil
 			}

--- a/pkg/webhook/types/user.go
+++ b/pkg/webhook/types/user.go
@@ -23,19 +23,19 @@ import (
 )
 
 type User struct {
-	ID                       gid.GID                         `json:"id"`
-	OrganizationID           gid.GID                         `json:"organizationId"`
-	EmailAddress             mail.Addr                       `json:"emailAddress"`
-	FullName                 string                          `json:"fullName"`
-	Kind                     *string                         `json:"kind"`
-	Source                   coredata.ProfileSource          `json:"source"`
-	State                    coredata.ProfileState           `json:"state"`
-	AdditionalEmailAddresses mail.Addrs                      `json:"additionalEmailAddresses"`
-	Position                 *string                         `json:"position"`
-	ContractStartDate        *time.Time                      `json:"contractStartDate"`
-	ContractEndDate          *time.Time                      `json:"contractEndDate"`
-	CreatedAt                time.Time                       `json:"createdAt"`
-	UpdatedAt                time.Time                       `json:"updatedAt"`
+	ID                       gid.GID                `json:"id"`
+	OrganizationID           gid.GID                `json:"organizationId"`
+	EmailAddress             mail.Addr              `json:"emailAddress"`
+	FullName                 string                 `json:"fullName"`
+	Kind                     *string                `json:"kind"`
+	Source                   coredata.ProfileSource `json:"source"`
+	State                    coredata.ProfileState  `json:"state"`
+	AdditionalEmailAddresses mail.Addrs             `json:"additionalEmailAddresses"`
+	Position                 *string                `json:"position"`
+	ContractStartDate        *time.Time             `json:"contractStartDate"`
+	ContractEndDate          *time.Time             `json:"contractEndDate"`
+	CreatedAt                time.Time              `json:"createdAt"`
+	UpdatedAt                time.Time              `json:"updatedAt"`
 }
 
 func NewUser(p *coredata.MembershipProfile) *User {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Run go fmt/fix and modernize code to Go 1.22 idioms across the repo. This replaces legacy patterns with stdlib helpers and newer language features; no functional changes intended.

- **Refactors**
  - Replace `interface{}` with `any`; use `reflect.Pointer`.
  - Adopt Go 1.22 features: integer range loops, `min(...)`, `maps.Copy`, `slices.Contains`, `strings.CutSuffix`, `strings.SplitSeq`.
  - Simplify map merges and iterations in e2e tests, policy conditions, and bootstrap origin parsing; update GraphQL scalar unmarshallers to accept `any`.
  - Normalize formatting and field alignment across SCIM service, core types, webhook `User`, and trust center types; tighten nil/guard handling and indentation in SCIM profile updates.

<sup>Written for commit d5c62a9383c29234f8ab0cd340cd9957f5738e45. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

