### PR TITLE
Fix missing owner ID in MCP datum responses

### DIFF
--- a/pkg/server/api/mcp/v1/types/datum.go
+++ b/pkg/server/api/mcp/v1/types/datum.go
@@ -23,6 +23,7 @@ func NewDatum(d *coredata.Datum) *Datum {
 	return &Datum{
 		ID:                 d.ID,
 		Name:               d.Name,
+		OwnerID:            d.OwnerID,
 		OrganizationID:     d.OrganizationID,
 		SnapshotID:         d.SnapshotID,
 		DataClassification: d.DataClassification,


### PR DESCRIPTION
The NewDatum type conversion helper was not mapping the OwnerID field from the coredata struct, causing MCP responses for data resources to return a zero-value owner_id.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix missing owner_id in MCP datum responses by mapping OwnerID in the `NewDatum` converter. MCP data resources now return the correct owner_id instead of 0.

<sup>Written for commit f05f0f95724f153cae519cd24f87812c71d3d32e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

