### PR TITLE
Distinguish expired magic links from invalid tokens

### DIFF
--- a/apps/trust/src/pages/auth/VerifyMagicLinkPage.tsx
+++ b/apps/trust/src/pages/auth/VerifyMagicLinkPage.tsx
@@ -46,9 +46,16 @@ export default function VerifyMagicLinkPagePageMutation() {
               return;
             }
           }
+
+          const hasExpiredToken = errors.some(
+            (err) => err.message === "token has expired",
+          );
+
           toast({
             title: __("Error"),
-            description: formatError(__("Failed to connect"), errors),
+            description: hasExpiredToken
+              ? __("This magic link has expired. Please request a new one.")
+              : formatError(__("Failed to connect"), errors),
             variant: "error",
           });
           return;

--- a/apps/trust/src/pages/auth/VerifyMagicLinkPage.tsx
+++ b/apps/trust/src/pages/auth/VerifyMagicLinkPage.tsx
@@ -48,7 +48,7 @@ export default function VerifyMagicLinkPagePageMutation() {
           }
 
           const hasExpiredToken = errors.some(
-            (err) => err.message === "token has expired",
+            err => err.message === "token has expired",
           );
 
           toast({

--- a/pkg/iam/auth_service.go
+++ b/pkg/iam/auth_service.go
@@ -634,6 +634,11 @@ func (s AuthService) SendMagicLink(ctx context.Context, req *SendMagicLinkReques
 func (s AuthService) GetMagicLinkEmail(ctx context.Context, tokenString string) (mail.Addr, error) {
 	payload, err := statelesstoken.ValidateToken[MagicLinkData](s.tokenSecret, TokenTypeMagicLink, tokenString)
 	if err != nil {
+		var errExpired *statelesstoken.ErrExpiredToken
+		if errors.As(err, &errExpired) {
+			return mail.Nil, NewExpiredTokenError()
+		}
+
 		return mail.Nil, NewInvalidTokenError()
 	}
 
@@ -649,6 +654,11 @@ func (s AuthService) OpenSessionWithMagicLink(ctx context.Context, tokenString s
 
 	payload, err := statelesstoken.ValidateToken[MagicLinkData](s.tokenSecret, TokenTypeMagicLink, tokenString)
 	if err != nil {
+		var errExpired *statelesstoken.ErrExpiredToken
+		if errors.As(err, &errExpired) {
+			return nil, nil, nil, NewExpiredTokenError()
+		}
+
 		return nil, nil, nil, NewInvalidTokenError()
 	}
 

--- a/pkg/iam/errors.go
+++ b/pkg/iam/errors.go
@@ -31,6 +31,16 @@ func (e ErrInvalidToken) Error() string {
 	return e.message
 }
 
+type ErrExpiredToken struct{ message string }
+
+func NewExpiredTokenError() error {
+	return &ErrExpiredToken{"token has expired"}
+}
+
+func (e ErrExpiredToken) Error() string {
+	return e.message
+}
+
 type ErrInvitationAlreadyAccepted struct{ InvitationID gid.GID }
 
 func NewInvitationAlreadyAcceptedError(invitationID gid.GID) error {

--- a/pkg/server/api/trust/v1/v1_resolver.go
+++ b/pkg/server/api/trust/v1/v1_resolver.go
@@ -225,6 +225,11 @@ func (r *mutationResolver) VerifyMagicLink(ctx context.Context, input types.Veri
 
 	email, err := r.iam.AuthService.GetMagicLinkEmail(ctx, input.Token)
 	if err != nil {
+		var errExpiredToken *iam.ErrExpiredToken
+		if errors.As(err, &errExpiredToken) {
+			return nil, gqlutils.Invalid(ctx, err)
+		}
+
 		var errInvalidToken *iam.ErrInvalidToken
 		if errors.As(err, &errInvalidToken) {
 			return nil, gqlutils.Invalid(ctx, err)
@@ -241,6 +246,11 @@ func (r *mutationResolver) VerifyMagicLink(ctx context.Context, input types.Veri
 		var err error
 		identity, session, continueURL, err = r.iam.AuthService.OpenSessionWithMagicLink(ctx, input.Token)
 		if err != nil {
+			var errExpiredToken *iam.ErrExpiredToken
+			if errors.As(err, &errExpiredToken) {
+				return nil, gqlutils.Invalid(ctx, err)
+			}
+
 			var errInvalidToken *iam.ErrInvalidToken
 			if errors.As(err, &errInvalidToken) {
 				return nil, gqlutils.Invalid(ctx, err)
@@ -258,6 +268,11 @@ func (r *mutationResolver) VerifyMagicLink(ctx context.Context, input types.Veri
 		var err error
 		identity, session, continueURL, err = r.iam.AuthService.OpenSessionWithMagicLink(ctx, input.Token)
 		if err != nil {
+			var errExpiredToken *iam.ErrExpiredToken
+			if errors.As(err, &errExpiredToken) {
+				return nil, gqlutils.Invalid(ctx, err)
+			}
+
 			var errInvalidToken *iam.ErrInvalidToken
 			if errors.As(err, &errInvalidToken) {
 				return nil, gqlutils.Invalid(ctx, err)


### PR DESCRIPTION
## Summary
- Adds a new `ErrExpiredToken` error type to the IAM package
- `GetMagicLinkEmail` and `OpenSessionWithMagicLink` now detect `statelesstoken.ErrExpiredToken` and return a specific expired token error instead of the generic invalid token error
- Trust resolver handles `ErrExpiredToken` in all `VerifyMagicLink` code paths, returning it as a GraphQL validation error
- Frontend checks for the "token has expired" message and shows a user-friendly toast: "This magic link has expired. Please request a new one."

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a clear expired-link error for magic links. Users now see "This magic link has expired. Please request a new one." instead of a generic failure.

- **New Features**
  - Added `ErrExpiredToken` in `pkg/iam`; map from `statelesstoken.ErrExpiredToken` in `GetMagicLinkEmail` and `OpenSessionWithMagicLink`.
  - `VerifyMagicLink` returns a GraphQL validation error for expired tokens; frontend checks for "token has expired" and shows a helpful toast.

- **Bug Fixes**
  - Fixed arrow-parens lint in `VerifyMagicLinkPage.tsx`.

<sup>Written for commit f1a6737a33f991b7b707ebadecdeb2126284c945. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

