### PR TITLE
Fix MCP snapshot issues for SOA and vendors

### DIFF
--- a/pkg/coredata/vendor_compliance_report.go
+++ b/pkg/coredata/vendor_compliance_report.go
@@ -269,6 +269,7 @@ WITH
 INSERT INTO vendor_compliance_reports (
 	tenant_id,
 	id,
+	organization_id,
 	snapshot_id,
 	source_id,
 	vendor_id,
@@ -282,6 +283,7 @@ INSERT INTO vendor_compliance_reports (
 SELECT
 	@tenant_id,
 	generate_gid(decode_base64_unpadded(@tenant_id), @vendor_compliance_report_entity_type),
+	@organization_id,
 	@snapshot_id,
 	vcr.id,
 	sv.id,

--- a/pkg/coredata/vendor_contact.go
+++ b/pkg/coredata/vendor_contact.go
@@ -314,6 +314,7 @@ WITH
 INSERT INTO vendor_contacts (
 	tenant_id,
 	id,
+	organization_id,
 	snapshot_id,
 	source_id,
 	vendor_id,
@@ -327,6 +328,7 @@ INSERT INTO vendor_contacts (
 SELECT
 	@tenant_id,
 	generate_gid(decode_base64_unpadded(@tenant_id), @vendor_contact_entity_type),
+	@organization_id,
 	@snapshot_id,
 	vc.id,
 	sv.id,

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -2869,7 +2869,13 @@ func (r *Resolver) ListStatementsOfApplicabilityTool(ctx context.Context, req *m
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	pg, err := prb.StatementsOfApplicability.ListForOrganizationID(ctx, input.OrganizationID, cursor, coredata.NewStatementOfApplicabilityFilter(nil))
+	noSnapshot := (*gid.GID)(nil)
+	filter := coredata.NewStatementOfApplicabilityFilter(&noSnapshot)
+	if input.Filter != nil {
+		filter = coredata.NewStatementOfApplicabilityFilter(&input.Filter.SnapshotID)
+	}
+
+	pg, err := prb.StatementsOfApplicability.ListForOrganizationID(ctx, input.OrganizationID, cursor, filter)
 	if err != nil {
 		return nil, types.ListStatementsOfApplicabilityOutput{}, fmt.Errorf("failed to list statements of applicability: %w", err)
 	}

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -4996,7 +4996,7 @@ components:
         - OBLIGATIONS
         - CONTINUAL_IMPROVEMENTS
         - PROCESSING_ACTIVITIES
-        - STATES_OF_APPLICABILITY
+        - STATEMENTS_OF_APPLICABILITY
       go.probo.inc/mcpgen/type: go.probo.inc/probo/pkg/coredata.SnapshotsType
 
     SnapshotOrderField:
@@ -6173,6 +6173,15 @@ components:
         cursor:
           $ref: "#/components/schemas/CursorKey"
           description: Page cursor
+        filter:
+          type: object
+          properties:
+            snapshot_id:
+              anyOf:
+                - $ref: "#/components/schemas/GID"
+                - type: "null"
+              description: Filter by snapshot ID. Defaults to null, which returns only statements of applicability with no snapshot (current live data). Pass a specific snapshot ID to retrieve statements of applicability as they were at that snapshot.
+              default: null
 
     ListStatementsOfApplicabilityOutput:
       type: object


### PR DESCRIPTION
- Fix SnapshotsType enum: STATES_OF_APPLICABILITY → STATEMENTS_OF_APPLICABILITY
- Add snapshot filter to ListStatementsOfApplicability MCP tool
- Add missing organization_id to vendor contacts and compliance reports snapshot inserts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SOA snapshot handling by correcting the enum and adding snapshot filtering to the MCP tool. Also ensures vendor contact and compliance report snapshots include `organization_id`.

- **Bug Fixes**
  - Corrected `SnapshotsType` enum: `STATES_OF_APPLICABILITY` → `STATEMENTS_OF_APPLICABILITY` in `specification.yaml`.
  - Added optional `filter.snapshot_id` to the `ListStatementsOfApplicability` MCP tool. Defaults to null (returns live SOA only); set to a snapshot ID to fetch SOA as of that snapshot.
  - Included `organization_id` in snapshot inserts for vendor contacts and vendor compliance reports.

<sup>Written for commit ff8da296e63161d055a36dec1238fe448bae621f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

