### PR TITLE
Hide meetings menu from auditors

### DIFF
--- a/pkg/probo/policies.go
+++ b/pkg/probo/policies.go
@@ -141,7 +141,6 @@ var AuditorPolicy = policy.NewPolicy(
 		ActionDataProtectionImpactAssessmentGet,
 		ActionTransferImpactAssessmentGet, ActionTransferImpactAssessmentList,
 		ActionSnapshotGet, ActionSnapshotList,
-		ActionMeetingGet, ActionMeetingList,
 		ActionFileGet, ActionFileDownloadUrl,
 		ActionStateOfApplicabilityGet, ActionStateOfApplicabilityList,
 		ActionApplicabilityStatementGet, ActionApplicabilityStatementList,


### PR DESCRIPTION
Removes meeting permissions from the auditor policy so the meetings menu item is not displayed in the sidebar navigation.

Auditors previously saw the meetings menu but lacked access, creating a confusing UI experience. This change hides the menu entirely for the auditor role.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the Meetings menu for the Auditor role by removing meeting permissions from `AuditorPolicy`. This avoids showing a menu item to users who can’t access meetings.

<sup>Written for commit cf07f702dfec1cf26d05631fcf1e0927cd4d9709. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

