### PR TITLE
Remove VERSION order field from MCP document versions

### DIFF
--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -5202,7 +5202,6 @@ components:
       type: string
       enum:
         - CREATED_AT
-        - VERSION
       go.probo.inc/mcpgen/type: go.probo.inc/probo/pkg/coredata.DocumentVersionOrderField
 
     DocumentVersionOrderBy:


### PR DESCRIPTION
CREATED_AT is sufficient for ordering document versions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `VERSION` order field for MCP document versions; ordering now uses `CREATED_AT` only.

- **Migration**
  - Replace any `order.field = VERSION` with `CREATED_AT` or omit it to use the default.
  - Regenerate client SDKs from `pkg/server/api/mcp/v1/specification.yaml`.

<sup>Written for commit b84fb1fb4a910d372d55eb12b2aeef10c5c6c879. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

