### PR TITLE
Drop legacy document columns and approver tables

### DIFF
--- a/pkg/coredata/migrations/20260319T160000Z.sql
+++ b/pkg/coredata/migrations/20260319T160000Z.sql
@@ -104,6 +104,3 @@ LEFT JOIN document_approvers da ON da.document_id = dv.document_id
 WHERE dv.status = 'PUBLISHED'
     AND COALESCE(dva.approver_profile_id, da.approver_profile_id) IS NOT NULL
 ON CONFLICT (quorum_id, approver_id) DO NOTHING;
-
--- TODO: DROP TABLE document_version_approvers once confirmed safe
--- TODO: DROP TABLE document_approvers once confirmed safe

--- a/pkg/coredata/migrations/20260328T120000Z.sql
+++ b/pkg/coredata/migrations/20260328T120000Z.sql
@@ -1,2 +1,1 @@
--- TODO: drop the classification column from documents.
 ALTER TABLE documents ALTER COLUMN classification SET DEFAULT 'SECRET';

--- a/pkg/coredata/migrations/20260331T120000Z.sql
+++ b/pkg/coredata/migrations/20260331T120000Z.sql
@@ -8,5 +8,4 @@ WHERE dv.document_id = d.id;
 
 ALTER TABLE document_versions ALTER COLUMN document_type DROP DEFAULT;
 
--- TODO: drop the document_type column from documents.
 ALTER TABLE documents ALTER COLUMN document_type SET DEFAULT 'OTHER';

--- a/pkg/coredata/migrations/20260409T130000Z.sql
+++ b/pkg/coredata/migrations/20260409T130000Z.sql
@@ -12,17 +12,11 @@
 -- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 -- PERFORMANCE OF THIS SOFTWARE.
 
-ALTER TABLE documents ALTER COLUMN title DROP NOT NULL;
+-- Drop legacy columns from documents that have been moved to document_versions.
+ALTER TABLE documents DROP COLUMN title;
+ALTER TABLE documents DROP COLUMN classification;
+ALTER TABLE documents DROP COLUMN document_type;
 
-ALTER TABLE documents DROP COLUMN description;
-
--- Move search_vector from documents to document_versions.
-DROP INDEX documents_search_idx;
-ALTER TABLE documents DROP COLUMN search_vector;
-
-ALTER TABLE document_versions ADD COLUMN search_vector tsvector
-GENERATED ALWAYS AS (
-    to_tsvector('simple', COALESCE(title, ''))
-) STORED;
-
-CREATE INDEX document_versions_search_idx ON document_versions USING gin(search_vector);
+-- Drop legacy approver tables replaced by approval quorums/decisions.
+DROP TABLE document_version_approvers;
+DROP TABLE document_approvers;


### PR DESCRIPTION
The title, classification, and document_type columns have been moved to document_versions. The document_approvers and document_version_approvers tables have been replaced by approval quorums and decisions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops legacy document columns (`title`, `classification`, `document_type`) from `documents` and removes old approver tables in favor of approval quorums/decisions. This completes the move of document metadata to `document_versions` and simplifies the approvals schema.

- **Migration**
  - Run migration `20260409T130000Z.sql` to drop `documents.title`, `documents.classification`, `documents.document_type`, `document_approvers`, and `document_version_approvers`.
  - Read metadata from `document_versions` and use approval quorums/decisions for approvals.

<sup>Written for commit eeee93e4648c4960ca8f3670333a97a1e1e82b95. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

