### PR TITLE
Add bulk authorization for batch resource operations

### DIFF
--- a/e2e/console/document_bulk_test.go
+++ b/e2e/console/document_bulk_test.go
@@ -1,0 +1,392 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package console_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/e2e/internal/factory"
+	"go.probo.inc/probo/e2e/internal/testutil"
+)
+
+func TestDocument_BulkDelete(t *testing.T) {
+	t.Parallel()
+
+	t.Run("owner can bulk delete", func(t *testing.T) {
+		t.Parallel()
+
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		approverID := factory.CreateUser(owner)
+		docID1 := factory.NewDocument(owner, approverID).Create()
+		docID2 := factory.NewDocument(owner, approverID).Create()
+
+		var result struct {
+			BulkDeleteDocuments struct {
+				DeletedDocumentIds []string `json:"deletedDocumentIds"`
+			} `json:"bulkDeleteDocuments"`
+		}
+
+		err := owner.Execute(`
+			mutation BulkDeleteDocuments($input: BulkDeleteDocumentsInput!) {
+				bulkDeleteDocuments(input: $input) {
+					deletedDocumentIds
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{
+				"documentIds": []string{docID1, docID2},
+			},
+		}, &result)
+		require.NoError(t, err, "owner should be able to bulk delete documents")
+		assert.Len(t, result.BulkDeleteDocuments.DeletedDocumentIds, 2)
+	})
+
+	t.Run("admin can bulk delete", func(t *testing.T) {
+		t.Parallel()
+
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		admin := testutil.NewClientInOrg(t, testutil.RoleAdmin, owner)
+		approverID := factory.CreateUser(owner)
+		docID1 := factory.NewDocument(owner, approverID).Create()
+		docID2 := factory.NewDocument(owner, approverID).Create()
+
+		var result struct {
+			BulkDeleteDocuments struct {
+				DeletedDocumentIds []string `json:"deletedDocumentIds"`
+			} `json:"bulkDeleteDocuments"`
+		}
+
+		err := admin.Execute(`
+			mutation BulkDeleteDocuments($input: BulkDeleteDocumentsInput!) {
+				bulkDeleteDocuments(input: $input) {
+					deletedDocumentIds
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{
+				"documentIds": []string{docID1, docID2},
+			},
+		}, &result)
+		require.NoError(t, err, "admin should be able to bulk delete documents")
+		assert.Len(t, result.BulkDeleteDocuments.DeletedDocumentIds, 2)
+	})
+
+	t.Run("viewer cannot bulk delete", func(t *testing.T) {
+		t.Parallel()
+
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+		approverID := factory.CreateUser(owner)
+		docID := factory.NewDocument(owner, approverID).Create()
+
+		_, err := viewer.Do(`
+			mutation BulkDeleteDocuments($input: BulkDeleteDocumentsInput!) {
+				bulkDeleteDocuments(input: $input) {
+					deletedDocumentIds
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{
+				"documentIds": []string{docID},
+			},
+		})
+		testutil.RequireForbiddenError(t, err, "viewer should not be able to bulk delete documents")
+	})
+}
+
+func TestDocument_BulkPublish(t *testing.T) {
+	t.Parallel()
+
+	t.Run("owner can bulk publish", func(t *testing.T) {
+		t.Parallel()
+
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		docID1, _ := createTestDocument(t, owner)
+		docID2, _ := createTestDocument(t, owner)
+
+		var result struct {
+			BulkPublishDocumentVersions struct {
+				DocumentVersionEdges []struct {
+					Node struct {
+						ID     string `json:"id"`
+						Status string `json:"status"`
+					} `json:"node"`
+				} `json:"documentVersionEdges"`
+			} `json:"bulkPublishDocumentVersions"`
+		}
+
+		err := owner.Execute(`
+			mutation BulkPublishDocumentVersions($input: BulkPublishDocumentVersionsInput!) {
+				bulkPublishDocumentVersions(input: $input) {
+					documentVersionEdges {
+						node { id status }
+					}
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{
+				"documentIds": []string{docID1, docID2},
+				"changelog":   "Bulk publish",
+			},
+		}, &result)
+		require.NoError(t, err, "owner should be able to bulk publish")
+		assert.Len(t, result.BulkPublishDocumentVersions.DocumentVersionEdges, 2)
+		for _, edge := range result.BulkPublishDocumentVersions.DocumentVersionEdges {
+			assert.Equal(t, "PUBLISHED", edge.Node.Status)
+		}
+	})
+
+	t.Run("admin can bulk publish", func(t *testing.T) {
+		t.Parallel()
+
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		admin := testutil.NewClientInOrg(t, testutil.RoleAdmin, owner)
+		docID1, _ := createTestDocument(t, owner)
+		docID2, _ := createTestDocument(t, owner)
+
+		var result struct {
+			BulkPublishDocumentVersions struct {
+				DocumentVersionEdges []struct {
+					Node struct {
+						ID     string `json:"id"`
+						Status string `json:"status"`
+					} `json:"node"`
+				} `json:"documentVersionEdges"`
+			} `json:"bulkPublishDocumentVersions"`
+		}
+
+		err := admin.Execute(`
+			mutation BulkPublishDocumentVersions($input: BulkPublishDocumentVersionsInput!) {
+				bulkPublishDocumentVersions(input: $input) {
+					documentVersionEdges {
+						node { id status }
+					}
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{
+				"documentIds": []string{docID1, docID2},
+				"changelog":   "Bulk publish",
+			},
+		}, &result)
+		require.NoError(t, err, "admin should be able to bulk publish")
+		assert.Len(t, result.BulkPublishDocumentVersions.DocumentVersionEdges, 2)
+	})
+
+	t.Run("viewer cannot bulk publish", func(t *testing.T) {
+		t.Parallel()
+
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+		docID, _ := createTestDocument(t, owner)
+
+		_, err := viewer.Do(`
+			mutation BulkPublishDocumentVersions($input: BulkPublishDocumentVersionsInput!) {
+				bulkPublishDocumentVersions(input: $input) {
+					documentVersionEdges {
+						node { id }
+					}
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{
+				"documentIds": []string{docID},
+				"changelog":   "Bulk publish",
+			},
+		})
+		testutil.RequireForbiddenError(t, err, "viewer should not be able to bulk publish")
+	})
+}
+
+func TestDocument_BulkArchive(t *testing.T) {
+	t.Parallel()
+
+	t.Run("owner can bulk archive", func(t *testing.T) {
+		t.Parallel()
+
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		approverID := factory.CreateUser(owner)
+		docID1 := factory.NewDocument(owner, approverID).Create()
+		docID2 := factory.NewDocument(owner, approverID).Create()
+
+		_, err := owner.Do(`
+			mutation BulkArchiveDocuments($input: BulkArchiveDocumentsInput!) {
+				bulkArchiveDocuments(input: $input) {
+					documents { id }
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{
+				"documentIds": []string{docID1, docID2},
+			},
+		})
+		require.NoError(t, err, "owner should be able to bulk archive documents")
+	})
+
+	t.Run("admin can bulk archive", func(t *testing.T) {
+		t.Parallel()
+
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		admin := testutil.NewClientInOrg(t, testutil.RoleAdmin, owner)
+		approverID := factory.CreateUser(owner)
+		docID1 := factory.NewDocument(owner, approverID).Create()
+		docID2 := factory.NewDocument(owner, approverID).Create()
+
+		_, err := admin.Do(`
+			mutation BulkArchiveDocuments($input: BulkArchiveDocumentsInput!) {
+				bulkArchiveDocuments(input: $input) {
+					documents { id }
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{
+				"documentIds": []string{docID1, docID2},
+			},
+		})
+		require.NoError(t, err, "admin should be able to bulk archive documents")
+	})
+
+	t.Run("viewer cannot bulk archive", func(t *testing.T) {
+		t.Parallel()
+
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+		approverID := factory.CreateUser(owner)
+		docID := factory.NewDocument(owner, approverID).Create()
+
+		_, err := viewer.Do(`
+			mutation BulkArchiveDocuments($input: BulkArchiveDocumentsInput!) {
+				bulkArchiveDocuments(input: $input) {
+					documents { id }
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{
+				"documentIds": []string{docID},
+			},
+		})
+		testutil.RequireForbiddenError(t, err, "viewer should not be able to bulk archive documents")
+	})
+}
+
+func TestDocument_BulkUnarchive(t *testing.T) {
+	t.Parallel()
+
+	t.Run("owner can bulk unarchive", func(t *testing.T) {
+		t.Parallel()
+
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		approverID := factory.CreateUser(owner)
+		docID1 := factory.NewDocument(owner, approverID).Create()
+		docID2 := factory.NewDocument(owner, approverID).Create()
+
+		for _, docID := range []string{docID1, docID2} {
+			_, err := owner.Do(`
+				mutation ArchiveDocument($input: ArchiveDocumentInput!) {
+					archiveDocument(input: $input) {
+						document { id }
+					}
+				}
+			`, map[string]any{
+				"input": map[string]any{"documentId": docID},
+			})
+			require.NoError(t, err, "setup: should archive document")
+		}
+
+		_, err := owner.Do(`
+			mutation BulkUnarchiveDocuments($input: BulkUnarchiveDocumentsInput!) {
+				bulkUnarchiveDocuments(input: $input) {
+					documents { id }
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{
+				"documentIds": []string{docID1, docID2},
+			},
+		})
+		require.NoError(t, err, "owner should be able to bulk unarchive documents")
+	})
+
+	t.Run("admin can bulk unarchive", func(t *testing.T) {
+		t.Parallel()
+
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		admin := testutil.NewClientInOrg(t, testutil.RoleAdmin, owner)
+		approverID := factory.CreateUser(owner)
+		docID1 := factory.NewDocument(owner, approverID).Create()
+		docID2 := factory.NewDocument(owner, approverID).Create()
+
+		for _, docID := range []string{docID1, docID2} {
+			_, err := owner.Do(`
+				mutation ArchiveDocument($input: ArchiveDocumentInput!) {
+					archiveDocument(input: $input) {
+						document { id }
+					}
+				}
+			`, map[string]any{
+				"input": map[string]any{"documentId": docID},
+			})
+			require.NoError(t, err, "setup: should archive document")
+		}
+
+		_, err := admin.Do(`
+			mutation BulkUnarchiveDocuments($input: BulkUnarchiveDocumentsInput!) {
+				bulkUnarchiveDocuments(input: $input) {
+					documents { id }
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{
+				"documentIds": []string{docID1, docID2},
+			},
+		})
+		require.NoError(t, err, "admin should be able to bulk unarchive documents")
+	})
+
+	t.Run("viewer cannot bulk unarchive", func(t *testing.T) {
+		t.Parallel()
+
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+		approverID := factory.CreateUser(owner)
+		docID := factory.NewDocument(owner, approverID).Create()
+
+		_, err := owner.Do(`
+			mutation ArchiveDocument($input: ArchiveDocumentInput!) {
+				archiveDocument(input: $input) {
+					document { id }
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{"documentId": docID},
+		})
+		require.NoError(t, err, "setup: should archive document")
+
+		_, err = viewer.Do(`
+			mutation BulkUnarchiveDocuments($input: BulkUnarchiveDocumentsInput!) {
+				bulkUnarchiveDocuments(input: $input) {
+					documents { id }
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{
+				"documentIds": []string{docID},
+			},
+		})
+		testutil.RequireForbiddenError(t, err, "viewer should not be able to bulk unarchive documents")
+	})
+}

--- a/pkg/coredata/document.go
+++ b/pkg/coredata/document.go
@@ -59,7 +59,6 @@ func (p Document) CursorKey(orderBy DocumentOrderField) page.CursorKey {
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-// AuthorizationAttributes returns the authorization attributes for policy evaluation.
 func (d *Document) AuthorizationAttributes(ctx context.Context, conn pg.Conn) (map[string]string, error) {
 	q := `SELECT organization_id, status FROM documents WHERE id = $1 LIMIT 1;`
 
@@ -76,6 +75,44 @@ func (d *Document) AuthorizationAttributes(ctx context.Context, conn pg.Conn) (m
 		"organization_id": organizationID.String(),
 		"document_status": documentStatus.String(),
 	}, nil
+}
+
+func (d Documents) AuthorizationAttributes(ctx context.Context, conn pg.Conn) (map[gid.GID]map[string]string, error) {
+	ids := make([]gid.GID, len(d))
+	for i, doc := range d {
+		ids[i] = doc.ID
+	}
+
+	q := `SELECT id, organization_id, status FROM documents WHERE id = ANY($1);`
+
+	rows, err := conn.Query(ctx, q, ids)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query document authorization attributes: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[gid.GID]map[string]string, len(d))
+	for rows.Next() {
+		var id, organizationID gid.GID
+		var documentStatus DocumentStatus
+		if err := rows.Scan(&id, &organizationID, &documentStatus); err != nil {
+			return nil, fmt.Errorf("cannot scan document authorization attributes: %w", err)
+		}
+		result[id] = map[string]string{
+			"organization_id": organizationID.String(),
+			"document_status": documentStatus.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate document authorization attributes: %w", err)
+	}
+
+	if len(result) != len(d) {
+		return nil, ErrResourceNotFound
+	}
+
+	return result, nil
 }
 
 func (p *Document) LoadByID(

--- a/pkg/coredata/entity_type_reg.go
+++ b/pkg/coredata/entity_type_reg.go
@@ -227,3 +227,27 @@ func NewEntityFromID(id gid.GID) (any, bool) {
 		return nil, false
 	}
 }
+
+func NewEntitiesFromIDs(ids []gid.GID) (any, bool) {
+	if len(ids) == 0 {
+		return nil, false
+	}
+
+	entityType := ids[0].EntityType()
+	for _, id := range ids[1:] {
+		if id.EntityType() != entityType {
+			return nil, false
+		}
+	}
+
+	switch entityType {
+	case DocumentEntityType:
+		docs := make(Documents, len(ids))
+		for i, id := range ids {
+			docs[i] = &Document{ID: id}
+		}
+		return docs, true
+	default:
+		return nil, false
+	}
+}

--- a/pkg/iam/authorizer.go
+++ b/pkg/iam/authorizer.go
@@ -27,29 +27,45 @@ import (
 	"go.probo.inc/probo/pkg/iam/policy"
 )
 
-// AuthorizationAttributer is implemented by entities that provide attributes
-// for policy condition evaluation.
-type AuthorizationAttributer interface {
-	AuthorizationAttributes(ctx context.Context, conn pg.Conn) (map[string]string, error)
-}
+type (
+	AuthorizationAttributes     = map[string]string
+	AuthorizationAttributesByID = map[gid.GID]AuthorizationAttributes
 
-// AuthorizeParams contains the parameters for an authorization request.
-type AuthorizeParams struct {
-	Principal          gid.GID
-	Resource           gid.GID
-	Session            *gid.GID
-	Action             string
-	ResourceAttributes map[string]string
-}
+	AuthorizationAttributer interface {
+		AuthorizationAttributes(ctx context.Context, conn pg.Conn) (AuthorizationAttributes, error)
+	}
 
-// Authorizer evaluates authorization requests against registered policies.
-type Authorizer struct {
-	pg        *pg.Client
-	evaluator *policy.Evaluator
-	policySet *PolicySet
-}
+	BulkAuthorizationAttributer interface {
+		AuthorizationAttributes(ctx context.Context, conn pg.Conn) (AuthorizationAttributesByID, error)
+	}
 
-// NewAuthorizer creates a new Authorizer instance.
+	AuthorizeParams struct {
+		Principal          gid.GID
+		Resource           gid.GID
+		Session            *gid.GID
+		Action             string
+		ResourceAttributes AuthorizationAttributes
+	}
+
+	BulkAuthorizeParams struct {
+		Principal gid.GID
+		Resources []gid.GID
+		Session   *gid.GID
+		Action    string
+	}
+
+	Authorizer struct {
+		pg        *pg.Client
+		evaluator *policy.Evaluator
+		policySet *PolicySet
+	}
+
+	evaluationContext struct {
+		principalAttrs AuthorizationAttributes
+		policies       []*policy.Policy
+	}
+)
+
 func NewAuthorizer(pgClient *pg.Client) *Authorizer {
 	return &Authorizer{
 		pg:        pgClient,
@@ -58,12 +74,10 @@ func NewAuthorizer(pgClient *pg.Client) *Authorizer {
 	}
 }
 
-// RegisterPolicySet merges the given policy set into the authorizer.
 func (a *Authorizer) RegisterPolicySet(ps *PolicySet) {
 	a.policySet.Merge(ps)
 }
 
-// Authorize checks if the principal is allowed to perform the action on the resource.
 func (a *Authorizer) Authorize(ctx context.Context, params AuthorizeParams) error {
 	if params.Principal.EntityType() != coredata.IdentityEntityType {
 		return NewUnsupportedPrincipalTypeError(params.Principal.EntityType())
@@ -72,36 +86,135 @@ func (a *Authorizer) Authorize(ctx context.Context, params AuthorizeParams) erro
 	return a.pg.WithConn(ctx, func(conn pg.Conn) error { return a.authorize(ctx, conn, params) })
 }
 
+func (a *Authorizer) BulkAuthorize(ctx context.Context, params BulkAuthorizeParams) error {
+	if params.Principal.EntityType() != coredata.IdentityEntityType {
+		return NewUnsupportedPrincipalTypeError(params.Principal.EntityType())
+	}
+
+	return a.pg.WithConn(ctx, func(conn pg.Conn) error {
+		return a.bulkAuthorize(ctx, conn, params)
+	})
+}
+
 func (a *Authorizer) authorize(ctx context.Context, conn pg.Conn, params AuthorizeParams) error {
 	resourceAttrs, err := a.buildResourceAttributes(ctx, conn, params)
 	if err != nil {
 		return fmt.Errorf("cannot build resource attributes: %w", err)
 	}
 
-	resourceOrgID := resourceAttrs["organization_id"]
-
-	// Find role for resource's organization
-	membership, err := a.loadMembership(ctx, conn, params.Principal, resourceOrgID)
+	evalCtx, err := a.buildEvaluationContext(
+		ctx,
+		conn,
+		params.Principal,
+		params.Session,
+		resourceAttrs["organization_id"],
+	)
 	if err != nil {
-		return fmt.Errorf("cannot load memberships for principal: %w", err)
+		return err
 	}
 
-	// Check whether the viewer is currently assuming the org of the accessed resource
-	if membership != nil && params.Session != nil {
+	req := policy.AuthorizationRequest{
+		Principal: params.Principal,
+		Resource:  params.Resource,
+		Action:    params.Action,
+		ConditionContext: policy.ConditionContext{
+			Principal: evalCtx.principalAttrs,
+			Resource:  resourceAttrs,
+		},
+	}
+
+	if a.evaluator.Evaluate(req, evalCtx.policies).IsAllowed() {
+		return nil
+	}
+
+	return NewInsufficientPermissionsError(params.Principal, params.Resource, params.Action)
+}
+
+func (a *Authorizer) bulkAuthorize(ctx context.Context, conn pg.Conn, params BulkAuthorizeParams) error {
+	if len(params.Resources) == 0 {
+		return nil
+	}
+
+	entity, ok := coredata.NewEntitiesFromIDs(params.Resources)
+	if !ok {
+		return fmt.Errorf("unsupported or mixed resource types for bulk authorization")
+	}
+
+	collection, ok := entity.(BulkAuthorizationAttributer)
+	if !ok {
+		return fmt.Errorf("resource type %d does not implement BulkAuthorizationAttributer", params.Resources[0].EntityType())
+	}
+
+	allAttrs, err := collection.AuthorizationAttributes(ctx, conn)
+	if err != nil {
+		return fmt.Errorf("cannot load bulk resource attributes: %w", err)
+	}
+
+	orgID := allAttrs[params.Resources[0]]["organization_id"]
+	for id, attrs := range allAttrs {
+		if attrs["organization_id"] != orgID {
+			return fmt.Errorf("cannot bulk authorize resources from different organizations")
+		}
+		attrs["id"] = id.String()
+	}
+
+	evalCtx, err := a.buildEvaluationContext(
+		ctx,
+		conn,
+		params.Principal,
+		params.Session,
+		orgID,
+	)
+	if err != nil {
+		return err
+	}
+
+	for _, resourceID := range params.Resources {
+		req := policy.AuthorizationRequest{
+			Principal: params.Principal,
+			Resource:  resourceID,
+			Action:    params.Action,
+			ConditionContext: policy.ConditionContext{
+				Principal: evalCtx.principalAttrs,
+				Resource:  allAttrs[resourceID],
+			},
+		}
+
+		if !a.evaluator.Evaluate(req, evalCtx.policies).IsAllowed() {
+			return NewInsufficientPermissionsError(params.Principal, resourceID, params.Action)
+		}
+	}
+
+	return nil
+}
+
+func (a *Authorizer) buildEvaluationContext(
+	ctx context.Context,
+	conn pg.Conn,
+	principalID gid.GID,
+	session *gid.GID,
+	resourceOrgID string,
+) (*evaluationContext, error) {
+	membership, err := a.loadMembership(ctx, conn, principalID, resourceOrgID)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load memberships for principal: %w", err)
+	}
+
+	if membership != nil && session != nil {
 		if _, err := a.getActiveChildSessionForMembership(
 			ctx,
 			conn,
-			*params.Session,
+			*session,
 			membership.ID,
 		); err != nil {
 			var errSessionNotFound *ErrSessionNotFound
 			var errSessionExpired *ErrSessionExpired
 
 			if errors.As(err, &errSessionNotFound) || errors.As(err, &errSessionExpired) {
-				return NewAssumptionRequiredError(params.Principal, membership.ID)
+				return nil, NewAssumptionRequiredError(principalID, membership.ID)
 			}
 
-			return fmt.Errorf("cannot get active child session for membership: %w", err)
+			return nil, fmt.Errorf("cannot get active child session for membership: %w", err)
 		}
 	}
 
@@ -110,37 +223,23 @@ func (a *Authorizer) authorize(ctx context.Context, conn pg.Conn, params Authori
 		role = membership.Role.String()
 	}
 
-	// Only set principal.organization_id if they have a role in this org
-	var scopedPrincipalAttrs map[string]string
+	var scopedPrincipalAttrs AuthorizationAttributes
 	if membership != nil && role != "" {
-		scopedPrincipalAttrs = map[string]string{
+		scopedPrincipalAttrs = AuthorizationAttributes{
 			"organization_id": membership.OrganizationID.String(),
 			"role":            membership.Role.String(),
 		}
 	}
 
-	principalAttrs, err := a.buildPrincipalAttributes(ctx, conn, params.Principal, scopedPrincipalAttrs)
+	principalAttrs, err := a.buildPrincipalAttributes(ctx, conn, principalID, scopedPrincipalAttrs)
 	if err != nil {
-		return fmt.Errorf("cannot build principal attributes: %w", err)
+		return nil, fmt.Errorf("cannot build principal attributes: %w", err)
 	}
 
-	policies := a.buildPoliciesForRole(role)
-
-	req := policy.AuthorizationRequest{
-		Principal: params.Principal,
-		Resource:  params.Resource,
-		Action:    params.Action,
-		ConditionContext: policy.ConditionContext{
-			Principal: principalAttrs,
-			Resource:  resourceAttrs,
-		},
-	}
-
-	if a.evaluator.Evaluate(req, policies).IsAllowed() {
-		return nil
-	}
-
-	return NewInsufficientPermissionsError(params.Principal, params.Resource, params.Action)
+	return &evaluationContext{
+		principalAttrs: principalAttrs,
+		policies:       a.buildPoliciesForRole(role),
+	}, nil
 }
 
 func (a *Authorizer) loadMembership(
@@ -197,9 +296,9 @@ func (a *Authorizer) buildPrincipalAttributes(
 	ctx context.Context,
 	conn pg.Conn,
 	principalID gid.GID,
-	defaultAttrs map[string]string,
-) (map[string]string, error) {
-	attrs := map[string]string{
+	defaultAttrs AuthorizationAttributes,
+) (AuthorizationAttributes, error) {
+	attrs := AuthorizationAttributes{
 		"id": principalID.String(),
 	}
 	maps.Copy(attrs, defaultAttrs)
@@ -221,8 +320,8 @@ func (a *Authorizer) buildResourceAttributes(
 	ctx context.Context,
 	conn pg.Conn,
 	params AuthorizeParams,
-) (map[string]string, error) {
-	attrs := map[string]string{
+) (AuthorizationAttributes, error) {
+	attrs := AuthorizationAttributes{
 		"id": params.Resource.String(),
 	}
 

--- a/pkg/server/api/authz/authorization.go
+++ b/pkg/server/api/authz/authorization.go
@@ -29,6 +29,7 @@ import (
 type (
 	AuthorizeFuncOption func(*iam.AuthorizeParams)
 	AuthorizeFunc       func(context.Context, gid.GID, string, ...AuthorizeFuncOption) error
+	BulkAuthorizeFunc   func(context.Context, []gid.GID, string) error
 )
 
 func WithAttr(key, value string) AuthorizeFuncOption {
@@ -42,6 +43,50 @@ func WithAttr(key, value string) AuthorizeFuncOption {
 func WithSkipAssumptionCheck() AuthorizeFuncOption {
 	return func(params *iam.AuthorizeParams) {
 		params.Session = nil
+	}
+}
+
+func NewBulkAuthorizeFunc(
+	svc *iam.Service,
+	logger *log.Logger,
+) BulkAuthorizeFunc {
+	return func(
+		ctx context.Context,
+		resourceIDs []gid.GID,
+		action string,
+	) error {
+		identity := authn.IdentityFromContext(ctx)
+		session := authn.SessionFromContext(ctx)
+
+		params := iam.BulkAuthorizeParams{
+			Principal: identity.ID,
+			Resources: resourceIDs,
+			Action:    action,
+		}
+		if session != nil {
+			params.Session = &session.ID
+		}
+
+		if err := svc.Authorizer.BulkAuthorize(ctx, params); err != nil {
+			var errAssumptionRequired *iam.ErrAssumptionRequired
+			if errors.As(err, &errAssumptionRequired) {
+				return gqlutils.AssumptionRequired(ctx, err)
+			}
+
+			var errInsufficientPermissions *iam.ErrInsufficientPermissions
+			if errors.As(err, &errInsufficientPermissions) {
+				return gqlutils.Forbidden(ctx, err)
+			}
+
+			if errors.Is(err, coredata.ErrResourceNotFound) {
+				return gqlutils.NotFoundf(ctx, "resource not found")
+			}
+
+			logger.ErrorCtx(ctx, "cannot bulk authorize", log.Error(err))
+			return gqlutils.Internal(ctx)
+		}
+
+		return nil
 	}
 }
 

--- a/pkg/server/api/console/v1/graphql_handler.go
+++ b/pkg/server/api/console/v1/graphql_handler.go
@@ -31,6 +31,7 @@ func NewGraphQLHandler(iamSvc *iam.Service, proboSvc *probo.Service, esignSvc *e
 	config := schema.Config{
 		Resolvers: &Resolver{
 			authorize:         authz.NewAuthorizeFunc(iamSvc, logger),
+			bulkAuthorize:     authz.NewBulkAuthorizeFunc(iamSvc, logger),
 			probo:             proboSvc,
 			iam:               iamSvc,
 			esign:             esignSvc,

--- a/pkg/server/api/console/v1/resolver.go
+++ b/pkg/server/api/console/v1/resolver.go
@@ -43,6 +43,7 @@ import (
 type (
 	Resolver struct {
 		authorize         authz.AuthorizeFunc
+		bulkAuthorize     authz.BulkAuthorizeFunc
 		probo             *probo.Service
 		iam               *iam.Service
 		esign             *esign.Service

--- a/pkg/server/api/console/v1/v1_resolver.go
+++ b/pkg/server/api/console/v1/v1_resolver.go
@@ -4677,10 +4677,8 @@ func (r *mutationResolver) BulkPublishDocumentVersions(ctx context.Context, inpu
 		}, nil
 	}
 
-	for _, documentID := range input.DocumentIds {
-		if err := r.authorize(ctx, documentID, probo.ActionDocumentVersionPublish); err != nil {
-			return nil, err
-		}
+	if err := r.bulkAuthorize(ctx, input.DocumentIds, probo.ActionDocumentVersionPublish); err != nil {
+		return nil, err
 	}
 
 	prb := r.ProboService(ctx, input.DocumentIds[0].TenantID())
@@ -4719,10 +4717,8 @@ func (r *mutationResolver) BulkDeleteDocuments(ctx context.Context, input types.
 		}, nil
 	}
 
-	for _, documentID := range input.DocumentIds {
-		if err := r.authorize(ctx, documentID, probo.ActionDocumentDelete); err != nil {
-			return nil, err
-		}
+	if err := r.bulkAuthorize(ctx, input.DocumentIds, probo.ActionDocumentDelete); err != nil {
+		return nil, err
 	}
 
 	prb := r.ProboService(ctx, input.DocumentIds[0].TenantID())
@@ -4746,10 +4742,8 @@ func (r *mutationResolver) BulkArchiveDocuments(ctx context.Context, input types
 		}, nil
 	}
 
-	for _, documentID := range input.DocumentIds {
-		if err := r.authorize(ctx, documentID, probo.ActionDocumentArchive); err != nil {
-			return nil, err
-		}
+	if err := r.bulkAuthorize(ctx, input.DocumentIds, probo.ActionDocumentArchive); err != nil {
+		return nil, err
 	}
 
 	prb := r.ProboService(ctx, input.DocumentIds[0].TenantID())
@@ -4772,10 +4766,8 @@ func (r *mutationResolver) BulkUnarchiveDocuments(ctx context.Context, input typ
 		}, nil
 	}
 
-	for _, documentID := range input.DocumentIds {
-		if err := r.authorize(ctx, documentID, probo.ActionDocumentUnarchive); err != nil {
-			return nil, err
-		}
+	if err := r.bulkAuthorize(ctx, input.DocumentIds, probo.ActionDocumentUnarchive); err != nil {
+		return nil, err
 	}
 
 	prb := r.ProboService(ctx, input.DocumentIds[0].TenantID())
@@ -4797,11 +4789,8 @@ func (r *mutationResolver) BulkExportDocuments(ctx context.Context, input types.
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	// TODO have a way to batch authorize for resources
-	for _, documentID := range input.DocumentIds {
-		if err := r.authorize(ctx, documentID, probo.ActionDocumentVersionExport); err != nil {
-			return nil, err
-		}
+	if err := r.bulkAuthorize(ctx, input.DocumentIds, probo.ActionDocumentVersionExport); err != nil {
+		return nil, err
 	}
 
 	prb := r.ProboService(ctx, input.DocumentIds[0].TenantID())
@@ -4954,10 +4943,8 @@ func (r *mutationResolver) BulkRequestSignatures(ctx context.Context, input type
 		}, nil
 	}
 
-	for _, documentID := range input.DocumentIds {
-		if err := r.authorize(ctx, documentID, probo.ActionDocumentVersionSignatureRequest); err != nil {
-			return nil, err
-		}
+	if err := r.bulkAuthorize(ctx, input.DocumentIds, probo.ActionDocumentVersionSignatureRequest); err != nil {
+		return nil, err
 	}
 
 	prb := r.ProboService(ctx, input.DocumentIds[0].TenantID())


### PR DESCRIPTION
Introduce BulkAuthorize in the IAM authorizer and the BulkAuthorizationAttributer interface. Collection types like Documents implement a single-query AuthorizationAttributes method (WHERE id = ANY), replacing per-resource N+1 lookups. The caller passes the collection type directly via BulkAuthorizeParams, keeping the authorizer free of entity-type dispatch logic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bulk authorization to remove N+1 checks in batch operations. This speeds up bulk document actions in GraphQL and simplifies how callers authorize multiple resources.

- **New Features**
  - `iam.Authorizer`: added `BulkAuthorize` with `BulkAuthorizeParams`; shares evaluation context, enforces same-organization across resources, injects `id` into attrs, and returns typed errors for caller mapping.
  - Introduced `BulkAuthorizationAttributer`; `coredata.Documents.AuthorizationAttributes` loads many IDs in one query.
  - Added `coredata.NewEntitiesFromIDs` to build homogeneous typed collections and reject mixed resource types.
  - Console GraphQL now wires `authz.NewBulkAuthorizeFunc` and uses bulk auth for document publish, delete, archive, unarchive, export, and request signatures; added e2e RBAC tests for these bulk actions.

<sup>Written for commit 798df3f08c73bf90fc6f050c6afd638003b56f2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

