### PR TITLE
Fix unchecked error on resp.Body.Close in genmodels

### DIFF
--- a/internal/cmd/genmodels/main.go
+++ b/internal/cmd/genmodels/main.go
@@ -96,7 +96,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "cannot fetch models: %v\n", err)
 		os.Exit(1)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		fmt.Fprintf(os.Stderr, "cannot fetch models: unexpected status %s\n", resp.Status)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix unchecked error on resp.Body.Close in `internal/cmd/genmodels` by deferring a closure that safely ignores the Close error. Satisfies errcheck without changing runtime behavior.

<sup>Written for commit e42979e1ff36104e4ebb71d7a47067b5c6859350. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

