### PR TITLE
Fix measure category filter not applying on initial page load

### DIFF
--- a/apps/console/src/pages/organizations/measures/MeasuresPage.tsx
+++ b/apps/console/src/pages/organizations/measures/MeasuresPage.tsx
@@ -193,6 +193,22 @@ export default function MeasuresPage({ queryRef }: MeasuresPageProps) {
     });
   };
 
+  const initialUrlCategory = useRef(urlCategory);
+  useEffect(() => {
+    if (initialUrlCategory.current) {
+      startTransition(() => {
+        refetch(
+          {
+            query: null,
+            state: null,
+            category: initialUrlCategory.current,
+          },
+          { fetchPolicy: "network-only" },
+        );
+      });
+    }
+  }, [refetch, startTransition]);
+
   useEffect(() => {
     if (urlCategory !== categoryFilter) {
       setCategoryFilter(urlCategory);


### PR DESCRIPTION
When navigating back to the measures page with a `?category` query parameter, the filter wasn't applied to the initial Relay query. The component state initialized from the URL, but the Relay fragment loaded with its default `category: null`.

Added a mount effect that triggers a refetch with the initial category parameter from the URL, ensuring the filter is applied from page load.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply the measures page category filter from the `?category` URL parameter on initial load. We now refetch on mount so the first Relay data matches the selected category.

- **Bug Fixes**
  - Store the initial URL category in `useRef` and, if present, `startTransition(() => refetch({ query: null, state: null, category }, { fetchPolicy: "network-only" }))` on mount to avoid loading unfiltered data.

<sup>Written for commit 8acaabb8bc1dc3446f8b36168926c7235dc57c3c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

