### PR TITLE
Cookie Banner new models + service base

### DIFF
--- a/pkg/cookiebanner/client.go
+++ b/pkg/cookiebanner/client.go
@@ -77,10 +77,10 @@ type (
 
 	UpdateCookieCategoryRequest struct {
 		CookieCategoryID gid.GID
-		Name        *string
-		Description *string
-		Rank        *int
-		Cookies     *coredata.CookieItems
+		Name             *string
+		Description      *string
+		Rank             *int
+		Cookies          *coredata.CookieItems
 	}
 )
 

--- a/pkg/cookiebanner/client.go
+++ b/pkg/cookiebanner/client.go
@@ -220,7 +220,7 @@ func (c *Client) GetCookieBanner(
 	return &banner, nil
 }
 
-func (c *Client) ListCookieBanners(
+func (c *Client) ListCookieBannersForOrganization(
 	ctx context.Context,
 	scope coredata.Scoper,
 	organizationID gid.GID,
@@ -246,7 +246,7 @@ func (c *Client) ListCookieBanners(
 	return banners, nil
 }
 
-func (c *Client) CountCookieBanners(
+func (c *Client) CountCookieBannersForOrganization(
 	ctx context.Context,
 	scope coredata.Scoper,
 	organizationID gid.GID,
@@ -512,7 +512,7 @@ func (c *Client) GetCookieCategory(
 	return &category, nil
 }
 
-func (c *Client) ListCookieCategories(
+func (c *Client) ListCookieCategoriesForBanner(
 	ctx context.Context,
 	scope coredata.Scoper,
 	bannerID gid.GID,
@@ -537,7 +537,7 @@ func (c *Client) ListCookieCategories(
 	return categories, nil
 }
 
-func (c *Client) CountCookieCategories(
+func (c *Client) CountCookieCategoriesForBanner(
 	ctx context.Context,
 	scope coredata.Scoper,
 	bannerID gid.GID,

--- a/pkg/cookiebanner/client.go
+++ b/pkg/cookiebanner/client.go
@@ -127,6 +127,7 @@ func (r *UpdateCookieCategoryRequest) Validate() error {
 	v.Check(r.CookieCategoryID, "cookie_category_id", validator.Required(), validator.GID(coredata.CookieCategoryEntityType))
 	v.Check(r.Name, "name", validator.SafeTextNoNewLine(255))
 	v.Check(r.Description, "description", validator.SafeText(1000))
+	v.Check(r.Rank, "rank", validator.Min(0))
 
 	return v.Error()
 }

--- a/pkg/cookiebanner/client.go
+++ b/pkg/cookiebanner/client.go
@@ -1,0 +1,644 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package cookiebanner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/page"
+	"go.probo.inc/probo/pkg/validator"
+)
+
+type Client struct {
+	pg *pg.Client
+}
+
+func NewClient(pgClient *pg.Client) *Client {
+	return &Client{pg: pgClient}
+}
+
+var defaultCategories = []struct {
+	Name        string
+	Description string
+	Required    bool
+	Rank        int
+}{
+	{"Necessary", "Essential cookies required for the website to function properly.", true, 0},
+	{"Analytics", "Cookies that help understand how visitors interact with the website.", false, 1},
+	{"Advertising", "Cookies used to deliver relevant advertisements and track campaigns.", false, 2},
+	{"Functional", "Cookies that enable enhanced functionality and personalization.", false, 3},
+}
+
+type (
+	CreateCookieBannerRequest struct {
+		OrganizationID    gid.GID
+		Name              string
+		Origin            string
+		PrivacyPolicyURL  string
+		ConsentExpiryDays int
+		ConsentMode       coredata.CookieConsentMode
+	}
+
+	CreateCookieCategoryRequest struct {
+		CookieBannerID gid.GID
+		Name           string
+		Description    string
+		Required       bool
+		Rank           int
+		Cookies        coredata.CookieItems
+	}
+
+	UpdateCookieBannerRequest struct {
+		CookieBannerID    gid.GID
+		Name              *string
+		Origin            *string
+		PrivacyPolicyURL  *string
+		ConsentExpiryDays *int
+		ConsentMode       *coredata.CookieConsentMode
+	}
+
+	UpdateCookieCategoryRequest struct {
+		CookieCategoryID gid.GID
+		Name        *string
+		Description *string
+		Rank        *int
+		Cookies     *coredata.CookieItems
+	}
+)
+
+func (r *CreateCookieBannerRequest) Validate() error {
+	v := validator.New()
+
+	v.Check(r.OrganizationID, "organization_id", validator.Required(), validator.GID(coredata.OrganizationEntityType))
+	v.Check(r.Name, "name", validator.Required(), validator.SafeTextNoNewLine(255))
+	v.Check(r.Origin, "origin", validator.Required(), validator.NotEmpty())
+	v.Check(r.PrivacyPolicyURL, "privacy_policy_url", validator.Required(), validator.URL())
+	v.Check(r.ConsentExpiryDays, "consent_expiry_days", validator.Required(), validator.Min(1))
+	v.Check(r.ConsentMode, "consent_mode", validator.Required(), validator.OneOfSlice(coredata.CookieConsentModes()))
+
+	return v.Error()
+}
+
+func (r *UpdateCookieBannerRequest) Validate() error {
+	v := validator.New()
+
+	v.Check(r.CookieBannerID, "cookie_banner_id", validator.Required(), validator.GID(coredata.CookieBannerEntityType))
+	v.Check(r.Name, "name", validator.SafeTextNoNewLine(255))
+	v.Check(r.Origin, "origin", validator.NotEmpty())
+	v.Check(r.PrivacyPolicyURL, "privacy_policy_url", validator.URL())
+	v.Check(r.ConsentExpiryDays, "consent_expiry_days", validator.Min(1))
+	v.Check(r.ConsentMode, "consent_mode", validator.OneOfSlice(coredata.CookieConsentModes()))
+
+	return v.Error()
+}
+
+func (r *CreateCookieCategoryRequest) Validate() error {
+	v := validator.New()
+
+	v.Check(r.CookieBannerID, "cookie_banner_id", validator.Required(), validator.GID(coredata.CookieBannerEntityType))
+	v.Check(r.Name, "name", validator.Required(), validator.SafeTextNoNewLine(255))
+	v.Check(r.Description, "description", validator.Required(), validator.SafeText(1000))
+	v.Check(r.Rank, "rank", validator.Min(0))
+
+	return v.Error()
+}
+
+func (r *UpdateCookieCategoryRequest) Validate() error {
+	v := validator.New()
+
+	v.Check(r.CookieCategoryID, "cookie_category_id", validator.Required(), validator.GID(coredata.CookieCategoryEntityType))
+	v.Check(r.Name, "name", validator.SafeTextNoNewLine(255))
+	v.Check(r.Description, "description", validator.SafeText(1000))
+
+	return v.Error()
+}
+
+func (c *Client) CreateCookieBanner(
+	ctx context.Context,
+	scope coredata.Scoper,
+	req CreateCookieBannerRequest,
+) (*coredata.CookieBanner, error) {
+	if err := req.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid request: %w", err)
+	}
+
+	var banner *coredata.CookieBanner
+
+	err := c.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			now := time.Now()
+
+			banner = &coredata.CookieBanner{
+				ID:                gid.New(scope.GetTenantID(), coredata.CookieBannerEntityType),
+				OrganizationID:    req.OrganizationID,
+				Name:              req.Name,
+				Origin:            req.Origin,
+				State:             coredata.CookieBannerStateDraft,
+				PrivacyPolicyURL:  req.PrivacyPolicyURL,
+				ConsentExpiryDays: req.ConsentExpiryDays,
+				ConsentMode:       req.ConsentMode,
+				CreatedAt:         now,
+				UpdatedAt:         now,
+			}
+
+			if err := banner.Insert(ctx, tx, scope); err != nil {
+				return fmt.Errorf("cannot insert cookie banner: %w", err)
+			}
+
+			for _, dc := range defaultCategories {
+				category := &coredata.CookieCategory{
+					ID:             gid.New(scope.GetTenantID(), coredata.CookieCategoryEntityType),
+					CookieBannerID: banner.ID,
+					Name:           dc.Name,
+					Description:    dc.Description,
+					Required:       dc.Required,
+					Rank:           dc.Rank,
+					Cookies:        coredata.CookieItems{},
+					CreatedAt:      now,
+					UpdatedAt:      now,
+				}
+
+				if err := category.Insert(ctx, tx, scope); err != nil {
+					return fmt.Errorf("cannot insert default cookie category %q: %w", dc.Name, err)
+				}
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return banner, nil
+}
+
+func (c *Client) GetCookieBanner(
+	ctx context.Context,
+	scope coredata.Scoper,
+	bannerID gid.GID,
+) (*coredata.CookieBanner, error) {
+	var banner coredata.CookieBanner
+
+	err := c.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			if err := banner.LoadByID(ctx, conn, scope, bannerID); err != nil {
+				if errors.Is(err, coredata.ErrResourceNotFound) {
+					return ErrBannerNotFound
+				}
+				return fmt.Errorf("cannot load cookie banner: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &banner, nil
+}
+
+func (c *Client) ListCookieBanners(
+	ctx context.Context,
+	scope coredata.Scoper,
+	organizationID gid.GID,
+	cursor *page.Cursor[coredata.CookieBannerOrderField],
+	filter *coredata.CookieBannerFilter,
+) (coredata.CookieBanners, error) {
+	var banners coredata.CookieBanners
+
+	err := c.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			if err := banners.LoadByOrganizationID(ctx, conn, scope, organizationID, cursor, filter); err != nil {
+				return fmt.Errorf("cannot list cookie banners: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return banners, nil
+}
+
+func (c *Client) CountCookieBanners(
+	ctx context.Context,
+	scope coredata.Scoper,
+	organizationID gid.GID,
+	filter *coredata.CookieBannerFilter,
+) (int, error) {
+	var count int
+
+	err := c.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			var banners coredata.CookieBanners
+			var err error
+
+			count, err = banners.CountByOrganizationID(ctx, conn, scope, organizationID, filter)
+			if err != nil {
+				return fmt.Errorf("cannot count cookie banners: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+func (c *Client) UpdateCookieBanner(
+	ctx context.Context,
+	scope coredata.Scoper,
+	req UpdateCookieBannerRequest,
+) (*coredata.CookieBanner, error) {
+	if err := req.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid request: %w", err)
+	}
+
+	var banner coredata.CookieBanner
+
+	err := c.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			if err := banner.LoadByID(ctx, tx, scope, req.CookieBannerID); err != nil {
+				if errors.Is(err, coredata.ErrResourceNotFound) {
+					return ErrBannerNotFound
+				}
+				return fmt.Errorf("cannot load cookie banner: %w", err)
+			}
+
+			// TODO: remove this guard once we add versioning.
+			if banner.State != coredata.CookieBannerStateDraft {
+				return ErrBannerNotDraft
+			}
+
+			if req.Name != nil {
+				banner.Name = *req.Name
+			}
+			if req.Origin != nil {
+				banner.Origin = *req.Origin
+			}
+			if req.PrivacyPolicyURL != nil {
+				banner.PrivacyPolicyURL = *req.PrivacyPolicyURL
+			}
+			if req.ConsentExpiryDays != nil {
+				banner.ConsentExpiryDays = *req.ConsentExpiryDays
+			}
+			if req.ConsentMode != nil {
+				banner.ConsentMode = *req.ConsentMode
+			}
+
+			banner.UpdatedAt = time.Now()
+
+			if err := banner.Update(ctx, tx, scope); err != nil {
+				return fmt.Errorf("cannot update cookie banner: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &banner, nil
+}
+
+func (c *Client) PublishCookieBanner(
+	ctx context.Context,
+	scope coredata.Scoper,
+	bannerID gid.GID,
+) (*coredata.CookieBanner, error) {
+	var banner coredata.CookieBanner
+
+	err := c.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			if err := banner.LoadByID(ctx, tx, scope, bannerID); err != nil {
+				if errors.Is(err, coredata.ErrResourceNotFound) {
+					return ErrBannerNotFound
+				}
+				return fmt.Errorf("cannot load cookie banner: %w", err)
+			}
+
+			if banner.State == coredata.CookieBannerStatePublished {
+				return ErrBannerAlreadyPublished
+			}
+
+			banner.State = coredata.CookieBannerStatePublished
+			banner.UpdatedAt = time.Now()
+
+			if err := banner.Update(ctx, tx, scope); err != nil {
+				return fmt.Errorf("cannot update cookie banner: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &banner, nil
+}
+
+func (c *Client) DisableCookieBanner(
+	ctx context.Context,
+	scope coredata.Scoper,
+	bannerID gid.GID,
+) (*coredata.CookieBanner, error) {
+	var banner coredata.CookieBanner
+
+	err := c.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			if err := banner.LoadByID(ctx, tx, scope, bannerID); err != nil {
+				if errors.Is(err, coredata.ErrResourceNotFound) {
+					return ErrBannerNotFound
+				}
+				return fmt.Errorf("cannot load cookie banner: %w", err)
+			}
+
+			if banner.State == coredata.CookieBannerStateDisabled {
+				return ErrBannerAlreadyDisabled
+			}
+
+			banner.State = coredata.CookieBannerStateDisabled
+			banner.UpdatedAt = time.Now()
+
+			if err := banner.Update(ctx, tx, scope); err != nil {
+				return fmt.Errorf("cannot update cookie banner: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &banner, nil
+}
+
+func (c *Client) DeleteCookieBanner(
+	ctx context.Context,
+	scope coredata.Scoper,
+	bannerID gid.GID,
+) error {
+	return c.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			var banner coredata.CookieBanner
+			if err := banner.LoadByID(ctx, tx, scope, bannerID); err != nil {
+				if errors.Is(err, coredata.ErrResourceNotFound) {
+					return ErrBannerNotFound
+				}
+				return fmt.Errorf("cannot load cookie banner: %w", err)
+			}
+
+			if banner.State != coredata.CookieBannerStateDraft {
+				return ErrBannerNotDraft
+			}
+
+			if err := banner.Delete(ctx, tx, scope); err != nil {
+				return fmt.Errorf("cannot delete cookie banner: %w", err)
+			}
+
+			return nil
+		},
+	)
+}
+
+func (c *Client) CreateCookieCategory(
+	ctx context.Context,
+	scope coredata.Scoper,
+	req CreateCookieCategoryRequest,
+) (*coredata.CookieCategory, error) {
+	if err := req.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid request: %w", err)
+	}
+
+	var category *coredata.CookieCategory
+
+	err := c.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			now := time.Now()
+
+			cookies := req.Cookies
+			if cookies == nil {
+				cookies = coredata.CookieItems{}
+			}
+
+			category = &coredata.CookieCategory{
+				ID:             gid.New(scope.GetTenantID(), coredata.CookieCategoryEntityType),
+				CookieBannerID: req.CookieBannerID,
+				Name:           req.Name,
+				Description:    req.Description,
+				Required:       req.Required,
+				Rank:           req.Rank,
+				Cookies:        cookies,
+				CreatedAt:      now,
+				UpdatedAt:      now,
+			}
+
+			if err := category.Insert(ctx, tx, scope); err != nil {
+				return fmt.Errorf("cannot insert cookie category: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return category, nil
+}
+
+func (c *Client) GetCookieCategory(
+	ctx context.Context,
+	scope coredata.Scoper,
+	categoryID gid.GID,
+) (*coredata.CookieCategory, error) {
+	var category coredata.CookieCategory
+
+	err := c.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			if err := category.LoadByID(ctx, conn, scope, categoryID); err != nil {
+				if errors.Is(err, coredata.ErrResourceNotFound) {
+					return ErrCategoryNotFound
+				}
+				return fmt.Errorf("cannot load cookie category: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &category, nil
+}
+
+func (c *Client) ListCookieCategories(
+	ctx context.Context,
+	scope coredata.Scoper,
+	bannerID gid.GID,
+	cursor *page.Cursor[coredata.CookieCategoryOrderField],
+) (coredata.CookieCategories, error) {
+	var categories coredata.CookieCategories
+
+	err := c.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			if err := categories.LoadByCookieBannerID(ctx, conn, scope, bannerID, cursor); err != nil {
+				return fmt.Errorf("cannot list cookie categories: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return categories, nil
+}
+
+func (c *Client) CountCookieCategories(
+	ctx context.Context,
+	scope coredata.Scoper,
+	bannerID gid.GID,
+) (int, error) {
+	var count int
+
+	err := c.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			var categories coredata.CookieCategories
+			var err error
+
+			count, err = categories.CountByCookieBannerID(ctx, conn, scope, bannerID)
+			if err != nil {
+				return fmt.Errorf("cannot count cookie categories: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+func (c *Client) UpdateCookieCategory(
+	ctx context.Context,
+	scope coredata.Scoper,
+	req UpdateCookieCategoryRequest,
+) (*coredata.CookieCategory, error) {
+	if err := req.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid request: %w", err)
+	}
+
+	var category coredata.CookieCategory
+
+	err := c.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			if err := category.LoadByID(ctx, tx, scope, req.CookieCategoryID); err != nil {
+				if errors.Is(err, coredata.ErrResourceNotFound) {
+					return ErrCategoryNotFound
+				}
+				return fmt.Errorf("cannot load cookie category: %w", err)
+			}
+
+			if req.Name != nil {
+				category.Name = *req.Name
+			}
+			if req.Description != nil {
+				category.Description = *req.Description
+			}
+			if req.Rank != nil {
+				category.Rank = *req.Rank
+			}
+			if req.Cookies != nil {
+				category.Cookies = *req.Cookies
+			}
+
+			category.UpdatedAt = time.Now()
+
+			if err := category.Update(ctx, tx, scope); err != nil {
+				return fmt.Errorf("cannot update cookie category: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &category, nil
+}
+
+func (c *Client) DeleteCookieCategory(
+	ctx context.Context,
+	scope coredata.Scoper,
+	categoryID gid.GID,
+) error {
+	return c.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			var category coredata.CookieCategory
+			if err := category.LoadByID(ctx, tx, scope, categoryID); err != nil {
+				if errors.Is(err, coredata.ErrResourceNotFound) {
+					return ErrCategoryNotFound
+				}
+				return fmt.Errorf("cannot load cookie category: %w", err)
+			}
+
+			if category.Required {
+				return ErrCannotDeleteRequiredCategory
+			}
+
+			if err := category.Delete(ctx, tx, scope); err != nil {
+				return fmt.Errorf("cannot delete cookie category: %w", err)
+			}
+
+			return nil
+		},
+	)
+}

--- a/pkg/cookiebanner/client.go
+++ b/pkg/cookiebanner/client.go
@@ -16,6 +16,7 @@ package cookiebanner
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -82,6 +83,15 @@ type (
 		Rank             *int
 		Cookies          *coredata.CookieItems
 	}
+
+	CreateCookieConsentRecordRequest struct {
+		CookieBannerID gid.GID
+		VisitorID      string
+		IPAddress      *string
+		UserAgent      *string
+		ConsentData    json.RawMessage
+		Action         coredata.CookieConsentAction
+	}
 )
 
 func (r *CreateCookieBannerRequest) Validate() error {
@@ -128,6 +138,16 @@ func (r *UpdateCookieCategoryRequest) Validate() error {
 	v.Check(r.Name, "name", validator.SafeTextNoNewLine(255))
 	v.Check(r.Description, "description", validator.SafeText(1000))
 	v.Check(r.Rank, "rank", validator.Min(0))
+
+	return v.Error()
+}
+
+func (r *CreateCookieConsentRecordRequest) Validate() error {
+	v := validator.New()
+
+	v.Check(r.CookieBannerID, "cookie_banner_id", validator.Required(), validator.GID(coredata.CookieBannerEntityType))
+	v.Check(r.VisitorID, "visitor_id", validator.Required(), validator.NotEmpty())
+	v.Check(r.Action, "action", validator.Required(), validator.OneOfSlice(coredata.CookieConsentActions()))
 
 	return v.Error()
 }
@@ -642,4 +662,98 @@ func (c *Client) DeleteCookieCategory(
 			return nil
 		},
 	)
+}
+
+func (c *Client) CreateCookieConsentRecord(
+	ctx context.Context,
+	scope coredata.Scoper,
+	req CreateCookieConsentRecordRequest,
+) (*coredata.CookieConsentRecord, error) {
+	if err := req.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid request: %w", err)
+	}
+
+	var record *coredata.CookieConsentRecord
+
+	err := c.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			record = &coredata.CookieConsentRecord{
+				ID:             gid.New(scope.GetTenantID(), coredata.CookieConsentRecordEntityType),
+				CookieBannerID: req.CookieBannerID,
+				VisitorID:      req.VisitorID,
+				IPAddress:      req.IPAddress,
+				UserAgent:      req.UserAgent,
+				ConsentData:    req.ConsentData,
+				Action:         req.Action,
+				CreatedAt:      time.Now(),
+			}
+
+			if err := record.Insert(ctx, tx, scope); err != nil {
+				return fmt.Errorf("cannot insert consent record: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return record, nil
+}
+
+func (c *Client) ListCookieConsentRecordsForBanner(
+	ctx context.Context,
+	scope coredata.Scoper,
+	bannerID gid.GID,
+	cursor *page.Cursor[coredata.CookieConsentRecordOrderField],
+	filter *coredata.CookieConsentRecordFilter,
+) (coredata.CookieConsentRecords, error) {
+	var records coredata.CookieConsentRecords
+
+	err := c.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			if err := records.LoadByCookieBannerID(ctx, conn, scope, bannerID, cursor, filter); err != nil {
+				return fmt.Errorf("cannot list consent records: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return records, nil
+}
+
+func (c *Client) CountCookieConsentRecordsForBanner(
+	ctx context.Context,
+	scope coredata.Scoper,
+	bannerID gid.GID,
+	filter *coredata.CookieConsentRecordFilter,
+) (int, error) {
+	var count int
+
+	err := c.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			var records coredata.CookieConsentRecords
+			var err error
+
+			count, err = records.CountByCookieBannerID(ctx, conn, scope, bannerID, filter)
+			if err != nil {
+				return fmt.Errorf("cannot count consent records: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
 }

--- a/pkg/cookiebanner/errors.go
+++ b/pkg/cookiebanner/errors.go
@@ -17,10 +17,10 @@ package cookiebanner
 import "errors"
 
 var (
-	ErrBannerNotFound              = errors.New("cookie banner not found")
-	ErrCategoryNotFound            = errors.New("cookie category not found")
-	ErrBannerNotDraft              = errors.New("cookie banner is not in draft state")
-	ErrBannerAlreadyPublished      = errors.New("cookie banner is already published")
-	ErrBannerAlreadyDisabled       = errors.New("cookie banner is already disabled")
+	ErrBannerNotFound               = errors.New("cookie banner not found")
+	ErrCategoryNotFound             = errors.New("cookie category not found")
+	ErrBannerNotDraft               = errors.New("cookie banner is not in draft state")
+	ErrBannerAlreadyPublished       = errors.New("cookie banner is already published")
+	ErrBannerAlreadyDisabled        = errors.New("cookie banner is already disabled")
 	ErrCannotDeleteRequiredCategory = errors.New("cannot delete required cookie category")
 )

--- a/pkg/cookiebanner/errors.go
+++ b/pkg/cookiebanner/errors.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package cookiebanner
+
+import "errors"
+
+var (
+	ErrBannerNotFound              = errors.New("cookie banner not found")
+	ErrCategoryNotFound            = errors.New("cookie category not found")
+	ErrBannerNotDraft              = errors.New("cookie banner is not in draft state")
+	ErrBannerAlreadyPublished      = errors.New("cookie banner is already published")
+	ErrBannerAlreadyDisabled       = errors.New("cookie banner is already disabled")
+	ErrCannotDeleteRequiredCategory = errors.New("cannot delete required cookie category")
+)

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -28,12 +28,12 @@ import (
 	"go.probo.inc/probo/pkg/validator"
 )
 
-type Client struct {
+type Service struct {
 	pg *pg.Client
 }
 
-func NewClient(pgClient *pg.Client) *Client {
-	return &Client{pg: pgClient}
+func NewService(pgClient *pg.Client) *Service {
+	return &Service{pg: pgClient}
 }
 
 var defaultCategories = []struct {
@@ -152,7 +152,7 @@ func (r *CreateCookieConsentRecordRequest) Validate() error {
 	return v.Error()
 }
 
-func (c *Client) CreateCookieBanner(
+func (s *Service) CreateCookieBanner(
 	ctx context.Context,
 	scope coredata.Scoper,
 	req CreateCookieBannerRequest,
@@ -163,7 +163,7 @@ func (c *Client) CreateCookieBanner(
 
 	var banner *coredata.CookieBanner
 
-	err := c.pg.WithTx(
+	err := s.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			now := time.Now()
@@ -213,14 +213,14 @@ func (c *Client) CreateCookieBanner(
 	return banner, nil
 }
 
-func (c *Client) GetCookieBanner(
+func (s *Service) GetCookieBanner(
 	ctx context.Context,
 	scope coredata.Scoper,
 	bannerID gid.GID,
 ) (*coredata.CookieBanner, error) {
 	var banner coredata.CookieBanner
 
-	err := c.pg.WithConn(
+	err := s.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			if err := banner.LoadByID(ctx, conn, scope, bannerID); err != nil {
@@ -240,7 +240,7 @@ func (c *Client) GetCookieBanner(
 	return &banner, nil
 }
 
-func (c *Client) ListCookieBannersForOrganization(
+func (s *Service) ListCookieBannersForOrganization(
 	ctx context.Context,
 	scope coredata.Scoper,
 	organizationID gid.GID,
@@ -249,7 +249,7 @@ func (c *Client) ListCookieBannersForOrganization(
 ) (coredata.CookieBanners, error) {
 	var banners coredata.CookieBanners
 
-	err := c.pg.WithConn(
+	err := s.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			if err := banners.LoadByOrganizationID(ctx, conn, scope, organizationID, cursor, filter); err != nil {
@@ -266,7 +266,7 @@ func (c *Client) ListCookieBannersForOrganization(
 	return banners, nil
 }
 
-func (c *Client) CountCookieBannersForOrganization(
+func (s *Service) CountCookieBannersForOrganization(
 	ctx context.Context,
 	scope coredata.Scoper,
 	organizationID gid.GID,
@@ -274,7 +274,7 @@ func (c *Client) CountCookieBannersForOrganization(
 ) (int, error) {
 	var count int
 
-	err := c.pg.WithConn(
+	err := s.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			var banners coredata.CookieBanners
@@ -295,7 +295,7 @@ func (c *Client) CountCookieBannersForOrganization(
 	return count, nil
 }
 
-func (c *Client) UpdateCookieBanner(
+func (s *Service) UpdateCookieBanner(
 	ctx context.Context,
 	scope coredata.Scoper,
 	req UpdateCookieBannerRequest,
@@ -306,7 +306,7 @@ func (c *Client) UpdateCookieBanner(
 
 	var banner coredata.CookieBanner
 
-	err := c.pg.WithTx(
+	err := s.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			if err := banner.LoadByID(ctx, tx, scope, req.CookieBannerID); err != nil {
@@ -353,14 +353,14 @@ func (c *Client) UpdateCookieBanner(
 	return &banner, nil
 }
 
-func (c *Client) PublishCookieBanner(
+func (s *Service) PublishCookieBanner(
 	ctx context.Context,
 	scope coredata.Scoper,
 	bannerID gid.GID,
 ) (*coredata.CookieBanner, error) {
 	var banner coredata.CookieBanner
 
-	err := c.pg.WithTx(
+	err := s.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			if err := banner.LoadByID(ctx, tx, scope, bannerID); err != nil {
@@ -391,14 +391,14 @@ func (c *Client) PublishCookieBanner(
 	return &banner, nil
 }
 
-func (c *Client) DisableCookieBanner(
+func (s *Service) DisableCookieBanner(
 	ctx context.Context,
 	scope coredata.Scoper,
 	bannerID gid.GID,
 ) (*coredata.CookieBanner, error) {
 	var banner coredata.CookieBanner
 
-	err := c.pg.WithTx(
+	err := s.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			if err := banner.LoadByID(ctx, tx, scope, bannerID); err != nil {
@@ -429,12 +429,12 @@ func (c *Client) DisableCookieBanner(
 	return &banner, nil
 }
 
-func (c *Client) DeleteCookieBanner(
+func (s *Service) DeleteCookieBanner(
 	ctx context.Context,
 	scope coredata.Scoper,
 	bannerID gid.GID,
 ) error {
-	return c.pg.WithTx(
+	return s.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			var banner coredata.CookieBanner
@@ -458,7 +458,7 @@ func (c *Client) DeleteCookieBanner(
 	)
 }
 
-func (c *Client) CreateCookieCategory(
+func (s *Service) CreateCookieCategory(
 	ctx context.Context,
 	scope coredata.Scoper,
 	req CreateCookieCategoryRequest,
@@ -469,7 +469,7 @@ func (c *Client) CreateCookieCategory(
 
 	var category *coredata.CookieCategory
 
-	err := c.pg.WithTx(
+	err := s.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			now := time.Now()
@@ -505,14 +505,14 @@ func (c *Client) CreateCookieCategory(
 	return category, nil
 }
 
-func (c *Client) GetCookieCategory(
+func (s *Service) GetCookieCategory(
 	ctx context.Context,
 	scope coredata.Scoper,
 	categoryID gid.GID,
 ) (*coredata.CookieCategory, error) {
 	var category coredata.CookieCategory
 
-	err := c.pg.WithConn(
+	err := s.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			if err := category.LoadByID(ctx, conn, scope, categoryID); err != nil {
@@ -532,7 +532,7 @@ func (c *Client) GetCookieCategory(
 	return &category, nil
 }
 
-func (c *Client) ListCookieCategoriesForBanner(
+func (s *Service) ListCookieCategoriesForBanner(
 	ctx context.Context,
 	scope coredata.Scoper,
 	bannerID gid.GID,
@@ -540,7 +540,7 @@ func (c *Client) ListCookieCategoriesForBanner(
 ) (coredata.CookieCategories, error) {
 	var categories coredata.CookieCategories
 
-	err := c.pg.WithConn(
+	err := s.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			if err := categories.LoadByCookieBannerID(ctx, conn, scope, bannerID, cursor); err != nil {
@@ -557,14 +557,14 @@ func (c *Client) ListCookieCategoriesForBanner(
 	return categories, nil
 }
 
-func (c *Client) CountCookieCategoriesForBanner(
+func (s *Service) CountCookieCategoriesForBanner(
 	ctx context.Context,
 	scope coredata.Scoper,
 	bannerID gid.GID,
 ) (int, error) {
 	var count int
 
-	err := c.pg.WithConn(
+	err := s.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			var categories coredata.CookieCategories
@@ -585,7 +585,7 @@ func (c *Client) CountCookieCategoriesForBanner(
 	return count, nil
 }
 
-func (c *Client) UpdateCookieCategory(
+func (s *Service) UpdateCookieCategory(
 	ctx context.Context,
 	scope coredata.Scoper,
 	req UpdateCookieCategoryRequest,
@@ -596,7 +596,7 @@ func (c *Client) UpdateCookieCategory(
 
 	var category coredata.CookieCategory
 
-	err := c.pg.WithTx(
+	err := s.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			if err := category.LoadByID(ctx, tx, scope, req.CookieCategoryID); err != nil {
@@ -635,12 +635,12 @@ func (c *Client) UpdateCookieCategory(
 	return &category, nil
 }
 
-func (c *Client) DeleteCookieCategory(
+func (s *Service) DeleteCookieCategory(
 	ctx context.Context,
 	scope coredata.Scoper,
 	categoryID gid.GID,
 ) error {
-	return c.pg.WithTx(
+	return s.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			var category coredata.CookieCategory
@@ -664,7 +664,7 @@ func (c *Client) DeleteCookieCategory(
 	)
 }
 
-func (c *Client) CreateCookieConsentRecord(
+func (s *Service) CreateCookieConsentRecord(
 	ctx context.Context,
 	scope coredata.Scoper,
 	req CreateCookieConsentRecordRequest,
@@ -675,7 +675,7 @@ func (c *Client) CreateCookieConsentRecord(
 
 	var record *coredata.CookieConsentRecord
 
-	err := c.pg.WithTx(
+	err := s.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			record = &coredata.CookieConsentRecord{
@@ -703,7 +703,7 @@ func (c *Client) CreateCookieConsentRecord(
 	return record, nil
 }
 
-func (c *Client) ListCookieConsentRecordsForBanner(
+func (s *Service) ListCookieConsentRecordsForBanner(
 	ctx context.Context,
 	scope coredata.Scoper,
 	bannerID gid.GID,
@@ -712,7 +712,7 @@ func (c *Client) ListCookieConsentRecordsForBanner(
 ) (coredata.CookieConsentRecords, error) {
 	var records coredata.CookieConsentRecords
 
-	err := c.pg.WithConn(
+	err := s.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			if err := records.LoadByCookieBannerID(ctx, conn, scope, bannerID, cursor, filter); err != nil {
@@ -729,7 +729,7 @@ func (c *Client) ListCookieConsentRecordsForBanner(
 	return records, nil
 }
 
-func (c *Client) CountCookieConsentRecordsForBanner(
+func (s *Service) CountCookieConsentRecordsForBanner(
 	ctx context.Context,
 	scope coredata.Scoper,
 	bannerID gid.GID,
@@ -737,7 +737,7 @@ func (c *Client) CountCookieConsentRecordsForBanner(
 ) (int, error) {
 	var count int
 
-	err := c.pg.WithConn(
+	err := s.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			var records coredata.CookieConsentRecords

--- a/pkg/coredata/cookie_banner.go
+++ b/pkg/coredata/cookie_banner.go
@@ -170,6 +170,7 @@ func (b *CookieBanners) LoadByOrganizationID(
 	scope Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[CookieBannerOrderField],
+	filter *CookieBannerFilter,
 ) error {
 	q := `
 SELECT
@@ -189,12 +190,14 @@ WHERE
 	%s
 	AND organization_id = @organization_id
 	AND %s
+	AND %s
 `
 
-	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+	q = fmt.Sprintf(q, scope.SQLFragment(), filter.SQLFragment(), cursor.SQLFragment())
 
 	args := pgx.StrictNamedArgs{"organization_id": organizationID}
 	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, filter.SQLArguments())
 	maps.Copy(args, cursor.SQLArguments())
 
 	rows, err := conn.Query(ctx, q, args)
@@ -217,6 +220,7 @@ func (b *CookieBanners) CountByOrganizationID(
 	conn pg.Querier,
 	scope Scoper,
 	organizationID gid.GID,
+	filter *CookieBannerFilter,
 ) (int, error) {
 	q := `
 SELECT
@@ -226,12 +230,14 @@ FROM
 WHERE
 	%s
 	AND organization_id = @organization_id
+	AND %s
 `
 
-	q = fmt.Sprintf(q, scope.SQLFragment())
+	q = fmt.Sprintf(q, scope.SQLFragment(), filter.SQLFragment())
 
 	args := pgx.StrictNamedArgs{"organization_id": organizationID}
 	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, filter.SQLArguments())
 
 	row := conn.QueryRow(ctx, q, args)
 

--- a/pkg/coredata/cookie_banner.go
+++ b/pkg/coredata/cookie_banner.go
@@ -1,0 +1,366 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/page"
+)
+
+type (
+	CookieBanner struct {
+		ID                gid.GID           `db:"id"`
+		OrganizationID    gid.GID           `db:"organization_id"`
+		Name              string            `db:"name"`
+		Origin            string            `db:"origin"`
+		State             CookieBannerState `db:"state"`
+		PrivacyPolicyURL  string            `db:"privacy_policy_url"`
+		ConsentExpiryDays int               `db:"consent_expiry_days"`
+		ConsentMode       CookieConsentMode `db:"consent_mode"`
+		CreatedAt         time.Time         `db:"created_at"`
+		UpdatedAt         time.Time         `db:"updated_at"`
+	}
+
+	CookieBanners []*CookieBanner
+)
+
+func (b *CookieBanner) CursorKey(field CookieBannerOrderField) page.CursorKey {
+	switch field {
+	case CookieBannerOrderFieldCreatedAt:
+		return page.NewCursorKey(b.ID, b.CreatedAt)
+	}
+
+	panic(fmt.Sprintf("unsupported order by: %s", field))
+}
+
+func (b *CookieBanner) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
+	q := `SELECT organization_id FROM cookie_banners WHERE id = $1 LIMIT 1;`
+
+	var organizationID gid.GID
+	if err := conn.QueryRow(ctx, q, b.ID).Scan(&organizationID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrResourceNotFound
+		}
+
+		return nil, fmt.Errorf("cannot query cookie banner authorization attributes: %w", err)
+	}
+
+	return map[string]string{"organization_id": organizationID.String()}, nil
+}
+
+func (b *CookieBanner) LoadByID(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	bannerID gid.GID,
+) error {
+	q := `
+SELECT
+	id,
+	organization_id,
+	name,
+	origin,
+	state,
+	privacy_policy_url,
+	consent_expiry_days,
+	consent_mode,
+	created_at,
+	updated_at
+FROM
+	cookie_banners
+WHERE
+	%s
+	AND id = @banner_id
+LIMIT 1;
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"banner_id": bannerID}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query cookie banners: %w", err)
+	}
+
+	banner, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[CookieBanner])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrResourceNotFound
+		}
+
+		return fmt.Errorf("cannot collect cookie banner: %w", err)
+	}
+
+	*b = banner
+
+	return nil
+}
+
+func (b *CookieBanner) LoadPublishedByID(
+	ctx context.Context,
+	conn pg.Querier,
+	bannerID gid.GID,
+) error {
+	q := `
+SELECT
+	id,
+	organization_id,
+	name,
+	origin,
+	state,
+	privacy_policy_url,
+	consent_expiry_days,
+	consent_mode,
+	created_at,
+	updated_at
+FROM
+	cookie_banners
+WHERE
+	id = @banner_id
+	AND state = 'PUBLISHED'
+LIMIT 1;
+`
+
+	args := pgx.StrictNamedArgs{"banner_id": bannerID}
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query cookie banners: %w", err)
+	}
+
+	banner, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[CookieBanner])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrResourceNotFound
+		}
+
+		return fmt.Errorf("cannot collect cookie banner: %w", err)
+	}
+
+	*b = banner
+
+	return nil
+}
+
+func (b *CookieBanners) LoadByOrganizationID(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	organizationID gid.GID,
+	cursor *page.Cursor[CookieBannerOrderField],
+) error {
+	q := `
+SELECT
+	id,
+	organization_id,
+	name,
+	origin,
+	state,
+	privacy_policy_url,
+	consent_expiry_days,
+	consent_mode,
+	created_at,
+	updated_at
+FROM
+	cookie_banners
+WHERE
+	%s
+	AND organization_id = @organization_id
+	AND %s
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, cursor.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query cookie banners: %w", err)
+	}
+
+	banners, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[CookieBanner])
+	if err != nil {
+		return fmt.Errorf("cannot collect cookie banners: %w", err)
+	}
+
+	*b = banners
+
+	return nil
+}
+
+func (b *CookieBanners) CountByOrganizationID(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	organizationID gid.GID,
+) (int, error) {
+	q := `
+SELECT
+	COUNT(id)
+FROM
+	cookie_banners
+WHERE
+	%s
+	AND organization_id = @organization_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"organization_id": organizationID}
+	maps.Copy(args, scope.SQLArguments())
+
+	row := conn.QueryRow(ctx, q, args)
+
+	var count int
+	if err := row.Scan(&count); err != nil {
+		return 0, fmt.Errorf("cannot scan count: %w", err)
+	}
+
+	return count, nil
+}
+
+func (b *CookieBanner) Insert(
+	ctx context.Context,
+	tx pg.Tx,
+	scope Scoper,
+) error {
+	q := `
+INSERT INTO cookie_banners (
+	id,
+	tenant_id,
+	organization_id,
+	name,
+	origin,
+	state,
+	privacy_policy_url,
+	consent_expiry_days,
+	consent_mode,
+	created_at,
+	updated_at
+) VALUES (
+	@id,
+	@tenant_id,
+	@organization_id,
+	@name,
+	@origin,
+	@state,
+	@privacy_policy_url,
+	@consent_expiry_days,
+	@consent_mode,
+	@created_at,
+	@updated_at
+)
+`
+
+	args := pgx.StrictNamedArgs{
+		"id":                  b.ID,
+		"tenant_id":           scope.GetTenantID(),
+		"organization_id":     b.OrganizationID,
+		"name":                b.Name,
+		"origin":              b.Origin,
+		"state":               b.State,
+		"privacy_policy_url":  b.PrivacyPolicyURL,
+		"consent_expiry_days": b.ConsentExpiryDays,
+		"consent_mode":        b.ConsentMode,
+		"created_at":          b.CreatedAt,
+		"updated_at":          b.UpdatedAt,
+	}
+
+	_, err := tx.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot insert cookie banner: %w", err)
+	}
+
+	return nil
+}
+
+func (b *CookieBanner) Update(
+	ctx context.Context,
+	tx pg.Tx,
+	scope Scoper,
+) error {
+	q := `
+UPDATE cookie_banners
+SET
+	name = @name,
+	origin = @origin,
+	state = @state,
+	privacy_policy_url = @privacy_policy_url,
+	consent_expiry_days = @consent_expiry_days,
+	consent_mode = @consent_mode,
+	updated_at = @updated_at
+WHERE
+	%s
+	AND id = @id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"id":                  b.ID,
+		"name":                b.Name,
+		"origin":              b.Origin,
+		"state":               b.State,
+		"privacy_policy_url":  b.PrivacyPolicyURL,
+		"consent_expiry_days": b.ConsentExpiryDays,
+		"consent_mode":        b.ConsentMode,
+		"updated_at":          b.UpdatedAt,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := tx.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot update cookie banner: %w", err)
+	}
+
+	return nil
+}
+
+func (b *CookieBanner) Delete(
+	ctx context.Context,
+	tx pg.Tx,
+	scope Scoper,
+) error {
+	q := `
+DELETE FROM cookie_banners
+WHERE
+	%s
+	AND id = @id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"id": b.ID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := tx.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete cookie banner: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/cookie_banner.go
+++ b/pkg/coredata/cookie_banner.go
@@ -338,9 +338,13 @@ WHERE
 	}
 	maps.Copy(args, scope.SQLArguments())
 
-	_, err := tx.Exec(ctx, q, args)
+	result, err := tx.Exec(ctx, q, args)
 	if err != nil {
 		return fmt.Errorf("cannot update cookie banner: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return ErrResourceNotFound
 	}
 
 	return nil

--- a/pkg/coredata/cookie_banner_filter.go
+++ b/pkg/coredata/cookie_banner_filter.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import "github.com/jackc/pgx/v5"
+
+type CookieBannerFilter struct {
+	state *CookieBannerState
+}
+
+func NewCookieBannerFilter(state *CookieBannerState) *CookieBannerFilter {
+	return &CookieBannerFilter{
+		state: state,
+	}
+}
+
+func (f *CookieBannerFilter) SQLFragment() string {
+	return `
+(
+	CASE
+		WHEN @filter_state::text IS NOT NULL THEN
+			state = @filter_state::cookie_banner_state
+		ELSE TRUE
+	END
+)`
+}
+
+func (f *CookieBannerFilter) SQLArguments() pgx.StrictNamedArgs {
+	args := pgx.StrictNamedArgs{
+		"filter_state": nil,
+	}
+
+	if f.state != nil {
+		args["filter_state"] = string(*f.state)
+	}
+
+	return args
+}

--- a/pkg/coredata/cookie_banner_order_field.go
+++ b/pkg/coredata/cookie_banner_order_field.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import "fmt"
+
+type CookieBannerOrderField string
+
+const (
+	CookieBannerOrderFieldCreatedAt CookieBannerOrderField = "CREATED_AT"
+)
+
+func (p CookieBannerOrderField) Column() string {
+	switch p {
+	case CookieBannerOrderFieldCreatedAt:
+		return "created_at"
+	}
+	panic(fmt.Sprintf("unsupported order by: %s", p))
+}
+
+func (p CookieBannerOrderField) IsValid() bool {
+	switch p {
+	case CookieBannerOrderFieldCreatedAt:
+		return true
+	}
+	return false
+}
+
+func (p CookieBannerOrderField) String() string {
+	return string(p)
+}
+
+func (p *CookieBannerOrderField) UnmarshalText(text []byte) error {
+	*p = CookieBannerOrderField(text)
+	if !p.IsValid() {
+		return fmt.Errorf("%s is not a valid CookieBannerOrderField", string(text))
+	}
+	return nil
+}
+
+func (p CookieBannerOrderField) MarshalText() ([]byte, error) {
+	return []byte(p.String()), nil
+}

--- a/pkg/coredata/cookie_banner_state.go
+++ b/pkg/coredata/cookie_banner_state.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+type CookieBannerState string
+
+const (
+	CookieBannerStateDraft     CookieBannerState = "DRAFT"
+	CookieBannerStatePublished CookieBannerState = "PUBLISHED"
+	CookieBannerStateDisabled  CookieBannerState = "DISABLED"
+)
+
+func CookieBannerStates() []CookieBannerState {
+	return []CookieBannerState{
+		CookieBannerStateDraft,
+		CookieBannerStatePublished,
+		CookieBannerStateDisabled,
+	}
+}
+
+func (s CookieBannerState) String() string {
+	return string(s)
+}
+
+func (s *CookieBannerState) Scan(value any) error {
+	var v string
+	switch val := value.(type) {
+	case string:
+		v = val
+	case []byte:
+		v = string(val)
+	default:
+		return fmt.Errorf("unsupported type for CookieBannerState: %T", value)
+	}
+
+	switch CookieBannerState(v) {
+	case CookieBannerStateDraft:
+		*s = CookieBannerStateDraft
+	case CookieBannerStatePublished:
+		*s = CookieBannerStatePublished
+	case CookieBannerStateDisabled:
+		*s = CookieBannerStateDisabled
+	default:
+		return fmt.Errorf("invalid CookieBannerState value: %q", v)
+	}
+	return nil
+}
+
+func (s CookieBannerState) Value() (driver.Value, error) {
+	switch s {
+	case CookieBannerStateDraft,
+		CookieBannerStatePublished,
+		CookieBannerStateDisabled:
+		return string(s), nil
+	default:
+		return nil, fmt.Errorf("invalid CookieBannerState: %s", s)
+	}
+}

--- a/pkg/coredata/cookie_category.go
+++ b/pkg/coredata/cookie_category.go
@@ -1,0 +1,396 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/page"
+)
+
+type (
+	CookieItem struct {
+		Name        string `json:"name"`
+		Duration    string `json:"duration"`
+		Description string `json:"description"`
+	}
+
+	CookieItems []CookieItem
+
+	CookieCategory struct {
+		ID             gid.GID     `db:"id"`
+		CookieBannerID gid.GID     `db:"cookie_banner_id"`
+		Name           string      `db:"name"`
+		Description    string      `db:"description"`
+		Required       bool        `db:"required"`
+		Rank           int         `db:"rank"`
+		Cookies        CookieItems `db:"cookies"`
+		CreatedAt      time.Time   `db:"created_at"`
+		UpdatedAt      time.Time   `db:"updated_at"`
+	}
+
+	CookieCategories []*CookieCategory
+)
+
+func (c CookieItems) MarshalJSON() ([]byte, error) {
+	if c == nil {
+		return []byte("[]"), nil
+	}
+	return json.Marshal([]CookieItem(c))
+}
+
+func (c *CookieItems) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || string(data) == "null" {
+		*c = CookieItems{}
+		return nil
+	}
+	return json.Unmarshal(data, (*[]CookieItem)(c))
+}
+
+func (c *CookieCategory) CursorKey(field CookieCategoryOrderField) page.CursorKey {
+	switch field {
+	case CookieCategoryOrderFieldRank:
+		return page.NewCursorKey(c.ID, c.Rank)
+	}
+
+	panic(fmt.Sprintf("unsupported order by: %s", field))
+}
+
+func (c *CookieCategory) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
+	q := `
+SELECT cb.organization_id
+FROM cookie_categories cc
+JOIN cookie_banners cb ON cc.cookie_banner_id = cb.id
+WHERE cc.id = $1
+LIMIT 1;
+`
+
+	var organizationID gid.GID
+	if err := conn.QueryRow(ctx, q, c.ID).Scan(&organizationID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrResourceNotFound
+		}
+		return nil, fmt.Errorf("cannot query cookie category authorization attributes: %w", err)
+	}
+
+	return map[string]string{"organization_id": organizationID.String()}, nil
+}
+
+func (c *CookieCategory) LoadByID(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	categoryID gid.GID,
+) error {
+	q := `
+SELECT
+	id,
+	cookie_banner_id,
+	name,
+	description,
+	required,
+	rank,
+	cookies,
+	created_at,
+	updated_at
+FROM
+	cookie_categories
+WHERE
+	%s
+	AND id = @category_id
+LIMIT 1;
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"category_id": categoryID}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query cookie categories: %w", err)
+	}
+
+	category, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[CookieCategory])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrResourceNotFound
+		}
+		return fmt.Errorf("cannot collect cookie category: %w", err)
+	}
+
+	*c = category
+
+	return nil
+}
+
+func (c *CookieCategories) LoadByCookieBannerID(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	cookieBannerID gid.GID,
+	cursor *page.Cursor[CookieCategoryOrderField],
+) error {
+	q := `
+SELECT
+	id,
+	cookie_banner_id,
+	name,
+	description,
+	required,
+	rank,
+	cookies,
+	created_at,
+	updated_at
+FROM
+	cookie_categories
+WHERE
+	%s
+	AND cookie_banner_id = @cookie_banner_id
+	AND %s
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"cookie_banner_id": cookieBannerID}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, cursor.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query cookie categories: %w", err)
+	}
+
+	categories, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[CookieCategory])
+	if err != nil {
+		return fmt.Errorf("cannot collect cookie categories: %w", err)
+	}
+
+	*c = categories
+
+	return nil
+}
+
+func (c *CookieCategories) CountByCookieBannerID(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	cookieBannerID gid.GID,
+) (int, error) {
+	q := `
+SELECT
+	COUNT(id)
+FROM
+	cookie_categories
+WHERE
+	%s
+	AND cookie_banner_id = @cookie_banner_id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"cookie_banner_id": cookieBannerID}
+	maps.Copy(args, scope.SQLArguments())
+
+	row := conn.QueryRow(ctx, q, args)
+
+	var count int
+	if err := row.Scan(&count); err != nil {
+		return 0, fmt.Errorf("cannot scan count: %w", err)
+	}
+
+	return count, nil
+}
+
+func (c *CookieCategories) LoadAllPublicByCookieBannerID(
+	ctx context.Context,
+	conn pg.Querier,
+	cookieBannerID gid.GID,
+) error {
+	q := `
+SELECT
+	id,
+	cookie_banner_id,
+	name,
+	description,
+	required,
+	rank,
+	cookies,
+	created_at,
+	updated_at
+FROM
+	cookie_categories
+WHERE
+	cookie_banner_id = @cookie_banner_id
+ORDER BY
+	rank ASC, id ASC;
+`
+
+	args := pgx.StrictNamedArgs{"cookie_banner_id": cookieBannerID}
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query cookie categories: %w", err)
+	}
+
+	categories, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[CookieCategory])
+	if err != nil {
+		return fmt.Errorf("cannot collect cookie categories: %w", err)
+	}
+
+	*c = categories
+
+	return nil
+}
+
+func (c *CookieCategory) Insert(
+	ctx context.Context,
+	tx pg.Tx,
+	scope Scoper,
+) error {
+	q := `
+INSERT INTO cookie_categories (
+	id,
+	tenant_id,
+	cookie_banner_id,
+	name,
+	description,
+	required,
+	rank,
+	cookies,
+	created_at,
+	updated_at
+) VALUES (
+	@id,
+	@tenant_id,
+	@cookie_banner_id,
+	@name,
+	@description,
+	@required,
+	@rank,
+	@cookies,
+	@created_at,
+	@updated_at
+)
+`
+
+	args := pgx.StrictNamedArgs{
+		"id":               c.ID,
+		"tenant_id":        scope.GetTenantID(),
+		"cookie_banner_id": c.CookieBannerID,
+		"name":             c.Name,
+		"description":      c.Description,
+		"required":         c.Required,
+		"rank":             c.Rank,
+		"cookies":          c.Cookies,
+		"created_at":       c.CreatedAt,
+		"updated_at":       c.UpdatedAt,
+	}
+
+	_, err := tx.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot insert cookie category: %w", err)
+	}
+
+	return nil
+}
+
+func (c *CookieCategory) Update(
+	ctx context.Context,
+	tx pg.Tx,
+	scope Scoper,
+) error {
+	q := `
+UPDATE cookie_categories
+SET
+	name = @name,
+	description = @description,
+	rank = @rank,
+	cookies = @cookies,
+	updated_at = @updated_at
+WHERE
+	%s
+	AND id = @id
+RETURNING
+	id,
+	cookie_banner_id,
+	name,
+	description,
+	required,
+	rank,
+	cookies,
+	created_at,
+	updated_at
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"id":          c.ID,
+		"name":        c.Name,
+		"description": c.Description,
+		"rank":        c.Rank,
+		"cookies":     c.Cookies,
+		"updated_at":  c.UpdatedAt,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := tx.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot update cookie category: %w", err)
+	}
+
+	category, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[CookieCategory])
+	if err != nil {
+		return fmt.Errorf("cannot collect updated cookie category: %w", err)
+	}
+
+	*c = category
+
+	return nil
+}
+
+func (c *CookieCategory) Delete(
+	ctx context.Context,
+	tx pg.Tx,
+	scope Scoper,
+) error {
+	q := `
+DELETE FROM cookie_categories
+WHERE
+	%s
+	AND id = @id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"id": c.ID}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := tx.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete cookie category: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/cookie_category_order_field.go
+++ b/pkg/coredata/cookie_category_order_field.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import "fmt"
+
+type CookieCategoryOrderField string
+
+const (
+	CookieCategoryOrderFieldRank CookieCategoryOrderField = "RANK"
+)
+
+func (p CookieCategoryOrderField) Column() string {
+	switch p {
+	case CookieCategoryOrderFieldRank:
+		return "rank"
+	}
+	panic(fmt.Sprintf("unsupported order by: %s", p))
+}
+
+func (p CookieCategoryOrderField) IsValid() bool {
+	switch p {
+	case CookieCategoryOrderFieldRank:
+		return true
+	}
+	return false
+}
+
+func (p CookieCategoryOrderField) String() string {
+	return string(p)
+}
+
+func (p *CookieCategoryOrderField) UnmarshalText(text []byte) error {
+	*p = CookieCategoryOrderField(text)
+	if !p.IsValid() {
+		return fmt.Errorf("%s is not a valid CookieCategoryOrderField", string(text))
+	}
+	return nil
+}
+
+func (p CookieCategoryOrderField) MarshalText() ([]byte, error) {
+	return []byte(p.String()), nil
+}

--- a/pkg/coredata/cookie_consent_action.go
+++ b/pkg/coredata/cookie_consent_action.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+type CookieConsentAction string
+
+const (
+	CookieConsentActionAcceptAll CookieConsentAction = "ACCEPT_ALL"
+	CookieConsentActionRejectAll CookieConsentAction = "REJECT_ALL"
+	CookieConsentActionCustomize CookieConsentAction = "CUSTOMIZE"
+	// Global Privacy Control
+	CookieConsentActionGPC CookieConsentAction = "GPC"
+)
+
+func CookieConsentActions() []CookieConsentAction {
+	return []CookieConsentAction{
+		CookieConsentActionAcceptAll,
+		CookieConsentActionRejectAll,
+		CookieConsentActionCustomize,
+		CookieConsentActionGPC,
+	}
+}
+
+func (a CookieConsentAction) String() string {
+	return string(a)
+}
+
+func (a *CookieConsentAction) Scan(value any) error {
+	var v string
+	switch val := value.(type) {
+	case string:
+		v = val
+	case []byte:
+		v = string(val)
+	default:
+		return fmt.Errorf("unsupported type for CookieConsentAction: %T", value)
+	}
+
+	switch CookieConsentAction(v) {
+	case CookieConsentActionAcceptAll:
+		*a = CookieConsentActionAcceptAll
+	case CookieConsentActionRejectAll:
+		*a = CookieConsentActionRejectAll
+	case CookieConsentActionCustomize:
+		*a = CookieConsentActionCustomize
+	case CookieConsentActionGPC:
+		*a = CookieConsentActionGPC
+	default:
+		return fmt.Errorf("invalid CookieConsentAction value: %q", v)
+	}
+
+	return nil
+}
+
+func (a CookieConsentAction) Value() (driver.Value, error) {
+	switch a {
+	case CookieConsentActionAcceptAll,
+		CookieConsentActionRejectAll,
+		CookieConsentActionCustomize,
+		CookieConsentActionGPC:
+		return string(a), nil
+	default:
+		return nil, fmt.Errorf("invalid CookieConsentAction: %s", a)
+	}
+}

--- a/pkg/coredata/cookie_consent_mode.go
+++ b/pkg/coredata/cookie_consent_mode.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+type CookieConsentMode string
+
+const (
+	CookieConsentModeOptIn  CookieConsentMode = "OPT_IN"
+	CookieConsentModeOptOut CookieConsentMode = "OPT_OUT"
+)
+
+func CookieConsentModes() []CookieConsentMode {
+	return []CookieConsentMode{
+		CookieConsentModeOptIn,
+		CookieConsentModeOptOut,
+	}
+}
+
+func (m CookieConsentMode) String() string {
+	return string(m)
+}
+
+func (m *CookieConsentMode) Scan(value any) error {
+	var v string
+	switch val := value.(type) {
+	case string:
+		v = val
+	case []byte:
+		v = string(val)
+	default:
+		return fmt.Errorf("unsupported type for CookieConsentMode: %T", value)
+	}
+
+	switch CookieConsentMode(v) {
+	case CookieConsentModeOptIn:
+		*m = CookieConsentModeOptIn
+	case CookieConsentModeOptOut:
+		*m = CookieConsentModeOptOut
+	default:
+		return fmt.Errorf("invalid CookieConsentMode value: %q", v)
+	}
+
+	return nil
+}
+
+func (m CookieConsentMode) Value() (driver.Value, error) {
+	switch m {
+	case CookieConsentModeOptIn,
+		CookieConsentModeOptOut:
+		return string(m), nil
+	default:
+		return nil, fmt.Errorf("invalid CookieConsentMode: %s", m)
+	}
+}

--- a/pkg/coredata/cookie_consent_record.go
+++ b/pkg/coredata/cookie_consent_record.go
@@ -1,0 +1,205 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/page"
+)
+
+type (
+	ConsentRecord struct {
+		ID             gid.GID             `db:"id"`
+		CookieBannerID gid.GID             `db:"cookie_banner_id"`
+		VisitorID      string              `db:"visitor_id"`
+		IPAddress      *string             `db:"ip_address"`
+		UserAgent      *string             `db:"user_agent"`
+		ConsentData    json.RawMessage     `db:"consent_data"`
+		Action         CookieConsentAction `db:"action"`
+		CreatedAt      time.Time           `db:"created_at"`
+	}
+
+	ConsentRecords []*ConsentRecord
+)
+
+func (r *ConsentRecord) CursorKey(field CookieConsentRecordOrderField) page.CursorKey {
+	switch field {
+	case CookieConsentRecordOrderFieldCreatedAt:
+		return page.NewCursorKey(r.ID, r.CreatedAt)
+	}
+
+	panic(fmt.Sprintf("unsupported order by: %s", field))
+}
+
+func (r *ConsentRecord) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
+	q := `
+SELECT cb.organization_id
+FROM cookie_consent_records cr
+JOIN cookie_banners cb ON cr.cookie_banner_id = cb.id
+WHERE cr.id = $1
+LIMIT 1;
+`
+
+	var organizationID gid.GID
+	if err := conn.QueryRow(ctx, q, r.ID).Scan(&organizationID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrResourceNotFound
+		}
+		return nil, fmt.Errorf("cannot query consent record authorization attributes: %w", err)
+	}
+
+	return map[string]string{"organization_id": organizationID.String()}, nil
+}
+
+func (r *ConsentRecords) LoadByCookieBannerID(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	cookieBannerID gid.GID,
+	cursor *page.Cursor[CookieConsentRecordOrderField],
+	filter *CookieConsentRecordFilter,
+) error {
+	q := `
+SELECT
+	id,
+	cookie_banner_id,
+	visitor_id,
+	ip_address,
+	user_agent,
+	consent_data,
+	action,
+	created_at
+FROM
+	cookie_consent_records
+WHERE
+	%s
+	AND cookie_banner_id = @cookie_banner_id
+	AND %s
+	AND %s
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment(), filter.SQLFragment(), cursor.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"cookie_banner_id": cookieBannerID}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, filter.SQLArguments())
+	maps.Copy(args, cursor.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query consent records: %w", err)
+	}
+
+	records, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[ConsentRecord])
+	if err != nil {
+		return fmt.Errorf("cannot collect consent records: %w", err)
+	}
+
+	*r = records
+
+	return nil
+}
+
+func (r *ConsentRecords) CountByCookieBannerID(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	cookieBannerID gid.GID,
+	filter *CookieConsentRecordFilter,
+) (int, error) {
+	q := `
+SELECT
+	COUNT(id)
+FROM
+	cookie_consent_records
+WHERE
+	%s
+	AND cookie_banner_id = @cookie_banner_id
+	AND %s
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment(), filter.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"cookie_banner_id": cookieBannerID}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, filter.SQLArguments())
+
+	row := conn.QueryRow(ctx, q, args)
+
+	var count int
+	if err := row.Scan(&count); err != nil {
+		return 0, fmt.Errorf("cannot scan count: %w", err)
+	}
+
+	return count, nil
+}
+
+func (r *ConsentRecord) Insert(
+	ctx context.Context,
+	tx pg.Tx,
+	scope Scoper,
+) error {
+	q := `
+INSERT INTO cookie_consent_records (
+	id,
+	tenant_id,
+	cookie_banner_id,
+	visitor_id,
+	ip_address,
+	user_agent,
+	consent_data,
+	action,
+	created_at
+) VALUES (
+	@id,
+	@tenant_id,
+	@cookie_banner_id,
+	@visitor_id,
+	@ip_address,
+	@user_agent,
+	@consent_data,
+	@action,
+	@created_at
+)
+`
+
+	args := pgx.StrictNamedArgs{
+		"id":               r.ID,
+		"tenant_id":        scope.GetTenantID(),
+		"cookie_banner_id": r.CookieBannerID,
+		"visitor_id":       r.VisitorID,
+		"ip_address":       r.IPAddress,
+		"user_agent":       r.UserAgent,
+		"consent_data":     r.ConsentData,
+		"action":           r.Action,
+		"created_at":       r.CreatedAt,
+	}
+
+	_, err := tx.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot insert consent record: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/cookie_consent_record.go
+++ b/pkg/coredata/cookie_consent_record.go
@@ -29,7 +29,7 @@ import (
 )
 
 type (
-	ConsentRecord struct {
+	CookieConsentRecord struct {
 		ID             gid.GID             `db:"id"`
 		CookieBannerID gid.GID             `db:"cookie_banner_id"`
 		VisitorID      string              `db:"visitor_id"`
@@ -40,10 +40,10 @@ type (
 		CreatedAt      time.Time           `db:"created_at"`
 	}
 
-	ConsentRecords []*ConsentRecord
+	CookieConsentRecords []*CookieConsentRecord
 )
 
-func (r *ConsentRecord) CursorKey(field CookieConsentRecordOrderField) page.CursorKey {
+func (r *CookieConsentRecord) CursorKey(field CookieConsentRecordOrderField) page.CursorKey {
 	switch field {
 	case CookieConsentRecordOrderFieldCreatedAt:
 		return page.NewCursorKey(r.ID, r.CreatedAt)
@@ -52,7 +52,7 @@ func (r *ConsentRecord) CursorKey(field CookieConsentRecordOrderField) page.Curs
 	panic(fmt.Sprintf("unsupported order by: %s", field))
 }
 
-func (r *ConsentRecord) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
+func (r *CookieConsentRecord) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
 	q := `
 SELECT cb.organization_id
 FROM cookie_consent_records cr
@@ -72,7 +72,7 @@ LIMIT 1;
 	return map[string]string{"organization_id": organizationID.String()}, nil
 }
 
-func (r *ConsentRecords) LoadByCookieBannerID(
+func (r *CookieConsentRecords) LoadByCookieBannerID(
 	ctx context.Context,
 	conn pg.Querier,
 	scope Scoper,
@@ -111,7 +111,7 @@ WHERE
 		return fmt.Errorf("cannot query consent records: %w", err)
 	}
 
-	records, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[ConsentRecord])
+	records, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[CookieConsentRecord])
 	if err != nil {
 		return fmt.Errorf("cannot collect consent records: %w", err)
 	}
@@ -121,7 +121,7 @@ WHERE
 	return nil
 }
 
-func (r *ConsentRecords) CountByCookieBannerID(
+func (r *CookieConsentRecords) CountByCookieBannerID(
 	ctx context.Context,
 	conn pg.Querier,
 	scope Scoper,
@@ -155,7 +155,7 @@ WHERE
 	return count, nil
 }
 
-func (r *ConsentRecord) Insert(
+func (r *CookieConsentRecord) Insert(
 	ctx context.Context,
 	tx pg.Tx,
 	scope Scoper,

--- a/pkg/coredata/cookie_consent_record_filter.go
+++ b/pkg/coredata/cookie_consent_record_filter.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import "github.com/jackc/pgx/v5"
+
+type CookieConsentRecordFilter struct {
+	action *CookieConsentAction
+}
+
+func NewCookieConsentRecordFilter(action *CookieConsentAction) *CookieConsentRecordFilter {
+	return &CookieConsentRecordFilter{
+		action: action,
+	}
+}
+
+func (f *CookieConsentRecordFilter) SQLFragment() string {
+	return `
+(
+	CASE
+		WHEN @filter_action::text IS NOT NULL THEN
+			action = @filter_action::consent_action
+		ELSE TRUE
+	END
+)`
+}
+
+func (f *CookieConsentRecordFilter) SQLArguments() pgx.StrictNamedArgs {
+	args := pgx.StrictNamedArgs{
+		"filter_action": nil,
+	}
+
+	if f.action != nil {
+		args["filter_action"] = string(*f.action)
+	}
+
+	return args
+}

--- a/pkg/coredata/cookie_consent_record_order_field.go
+++ b/pkg/coredata/cookie_consent_record_order_field.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import "fmt"
+
+type CookieConsentRecordOrderField string
+
+const (
+	CookieConsentRecordOrderFieldCreatedAt CookieConsentRecordOrderField = "CREATED_AT"
+)
+
+func (p CookieConsentRecordOrderField) Column() string {
+	switch p {
+	case CookieConsentRecordOrderFieldCreatedAt:
+		return "created_at"
+	}
+	panic(fmt.Sprintf("unsupported order by: %s", p))
+}
+
+func (p CookieConsentRecordOrderField) IsValid() bool {
+	switch p {
+	case CookieConsentRecordOrderFieldCreatedAt:
+		return true
+	}
+	return false
+}
+
+func (p CookieConsentRecordOrderField) String() string {
+	return string(p)
+}
+
+func (p *CookieConsentRecordOrderField) UnmarshalText(text []byte) error {
+	*p = CookieConsentRecordOrderField(text)
+	if !p.IsValid() {
+		return fmt.Errorf("%s is not a valid CookieConsentRecordOrderField", string(text))
+	}
+	return nil
+}
+
+func (p CookieConsentRecordOrderField) MarshalText() ([]byte, error) {
+	return []byte(p.String()), nil
+}

--- a/pkg/coredata/entity_type_reg.go
+++ b/pkg/coredata/entity_type_reg.go
@@ -100,7 +100,7 @@ const (
 	AccessEntryDecisionHistoryEntityType       uint16 = 74
 	CookieBannerEntityType                     uint16 = 75
 	CookieCategoryEntityType                   uint16 = 76
-	ConsentRecordEntityType                    uint16 = 77
+	CookieConsentRecordEntityType              uint16 = 77
 )
 
 func NewEntityFromID(id gid.GID) (any, bool) {
@@ -251,8 +251,8 @@ func NewEntityFromID(id gid.GID) (any, bool) {
 		return &CookieBanner{ID: id}, true
 	case CookieCategoryEntityType:
 		return &CookieCategory{ID: id}, true
-	case ConsentRecordEntityType:
-		return &ConsentRecord{ID: id}, true
+	case CookieConsentRecordEntityType:
+		return &CookieConsentRecord{ID: id}, true
 	default:
 		return nil, false
 	}

--- a/pkg/coredata/entity_type_reg.go
+++ b/pkg/coredata/entity_type_reg.go
@@ -98,6 +98,9 @@ const (
 	AccessReviewCampaignEntityType             uint16 = 72
 	AccessEntryEntityType                      uint16 = 73
 	AccessEntryDecisionHistoryEntityType       uint16 = 74
+	CookieBannerEntityType                     uint16 = 75
+	CookieCategoryEntityType                   uint16 = 76
+	ConsentRecordEntityType                    uint16 = 77
 )
 
 func NewEntityFromID(id gid.GID) (any, bool) {
@@ -244,6 +247,12 @@ func NewEntityFromID(id gid.GID) (any, bool) {
 		return &AccessEntry{ID: id}, true
 	case AccessEntryDecisionHistoryEntityType:
 		return &AccessEntryDecisionHistory{ID: id}, true
+	case CookieBannerEntityType:
+		return &CookieBanner{ID: id}, true
+	case CookieCategoryEntityType:
+		return &CookieCategory{ID: id}, true
+	case ConsentRecordEntityType:
+		return &ConsentRecord{ID: id}, true
 	default:
 		return nil, false
 	}

--- a/pkg/coredata/migrations/20260410T121735Z.sql
+++ b/pkg/coredata/migrations/20260410T121735Z.sql
@@ -1,0 +1,59 @@
+-- Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+--
+-- Permission to use, copy, modify, and/or distribute this software for any
+-- purpose with or without fee is hereby granted, provided that the above
+-- copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+-- REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+-- INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+-- LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+-- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+CREATE TYPE cookie_banner_state AS ENUM ('DRAFT', 'PUBLISHED', 'DISABLED');
+CREATE TYPE cookie_consent_mode AS ENUM ('OPT_IN', 'OPT_OUT');
+CREATE TYPE cookie_consent_action AS ENUM ('ACCEPT_ALL', 'REJECT_ALL', 'CUSTOMIZE', 'GPC');
+
+CREATE TABLE cookie_banners (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    origin TEXT NOT NULL,
+    state cookie_banner_state NOT NULL,
+    privacy_policy_url TEXT NOT NULL,
+    consent_expiry_days INTEGER NOT NULL,
+    consent_mode cookie_consent_mode NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+CREATE TABLE cookie_categories (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    cookie_banner_id TEXT NOT NULL REFERENCES cookie_banners(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL,
+    required BOOLEAN NOT NULL,
+    rank INTEGER NOT NULL,
+    cookies JSONB NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+CREATE UNIQUE INDEX idx_cookie_categories_one_required_per_banner
+    ON cookie_categories (cookie_banner_id) WHERE required = TRUE;
+
+CREATE TABLE cookie_consent_records (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    cookie_banner_id TEXT NOT NULL REFERENCES cookie_banners(id) ON DELETE CASCADE,
+    visitor_id TEXT NOT NULL,
+    ip_address TEXT,
+    user_agent TEXT,
+    consent_data JSONB NOT NULL,
+    action cookie_consent_action NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL
+);


### PR DESCRIPTION
Closes ENG-266


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds core models, DB schema, and a `cookiebanner` service to manage cookie banners, categories, and cookie consent records. Validates inputs, seeds default categories, supports public reads, cursor pagination, and state/action filters to meet ENG-266.

- **New Features**
  - `cookiebanner` service: banner create/get/list/count/update/delete (update/delete are draft-only), publish/disable, state filter; category create/get/list/count/update/delete (cannot delete required), ordered by rank; consent record create/list/count with action filter; strict validation and clear state errors.

- **Migration**
  - Enums: cookie_banner_state, cookie_consent_mode, cookie_consent_action (includes GPC).
  - Tables: cookie_banners, cookie_categories (JSONB `cookies`), cookie_consent_records (JSONB `consent_data`); unique index to enforce one required category per banner.

<sup>Written for commit a153427a0815a0385b230ead5751472c4e7375d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



