### PR TITLE
Prefer errors.AsType over errors.As in style guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,20 @@ return nil, fmt.Errorf("cannot load trust center: %w", err)
 return nil, fmt.Errorf("cannot create SAML service: %w", err)
 ```
 
-Sentinel errors in grouped `var ()` blocks. Custom error types implement `Unwrap() error`. Use `errors.Is` / `errors.As` for checks.
+Sentinel errors in grouped `var ()` blocks. Custom error types implement `Unwrap() error`. Use `errors.Is` for sentinel checks. Use `errors.AsType[T](err)` (generic form) instead of `errors.As(err, &ptr)` for type assertions:
+
+```go
+// Good
+if e, ok := errors.AsType[*ValidationError](err); ok {
+	// use e
+}
+
+// Bad — avoid the two-argument form
+var ve *ValidationError
+if errors.As(err, &ve) {
+	// use ve
+}
+```
 
 ### Naming
 


### PR DESCRIPTION
## Summary

Update the Go style guide to prefer the generic `errors.AsType[T](err)` form over `errors.As(err, &ptr)` for error type assertions. Adds code examples showing the preferred and discouraged patterns.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Go style guide to prefer generic `errors.AsType[T](err)` for error type assertions and keep using `errors.Is` for sentinel checks. Adds a clear Good/Bad example and discourages the two-argument `errors.As(err, &ptr)` form.

<sup>Written for commit 16b1a48c556934ca3f5ee52051937440fa932453. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

