### PR TITLE
Fix flaky finding e2e tests: move advisory lock outside CTE

### DIFF
--- a/pkg/coredata/finding.go
+++ b/pkg/coredata/finding.go
@@ -243,9 +243,19 @@ func (f *Finding) Insert(
 	conn pg.Conn,
 	scope Scoper,
 ) error {
+	lockQuery := `SELECT pg_advisory_xact_lock(hashtext(@organization_id::text))`
+
+	lockArgs := pgx.StrictNamedArgs{
+		"organization_id": f.OrganizationID,
+	}
+
+	if _, err := conn.Exec(ctx, lockQuery, lockArgs); err != nil {
+		return fmt.Errorf("cannot acquire advisory lock: %w", err)
+	}
+
 	q := `
 WITH next_ref AS (
-	SELECT pg_advisory_xact_lock(hashtext(@organization_id::text)),
+	SELECT
 		COALESCE(
 			MAX(CAST(SUBSTRING(reference_id FROM 5) AS INTEGER)),
 			0
@@ -306,7 +316,7 @@ RETURNING reference_id
 		"identified_on":       f.IdentifiedOn,
 		"root_cause":          f.RootCause,
 		"corrective_action":   f.CorrectiveAction,
-		"owner_id":    f.OwnerID,
+		"owner_id":            f.OwnerID,
 		"due_date":            f.DueDate,
 		"status":              f.Status,
 		"priority":            f.Priority,


### PR DESCRIPTION
## Summary

The pg_advisory_xact_lock inside the WITH clause caused race conditions in PostgreSQL READ COMMITTED mode. When a transaction blocked on the lock and resumed after acquiring it, it used a stale snapshot and computed the same reference ID as the previous transaction, violating the unique constraint. Moving the lock to a separate statement before the INSERT ensures the snapshot includes all previously committed data.

All 966 e2e tests now pass consistently without flakiness.

## Test plan

- [x] Run full e2e test suite (966 tests pass)
- [x] Run TestFinding_StatusAndPriorityValues 3 times (all pass)
- [x] Run make lint (clean)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the PostgreSQL advisory lock out of the CTE into a separate pre-INSERT statement to avoid stale READ COMMITTED snapshots that caused duplicate `reference_id`s. This removes the flakiness in the finding e2e tests; all 966 now pass consistently.

- **Bug Fixes**
  - Acquire `pg_advisory_xact_lock` with a standalone SELECT before the INSERT so the snapshot includes committed rows.
  - Prevents duplicate `reference_id` generation and unique constraint violations under concurrency.

<sup>Written for commit b63aa879fcd80afa616f948ff8d4b49f7d05158a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

