### PR TITLE
Use pull request for Homebrew tap formula updates

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -157,6 +157,8 @@ brews:
       owner: getprobo
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+      pull_request:
+        enabled: true
     commit_author:
       name: probo-bot
       email: bot@getprobo.com


### PR DESCRIPTION
The homebrew-tap repository enforces verified commit signatures via org-level rulesets. Since these rules cannot be excluded per-repo, switch GoReleaser to open a PR on the tap instead of pushing directly.

This allows the formula update to bypass the signed commit requirement while maintaining the security posture of the repository.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configure GoReleaser to open a pull request for Homebrew tap updates instead of pushing directly, so releases comply with the tap’s verified-signature rules. Updates `.goreleaser.yaml` to enable PRs for `getprobo/homebrew-tap` via `pull_request.enabled: true`.

<sup>Written for commit 4992ba591a9b6bbd4d58326f41ca67cb2a1372d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

