### PR TITLE
Add reviewdog to post lint errors as PR review comments

### DIFF
--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -125,6 +125,8 @@ jobs:
     runs-on: "ubuntu-22.04"
     permissions:
       contents: "read"
+      pull-requests: "write"
+      checks: "write"
     steps:
       - uses: "actions/checkout@v6"
         with:
@@ -140,13 +142,37 @@ jobs:
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           install-only: true
+      - uses: reviewdog/action-setup@d8a7baabd7f3e8544ee4dbde3ee41d0011c3a93f # v1.5.0
       - run: "npm i -g npm@11.8.0"
       - run: "npm ci"
       - uses: "actions/download-artifact@v6"
         with:
           name: "build-artifacts"
       - run: "chmod +x bin/probod"
-      - run: "make lint"
+      - name: "Run go vet"
+        run: "go vet ./..."
+      - name: "Run golangci-lint"
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            golangci-lint run --out-format=line-number ./... 2>&1 | \
+              reviewdog -f=golangci-lint -reporter=github-pr-review -filter-mode=nofilter -fail-level=error -name="golangci-lint"
+          else
+            golangci-lint run ./...
+          fi
+      - name: "Run eslint"
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            for dir in apps/console apps/trust packages/ui packages/eslint-config packages/n8n-node; do
+              (cd "$dir" && npx eslint . --concurrency 4 --format stylish 2>/dev/null) | \
+                reviewdog -f=eslint -reporter=github-pr-review -filter-mode=nofilter -fail-level=error -name="eslint ($dir)"
+            done
+          else
+            npm run lint
+          fi
 
   test:
     name: "test"


### PR DESCRIPTION
Use reviewdog in the CI lint job so golangci-lint and eslint failures appear as inline comments on pull request files instead of only in job logs.

This allows developers to see lint errors directly on the changed code without opening the CI workflow logs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `reviewdog` to the CI lint job to post `golangci-lint` and `eslint` errors as inline PR review comments. Also adds `go vet` and updates workflow permissions.

- **New Features**
  - Inline PR comments for `golangci-lint` and per-project `eslint` (`--format stylish`) via `reviewdog`.
  - On PRs, pipe linter output to `reviewdog`; on non-PRs, run normal linting; failures fail CI.
  - Grants `pull-requests: write` and `checks: write` permissions.

<sup>Written for commit 5c227896244afc7485c6f24a0cf341e0b5ab896b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

