### PR TITLE
Add OIDC login support for Google and Microsoft

### DIFF
--- a/apps/console/src/pages/iam/auth/sign-in/SignInPage.tsx
+++ b/apps/console/src/pages/iam/auth/sign-in/SignInPage.tsx
@@ -3,7 +3,7 @@ import { useTranslate } from "@probo/i18n";
 import { Button, Field, Google, Microsoft, useToast } from "@probo/ui";
 import { type ComponentProps, type FormEventHandler, Suspense } from "react";
 import { useLazyLoadQuery, useMutation } from "react-relay";
-import { Link, useLocation, matchPath } from "react-router";
+import { Link, matchPath, useLocation } from "react-router";
 import { graphql } from "relay-runtime";
 
 import type { SignInPageMutation } from "#/__generated__/iam/SignInPageMutation.graphql";
@@ -68,10 +68,10 @@ function OIDCButtons() {
             variant="secondary"
             className="w-full h-10"
             onClick={() => {
-              window.location.href =
-                provider.loginURL +
-                "?continue=" +
-                encodeURIComponent(
+              window.location.href
+                = provider.loginURL
+                + "?continue="
+                + encodeURIComponent(
                   safeContinueUrl.pathname + safeContinueUrl.search,
                 );
             }}
@@ -93,8 +93,8 @@ export default function SignInPage() {
   const location = useLocation();
   const safeContinueUrl = useSafeContinueUrl();
 
-  const [signIn, isSigningIn] =
-    useMutation<SignInPageMutation>(signInMutation);
+  const [signIn, isSigningIn]
+    = useMutation<SignInPageMutation>(signInMutation);
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();

--- a/apps/console/src/pages/iam/auth/sign-in/SignInPage.tsx
+++ b/apps/console/src/pages/iam/auth/sign-in/SignInPage.tsx
@@ -70,10 +70,10 @@ function OIDCButtons() {
             onClick={() => {
               window.location.href
                 = provider.loginURL
-                + "?continue="
-                + encodeURIComponent(
-                  safeContinueUrl.pathname + safeContinueUrl.search,
-                );
+                  + "?continue="
+                  + encodeURIComponent(
+                    safeContinueUrl.pathname + safeContinueUrl.search,
+                  );
             }}
           >
             <span className="flex items-center gap-2">

--- a/apps/console/src/pages/iam/auth/sign-in/SignInPage.tsx
+++ b/apps/console/src/pages/iam/auth/sign-in/SignInPage.tsx
@@ -2,7 +2,8 @@ import { formatError, type GraphQLError } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
 import { Button, Field, useToast } from "@probo/ui";
 import type { FormEventHandler } from "react";
-import { useLazyLoadQuery, useMutation } from "react-relay";
+import { useMutation, usePreloadedQuery } from "react-relay";
+import type { PreloadedQuery } from "react-relay";
 import { Link, matchPath, useLocation } from "react-router";
 import { graphql } from "relay-runtime";
 
@@ -23,7 +24,7 @@ const signInMutation = graphql`
   }
 `;
 
-const signInPageQuery = graphql`
+export const signInPageQuery = graphql`
   query SignInPageQuery {
     oidcProviders {
       ...OIDCButtonsFragment
@@ -31,13 +32,17 @@ const signInPageQuery = graphql`
   }
 `;
 
-export default function SignInPage() {
+type Props = {
+  queryRef: PreloadedQuery<SignInPageQuery>;
+};
+
+export default function SignInPage(props: Props) {
   const { __ } = useTranslate();
   const { toast } = useToast();
   const location = useLocation();
   const safeContinueUrl = useSafeContinueUrl();
 
-  const data = useLazyLoadQuery<SignInPageQuery>(signInPageQuery, {});
+  const data = usePreloadedQuery<SignInPageQuery>(signInPageQuery, props.queryRef);
 
   const [signIn, isSigningIn]
     = useMutation<SignInPageMutation>(signInMutation);

--- a/apps/console/src/pages/iam/auth/sign-in/SignInPage.tsx
+++ b/apps/console/src/pages/iam/auth/sign-in/SignInPage.tsx
@@ -1,14 +1,27 @@
+import { formatError, type GraphQLError } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
-import { Button } from "@probo/ui";
-import { useLazyLoadQuery } from "react-relay";
-import { Link, useLocation } from "react-router";
+import { Button, Field, useToast } from "@probo/ui";
+import type { FormEventHandler } from "react";
+import { useLazyLoadQuery, useMutation } from "react-relay";
+import { Link, matchPath, useLocation } from "react-router";
 import { graphql } from "relay-runtime";
 
+import type { SignInPageMutation } from "#/__generated__/iam/SignInPageMutation.graphql";
 import type { SignInPageQuery } from "#/__generated__/iam/SignInPageQuery.graphql";
 import { useSafeContinueUrl } from "#/hooks/useSafeContinueUrl";
 
 import { Divider } from "./_components/Divider";
 import { OIDCButtons } from "./_components/OIDCButtons";
+
+const signInMutation = graphql`
+  mutation SignInPageMutation($input: SignInInput!) {
+    signIn(input: $input) {
+      session {
+        id
+      }
+    }
+  }
+`;
 
 const signInPageQuery = graphql`
   query SignInPageQuery {
@@ -20,10 +33,64 @@ const signInPageQuery = graphql`
 
 export default function SignInPage() {
   const { __ } = useTranslate();
+  const { toast } = useToast();
   const location = useLocation();
   const safeContinueUrl = useSafeContinueUrl();
 
   const data = useLazyLoadQuery<SignInPageQuery>(signInPageQuery, {});
+
+  const [signIn, isSigningIn]
+    = useMutation<SignInPageMutation>(signInMutation);
+
+  const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    const email = (formData.get("email") as string) ?? "";
+    const password = (formData.get("password") as string) ?? "";
+
+    if (!email || !password) return;
+
+    const match = matchPath(
+      {
+        path: "/organizations/:organizationId",
+        caseSensitive: false,
+        end: false,
+      },
+      safeContinueUrl.pathname,
+    );
+
+    signIn({
+      variables: {
+        input: {
+          email,
+          password,
+          organizationId: match?.params.organizationId ?? null,
+        },
+      },
+      onCompleted: (_, error) => {
+        if (error) {
+          toast({
+            title: __("Error"),
+            description: formatError(
+              __("Failed to sign in"),
+              error as GraphQLError,
+            ),
+            variant: "error",
+          });
+          return;
+        }
+
+        window.location.href = safeContinueUrl.href;
+      },
+      onError: (e) => {
+        toast({
+          title: __("Error"),
+          description: e.message,
+          variant: "error",
+        });
+      },
+    });
+  };
 
   return (
     <div className="w-full max-w-sm mx-auto pt-8">
@@ -31,23 +98,47 @@ export default function SignInPage() {
         {__("Sign in to your account")}
       </h1>
 
+      <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
+        <Field
+          required
+          name="email"
+          type="email"
+          label={__("Email")}
+          autoFocus
+        />
+
+        <div>
+          <div className="flex items-center justify-between mb-1">
+            <label className="text-sm font-medium" htmlFor="password">
+              {__("Password")}
+            </label>
+            <Link
+              to="/auth/forgot-password"
+              className="text-sm text-txt-secondary hover:text-txt-primary"
+            >
+              {__("Forgot your password?")}
+            </Link>
+          </div>
+          <Field
+            required
+            name="password"
+            id="password"
+            type="password"
+          />
+        </div>
+
+        <Button className="w-full h-10" disabled={isSigningIn}>
+          {isSigningIn ? __("Signing in...") : __("Sign in")}
+        </Button>
+      </form>
+
       <div className="mt-6 space-y-4">
+        <Divider>{__("Or")}</Divider>
+
         <OIDCButtons
           providers={data.oidcProviders}
           safeContinueUrl={safeContinueUrl}
         />
-
-        {data.oidcProviders.length > 0 && (
-          <Divider>{__("Or")}</Divider>
-        )}
-
-        <Button
-          variant="secondary"
-          className="w-full h-10"
-          to={{ pathname: "/auth/password-login", search: location.search }}
-        >
-          {__("Sign in with Email")}
-        </Button>
 
         <Button
           variant="secondary"

--- a/apps/console/src/pages/iam/auth/sign-in/SignInPage.tsx
+++ b/apps/console/src/pages/iam/auth/sign-in/SignInPage.tsx
@@ -1,6 +1,52 @@
 import { useTranslate } from "@probo/i18n";
 import { Button } from "@probo/ui";
+import { Suspense } from "react";
+import { useLazyLoadQuery } from "react-relay";
 import { Link, useLocation } from "react-router";
+import { graphql } from "relay-runtime";
+
+import type { SignInPageQuery } from "#/__generated__/iam/SignInPageQuery.graphql";
+import { useSafeContinueUrl } from "#/hooks/useSafeContinueUrl";
+
+const oidcProvidersQuery = graphql`
+  query SignInPageQuery {
+    oidcProviders {
+      name
+      loginURL
+    }
+  }
+`;
+
+function OIDCButtons() {
+  const { __ } = useTranslate();
+  const safeContinueUrl = useSafeContinueUrl();
+
+  const data = useLazyLoadQuery<SignInPageQuery>(oidcProvidersQuery, {});
+
+  if (data.oidcProviders.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {data.oidcProviders.map((provider) => (
+        <Button
+          key={provider.name}
+          variant="secondary"
+          className="w-xs h-10 mx-auto"
+          onClick={() => {
+            window.location.href =
+              provider.loginURL +
+              "?continue=" +
+              encodeURIComponent(safeContinueUrl.pathname + safeContinueUrl.search);
+          }}
+        >
+          {__("Continue with %s", provider.name.charAt(0).toUpperCase() + provider.name.slice(1))}
+        </Button>
+      ))}
+    </>
+  );
+}
 
 export default function SignInPage() {
   const { __ } = useTranslate();
@@ -22,6 +68,10 @@ export default function SignInPage() {
       >
         {__("Login with Email")}
       </Button>
+
+      <Suspense fallback={null}>
+        <OIDCButtons />
+      </Suspense>
 
       <div className="relative my-6 w-full">
         <div className="w-xs border-t border-border-mid mx-auto" />

--- a/apps/console/src/pages/iam/auth/sign-in/SignInPage.tsx
+++ b/apps/console/src/pages/iam/auth/sign-in/SignInPage.tsx
@@ -1,34 +1,15 @@
-import { formatError, type GraphQLError } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
-import { Button, Field, Google, Microsoft, useToast } from "@probo/ui";
-import { type ComponentProps, type FormEventHandler, Suspense } from "react";
-import { useLazyLoadQuery, useMutation } from "react-relay";
-import { Link, matchPath, useLocation } from "react-router";
+import { Button } from "@probo/ui";
+import { useLazyLoadQuery } from "react-relay";
+import { Link, useLocation } from "react-router";
 import { graphql } from "relay-runtime";
 
-import type { SignInPageMutation } from "#/__generated__/iam/SignInPageMutation.graphql";
 import type { SignInPageQuery } from "#/__generated__/iam/SignInPageQuery.graphql";
 import { useSafeContinueUrl } from "#/hooks/useSafeContinueUrl";
+import { Divider } from "./_components/Divider";
+import { OIDCButtons } from "./_components/OIDCButtons";
 
-const providerIcons: Record<
-  string,
-  (props: ComponentProps<"svg">) => React.ReactNode
-> = {
-  google: Google,
-  microsoft: Microsoft,
-};
-
-const signInMutation = graphql`
-  mutation SignInPageMutation($input: SignInInput!) {
-    signIn(input: $input) {
-      session {
-        id
-      }
-    }
-  }
-`;
-
-const oidcProvidersQuery = graphql`
+const signInPageQuery = graphql`
   query SignInPageQuery {
     oidcProviders {
       name
@@ -37,114 +18,12 @@ const oidcProvidersQuery = graphql`
   }
 `;
 
-function Divider({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="relative my-6 w-full">
-      <div className="border-t border-border-mid" />
-      <span className="px-4 text-xs uppercase text-txt-secondary bg-level-0 absolute top-0 left-1/2 -translate-1/2">
-        {children}
-      </span>
-    </div>
-  );
-}
-
-function OIDCButtons() {
-  const { __ } = useTranslate();
-  const safeContinueUrl = useSafeContinueUrl();
-
-  const data = useLazyLoadQuery<SignInPageQuery>(oidcProvidersQuery, {});
-
-  if (data.oidcProviders.length === 0) {
-    return null;
-  }
-
-  return (
-    <>
-      {data.oidcProviders.map((provider) => {
-        const Icon = providerIcons[provider.name];
-        return (
-          <Button
-            key={provider.name}
-            variant="secondary"
-            className="w-full h-10"
-            onClick={() => {
-              window.location.href
-                = provider.loginURL
-                  + "?continue="
-                  + encodeURIComponent(
-                    safeContinueUrl.pathname + safeContinueUrl.search,
-                  );
-            }}
-          >
-            <span className="flex items-center gap-2">
-              {Icon && <Icon width={18} height={18} />}
-              {__(`Sign in with ${provider.name.charAt(0).toUpperCase() + provider.name.slice(1)}`)}
-            </span>
-          </Button>
-        );
-      })}
-    </>
-  );
-}
-
 export default function SignInPage() {
   const { __ } = useTranslate();
-  const { toast } = useToast();
   const location = useLocation();
   const safeContinueUrl = useSafeContinueUrl();
 
-  const [signIn, isSigningIn]
-    = useMutation<SignInPageMutation>(signInMutation);
-
-  const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
-    e.preventDefault();
-    const formData = new FormData(e.currentTarget);
-    const email = (formData.get("email") as string) ?? "";
-    const password = (formData.get("password") as string) ?? "";
-
-    if (!email || !password) return;
-
-    const match = matchPath(
-      {
-        path: "/organizations/:organizationId",
-        caseSensitive: false,
-        end: false,
-      },
-      safeContinueUrl.pathname,
-    );
-
-    signIn({
-      variables: {
-        input: {
-          email,
-          password,
-          organizationId: match?.params.organizationId ?? null,
-        },
-      },
-      onCompleted: (_, error) => {
-        if (error) {
-          toast({
-            title: __("Error"),
-            description: formatError(
-              __("Failed to sign in"),
-              error as GraphQLError,
-            ),
-            variant: "error",
-          });
-          return;
-        }
-
-        window.location.href = safeContinueUrl.href;
-      },
-      onError: (e) => {
-        toast({
-          title: __("Error"),
-          description: e.message,
-          variant: "error",
-        });
-      },
-    });
-  };
+  const data = useLazyLoadQuery<SignInPageQuery>(signInPageQuery, {});
 
   return (
     <div className="w-full max-w-sm mx-auto pt-8">
@@ -152,46 +31,23 @@ export default function SignInPage() {
         {__("Sign in to your account")}
       </h1>
 
-      <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
-        <Field
-          required
-          name="email"
-          type="email"
-          label={__("Email")}
-          autoFocus
+      <div className="mt-6 space-y-4">
+        <OIDCButtons
+          providers={data.oidcProviders}
+          safeContinueUrl={safeContinueUrl}
         />
 
-        <div>
-          <div className="flex items-center justify-between mb-1">
-            <label className="text-sm font-medium" htmlFor="password">
-              {__("Password")}
-            </label>
-            <Link
-              to="/auth/forgot-password"
-              className="text-sm text-txt-secondary hover:text-txt-primary"
-            >
-              {__("Forgot your password?")}
-            </Link>
-          </div>
-          <Field
-            required
-            name="password"
-            id="password"
-            type="password"
-          />
-        </div>
+        {data.oidcProviders.length > 0 && (
+          <Divider>{__("Or")}</Divider>
+        )}
 
-        <Button className="w-full h-10" disabled={isSigningIn}>
-          {isSigningIn ? __("Signing in...") : __("Sign in")}
+        <Button
+          variant="secondary"
+          className="w-full h-10"
+          to={{ pathname: "/auth/password-login", search: location.search }}
+        >
+          {__("Sign in with Email")}
         </Button>
-      </form>
-
-      <div className="mt-6 space-y-4">
-        <Divider>{__("Or")}</Divider>
-
-        <Suspense fallback={null}>
-          <OIDCButtons />
-        </Suspense>
 
         <Button
           variant="secondary"

--- a/apps/console/src/pages/iam/auth/sign-in/SignInPage.tsx
+++ b/apps/console/src/pages/iam/auth/sign-in/SignInPage.tsx
@@ -1,12 +1,32 @@
+import { formatError, type GraphQLError } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
-import { Button } from "@probo/ui";
-import { Suspense } from "react";
-import { useLazyLoadQuery } from "react-relay";
-import { Link, useLocation } from "react-router";
+import { Button, Field, Google, Microsoft, useToast } from "@probo/ui";
+import { type ComponentProps, type FormEventHandler, Suspense } from "react";
+import { useLazyLoadQuery, useMutation } from "react-relay";
+import { Link, useLocation, matchPath } from "react-router";
 import { graphql } from "relay-runtime";
 
+import type { SignInPageMutation } from "#/__generated__/iam/SignInPageMutation.graphql";
 import type { SignInPageQuery } from "#/__generated__/iam/SignInPageQuery.graphql";
 import { useSafeContinueUrl } from "#/hooks/useSafeContinueUrl";
+
+const providerIcons: Record<
+  string,
+  (props: ComponentProps<"svg">) => React.ReactNode
+> = {
+  google: Google,
+  microsoft: Microsoft,
+};
+
+const signInMutation = graphql`
+  mutation SignInPageMutation($input: SignInInput!) {
+    signIn(input: $input) {
+      session {
+        id
+      }
+    }
+  }
+`;
 
 const oidcProvidersQuery = graphql`
   query SignInPageQuery {
@@ -16,6 +36,17 @@ const oidcProvidersQuery = graphql`
     }
   }
 `;
+
+function Divider({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="relative my-6 w-full">
+      <div className="border-t border-border-mid" />
+      <span className="px-4 text-xs uppercase text-txt-secondary bg-level-0 absolute top-0 left-1/2 -translate-1/2">
+        {children}
+      </span>
+    </div>
+  );
+}
 
 function OIDCButtons() {
   const { __ } = useTranslate();
@@ -29,88 +60,158 @@ function OIDCButtons() {
 
   return (
     <>
-      {data.oidcProviders.map((provider) => (
-        <Button
-          key={provider.name}
-          variant="secondary"
-          className="w-xs h-10 mx-auto"
-          onClick={() => {
-            window.location.href =
-              provider.loginURL +
-              "?continue=" +
-              encodeURIComponent(safeContinueUrl.pathname + safeContinueUrl.search);
-          }}
-        >
-          {__("Continue with %s", provider.name.charAt(0).toUpperCase() + provider.name.slice(1))}
-        </Button>
-      ))}
+      {data.oidcProviders.map((provider) => {
+        const Icon = providerIcons[provider.name];
+        return (
+          <Button
+            key={provider.name}
+            variant="secondary"
+            className="w-full h-10"
+            onClick={() => {
+              window.location.href =
+                provider.loginURL +
+                "?continue=" +
+                encodeURIComponent(
+                  safeContinueUrl.pathname + safeContinueUrl.search,
+                );
+            }}
+          >
+            <span className="flex items-center gap-2">
+              {Icon && <Icon width={18} height={18} />}
+              {__(`Sign in with ${provider.name.charAt(0).toUpperCase() + provider.name.slice(1)}`)}
+            </span>
+          </Button>
+        );
+      })}
     </>
   );
 }
 
 export default function SignInPage() {
   const { __ } = useTranslate();
-
+  const { toast } = useToast();
   const location = useLocation();
+  const safeContinueUrl = useSafeContinueUrl();
+
+  const [signIn, isSigningIn] =
+    useMutation<SignInPageMutation>(signInMutation);
+
+  const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    const email = (formData.get("email") as string) ?? "";
+    const password = (formData.get("password") as string) ?? "";
+
+    if (!email || !password) return;
+
+    const match = matchPath(
+      {
+        path: "/organizations/:organizationId",
+        caseSensitive: false,
+        end: false,
+      },
+      safeContinueUrl.pathname,
+    );
+
+    signIn({
+      variables: {
+        input: {
+          email,
+          password,
+          organizationId: match?.params.organizationId ?? null,
+        },
+      },
+      onCompleted: (_, error) => {
+        if (error) {
+          toast({
+            title: __("Error"),
+            description: formatError(
+              __("Failed to sign in"),
+              error as GraphQLError,
+            ),
+            variant: "error",
+          });
+          return;
+        }
+
+        window.location.href = safeContinueUrl.href;
+      },
+      onError: (e) => {
+        toast({
+          title: __("Error"),
+          description: e.message,
+          variant: "error",
+        });
+      },
+    });
+  };
 
   return (
-    <div className="space-y-6 w-full max-w-md mx-auto pt-8">
-      <h1 className="text-center text-2xl font-bold">
-        {__("Login to your account")}
+    <div className="w-full max-w-sm mx-auto pt-8">
+      <h1 className="text-2xl font-bold">
+        {__("Sign in to your account")}
       </h1>
-      <p className="text-center text-txt-tertiary mt-1 mb-6">
-        {__("Choose your login method")}
-      </p>
 
-      <Button
-        className="w-xs h-10 mx-auto"
-        to={{ pathname: "/auth/password-login", search: location.search }}
-      >
-        {__("Login with Email")}
-      </Button>
+      <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
+        <Field
+          required
+          name="email"
+          type="email"
+          label={__("Email")}
+          autoFocus
+        />
 
-      <Suspense fallback={null}>
-        <OIDCButtons />
-      </Suspense>
+        <div>
+          <div className="flex items-center justify-between mb-1">
+            <label className="text-sm font-medium" htmlFor="password">
+              {__("Password")}
+            </label>
+            <Link
+              to="/auth/forgot-password"
+              className="text-sm text-txt-secondary hover:text-txt-primary"
+            >
+              {__("Forgot your password?")}
+            </Link>
+          </div>
+          <Field
+            required
+            name="password"
+            id="password"
+            type="password"
+          />
+        </div>
 
-      <div className="relative my-6 w-full">
-        <div className="w-xs border-t border-border-mid mx-auto" />
-        <span
-          className="px-4 text-xs uppercase text-txt-secondary bg-level-0 absolute top-0 left-1/2 -translate-1/2"
+        <Button className="w-full h-10" disabled={isSigningIn}>
+          {isSigningIn ? __("Signing in...") : __("Sign in")}
+        </Button>
+      </form>
+
+      <div className="mt-6 space-y-4">
+        <Divider>{__("Or")}</Divider>
+
+        <Suspense fallback={null}>
+          <OIDCButtons />
+        </Suspense>
+
+        <Button
+          variant="secondary"
+          className="w-full h-10"
+          to={{ pathname: "/auth/sso-login", search: location.search }}
         >
-          {__("Or")}
-        </span>
+          {__("Sign in with SSO")}
+        </Button>
       </div>
 
-      <Button
-        variant="secondary"
-        className="w-xs h-10 mx-auto"
-        to={{ pathname: "/auth/sso-login", search: location.search }}
-      >
-        {__("Login with SSO")}
-      </Button>
-
-      <div className="text-center mt-6 text-sm text-txt-secondary">
-        {__("Don't have an account ?")}
+      <p className="mt-8 text-center text-sm text-txt-secondary">
+        {__("New to Probo?")}
         {" "}
         <Link
           to={{ pathname: "/auth/register", search: location.search }}
           className="underline hover:text-txt-primary"
         >
-          {__("Register")}
+          {__("Create account")}
         </Link>
-      </div>
-
-      <div className="text-center text-sm text-txt-secondary">
-        {__("Forgot password?")}
-        {" "}
-        <Link
-          to="/auth/forgot-password"
-          className="underline hover:text-txt-primary"
-        >
-          {__("Reset password")}
-        </Link>
-      </div>
+      </p>
     </div>
   );
 }

--- a/apps/console/src/pages/iam/auth/sign-in/SignInPage.tsx
+++ b/apps/console/src/pages/iam/auth/sign-in/SignInPage.tsx
@@ -1,27 +1,13 @@
-import { formatError, type GraphQLError } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
-import { Button, Field, useToast } from "@probo/ui";
-import type { FormEventHandler } from "react";
-import { type PreloadedQuery, useMutation, usePreloadedQuery } from "react-relay";
-import { Link, matchPath, useLocation } from "react-router";
+import { Button } from "@probo/ui";
+import { type PreloadedQuery, usePreloadedQuery } from "react-relay";
+import { Link, useLocation } from "react-router";
 import { graphql } from "relay-runtime";
 
-import type { SignInPageMutation } from "#/__generated__/iam/SignInPageMutation.graphql";
 import type { SignInPageQuery } from "#/__generated__/iam/SignInPageQuery.graphql";
-import { useSafeContinueUrl } from "#/hooks/useSafeContinueUrl";
 
 import { Divider } from "./_components/Divider";
 import { OIDCButton } from "./_components/OIDCButton";
-
-const signInMutation = graphql`
-  mutation SignInPageMutation($input: SignInInput!) {
-    signIn(input: $input) {
-      session {
-        id
-      }
-    }
-  }
-`;
 
 export const signInPageQuery = graphql`
   query SignInPageQuery {
@@ -37,64 +23,9 @@ type Props = {
 
 export default function SignInPage(props: Props) {
   const { __ } = useTranslate();
-  const { toast } = useToast();
   const location = useLocation();
-  const safeContinueUrl = useSafeContinueUrl();
 
   const data = usePreloadedQuery<SignInPageQuery>(signInPageQuery, props.queryRef);
-
-  const [signIn, isSigningIn]
-    = useMutation<SignInPageMutation>(signInMutation);
-
-  const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
-    e.preventDefault();
-    const formData = new FormData(e.currentTarget);
-    const email = (formData.get("email") as string) ?? "";
-    const password = (formData.get("password") as string) ?? "";
-
-    if (!email || !password) return;
-
-    const match = matchPath(
-      {
-        path: "/organizations/:organizationId",
-        caseSensitive: false,
-        end: false,
-      },
-      safeContinueUrl.pathname,
-    );
-
-    signIn({
-      variables: {
-        input: {
-          email,
-          password,
-          organizationId: match?.params.organizationId ?? null,
-        },
-      },
-      onCompleted: (_, error) => {
-        if (error) {
-          toast({
-            title: __("Error"),
-            description: formatError(
-              __("Failed to sign in"),
-              error as GraphQLError,
-            ),
-            variant: "error",
-          });
-          return;
-        }
-
-        window.location.href = safeContinueUrl.href;
-      },
-      onError: (e) => {
-        toast({
-          title: __("Error"),
-          description: e.message,
-          variant: "error",
-        });
-      },
-    });
-  };
 
   return (
     <div className="w-full max-w-sm mx-auto pt-8">
@@ -102,43 +33,7 @@ export default function SignInPage(props: Props) {
         {__("Sign in to your account")}
       </h1>
 
-      <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
-        <Field
-          required
-          name="email"
-          type="email"
-          label={__("Email")}
-          autoFocus
-        />
-
-        <div>
-          <div className="flex items-center justify-between mb-1">
-            <label className="text-sm font-medium" htmlFor="password">
-              {__("Password")}
-            </label>
-            <Link
-              to="/auth/forgot-password"
-              className="text-sm text-txt-secondary hover:text-txt-primary"
-            >
-              {__("Forgot your password?")}
-            </Link>
-          </div>
-          <Field
-            required
-            name="password"
-            id="password"
-            type="password"
-          />
-        </div>
-
-        <Button className="w-full h-10" disabled={isSigningIn}>
-          {isSigningIn ? __("Signing in...") : __("Sign in")}
-        </Button>
-      </form>
-
       <div className="mt-6 space-y-4">
-        <Divider>{__("Or")}</Divider>
-
         {data.oidcProviders.map((providerRef, index) => (
           <OIDCButton key={index} providerRef={providerRef} />
         ))}
@@ -149,6 +44,16 @@ export default function SignInPage(props: Props) {
           to={{ pathname: "/auth/sso-login", search: location.search }}
         >
           {__("Sign in with SSO")}
+        </Button>
+
+        <Divider>{__("Or")}</Divider>
+
+        <Button
+          variant="secondary"
+          className="w-full h-10"
+          to={{ pathname: "/auth/password-login", search: location.search }}
+        >
+          {__("Sign in with email")}
         </Button>
       </div>
 

--- a/apps/console/src/pages/iam/auth/sign-in/SignInPage.tsx
+++ b/apps/console/src/pages/iam/auth/sign-in/SignInPage.tsx
@@ -2,8 +2,7 @@ import { formatError, type GraphQLError } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
 import { Button, Field, useToast } from "@probo/ui";
 import type { FormEventHandler } from "react";
-import { useMutation, usePreloadedQuery } from "react-relay";
-import type { PreloadedQuery } from "react-relay";
+import { type PreloadedQuery, useMutation, usePreloadedQuery } from "react-relay";
 import { Link, matchPath, useLocation } from "react-router";
 import { graphql } from "relay-runtime";
 
@@ -12,7 +11,7 @@ import type { SignInPageQuery } from "#/__generated__/iam/SignInPageQuery.graphq
 import { useSafeContinueUrl } from "#/hooks/useSafeContinueUrl";
 
 import { Divider } from "./_components/Divider";
-import { OIDCButtons } from "./_components/OIDCButtons";
+import { OIDCButton } from "./_components/OIDCButton";
 
 const signInMutation = graphql`
   mutation SignInPageMutation($input: SignInInput!) {
@@ -27,7 +26,7 @@ const signInMutation = graphql`
 export const signInPageQuery = graphql`
   query SignInPageQuery {
     oidcProviders {
-      ...OIDCButtonsFragment
+      ...OIDCButtonFragment
     }
   }
 `;
@@ -140,10 +139,9 @@ export default function SignInPage(props: Props) {
       <div className="mt-6 space-y-4">
         <Divider>{__("Or")}</Divider>
 
-        <OIDCButtons
-          providers={data.oidcProviders}
-          safeContinueUrl={safeContinueUrl}
-        />
+        {data.oidcProviders.map((providerRef, index) => (
+          <OIDCButton key={index} providerRef={providerRef} />
+        ))}
 
         <Button
           variant="secondary"

--- a/apps/console/src/pages/iam/auth/sign-in/SignInPage.tsx
+++ b/apps/console/src/pages/iam/auth/sign-in/SignInPage.tsx
@@ -6,14 +6,14 @@ import { graphql } from "relay-runtime";
 
 import type { SignInPageQuery } from "#/__generated__/iam/SignInPageQuery.graphql";
 import { useSafeContinueUrl } from "#/hooks/useSafeContinueUrl";
+
 import { Divider } from "./_components/Divider";
 import { OIDCButtons } from "./_components/OIDCButtons";
 
 const signInPageQuery = graphql`
   query SignInPageQuery {
     oidcProviders {
-      name
-      loginURL
+      ...OIDCButtonsFragment
     }
   }
 `;

--- a/apps/console/src/pages/iam/auth/sign-in/SignInPageLoader.tsx
+++ b/apps/console/src/pages/iam/auth/sign-in/SignInPageLoader.tsx
@@ -6,8 +6,8 @@ import type { SignInPageQuery } from "#/__generated__/iam/SignInPageQuery.graphq
 import SignInPage, { signInPageQuery } from "./SignInPage";
 
 function SignInPageQueryLoader() {
-  const [queryRef, loadQuery] =
-    useQueryLoader<SignInPageQuery>(signInPageQuery);
+  const [queryRef, loadQuery]
+    = useQueryLoader<SignInPageQuery>(signInPageQuery);
 
   useEffect(() => {
     loadQuery({});

--- a/apps/console/src/pages/iam/auth/sign-in/SignInPageLoader.tsx
+++ b/apps/console/src/pages/iam/auth/sign-in/SignInPageLoader.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+import { useQueryLoader } from "react-relay";
+
+import type { SignInPageQuery } from "#/__generated__/iam/SignInPageQuery.graphql";
+
+import SignInPage, { signInPageQuery } from "./SignInPage";
+
+function SignInPageQueryLoader() {
+  const [queryRef, loadQuery] =
+    useQueryLoader<SignInPageQuery>(signInPageQuery);
+
+  useEffect(() => {
+    loadQuery({});
+  }, [loadQuery]);
+
+  if (!queryRef) return null;
+
+  return <SignInPage queryRef={queryRef} />;
+}
+
+export default function SignInPageLoader() {
+  return <SignInPageQueryLoader />;
+}

--- a/apps/console/src/pages/iam/auth/sign-in/_components/Divider.tsx
+++ b/apps/console/src/pages/iam/auth/sign-in/_components/Divider.tsx
@@ -1,0 +1,10 @@
+export function Divider({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="relative my-6 w-full">
+      <div className="border-t border-border-mid" />
+      <span className="px-4 text-xs uppercase text-txt-secondary bg-level-0 absolute top-0 left-1/2 -translate-1/2">
+        {children}
+      </span>
+    </div>
+  );
+}

--- a/apps/console/src/pages/iam/auth/sign-in/_components/OIDCButton.tsx
+++ b/apps/console/src/pages/iam/auth/sign-in/_components/OIDCButton.tsx
@@ -4,10 +4,11 @@ import type { ComponentProps } from "react";
 import { useFragment } from "react-relay";
 import { graphql } from "relay-runtime";
 
-import type { OIDCButtonsFragment$key } from "#/__generated__/iam/OIDCButtonsFragment.graphql";
+import type { OIDCButtonFragment$key } from "#/__generated__/iam/OIDCButtonFragment.graphql";
+import { useSafeContinueUrl } from "#/hooks/useSafeContinueUrl";
 
 const fragment = graphql`
-  fragment OIDCButtonsFragment on OIDCProviderInfo {
+  fragment OIDCButtonFragment on OIDCProviderInfo {
     name
     loginURL
   }
@@ -21,38 +22,13 @@ const providerIcons: Record<
   microsoft: Microsoft,
 };
 
-export function OIDCButtons({
-  providers,
-  safeContinueUrl,
+export function OIDCButton({
+  providerRef,
 }: {
-  providers: ReadonlyArray<OIDCButtonsFragment$key>;
-  safeContinueUrl: URL;
+  providerRef: OIDCButtonFragment$key;
 }) {
   const { __ } = useTranslate();
-
-  return (
-    <>
-      {providers.map((providerRef, index) => (
-        <OIDCButton
-          key={index}
-          providerRef={providerRef}
-          safeContinueUrl={safeContinueUrl}
-          __={__}
-        />
-      ))}
-    </>
-  );
-}
-
-function OIDCButton({
-  providerRef,
-  safeContinueUrl,
-  __,
-}: {
-  providerRef: OIDCButtonsFragment$key;
-  safeContinueUrl: URL;
-  __: (s: string) => string;
-}) {
+  const safeContinueUrl = useSafeContinueUrl();
   const provider = useFragment(fragment, providerRef);
   const Icon = providerIcons[provider.name];
 

--- a/apps/console/src/pages/iam/auth/sign-in/_components/OIDCButtons.tsx
+++ b/apps/console/src/pages/iam/auth/sign-in/_components/OIDCButtons.tsx
@@ -1,6 +1,17 @@
 import { useTranslate } from "@probo/i18n";
 import { Button, Google, Microsoft } from "@probo/ui";
 import type { ComponentProps } from "react";
+import { useFragment } from "react-relay";
+import { graphql } from "relay-runtime";
+
+import type { OIDCButtonsFragment$key } from "#/__generated__/iam/OIDCButtonsFragment.graphql";
+
+const fragment = graphql`
+  fragment OIDCButtonsFragment on OIDCProviderInfo {
+    name
+    loginURL
+  }
+`;
 
 const providerIcons: Record<
   string,
@@ -14,38 +25,52 @@ export function OIDCButtons({
   providers,
   safeContinueUrl,
 }: {
-  providers: ReadonlyArray<{ readonly name: string; readonly loginURL: string }>;
+  providers: ReadonlyArray<OIDCButtonsFragment$key>;
   safeContinueUrl: URL;
 }) {
   const { __ } = useTranslate();
 
-  if (providers.length === 0) {
-    return null;
-  }
-
   return (
     <>
-      {providers.map((provider) => {
-        const Icon = providerIcons[provider.name];
-        return (
-          <Button
-            key={provider.name}
-            variant="secondary"
-            className="w-full h-10"
-            onClick={() => {
-              window.location.href
-                = provider.loginURL
-                  + "?continue="
-                  + encodeURIComponent(safeContinueUrl.toString());
-            }}
-          >
-            <span className="flex items-center gap-2">
-              {Icon && <Icon width={18} height={18} />}
-              {__(`Sign in with ${provider.name.charAt(0).toUpperCase() + provider.name.slice(1)}`)}
-            </span>
-          </Button>
-        );
-      })}
+      {providers.map((providerRef, index) => (
+        <OIDCButton
+          key={index}
+          providerRef={providerRef}
+          safeContinueUrl={safeContinueUrl}
+          __={__}
+        />
+      ))}
     </>
+  );
+}
+
+function OIDCButton({
+  providerRef,
+  safeContinueUrl,
+  __,
+}: {
+  providerRef: OIDCButtonsFragment$key;
+  safeContinueUrl: URL;
+  __: (s: string) => string;
+}) {
+  const provider = useFragment(fragment, providerRef);
+  const Icon = providerIcons[provider.name];
+
+  return (
+    <Button
+      variant="secondary"
+      className="w-full h-10"
+      onClick={() => {
+        window.location.href
+          = provider.loginURL
+            + "?continue="
+            + encodeURIComponent(safeContinueUrl.toString());
+      }}
+    >
+      <span className="flex items-center gap-2">
+        {Icon && <Icon width={18} height={18} />}
+        {__(`Sign in with ${provider.name.charAt(0).toUpperCase() + provider.name.slice(1)}`)}
+      </span>
+    </Button>
   );
 }

--- a/apps/console/src/pages/iam/auth/sign-in/_components/OIDCButtons.tsx
+++ b/apps/console/src/pages/iam/auth/sign-in/_components/OIDCButtons.tsx
@@ -1,0 +1,51 @@
+import { useTranslate } from "@probo/i18n";
+import { Button, Google, Microsoft } from "@probo/ui";
+import type { ComponentProps } from "react";
+
+const providerIcons: Record<
+  string,
+  (props: ComponentProps<"svg">) => React.ReactNode
+> = {
+  google: Google,
+  microsoft: Microsoft,
+};
+
+export function OIDCButtons({
+  providers,
+  safeContinueUrl,
+}: {
+  providers: ReadonlyArray<{ readonly name: string; readonly loginURL: string }>;
+  safeContinueUrl: URL;
+}) {
+  const { __ } = useTranslate();
+
+  if (providers.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {providers.map((provider) => {
+        const Icon = providerIcons[provider.name];
+        return (
+          <Button
+            key={provider.name}
+            variant="secondary"
+            className="w-full h-10"
+            onClick={() => {
+              window.location.href
+                = provider.loginURL
+                  + "?continue="
+                  + encodeURIComponent(safeContinueUrl.toString());
+            }}
+          >
+            <span className="flex items-center gap-2">
+              {Icon && <Icon width={18} height={18} />}
+              {__(`Sign in with ${provider.name.charAt(0).toUpperCase() + provider.name.slice(1)}`)}
+            </span>
+          </Button>
+        );
+      })}
+    </>
+  );
+}

--- a/apps/console/src/routes.tsx
+++ b/apps/console/src/routes.tsx
@@ -41,7 +41,9 @@ const routes = [
     children: [
       {
         path: "login",
-        Component: lazy(() => import("./pages/iam/auth/sign-in/SignInPage")),
+        Component: lazy(
+          () => import("./pages/iam/auth/sign-in/SignInPageLoader"),
+        ),
       },
       {
         path: "password-login",

--- a/apps/trust/src/hooks/useSafeContinueUrl.ts
+++ b/apps/trust/src/hooks/useSafeContinueUrl.ts
@@ -1,0 +1,36 @@
+import { useMemo } from "react";
+import { useSearchParams } from "react-router";
+
+import { getPathPrefix } from "#/utils/pathPrefix";
+
+export function useSafeContinueUrl(): URL {
+  const [searchParams] = useSearchParams();
+
+  const continueUrlParam = searchParams.get("continue");
+  const prefix = getPathPrefix();
+  const fallback = window.location.origin + (prefix || "/");
+
+  const safeContinueUrl = useMemo(() => {
+    if (continueUrlParam) {
+      let continueUrl: URL;
+      try {
+        continueUrl = new URL(continueUrlParam, window.location.origin);
+      } catch {
+        return new URL(fallback, window.location.origin);
+      }
+      if (
+        continueUrl.origin === window.location.origin
+        && continueUrl.pathname.startsWith(`${prefix}/`)
+      ) {
+        return new URL(
+          continueUrl.pathname + continueUrl.search,
+          window.location.origin,
+        );
+      }
+      return new URL(fallback, window.location.origin);
+    }
+    return new URL(fallback, window.location.origin);
+  }, [continueUrlParam, fallback, prefix]);
+
+  return safeContinueUrl;
+}

--- a/apps/trust/src/pages/auth/ConnectPage.tsx
+++ b/apps/trust/src/pages/auth/ConnectPage.tsx
@@ -1,14 +1,9 @@
 import type { GraphQLError } from "@probo/helpers";
 import { usePageTitle } from "@probo/hooks";
 import { useTranslate } from "@probo/i18n";
-import { Button, Field, Google, Microsoft, useToast } from "@probo/ui";
-import { type ComponentProps, useEffect, useRef, useState } from "react";
-import {
-  type PreloadedQuery,
-  useFragment,
-  useMutation,
-  usePreloadedQuery,
-} from "react-relay";
+import { Button, Field, useToast } from "@probo/ui";
+import { useEffect, useRef, useState } from "react";
+import { type PreloadedQuery, useMutation, usePreloadedQuery } from "react-relay";
 import { graphql } from "relay-runtime";
 import { z } from "zod";
 
@@ -17,9 +12,9 @@ import { useSafeContinueUrl } from "#/hooks/useSafeContinueUrl";
 import { getPathPrefix } from "#/utils/pathPrefix";
 
 import { Divider } from "./_components/Divider";
+import { OIDCButton } from "./_components/OIDCButton";
 
 import type { ConnectPageMutation, SendMagicLinkInput } from "./__generated__/ConnectPageMutation.graphql";
-import type { ConnectPageOIDCButtonFragment$key } from "./__generated__/ConnectPageOIDCButtonFragment.graphql";
 import type { ConnectPageQuery } from "./__generated__/ConnectPageQuery.graphql";
 
 export const connectPageQuery = graphql`
@@ -30,7 +25,7 @@ export const connectPageQuery = graphql`
       }
     }
     oidcProviders {
-      ...ConnectPageOIDCButtonFragment
+      ...OIDCButtonFragment
     }
   }
 `;
@@ -43,21 +38,6 @@ const sendMagicLinkMutation = graphql`
   }
 `;
 
-const oidcButtonFragment = graphql`
-  fragment ConnectPageOIDCButtonFragment on OIDCProviderInfo {
-    name
-    loginURL
-  }
-`;
-
-const providerIcons: Record<
-  string,
-  (props: ComponentProps<"svg">) => React.ReactNode
-> = {
-  google: Google,
-  microsoft: Microsoft,
-};
-
 const schema = z.object({
   email: z.string().email(),
 });
@@ -65,65 +45,6 @@ const schema = z.object({
 type FormData = z.infer<typeof schema>;
 
 const timerDurationSeconds = 60;
-
-function OIDCButtons({
-  providers,
-  safeContinueUrl,
-}: {
-  providers: ReadonlyArray<ConnectPageOIDCButtonFragment$key>;
-  safeContinueUrl: URL;
-}) {
-  const { __ } = useTranslate();
-
-  if (providers.length === 0) {
-    return null;
-  }
-
-  return (
-    <>
-      {providers.map((providerRef, index) => (
-        <OIDCButton
-          key={index}
-          providerRef={providerRef}
-          safeContinueUrl={safeContinueUrl}
-          __={__}
-        />
-      ))}
-      <Divider>{__("Or")}</Divider>
-    </>
-  );
-}
-
-function OIDCButton({
-  providerRef,
-  safeContinueUrl,
-  __,
-}: {
-  providerRef: ConnectPageOIDCButtonFragment$key;
-  safeContinueUrl: URL;
-  __: (s: string) => string;
-}) {
-  const provider = useFragment(oidcButtonFragment, providerRef);
-  const Icon = providerIcons[provider.name];
-
-  return (
-    <Button
-      variant="secondary"
-      className="w-full h-10"
-      onClick={() => {
-        window.location.href
-          = provider.loginURL
-            + "?continue="
-            + encodeURIComponent(safeContinueUrl.toString());
-      }}
-    >
-      <span className="flex items-center gap-2">
-        {Icon && <Icon width={18} height={18} />}
-        {__(`Sign in with ${provider.name.charAt(0).toUpperCase() + provider.name.slice(1)}`)}
-      </span>
-    </Button>
-  );
-}
 
 export function ConnectPage(props: {
   queryRef: PreloadedQuery<ConnectPageQuery>;
@@ -234,12 +155,14 @@ export function ConnectPage(props: {
         </p>
       </div>
 
-      <div className="space-y-4">
-        <OIDCButtons
-          providers={oidcProviders}
-          safeContinueUrl={safeContinueUrl}
-        />
-      </div>
+      {oidcProviders.length > 0 && (
+        <div className="space-y-4">
+          {oidcProviders.map((providerRef, index) => (
+            <OIDCButton key={index} providerRef={providerRef} />
+          ))}
+          <Divider>{__("Or")}</Divider>
+        </div>
+      )}
 
       <form onSubmit={e => void handleSubmit(e)} className="space-y-6">
         <Field

--- a/apps/trust/src/pages/auth/ConnectPage.tsx
+++ b/apps/trust/src/pages/auth/ConnectPage.tsx
@@ -1,10 +1,11 @@
 import type { GraphQLError } from "@probo/helpers";
 import { usePageTitle } from "@probo/hooks";
 import { useTranslate } from "@probo/i18n";
-import { Button, Field, useToast } from "@probo/ui";
-import { useEffect, useRef, useState } from "react";
+import { Button, Field, Google, Microsoft, useToast } from "@probo/ui";
+import { type ComponentProps, Suspense, useEffect, useRef, useState } from "react";
 import {
   type PreloadedQuery,
+  useLazyLoadQuery,
   useMutation,
   usePreloadedQuery,
 } from "react-relay";
@@ -16,6 +17,7 @@ import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { getPathPrefix } from "#/utils/pathPrefix";
 
 import type { ConnectPageMutation, SendMagicLinkInput } from "./__generated__/ConnectPageMutation.graphql";
+import type { ConnectPageOIDCQuery } from "./__generated__/ConnectPageOIDCQuery.graphql";
 import type { ConnectPageQuery } from "./__generated__/ConnectPageQuery.graphql";
 
 export const connectPageQuery = graphql`
@@ -28,6 +30,15 @@ export const connectPageQuery = graphql`
   }
 `;
 
+const oidcProvidersQuery = graphql`
+  query ConnectPageOIDCQuery {
+    oidcProviders {
+      name
+      loginURL
+    }
+  }
+`;
+
 const sendMagicLinkMutation = graphql`
   mutation ConnectPageMutation($input: SendMagicLinkInput!) {
     sendMagicLink(input: $input) {
@@ -36,6 +47,14 @@ const sendMagicLinkMutation = graphql`
   }
 `;
 
+const providerIcons: Record<
+  string,
+  (props: ComponentProps<"svg">) => React.ReactNode
+> = {
+  google: Google,
+  microsoft: Microsoft,
+};
+
 const schema = z.object({
   email: z.string().email(),
 });
@@ -43,6 +62,58 @@ const schema = z.object({
 type FormData = z.infer<typeof schema>;
 
 const timerDurationSeconds = 60;
+
+function Divider({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="relative my-6 w-full">
+      <div className="border-t border-border-mid" />
+      <span className="px-4 text-xs uppercase text-txt-secondary bg-level-0 absolute top-0 left-1/2 -translate-1/2">
+        {children}
+      </span>
+    </div>
+  );
+}
+
+function OIDCButtons({ safeContinueUrl }: { safeContinueUrl: string }) {
+  const { __ } = useTranslate();
+
+  const data = useLazyLoadQuery<ConnectPageOIDCQuery>(oidcProvidersQuery, {});
+
+  if (data.oidcProviders.length === 0) {
+    return null;
+  }
+
+  const continueUrl = new URL(safeContinueUrl);
+
+  return (
+    <>
+      {data.oidcProviders.map((provider) => {
+        const Icon = providerIcons[provider.name];
+        return (
+          <Button
+            key={provider.name}
+            variant="secondary"
+            className="w-full h-10"
+            onClick={() => {
+              window.location.href
+                = provider.loginURL
+                  + "?continue="
+                  + encodeURIComponent(
+                    continueUrl.pathname + continueUrl.search,
+                  );
+            }}
+          >
+            <span className="flex items-center gap-2">
+              {Icon && <Icon width={18} height={18} />}
+              {__(`Sign in with ${provider.name.charAt(0).toUpperCase() + provider.name.slice(1)}`)}
+            </span>
+          </Button>
+        );
+      })}
+      <Divider>{__("Or")}</Divider>
+    </>
+  );
+}
 
 export function ConnectPage(props: {
   queryRef: PreloadedQuery<ConnectPageQuery>;
@@ -164,9 +235,15 @@ export function ConnectPage(props: {
         </h1>
         <p className="text-txt-tertiary">
           {__(
-            "Enter your email address to connect with a magic link and start requesting access to documents",
+            "Sign in to start requesting access to documents",
           )}
         </p>
+      </div>
+
+      <div className="space-y-4">
+        <Suspense fallback={null}>
+          <OIDCButtons safeContinueUrl={safeContinueUrl} />
+        </Suspense>
       </div>
 
       <form onSubmit={e => void handleSubmit(e)} className="space-y-6">

--- a/apps/trust/src/pages/auth/ConnectPage.tsx
+++ b/apps/trust/src/pages/auth/ConnectPage.tsx
@@ -2,22 +2,20 @@ import type { GraphQLError } from "@probo/helpers";
 import { usePageTitle } from "@probo/hooks";
 import { useTranslate } from "@probo/i18n";
 import { Button, Field, Google, Microsoft, useToast } from "@probo/ui";
-import { type ComponentProps, Suspense, useEffect, useRef, useState } from "react";
+import { type ComponentProps, useEffect, useRef, useState } from "react";
 import {
   type PreloadedQuery,
-  useLazyLoadQuery,
   useMutation,
   usePreloadedQuery,
 } from "react-relay";
-import { useSearchParams } from "react-router";
 import { graphql } from "relay-runtime";
 import { z } from "zod";
 
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+import { useSafeContinueUrl } from "#/hooks/useSafeContinueUrl";
 import { getPathPrefix } from "#/utils/pathPrefix";
 
 import type { ConnectPageMutation, SendMagicLinkInput } from "./__generated__/ConnectPageMutation.graphql";
-import type { ConnectPageOIDCQuery } from "./__generated__/ConnectPageOIDCQuery.graphql";
 import type { ConnectPageQuery } from "./__generated__/ConnectPageQuery.graphql";
 
 export const connectPageQuery = graphql`
@@ -27,11 +25,6 @@ export const connectPageQuery = graphql`
         name
       }
     }
-  }
-`;
-
-const oidcProvidersQuery = graphql`
-  query ConnectPageOIDCQuery {
     oidcProviders {
       name
       loginURL
@@ -74,20 +67,22 @@ function Divider({ children }: { children: React.ReactNode }) {
   );
 }
 
-function OIDCButtons({ safeContinueUrl }: { safeContinueUrl: string }) {
+function OIDCButtons({
+  providers,
+  safeContinueUrl,
+}: {
+  providers: ReadonlyArray<{ readonly name: string; readonly loginURL: string }>;
+  safeContinueUrl: URL;
+}) {
   const { __ } = useTranslate();
 
-  const data = useLazyLoadQuery<ConnectPageOIDCQuery>(oidcProvidersQuery, {});
-
-  if (data.oidcProviders.length === 0) {
+  if (providers.length === 0) {
     return null;
   }
 
-  const continueUrl = new URL(safeContinueUrl);
-
   return (
     <>
-      {data.oidcProviders.map((provider) => {
+      {providers.map((provider) => {
         const Icon = providerIcons[provider.name];
         return (
           <Button
@@ -98,9 +93,7 @@ function OIDCButtons({ safeContinueUrl }: { safeContinueUrl: string }) {
               window.location.href
                 = provider.loginURL
                   + "?continue="
-                  + encodeURIComponent(
-                    continueUrl.pathname + continueUrl.search,
-                  );
+                  + encodeURIComponent(safeContinueUrl.toString());
             }}
           >
             <span className="flex items-center gap-2">
@@ -125,28 +118,12 @@ export function ConnectPage(props: {
   const [magicLinkSent, setMagicLinkSent] = useState<boolean>(false);
   const interval = useRef<NodeJS.Timeout>(undefined);
   const [timer, setTimer] = useState<number>(timerDurationSeconds);
-  const [searchParams] = useSearchParams();
+  const safeContinueUrl = useSafeContinueUrl();
 
   const {
     currentTrustCenter: { organization },
+    oidcProviders,
   } = usePreloadedQuery<ConnectPageQuery>(connectPageQuery, queryRef);
-
-  const continueUrlParam = searchParams.get("continue");
-  let safeContinueUrl: string;
-  if (continueUrlParam) {
-    try {
-      const continueUrl = new URL(continueUrlParam, window.location.origin);
-      if (continueUrl.origin === window.location.origin && continueUrl.pathname.startsWith(`${getPathPrefix()}/`)) {
-        safeContinueUrl = window.location.origin + continueUrl.pathname + continueUrl.search;
-      } else {
-        safeContinueUrl = window.location.origin + getPathPrefix();
-      }
-    } catch {
-      safeContinueUrl = window.location.origin + getPathPrefix();
-    }
-  } else {
-    safeContinueUrl = window.location.origin + getPathPrefix();
-  }
 
   useEffect(() => {
     if (!magicLinkSent && interval.current) {
@@ -184,13 +161,13 @@ export function ConnectPage(props: {
   const handleSubmit = handleSubmitWrapper(({ email }: FormData) => {
     const input: SendMagicLinkInput = { email };
     if (safeContinueUrl) {
-      input.continue = safeContinueUrl;
+      input.continue = safeContinueUrl.toString();
     }
     sendMagicLink({
       variables: {
         input: {
           email,
-          continue: safeContinueUrl,
+          continue: safeContinueUrl.toString(),
         },
       },
       onCompleted: (_, errors: GraphQLError[] | null) => {
@@ -241,9 +218,10 @@ export function ConnectPage(props: {
       </div>
 
       <div className="space-y-4">
-        <Suspense fallback={null}>
-          <OIDCButtons safeContinueUrl={safeContinueUrl} />
-        </Suspense>
+        <OIDCButtons
+          providers={oidcProviders}
+          safeContinueUrl={safeContinueUrl}
+        />
       </div>
 
       <form onSubmit={e => void handleSubmit(e)} className="space-y-6">

--- a/apps/trust/src/pages/auth/ConnectPage.tsx
+++ b/apps/trust/src/pages/auth/ConnectPage.tsx
@@ -11,11 +11,10 @@ import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useSafeContinueUrl } from "#/hooks/useSafeContinueUrl";
 import { getPathPrefix } from "#/utils/pathPrefix";
 
-import { Divider } from "./_components/Divider";
-import { OIDCButton } from "./_components/OIDCButton";
-
 import type { ConnectPageMutation, SendMagicLinkInput } from "./__generated__/ConnectPageMutation.graphql";
 import type { ConnectPageQuery } from "./__generated__/ConnectPageQuery.graphql";
+import { Divider } from "./_components/Divider";
+import { OIDCButton } from "./_components/OIDCButton";
 
 export const connectPageQuery = graphql`
   query ConnectPageQuery {

--- a/apps/trust/src/pages/auth/ConnectPage.tsx
+++ b/apps/trust/src/pages/auth/ConnectPage.tsx
@@ -5,6 +5,7 @@ import { Button, Field, Google, Microsoft, useToast } from "@probo/ui";
 import { type ComponentProps, useEffect, useRef, useState } from "react";
 import {
   type PreloadedQuery,
+  useFragment,
   useMutation,
   usePreloadedQuery,
 } from "react-relay";
@@ -16,6 +17,7 @@ import { useSafeContinueUrl } from "#/hooks/useSafeContinueUrl";
 import { getPathPrefix } from "#/utils/pathPrefix";
 
 import type { ConnectPageMutation, SendMagicLinkInput } from "./__generated__/ConnectPageMutation.graphql";
+import type { ConnectPageOIDCButtonFragment$key } from "./__generated__/ConnectPageOIDCButtonFragment.graphql";
 import type { ConnectPageQuery } from "./__generated__/ConnectPageQuery.graphql";
 
 export const connectPageQuery = graphql`
@@ -26,8 +28,7 @@ export const connectPageQuery = graphql`
       }
     }
     oidcProviders {
-      name
-      loginURL
+      ...ConnectPageOIDCButtonFragment
     }
   }
 `;
@@ -37,6 +38,13 @@ const sendMagicLinkMutation = graphql`
     sendMagicLink(input: $input) {
       success
     }
+  }
+`;
+
+const oidcButtonFragment = graphql`
+  fragment ConnectPageOIDCButtonFragment on OIDCProviderInfo {
+    name
+    loginURL
   }
 `;
 
@@ -71,7 +79,7 @@ function OIDCButtons({
   providers,
   safeContinueUrl,
 }: {
-  providers: ReadonlyArray<{ readonly name: string; readonly loginURL: string }>;
+  providers: ReadonlyArray<ConnectPageOIDCButtonFragment$key>;
   safeContinueUrl: URL;
 }) {
   const { __ } = useTranslate();
@@ -82,29 +90,47 @@ function OIDCButtons({
 
   return (
     <>
-      {providers.map((provider) => {
-        const Icon = providerIcons[provider.name];
-        return (
-          <Button
-            key={provider.name}
-            variant="secondary"
-            className="w-full h-10"
-            onClick={() => {
-              window.location.href
-                = provider.loginURL
-                  + "?continue="
-                  + encodeURIComponent(safeContinueUrl.toString());
-            }}
-          >
-            <span className="flex items-center gap-2">
-              {Icon && <Icon width={18} height={18} />}
-              {__(`Sign in with ${provider.name.charAt(0).toUpperCase() + provider.name.slice(1)}`)}
-            </span>
-          </Button>
-        );
-      })}
+      {providers.map((providerRef, index) => (
+        <OIDCButton
+          key={index}
+          providerRef={providerRef}
+          safeContinueUrl={safeContinueUrl}
+          __={__}
+        />
+      ))}
       <Divider>{__("Or")}</Divider>
     </>
+  );
+}
+
+function OIDCButton({
+  providerRef,
+  safeContinueUrl,
+  __,
+}: {
+  providerRef: ConnectPageOIDCButtonFragment$key;
+  safeContinueUrl: URL;
+  __: (s: string) => string;
+}) {
+  const provider = useFragment(oidcButtonFragment, providerRef);
+  const Icon = providerIcons[provider.name];
+
+  return (
+    <Button
+      variant="secondary"
+      className="w-full h-10"
+      onClick={() => {
+        window.location.href
+          = provider.loginURL
+            + "?continue="
+            + encodeURIComponent(safeContinueUrl.toString());
+      }}
+    >
+      <span className="flex items-center gap-2">
+        {Icon && <Icon width={18} height={18} />}
+        {__(`Sign in with ${provider.name.charAt(0).toUpperCase() + provider.name.slice(1)}`)}
+      </span>
+    </Button>
   );
 }
 

--- a/apps/trust/src/pages/auth/ConnectPage.tsx
+++ b/apps/trust/src/pages/auth/ConnectPage.tsx
@@ -16,6 +16,8 @@ import { useFormWithSchema } from "#/hooks/useFormWithSchema";
 import { useSafeContinueUrl } from "#/hooks/useSafeContinueUrl";
 import { getPathPrefix } from "#/utils/pathPrefix";
 
+import { Divider } from "./_components/Divider";
+
 import type { ConnectPageMutation, SendMagicLinkInput } from "./__generated__/ConnectPageMutation.graphql";
 import type { ConnectPageOIDCButtonFragment$key } from "./__generated__/ConnectPageOIDCButtonFragment.graphql";
 import type { ConnectPageQuery } from "./__generated__/ConnectPageQuery.graphql";
@@ -63,17 +65,6 @@ const schema = z.object({
 type FormData = z.infer<typeof schema>;
 
 const timerDurationSeconds = 60;
-
-function Divider({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="relative my-6 w-full">
-      <div className="border-t border-border-mid" />
-      <span className="px-4 text-xs uppercase text-txt-secondary bg-level-0 absolute top-0 left-1/2 -translate-1/2">
-        {children}
-      </span>
-    </div>
-  );
-}
 
 function OIDCButtons({
   providers,

--- a/apps/trust/src/pages/auth/_components/Divider.tsx
+++ b/apps/trust/src/pages/auth/_components/Divider.tsx
@@ -1,0 +1,10 @@
+export function Divider({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="relative my-6 w-full">
+      <div className="border-t border-border-mid" />
+      <span className="px-4 text-xs uppercase text-txt-secondary bg-level-0 absolute top-0 left-1/2 -translate-1/2">
+        {children}
+      </span>
+    </div>
+  );
+}

--- a/apps/trust/src/pages/auth/_components/OIDCButton.tsx
+++ b/apps/trust/src/pages/auth/_components/OIDCButton.tsx
@@ -1,0 +1,52 @@
+import { useTranslate } from "@probo/i18n";
+import { Button, Google, Microsoft } from "@probo/ui";
+import type { ComponentProps } from "react";
+import { useFragment } from "react-relay";
+import { graphql } from "relay-runtime";
+
+import type { OIDCButtonFragment$key } from "./__generated__/OIDCButtonFragment.graphql";
+import { useSafeContinueUrl } from "#/hooks/useSafeContinueUrl";
+
+const fragment = graphql`
+  fragment OIDCButtonFragment on OIDCProviderInfo {
+    name
+    loginURL
+  }
+`;
+
+const providerIcons: Record<
+  string,
+  (props: ComponentProps<"svg">) => React.ReactNode
+> = {
+  google: Google,
+  microsoft: Microsoft,
+};
+
+export function OIDCButton({
+  providerRef,
+}: {
+  providerRef: OIDCButtonFragment$key;
+}) {
+  const { __ } = useTranslate();
+  const safeContinueUrl = useSafeContinueUrl();
+  const provider = useFragment(fragment, providerRef);
+  const Icon = providerIcons[provider.name];
+
+  return (
+    <Button
+      variant="secondary"
+      className="w-full h-10"
+      onClick={() => {
+        window.location.href
+          = provider.loginURL
+            + "?continue="
+            + encodeURIComponent(safeContinueUrl.toString());
+      }}
+    >
+      <span className="flex items-center gap-2">
+        {Icon && <Icon width={18} height={18} />}
+        {__(`Sign in with ${provider.name.charAt(0).toUpperCase() + provider.name.slice(1)}`)}
+      </span>
+    </Button>
+  );
+}

--- a/apps/trust/src/pages/auth/_components/OIDCButton.tsx
+++ b/apps/trust/src/pages/auth/_components/OIDCButton.tsx
@@ -4,8 +4,9 @@ import type { ComponentProps } from "react";
 import { useFragment } from "react-relay";
 import { graphql } from "relay-runtime";
 
-import type { OIDCButtonFragment$key } from "./__generated__/OIDCButtonFragment.graphql";
 import { useSafeContinueUrl } from "#/hooks/useSafeContinueUrl";
+
+import type { OIDCButtonFragment$key } from "./__generated__/OIDCButtonFragment.graphql";
 
 const fragment = graphql`
   fragment OIDCButtonFragment on OIDCProviderInfo {

--- a/packages/ui/src/Atoms/Vendors/Microsoft.tsx
+++ b/packages/ui/src/Atoms/Vendors/Microsoft.tsx
@@ -1,0 +1,19 @@
+import type { ComponentProps } from "react";
+
+export function Microsoft(props: ComponentProps<"svg">) {
+  return (
+    <svg
+      width="800px"
+      height="800px"
+      viewBox="0 0 256 256"
+      xmlns="http://www.w3.org/2000/svg"
+      preserveAspectRatio="xMidYMid"
+      {...props}
+    >
+      <rect x="0" y="0" width="121" height="121" fill="#F25022" />
+      <rect x="135" y="0" width="121" height="121" fill="#7FBA00" />
+      <rect x="0" y="135" width="121" height="121" fill="#00A4EF" />
+      <rect x="135" y="135" width="121" height="121" fill="#FFB900" />
+    </svg>
+  );
+}

--- a/packages/ui/src/Atoms/Vendors/index.ts
+++ b/packages/ui/src/Atoms/Vendors/index.ts
@@ -1,2 +1,3 @@
 export { Google } from "./Google";
+export { Microsoft } from "./Microsoft";
 export { Slack } from "./Slack";

--- a/pkg/bootstrap/builder.go
+++ b/pkg/bootstrap/builder.go
@@ -110,6 +110,16 @@ func (b *Builder) Build() (*probod.FullConfig, error) {
 					DomainVerificationIntervalSeconds: b.getEnvIntOrDefault("SAML_DOMAIN_VERIFICATION_INTERVAL_SECONDS", 60),
 					DomainVerificationResolverAddr:    b.getEnvOrDefault("SAML_DOMAIN_VERIFICATION_RESOLVER_ADDR", "8.8.8.8:53"),
 				},
+				Google: probod.OIDCProviderConfig{
+					ClientID:     b.getEnv("AUTH_GOOGLE_CLIENT_ID"),
+					ClientSecret: b.getEnv("AUTH_GOOGLE_CLIENT_SECRET"),
+					Enabled:      b.getEnv("AUTH_GOOGLE_CLIENT_ID") != "",
+				},
+				Microsoft: probod.OIDCProviderConfig{
+					ClientID:     b.getEnv("AUTH_MICROSOFT_CLIENT_ID"),
+					ClientSecret: b.getEnv("AUTH_MICROSOFT_CLIENT_SECRET"),
+					Enabled:      b.getEnv("AUTH_MICROSOFT_CLIENT_ID") != "",
+				},
 			},
 			TrustCenter: probod.TrustCenterConfig{
 				HTTPAddr:  b.getEnvOrDefault("TRUST_CENTER_HTTP_ADDR", ":80"),

--- a/pkg/bootstrap/builder.go
+++ b/pkg/bootstrap/builder.go
@@ -113,12 +113,12 @@ func (b *Builder) Build() (*probod.FullConfig, error) {
 				Google: probod.OIDCProviderConfig{
 					ClientID:     b.getEnv("AUTH_GOOGLE_CLIENT_ID"),
 					ClientSecret: b.getEnv("AUTH_GOOGLE_CLIENT_SECRET"),
-					Enabled:      b.getEnv("AUTH_GOOGLE_CLIENT_ID") != "",
+					Enabled:      b.getEnv("AUTH_GOOGLE_CLIENT_ID") != "" && b.getEnv("AUTH_GOOGLE_CLIENT_SECRET") != "",
 				},
 				Microsoft: probod.OIDCProviderConfig{
 					ClientID:     b.getEnv("AUTH_MICROSOFT_CLIENT_ID"),
 					ClientSecret: b.getEnv("AUTH_MICROSOFT_CLIENT_SECRET"),
-					Enabled:      b.getEnv("AUTH_MICROSOFT_CLIENT_ID") != "",
+					Enabled:      b.getEnv("AUTH_MICROSOFT_CLIENT_ID") != "" && b.getEnv("AUTH_MICROSOFT_CLIENT_SECRET") != "",
 				},
 			},
 			TrustCenter: probod.TrustCenterConfig{

--- a/pkg/coredata/migrations/20260319T150000Z.sql
+++ b/pkg/coredata/migrations/20260319T150000Z.sql
@@ -1,5 +1,4 @@
-ALTER TYPE session_auth_method ADD VALUE 'GOOGLE';
-ALTER TYPE session_auth_method ADD VALUE 'MICROSOFT';
+ALTER TYPE session_auth_method ADD VALUE 'OIDC';
 
 CREATE TYPE iam_oidc_provider AS ENUM (
     'GOOGLE',

--- a/pkg/coredata/migrations/20260319T150000Z.sql
+++ b/pkg/coredata/migrations/20260319T150000Z.sql
@@ -1,0 +1,19 @@
+ALTER TYPE session_auth_method ADD VALUE 'GOOGLE';
+ALTER TYPE session_auth_method ADD VALUE 'MICROSOFT';
+
+CREATE TYPE iam_oidc_provider AS ENUM (
+    'GOOGLE',
+    'MICROSOFT'
+);
+
+CREATE TABLE iam_oidc_states (
+    id TEXT PRIMARY KEY,
+    provider iam_oidc_provider NOT NULL,
+    nonce TEXT NOT NULL,
+    code_verifier TEXT NOT NULL,
+    continue_url TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMP NOT NULL,
+    expires_at TIMESTAMP NOT NULL
+);
+
+CREATE INDEX idx_iam_oidc_states_expires_at ON iam_oidc_states(expires_at);

--- a/pkg/coredata/oidc_provider.go
+++ b/pkg/coredata/oidc_provider.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import "fmt"
+
+type OIDCProvider string
+
+const (
+	OIDCProviderGoogle    OIDCProvider = "GOOGLE"
+	OIDCProviderMicrosoft OIDCProvider = "MICROSOFT"
+)
+
+func (p OIDCProvider) IsValid() bool {
+	switch p {
+	case OIDCProviderGoogle, OIDCProviderMicrosoft:
+		return true
+	}
+	return false
+}
+
+func (p OIDCProvider) String() string { return string(p) }
+
+func (p *OIDCProvider) UnmarshalText(text []byte) error {
+	*p = OIDCProvider(text)
+	if !p.IsValid() {
+		return fmt.Errorf("%s is not a valid OIDCProvider", string(text))
+	}
+	return nil
+}
+
+func (p OIDCProvider) MarshalText() ([]byte, error) {
+	return []byte(p.String()), nil
+}

--- a/pkg/coredata/oidc_state.go
+++ b/pkg/coredata/oidc_state.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"go.gearno.de/kit/pg"
+)
+
+type (
+	OIDCProvider string
+
+	OIDCState struct {
+		ID           string       `db:"id"`
+		Provider     OIDCProvider `db:"provider"`
+		Nonce        string       `db:"nonce"`
+		CodeVerifier string       `db:"code_verifier"`
+		ContinueURL  string       `db:"continue_url"`
+		CreatedAt    time.Time    `db:"created_at"`
+		ExpiresAt    time.Time    `db:"expires_at"`
+	}
+)
+
+const (
+	OIDCProviderGoogle    OIDCProvider = "GOOGLE"
+	OIDCProviderMicrosoft OIDCProvider = "MICROSOFT"
+)
+
+func (p OIDCProvider) IsValid() bool {
+	switch p {
+	case OIDCProviderGoogle, OIDCProviderMicrosoft:
+		return true
+	}
+	return false
+}
+
+func (p OIDCProvider) String() string { return string(p) }
+
+func (p *OIDCProvider) UnmarshalText(text []byte) error {
+	*p = OIDCProvider(text)
+	if !p.IsValid() {
+		return fmt.Errorf("%s is not a valid OIDCProvider", string(text))
+	}
+	return nil
+}
+
+func (p OIDCProvider) MarshalText() ([]byte, error) {
+	return []byte(p.String()), nil
+}
+
+func (s *OIDCState) Insert(ctx context.Context, conn pg.Conn) error {
+	query := `
+INSERT INTO iam_oidc_states (id, provider, nonce, code_verifier, continue_url, created_at, expires_at)
+VALUES (@id, @provider, @nonce, @code_verifier, @continue_url, @created_at, @expires_at)
+`
+
+	args := pgx.StrictNamedArgs{
+		"id":            s.ID,
+		"provider":      s.Provider,
+		"nonce":         s.Nonce,
+		"code_verifier": s.CodeVerifier,
+		"continue_url":  s.ContinueURL,
+		"created_at":    s.CreatedAt,
+		"expires_at":    s.ExpiresAt,
+	}
+
+	_, err := conn.Exec(ctx, query, args)
+	if err != nil {
+		return fmt.Errorf("cannot insert oidc_state: %w", err)
+	}
+
+	return nil
+}
+
+func (s *OIDCState) LoadByIDForUpdate(ctx context.Context, conn pg.Conn, id string) error {
+	query := `
+SELECT id, provider, nonce, code_verifier, continue_url, created_at, expires_at
+FROM iam_oidc_states
+WHERE id = @id
+FOR UPDATE
+`
+
+	rows, err := conn.Query(ctx, query, pgx.StrictNamedArgs{"id": id})
+	if err != nil {
+		return fmt.Errorf("cannot query oidc_state: %w", err)
+	}
+
+	state, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[OIDCState])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrResourceNotFound
+		}
+		return fmt.Errorf("cannot collect oidc_state: %w", err)
+	}
+
+	*s = state
+	return nil
+}
+
+func (s *OIDCState) Delete(ctx context.Context, conn pg.Conn) error {
+	query := `DELETE FROM iam_oidc_states WHERE id = @id`
+
+	_, err := conn.Exec(ctx, query, pgx.StrictNamedArgs{"id": s.ID})
+	if err != nil {
+		return fmt.Errorf("cannot delete oidc_state: %w", err)
+	}
+
+	return nil
+}
+
+func DeleteExpiredOIDCStates(ctx context.Context, conn pg.Conn, now time.Time) (int64, error) {
+	query := `DELETE FROM iam_oidc_states WHERE expires_at < @now`
+
+	result, err := conn.Exec(ctx, query, pgx.StrictNamedArgs{"now": now})
+	if err != nil {
+		return 0, fmt.Errorf("cannot delete expired oidc_states: %w", err)
+	}
+
+	return result.RowsAffected(), nil
+}

--- a/pkg/coredata/oidc_state.go
+++ b/pkg/coredata/oidc_state.go
@@ -24,45 +24,14 @@ import (
 	"go.gearno.de/kit/pg"
 )
 
-type (
-	OIDCProvider string
-
-	OIDCState struct {
-		ID           string       `db:"id"`
-		Provider     OIDCProvider `db:"provider"`
-		Nonce        string       `db:"nonce"`
-		CodeVerifier string       `db:"code_verifier"`
-		ContinueURL  string       `db:"continue_url"`
-		CreatedAt    time.Time    `db:"created_at"`
-		ExpiresAt    time.Time    `db:"expires_at"`
-	}
-)
-
-const (
-	OIDCProviderGoogle    OIDCProvider = "GOOGLE"
-	OIDCProviderMicrosoft OIDCProvider = "MICROSOFT"
-)
-
-func (p OIDCProvider) IsValid() bool {
-	switch p {
-	case OIDCProviderGoogle, OIDCProviderMicrosoft:
-		return true
-	}
-	return false
-}
-
-func (p OIDCProvider) String() string { return string(p) }
-
-func (p *OIDCProvider) UnmarshalText(text []byte) error {
-	*p = OIDCProvider(text)
-	if !p.IsValid() {
-		return fmt.Errorf("%s is not a valid OIDCProvider", string(text))
-	}
-	return nil
-}
-
-func (p OIDCProvider) MarshalText() ([]byte, error) {
-	return []byte(p.String()), nil
+type OIDCState struct {
+	ID           string       `db:"id"`
+	Provider     OIDCProvider `db:"provider"`
+	Nonce        string       `db:"nonce"`
+	CodeVerifier string       `db:"code_verifier"`
+	ContinueURL  string       `db:"continue_url"`
+	CreatedAt    time.Time    `db:"created_at"`
+	ExpiresAt    time.Time    `db:"expires_at"`
 }
 
 func (s *OIDCState) Insert(ctx context.Context, conn pg.Conn) error {
@@ -125,7 +94,7 @@ func (s *OIDCState) Delete(ctx context.Context, conn pg.Conn) error {
 	return nil
 }
 
-func DeleteExpiredOIDCStates(ctx context.Context, conn pg.Conn, now time.Time) (int64, error) {
+func (s *OIDCState) DeleteExpired(ctx context.Context, conn pg.Conn, now time.Time) (int64, error) {
 	query := `DELETE FROM iam_oidc_states WHERE expires_at < @now`
 
 	result, err := conn.Exec(ctx, query, pgx.StrictNamedArgs{"now": now})

--- a/pkg/coredata/session.go
+++ b/pkg/coredata/session.go
@@ -57,8 +57,7 @@ const (
 	AuthMethodMagicLink AuthMethod = "MAGIC_LINK"
 	AuthMethodPassword  AuthMethod = "PASSWORD"
 	AuthMethodSAML      AuthMethod = "SAML"
-	AuthMethodGoogle    AuthMethod = "GOOGLE"
-	AuthMethodMicrosoft AuthMethod = "MICROSOFT"
+	AuthMethodOIDC      AuthMethod = "OIDC"
 )
 
 func NewRootSession(identityID gid.GID, method AuthMethod, duration time.Duration) *Session {

--- a/pkg/coredata/session.go
+++ b/pkg/coredata/session.go
@@ -57,6 +57,8 @@ const (
 	AuthMethodMagicLink AuthMethod = "MAGIC_LINK"
 	AuthMethodPassword  AuthMethod = "PASSWORD"
 	AuthMethodSAML      AuthMethod = "SAML"
+	AuthMethodGoogle    AuthMethod = "GOOGLE"
+	AuthMethodMicrosoft AuthMethod = "MICROSOFT"
 )
 
 func NewRootSession(identityID gid.GID, method AuthMethod, duration time.Duration) *Session {

--- a/pkg/iam/auth_service.go
+++ b/pkg/iam/auth_service.go
@@ -444,6 +444,29 @@ func (s AuthService) OpenSessionWithSAML(ctx context.Context, identityID gid.GID
 	return session, nil
 }
 
+func (s AuthService) OpenSessionWithOIDC(ctx context.Context, identityID gid.GID, authMethod coredata.AuthMethod) (*coredata.Session, error) {
+	session := &coredata.Session{}
+
+	err := s.pg.WithTx(
+		ctx,
+		func(conn pg.Conn) (err error) {
+			session = coredata.NewRootSession(identityID, authMethod, s.sessionDuration)
+			err = session.Insert(ctx, conn)
+			if err != nil {
+				return fmt.Errorf("cannot insert session: %w", err)
+			}
+
+			return nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return session, nil
+}
+
 func (s AuthService) CheckCredentials(
 	ctx context.Context,
 	email mail.Addr,

--- a/pkg/iam/oidc/errors.go
+++ b/pkg/iam/oidc/errors.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package oidc
+
+import (
+	"fmt"
+
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+type ErrProviderNotEnabled struct {
+	Provider coredata.OIDCProvider
+}
+
+func NewProviderNotEnabledError(provider coredata.OIDCProvider) error {
+	return &ErrProviderNotEnabled{Provider: provider}
+}
+
+func (e ErrProviderNotEnabled) Error() string {
+	return fmt.Sprintf("cannot authenticate: OIDC provider %q is not enabled", e.Provider)
+}
+
+type ErrInvalidState struct{}
+
+func NewInvalidStateError() error {
+	return &ErrInvalidState{}
+}
+
+func (e ErrInvalidState) Error() string {
+	return "cannot validate OIDC state: invalid or expired"
+}
+
+type ErrCodeExchange struct {
+	Err error
+}
+
+func NewCodeExchangeError(err error) error {
+	return &ErrCodeExchange{Err: err}
+}
+
+func (e ErrCodeExchange) Error() string {
+	return fmt.Sprintf("cannot exchange authorization code: %v", e.Err)
+}
+
+func (e ErrCodeExchange) Unwrap() error {
+	return e.Err
+}
+
+type ErrIDTokenMissing struct{}
+
+func NewIDTokenMissingError() error {
+	return &ErrIDTokenMissing{}
+}
+
+func (e ErrIDTokenMissing) Error() string {
+	return "cannot extract id_token: not present in token response"
+}
+
+type ErrMissingEmailClaim struct{}
+
+func NewMissingEmailClaimError() error {
+	return &ErrMissingEmailClaim{}
+}
+
+func (e ErrMissingEmailClaim) Error() string {
+	return "cannot extract email: claim missing from id token"
+}
+
+type ErrEmailNotVerified struct{}
+
+func NewEmailNotVerifiedError() error {
+	return &ErrEmailNotVerified{}
+}
+
+func (e ErrEmailNotVerified) Error() string {
+	return "cannot authenticate: email address is not verified by the OIDC provider"
+}
+
+type ErrPersonalAccountNotAllowed struct{}
+
+func NewPersonalAccountNotAllowedError() error {
+	return &ErrPersonalAccountNotAllowed{}
+}
+
+func (e ErrPersonalAccountNotAllowed) Error() string {
+	return "cannot authenticate: personal accounts are not allowed, use an enterprise account"
+}

--- a/pkg/iam/oidc/gc.go
+++ b/pkg/iam/oidc/gc.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package oidc
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.gearno.de/kit/log"
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+const (
+	DefaultGarbageCollectionInterval = 1 * time.Hour
+)
+
+type GarbageCollector struct {
+	pg       *pg.Client
+	interval time.Duration
+	logger   *log.Logger
+}
+
+func NewGarbageCollector(
+	pg *pg.Client,
+	interval time.Duration,
+	logger *log.Logger,
+) *GarbageCollector {
+	return &GarbageCollector{
+		pg:       pg,
+		interval: interval,
+		logger:   logger.Named("oidc.garbage_collector").With(log.Duration("interval", interval)),
+	}
+}
+
+func (gc *GarbageCollector) Run(ctx context.Context) error {
+	gc.logger.InfoCtx(ctx, "oidc garbage collector starting")
+
+	if err := gc.cleanup(ctx); err != nil {
+		gc.logger.ErrorCtx(ctx, "cannot run initial cleanup", log.Error(err))
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			gc.logger.InfoCtx(ctx, "oidc garbage collector shutting down")
+			return ctx.Err()
+		case <-time.After(gc.interval):
+			if err := gc.cleanup(ctx); err != nil {
+				gc.logger.ErrorCtx(ctx, "cannot run periodic cleanup", log.Error(err))
+			}
+		}
+	}
+}
+
+func (gc *GarbageCollector) cleanup(ctx context.Context) error {
+	now := time.Now()
+
+	return gc.pg.WithTx(
+		ctx,
+		func(tx pg.Conn) error {
+			deleted, err := coredata.DeleteExpiredOIDCStates(ctx, tx, now)
+			if err != nil {
+				return fmt.Errorf("cannot delete expired oidc states: %w", err)
+			}
+
+			gc.logger.InfoCtx(
+				ctx,
+				"oidc garbage collector cleaned up expired states",
+				log.Int64("deleted", deleted),
+			)
+
+			return nil
+		},
+	)
+}

--- a/pkg/iam/oidc/gc.go
+++ b/pkg/iam/oidc/gc.go
@@ -28,22 +28,40 @@ const (
 	DefaultGarbageCollectionInterval = 1 * time.Hour
 )
 
-type GarbageCollector struct {
-	pg       *pg.Client
-	interval time.Duration
-	logger   *log.Logger
+type (
+	GarbageCollector struct {
+		pg       *pg.Client
+		interval time.Duration
+		logger   *log.Logger
+	}
+
+	GarbageCollectorOption func(*GarbageCollector)
+)
+
+func WithGarbageCollectionInterval(interval time.Duration) GarbageCollectorOption {
+	return func(gc *GarbageCollector) {
+		gc.interval = interval
+	}
 }
 
 func NewGarbageCollector(
-	pg *pg.Client,
-	interval time.Duration,
+	pgClient *pg.Client,
 	logger *log.Logger,
+	opts ...GarbageCollectorOption,
 ) *GarbageCollector {
-	return &GarbageCollector{
-		pg:       pg,
-		interval: interval,
-		logger:   logger.Named("oidc.garbage_collector").With(log.Duration("interval", interval)),
+	gc := &GarbageCollector{
+		pg:       pgClient,
+		interval: DefaultGarbageCollectionInterval,
+		logger:   logger.Named("oidc.garbage_collector"),
 	}
+
+	for _, opt := range opts {
+		opt(gc)
+	}
+
+	gc.logger = gc.logger.With(log.Duration("interval", gc.interval))
+
+	return gc
 }
 
 func (gc *GarbageCollector) Run(ctx context.Context) error {
@@ -53,12 +71,15 @@ func (gc *GarbageCollector) Run(ctx context.Context) error {
 		gc.logger.ErrorCtx(ctx, "cannot run initial cleanup", log.Error(err))
 	}
 
+	ticker := time.NewTicker(gc.interval)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
 			gc.logger.InfoCtx(ctx, "oidc garbage collector shutting down")
 			return ctx.Err()
-		case <-time.After(gc.interval):
+		case <-ticker.C:
 			if err := gc.cleanup(ctx); err != nil {
 				gc.logger.ErrorCtx(ctx, "cannot run periodic cleanup", log.Error(err))
 			}
@@ -72,7 +93,8 @@ func (gc *GarbageCollector) cleanup(ctx context.Context) error {
 	return gc.pg.WithTx(
 		ctx,
 		func(tx pg.Conn) error {
-			deleted, err := coredata.DeleteExpiredOIDCStates(ctx, tx, now)
+			var state coredata.OIDCState
+			deleted, err := state.DeleteExpired(ctx, tx, now)
 			if err != nil {
 				return fmt.Errorf("cannot delete expired oidc states: %w", err)
 			}

--- a/pkg/iam/oidc/service.go
+++ b/pkg/iam/oidc/service.go
@@ -34,6 +34,7 @@ import (
 	"sync"
 	"time"
 
+	"go.gearno.de/kit/httpclient"
 	"go.gearno.de/kit/log"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/coredata"
@@ -64,10 +65,11 @@ type (
 	}
 
 	Service struct {
-		pg        *pg.Client
-		baseURL   string
-		logger    *log.Logger
-		providers map[coredata.OIDCProvider]*providerInfo
+		pg         *pg.Client
+		baseURL    string
+		logger     *log.Logger
+		httpClient *http.Client
+		providers  map[coredata.OIDCProvider]*providerInfo
 
 		jwksMu    sync.RWMutex
 		jwksCache map[string]*jwksEntry
@@ -157,11 +159,12 @@ func NewService(
 	logger *log.Logger,
 ) *Service {
 	s := &Service{
-		pg:        pgClient,
-		baseURL:   baseURL,
-		logger:    logger.Named("oidc"),
-		providers: make(map[coredata.OIDCProvider]*providerInfo),
-		jwksCache: make(map[string]*jwksEntry),
+		pg:         pgClient,
+		baseURL:    baseURL,
+		logger:     logger.Named("oidc"),
+		httpClient: httpclient.DefaultPooledClient(httpclient.WithLogger(logger)),
+		providers:  make(map[coredata.OIDCProvider]*providerInfo),
+		jwksCache:  make(map[string]*jwksEntry),
 	}
 
 	if google.Enabled {
@@ -488,7 +491,7 @@ func (s *Service) verifyAndParseIDToken(ctx context.Context, info *providerInfo,
 	}
 
 	if claims.Nonce != expectedNonce {
-		return nil, fmt.Errorf("cannot validate nonce: expected %q, got %q", expectedNonce, claims.Nonce)
+		return nil, fmt.Errorf("cannot validate nonce: mismatch")
 	}
 
 	if time.Now().After(time.Unix(int64(claims.ExpiresAt), 0)) {
@@ -504,7 +507,7 @@ func (s *Service) getSigningKey(ctx context.Context, jwksURL string, kid string)
 	s.jwksMu.RUnlock()
 
 	if !ok || time.Since(entry.fetchedAt) > jwksCacheTTL {
-		keys, err := fetchJWKS(ctx, jwksURL)
+		keys, err := fetchJWKS(ctx, s.httpClient, jwksURL)
 		if err != nil {
 			return nil, err
 		}
@@ -522,7 +525,7 @@ func (s *Service) getSigningKey(ctx context.Context, jwksURL string, kid string)
 	}
 
 	// Key not found in cache, try refreshing
-	keys, err := fetchJWKS(ctx, jwksURL)
+	keys, err := fetchJWKS(ctx, s.httpClient, jwksURL)
 	if err != nil {
 		return nil, err
 	}
@@ -541,13 +544,13 @@ func (s *Service) getSigningKey(ctx context.Context, jwksURL string, kid string)
 	return nil, fmt.Errorf("cannot find signing key %q in JWKS", kid)
 }
 
-func fetchJWKS(ctx context.Context, jwksURL string) ([]jwk, error) {
+func fetchJWKS(ctx context.Context, httpClient *http.Client, jwksURL string) ([]jwk, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, jwksURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create jwks request: %w", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("cannot fetch jwks: %w", err)
 	}

--- a/pkg/iam/oidc/service.go
+++ b/pkg/iam/oidc/service.go
@@ -30,6 +30,7 @@ import (
 	"io"
 	"math/big"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -258,6 +259,7 @@ func (s *Service) EnabledProviders() []coredata.OIDCProvider {
 	for p := range s.providers {
 		providers = append(providers, p)
 	}
+	slices.Sort(providers)
 	return providers
 }
 

--- a/pkg/iam/oidc/service.go
+++ b/pkg/iam/oidc/service.go
@@ -57,6 +57,12 @@ type (
 		jwksURL           string
 		issuerValidator   func(string) bool
 		enterpriseChecker func(*idTokenClaims) bool
+
+		// trustProviderEmail indicates that the provider's directory
+		// guarantees email verification for enterprise accounts, so
+		// the email_verified claim does not need to be present in
+		// the ID token.
+		trustProviderEmail bool
 	}
 
 	UserInfo struct {
@@ -198,7 +204,8 @@ func NewService(
 				RedirectURL:  baseURL + "/api/connect/v1/oidc/microsoft/callback",
 				Scopes:       []string{"openid", "email", "profile"},
 			},
-			jwksURL: microsoftJWKSURL,
+			jwksURL:            microsoftJWKSURL,
+			trustProviderEmail: true,
 			issuerValidator: func(iss string) bool {
 				return strings.HasPrefix(iss, "https://login.microsoftonline.com/") &&
 					strings.HasSuffix(iss, "/v2.0")
@@ -224,11 +231,13 @@ func (s *Service) Run(ctx context.Context) error {
 
 	gcCtx, stopGC := context.WithCancel(context.WithoutCancel(ctx))
 	gc := NewGarbageCollector(s.pg, s.logger)
-	wg.Go(func() {
-		if err := gc.Run(gcCtx); err != nil {
-			cancel(fmt.Errorf("oidc garbage collector crashed: %w", err))
-		}
-	})
+	wg.Go(
+		func() {
+			if err := gc.Run(gcCtx); err != nil {
+				cancel(fmt.Errorf("oidc garbage collector crashed: %w", err))
+			}
+		},
+	)
 
 	<-ctx.Done()
 
@@ -377,7 +386,7 @@ func (s *Service) HandleCallback(
 		return nil, "", NewMissingEmailClaimError()
 	}
 
-	if !claims.isEmailVerified() {
+	if !info.trustProviderEmail && !claims.isEmailVerified() {
 		return nil, "", NewEmailNotVerifiedError()
 	}
 

--- a/pkg/iam/oidc/service.go
+++ b/pkg/iam/oidc/service.go
@@ -1,0 +1,686 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package oidc
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	cryptorand "crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"go.gearno.de/kit/log"
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/mail"
+	"golang.org/x/oauth2"
+)
+
+var cryptoRandReader io.Reader = cryptorand.Reader
+
+type (
+	ProviderConfig struct {
+		ClientID     string
+		ClientSecret string
+		Enabled      bool
+	}
+
+	providerInfo struct {
+		oauth2Config      oauth2.Config
+		jwksURL           string
+		issuerValidator   func(string) bool
+		enterpriseChecker func(*idTokenClaims) bool
+	}
+
+	UserInfo struct {
+		Email    mail.Addr
+		FullName string
+	}
+
+	Service struct {
+		pg        *pg.Client
+		baseURL   string
+		logger    *log.Logger
+		providers map[coredata.OIDCProvider]*providerInfo
+
+		jwksMu    sync.RWMutex
+		jwksCache map[string]*jwksEntry
+	}
+
+	jwksEntry struct {
+		keys      []jwk
+		fetchedAt time.Time
+	}
+
+	jwk struct {
+		Kty string `json:"kty"`
+		Kid string `json:"kid"`
+		Use string `json:"use"`
+		N   string `json:"n"`
+		E   string `json:"e"`
+		Crv string `json:"crv"`
+		X   string `json:"x"`
+		Y   string `json:"y"`
+	}
+
+	jwksResponse struct {
+		Keys []jwk `json:"keys"`
+	}
+
+	idTokenClaims struct {
+		Issuer        string  `json:"iss"`
+		Subject       string  `json:"sub"`
+		Audience      any     `json:"aud"`
+		ExpiresAt     float64 `json:"exp"`
+		Nonce         string  `json:"nonce"`
+		Email         string  `json:"email"`
+		EmailVerified any     `json:"email_verified"`
+		Name          string  `json:"name"`
+		HostedDomain  string  `json:"hd"`
+	}
+)
+
+func (c *idTokenClaims) hasAudience(clientID string) bool {
+	switch aud := c.Audience.(type) {
+	case string:
+		return aud == clientID
+	case []any:
+		for _, v := range aud {
+			if s, ok := v.(string); ok && s == clientID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (c *idTokenClaims) isEmailVerified() bool {
+	switch v := c.EmailVerified.(type) {
+	case bool:
+		return v
+	case string:
+		return strings.EqualFold(v, "true")
+	}
+	return false
+}
+
+var (
+	googleEndpoint = oauth2.Endpoint{
+		AuthURL:  "https://accounts.google.com/o/oauth2/v2/auth",
+		TokenURL: "https://oauth2.googleapis.com/token",
+	}
+
+	microsoftEndpoint = oauth2.Endpoint{
+		AuthURL:  "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+		TokenURL: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+	}
+)
+
+const (
+	googleJWKSURL             = "https://www.googleapis.com/oauth2/v3/certs"
+	microsoftJWKSURL          = "https://login.microsoftonline.com/common/discovery/v2.0/keys"
+	microsoftConsumerTenantID = "9188040d-6c67-4c5b-b112-36a304b66dad"
+	jwksCacheTTL              = 1 * time.Hour
+)
+
+func NewService(
+	pgClient *pg.Client,
+	baseURL string,
+	google ProviderConfig,
+	microsoft ProviderConfig,
+	logger *log.Logger,
+) *Service {
+	s := &Service{
+		pg:        pgClient,
+		baseURL:   baseURL,
+		logger:    logger.Named("oidc"),
+		providers: make(map[coredata.OIDCProvider]*providerInfo),
+		jwksCache: make(map[string]*jwksEntry),
+	}
+
+	if google.Enabled {
+		s.providers[coredata.OIDCProviderGoogle] = &providerInfo{
+			oauth2Config: oauth2.Config{
+				ClientID:     google.ClientID,
+				ClientSecret: google.ClientSecret,
+				Endpoint:     googleEndpoint,
+				RedirectURL:  baseURL + "/api/connect/v1/oidc/google/callback",
+				Scopes:       []string{"openid", "email", "profile"},
+			},
+			jwksURL: googleJWKSURL,
+			issuerValidator: func(iss string) bool {
+				return iss == "https://accounts.google.com"
+			},
+			enterpriseChecker: func(claims *idTokenClaims) bool {
+				// The "hd" (hosted domain) claim is only present for
+				// Google Workspace accounts. Personal gmail.com accounts
+				// do not have this claim.
+				return claims.HostedDomain != ""
+			},
+		}
+	}
+
+	if microsoft.Enabled {
+		s.providers[coredata.OIDCProviderMicrosoft] = &providerInfo{
+			oauth2Config: oauth2.Config{
+				ClientID:     microsoft.ClientID,
+				ClientSecret: microsoft.ClientSecret,
+				Endpoint:     microsoftEndpoint,
+				RedirectURL:  baseURL + "/api/connect/v1/oidc/microsoft/callback",
+				Scopes:       []string{"openid", "email", "profile"},
+			},
+			jwksURL: microsoftJWKSURL,
+			issuerValidator: func(iss string) bool {
+				return strings.HasPrefix(iss, "https://login.microsoftonline.com/") &&
+					strings.HasSuffix(iss, "/v2.0")
+			},
+			enterpriseChecker: func(claims *idTokenClaims) bool {
+				// Personal Microsoft accounts (live.com, outlook.com,
+				// hotmail.com) use the consumer tenant ID. Reject them.
+				return !strings.Contains(
+					claims.Issuer,
+					microsoftConsumerTenantID,
+				)
+			},
+		}
+	}
+
+	return s
+}
+
+func (s *Service) Run(ctx context.Context) error {
+	gc := NewGarbageCollector(s.pg, DefaultGarbageCollectionInterval, s.logger)
+
+	gcCtx, stopGC := context.WithCancel(ctx)
+	defer stopGC()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- gc.Run(gcCtx)
+	}()
+
+	select {
+	case <-ctx.Done():
+		stopGC()
+		<-errCh
+		return ctx.Err()
+	case err := <-errCh:
+		if err != nil {
+			s.logger.ErrorCtx(ctx, "oidc garbage collector failed", log.Error(err))
+			return err
+		}
+
+		return nil
+	}
+}
+
+func (s *Service) IsProviderEnabled(provider coredata.OIDCProvider) bool {
+	_, ok := s.providers[provider]
+	return ok
+}
+
+func (s *Service) EnabledProviders() []coredata.OIDCProvider {
+	providers := make([]coredata.OIDCProvider, 0, len(s.providers))
+	for p := range s.providers {
+		providers = append(providers, p)
+	}
+	return providers
+}
+
+func (s *Service) InitiateLogin(
+	ctx context.Context,
+	provider coredata.OIDCProvider,
+	continueURL string,
+) (string, error) {
+	info, ok := s.providers[provider]
+	if !ok {
+		return "", NewProviderNotEnabledError(provider)
+	}
+
+	state, err := generateRandomString(32)
+	if err != nil {
+		return "", fmt.Errorf("cannot generate state: %w", err)
+	}
+
+	nonce, err := generateRandomString(32)
+	if err != nil {
+		return "", fmt.Errorf("cannot generate nonce: %w", err)
+	}
+
+	codeVerifier, err := generateRandomString(64)
+	if err != nil {
+		return "", fmt.Errorf("cannot generate code verifier: %w", err)
+	}
+
+	now := time.Now()
+	oidcState := &coredata.OIDCState{
+		ID:           state,
+		Provider:     provider,
+		Nonce:        nonce,
+		CodeVerifier: codeVerifier,
+		ContinueURL:  continueURL,
+		CreatedAt:    now,
+		ExpiresAt:    now.Add(10 * time.Minute),
+	}
+
+	err = s.pg.WithTx(
+		ctx,
+		func(tx pg.Conn) error {
+			if err := oidcState.Insert(ctx, tx); err != nil {
+				return fmt.Errorf("cannot store oidc state: %w", err)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+
+	codeChallenge := computeCodeChallenge(codeVerifier)
+
+	authURL := info.oauth2Config.AuthCodeURL(
+		state,
+		oauth2.SetAuthURLParam("nonce", nonce),
+		oauth2.SetAuthURLParam("code_challenge", codeChallenge),
+		oauth2.SetAuthURLParam("code_challenge_method", "S256"),
+	)
+
+	return authURL, nil
+}
+
+func (s *Service) HandleCallback(
+	ctx context.Context,
+	provider coredata.OIDCProvider,
+	stateParam string,
+	code string,
+) (*coredata.Identity, string, error) {
+	info, ok := s.providers[provider]
+	if !ok {
+		return nil, "", NewProviderNotEnabledError(provider)
+	}
+
+	var oidcState coredata.OIDCState
+	err := s.pg.WithTx(
+		ctx,
+		func(tx pg.Conn) error {
+			if err := oidcState.LoadByIDForUpdate(ctx, tx, stateParam); err != nil {
+				if errors.Is(err, coredata.ErrResourceNotFound) {
+					return NewInvalidStateError()
+				}
+				return fmt.Errorf("cannot load oidc state: %w", err)
+			}
+
+			if err := oidcState.Delete(ctx, tx); err != nil {
+				return fmt.Errorf("cannot delete oidc state: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if time.Now().After(oidcState.ExpiresAt) {
+		return nil, "", NewInvalidStateError()
+	}
+
+	if oidcState.Provider != provider {
+		return nil, "", NewInvalidStateError()
+	}
+
+	token, err := info.oauth2Config.Exchange(
+		ctx,
+		code,
+		oauth2.SetAuthURLParam("code_verifier", oidcState.CodeVerifier),
+	)
+	if err != nil {
+		return nil, "", NewCodeExchangeError(err)
+	}
+
+	rawIDToken, ok := token.Extra("id_token").(string)
+	if !ok {
+		return nil, "", NewIDTokenMissingError()
+	}
+
+	claims, err := s.verifyAndParseIDToken(ctx, info, rawIDToken, oidcState.Nonce)
+	if err != nil {
+		return nil, "", fmt.Errorf("cannot verify id token: %w", err)
+	}
+
+	if claims.Email == "" {
+		return nil, "", NewMissingEmailClaimError()
+	}
+
+	if !claims.isEmailVerified() {
+		return nil, "", NewEmailNotVerifiedError()
+	}
+
+	if !info.enterpriseChecker(claims) {
+		return nil, "", NewPersonalAccountNotAllowedError()
+	}
+
+	email, err := mail.ParseAddr(claims.Email)
+	if err != nil {
+		return nil, "", fmt.Errorf("cannot parse email from id token: %w", err)
+	}
+
+	var identity *coredata.Identity
+	now := time.Now()
+
+	err = s.pg.WithTx(
+		ctx,
+		func(tx pg.Conn) error {
+			identity = &coredata.Identity{}
+			err := identity.LoadByEmail(ctx, tx, email)
+			if err != nil {
+				if !errors.Is(err, coredata.ErrResourceNotFound) {
+					return fmt.Errorf("cannot load identity by email: %w", err)
+				}
+
+				identity = &coredata.Identity{
+					ID:                   gid.New(gid.NilTenant, coredata.IdentityEntityType),
+					EmailAddress:         email,
+					FullName:             claims.Name,
+					EmailAddressVerified: true,
+					CreatedAt:            now,
+					UpdatedAt:            now,
+				}
+
+				if err := identity.Insert(ctx, tx); err != nil {
+					return fmt.Errorf("cannot insert identity: %w", err)
+				}
+
+				return nil
+			}
+
+			if !identity.EmailAddressVerified {
+				identity.EmailAddressVerified = true
+				identity.UpdatedAt = now
+
+				if err := identity.Update(ctx, tx); err != nil {
+					return fmt.Errorf("cannot update identity: %w", err)
+				}
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return identity, oidcState.ContinueURL, nil
+}
+
+func (s *Service) verifyAndParseIDToken(ctx context.Context, info *providerInfo, rawIDToken string, expectedNonce string) (*idTokenClaims, error) {
+	parts := strings.Split(rawIDToken, ".")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("cannot parse id token: invalid format")
+	}
+
+	headerJSON, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("cannot decode id token header: %w", err)
+	}
+
+	var header struct {
+		Alg string `json:"alg"`
+		Kid string `json:"kid"`
+	}
+	if err := json.Unmarshal(headerJSON, &header); err != nil {
+		return nil, fmt.Errorf("cannot parse id token header: %w", err)
+	}
+
+	key, err := s.getSigningKey(ctx, info.jwksURL, header.Kid)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get signing key: %w", err)
+	}
+
+	signedContent := parts[0] + "." + parts[1]
+	signature, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return nil, fmt.Errorf("cannot decode signature: %w", err)
+	}
+
+	if err := verifySignature(header.Alg, key, []byte(signedContent), signature); err != nil {
+		return nil, fmt.Errorf("cannot verify id token signature: %w", err)
+	}
+
+	payloadJSON, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("cannot decode id token payload: %w", err)
+	}
+
+	var claims idTokenClaims
+	if err := json.Unmarshal(payloadJSON, &claims); err != nil {
+		return nil, fmt.Errorf("cannot parse id token claims: %w", err)
+	}
+
+	if !info.issuerValidator(claims.Issuer) {
+		return nil, fmt.Errorf("cannot validate issuer: unexpected issuer %q", claims.Issuer)
+	}
+
+	if !claims.hasAudience(info.oauth2Config.ClientID) {
+		return nil, fmt.Errorf("cannot validate audience: expected %q", info.oauth2Config.ClientID)
+	}
+
+	if claims.Nonce != expectedNonce {
+		return nil, fmt.Errorf("cannot validate nonce: expected %q, got %q", expectedNonce, claims.Nonce)
+	}
+
+	if time.Now().After(time.Unix(int64(claims.ExpiresAt), 0)) {
+		return nil, fmt.Errorf("cannot validate id token: token has expired")
+	}
+
+	return &claims, nil
+}
+
+func (s *Service) getSigningKey(ctx context.Context, jwksURL string, kid string) (crypto.PublicKey, error) {
+	s.jwksMu.RLock()
+	entry, ok := s.jwksCache[jwksURL]
+	s.jwksMu.RUnlock()
+
+	if !ok || time.Since(entry.fetchedAt) > jwksCacheTTL {
+		keys, err := fetchJWKS(ctx, jwksURL)
+		if err != nil {
+			return nil, err
+		}
+
+		entry = &jwksEntry{keys: keys, fetchedAt: time.Now()}
+		s.jwksMu.Lock()
+		s.jwksCache[jwksURL] = entry
+		s.jwksMu.Unlock()
+	}
+
+	for _, k := range entry.keys {
+		if k.Kid == kid {
+			return parseJWK(k)
+		}
+	}
+
+	// Key not found in cache, try refreshing
+	keys, err := fetchJWKS(ctx, jwksURL)
+	if err != nil {
+		return nil, err
+	}
+
+	entry = &jwksEntry{keys: keys, fetchedAt: time.Now()}
+	s.jwksMu.Lock()
+	s.jwksCache[jwksURL] = entry
+	s.jwksMu.Unlock()
+
+	for _, k := range entry.keys {
+		if k.Kid == kid {
+			return parseJWK(k)
+		}
+	}
+
+	return nil, fmt.Errorf("cannot find signing key %q in JWKS", kid)
+}
+
+func fetchJWKS(ctx context.Context, jwksURL string) ([]jwk, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, jwksURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create jwks request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot fetch jwks: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("cannot read jwks response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("cannot fetch jwks: unexpected status %d", resp.StatusCode)
+	}
+
+	var jwksResp jwksResponse
+	if err := json.Unmarshal(body, &jwksResp); err != nil {
+		return nil, fmt.Errorf("cannot parse jwks response: %w", err)
+	}
+
+	return jwksResp.Keys, nil
+}
+
+func parseJWK(k jwk) (crypto.PublicKey, error) {
+	switch k.Kty {
+	case "RSA":
+		nBytes, err := base64.RawURLEncoding.DecodeString(k.N)
+		if err != nil {
+			return nil, fmt.Errorf("cannot decode RSA modulus: %w", err)
+		}
+		eBytes, err := base64.RawURLEncoding.DecodeString(k.E)
+		if err != nil {
+			return nil, fmt.Errorf("cannot decode RSA exponent: %w", err)
+		}
+
+		n := new(big.Int).SetBytes(nBytes)
+		e := 0
+		for _, b := range eBytes {
+			e = e<<8 + int(b)
+		}
+
+		return &rsa.PublicKey{N: n, E: e}, nil
+
+	case "EC":
+		var curve elliptic.Curve
+		switch k.Crv {
+		case "P-256":
+			curve = elliptic.P256()
+		case "P-384":
+			curve = elliptic.P384()
+		case "P-521":
+			curve = elliptic.P521()
+		default:
+			return nil, fmt.Errorf("unsupported EC curve: %s", k.Crv)
+		}
+
+		xBytes, err := base64.RawURLEncoding.DecodeString(k.X)
+		if err != nil {
+			return nil, fmt.Errorf("cannot decode EC X: %w", err)
+		}
+		yBytes, err := base64.RawURLEncoding.DecodeString(k.Y)
+		if err != nil {
+			return nil, fmt.Errorf("cannot decode EC Y: %w", err)
+		}
+
+		return &ecdsa.PublicKey{
+			Curve: curve,
+			X:     new(big.Int).SetBytes(xBytes),
+			Y:     new(big.Int).SetBytes(yBytes),
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unsupported key type: %s", k.Kty)
+	}
+}
+
+func verifySignature(alg string, key crypto.PublicKey, signedContent []byte, signature []byte) error {
+	hash := sha256.Sum256(signedContent)
+
+	switch alg {
+	case "RS256":
+		rsaKey, ok := key.(*rsa.PublicKey)
+		if !ok {
+			return fmt.Errorf("cannot verify RS256 signature: expected RSA public key")
+		}
+		return rsa.VerifyPKCS1v15(rsaKey, crypto.SHA256, hash[:], signature)
+
+	case "ES256":
+		ecKey, ok := key.(*ecdsa.PublicKey)
+		if !ok {
+			return fmt.Errorf("cannot verify ES256 signature: expected ECDSA public key")
+		}
+
+		// JWS (RFC 7515) encodes ECDSA signatures as raw R||S
+		// concatenation (2x32 bytes for P-256), not ASN.1 DER.
+		// Convert to ASN.1 for ecdsa.VerifyASN1.
+		keySize := (ecKey.Curve.Params().BitSize + 7) / 8
+		if len(signature) != 2*keySize {
+			return fmt.Errorf("cannot verify ES256 signature: invalid length %d, expected %d", len(signature), 2*keySize)
+		}
+
+		r := new(big.Int).SetBytes(signature[:keySize])
+		sigS := new(big.Int).SetBytes(signature[keySize:])
+
+		derSig, err := asn1.Marshal(struct {
+			R, S *big.Int
+		}{r, sigS})
+		if err != nil {
+			return fmt.Errorf("cannot encode ECDSA signature to ASN.1: %w", err)
+		}
+
+		if !ecdsa.VerifyASN1(ecKey, hash[:], derSig) {
+			return fmt.Errorf("cannot verify ECDSA signature")
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("cannot verify signature: unsupported algorithm %s", alg)
+	}
+}
+
+func computeCodeChallenge(codeVerifier string) string {
+	hash := sha256.Sum256([]byte(codeVerifier))
+	return base64.RawURLEncoding.EncodeToString(hash[:])
+}
+
+func generateRandomString(length int) (string, error) {
+	b := make([]byte, length)
+	if _, err := io.ReadFull(cryptoRandReader, b); err != nil {
+		return "", fmt.Errorf("cannot generate random bytes: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}

--- a/pkg/iam/oidc/service.go
+++ b/pkg/iam/oidc/service.go
@@ -215,29 +215,25 @@ func NewService(
 }
 
 func (s *Service) Run(ctx context.Context) error {
-	gc := NewGarbageCollector(s.pg, DefaultGarbageCollectionInterval, s.logger)
+	wg := sync.WaitGroup{}
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(context.Canceled)
 
-	gcCtx, stopGC := context.WithCancel(ctx)
-	defer stopGC()
-
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- gc.Run(gcCtx)
-	}()
-
-	select {
-	case <-ctx.Done():
-		stopGC()
-		<-errCh
-		return ctx.Err()
-	case err := <-errCh:
-		if err != nil {
-			s.logger.ErrorCtx(ctx, "oidc garbage collector failed", log.Error(err))
-			return err
+	gcCtx, stopGC := context.WithCancel(context.WithoutCancel(ctx))
+	gc := NewGarbageCollector(s.pg, s.logger)
+	wg.Go(func() {
+		if err := gc.Run(gcCtx); err != nil {
+			cancel(fmt.Errorf("oidc garbage collector crashed: %w", err))
 		}
+	})
 
-		return nil
-	}
+	<-ctx.Done()
+
+	stopGC()
+
+	wg.Wait()
+
+	return context.Cause(ctx)
 }
 
 func (s *Service) IsProviderEnabled(provider coredata.OIDCProvider) bool {

--- a/pkg/iam/saml/gc.go
+++ b/pkg/iam/saml/gc.go
@@ -71,6 +71,10 @@ func (gc *GarbageCollector) Run(ctx context.Context) error {
 		gc.logger.ErrorCtx(ctx, "cannot run initial cleanup", log.Error(err))
 	}
 
+	if gc.interval <= 0 {
+		return fmt.Errorf("cannot run SAML garbage collector: interval must be greater than zero")
+	}
+
 	ticker := time.NewTicker(gc.interval)
 	defer ticker.Stop()
 

--- a/pkg/iam/saml/gc.go
+++ b/pkg/iam/saml/gc.go
@@ -34,18 +34,34 @@ type (
 		interval time.Duration
 		logger   *log.Logger
 	}
+
+	GarbageCollectorOption func(*GarbageCollector)
 )
 
-func NewGarbageCollector(
-	pg *pg.Client,
-	interval time.Duration,
-	logger *log.Logger,
-) *GarbageCollector {
-	return &GarbageCollector{
-		pg:       pg,
-		interval: interval,
-		logger:   logger.Named("saml.garbage_collector").With(log.Duration("interval", interval)),
+func WithGarbageCollectionInterval(interval time.Duration) GarbageCollectorOption {
+	return func(gc *GarbageCollector) {
+		gc.interval = interval
 	}
+}
+
+func NewGarbageCollector(
+	pgClient *pg.Client,
+	logger *log.Logger,
+	opts ...GarbageCollectorOption,
+) *GarbageCollector {
+	gc := &GarbageCollector{
+		pg:       pgClient,
+		interval: DefaultGarbageCollectionInterval,
+		logger:   logger.Named("saml.garbage_collector"),
+	}
+
+	for _, opt := range opts {
+		opt(gc)
+	}
+
+	gc.logger = gc.logger.With(log.Duration("interval", gc.interval))
+
+	return gc
 }
 
 func (gc *GarbageCollector) Run(ctx context.Context) error {
@@ -55,12 +71,15 @@ func (gc *GarbageCollector) Run(ctx context.Context) error {
 		gc.logger.ErrorCtx(ctx, "cannot run initial cleanup", log.Error(err))
 	}
 
+	ticker := time.NewTicker(gc.interval)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
 			gc.logger.InfoCtx(ctx, "saml garbage collector shutting down")
 			return ctx.Err()
-		case <-time.After(gc.interval):
+		case <-ticker.C:
 			if err := gc.cleanup(ctx); err != nil {
 				gc.logger.ErrorCtx(ctx, "cannot run periodic cleanup", log.Error(err))
 			}

--- a/pkg/iam/saml/service.go
+++ b/pkg/iam/saml/service.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/crewjam/saml"
@@ -70,29 +71,25 @@ func NewService(
 }
 
 func (s *Service) Run(ctx context.Context) error {
-	gc := NewGarbageCollector(s.pg, DefaultGarbageCollectionInterval, s.logger)
+	wg := sync.WaitGroup{}
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(context.Canceled)
 
-	gcCtx, stopGC := context.WithCancel(ctx)
-	defer stopGC()
-
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- gc.Run(gcCtx)
-	}()
-
-	select {
-	case <-ctx.Done():
-		stopGC()
-		<-errCh
-		return ctx.Err()
-	case err := <-errCh:
-		if err != nil {
-			s.logger.ErrorCtx(ctx, "saml garbage collector failed", log.Error(err))
-			return err
+	gcCtx, stopGC := context.WithCancel(context.WithoutCancel(ctx))
+	gc := NewGarbageCollector(s.pg, s.logger)
+	wg.Go(func() {
+		if err := gc.Run(gcCtx); err != nil {
+			cancel(fmt.Errorf("saml garbage collector crashed: %w", err))
 		}
+	})
 
-		return nil
-	}
+	<-ctx.Done()
+
+	stopGC()
+
+	wg.Wait()
+
+	return context.Cause(ctx)
 }
 
 func (s *Service) GenerateSpMetadata() ([]byte, error) {

--- a/pkg/iam/saml_domain_verifier.go
+++ b/pkg/iam/saml_domain_verifier.go
@@ -69,6 +69,10 @@ func (v *SAMLDomainVerifier) Run(ctx context.Context) error {
 
 	v.runOnce(ctx)
 
+	if v.interval <= 0 {
+		return fmt.Errorf("cannot run SAML domain verifier: interval must be greater than zero")
+	}
+
 	ticker := time.NewTicker(v.interval)
 	defer ticker.Stop()
 

--- a/pkg/iam/saml_domain_verifier.go
+++ b/pkg/iam/saml_domain_verifier.go
@@ -67,14 +67,18 @@ func NewSAMLDomainVerifier(
 func (v *SAMLDomainVerifier) Run(ctx context.Context) error {
 	v.logger.InfoCtx(ctx, "starting", log.Duration("interval", v.interval))
 
-	for {
-		v.runOnce(ctx)
+	v.runOnce(ctx)
 
+	ticker := time.NewTicker(v.interval)
+	defer ticker.Stop()
+
+	for {
 		select {
 		case <-ctx.Done():
 			v.logger.InfoCtx(ctx, "shutting down")
 			return ctx.Err()
-		case <-time.After(v.interval):
+		case <-ticker.C:
+			v.runOnce(ctx)
 		}
 	}
 }

--- a/pkg/iam/service.go
+++ b/pkg/iam/service.go
@@ -18,6 +18,7 @@ import (
 	"go.probo.inc/probo/pkg/crypto/passwdhash"
 	"go.probo.inc/probo/pkg/filemanager"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/oidc"
 	"go.probo.inc/probo/pkg/iam/saml"
 	"go.probo.inc/probo/pkg/iam/scim"
 	"golang.org/x/sync/errgroup"
@@ -46,6 +47,7 @@ type (
 		SessionService        *SessionService
 		AuthService           *AuthService
 		SAMLService           *saml.Service
+		OIDCService           *oidc.Service
 		SCIMService           *scim.Service
 		APIKeyService         *APIKeyService
 		Authorizer            *Authorizer
@@ -73,6 +75,8 @@ type (
 		DomainVerificationResolverAddr string
 		SCIMBridgeSyncInterval         time.Duration
 		SCIMBridgePollInterval         time.Duration
+		GoogleOIDC                     oidc.ProviderConfig
+		MicrosoftOIDC                  oidc.ProviderConfig
 	}
 )
 
@@ -135,6 +139,14 @@ func NewService(
 	}
 	svc.SAMLService = samlService
 
+	svc.OIDCService = oidc.NewService(
+		svc.pg,
+		svc.baseURL,
+		cfg.GoogleOIDC,
+		cfg.MicrosoftOIDC,
+		cfg.Logger,
+	)
+
 	svc.SCIMService = scim.NewService(
 		svc.pg,
 		cfg.Logger.Named("scim"),
@@ -166,6 +178,7 @@ func (s *Service) Run(ctx context.Context) error {
 	g, ctx := errgroup.WithContext(ctx)
 
 	g.Go(func() error { return s.SAMLService.Run(ctx) })
+	g.Go(func() error { return s.OIDCService.Run(ctx) })
 	g.Go(func() error { return s.samlDomainVerifier.Run(ctx) })
 	g.Go(func() error { return s.SCIMService.Run(ctx) })
 

--- a/pkg/iam/service.go
+++ b/pkg/iam/service.go
@@ -180,32 +180,40 @@ func (s *Service) Run(ctx context.Context) error {
 	defer cancel(context.Canceled)
 
 	samlCtx, stopSAML := context.WithCancel(context.WithoutCancel(ctx))
-	wg.Go(func() {
-		if err := s.SAMLService.Run(samlCtx); err != nil {
-			cancel(fmt.Errorf("saml service crashed: %w", err))
-		}
-	})
+	wg.Go(
+		func() {
+			if err := s.SAMLService.Run(samlCtx); err != nil {
+				cancel(fmt.Errorf("saml service crashed: %w", err))
+			}
+		},
+	)
 
 	oidcCtx, stopOIDC := context.WithCancel(context.WithoutCancel(ctx))
-	wg.Go(func() {
-		if err := s.OIDCService.Run(oidcCtx); err != nil {
-			cancel(fmt.Errorf("oidc service crashed: %w", err))
-		}
-	})
+	wg.Go(
+		func() {
+			if err := s.OIDCService.Run(oidcCtx); err != nil {
+				cancel(fmt.Errorf("oidc service crashed: %w", err))
+			}
+		},
+	)
 
 	domainVerifierCtx, stopDomainVerifier := context.WithCancel(context.WithoutCancel(ctx))
-	wg.Go(func() {
-		if err := s.samlDomainVerifier.Run(domainVerifierCtx); err != nil {
-			cancel(fmt.Errorf("saml domain verifier crashed: %w", err))
-		}
-	})
+	wg.Go(
+		func() {
+			if err := s.samlDomainVerifier.Run(domainVerifierCtx); err != nil {
+				cancel(fmt.Errorf("saml domain verifier crashed: %w", err))
+			}
+		},
+	)
 
 	scimCtx, stopSCIM := context.WithCancel(context.WithoutCancel(ctx))
-	wg.Go(func() {
-		if err := s.SCIMService.Run(scimCtx); err != nil {
-			cancel(fmt.Errorf("scim service crashed: %w", err))
-		}
-	})
+	wg.Go(
+		func() {
+			if err := s.SCIMService.Run(scimCtx); err != nil {
+				cancel(fmt.Errorf("scim service crashed: %w", err))
+			}
+		},
+	)
 
 	<-ctx.Done()
 

--- a/pkg/iam/service.go
+++ b/pkg/iam/service.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -21,7 +22,6 @@ import (
 	"go.probo.inc/probo/pkg/iam/oidc"
 	"go.probo.inc/probo/pkg/iam/saml"
 	"go.probo.inc/probo/pkg/iam/scim"
-	"golang.org/x/sync/errgroup"
 )
 
 type (
@@ -175,14 +175,48 @@ func NewService(
 }
 
 func (s *Service) Run(ctx context.Context) error {
-	g, ctx := errgroup.WithContext(ctx)
+	wg := sync.WaitGroup{}
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(context.Canceled)
 
-	g.Go(func() error { return s.SAMLService.Run(ctx) })
-	g.Go(func() error { return s.OIDCService.Run(ctx) })
-	g.Go(func() error { return s.samlDomainVerifier.Run(ctx) })
-	g.Go(func() error { return s.SCIMService.Run(ctx) })
+	samlCtx, stopSAML := context.WithCancel(context.WithoutCancel(ctx))
+	wg.Go(func() {
+		if err := s.SAMLService.Run(samlCtx); err != nil {
+			cancel(fmt.Errorf("saml service crashed: %w", err))
+		}
+	})
 
-	return g.Wait()
+	oidcCtx, stopOIDC := context.WithCancel(context.WithoutCancel(ctx))
+	wg.Go(func() {
+		if err := s.OIDCService.Run(oidcCtx); err != nil {
+			cancel(fmt.Errorf("oidc service crashed: %w", err))
+		}
+	})
+
+	domainVerifierCtx, stopDomainVerifier := context.WithCancel(context.WithoutCancel(ctx))
+	wg.Go(func() {
+		if err := s.samlDomainVerifier.Run(domainVerifierCtx); err != nil {
+			cancel(fmt.Errorf("saml domain verifier crashed: %w", err))
+		}
+	})
+
+	scimCtx, stopSCIM := context.WithCancel(context.WithoutCancel(ctx))
+	wg.Go(func() {
+		if err := s.SCIMService.Run(scimCtx); err != nil {
+			cancel(fmt.Errorf("scim service crashed: %w", err))
+		}
+	})
+
+	<-ctx.Done()
+
+	stopSAML()
+	stopOIDC()
+	stopDomainVerifier()
+	stopSCIM()
+
+	wg.Wait()
+
+	return context.Cause(ctx)
 }
 
 func (s *Service) GetMembership(ctx context.Context, membershipID gid.GID) (*coredata.Membership, error) {

--- a/pkg/probod/auth_config.go
+++ b/pkg/probod/auth_config.go
@@ -20,13 +20,15 @@ import (
 )
 
 type AuthConfig struct {
-	Cookie                              CookieConfig   `json:"cookie"`
-	Password                            PasswordConfig `json:"password"`
-	DisableSignup                       bool           `json:"disable-signup"`
-	InvitationConfirmationTokenValidity int            `json:"invitation-confirmation-token-validity"`
-	PasswordResetTokenValidity          int            `json:"password-reset-token-validity"`
-	MagicLinkTokenValidity              int            `json:"magic-link-token-validity"`
-	SAML                                SAMLConfig     `json:"saml"`
+	Cookie                              CookieConfig       `json:"cookie"`
+	Password                            PasswordConfig     `json:"password"`
+	DisableSignup                       bool               `json:"disable-signup"`
+	InvitationConfirmationTokenValidity int                `json:"invitation-confirmation-token-validity"`
+	PasswordResetTokenValidity          int                `json:"password-reset-token-validity"`
+	MagicLinkTokenValidity              int                `json:"magic-link-token-validity"`
+	SAML                                SAMLConfig         `json:"saml"`
+	Google                              OIDCProviderConfig `json:"google"`
+	Microsoft                           OIDCProviderConfig `json:"microsoft"`
 }
 
 type CookieConfig struct {

--- a/pkg/probod/oidc_config.go
+++ b/pkg/probod/oidc_config.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package probod
+
+type OIDCProviderConfig struct {
+	ClientID     string `json:"client-id"`
+	ClientSecret string `json:"client-secret"`
+	Enabled      bool   `json:"enabled"`
+}

--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -55,6 +55,7 @@ import (
 	"go.probo.inc/probo/pkg/filemanager"
 	"go.probo.inc/probo/pkg/html2pdf"
 	"go.probo.inc/probo/pkg/iam"
+	"go.probo.inc/probo/pkg/iam/oidc"
 	"go.probo.inc/probo/pkg/mailer"
 	"go.probo.inc/probo/pkg/mailman"
 	"go.probo.inc/probo/pkg/probo"
@@ -381,6 +382,16 @@ func (impl *Implm) Run(
 			DomainVerificationResolverAddr: impl.cfg.Auth.SAML.DomainVerificationResolverAddr,
 			SCIMBridgeSyncInterval:         time.Duration(impl.cfg.SCIMBridge.SyncInterval) * time.Second,
 			SCIMBridgePollInterval:         time.Duration(impl.cfg.SCIMBridge.PollInterval) * time.Second,
+			GoogleOIDC: oidc.ProviderConfig{
+				ClientID:     impl.cfg.Auth.Google.ClientID,
+				ClientSecret: impl.cfg.Auth.Google.ClientSecret,
+				Enabled:      impl.cfg.Auth.Google.Enabled,
+			},
+			MicrosoftOIDC: oidc.ProviderConfig{
+				ClientID:     impl.cfg.Auth.Microsoft.ClientID,
+				ClientSecret: impl.cfg.Auth.Microsoft.ClientSecret,
+				Enabled:      impl.cfg.Auth.Microsoft.Enabled,
+			},
 		},
 	)
 	if err != nil {

--- a/pkg/server/api/connect/v1/oidc_handler.go
+++ b/pkg/server/api/connect/v1/oidc_handler.go
@@ -1,0 +1,161 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package connect_v1
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"go.gearno.de/kit/httpserver"
+	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/baseurl"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/iam"
+	"go.probo.inc/probo/pkg/saferedirect"
+	"go.probo.inc/probo/pkg/securecookie"
+	"go.probo.inc/probo/pkg/server/api/authn"
+)
+
+type OIDCHandler struct {
+	iam           *iam.Service
+	sessionCookie *authn.Cookie
+	baseURL       *baseurl.BaseURL
+	logger        *log.Logger
+	safeRedirect  *saferedirect.SafeRedirect
+}
+
+func NewOIDCHandler(iam *iam.Service, cookieConfig securecookie.Config, baseURL *baseurl.BaseURL, logger *log.Logger) *OIDCHandler {
+	return &OIDCHandler{
+		iam:           iam,
+		sessionCookie: authn.NewCookie(&cookieConfig),
+		baseURL:       baseURL,
+		logger:        logger,
+		safeRedirect:  &saferedirect.SafeRedirect{AllowedHost: baseURL.Host()},
+	}
+}
+
+func (h *OIDCHandler) LoginHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	provider, err := parseOIDCProvider(chi.URLParam(r, "provider"))
+	if err != nil {
+		httpserver.RenderError(w, http.StatusBadRequest, errors.New("invalid provider"))
+		return
+	}
+
+	if !h.iam.OIDCService.IsProviderEnabled(provider) {
+		httpserver.RenderError(w, http.StatusNotFound, errors.New("provider not enabled"))
+		return
+	}
+
+	continueURL := r.URL.Query().Get("continue")
+
+	authURL, err := h.iam.OIDCService.InitiateLogin(ctx, provider, continueURL)
+	if err != nil {
+		h.logger.ErrorCtx(ctx, "cannot initiate OIDC login", log.Error(err))
+		httpserver.RenderError(w, http.StatusInternalServerError, errors.New("internal server error"))
+		return
+	}
+
+	http.Redirect(w, r, authURL, http.StatusFound)
+}
+
+func (h *OIDCHandler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	provider, err := parseOIDCProvider(chi.URLParam(r, "provider"))
+	if err != nil {
+		httpserver.RenderError(w, http.StatusBadRequest, errors.New("invalid provider"))
+		return
+	}
+
+	errParam := r.URL.Query().Get("error")
+	if errParam != "" {
+		h.logger.WarnCtx(
+			ctx,
+			"OIDC provider returned error",
+			log.String("error", errParam),
+			log.String("error_description", r.URL.Query().Get("error_description")),
+		)
+		httpserver.RenderError(w, http.StatusUnauthorized, errors.New("authentication failed"))
+		return
+	}
+
+	stateParam := r.URL.Query().Get("state")
+	code := r.URL.Query().Get("code")
+
+	if stateParam == "" || code == "" {
+		httpserver.RenderError(w, http.StatusBadRequest, errors.New("missing state or code"))
+		return
+	}
+
+	identity, continueURL, err := h.iam.OIDCService.HandleCallback(ctx, provider, stateParam, code)
+	if err != nil {
+		h.logger.ErrorCtx(ctx, "cannot handle OIDC callback", log.Error(err))
+		httpserver.RenderError(w, http.StatusUnauthorized, errors.New("authentication failed"))
+		return
+	}
+
+	var authMethod coredata.AuthMethod
+	switch provider {
+	case coredata.OIDCProviderGoogle:
+		authMethod = coredata.AuthMethodGoogle
+	case coredata.OIDCProviderMicrosoft:
+		authMethod = coredata.AuthMethodMicrosoft
+	}
+
+	rootSession := authn.SessionFromContext(ctx)
+
+	switch {
+	case rootSession == nil:
+		rootSession, err = h.iam.AuthService.OpenSessionWithOIDC(ctx, identity.ID, authMethod)
+		if err != nil {
+			h.logger.ErrorCtx(ctx, "cannot open root session", log.Error(err))
+			httpserver.RenderError(w, http.StatusInternalServerError, errors.New("internal server error"))
+			return
+		}
+	case rootSession.IdentityID != identity.ID:
+		err = h.iam.SessionService.CloseSession(ctx, rootSession.ID)
+		if err != nil {
+			h.logger.ErrorCtx(ctx, "cannot close session", log.Error(err))
+			httpserver.RenderError(w, http.StatusInternalServerError, errors.New("internal server error"))
+			return
+		}
+
+		rootSession, err = h.iam.AuthService.OpenSessionWithOIDC(ctx, identity.ID, authMethod)
+		if err != nil {
+			h.logger.ErrorCtx(ctx, "cannot open root session", log.Error(err))
+			httpserver.RenderError(w, http.StatusInternalServerError, errors.New("internal server error"))
+			return
+		}
+	}
+
+	h.sessionCookie.Set(w, rootSession)
+
+	h.safeRedirect.Redirect(w, r, continueURL, "/", http.StatusFound)
+}
+
+func parseOIDCProvider(s string) (coredata.OIDCProvider, error) {
+	switch strings.ToLower(s) {
+	case "google":
+		return coredata.OIDCProviderGoogle, nil
+	case "microsoft":
+		return coredata.OIDCProviderMicrosoft, nil
+	default:
+		return "", errors.New("unknown provider")
+	}
+}

--- a/pkg/server/api/connect/v1/oidc_handler.go
+++ b/pkg/server/api/connect/v1/oidc_handler.go
@@ -110,19 +110,11 @@ func (h *OIDCHandler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var authMethod coredata.AuthMethod
-	switch provider {
-	case coredata.OIDCProviderGoogle:
-		authMethod = coredata.AuthMethodGoogle
-	case coredata.OIDCProviderMicrosoft:
-		authMethod = coredata.AuthMethodMicrosoft
-	}
-
 	rootSession := authn.SessionFromContext(ctx)
 
 	switch {
 	case rootSession == nil:
-		rootSession, err = h.iam.AuthService.OpenSessionWithOIDC(ctx, identity.ID, authMethod)
+		rootSession, err = h.iam.AuthService.OpenSessionWithOIDC(ctx, identity.ID, coredata.AuthMethodOIDC)
 		if err != nil {
 			h.logger.ErrorCtx(ctx, "cannot open root session", log.Error(err))
 			httpserver.RenderError(w, http.StatusInternalServerError, errors.New("internal server error"))
@@ -136,7 +128,7 @@ func (h *OIDCHandler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		rootSession, err = h.iam.AuthService.OpenSessionWithOIDC(ctx, identity.ID, authMethod)
+		rootSession, err = h.iam.AuthService.OpenSessionWithOIDC(ctx, identity.ID, coredata.AuthMethodOIDC)
 		if err != nil {
 			h.logger.ErrorCtx(ctx, "cannot open root session", log.Error(err))
 			httpserver.RenderError(w, http.StatusInternalServerError, errors.New("internal server error"))

--- a/pkg/server/api/connect/v1/resolver.go
+++ b/pkg/server/api/connect/v1/resolver.go
@@ -52,10 +52,14 @@ func NewMux(logger *log.Logger, svc *iam.Service, cookieConfig securecookie.Conf
 
 	router := r.With(sessionMiddleware, apiKeyMiddleware)
 
+	oidcHandler := NewOIDCHandler(svc, cookieConfig, baseURL, logger)
+
 	router.Handle("/graphql", graphqlHandler)
 	router.Get("/saml/2.0/metadata", samlHandler.MetadataHandler)
 	router.Post("/saml/2.0/consume", samlHandler.ConsumeHandler)
 	router.Get("/saml/2.0/{samlConfigID}", samlHandler.LoginHandler)
+	router.Get("/oidc/{provider}/login", oidcHandler.LoginHandler)
+	router.Get("/oidc/{provider}/callback", oidcHandler.CallbackHandler)
 
 	// SCIM 2.0 endpoints - these use their own bearer token authentication
 	scimServer := NewSCIMServer(scimHandler)

--- a/pkg/server/api/connect/v1/schema.graphql
+++ b/pkg/server/api/connect/v1/schema.graphql
@@ -41,10 +41,18 @@ interface Node {
   id: ID!
 }
 
+type OIDCProviderInfo {
+  name: String!
+  loginURL: String!
+}
+
 type Query {
   node(id: ID!): Node @session(required: PRESENT)
   viewer: Identity @session(required: PRESENT)
   ssoLoginURL(email: EmailAddr!): String
+    @goField(forceResolver: true)
+    @session(required: OPTIONAL)
+  oidcProviders: [OIDCProviderInfo!]!
     @goField(forceResolver: true)
     @session(required: OPTIONAL)
 }

--- a/pkg/server/api/connect/v1/v1_resolver.go
+++ b/pkg/server/api/connect/v1/v1_resolver.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/99designs/gqlgen/graphql"
@@ -1744,6 +1745,21 @@ func (r *queryResolver) SsoLoginURL(ctx context.Context, email mail.Addr) (*stri
 	loginURL := r.SSOLoginURL(samlConfig.ID)
 
 	return &loginURL, nil
+}
+
+// OidcProviders is the resolver for the oidcProviders field.
+func (r *queryResolver) OidcProviders(ctx context.Context) ([]*types.OIDCProviderInfo, error) {
+	providers := r.iam.OIDCService.EnabledProviders()
+	result := make([]*types.OIDCProviderInfo, 0, len(providers))
+
+	for _, p := range providers {
+		result = append(result, &types.OIDCProviderInfo{
+			Name:     strings.ToLower(p.String()),
+			LoginURL: r.baseURL.WithPath("/api/connect/v1/oidc/" + strings.ToLower(p.String()) + "/login").MustString(),
+		})
+	}
+
+	return result, nil
 }
 
 // TestLoginURL is the resolver for the testLoginUrl field.

--- a/pkg/server/api/trust/v1/schema.graphql
+++ b/pkg/server/api/trust/v1/schema.graphql
@@ -880,10 +880,18 @@ type RecordSigningEventPayload {
   success: Boolean!
 }
 
+type OIDCProviderInfo {
+  name: String!
+  loginURL: String!
+}
+
 type Query {
   viewer: Identity
   node(id: ID!): Node
   currentTrustCenter: TrustCenter
+  oidcProviders: [OIDCProviderInfo!]!
+    @goField(forceResolver: true)
+    @session(required: OPTIONAL)
 }
 
 type Mutation {

--- a/pkg/server/api/trust/v1/v1_resolver.go
+++ b/pkg/server/api/trust/v1/v1_resolver.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	"go.gearno.de/kit/log"
@@ -991,6 +992,22 @@ func (r *queryResolver) CurrentTrustCenter(ctx context.Context) (*types.TrustCen
 	response.Organization = types.NewOrganization(org)
 
 	return response, nil
+}
+
+// OidcProviders is the resolver for the oidcProviders field.
+func (r *queryResolver) OidcProviders(ctx context.Context) ([]*types.OIDCProviderInfo, error) {
+	providers := r.iam.OIDCService.EnabledProviders()
+	result := make([]*types.OIDCProviderInfo, 0, len(providers))
+
+	for _, p := range providers {
+		name := strings.ToLower(p.String())
+		result = append(result, &types.OIDCProviderInfo{
+			Name:     name,
+			LoginURL: r.baseURL.WithPath("/api/connect/v1/oidc/" + name + "/login").MustString(),
+		})
+	}
+
+	return result, nil
 }
 
 // IsUserAuthorized is the resolver for the isUserAuthorized field.


### PR DESCRIPTION
## Summary

Implements OpenID Connect (OIDC) authentication flow for Google and Microsoft enterprise accounts with:
- JWT verification, PKCE, and nonce validation
- Server-side state management with garbage collection
- Enterprise-only account restrictions (rejects personal gmail/outlook)
- Sign-in UI integration with provider button list

## Changes

**Backend (Go):**
- New `pkg/iam/oidc` service package with JWKS caching, ID token verification, and OAuth2 flow
- OIDC state management in `pkg/coredata/oidc_state.go` with database migration
- HTTP handlers for `/oidc/{provider}/login` and `/oidc/{provider}/callback` endpoints
- GraphQL `oidcProviders` query for listing available providers
- Session creation via `OpenSessionWithOIDC`

**Frontend (React):**
- Sign-in page integrated with `OIDCButtons` component that lists and initiates OIDC flows
- Uses safe redirect to continue URL after authentication

**Configuration:**
- Environment variables: `AUTH_GOOGLE_CLIENT_ID`, `AUTH_GOOGLE_CLIENT_SECRET`, `AUTH_MICROSOFT_CLIENT_ID`, `AUTH_MICROSOFT_CLIENT_SECRET`
- Providers enabled by presence of client ID

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OIDC sign‑in for Google and Microsoft with enterprise‑only restrictions, PKCE, and JWKS‑verified tokens. Console Sign‑in now shows Google/Microsoft buttons plus SSO and an email sign‑in link (no inline form); Trust Center Connect also shows provider buttons with safe continue redirects and stable provider order.

- **New Features**
  - Added GET `/api/connect/v1/oidc/{provider}/login` and GET `/api/connect/v1/oidc/{provider}/callback` to open sessions via OIDC; personal Gmail/Outlook accounts are rejected.
  - Security: JWT verification via JWKS caching (pooled HTTP client), PKCE and nonce checks with redacted errors, server‑side OIDC state with GC, guarded ticker intervals, and graceful shutdown for IAM services.
  - GraphQL/UI: `oidcProviders` in Connect and Trust returns a sorted list (`name`, `loginURL`); local `OIDCButton` components use a Relay fragment and vendor icons (`Google`, `Microsoft`) and build safe `continue` params via `useSafeContinueUrl`; pages inline the `.map()` over providers; Console Sign‑in uses a preloaded Relay query for provider data; extracted `Divider` into `_components` for Console and Trust auth pages; Sign‑in page links to the dedicated email/password page.

- **Migration**
  - Apply the DB migration to add `iam_oidc_states` and a new `session_auth_method` value: `OIDC`.
  - Set env vars: `AUTH_GOOGLE_CLIENT_ID`/`AUTH_GOOGLE_CLIENT_SECRET`, `AUTH_MICROSOFT_CLIENT_ID`/`AUTH_MICROSOFT_CLIENT_SECRET` (a provider is enabled only when both are set).
  - Add OAuth redirect URIs:
    - `<base>/api/connect/v1/oidc/google/callback`
    - `<base>/api/connect/v1/oidc/microsoft/callback`

<sup>Written for commit 4d2aab5f9b0ec8f8250c73c62d9fb8582183051c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

