### PR TITLE
Add license header check script and integrate into lint

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -62,7 +62,7 @@ endif
 all: build
 
 .PHONY: lint
-lint: vet go-fmt go-fix go-lint npm-lint
+lint: vet go-fmt go-fix go-lint npm-lint license-check
 
 .PHONY: vet
 vet: generate apps/console/dist/index.html apps/trust/dist/index.html @probo/emails
@@ -93,6 +93,14 @@ go-fix: generate apps/console/dist/index.html apps/trust/dist/index.html @probo/
 .PHONY: go-lint
 go-lint: generate
 	$(GOLINTCMD) run ./...
+
+.PHONY: license-check
+license-check: ## Check that all source files have the ISC license header
+	@./contrib/license-header.sh check
+
+.PHONY: license-fix
+license-fix: ## Add ISC license header to files that are missing it
+	@./contrib/license-header.sh fix
 
 .PHONY: test
 test: generate

--- a/contrib/license-header.sh
+++ b/contrib/license-header.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+# REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+# AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+# INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+# LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+# OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+# PERFORMANCE OF THIS SOFTWARE.
+
+set -euo pipefail
+
+YEAR="$(date +%Y)"
+
+# The license text without comment markers. Each line is prefixed at runtime.
+HEADER_LINES=(
+	"Copyright (c) %YEAR% Probo Inc <hello@getprobo.com>."
+	""
+	"Permission to use, copy, modify, and/or distribute this software for any"
+	"purpose with or without fee is hereby granted, provided that the above"
+	"copyright notice and this permission notice appear in all copies."
+	""
+	"THE SOFTWARE IS PROVIDED \"AS IS\" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH"
+	"REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY"
+	"AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,"
+	"INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM"
+	"LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR"
+	"OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR"
+	"PERFORMANCE OF THIS SOFTWARE."
+)
+
+# Number of lines the header occupies (used to strip an existing header).
+HEADER_LINE_COUNT=${#HEADER_LINES[@]}
+
+# Files containing "--license-header-ignore" in the first 3 lines are skipped.
+is_excluded() {
+	head -3 "$1" | grep -q -- "--license-header-ignore"
+}
+
+# ---------------------------------------------------------------------------
+# Comment prefix by file extension
+# ---------------------------------------------------------------------------
+
+comment_prefix() {
+	case "$1" in
+		*.go|*.ts|*.tsx) echo "//" ;;
+		*.sql)           echo "--" ;;
+	esac
+}
+
+# ---------------------------------------------------------------------------
+# Build a header string for a given file
+# ---------------------------------------------------------------------------
+
+build_header() {
+	local prefix="$1" year="$2"
+	local line
+	for line in "${HEADER_LINES[@]}"; do
+		line="${line//%YEAR%/$year}"
+		if [ -z "$line" ]; then
+			echo "$prefix"
+		else
+			echo "$prefix $line"
+		fi
+	done
+}
+
+# ---------------------------------------------------------------------------
+# Year helpers
+# ---------------------------------------------------------------------------
+
+git_year() {
+	local f="$1"
+	local created modified
+
+	created=$(git log --diff-filter=A --format='%ad' --date=format:'%Y' -- "$f" 2>/dev/null | tail -1)
+	modified=$(git log -1 --format='%ad' --date=format:'%Y' -- "$f" 2>/dev/null)
+
+	: "${created:=$YEAR}"
+	: "${modified:=$YEAR}"
+
+	if [ "$created" = "$modified" ]; then
+		echo "$created"
+	else
+		echo "${created}-${modified}"
+	fi
+}
+
+# ---------------------------------------------------------------------------
+# Detect whether a file already has the header and extract its year
+# ---------------------------------------------------------------------------
+
+# Returns 0 if any of the first 5 lines contains a Probo copyright notice
+# using the expected prefix. Prints the existing year string.
+has_header() {
+	local f="$1" prefix="$2"
+	local line year
+	for line in $(seq 1 5); do
+		local text
+		text=$(sed -n "${line}p" "$f")
+		if [[ "$text" =~ ^"$prefix Copyright (c) "([0-9]{4}(-[0-9]{4})?)" Probo Inc" ]]; then
+			echo "${BASH_REMATCH[1]}"
+			return 0
+		fi
+	done
+	return 1
+}
+
+# ---------------------------------------------------------------------------
+# Strip an existing header (HEADER_LINE_COUNT lines + optional blank line)
+# ---------------------------------------------------------------------------
+
+strip_header() {
+	local f="$1"
+	local skip=$HEADER_LINE_COUNT
+
+	# If the line right after the header is blank, skip it too.
+	local next_line
+	next_line=$(sed -n "$((skip + 1))p" "$f")
+	if [ -z "$next_line" ]; then
+		skip=$((skip + 1))
+	fi
+
+	tail -n +"$((skip + 1))" "$f"
+}
+
+# ---------------------------------------------------------------------------
+# Collect files
+# ---------------------------------------------------------------------------
+
+find_source_files() {
+	find . -type f \( \
+		-name "*.go" -o \
+		-name "*.ts" -o -name "*.tsx" -o \
+		-name "*.sql" \
+	\) \
+		-not -path "*/node_modules/*" \
+		-not -path "*/.context/*" \
+		-not -path "*/dist/*" \
+		-not -path "*/__generated__/*" \
+		-not -path "*/vendor/*"
+}
+
+# ---------------------------------------------------------------------------
+# Modes
+# ---------------------------------------------------------------------------
+
+check_files() {
+	local missing=0
+	while IFS= read -r f; do
+		is_excluded "$f" && continue
+
+		local prefix
+		prefix=$(comment_prefix "$f")
+		if ! has_header "$f" "$prefix" > /dev/null; then
+			echo "missing header: $f"
+			missing=$((missing + 1))
+		fi
+	done < <(find_source_files)
+
+	if [ "$missing" -gt 0 ]; then
+		echo ""
+		echo "error: $missing file(s) missing ISC license header"
+		echo "run 'contrib/license-header.sh fix' to add them"
+		exit 1
+	fi
+}
+
+fix_files() {
+	local fixed=0
+	while IFS= read -r f; do
+		is_excluded "$f" && continue
+
+		local prefix
+		prefix=$(comment_prefix "$f")
+		local year
+		year=$(git_year "$f")
+
+		local existing_year
+		if existing_year=$(has_header "$f" "$prefix"); then
+			# Header exists — update only if the year changed.
+			if [ "$existing_year" = "$year" ]; then
+				continue
+			fi
+			# Strip old header, will re-add below.
+			local body
+			body=$(strip_header "$f")
+			local tmpfile
+			tmpfile=$(mktemp)
+			{ build_header "$prefix" "$year"; echo; echo "$body"; } > "$tmpfile" && mv "$tmpfile" "$f"
+		else
+			# No header — prepend.
+			local tmpfile
+			tmpfile=$(mktemp)
+			{ build_header "$prefix" "$year"; echo; cat "$f"; } > "$tmpfile" && mv "$tmpfile" "$f"
+		fi
+
+		fixed=$((fixed + 1))
+		echo "fixed: $f ($year)"
+	done < <(find_source_files)
+
+	echo ""
+	echo "$fixed file(s) fixed"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+usage() {
+	echo "Usage: $0 {check|fix}" >&2
+	exit 1
+}
+
+case "${1:-}" in
+	check) check_files ;;
+	fix)   fix_files ;;
+	*)     usage ;;
+esac

