### PR TITLE
feat(connector): scope-preserving OAuth2 reconnect

### DIFF
--- a/apps/console/src/pages/iam/organizations/settings/_components/GoogleWorkspaceConnector.tsx
+++ b/apps/console/src/pages/iam/organizations/settings/_components/GoogleWorkspaceConnector.tsx
@@ -12,7 +12,7 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import { formatError, type GraphQLError, sprintf } from "@probo/helpers";
+import { sprintf } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
 import {
   Badge,
@@ -128,10 +128,7 @@ export function GoogleWorkspaceConnector(props: {
         if (errors?.length) {
           toast({
             title: __("Error"),
-            description: formatError(
-              __("Failed to disconnect Google Workspace"),
-              errors as GraphQLError[],
-            ),
+            description: errors.map((e) => e.message).join(", "),
             variant: "error",
           });
           return;
@@ -146,10 +143,7 @@ export function GoogleWorkspaceConnector(props: {
       onError(error) {
         toast({
           title: __("Error"),
-          description: formatError(
-            __("Failed to disconnect Google Workspace"),
-            error as GraphQLError,
-          ),
+          description: error.message,
           variant: "error",
         });
       },
@@ -179,10 +173,7 @@ export function GoogleWorkspaceConnector(props: {
         if (errors?.length) {
           toast({
             title: __("Error"),
-            description: formatError(
-              __("Failed to update excluded user names"),
-              errors as GraphQLError[],
-            ),
+            description: errors.map((e) => e.message).join(", "),
             variant: "error",
           });
           return;
@@ -196,10 +187,7 @@ export function GoogleWorkspaceConnector(props: {
       onError(error) {
         toast({
           title: __("Error"),
-          description: formatError(
-            __("Failed to update excluded user names"),
-            error as GraphQLError,
-          ),
+          description: error.message,
           variant: "error",
         });
       },

--- a/apps/console/src/pages/iam/organizations/settings/_components/GoogleWorkspaceConnector.tsx
+++ b/apps/console/src/pages/iam/organizations/settings/_components/GoogleWorkspaceConnector.tsx
@@ -128,7 +128,7 @@ export function GoogleWorkspaceConnector(props: {
         if (errors?.length) {
           toast({
             title: __("Error"),
-            description: errors.map((e) => e.message).join(", "),
+            description: errors.map(e => e.message).join(", "),
             variant: "error",
           });
           return;
@@ -173,7 +173,7 @@ export function GoogleWorkspaceConnector(props: {
         if (errors?.length) {
           toast({
             title: __("Error"),
-            description: errors.map((e) => e.message).join(", "),
+            description: errors.map(e => e.message).join(", "),
             variant: "error",
           });
           return;

--- a/apps/console/src/pages/iam/organizations/settings/_components/GoogleWorkspaceConnector.tsx
+++ b/apps/console/src/pages/iam/organizations/settings/_components/GoogleWorkspaceConnector.tsx
@@ -12,7 +12,7 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import { sprintf } from "@probo/helpers";
+import { formatError, type GraphQLError, sprintf } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
 import {
   Badge,
@@ -25,14 +25,14 @@ import {
   IconSettingsGear2,
   Input,
   useDialogRef,
+  useToast,
 } from "@probo/ui";
 import { useState } from "react";
-import { graphql, useFragment } from "react-relay";
+import { graphql, useFragment, useMutation } from "react-relay";
 
 import type { GoogleWorkspaceConnectorDeleteMutation } from "#/__generated__/iam/GoogleWorkspaceConnectorDeleteMutation.graphql";
 import type { GoogleWorkspaceConnectorFragment$key } from "#/__generated__/iam/GoogleWorkspaceConnectorFragment.graphql";
 import type { GoogleWorkspaceConnectorUpdateSCIMBridgeMutation } from "#/__generated__/iam/GoogleWorkspaceConnectorUpdateSCIMBridgeMutation.graphql";
-import { useMutationWithToasts } from "#/hooks/useMutationWithToasts";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
 
 const googleWorkspaceConnectorFragment = graphql`
@@ -85,27 +85,20 @@ export function GoogleWorkspaceConnector(props: {
 
   const organizationId = useOrganizationId();
   const { __, dateTimeFormat } = useTranslate();
+  const { toast } = useToast();
   const dialogRef = useDialogRef();
   const excludedUserNamesDialogRef = useDialogRef();
 
   const [newUser, setNewUser] = useState("");
 
   const [deleteSCIMConfiguration, isDeleting]
-    = useMutationWithToasts<GoogleWorkspaceConnectorDeleteMutation>(
+    = useMutation<GoogleWorkspaceConnectorDeleteMutation>(
       deleteSCIMConfigurationMutation,
-      {
-        successMessage: __("Google Workspace disconnected successfully"),
-        errorMessage: __("Failed to disconnect Google Workspace"),
-      },
     );
 
   const [updateSCIMBridge, isUpdating]
-    = useMutationWithToasts<GoogleWorkspaceConnectorUpdateSCIMBridgeMutation>(
+    = useMutation<GoogleWorkspaceConnectorUpdateSCIMBridgeMutation>(
       updateSCIMBridgeMutation,
-      {
-        successMessage: __("Excluded user names updated successfully"),
-        errorMessage: __("Failed to update excluded user names"),
-      },
     );
 
   const handleConnect = () => {
@@ -131,8 +124,34 @@ export function GoogleWorkspaceConnector(props: {
           scimConfigurationId: scimConfigurationId,
         },
       },
-      onCompleted: () => {
+      onCompleted(_, errors) {
+        if (errors?.length) {
+          toast({
+            title: __("Error"),
+            description: formatError(
+              __("Failed to disconnect Google Workspace"),
+              errors as GraphQLError[],
+            ),
+            variant: "error",
+          });
+          return;
+        }
+        toast({
+          title: __("Success"),
+          description: __("Google Workspace disconnected successfully"),
+          variant: "success",
+        });
         dialogRef.current?.close();
+      },
+      onError(error) {
+        toast({
+          title: __("Error"),
+          description: formatError(
+            __("Failed to disconnect Google Workspace"),
+            error as GraphQLError,
+          ),
+          variant: "error",
+        });
       },
       updater: (store) => {
         const organizationRecord = store.get(organizationId);
@@ -155,6 +174,34 @@ export function GoogleWorkspaceConnector(props: {
           scimBridgeId: bridgeId,
           excludedUserNames: newList,
         },
+      },
+      onCompleted(_, errors) {
+        if (errors?.length) {
+          toast({
+            title: __("Error"),
+            description: formatError(
+              __("Failed to update excluded user names"),
+              errors as GraphQLError[],
+            ),
+            variant: "error",
+          });
+          return;
+        }
+        toast({
+          title: __("Success"),
+          description: __("Excluded user names updated successfully"),
+          variant: "success",
+        });
+      },
+      onError(error) {
+        toast({
+          title: __("Error"),
+          description: formatError(
+            __("Failed to update excluded user names"),
+            error as GraphQLError,
+          ),
+          variant: "error",
+        });
       },
     });
   };

--- a/cfg/dev.yaml
+++ b/cfg/dev.yaml
@@ -94,16 +94,6 @@ probod:
       config:
         client-id: "your-slack-client-id"
         client-secret: "your-slack-client-secret"
-        redirect-uri: "https://localhost:8080/api/console/v1/connectors/complete"
-        auth-url: "https://slack.com/oauth/v2/authorize"
-        token-url: "https://slack.com/api/oauth.v2.access"
-
-        scopes:
-          - "chat:write"
-          - "channels:join"
-          - "incoming-webhook"
-          - "users:read"
-          - "users:read.email"
       settings:
         signing-secret: "your-slack-signing-secret"
     - provider: "GOOGLE_WORKSPACE"
@@ -111,105 +101,43 @@ probod:
       config:
         client-id: "your-google-client-id.apps.googleusercontent.com"
         client-secret: "your-google-client-secret"
-        redirect-uri: "http://localhost:8080/api/console/v1/connectors/complete"
-        auth-url: "https://accounts.google.com/o/oauth2/v2/auth"
-        token-url: "https://oauth2.googleapis.com/token"
-
-        scopes:
-          - "https://www.googleapis.com/auth/admin.directory.user.readonly"
-          - "https://www.googleapis.com/auth/admin.directory.userschema.readonly"
-          - "https://www.googleapis.com/auth/admin.directory.group.member.readonly"
-          - "https://www.googleapis.com/auth/admin.directory.customer.readonly"
-        extra-auth-params:
-          access_type: "offline"
-          prompt: "consent"
     - provider: "LINEAR"
       protocol: "oauth2"
       config:
         client-id: "your-linear-client-id"
         client-secret: "your-linear-client-secret"
-        redirect-uri: "http://localhost:8080/api/console/v1/connectors/complete"
-        auth-url: "https://linear.app/oauth/authorize"
-        token-url: "https://api.linear.app/oauth/token"
-
-        scopes:
-          - "read"
-          - "write"
     - provider: "BREX"
       protocol: "oauth2"
       config:
         client-id: "your-brex-client-id"
         client-secret: "your-brex-client-secret"
-        redirect-uri: "http://localhost:8080/api/console/v1/connectors/complete"
-        auth-url: "https://accounts-api.brex.com/oauth2/default/v1/authorize"
-        token-url: "https://accounts-api.brex.com/oauth2/default/v1/token"
-
-        scopes:
-          - "openid"
-          - "offline_access"
     - provider: "HUBSPOT"
       protocol: "oauth2"
       config:
         client-id: "your-hubspot-client-id"
         client-secret: "your-hubspot-client-secret"
-        redirect-uri: "http://localhost:8080/api/console/v1/connectors/complete"
-        auth-url: "https://app.hubspot.com/oauth/authorize"
-        token-url: "https://api.hubapi.com/oauth/v1/token"
-
-        scopes:
-          - "settings.users.read"
     - provider: "DOCUSIGN"
       protocol: "oauth2"
       config:
         client-id: "your-docusign-client-id"
         client-secret: "your-docusign-client-secret"
-        redirect-uri: "http://localhost:8080/api/console/v1/connectors/complete"
-        auth-url: "https://account-d.docusign.com/oauth/auth"
-        token-url: "https://account-d.docusign.com/oauth/token"
-
-        scopes:
-          - "signature"
-        token-endpoint-auth: "basic-form"
     - provider: "NOTION"
       protocol: "oauth2"
       config:
         client-id: "your-notion-client-id"
         client-secret: "your-notion-client-secret"
-        redirect-uri: "http://localhost:8080/api/console/v1/connectors/complete"
-        auth-url: "https://api.notion.com/v1/oauth/authorize"
-        token-url: "https://api.notion.com/v1/oauth/token"
-
-        extra-auth-params:
-          owner: "user"
-        token-endpoint-auth: "basic-json"
     - provider: "GITHUB"
       protocol: "oauth2"
       config:
         client-id: "your-github-client-id"
         client-secret: "your-github-client-secret"
-        redirect-uri: "http://localhost:8080/api/console/v1/connectors/complete"
-        auth-url: "https://github.com/login/oauth/authorize"
-        token-url: "https://github.com/login/oauth/access_token"
-
-        scopes:
-          - "read:org"
     - provider: "SENTRY"
       protocol: "oauth2"
       config:
         client-id: "your-sentry-client-id"
         client-secret: "your-sentry-client-secret"
-        redirect-uri: "http://localhost:8080/api/console/v1/connectors/complete"
-        auth-url: "https://sentry.io/oauth/authorize/"
-        token-url: "https://sentry.io/oauth/token/"
-
-        scopes:
-          - "org:read"
-          - "member:read"
     - provider: "INTERCOM"
       protocol: "oauth2"
       config:
         client-id: "your-intercom-client-id"
         client-secret: "your-intercom-client-secret"
-        redirect-uri: "http://localhost:8080/api/console/v1/connectors/complete"
-        auth-url: "https://app.intercom.com/oauth"
-        token-url: "https://api.intercom.io/auth/eagle/token"

--- a/pkg/accessreview/drivers/oauth2_scopes.go
+++ b/pkg/accessreview/drivers/oauth2_scopes.go
@@ -27,6 +27,7 @@ var providerOAuth2Scopes = map[coredata.ConnectorProvider][]string{
 	coredata.ConnectorProviderBrex:     {"openid", "offline_access"},
 	coredata.ConnectorProviderDocuSign: {"signature"},
 	coredata.ConnectorProviderLinear:   {"read"},
+	coredata.ConnectorProviderSlack:    {"users:read", "users:read.email"},
 	coredata.ConnectorProviderGoogleWorkspace: {
 		"https://www.googleapis.com/auth/admin.directory.user.readonly",
 		"https://www.googleapis.com/auth/admin.directory.group.member.readonly",

--- a/pkg/connector/apikey.go
+++ b/pkg/connector/apikey.go
@@ -32,6 +32,10 @@ func (c *APIKeyConnection) Type() ProtocolType {
 	return ProtocolAPIKey
 }
 
+func (c *APIKeyConnection) Scopes() []string {
+	return nil
+}
+
 func (c *APIKeyConnection) Client(ctx context.Context) (*http.Client, error) {
 	transport := &oauth2Transport{
 		token:      c.APIKey,

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -32,6 +32,13 @@ type (
 	// a different set of scopes (e.g. SCIM bridge vs access review).
 	InitiateOptions struct {
 		Scopes []string
+		// IncludeGrantedScopes is honored only when the provider has
+		// SupportsIncrementalAuth=true.
+		IncludeGrantedScopes bool
+		// ConnectorID, when set, marks this flow as a reconnect of an
+		// existing connector: the callback updates the row in place
+		// instead of creating a new one.
+		ConnectorID string
 	}
 
 	Connector interface {
@@ -42,6 +49,7 @@ type (
 	Connection interface {
 		Type() ProtocolType
 		Client(ctx context.Context) (*http.Client, error)
+		Scopes() []string
 
 		json.Unmarshaler
 		json.Marshaler

--- a/pkg/connector/oauth2.go
+++ b/pkg/connector/oauth2.go
@@ -41,20 +41,22 @@ import (
 
 type (
 	OAuth2Connector struct {
-		ClientID          string
-		ClientSecret      string
-		RedirectURI       string
-		AuthURL           string
-		TokenURL          string
-		ExtraAuthParams   map[string]string // Optional: extra params for auth URL (e.g., access_type=offline for Google)
-		TokenEndpointAuth string            // "post-form" (default), "basic-form", or "basic-json"
+		ClientID                string
+		ClientSecret            string
+		RedirectURI             string
+		AuthURL                 string
+		TokenURL                string
+		ExtraAuthParams         map[string]string // Optional: extra params for auth URL (e.g., access_type=offline for Google)
+		TokenEndpointAuth       string            // "post-form" (default), "basic-form", or "basic-json"
+		SupportsIncrementalAuth bool
 	}
 
 	OAuth2State struct {
-		OrganizationID string `json:"oid"`
-		Provider       string `json:"provider"`
-		ContinueURL    string `json:"continue,omitempty"`
-		ConnectorID    string `json:"cid,omitempty"` // Set when reconnecting an existing connector
+		OrganizationID  string   `json:"oid"`
+		Provider        string   `json:"provider"`
+		ContinueURL     string   `json:"continue,omitempty"`
+		ConnectorID     string   `json:"cid,omitempty"` // Set when reconnecting an existing connector
+		RequestedScopes []string `json:"scopes,omitempty"`
 	}
 
 	OAuth2Connection struct {
@@ -105,15 +107,14 @@ func (c *OAuth2Connector) Initiate(
 	r *http.Request,
 ) (string, error) {
 	stateData := OAuth2State{
-		OrganizationID: organizationID.String(),
-		Provider:       provider,
+		OrganizationID:  organizationID.String(),
+		Provider:        provider,
+		ConnectorID:     opts.ConnectorID,
+		RequestedScopes: opts.Scopes,
 	}
 	if r != nil {
 		if continueURL := r.URL.Query().Get("continue"); continueURL != "" {
 			stateData.ContinueURL = continueURL
-		}
-		if connectorID := r.URL.Query().Get("connector_id"); connectorID != "" {
-			stateData.ConnectorID = connectorID
 		}
 	}
 	return c.InitiateWithState(ctx, stateData, opts, r)
@@ -141,8 +142,18 @@ func (c *OAuth2Connector) InitiateWithState(
 		authCodeQuery.Set("scope", strings.Join(opts.Scopes, " "))
 	}
 
-	// Add any extra auth params (e.g., access_type=offline, prompt=consent for Google)
+	incrementalAuth := c.SupportsIncrementalAuth && opts.IncludeGrantedScopes
+	if incrementalAuth {
+		authCodeQuery.Set("include_granted_scopes", "true")
+	}
+
+	// Skip prompt=consent when doing incremental auth so the user sees
+	// only the delta, not a full re-consent. First-install flows keep it
+	// because IncludeGrantedScopes is false there.
 	for k, v := range c.ExtraAuthParams {
+		if incrementalAuth && k == "prompt" && v == "consent" {
+			continue
+		}
 		authCodeQuery.Set(k, v)
 	}
 
@@ -225,11 +236,19 @@ func (c *OAuth2Connector) CompleteWithState(ctx context.Context, r *http.Request
 		return nil, nil, fmt.Errorf("cannot decode token response: %w", err)
 	}
 
+	grantedScope := rawToken.Scope
+	if grantedScope == "" {
+		// RFC 6749 §5.1: scope is OPTIONAL when identical to the
+		// requested scope. Fall back to what we asked for so
+		// subsequent reconnect diffs have a meaningful base.
+		grantedScope = FormatScopeString(payload.Data.RequestedScopes)
+	}
+
 	oauth2Conn := OAuth2Connection{
 		AccessToken:  rawToken.AccessToken,
 		RefreshToken: rawToken.RefreshToken,
 		TokenType:    rawToken.TokenType,
-		Scope:        rawToken.Scope,
+		Scope:        grantedScope,
 	}
 
 	// Convert expires_in (seconds) to expires_at (absolute time)
@@ -333,6 +352,10 @@ func (c *OAuth2Connector) buildTokenRequest(ctx context.Context, code, redirectU
 
 func (c *OAuth2Connection) Type() ProtocolType {
 	return ProtocolOAuth2
+}
+
+func (c *OAuth2Connection) Scopes() []string {
+	return ParseScopeString(c.Scope)
 }
 
 func (c *OAuth2Connection) Client(ctx context.Context) (*http.Client, error) {

--- a/pkg/connector/oauth2.go
+++ b/pkg/connector/oauth2.go
@@ -117,7 +117,7 @@ func (c *OAuth2Connector) Initiate(
 			stateData.ContinueURL = continueURL
 		}
 	}
-	return c.InitiateWithState(ctx, stateData, opts, r)
+	return c.InitiateWithState(ctx, stateData, opts)
 }
 
 // InitiateWithState generates an OAuth2 authorization URL with a custom state.
@@ -126,7 +126,6 @@ func (c *OAuth2Connector) InitiateWithState(
 	ctx context.Context,
 	stateData OAuth2State,
 	opts InitiateOptions,
-	r *http.Request,
 ) (string, error) {
 	state, err := statelesstoken.NewToken(c.ClientSecret, OAuth2TokenType, OAuth2TokenTTL, stateData)
 	if err != nil {

--- a/pkg/connector/oauth2_test.go
+++ b/pkg/connector/oauth2_test.go
@@ -278,7 +278,6 @@ func TestInitiateWithState_Scopes(t *testing.T) {
 			context.Background(),
 			OAuth2State{OrganizationID: orgID.String(), Provider: "TEST"},
 			InitiateOptions{Scopes: []string{"read:user", "write:user"}},
-			nil,
 		)
 		require.NoError(t, err)
 
@@ -303,7 +302,6 @@ func TestInitiateWithState_Scopes(t *testing.T) {
 			context.Background(),
 			OAuth2State{OrganizationID: orgID.String(), Provider: "TEST"},
 			InitiateOptions{},
-			nil,
 		)
 		require.NoError(t, err)
 
@@ -332,7 +330,6 @@ func TestInitiateWithState_Scopes(t *testing.T) {
 				Scopes:               []string{"read:user"},
 				IncludeGrantedScopes: true,
 			},
-			nil,
 		)
 		require.NoError(t, err)
 
@@ -361,7 +358,6 @@ func TestInitiateWithState_Scopes(t *testing.T) {
 				Scopes:               []string{"read:user"},
 				IncludeGrantedScopes: true,
 			},
-			nil,
 		)
 		require.NoError(t, err)
 
@@ -387,7 +383,6 @@ func TestInitiateWithState_Scopes(t *testing.T) {
 			context.Background(),
 			OAuth2State{OrganizationID: orgID.String(), Provider: "TEST"},
 			InitiateOptions{Scopes: []string{"read:user"}},
-			nil,
 		)
 		require.NoError(t, err)
 
@@ -420,7 +415,6 @@ func TestInitiateWithState_Scopes(t *testing.T) {
 				Scopes:               []string{"read:user"},
 				IncludeGrantedScopes: true,
 			},
-			nil,
 		)
 		require.NoError(t, err)
 
@@ -455,7 +449,6 @@ func TestInitiateWithState_Scopes(t *testing.T) {
 				Scopes:               []string{"read:user"},
 				IncludeGrantedScopes: false, // first install, no existing grant
 			},
-			nil,
 		)
 		require.NoError(t, err)
 
@@ -489,7 +482,6 @@ func TestInitiateWithState_Scopes(t *testing.T) {
 				Scopes:               []string{"read:user"},
 				IncludeGrantedScopes: true, // caller requested, but provider does not support
 			},
-			nil,
 		)
 		require.NoError(t, err)
 

--- a/pkg/connector/oauth2_test.go
+++ b/pkg/connector/oauth2_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/statelesstoken"
 )
 
 func TestBuildTokenRequest_PostForm(t *testing.T) {
@@ -310,4 +311,247 @@ func TestInitiateWithState_Scopes(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, parsed.Query().Has("scope"), "scope param should be absent when no scopes provided")
 	})
+
+	t.Run("include_granted_scopes set when provider supports and caller requests", func(t *testing.T) {
+		t.Parallel()
+
+		c := &OAuth2Connector{
+			ClientID:                "id",
+			ClientSecret:            "secret",
+			RedirectURI:             "https://example.com/cb",
+			AuthURL:                 "https://provider.example.com/authorize",
+			SupportsIncrementalAuth: true,
+		}
+
+		orgID := gid.New(gid.NewTenantID(), 0)
+
+		u, err := c.InitiateWithState(
+			context.Background(),
+			OAuth2State{OrganizationID: orgID.String(), Provider: "TEST"},
+			InitiateOptions{
+				Scopes:               []string{"read:user"},
+				IncludeGrantedScopes: true,
+			},
+			nil,
+		)
+		require.NoError(t, err)
+
+		parsed, err := url.Parse(u)
+		require.NoError(t, err)
+		assert.Equal(t, "true", parsed.Query().Get("include_granted_scopes"))
+	})
+
+	t.Run("include_granted_scopes absent when provider does not support it", func(t *testing.T) {
+		t.Parallel()
+
+		c := &OAuth2Connector{
+			ClientID:                "id",
+			ClientSecret:            "secret",
+			RedirectURI:             "https://example.com/cb",
+			AuthURL:                 "https://provider.example.com/authorize",
+			SupportsIncrementalAuth: false,
+		}
+
+		orgID := gid.New(gid.NewTenantID(), 0)
+
+		u, err := c.InitiateWithState(
+			context.Background(),
+			OAuth2State{OrganizationID: orgID.String(), Provider: "TEST"},
+			InitiateOptions{
+				Scopes:               []string{"read:user"},
+				IncludeGrantedScopes: true,
+			},
+			nil,
+		)
+		require.NoError(t, err)
+
+		parsed, err := url.Parse(u)
+		require.NoError(t, err)
+		assert.False(t, parsed.Query().Has("include_granted_scopes"))
+	})
+
+	t.Run("include_granted_scopes absent when caller does not request", func(t *testing.T) {
+		t.Parallel()
+
+		c := &OAuth2Connector{
+			ClientID:                "id",
+			ClientSecret:            "secret",
+			RedirectURI:             "https://example.com/cb",
+			AuthURL:                 "https://provider.example.com/authorize",
+			SupportsIncrementalAuth: true,
+		}
+
+		orgID := gid.New(gid.NewTenantID(), 0)
+
+		u, err := c.InitiateWithState(
+			context.Background(),
+			OAuth2State{OrganizationID: orgID.String(), Provider: "TEST"},
+			InitiateOptions{Scopes: []string{"read:user"}},
+			nil,
+		)
+		require.NoError(t, err)
+
+		parsed, err := url.Parse(u)
+		require.NoError(t, err)
+		assert.False(t, parsed.Query().Has("include_granted_scopes"))
+	})
+
+	t.Run("prompt=consent skipped when incremental auth is active", func(t *testing.T) {
+		t.Parallel()
+
+		c := &OAuth2Connector{
+			ClientID:                "id",
+			ClientSecret:            "secret",
+			RedirectURI:             "https://example.com/cb",
+			AuthURL:                 "https://provider.example.com/authorize",
+			SupportsIncrementalAuth: true,
+			ExtraAuthParams: map[string]string{
+				"access_type": "offline",
+				"prompt":      "consent",
+			},
+		}
+
+		orgID := gid.New(gid.NewTenantID(), 0)
+
+		u, err := c.InitiateWithState(
+			context.Background(),
+			OAuth2State{OrganizationID: orgID.String(), Provider: "TEST"},
+			InitiateOptions{
+				Scopes:               []string{"read:user"},
+				IncludeGrantedScopes: true,
+			},
+			nil,
+		)
+		require.NoError(t, err)
+
+		parsed, err := url.Parse(u)
+		require.NoError(t, err)
+		assert.Equal(t, "offline", parsed.Query().Get("access_type"))
+		assert.False(t, parsed.Query().Has("prompt"), "prompt=consent should be skipped when doing incremental auth on a provider that supports it")
+		assert.Equal(t, "true", parsed.Query().Get("include_granted_scopes"))
+	})
+
+	t.Run("prompt=consent preserved on first install", func(t *testing.T) {
+		t.Parallel()
+
+		c := &OAuth2Connector{
+			ClientID:                "id",
+			ClientSecret:            "secret",
+			RedirectURI:             "https://example.com/cb",
+			AuthURL:                 "https://provider.example.com/authorize",
+			SupportsIncrementalAuth: true,
+			ExtraAuthParams: map[string]string{
+				"access_type": "offline",
+				"prompt":      "consent",
+			},
+		}
+
+		orgID := gid.New(gid.NewTenantID(), 0)
+
+		u, err := c.InitiateWithState(
+			context.Background(),
+			OAuth2State{OrganizationID: orgID.String(), Provider: "TEST"},
+			InitiateOptions{
+				Scopes:               []string{"read:user"},
+				IncludeGrantedScopes: false, // first install, no existing grant
+			},
+			nil,
+		)
+		require.NoError(t, err)
+
+		parsed, err := url.Parse(u)
+		require.NoError(t, err)
+		assert.Equal(t, "offline", parsed.Query().Get("access_type"))
+		assert.Equal(t, "consent", parsed.Query().Get("prompt"), "prompt=consent must still fire on first install so Google issues a refresh token")
+		assert.False(t, parsed.Query().Has("include_granted_scopes"))
+	})
+
+	t.Run("prompt=consent preserved when provider does not support incremental auth", func(t *testing.T) {
+		t.Parallel()
+
+		c := &OAuth2Connector{
+			ClientID:                "id",
+			ClientSecret:            "secret",
+			RedirectURI:             "https://example.com/cb",
+			AuthURL:                 "https://provider.example.com/authorize",
+			SupportsIncrementalAuth: false,
+			ExtraAuthParams: map[string]string{
+				"prompt": "consent",
+			},
+		}
+
+		orgID := gid.New(gid.NewTenantID(), 0)
+
+		u, err := c.InitiateWithState(
+			context.Background(),
+			OAuth2State{OrganizationID: orgID.String(), Provider: "TEST"},
+			InitiateOptions{
+				Scopes:               []string{"read:user"},
+				IncludeGrantedScopes: true, // caller requested, but provider does not support
+			},
+			nil,
+		)
+		require.NoError(t, err)
+
+		parsed, err := url.Parse(u)
+		require.NoError(t, err)
+		assert.Equal(t, "consent", parsed.Query().Get("prompt"), "prompt=consent must not be skipped for providers that do not support incremental auth")
+	})
+}
+
+// TestCompleteWithState_ScopeFallback verifies that when the provider's
+// token endpoint returns a successful token response that omits the
+// `scope` field (which RFC 6749 §5.1 allows when the granted scope is
+// identical to the requested scope), CompleteWithState falls back to
+// the RequestedScopes carried in the OAuth2State so the persisted
+// connection still carries the scope set. This is load-bearing for the
+// scope-union logic on subsequent reconnects -- without it we would
+// store empty scope and lose the diff.
+func TestCompleteWithState_ScopeFallback(t *testing.T) {
+	t.Parallel()
+
+	// Fake provider token endpoint: returns a valid token response
+	// with NO `scope` field, matching RFC 6749 §5.1 "identical to
+	// requested" shape.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"live-token","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer server.Close()
+
+	c := &OAuth2Connector{
+		ClientID:     "id",
+		ClientSecret: "secret",
+		RedirectURI:  "https://example.com/cb",
+		AuthURL:      "https://provider.example.com/authorize",
+		TokenURL:     server.URL,
+	}
+
+	orgID := gid.New(gid.NewTenantID(), 0)
+	stateData := OAuth2State{
+		OrganizationID:  orgID.String(),
+		Provider:        "TEST",
+		RequestedScopes: []string{"read:user", "write:user"},
+	}
+	stateToken, err := statelesstoken.NewToken(c.ClientSecret, OAuth2TokenType, OAuth2TokenTTL, stateData)
+	require.NoError(t, err)
+
+	// Fabricate a callback request with a code + the signed state.
+	req := httptest.NewRequest(http.MethodGet, "https://example.com/cb?code=the-code&state="+stateToken, nil)
+
+	conn, returnedState, err := c.CompleteWithState(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	require.NotNil(t, returnedState)
+
+	oauth2Conn, ok := conn.(*OAuth2Connection)
+	require.True(t, ok, "expected *OAuth2Connection, got %T", conn)
+
+	assert.Equal(t, "live-token", oauth2Conn.AccessToken)
+	// The provider omitted scope, so CompleteWithState must fall back
+	// to the RequestedScopes carried in the state token, formatted as
+	// a space-separated RFC 6749 §3.3 scope string (sorted).
+	assert.Equal(t, "read:user write:user", oauth2Conn.Scope)
+	assert.Equal(t, []string{"read:user", "write:user"}, returnedState.RequestedScopes)
 }

--- a/pkg/connector/providers.go
+++ b/pkg/connector/providers.go
@@ -14,25 +14,21 @@
 
 package connector
 
-const (
-	// CallbackPath is the HTTP path for the OAuth2 callback endpoint.
-	CallbackPath = "/api/console/v1/connectors/complete"
-)
+// CallbackPath is the HTTP path for the OAuth2 callback endpoint.
+const CallbackPath = "/api/console/v1/connectors/complete"
 
-type (
-	// providerDefinition holds the static OAuth2 properties for a provider.
-	// These are intrinsic to the provider and do not vary between deployments.
-	// Scopes are not part of this — they are passed by the caller at
-	// initiate time via InitiateOptions, since the same provider may be used
-	// in multiple contexts requiring different scope sets.
-	providerDefinition struct {
-		AuthURL                 string
-		TokenURL                string
-		ExtraAuthParams         map[string]string
-		TokenEndpointAuth       string // "post-form" (default), "basic-form", or "basic-json"
-		SupportsIncrementalAuth bool
-	}
-)
+// providerDefinition holds the static OAuth2 properties for a provider.
+// These are intrinsic to the provider and do not vary between deployments.
+// Scopes are not part of this — they are passed by the caller at
+// initiate time via InitiateOptions, since the same provider may be used
+// in multiple contexts requiring different scope sets.
+type providerDefinition struct {
+	AuthURL                 string
+	TokenURL                string
+	ExtraAuthParams         map[string]string
+	TokenEndpointAuth       string // "post-form" (default), "basic-form", or "basic-json"
+	SupportsIncrementalAuth bool
+}
 
 // providerDefinitions maps provider names to their static OAuth2 definitions.
 // Only ClientID and ClientSecret come from deployment config.

--- a/pkg/connector/providers.go
+++ b/pkg/connector/providers.go
@@ -26,10 +26,11 @@ type (
 	// initiate time via InitiateOptions, since the same provider may be used
 	// in multiple contexts requiring different scope sets.
 	providerDefinition struct {
-		AuthURL           string
-		TokenURL          string
-		ExtraAuthParams   map[string]string
-		TokenEndpointAuth string // "post-form" (default), "basic-form", or "basic-json"
+		AuthURL                 string
+		TokenURL                string
+		ExtraAuthParams         map[string]string
+		TokenEndpointAuth       string // "post-form" (default), "basic-form", or "basic-json"
+		SupportsIncrementalAuth bool
 	}
 )
 
@@ -79,6 +80,7 @@ var (
 				"access_type": "offline",
 				"prompt":      "consent",
 			},
+			SupportsIncrementalAuth: true,
 		},
 		"LINEAR": {
 			AuthURL:  "https://linear.app/oauth/authorize",
@@ -98,5 +100,6 @@ func ApplyProviderDefaults(provider string, redirectURI string, c *OAuth2Connect
 		c.TokenURL = def.TokenURL
 		c.ExtraAuthParams = def.ExtraAuthParams
 		c.TokenEndpointAuth = def.TokenEndpointAuth
+		c.SupportsIncrementalAuth = def.SupportsIncrementalAuth
 	}
 }

--- a/pkg/connector/scopes.go
+++ b/pkg/connector/scopes.go
@@ -76,21 +76,3 @@ func UnionScopes(scopeSets ...[]string) []string {
 	sort.Strings(out)
 	return out
 }
-
-// ScopesCover reports whether `granted` already contains every scope in
-// `required`. An empty `required` set is trivially covered.
-func ScopesCover(granted, required []string) bool {
-	if len(required) == 0 {
-		return true
-	}
-	grantedSet := make(map[string]struct{}, len(granted))
-	for _, s := range granted {
-		grantedSet[s] = struct{}{}
-	}
-	for _, r := range required {
-		if _, ok := grantedSet[r]; !ok {
-			return false
-		}
-	}
-	return true
-}

--- a/pkg/connector/scopes.go
+++ b/pkg/connector/scopes.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package connector
+
+import (
+	"sort"
+	"strings"
+	"unicode"
+)
+
+// ParseScopeString splits an OAuth2 scope string into a sorted,
+// deduplicated slice. Accepts both RFC 6749 §3.3 space-separated form
+// (the standard) and GitHub's non-compliant comma-separated form. An
+// empty or whitespace-only input returns an empty slice.
+func ParseScopeString(s string) []string {
+	fields := strings.FieldsFunc(s, func(r rune) bool {
+		return unicode.IsSpace(r) || r == ','
+	})
+	if len(fields) == 0 {
+		return []string{}
+	}
+	seen := make(map[string]struct{}, len(fields))
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if _, ok := seen[f]; ok {
+			continue
+		}
+		seen[f] = struct{}{}
+		out = append(out, f)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// FormatScopeString joins scopes into the RFC 6749 §3.3 space-separated
+// form. The output order is deterministic (sorted).
+func FormatScopeString(scopes []string) string {
+	if len(scopes) == 0 {
+		return ""
+	}
+	sorted := make([]string, len(scopes))
+	copy(sorted, scopes)
+	sort.Strings(sorted)
+	return strings.Join(sorted, " ")
+}
+
+// UnionScopes returns the sorted, deduplicated union of the given scope
+// slices. Empty strings and empty slices are handled gracefully. The
+// result is a fresh slice and never aliases any input.
+func UnionScopes(scopeSets ...[]string) []string {
+	seen := map[string]struct{}{}
+	for _, set := range scopeSets {
+		for _, s := range set {
+			if s == "" {
+				continue
+			}
+			seen[s] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for s := range seen {
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ScopesCover reports whether `granted` already contains every scope in
+// `required`. An empty `required` set is trivially covered.
+func ScopesCover(granted, required []string) bool {
+	if len(required) == 0 {
+		return true
+	}
+	grantedSet := make(map[string]struct{}, len(granted))
+	for _, s := range granted {
+		grantedSet[s] = struct{}{}
+	}
+	for _, r := range required {
+		if _, ok := grantedSet[r]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/connector/scopes_test.go
+++ b/pkg/connector/scopes_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package connector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseScopeString(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", []string{}},
+		{"whitespace only", "   ", []string{}},
+		{"single", "read:user", []string{"read:user"}},
+		{"multi space", "read:user write:user", []string{"read:user", "write:user"}},
+		{"multi comma github style", "repo,gist", []string{"gist", "repo"}},
+		{"mixed separators", "read:user,write:user", []string{"read:user", "write:user"}},
+		{"extra whitespace", "  read:user   write:user  ", []string{"read:user", "write:user"}},
+		{"duplicates", "a a b", []string{"a", "b"}},
+		{"sorted output", "z y a", []string{"a", "y", "z"}},
+		{"github comma with space", "repo, gist", []string{"gist", "repo"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, c.want, ParseScopeString(c.in))
+		})
+	}
+}
+
+func TestUnionScopes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   [][]string
+		want []string
+	}{
+		{"both empty", [][]string{{}, {}}, []string{}},
+		{"first empty", [][]string{{}, {"a", "b"}}, []string{"a", "b"}},
+		{"second empty", [][]string{{"a", "b"}, {}}, []string{"a", "b"}},
+		{"disjoint", [][]string{{"a"}, {"b"}}, []string{"a", "b"}},
+		{"overlap", [][]string{{"a", "b"}, {"b", "c"}}, []string{"a", "b", "c"}},
+		{"three sets", [][]string{{"a"}, {"b"}, {"c"}}, []string{"a", "b", "c"}},
+		{"deduplicates", [][]string{{"a", "a"}, {"a"}}, []string{"a"}},
+		{"drops empty strings", [][]string{{"a", ""}, {""}}, []string{"a"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, c.want, UnionScopes(c.in...))
+		})
+	}
+}
+
+func TestScopesCover(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		granted  []string
+		required []string
+		want     bool
+	}{
+		{"empty required is covered", []string{"a"}, []string{}, true},
+		{"empty granted does not cover non-empty required", []string{}, []string{"a"}, false},
+		{"exact match", []string{"a", "b"}, []string{"a", "b"}, true},
+		{"granted superset", []string{"a", "b", "c"}, []string{"a", "b"}, true},
+		{"missing one", []string{"a"}, []string{"a", "b"}, false},
+		{"reordered match", []string{"b", "a"}, []string{"a", "b"}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, c.want, ScopesCover(c.granted, c.required))
+		})
+	}
+}
+
+func TestFormatScopeString(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{"empty", []string{}, ""},
+		{"single", []string{"a"}, "a"},
+		{"multi sorted", []string{"b", "a"}, "a b"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, c.want, FormatScopeString(c.in))
+		})
+	}
+}

--- a/pkg/connector/scopes_test.go
+++ b/pkg/connector/scopes_test.go
@@ -72,30 +72,6 @@ func TestUnionScopes(t *testing.T) {
 	}
 }
 
-func TestScopesCover(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name     string
-		granted  []string
-		required []string
-		want     bool
-	}{
-		{"empty required is covered", []string{"a"}, []string{}, true},
-		{"empty granted does not cover non-empty required", []string{}, []string{"a"}, false},
-		{"exact match", []string{"a", "b"}, []string{"a", "b"}, true},
-		{"granted superset", []string{"a", "b", "c"}, []string{"a", "b"}, true},
-		{"missing one", []string{"a"}, []string{"a", "b"}, false},
-		{"reordered match", []string{"b", "a"}, []string{"a", "b"}, true},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, c.want, ScopesCover(c.granted, c.required))
-		})
-	}
-}
-
 func TestFormatScopeString(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/connector/slack.go
+++ b/pkg/connector/slack.go
@@ -44,6 +44,8 @@ type (
 	}
 
 	SlackTokenResponse struct {
+		Ok              bool             `json:"ok"`
+		Error           string           `json:"error,omitempty"`
 		IncomingWebhook *IncomingWebhook `json:"incoming_webhook,omitempty"`
 	}
 )
@@ -113,6 +115,16 @@ func ParseSlackTokenResponse(body []byte, oauth2Conn OAuth2Connection, organizat
 	var slackResponse SlackTokenResponse
 	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&slackResponse); err != nil {
 		return nil, nil, fmt.Errorf("cannot decode Slack token response: %w", err)
+	}
+
+	if slackResponse.Error != "" {
+		return nil, nil, fmt.Errorf("cannot complete Slack OAuth2 flow: %s", slackResponse.Error)
+	}
+	if !slackResponse.Ok {
+		return nil, nil, fmt.Errorf("cannot complete Slack OAuth2 flow: ok=false")
+	}
+	if oauth2Conn.AccessToken == "" {
+		return nil, nil, fmt.Errorf("cannot complete Slack OAuth2 flow: missing access token")
 	}
 
 	settings := SlackSettings{}

--- a/pkg/connector/slack.go
+++ b/pkg/connector/slack.go
@@ -111,20 +111,15 @@ func (c *SlackConnection) UnmarshalJSON(data []byte) error {
 
 func ParseSlackTokenResponse(body []byte, oauth2Conn OAuth2Connection, organizationID gid.GID) (*SlackConnection, *gid.GID, error) {
 	var slackResponse SlackTokenResponse
-	var buf bytes.Buffer
-	buf.Write(body)
-	if err := json.NewDecoder(&buf).Decode(&slackResponse); err != nil {
+	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&slackResponse); err != nil {
 		return nil, nil, fmt.Errorf("cannot decode Slack token response: %w", err)
 	}
 
-	if slackResponse.IncomingWebhook == nil {
-		return nil, nil, fmt.Errorf("incoming webhook is required for Slack")
-	}
-
-	settings := SlackSettings{
-		WebhookURL: slackResponse.IncomingWebhook.URL,
-		Channel:    slackResponse.IncomingWebhook.Channel,
-		ChannelID:  slackResponse.IncomingWebhook.ChannelID,
+	settings := SlackSettings{}
+	if slackResponse.IncomingWebhook != nil {
+		settings.WebhookURL = slackResponse.IncomingWebhook.URL
+		settings.Channel = slackResponse.IncomingWebhook.Channel
+		settings.ChannelID = slackResponse.IncomingWebhook.ChannelID
 	}
 
 	return &SlackConnection{

--- a/pkg/connector/slack_test.go
+++ b/pkg/connector/slack_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package connector
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/gid"
+)
+
+func TestParseSlackTokenResponse(t *testing.T) {
+	t.Parallel()
+
+	orgID := gid.New(gid.NewTenantID(), 0)
+	base := OAuth2Connection{
+		AccessToken: "xoxb-test",
+		TokenType:   "bot",
+		ExpiresAt:   time.Now().Add(time.Hour),
+		Scope:       "chat:write channels:join incoming-webhook",
+	}
+
+	t.Run("with incoming webhook", func(t *testing.T) {
+		t.Parallel()
+		body := []byte(`{"ok":true,"incoming_webhook":{"url":"https://hooks.slack.com/services/T/B/X","channel":"#general","channel_id":"C123"}}`)
+
+		conn, returnedOrgID, err := ParseSlackTokenResponse(body, base, orgID)
+		require.NoError(t, err)
+		require.NotNil(t, conn)
+		require.NotNil(t, returnedOrgID)
+
+		assert.Equal(t, orgID, *returnedOrgID)
+		assert.Equal(t, "https://hooks.slack.com/services/T/B/X", conn.Settings.WebhookURL)
+		assert.Equal(t, "#general", conn.Settings.Channel)
+		assert.Equal(t, "C123", conn.Settings.ChannelID)
+		assert.Equal(t, "xoxb-test", conn.AccessToken)
+	})
+
+	t.Run("without incoming webhook", func(t *testing.T) {
+		t.Parallel()
+		body := []byte(`{"ok":true}`)
+
+		conn, returnedOrgID, err := ParseSlackTokenResponse(body, base, orgID)
+		require.NoError(t, err)
+		require.NotNil(t, conn)
+		require.NotNil(t, returnedOrgID)
+
+		assert.Empty(t, conn.Settings.WebhookURL)
+		assert.Empty(t, conn.Settings.Channel)
+		assert.Empty(t, conn.Settings.ChannelID)
+		assert.Equal(t, "xoxb-test", conn.AccessToken)
+	})
+}

--- a/pkg/connector/slack_test.go
+++ b/pkg/connector/slack_test.go
@@ -64,4 +64,28 @@ func TestParseSlackTokenResponse(t *testing.T) {
 		assert.Empty(t, conn.Settings.ChannelID)
 		assert.Equal(t, "xoxb-test", conn.AccessToken)
 	})
+
+	t.Run("slack error response", func(t *testing.T) {
+		t.Parallel()
+		body := []byte(`{"ok":false,"error":"invalid_code"}`)
+
+		conn, returnedOrgID, err := ParseSlackTokenResponse(body, base, orgID)
+		require.Error(t, err)
+		assert.Nil(t, conn)
+		assert.Nil(t, returnedOrgID)
+		assert.ErrorContains(t, err, "invalid_code")
+	})
+
+	t.Run("missing access token", func(t *testing.T) {
+		t.Parallel()
+		body := []byte(`{"ok":true}`)
+		connWithoutToken := base
+		connWithoutToken.AccessToken = ""
+
+		conn, returnedOrgID, err := ParseSlackTokenResponse(body, connWithoutToken, orgID)
+		require.Error(t, err)
+		assert.Nil(t, conn)
+		assert.Nil(t, returnedOrgID)
+		assert.ErrorContains(t, err, "missing access token")
+	})
 }

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -283,7 +283,7 @@ func (s *Service) CreateCookieBanner(
 			}
 
 			var categories coredata.CookieCategories
-			if err := categories.LoadAllByCookieBannerID(ctx, tx, banner.ID); err != nil {
+			if err := categories.LoadAllByCookieBannerID(ctx, tx, scope, banner.ID); err != nil {
 				return fmt.Errorf("cannot load cookie categories: %w", err)
 			}
 
@@ -430,7 +430,7 @@ func (s *Service) UpdateCookieBanner(
 
 			if consentChanged {
 				var categories coredata.CookieCategories
-				if err := categories.LoadAllByCookieBannerID(ctx, tx, banner.ID); err != nil {
+				if err := categories.LoadAllByCookieBannerID(ctx, tx, scope, banner.ID); err != nil {
 					return fmt.Errorf("cannot load cookie categories: %w", err)
 				}
 
@@ -635,7 +635,7 @@ func (s *Service) CreateCookieCategory(
 			}
 
 			var categories coredata.CookieCategories
-			if err := categories.LoadAllByCookieBannerID(ctx, tx, req.CookieBannerID); err != nil {
+			if err := categories.LoadAllByCookieBannerID(ctx, tx, scope, req.CookieBannerID); err != nil {
 				return fmt.Errorf("cannot load cookie categories: %w", err)
 			}
 
@@ -779,7 +779,7 @@ func (s *Service) UpdateCookieCategory(
 			}
 
 			var categories coredata.CookieCategories
-			if err := categories.LoadAllByCookieBannerID(ctx, tx, category.CookieBannerID); err != nil {
+			if err := categories.LoadAllByCookieBannerID(ctx, tx, scope, category.CookieBannerID); err != nil {
 				return fmt.Errorf("cannot load cookie categories: %w", err)
 			}
 
@@ -829,7 +829,7 @@ func (s *Service) DeleteCookieCategory(
 			}
 
 			var categories coredata.CookieCategories
-			if err := categories.LoadAllByCookieBannerID(ctx, tx, bannerID); err != nil {
+			if err := categories.LoadAllByCookieBannerID(ctx, tx, scope, bannerID); err != nil {
 				return fmt.Errorf("cannot load cookie categories: %w", err)
 			}
 

--- a/pkg/coredata/connector.go
+++ b/pkg/coredata/connector.go
@@ -147,7 +147,7 @@ func (c *Connector) LoadOneByOrganizationIDAndProvider(
 	}
 
 	// Widest-scope-wins, tiebreak by most recent updated_at.
-	sort.SliceStable(connectors, func(i, j int) bool {
+	sort.Slice(connectors, func(i, j int) bool {
 		ci, cj := connectorScopeCount(connectors[i]), connectorScopeCount(connectors[j])
 		if ci != cj {
 			return ci > cj

--- a/pkg/coredata/connector.go
+++ b/pkg/coredata/connector.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"sort"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -114,6 +115,58 @@ func (c *Connectors) LoadAllByOrganizationIDProtocolAndProvider(
 	}
 
 	return nil
+}
+
+// LoadOneByOrganizationIDAndProvider loads the effective OAuth2
+// connector for an (organization, provider) pair, picking the row with
+// the widest stored scope set. Ties are broken by most recent
+// updated_at. Returns ErrResourceNotFound if no OAuth2 row exists.
+func (c *Connector) LoadOneByOrganizationIDAndProvider(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	encryptionKey cipher.EncryptionKey,
+	organizationID gid.GID,
+	provider ConnectorProvider,
+) error {
+	var connectors Connectors
+	if err := connectors.LoadAllByOrganizationIDProtocolAndProvider(
+		ctx,
+		conn,
+		scope,
+		organizationID,
+		ConnectorProtocolOAuth2,
+		provider,
+		encryptionKey,
+	); err != nil {
+		return fmt.Errorf("cannot load connectors: %w", err)
+	}
+
+	if len(connectors) == 0 {
+		return ErrResourceNotFound
+	}
+
+	// Widest-scope-wins, tiebreak by most recent updated_at.
+	sort.SliceStable(connectors, func(i, j int) bool {
+		ci, cj := connectorScopeCount(connectors[i]), connectorScopeCount(connectors[j])
+		if ci != cj {
+			return ci > cj
+		}
+		return connectors[i].UpdatedAt.After(connectors[j].UpdatedAt)
+	})
+
+	*c = *connectors[0]
+	return nil
+}
+
+// connectorScopeCount returns the number of scopes granted on a
+// decrypted connector's connection. Returns 0 if the connection is nil.
+// Used by the widest-scope selector.
+func connectorScopeCount(c *Connector) int {
+	if c == nil || c.Connection == nil {
+		return 0
+	}
+	return len(c.Connection.Scopes())
 }
 
 func (c *Connectors) LoadByOrganizationIDWithoutDecryptedConnection(

--- a/pkg/coredata/connector_test.go
+++ b/pkg/coredata/connector_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.probo.inc/probo/pkg/connector"
+)
+
+func TestConnectorScopeCount(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   *Connector
+		want int
+	}{
+		{
+			name: "nil connector",
+			in:   nil,
+			want: 0,
+		},
+		{
+			name: "nil connection",
+			in:   &Connector{},
+			want: 0,
+		},
+		{
+			name: "oauth2 empty scope",
+			in: &Connector{
+				Connection: &connector.OAuth2Connection{Scope: ""},
+			},
+			want: 0,
+		},
+		{
+			name: "oauth2 single scope",
+			in: &Connector{
+				Connection: &connector.OAuth2Connection{Scope: "read:user"},
+			},
+			want: 1,
+		},
+		{
+			name: "oauth2 multiple scopes",
+			in: &Connector{
+				Connection: &connector.OAuth2Connection{Scope: "read:user write:user admin:org"},
+			},
+			want: 3,
+		},
+		{
+			name: "oauth2 github comma scopes",
+			in: &Connector{
+				Connection: &connector.OAuth2Connection{Scope: "repo,gist,user"},
+			},
+			want: 3,
+		},
+		{
+			name: "slack multi scope",
+			in: &Connector{
+				Connection: &connector.SlackConnection{
+					OAuth2Connection: connector.OAuth2Connection{Scope: "chat:write channels:join incoming-webhook"},
+				},
+			},
+			want: 3,
+		},
+		{
+			name: "unknown connection type",
+			in: &Connector{
+				Connection: &connector.APIKeyConnection{},
+			},
+			want: 0,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, c.want, connectorScopeCount(c.in))
+		})
+	}
+}

--- a/pkg/coredata/cookie_category.go
+++ b/pkg/coredata/cookie_category.go
@@ -212,6 +212,7 @@ WHERE
 func (c *CookieCategories) LoadAllByCookieBannerID(
 	ctx context.Context,
 	conn pg.Querier,
+	scope Scoper,
 	cookieBannerID gid.GID,
 ) error {
 	q := `
@@ -229,12 +230,16 @@ SELECT
 FROM
 	cookie_categories
 WHERE
-	cookie_banner_id = @cookie_banner_id
+	%s
+	AND cookie_banner_id = @cookie_banner_id
 ORDER BY
 	rank ASC, id ASC;
 `
 
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
 	args := pgx.StrictNamedArgs{"cookie_banner_id": cookieBannerID}
+	maps.Copy(args, scope.SQLArguments())
 
 	rows, err := conn.Query(ctx, q, args)
 	if err != nil {

--- a/pkg/probo/connector_service.go
+++ b/pkg/probo/connector_service.go
@@ -356,7 +356,8 @@ func (s *ConnectorService) Reconnect(
 				return fmt.Errorf("cannot reconnect connector: not an OAuth2 connector")
 			}
 
-			cnnctr.Connection = preserveConnectionFields(req.Connection, cnnctr.Connection)
+			preserveConnectionFields(req.Connection, cnnctr.Connection)
+			cnnctr.Connection = req.Connection
 			cnnctr.UpdatedAt = time.Now()
 
 			return cnnctr.Update(ctx, conn, s.svc.scope, s.svc.encryptionKey)
@@ -369,11 +370,11 @@ func (s *ConnectorService) Reconnect(
 	return cnnctr, nil
 }
 
-// preserveConnectionFields returns newConn with refresh token and Slack
-// webhook settings copied from oldConn when newConn omits them. Google
+// preserveConnectionFields copies refresh token and Slack webhook
+// settings from oldConn into newConn when newConn omits them. Google
 // omits refresh_token on incremental-auth reuse; a Slack access-review
 // reconnect with no incoming-webhook scope omits the webhook settings.
-func preserveConnectionFields(newConn, oldConn connector.Connection) connector.Connection {
+func preserveConnectionFields(newConn, oldConn connector.Connection) {
 	switch n := newConn.(type) {
 	case *connector.OAuth2Connection:
 		if o, ok := oldConn.(*connector.OAuth2Connection); ok {
@@ -393,5 +394,4 @@ func preserveConnectionFields(newConn, oldConn connector.Connection) connector.C
 			}
 		}
 	}
-	return newConn
 }

--- a/pkg/probo/connector_service.go
+++ b/pkg/probo/connector_service.go
@@ -60,6 +60,13 @@ type (
 		GitHubSettings              *coredata.GitHubConnectorSettings
 		OnePasswordUsersAPISettings *coredata.OnePasswordUsersAPISettings
 	}
+
+	ReconnectConnectorRequest struct {
+		ConnectorID    gid.GID
+		OrganizationID gid.GID
+		Provider       coredata.ConnectorProvider
+		Connection     connector.Connection
+	}
 )
 
 func (car *CreateConnectorRequest) Validate() error {
@@ -68,6 +75,15 @@ func (car *CreateConnectorRequest) Validate() error {
 	v.Check(car.Provider, "provider", validator.Required(), validator.OneOfSlice(coredata.ConnectorProviders()))
 	v.Check(car.Protocol, "protocol", validator.Required(), validator.OneOfSlice(coredata.ConnectorProtocols()))
 	v.Check(car.Connection, "connection", validator.Required())
+	return v.Error()
+}
+
+func (rcr *ReconnectConnectorRequest) Validate() error {
+	v := validator.New()
+	v.Check(rcr.ConnectorID, "connector_id", validator.Required(), validator.GID(coredata.ConnectorEntityType))
+	v.Check(rcr.OrganizationID, "organization_id", validator.Required(), validator.GID(coredata.OrganizationEntityType))
+	v.Check(rcr.Provider, "provider", validator.Required(), validator.OneOfSlice(coredata.ConnectorProviders()))
+	v.Check(rcr.Connection, "connection", validator.Required())
 	return v.Error()
 }
 
@@ -129,32 +145,51 @@ func (s *ConnectorService) GetByOrganizationIDAndProvider(
 	organizationID gid.GID,
 	provider coredata.ConnectorProvider,
 ) (*coredata.Connector, error) {
-	var connectors coredata.Connectors
+	cnnctr := &coredata.Connector{}
 
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return connectors.LoadAllByOrganizationIDProtocolAndProvider(
+			return cnnctr.LoadOneByOrganizationIDAndProvider(
 				ctx,
 				conn,
 				s.svc.scope,
-				organizationID,
-				coredata.ConnectorProtocolOAuth2,
-				provider,
 				s.svc.encryptionKey,
+				organizationID,
+				provider,
 			)
 		},
 	)
-
 	if err != nil {
 		return nil, fmt.Errorf("cannot get connector: %w", err)
 	}
 
-	if len(connectors) == 0 {
-		return nil, coredata.ErrResourceNotFound
+	return cnnctr, nil
+}
+
+// GetWithConnection loads a specific connector by ID and returns the
+// full *coredata.Connector with Connection populated. Used by the
+// initiate handler's explicit reconnect path (?connector_id=<id>),
+// which needs to read the stored scope set to compute the union.
+// Contrast with Get, which uses LoadMetadataByID and returns a
+// connector with Connection == nil.
+func (s *ConnectorService) GetWithConnection(
+	ctx context.Context,
+	connectorID gid.GID,
+) (*coredata.Connector, error) {
+	cnnctr := &coredata.Connector{}
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			return cnnctr.LoadByID(ctx, conn, s.svc.scope, connectorID, s.svc.encryptionKey)
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get connector: %w", err)
 	}
 
-	return connectors[0], nil
+	return cnnctr, nil
 }
 
 func (s *ConnectorService) Get(
@@ -288,29 +323,75 @@ func (s *ConnectorService) Create(
 	return newConnector, nil
 }
 
-// Reconnect updates an existing connector's connection (token) without
-// changing its settings or identity. Used when an OAuth token expires
-// and the user re-authenticates.
+// Reconnect updates an existing OAuth2 connector's connection (token)
+// in place. It validates that the loaded connector belongs to the
+// expected org and provider inside the same transaction, blocking
+// cross-org and cross-provider corruption via a crafted connector_id
+// in the initiate URL. Refresh tokens and Slack webhook settings are
+// preserved from the existing connection when the new one omits them.
 func (s *ConnectorService) Reconnect(
 	ctx context.Context,
-	connectorID gid.GID,
-	connection connector.Connection,
+	req ReconnectConnectorRequest,
 ) (*coredata.Connector, error) {
+	if err := req.Validate(); err != nil {
+		return nil, fmt.Errorf("cannot reconnect connector: %w", err)
+	}
+
 	cnnctr := &coredata.Connector{}
 
-	err := s.svc.pg.WithTx(ctx, func(ctx context.Context, conn pg.Tx) error {
-		if err := cnnctr.LoadMetadataByID(ctx, conn, s.svc.scope, connectorID); err != nil {
-			return fmt.Errorf("cannot load connector: %w", err)
-		}
+	err := s.svc.pg.WithTx(
+		ctx,
+		func(ctx context.Context, conn pg.Tx) error {
+			if err := cnnctr.LoadByID(ctx, conn, s.svc.scope, req.ConnectorID, s.svc.encryptionKey); err != nil {
+				return fmt.Errorf("cannot load connector: %w", err)
+			}
 
-		cnnctr.Connection = connection
-		cnnctr.UpdatedAt = time.Now()
+			if cnnctr.OrganizationID != req.OrganizationID {
+				return fmt.Errorf("cannot reconnect connector: organization mismatch")
+			}
+			if cnnctr.Provider != req.Provider {
+				return fmt.Errorf("cannot reconnect connector: provider mismatch")
+			}
+			if cnnctr.Protocol != coredata.ConnectorProtocolOAuth2 {
+				return fmt.Errorf("cannot reconnect connector: not an OAuth2 connector")
+			}
 
-		return cnnctr.Update(ctx, conn, s.svc.scope, s.svc.encryptionKey)
-	})
+			cnnctr.Connection = preserveConnectionFields(req.Connection, cnnctr.Connection)
+			cnnctr.UpdatedAt = time.Now()
+
+			return cnnctr.Update(ctx, conn, s.svc.scope, s.svc.encryptionKey)
+		},
+	)
 	if err != nil {
 		return nil, fmt.Errorf("cannot reconnect connector: %w", err)
 	}
 
 	return cnnctr, nil
+}
+
+// preserveConnectionFields returns newConn with refresh token and Slack
+// webhook settings copied from oldConn when newConn omits them. Google
+// omits refresh_token on incremental-auth reuse; a Slack access-review
+// reconnect with no incoming-webhook scope omits the webhook settings.
+func preserveConnectionFields(newConn, oldConn connector.Connection) connector.Connection {
+	switch n := newConn.(type) {
+	case *connector.OAuth2Connection:
+		if o, ok := oldConn.(*connector.OAuth2Connection); ok {
+			if n.RefreshToken == "" {
+				n.RefreshToken = o.RefreshToken
+			}
+		}
+	case *connector.SlackConnection:
+		if o, ok := oldConn.(*connector.SlackConnection); ok {
+			if n.RefreshToken == "" {
+				n.RefreshToken = o.RefreshToken
+			}
+			if n.Settings.WebhookURL == "" {
+				n.Settings.WebhookURL = o.Settings.WebhookURL
+				n.Settings.Channel = o.Settings.Channel
+				n.Settings.ChannelID = o.Settings.ChannelID
+			}
+		}
+	}
+	return newConn
 }

--- a/pkg/server/api/console/v1/connector_initiate.go
+++ b/pkg/server/api/console/v1/connector_initiate.go
@@ -29,6 +29,10 @@ import (
 	"go.probo.inc/probo/pkg/server/api/authn"
 )
 
+var (
+	errInvalidReconnectConnector = errors.New("invalid reconnect connector")
+)
+
 func handleConnectorInitiate(
 	logger *log.Logger,
 	proboSvc *probo.Service,
@@ -91,8 +95,12 @@ func handleConnectorInitiate(
 				httpserver.RenderError(w, http.StatusBadRequest, fmt.Errorf("cannot reconnect: connector not found"))
 				return
 			}
+			if errors.Is(err, errInvalidReconnectConnector) {
+				httpserver.RenderError(w, http.StatusBadRequest, err)
+				return
+			}
 			logger.ErrorCtx(r.Context(), "cannot look up existing connector", log.Error(err))
-			httpserver.RenderError(w, http.StatusInternalServerError, fmt.Errorf("cannot look up existing connector: %w", err))
+			httpserver.RenderError(w, http.StatusInternalServerError, fmt.Errorf("cannot look up existing connector"))
 			return
 		}
 
@@ -131,9 +139,17 @@ func loadExistingConnector(
 	if explicitID := r.URL.Query().Get("connector_id"); explicitID != "" {
 		parsedID, err := gid.ParseGID(explicitID)
 		if err != nil {
-			return nil, fmt.Errorf("cannot parse connector id: %w", err)
+			return nil, fmt.Errorf("%w: cannot parse connector id: %w", errInvalidReconnectConnector, err)
 		}
-		return prb.Connectors.GetWithConnection(r.Context(), parsedID)
+
+		found, err := prb.Connectors.GetWithConnection(r.Context(), parsedID)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateReconnectConnector(found, organizationID, provider); err != nil {
+			return nil, err
+		}
+		return found, nil
 	}
 
 	found, err := prb.Connectors.GetByOrganizationIDAndProvider(
@@ -145,4 +161,34 @@ func loadExistingConnector(
 		return nil, nil
 	}
 	return found, err
+}
+
+func validateReconnectConnector(
+	c *coredata.Connector,
+	organizationID gid.GID,
+	provider string,
+) error {
+	if c == nil {
+		return fmt.Errorf("%w: connector not found", errInvalidReconnectConnector)
+	}
+
+	var connectorProvider coredata.ConnectorProvider
+	if err := connectorProvider.Scan(provider); err != nil {
+		return fmt.Errorf("%w: unsupported provider: %w", errInvalidReconnectConnector, err)
+	}
+
+	if c.OrganizationID != organizationID {
+		return fmt.Errorf("%w: organization mismatch", errInvalidReconnectConnector)
+	}
+	if c.Provider != connectorProvider {
+		return fmt.Errorf("%w: provider mismatch", errInvalidReconnectConnector)
+	}
+	if c.Protocol != coredata.ConnectorProtocolOAuth2 {
+		return fmt.Errorf("%w: not an OAuth2 connector", errInvalidReconnectConnector)
+	}
+	if c.Connection == nil {
+		return fmt.Errorf("%w: connector has nil connection", errInvalidReconnectConnector)
+	}
+
+	return nil
 }

--- a/pkg/server/api/console/v1/connector_initiate.go
+++ b/pkg/server/api/console/v1/connector_initiate.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package console_v1
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"go.gearno.de/kit/httpserver"
+	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/connector"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam"
+	"go.probo.inc/probo/pkg/probo"
+	"go.probo.inc/probo/pkg/server/api/authn"
+)
+
+func handleConnectorInitiate(
+	logger *log.Logger,
+	proboSvc *probo.Service,
+	iamSvc *iam.Service,
+	connectorRegistry *connector.ConnectorRegistry,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		provider := r.URL.Query().Get("provider")
+		if provider == "" {
+			httpserver.RenderError(w, http.StatusBadRequest, fmt.Errorf("missing provider parameter"))
+			return
+		}
+
+		if _, err := connectorRegistry.Get(provider); err != nil {
+			httpserver.RenderError(w, http.StatusBadRequest, fmt.Errorf("unsupported provider: %q", provider))
+			return
+		}
+
+		organizationID, err := gid.ParseGID(r.URL.Query().Get("organization_id"))
+		if err != nil {
+			panic(fmt.Errorf("cannot parse organization id: %w", err))
+		}
+
+		if authn.APIKeyFromContext(r.Context()) != nil {
+			httpserver.RenderError(w, http.StatusBadRequest, fmt.Errorf("api key authentication cannot be used for this endpoint"))
+			return
+		}
+
+		identity := authn.IdentityFromContext(r.Context())
+		if identity == nil {
+			httpserver.RenderError(w, http.StatusUnauthorized, fmt.Errorf("authentication required"))
+			return
+		}
+		session := authn.SessionFromContext(r.Context())
+		if session == nil {
+			httpserver.RenderError(w, http.StatusUnauthorized, fmt.Errorf("authentication required"))
+			return
+		}
+
+		if err := iamSvc.Authorizer.Authorize(r.Context(), iam.AuthorizeParams{
+			Principal: identity.ID,
+			Resource:  organizationID,
+			Session:   &session.ID,
+			Action:    probo.ActionConnectorInitiate,
+		}); err != nil {
+			httpserver.RenderError(w, http.StatusForbidden, err)
+			return
+		}
+
+		requestedScopes := r.URL.Query()["scope"]
+		prb := proboSvc.WithTenant(organizationID.TenantID())
+
+		// Look up any existing connector so we can union its stored scopes
+		// into the new auth request. Cross-org/provider/protocol mismatches
+		// are caught inside Reconnect at callback time; this handler only
+		// needs the scope set.
+		existing, err := loadExistingConnector(r, prb, organizationID, provider)
+		if err != nil {
+			if errors.Is(err, coredata.ErrResourceNotFound) {
+				httpserver.RenderError(w, http.StatusBadRequest, fmt.Errorf("cannot reconnect: connector not found"))
+				return
+			}
+			logger.ErrorCtx(r.Context(), "cannot look up existing connector", log.Error(err))
+			httpserver.RenderError(w, http.StatusInternalServerError, fmt.Errorf("cannot look up existing connector: %w", err))
+			return
+		}
+
+		// Always request the union of (old granted ∪ new requested).
+		// Union-not-delta because most providers replace rather than
+		// merge. No short-circuit: every reconnect runs the full OAuth
+		// flow so revoked or stale tokens are never silently reused.
+		opts := connector.InitiateOptions{Scopes: requestedScopes}
+		if existing != nil {
+			opts.Scopes = connector.UnionScopes(existing.Connection.Scopes(), requestedScopes)
+			opts.IncludeGrantedScopes = true
+			opts.ConnectorID = existing.ID.String()
+		}
+
+		redirectURL, err := connectorRegistry.Initiate(r.Context(), provider, organizationID, opts, r)
+		if err != nil {
+			panic(fmt.Errorf("cannot initiate connector: %w", err))
+		}
+
+		http.Redirect(w, r, redirectURL, http.StatusSeeOther)
+	}
+}
+
+// loadExistingConnector returns the connector the initiate handler
+// should reconnect, or nil if this is a fresh install. An explicit
+// `connector_id` query parameter selects a specific row; otherwise the
+// handler falls back to the widest-scope (org, provider) row. Callers
+// must distinguish ErrResourceNotFound (explicit id not found — 400)
+// from nil (no existing row — fresh install path).
+func loadExistingConnector(
+	r *http.Request,
+	prb *probo.TenantService,
+	organizationID gid.GID,
+	provider string,
+) (*coredata.Connector, error) {
+	if explicitID := r.URL.Query().Get("connector_id"); explicitID != "" {
+		parsedID, err := gid.ParseGID(explicitID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse connector id: %w", err)
+		}
+		return prb.Connectors.GetWithConnection(r.Context(), parsedID)
+	}
+
+	found, err := prb.Connectors.GetByOrganizationIDAndProvider(
+		r.Context(),
+		organizationID,
+		coredata.ConnectorProvider(provider),
+	)
+	if errors.Is(err, coredata.ErrResourceNotFound) {
+		return nil, nil
+	}
+	return found, err
+}

--- a/pkg/server/api/console/v1/connector_initiate.go
+++ b/pkg/server/api/console/v1/connector_initiate.go
@@ -29,9 +29,7 @@ import (
 	"go.probo.inc/probo/pkg/server/api/authn"
 )
 
-var (
-	errInvalidReconnectConnector = errors.New("invalid reconnect connector")
-)
+var errInvalidReconnectConnector = errors.New("invalid reconnect connector")
 
 func handleConnectorInitiate(
 	logger *log.Logger,
@@ -53,7 +51,8 @@ func handleConnectorInitiate(
 
 		organizationID, err := gid.ParseGID(r.URL.Query().Get("organization_id"))
 		if err != nil {
-			panic(fmt.Errorf("cannot parse organization id: %w", err))
+			httpserver.RenderError(w, http.StatusBadRequest, fmt.Errorf("invalid organization_id parameter"))
+			return
 		}
 
 		if authn.APIKeyFromContext(r.Context()) != nil {
@@ -100,7 +99,7 @@ func handleConnectorInitiate(
 				return
 			}
 			logger.ErrorCtx(r.Context(), "cannot look up existing connector", log.Error(err))
-			httpserver.RenderError(w, http.StatusInternalServerError, fmt.Errorf("cannot look up existing connector"))
+			httpserver.RenderError(w, http.StatusInternalServerError, fmt.Errorf("internal error"))
 			return
 		}
 
@@ -146,9 +145,6 @@ func loadExistingConnector(
 		if err != nil {
 			return nil, err
 		}
-		if err := validateReconnectConnector(found, organizationID, provider); err != nil {
-			return nil, err
-		}
 		return found, nil
 	}
 
@@ -163,32 +159,3 @@ func loadExistingConnector(
 	return found, err
 }
 
-func validateReconnectConnector(
-	c *coredata.Connector,
-	organizationID gid.GID,
-	provider string,
-) error {
-	if c == nil {
-		return fmt.Errorf("%w: connector not found", errInvalidReconnectConnector)
-	}
-
-	var connectorProvider coredata.ConnectorProvider
-	if err := connectorProvider.Scan(provider); err != nil {
-		return fmt.Errorf("%w: unsupported provider: %w", errInvalidReconnectConnector, err)
-	}
-
-	if c.OrganizationID != organizationID {
-		return fmt.Errorf("%w: organization mismatch", errInvalidReconnectConnector)
-	}
-	if c.Provider != connectorProvider {
-		return fmt.Errorf("%w: provider mismatch", errInvalidReconnectConnector)
-	}
-	if c.Protocol != coredata.ConnectorProtocolOAuth2 {
-		return fmt.Errorf("%w: not an OAuth2 connector", errInvalidReconnectConnector)
-	}
-	if c.Connection == nil {
-		return fmt.Errorf("%w: connector has nil connection", errInvalidReconnectConnector)
-	}
-
-	return nil
-}

--- a/pkg/server/api/console/v1/connector_initiate.go
+++ b/pkg/server/api/console/v1/connector_initiate.go
@@ -116,7 +116,9 @@ func handleConnectorInitiate(
 
 		redirectURL, err := connectorRegistry.Initiate(r.Context(), provider, organizationID, opts, r)
 		if err != nil {
-			panic(fmt.Errorf("cannot initiate connector: %w", err))
+			logger.ErrorCtx(r.Context(), "cannot initiate connector", log.Error(err))
+			httpserver.RenderError(w, http.StatusInternalServerError, fmt.Errorf("internal error"))
+			return
 		}
 
 		http.Redirect(w, r, redirectURL, http.StatusSeeOther)
@@ -158,4 +160,3 @@ func loadExistingConnector(
 	}
 	return found, err
 }
-

--- a/pkg/server/api/console/v1/resolver.go
+++ b/pkg/server/api/console/v1/resolver.go
@@ -152,7 +152,9 @@ func handleConnectorComplete(
 
 		connection, state, err := connectorRegistry.CompleteWithState(r.Context(), provider, r)
 		if err != nil {
-			panic(fmt.Errorf("cannot complete connector: %w", err))
+			logger.ErrorCtx(r.Context(), "cannot complete connector", log.Error(err))
+			httpserver.RenderError(w, http.StatusInternalServerError, fmt.Errorf("internal error"))
+			return
 		}
 
 		organizationID, err := gid.ParseGID(state.OrganizationID)
@@ -184,7 +186,9 @@ func handleConnectorComplete(
 				},
 			)
 			if err != nil {
-				panic(fmt.Errorf("cannot reconnect connector: %w", err))
+				logger.ErrorCtx(r.Context(), "cannot reconnect connector", log.Error(err))
+				httpserver.RenderError(w, http.StatusInternalServerError, fmt.Errorf("internal error"))
+				return
 			}
 		} else {
 			cnnctr, err = svc.Connectors.Create(
@@ -197,7 +201,9 @@ func handleConnectorComplete(
 				},
 			)
 			if err != nil {
-				panic(fmt.Errorf("cannot create connector: %w", err))
+				logger.ErrorCtx(r.Context(), "cannot create connector", log.Error(err))
+				httpserver.RenderError(w, http.StatusInternalServerError, fmt.Errorf("internal error"))
+				return
 			}
 		}
 

--- a/pkg/server/api/console/v1/resolver.go
+++ b/pkg/server/api/console/v1/resolver.go
@@ -97,61 +97,10 @@ func NewMux(
 
 		r.Handle("/graphql", graphqlHandler)
 
-		r.Get("/connectors/initiate", func(w http.ResponseWriter, r *http.Request) {
-			provider := r.URL.Query().Get("provider")
-			if provider == "" {
-				httpserver.RenderError(w, http.StatusBadRequest, fmt.Errorf("missing provider parameter"))
-				return
-			}
-
-			if _, err := connectorRegistry.Get(provider); err != nil {
-				httpserver.RenderError(w, http.StatusBadRequest, fmt.Errorf("unsupported provider: %q", provider))
-				return
-			}
-
-			organizationID, err := gid.ParseGID(r.URL.Query().Get("organization_id"))
-			if err != nil {
-				panic(fmt.Errorf("cannot parse organization id: %w", err))
-			}
-
-			apiKey := authn.APIKeyFromContext(r.Context())
-			if apiKey != nil {
-				httpserver.RenderError(w, http.StatusBadRequest, fmt.Errorf("api key authentication cannot be used for this endpoint"))
-				return
-			}
-
-			identity := authn.IdentityFromContext(r.Context())
-			if identity == nil {
-				httpserver.RenderError(w, http.StatusUnauthorized, fmt.Errorf("authentication required"))
-				return
-			}
-			session := authn.SessionFromContext(r.Context())
-			if session == nil {
-				httpserver.RenderError(w, http.StatusUnauthorized, fmt.Errorf("authentication required"))
-				return
-			}
-
-			if err := iamSvc.Authorizer.Authorize(r.Context(), iam.AuthorizeParams{
-				Principal: identity.ID,
-				Resource:  organizationID,
-				Session:   &session.ID,
-				Action:    probo.ActionConnectorInitiate,
-			}); err != nil {
-				httpserver.RenderError(w, http.StatusForbidden, err)
-				return
-			}
-
-			opts := connector.InitiateOptions{
-				Scopes: r.URL.Query()["scope"],
-			}
-
-			redirectURL, err := connectorRegistry.Initiate(r.Context(), provider, organizationID, opts, r)
-			if err != nil {
-				panic(fmt.Errorf("cannot initiate connector: %w", err))
-			}
-
-			http.Redirect(w, r, redirectURL, http.StatusSeeOther)
-		})
+		r.Get(
+			"/connectors/initiate",
+			handleConnectorInitiate(logger, proboSvc, iamSvc, connectorRegistry),
+		)
 
 		r.Get(
 			"/connectors/complete",

--- a/pkg/server/api/console/v1/resolver.go
+++ b/pkg/server/api/console/v1/resolver.go
@@ -225,7 +225,15 @@ func handleConnectorComplete(
 				return
 			}
 
-			cnnctr, err = svc.Connectors.Reconnect(r.Context(), connectorID, connection)
+			cnnctr, err = svc.Connectors.Reconnect(
+				r.Context(),
+				probo.ReconnectConnectorRequest{
+					ConnectorID:    connectorID,
+					OrganizationID: organizationID,
+					Provider:       connectorProvider,
+					Connection:     connection,
+				},
+			)
 			if err != nil {
 				panic(fmt.Errorf("cannot reconnect connector: %w", err))
 			}

--- a/pkg/slack/sender.go
+++ b/pkg/slack/sender.go
@@ -148,39 +148,36 @@ func (s *Sender) sendMessage(ctx context.Context, tx pg.Querier, message *coreda
 	tenantID := message.ID.TenantID()
 	scope := coredata.NewScope(tenantID)
 
-	var connectors coredata.Connectors
-	if err := connectors.LoadAllByOrganizationIDProtocolAndProvider(
+	var c coredata.Connector
+	if err := c.LoadOneByOrganizationIDAndProvider(
 		ctx,
 		tx,
 		scope,
-		message.OrganizationID,
-		coredata.ConnectorProtocolOAuth2,
-		coredata.ConnectorProviderSlack,
 		s.encryptionKey,
+		message.OrganizationID,
+		coredata.ConnectorProviderSlack,
 	); err != nil {
-		return nil, nil, fmt.Errorf("cannot load slack connectors: %w", err)
+		if errors.Is(err, coredata.ErrResourceNotFound) {
+			return nil, nil, fmt.Errorf("cannot send slack message: no connector configured for organization")
+		}
+		return nil, nil, fmt.Errorf("cannot load slack connector: %w", err)
 	}
 
-	if len(connectors) == 0 {
-		return nil, nil, fmt.Errorf("no slack connectors configured for organization")
-	}
-
-	c := connectors[0]
 	if c.Connection == nil {
-		return nil, nil, fmt.Errorf("slack connector has nil connection")
+		return nil, nil, fmt.Errorf("cannot send slack message: connector has nil connection")
 	}
 
 	slackConn, ok := c.Connection.(*connector.SlackConnection)
 	if !ok {
-		return nil, nil, fmt.Errorf("slack connector must have SlackConnection type, got %T", c.Connection)
+		return nil, nil, fmt.Errorf("cannot send slack message: unexpected connection type %T", c.Connection)
 	}
 
 	if slackConn.Settings.ChannelID == "" {
-		return nil, nil, fmt.Errorf("slack connector %s has no channel ID", c.ID)
+		return nil, nil, fmt.Errorf("cannot send slack message: connector %s has no channel ID", c.ID)
 	}
 
 	if slackConn.AccessToken == "" {
-		return nil, nil, fmt.Errorf("slack connector %s has no access token", c.ID)
+		return nil, nil, fmt.Errorf("cannot send slack message: connector %s has no access token", c.ID)
 	}
 
 	client := NewClient(s.logger)
@@ -269,41 +266,38 @@ func (s *Sender) batchUpdateMessages(ctx context.Context) error {
 
 func (s *Sender) updateMessage(ctx context.Context, tx pg.Querier, updateMessage *coredata.SlackMessage) error {
 	if updateMessage.ChannelID == nil || updateMessage.MessageTS == nil {
-		return fmt.Errorf("slack message has no channel ID or message TS")
+		return fmt.Errorf("cannot update slack message: missing channel ID or message TS")
 	}
 
 	tenantID := updateMessage.ID.TenantID()
 	scope := coredata.NewScope(tenantID)
 
-	var connectors coredata.Connectors
-	if err := connectors.LoadAllByOrganizationIDProtocolAndProvider(
+	var c coredata.Connector
+	if err := c.LoadOneByOrganizationIDAndProvider(
 		ctx,
 		tx,
 		scope,
-		updateMessage.OrganizationID,
-		coredata.ConnectorProtocolOAuth2,
-		coredata.ConnectorProviderSlack,
 		s.encryptionKey,
+		updateMessage.OrganizationID,
+		coredata.ConnectorProviderSlack,
 	); err != nil {
-		return fmt.Errorf("cannot load slack connectors: %w", err)
+		if errors.Is(err, coredata.ErrResourceNotFound) {
+			return fmt.Errorf("cannot update slack message: no connector configured for organization")
+		}
+		return fmt.Errorf("cannot load slack connector: %w", err)
 	}
 
-	if len(connectors) == 0 {
-		return fmt.Errorf("no slack connectors configured for organization")
-	}
-
-	c := connectors[0]
 	if c.Connection == nil {
-		return fmt.Errorf("slack connector has nil connection")
+		return fmt.Errorf("cannot update slack message: connector has nil connection")
 	}
 
 	slackConn, ok := c.Connection.(*connector.SlackConnection)
 	if !ok {
-		return fmt.Errorf("slack connector must have SlackConnection type, got %T", c.Connection)
+		return fmt.Errorf("cannot update slack message: unexpected connection type %T", c.Connection)
 	}
 
 	if slackConn.AccessToken == "" {
-		return fmt.Errorf("slack connector %s has no access token", c.ID)
+		return fmt.Errorf("cannot update slack message: connector %s has no access token", c.ID)
 	}
 
 	client := NewClient(s.logger)

--- a/pkg/slack/sender.go
+++ b/pkg/slack/sender.go
@@ -160,7 +160,7 @@ func (s *Sender) sendMessage(ctx context.Context, tx pg.Querier, message *coreda
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil, fmt.Errorf("cannot send slack message: no connector configured for organization")
 		}
-		return nil, nil, fmt.Errorf("cannot load slack connector: %w", err)
+		return nil, nil, fmt.Errorf("cannot send slack message: %w", err)
 	}
 
 	if c.Connection == nil {
@@ -284,7 +284,7 @@ func (s *Sender) updateMessage(ctx context.Context, tx pg.Querier, updateMessage
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return fmt.Errorf("cannot update slack message: no connector configured for organization")
 		}
-		return fmt.Errorf("cannot load slack connector: %w", err)
+		return fmt.Errorf("cannot update slack message: %w", err)
 	}
 
 	if c.Connection == nil {


### PR DESCRIPTION
## Summary

- Reconnecting an OAuth2 connector now requests the **union** of previously granted and newly requested scopes, so a SCIM reconnect never drops the access-review scopes (and vice versa). Portable across every provider.
- The widest-scope row wins when multiple connectors exist for the same `(org, provider)` pair — tiebreak by most recent `updated_at`. Fixes the latent "oldest wins" bug in the Slack sender where re-installing Slack to switch channels silently did nothing.
- Defense-in-depth validation on reconnect: `ConnectorService.Reconnect` takes a `ReconnectConnectorRequest` and verifies the loaded row's organization, provider and protocol inside the same transaction, blocking cross-org/cross-provider corruption via a crafted `connector_id` in the initiate URL.
- Google Workspace reuse flows now carry `include_granted_scopes=true` and skip `prompt=consent`, so the user sees the delta consent screen instead of a full re-consent. Refresh tokens and Slack webhook settings are preserved through reconnect when the provider omits them.

## Why

Users re-connecting Google Workspace for a new SCIM scope were silently losing the access-review scopes (and the reverse). Slack re-installs to switch channels silently broke because `pkg/slack/sender.go` picked `connectors[0]` ordered by `created_at ASC`. A stale `connector_id` in the initiate URL could target a connector in a sibling organization inside the same tenant.

All three are fixed at the runtime entry points (initiate handler, Slack sender, `ConnectorService.GetByOrganizationIDAndProvider`) without a DB schema change. Legacy duplicate rows remain in place and are consolidated forward via auto-reconnect.

## Commits

Small, buildable, conventional commits:

1. `feat(connector): add scope parsing utilities` — `ParseScopeString`/`FormatScopeString`/`UnionScopes`/`ScopesCover`, tolerant of GitHub's comma-separated form.
2. `fix(connector): relax Slack incoming webhook requirement` — access-review Slack flows no longer fail at token parsing.
3. `feat(connector): support OAuth2 scope preservation and incremental auth` — `Connection.Scopes()`, `OAuth2State.RequestedScopes` fallback, `SupportsIncrementalAuth`, conditional `include_granted_scopes`/`prompt=consent`.
4. `feat(coredata): add widest-scope connector loader` — `LoadOneByOrganizationIDAndProvider` with `Scopes()`-driven selection.
5. `feat(probo): validate reconnects and preserve dropped token fields` — `ReconnectConnectorRequest` + in-tx validation + `preserveConnectionFields` for refresh token and Slack webhook.
6. `refactor(console): rewrite /connectors/initiate to union scopes` — extracted handler, scope union, `InitiateOptions.ConnectorID` passed explicitly instead of mutating `r.URL`.
7. `fix(slack): select widest-scope connector in sender` — replaces `LoadAll[0]` with the widest-scope loader in `sendMessage` and `updateMessage`.

The earlier commit `Add Slack access review scopes` (1-line fix to the `providerOAuth2Scopes` map) is carried along — it was not in the squash-merged state of #997.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./pkg/connector/... ./pkg/coredata/...` — all passing (`scopes_test.go`, `slack_test.go`, new `oauth2_test.go` subtests, `connector_test.go` for `connectorScopeCount`)
- [ ] **Manual smoke — Google Workspace SCIM + access review**: connect Google Workspace for SCIM (4 scopes), then click "Add Access Source → Google Workspace". Expect the user to go through the full OAuth flow with `include_granted_scopes=true` and a delta consent screen, and a single connector row updated in place.
- [ ] **Manual smoke — Slack re-install to switch channels**: connect Slack to `#general`, then reconnect to `#audit`. Expect subsequent compliance events to route to `#audit` (the latent "oldest wins" bug being fixed).
- [ ] **Manual smoke — explicit reconnect on a revoked token**: revoke the Google token at the provider, click `Reconnect` on the access source. Expect a fresh token exchange (no short-circuit on stored scope coverage).
- [ ] **Manual smoke — cross-org `connector_id` blocked**: craft `organization_id=OrgA&connector_id=<OrgB's id>` in the initiate URL. Expect a 400 at callback time (caught inside `Reconnect`).

## Out of scope

- Broader `createAccessSource`/`updateAccessSource` cross-org `connector_id` validation — flagged as a follow-up security PR (see design decision §6 in the plan).
- Consolidating `Organization.slackConnections` resolver duplicates — the sender picks the right row but the compliance page UI may still list legacy duplicates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds scope‑preserving OAuth2 reconnects with an initiate flow that unions scopes and supports incremental auth; Slack now picks the correct connector and validates token responses. Handlers return clean HTTP errors, and cookie category queries are tenant‑scoped.

- **New Features**
  - Initiate unions stored + requested scopes and supports explicit reconnect via `connector_id`; `InitiateOptions.IncludeGrantedScopes` enables incremental auth (Google adds `include_granted_scopes=true` and skips `prompt=consent`).
  - If a token response omits `scope`, we fall back to requested scopes from state; added `Connection.Scopes()` and scope helpers (`ParseScopeString`, `FormatScopeString`, `UnionScopes`), plus a widest‑scope connector selector used by `GetByOrganizationIDAndProvider` and the Slack sender.
  - `ReconnectConnectorRequest` validates org/provider/protocol in‑transaction and preserves missing fields (refresh token, Slack webhook settings) during reconnect.

- **Bug Fixes**
  - Slack: added access‑review scopes, made `incoming_webhook` optional, validated `ok`/`error`, required access token, and selected the widest‑scope/most‑recent connector with clearer errors.
  - Connector handlers no longer panic and now log + return generic 4xx/5xx responses (no leaked internals); cookie categories loading is tenant‑scoped; `cfg/dev.yaml` drops redundant OAuth2 fields; Console uses `useMutation` + `useToast`.

<sup>Written for commit d990d566a88076e3e6662be58ba8505c8caaebca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

