### PR TITLE
Cookie banner client consent

### DIFF
--- a/pkg/cookiebanner/client.go
+++ b/pkg/cookiebanner/client.go
@@ -16,6 +16,7 @@ package cookiebanner
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -82,6 +83,15 @@ type (
 		Rank             *int
 		Cookies          *coredata.CookieItems
 	}
+
+	CreateCookieConsentRecordRequest struct {
+		CookieBannerID gid.GID
+		VisitorID      string
+		IPAddress      *string
+		UserAgent      *string
+		ConsentData    json.RawMessage
+		Action         coredata.CookieConsentAction
+	}
 )
 
 func (r *CreateCookieBannerRequest) Validate() error {
@@ -128,6 +138,16 @@ func (r *UpdateCookieCategoryRequest) Validate() error {
 	v.Check(r.Name, "name", validator.SafeTextNoNewLine(255))
 	v.Check(r.Description, "description", validator.SafeText(1000))
 	v.Check(r.Rank, "rank", validator.Min(0))
+
+	return v.Error()
+}
+
+func (r *CreateCookieConsentRecordRequest) Validate() error {
+	v := validator.New()
+
+	v.Check(r.CookieBannerID, "cookie_banner_id", validator.Required(), validator.GID(coredata.CookieBannerEntityType))
+	v.Check(r.VisitorID, "visitor_id", validator.Required(), validator.NotEmpty())
+	v.Check(r.Action, "action", validator.Required(), validator.OneOfSlice(coredata.CookieConsentActions()))
 
 	return v.Error()
 }
@@ -642,4 +662,98 @@ func (c *Client) DeleteCookieCategory(
 			return nil
 		},
 	)
