### PR TITLE
Fix race condition in magic link token verification

### DIFF
--- a/pkg/iam/auth_service.go
+++ b/pkg/iam/auth_service.go
@@ -628,21 +628,12 @@ func (s AuthService) OpenSessionWithMagicLink(ctx context.Context, tokenString s
 			hashedValue := HashToken(tokenString)
 			token := &coredata.Token{}
 
-			if err := s.pg.WithConn(
-				ctx,
-				func(conn pg.Conn) error {
-					if err := token.LoadByHashedValueForUpdate(ctx, conn, hashedValue); err != nil {
-						if errors.Is(err, coredata.ErrResourceNotFound) {
-							return NewInvalidTokenError()
-						}
+			if err := token.LoadByHashedValueForUpdate(ctx, tx, hashedValue); err != nil {
+				if errors.Is(err, coredata.ErrResourceNotFound) {
+					return NewInvalidTokenError()
+				}
 
-						return fmt.Errorf("cannot load token by hashed value: %w", err)
-					}
-
-					return nil
-				},
-			); err != nil {
-				return fmt.Errorf("cannot load token: %w", err)
+				return fmt.Errorf("cannot load token by hashed value: %w", err)
 			}
 
 			err := identity.LoadByEmail(ctx, tx, payload.Data.Email)

--- a/pkg/server/api/authn/identity_presence_middleware.go
+++ b/pkg/server/api/authn/identity_presence_middleware.go
@@ -37,7 +37,7 @@ func NewIdentityPresenceMiddleware() func(next http.Handler) http.Handler {
 							Errors: gqlerror.List{
 								gqlutils.Unauthenticatedf(
 									r.Context(),
-									"authentication is required to access this resouce",
+									"authentication is required to access this resource",
 								),
 							},
 						},

--- a/pkg/server/gqlutils/directives/session/session.go
+++ b/pkg/server/gqlutils/directives/session/session.go
@@ -92,7 +92,7 @@ func Directive(ctx context.Context, obj any, next graphql.Resolver, required Ses
 		if identity == nil {
 			return nil, gqlutils.Unauthenticatedf(
 				ctx,
-				"authentication is required to access this resouce",
+				"authentication is required to access this resource",
 			)
 		}
 	case SessionRequirementNone:


### PR DESCRIPTION
## Summary

- Fixed race condition in `OpenSessionWithMagicLink` where token lookup used a separate connection instead of the transaction, breaking the `FOR UPDATE` lock that prevents concurrent magic link verification
- Corrected "resouce" → "resource" typo in authentication error messages

## Changes

The `SELECT ... FOR UPDATE` lock must be held within the transaction to provide mutual exclusion. Now uses the transaction connection directly for the token lookup, ensuring the lock is held until commit/rollback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race condition in magic link token verification by loading the token with SELECT FOR UPDATE using the same transaction (`tx`), ensuring the lock is held until commit. Also fixes an authentication error message typo: "resouce" → "resource".

<sup>Written for commit bf6965aff14943d4f7f7f2a1aa68acd781203703. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

