### PR TITLE
Allow editing contract dates on SCIM-managed profiles

### DIFF
--- a/apps/console/src/pages/iam/organizations/people/_components/PersonForm.tsx
+++ b/apps/console/src/pages/iam/organizations/people/_components/PersonForm.tsx
@@ -77,6 +77,7 @@ export function PersonForm(props: {
   id?: string;
   connectionId?: DataID;
   disabled?: boolean;
+  scimManaged?: boolean;
   defaultValues?: z.infer<typeof schema>;
   onSubmit?: () => void;
 }) {
@@ -84,6 +85,7 @@ export function PersonForm(props: {
     id,
     connectionId = "",
     disabled = false,
+    scimManaged = false,
     defaultValues = {
       fullName: "",
       emailAddress: "",
@@ -162,7 +164,7 @@ export function PersonForm(props: {
 
   return (
     <form onSubmit={e => void handleSubmit(e)} className="space-y-4">
-      <Field label={__("Full name *")} {...register("fullName")} type="text" disabled={disabled} />
+      <Field label={__("Full name *")} {...register("fullName")} type="text" disabled={disabled || scimManaged} />
       {id
         ? (
             <>
@@ -223,7 +225,7 @@ export function PersonForm(props: {
         name="kind"
         type="select"
         label={__("Type")}
-        disabled={disabled}
+        disabled={disabled || scimManaged}
       >
         {getRoles(__).map(role => (
           <Option key={role.value} value={role.value}>
@@ -236,9 +238,9 @@ export function PersonForm(props: {
         {...register("position")}
         type="text"
         placeholder={__("e.g. CEO, CFO, etc.")}
-        disabled={disabled}
+        disabled={disabled || scimManaged}
       />
-      <EmailsField control={control} register={register} disabled={disabled} />
+      <EmailsField control={control} register={register} disabled={disabled || scimManaged} />
       <Field label={__("Contract start date")}>
         <Input
           {...register("contractStartDate")}
@@ -272,7 +274,8 @@ export function PersonFormLoader(props: { fragmentRef: PersonFormFragment$key })
   return (
     <PersonForm
       id={person.id}
-      disabled={!person.canUpdate || person.source === "SCIM"}
+      disabled={!person.canUpdate}
+      scimManaged={person.source === "SCIM"}
       defaultValues={
         {
           kind: person.kind,

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -977,10 +977,12 @@ func (s *OrganizationService) UpdateUser(ctx context.Context, req *UpdateUserReq
 				return fmt.Errorf("cannot load profile: %w", err)
 			}
 
-			profile.FullName = req.FullName
-			profile.Kind = req.Kind
-			profile.AdditionalEmailAddresses = req.AdditionalEmailAddresses
-			profile.Position = req.Position
+			if profile.Source != coredata.ProfileSourceSCIM {
+				profile.FullName = req.FullName
+				profile.Kind = req.Kind
+				profile.AdditionalEmailAddresses = req.AdditionalEmailAddresses
+				profile.Position = req.Position
+			}
 
 			if req.ContractStartDate != nil {
 				profile.ContractStartDate = *req.ContractStartDate


### PR DESCRIPTION
## Summary
- Contract start/end dates are never synced by SCIM, but the UI previously disabled the entire form for SCIM-managed profiles
- Frontend now separates permission-based disabling from SCIM field protection, keeping contract date fields editable
- Backend `UpdateUser` now skips overwriting SCIM-synced fields (fullName, kind, position, additionalEmailAddresses) when the profile source is SCIM

## Test plan
- [ ] Open a SCIM-managed profile and verify contract date fields are editable
- [ ] Verify SCIM-synced fields (full name, type, position, emails) remain disabled
- [ ] Update contract dates on a SCIM profile and confirm the save succeeds
- [ ] Verify non-SCIM profiles still allow editing all fields

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow editing contract start/end dates on SCIM-managed profiles while keeping SCIM-synced fields protected. Frontend now only locks SCIM fields; backend ignores writes to those fields for SCIM profiles but still updates contract dates.

- **Bug Fixes**
  - UI: Added `scimManaged` flag; disables only full name, type, position, and additional emails for SCIM users. Contract dates remain editable.
  - API: `UpdateUser` skips overwriting SCIM-synced fields when `profile.Source == SCIM`; still applies contract start/end date updates.
  - Non-SCIM profiles behave unchanged.

<sup>Written for commit e6fe2a2acf7efe2e5eb1d84992ea45c78dea3986. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

