### PR TITLE
fix: set cookie secure flag to false in dev config

### DIFF
--- a/cfg/dev.yaml
+++ b/cfg/dev.yaml
@@ -40,7 +40,7 @@ probod:
       domain: "localhost"
       secret: "this-is-a-secure-secret-for-cookie-signing-at-least-32-bytes"
       duration: 24
-      secure: true
+      secure: false
     password:
       pepper: "this-is-a-secure-pepper-for-password-hashing-at-least-32-bytes"
       iterations: 1000000


### PR DESCRIPTION
The dev config (`cfg/dev.yaml`) uses `http://localhost:8080` (plain HTTP), but the session cookie had `secure: true`, which tells browsers to only send cookies over HTTPS. This caused a sign-in loop where authentication succeeded but the browser dropped the cookie, redirecting back to login.

This change sets `secure: false` for the cookie configuration in the dev config only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the session cookie secure=false in `cfg/dev.yaml` to match http://localhost:8080 and fix the sign-in loop where browsers dropped HTTPS-only cookies in dev. Dev-only; production config unchanged.

<sup>Written for commit fbfb0880a944bd0041e97a04efa2e23edc244efd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