+}
+
+func (c *Client) CreateCookieConsentRecord(
+	ctx context.Context,
+	scope coredata.Scoper,
+	req CreateCookieConsentRecordRequest,
+) (*coredata.CookieConsentRecord, error) {
+	if err := req.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid request: %w", err)
+	}
+
+	var record *coredata.CookieConsentRecord
+
+	err := c.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			record = &coredata.CookieConsentRecord{
+				ID:             gid.New(scope.GetTenantID(), coredata.CookieConsentRecordEntityType),
+				CookieBannerID: req.CookieBannerID,
+				VisitorID:      req.VisitorID,
+				IPAddress:      req.IPAddress,
+				UserAgent:      req.UserAgent,
+				ConsentData:    req.ConsentData,
+				Action:         req.Action,
+				CreatedAt:      time.Now(),
+			}
+
+			if err := record.Insert(ctx, tx, scope); err != nil {
+				return fmt.Errorf("cannot insert consent record: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return record, nil
+}
+
+func (c *Client) ListCookieConsentRecordsForBanner(
+	ctx context.Context,
+	scope coredata.Scoper,
+	bannerID gid.GID,
+	cursor *page.Cursor[coredata.CookieConsentRecordOrderField],
+	filter *coredata.CookieConsentRecordFilter,
+) (coredata.CookieConsentRecords, error) {
+	var records coredata.CookieConsentRecords
+
+	err := c.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			if err := records.LoadByCookieBannerID(ctx, conn, scope, bannerID, cursor, filter); err != nil {
+				return fmt.Errorf("cannot list consent records: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return records, nil
+}
+
+func (c *Client) CountCookieConsentRecordsForBanner(
+	ctx context.Context,
+	scope coredata.Scoper,
+	bannerID gid.GID,
+	filter *coredata.CookieConsentRecordFilter,
+) (int, error) {
+	var count int
+
+	err := c.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			var records coredata.CookieConsentRecords
+			var err error
+
+			count, err = records.CountByCookieBannerID(ctx, conn, scope, bannerID, filter)
+			if err != nil {
+				return fmt.Errorf("cannot count consent records: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
 }

--- a/pkg/coredata/cookie_consent_record.go
+++ b/pkg/coredata/cookie_consent_record.go
@@ -29,7 +29,7 @@ import (
 )
 
 type (
-	ConsentRecord struct {
+	CookieConsentRecord struct {
 		ID             gid.GID             `db:"id"`
 		CookieBannerID gid.GID             `db:"cookie_banner_id"`
 		VisitorID      string              `db:"visitor_id"`
@@ -40,10 +40,10 @@ type (
 		CreatedAt      time.Time           `db:"created_at"`
 	}
 
-	ConsentRecords []*ConsentRecord
+	CookieConsentRecords []*CookieConsentRecord
 )
 
-func (r *ConsentRecord) CursorKey(field CookieConsentRecordOrderField) page.CursorKey {
+func (r *CookieConsentRecord) CursorKey(field CookieConsentRecordOrderField) page.CursorKey {
 	switch field {
 	case CookieConsentRecordOrderFieldCreatedAt:
 		return page.NewCursorKey(r.ID, r.CreatedAt)
@@ -52,7 +52,7 @@ func (r *ConsentRecord) CursorKey(field CookieConsentRecordOrderField) page.Curs
 	panic(fmt.Sprintf("unsupported order by: %s", field))
 }
 
-func (r *ConsentRecord) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
+func (r *CookieConsentRecord) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
 	q := `
 SELECT cb.organization_id
 FROM cookie_consent_records cr
@@ -72,7 +72,7 @@ LIMIT 1;
 	return map[string]string{"organization_id": organizationID.String()}, nil
 }
 
-func (r *ConsentRecords) LoadByCookieBannerID(
+func (r *CookieConsentRecords) LoadByCookieBannerID(
 	ctx context.Context,
 	conn pg.Querier,
 	scope Scoper,
@@ -111,7 +111,7 @@ WHERE
 		return fmt.Errorf("cannot query consent records: %w", err)
 	}
 
-	records, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[ConsentRecord])
+	records, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[CookieConsentRecord])
 	if err != nil {
 		return fmt.Errorf("cannot collect consent records: %w", err)
 	}
@@ -121,7 +121,7 @@ WHERE
 	return nil
 }
 
-func (r *ConsentRecords) CountByCookieBannerID(
+func (r *CookieConsentRecords) CountByCookieBannerID(
 	ctx context.Context,
 	conn pg.Querier,
 	scope Scoper,
@@ -155,7 +155,7 @@ WHERE
 	return count, nil
 }
 
-func (r *ConsentRecord) Insert(
+func (r *CookieConsentRecord) Insert(
 	ctx context.Context,
 	tx pg.Tx,
 	scope Scoper,

--- a/pkg/coredata/entity_type_reg.go
+++ b/pkg/coredata/entity_type_reg.go
@@ -100,7 +100,7 @@ const (
 	AccessEntryDecisionHistoryEntityType       uint16 = 74
 	CookieBannerEntityType                     uint16 = 75
 	CookieCategoryEntityType                   uint16 = 76
-	ConsentRecordEntityType                    uint16 = 77
+	CookieConsentRecordEntityType              uint16 = 77
 )
 
 func NewEntityFromID(id gid.GID) (any, bool) {
@@ -251,8 +251,8 @@ func NewEntityFromID(id gid.GID) (any, bool) {
 		return &CookieBanner{ID: id}, true
 	case CookieCategoryEntityType:
 		return &CookieCategory{ID: id}, true
-	case ConsentRecordEntityType:
-		return &ConsentRecord{ID: id}, true
+	case CookieConsentRecordEntityType:
+		return &CookieConsentRecord{ID: id}, true
 	default:
 		return nil, false
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a complete cookie banner and consent collection system. Introduces data models, DB schema, and a `pkg/cookiebanner` client to manage banners, categories, and consent records.

- **New Features**
  - New `pkg/coredata` models and enums: cookie banners, categories, consent records; states (DRAFT/PUBLISHED/DISABLED), consent modes (OPT_IN/OPT_OUT), and actions (ACCEPT_ALL/REJECT_ALL/CUSTOMIZE/GPC).
  - `pkg/cookiebanner` client:
    - Banners: create (seeds default categories), get/list/count, update (draft-only), publish/disable, delete (draft-only).
    - Categories: create/get/list/count/update/delete; ordered by rank; cannot delete the required category.
    - Consent records: create and list/count; stores visitor ID, IP, UA, action, and raw JSON consent payload.
  - Pagination and filters: cursor-based ordering (banners and consent records by created_at; categories by rank) with filters for banner state and consent action.
  - Validation and scoping: strict input validation, tenant scoping, and org-based authorization attributes; unique index ensures only one required category per banner.

- **Migration**
  - Apply `pkg/coredata/migrations/20260410T121735Z.sql` to create tables and enums. No backfill needed.

<sup>Written for commit e41b75d4393f3e2870f746fd6670fcb1d87b3f6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

