### PR TITLE
Align risk severity across views

### DIFF
--- a/apps/console/src/hooks/forms/useRiskForm.tsx
+++ b/apps/console/src/hooks/forms/useRiskForm.tsx
@@ -42,6 +42,10 @@ const RiskFragment = graphql`
     # eslint-disable-next-line relay/unused-fields
     residualImpact
     # eslint-disable-next-line relay/unused-fields
+    inherentRiskScore
+    # eslint-disable-next-line relay/unused-fields
+    residualRiskScore
+    # eslint-disable-next-line relay/unused-fields
     note
     owner {
       id

--- a/packages/ui/src/Molecules/Badge/SeverityBadge.tsx
+++ b/packages/ui/src/Molecules/Badge/SeverityBadge.tsx
@@ -12,6 +12,7 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
+import { getSeverity } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
 
 import { Badge } from "../../Atoms/Badge/Badge";
@@ -20,26 +21,8 @@ type Props = {
   score: number;
 };
 
-const badgeVariant = (score: number) => {
-  if (score >= 15) {
-    return "danger";
-  }
-  if (score > 6) {
-    return "warning";
-  }
-  return "success";
-};
-
 export function SeverityBadge({ score }: Props) {
   const { __ } = useTranslate();
-  const label = () => {
-    if (score >= 15) {
-      return __("High");
-    }
-    if (score > 6) {
-      return __("Medium");
-    }
-    return __("Low");
-  };
-  return <Badge variant={badgeVariant(score)}>{label()}</Badge>;
+  const severity = getSeverity(__, score);
+  return <Badge variant={severity?.variant}>{severity?.label}</Badge>;
 }

--- a/packages/ui/src/Molecules/Risks/RisksChart.tsx
+++ b/packages/ui/src/Molecules/Risks/RisksChart.tsx
@@ -47,7 +47,7 @@ const getLevel = (score: number): 0 | 1 | 2 => {
   if (score >= 15) {
     return 2;
   }
-  if (score > 6) {
+  if (score >= 5) {
     return 1;
   }
   return 0;
@@ -62,7 +62,7 @@ const cellKey = (impact: number, likelihood: number) =>
 export function RisksChart({ organizationId, type, risks }: Props) {
   const { __ } = useTranslate();
 
-  const legend = [__("Low"), __("Medium"), __("High")];
+  const legend = [__("Low"), __("High"), __("Critical")];
 
   const impacts = getRiskImpacts(__).reverse();
   const likelihoods = getRiskLikelihoods(__);

--- a/pkg/coredata/risk.go
+++ b/pkg/coredata/risk.go
@@ -506,6 +506,7 @@ SET
 WHERE %s
 	AND id = @risk_id
 	AND snapshot_id IS NULL
+RETURNING inherent_risk_score, residual_risk_score
 `
 	q = fmt.Sprintf(q, scope.SQLFragment())
 
@@ -525,8 +526,15 @@ WHERE %s
 	}
 	maps.Copy(args, scope.SQLArguments())
 
-	_, err := conn.Exec(ctx, q, args)
-	return err
+	err := conn.QueryRow(ctx, q, args).Scan(
+		&r.InherentRiskScore,
+		&r.ResidualRiskScore,
+	)
+	if err != nil {
+		return fmt.Errorf("cannot update risk: %w", err)
+	}
+
+	return nil
 }
 
 func (r *Risk) Delete(


### PR DESCRIPTION
Use the shared getSeverity helper from @probo/helpers in SeverityBadge so the list view displays the same labels (Low/High/Critical) and thresholds (0/5/15) as the detail view. Also fix the RisksChart legend and getLevel thresholds to match.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align risk severity across list, detail, and chart views, and update risk scores instantly after edits without a page refresh. Use `getSeverity` from `@probo/helpers`; labels and thresholds are Low/High/Critical at 0/5/15.

- **Bug Fixes**
  - `SeverityBadge` now uses `getSeverity` for consistent labels and variants.
  - `RisksChart` legend set to Low/High/Critical; `getLevel` thresholds now >=5 and >=15.
  - Relay fragment includes `inherentRiskScore` and `residualRiskScore`; backend uses RETURNING to send recomputed scores so the store stays in sync after mutations.

<sup>Written for commit 808fdffc9b9a0870bc33880ec8c7f1490aaa1275. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