--- a/packages/ui/src/Atoms/Frameworks/21CFRPart11.tsx
+++ b/packages/ui/src/Atoms/Frameworks/21CFRPart11.tsx
@@ -1,4 +1,5 @@
-export function TwentyOneCFRPart11(props: { className?: string }) {
+// --license-header-ignore
+// 21 CFR Part 11 — U.S. FDA regulation
   const { className } = props;
 
   return (

--- a/packages/ui/src/Atoms/Frameworks/CASA.tsx
+++ b/packages/ui/src/Atoms/Frameworks/CASA.tsx
@@ -1,4 +1,5 @@
-export function CASA(props: { className?: string }) {
+// --license-header-ignore
+// CASA — trademark of the App Defense Alliance
   const { className } = props;
 
   return (

--- a/packages/ui/src/Atoms/Frameworks/CCPA.tsx
+++ b/packages/ui/src/Atoms/Frameworks/CCPA.tsx
@@ -1,4 +1,5 @@
-export function CCPA(props: { className?: string }) {
+// --license-header-ignore
+// CCPA — California Consumer Privacy Act
   const { className } = props;
 
   return (

--- a/packages/ui/src/Atoms/Frameworks/DORA.tsx
+++ b/packages/ui/src/Atoms/Frameworks/DORA.tsx
@@ -1,4 +1,5 @@
-export function DORA(props: { className?: string }) {
+// --license-header-ignore
+// DORA — EU Digital Operational Resilience Act
   const { className } = props;
 
   return (

--- a/packages/ui/src/Atoms/Frameworks/FERPA.tsx
+++ b/packages/ui/src/Atoms/Frameworks/FERPA.tsx
@@ -1,4 +1,5 @@
-export function FERPA() {
+// --license-header-ignore
+// FERPA — U.S. Family Educational Rights and Privacy Act
   return (
     <svg
       version="1.1"

--- a/packages/ui/src/Atoms/Frameworks/GDPR.tsx
+++ b/packages/ui/src/Atoms/Frameworks/GDPR.tsx
@@ -1,4 +1,5 @@
-export function GDPR(props: { className?: string }) {
+// --license-header-ignore
+// GDPR — EU General Data Protection Regulation
   const { className } = props;
 
   return (

--- a/packages/ui/src/Atoms/Frameworks/HDS.tsx
+++ b/packages/ui/src/Atoms/Frameworks/HDS.tsx
@@ -1,4 +1,5 @@
-export function HDS(props: { className?: string }) {
+// --license-header-ignore
+// HDS — French health data hosting certification
   const { className } = props;
 
   return (

--- a/packages/ui/src/Atoms/Frameworks/HIPAA.tsx
+++ b/packages/ui/src/Atoms/Frameworks/HIPAA.tsx
@@ -1,4 +1,5 @@
-export function HIPAA(props: { className?: string }) {
+// --license-header-ignore
+// HIPAA — U.S. Health Insurance Portability and Accountability Act
   const { className } = props;
 
   return (

--- a/packages/ui/src/Atoms/Frameworks/ISO27001.tsx
+++ b/packages/ui/src/Atoms/Frameworks/ISO27001.tsx
@@ -1,4 +1,5 @@
-export function ISO27001(props: { className?: string }) {
+// --license-header-ignore
+// ISO 27001 — trademark of ISO/IEC
   const { className } = props;
 
   return (

--- a/packages/ui/src/Atoms/Frameworks/ISO27701.tsx
+++ b/packages/ui/src/Atoms/Frameworks/ISO27701.tsx
@@ -1,4 +1,5 @@
-export function ISO27701(props: { className?: string }) {
+// --license-header-ignore
+// ISO 27701 — trademark of ISO/IEC
   const { className } = props;
 
   return (

--- a/packages/ui/src/Atoms/Frameworks/ISO42001.tsx
+++ b/packages/ui/src/Atoms/Frameworks/ISO42001.tsx
@@ -1,4 +1,5 @@
-export function ISO42001(props: { className?: string }) {
+// --license-header-ignore
+// ISO 42001 — trademark of ISO/IEC
   const { className } = props;
 
   return (

--- a/packages/ui/src/Atoms/Frameworks/NIS2.tsx
+++ b/packages/ui/src/Atoms/Frameworks/NIS2.tsx
@@ -1,4 +1,5 @@
-export function NIS2(props: { className?: string }) {
+// --license-header-ignore
+// NIS2 — EU Network and Information Security Directive
   const { className } = props;
 
   return (

--- a/packages/ui/src/Atoms/Frameworks/SOC2.tsx
+++ b/packages/ui/src/Atoms/Frameworks/SOC2.tsx
@@ -1,4 +1,5 @@
-export function SOC2(props: { className?: string }) {
+// --license-header-ignore
+// SOC 2 — trademark of the AICPA
   const { className } = props;
 
   return (

--- a/packages/ui/src/Atoms/Frameworks/SOC2_TYPE1.tsx
+++ b/packages/ui/src/Atoms/Frameworks/SOC2_TYPE1.tsx
@@ -1,4 +1,5 @@
-export function SOC2_TYPE1() {
+// --license-header-ignore
+// SOC 2 Type 1 — trademark of the AICPA
   return (
     <svg
       version="1.1"

--- a/packages/ui/src/Atoms/Frameworks/SOC2_TYPE2.tsx
+++ b/packages/ui/src/Atoms/Frameworks/SOC2_TYPE2.tsx
@@ -1,4 +1,5 @@
-export function SOC2_TYPE2() {
+// --license-header-ignore
+// SOC 2 Type 2 — trademark of the AICPA
   return (
     <svg
       version="1.1"

--- a/packages/ui/src/Atoms/Frameworks/SOC3.tsx
+++ b/packages/ui/src/Atoms/Frameworks/SOC3.tsx
@@ -1,4 +1,5 @@
-export function SOC3() {
+// --license-header-ignore
+// SOC 3 — trademark of the AICPA
   return (
     <svg
       version="1.1"

--- a/packages/ui/src/Atoms/Icons/IconBrandFacebook.tsx
+++ b/packages/ui/src/Atoms/Icons/IconBrandFacebook.tsx
@@ -1,3 +1,4 @@
+// --license-header-ignore
 // Facebook logo — trademark of Meta Platforms, Inc.
 // Used here solely for brand identification (nominative fair use).
 // SVG path from Simple Icons (https://simpleicons.org), CC0 license.

--- a/packages/ui/src/Atoms/Icons/IconBrandLinkedin.tsx
+++ b/packages/ui/src/Atoms/Icons/IconBrandLinkedin.tsx
@@ -1,3 +1,4 @@
+// --license-header-ignore
 // LinkedIn logo — trademark of LinkedIn Corporation.
 // Used here solely for brand identification (nominative fair use).
 // SVG path from Simple Icons (https://simpleicons.org), CC0 license.

--- a/packages/ui/src/Atoms/Icons/IconBrandX.tsx
+++ b/packages/ui/src/Atoms/Icons/IconBrandX.tsx
@@ -1,3 +1,4 @@
+// --license-header-ignore
 // X (formerly Twitter) logo — trademark of X Corp.
 // Used here solely for brand identification (nominative fair use).
 // SVG path from Simple Icons (https://simpleicons.org), CC0 license.

--- a/packages/ui/src/Atoms/Vendors/Google.tsx
+++ b/packages/ui/src/Atoms/Vendors/Google.tsx
@@ -1,3 +1,5 @@
+// --license-header-ignore
+// Google logo — trademark of Google LLC
 import type { ComponentProps } from "react";
 
 export function Google(props: ComponentProps<"svg">) {

--- a/packages/ui/src/Atoms/Vendors/Microsoft.tsx
+++ b/packages/ui/src/Atoms/Vendors/Microsoft.tsx
@@ -1,3 +1,5 @@
+// --license-header-ignore
+// Microsoft logo — trademark of Microsoft Corporation
 import type { ComponentProps } from "react";
 
 export function Microsoft(props: ComponentProps<"svg">) {

--- a/packages/ui/src/Atoms/Vendors/Slack.tsx
+++ b/packages/ui/src/Atoms/Vendors/Slack.tsx
@@ -1,3 +1,5 @@
+// --license-header-ignore
+// Slack logo — trademark of Salesforce, Inc.
 import type { ComponentProps } from "react";
 
 export function Slack(props: ComponentProps<"svg">) {

--- a/packages/ui/src/Atoms/Vendors/index.ts
+++ b/packages/ui/src/Atoms/Vendors/index.ts
@@ -1,3 +1,5 @@
+// --license-header-ignore
+// Vendor logos — trademarks of their respective owners
 export { Google } from "./Google";
 export { Microsoft } from "./Microsoft";
 export { Slack } from "./Slack";


### PR DESCRIPTION
Introduce contrib/license-header.sh with check and fix modes covering .go, .ts, .tsx, and .sql files. Files containing --license-header-ignore in the first 3 lines are skipped.

The check mode is wired into make lint via the new license-check target. A license-fix target is also available to add missing headers automatically using git history for the copyright year.

Trademarked brand icons, vendor logos, and compliance framework logos are marked with --license-header-ignore to opt out of the header requirement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an ISC license header check with auto-fix and wire it into `make lint` to enforce headers across `.go`, `.ts`, `.tsx`, and `.sql` files while skipping trademarked logos and compliance icons.

- **New Features**
  - Added `contrib/license-header.sh` with `check` and `fix` modes; uses `git` history to set the year (supports ranges).
  - Integrated `license-check` into `make lint`; added `license-fix` to auto-add/update headers.
  - Skips files with `--license-header-ignore` in the first 3 lines; applied to brand/vendor logos and compliance framework icons.
  - Supports comment styles: `//` for `.go/.ts/.tsx`, `--` for `.sql`; ignores common build/vendor dirs.

<sup>Written for commit f5d4189db2dd160f823ee18e47e5905981af73f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

