### PR TITLE
Fix SCIM duplicate profile constraint violation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- SCIM provisioning failure when enrolling existing manual users due to stale external_id conflicts
+- SCIM reset not clearing external_id and user_name on profiles
+
 ## [0.142.2] - 2026-03-13
 
 ### Fixed

--- a/pkg/coredata/membership_profile.go
+++ b/pkg/coredata/membership_profile.go
@@ -1396,6 +1396,42 @@ WHERE
 	return nil
 }
 
+func (p *MembershipProfile) ClearExternalID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	externalID string,
+	organizationID gid.GID,
+) error {
+	q := `
+UPDATE iam_membership_profiles
+SET
+    external_id = NULL,
+    updated_at = @updated_at
+WHERE
+    %s
+    AND external_id = @external_id
+    AND organization_id = @organization_id
+    AND id != @exclude_id
+`
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.NamedArgs{
+		"external_id":     externalID,
+		"organization_id": organizationID,
+		"exclude_id":      p.ID,
+		"updated_at":      time.Now(),
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot clear external id: %w", err)
+	}
+
+	return nil
+}
+
 func (p *MembershipProfile) Delete(
 	ctx context.Context,
 	conn pg.Conn,

--- a/pkg/coredata/membership_profile.go
+++ b/pkg/coredata/membership_profile.go
@@ -1372,6 +1372,8 @@ func (p *MembershipProfiles) ResetSCIMSources(
 UPDATE iam_membership_profiles
 SET
     source = 'MANUAL',
+    external_id = NULL,
+    user_name = NULL,
     updated_at = @updated_at
 WHERE
     %s

--- a/pkg/coredata/membership_profile.go
+++ b/pkg/coredata/membership_profile.go
@@ -1263,8 +1263,7 @@ VALUES (
 
 	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" {
 			return ErrResourceAlreadyExists
 		}
 

--- a/pkg/iam/scim/service.go
+++ b/pkg/iam/scim/service.go
@@ -244,6 +244,18 @@ func (s *Service) CreateUser(
 				return scimerrors.ScimErrorUniqueness
 			}
 
+			if externalIdPtr != nil {
+				if err := profile.ClearExternalID(
+					ctx,
+					tx,
+					scope,
+					*externalIdPtr,
+					config.OrganizationID,
+				); err != nil {
+					return fmt.Errorf("cannot clear conflicting external id: %w", err)
+				}
+			}
+
 			profile.Source = coredata.ProfileSourceSCIM
 			profile.State = profileState
 			profile.FullName = attrs.FullName


### PR DESCRIPTION
## Summary
- Clear `external_id` and `user_name` when SCIM is reset to fix duplicate constraint violations when reconfiguring SCIM
- Use `errors.AsType` for cleaner error type checking in profile Insert

## Problem
When SCIM configuration was deleted and reconfigured, stale `external_id` values from the previous SCIM config remained on profiles. When SCIM tried to enroll existing manual users, the UPDATE would fail with a unique constraint violation on `idx_profiles_external_id_organization_id`.

## Solution
`ResetSCIMSources` now clears both `external_id` and `user_name` when resetting profiles from SCIM back to MANUAL source, preventing conflicts when SCIM is reconfigured.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent SCIM duplicate profile errors by clearing stale or conflicting identifiers during reset and enrollment. Also simplify duplicate insert error handling.

- **Bug Fixes**
  - `ResetSCIMSources` now NULLs `external_id` and `user_name` when setting `source='MANUAL'`, and `CreateUser` clears conflicting `external_id` before enrolling a matching manual profile—both prevent collisions on `idx_profiles_external_id_organization_id` after SCIM setup.
  - Use `errors.AsType[*pgconn.PgError]` in `MembershipProfile.Insert` to detect code `23505` and return `ErrResourceAlreadyExists`.

<sup>Written for commit 7a31833956e96c40c1769f844fbe122055f36fbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

