### PR TITLE
Add @probo/cookie-banner SDK package scaffold

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -516,3 +516,79 @@ jobs:
             packages/n8n-node/sbom.json
             packages/n8n-node/checksums.txt
           retention-days: 30
+
+  # ── Cookie banner SDK release ──────────────────────────────────────
+  cookie-banner-release:
+    name: "cookie-banner-release"
+    needs: [github-release]
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - uses: "actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f" # v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
+          scope: "@probo"
+      - run: "npm install -g npm@latest"
+      - run: "npm ci"
+      - name: "Check if publish is needed"
+        id: check
+        run: |
+          LOCAL=$(node -p "require('./packages/cookie-banner/package.json').version")
+          PUBLISHED=$(npm view @probo/cookie-banner version 2>/dev/null || echo "0.0.0")
+          echo "local=$LOCAL published=$PUBLISHED"
+          if [ "$LOCAL" = "$PUBLISHED" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+      - run: "npm --workspace @probo/cookie-banner run build"
+        if: steps.check.outputs.skip != 'true'
+      - uses: "anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610" # v0.24.0
+        if: steps.check.outputs.skip != 'true'
+        with:
+          path: ./packages/cookie-banner
+          format: cyclonedx-json
+          output-file: packages/cookie-banner/sbom.json
+      - uses: "anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2" # v7.4.0
+        if: steps.check.outputs.skip != 'true'
+        with:
+          path: ./packages/cookie-banner
+          fail-build: true
+          severity-cutoff: critical
+      - name: "Generate checksums for dist files"
+        id: checksum
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          cd packages/cookie-banner/dist
+          find . -type f | while read file; do
+            echo "$(sha256sum "$file" | head -c 64)  $file"
+          done > ../checksums.txt
+          echo "hashes=$(cat ../checksums.txt | base64 -w0)" >> "$GITHUB_OUTPUT"
+      - run: "npm --workspace @probo/cookie-banner publish --access public --dry-run"
+        if: steps.check.outputs.skip != 'true'
+      # - run: "npm --workspace @probo/cookie-banner publish --access public"
+      #   if: steps.check.outputs.skip != 'true'
+      - uses: "actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e" # v4
+        if: steps.check.outputs.skip != 'true'
+        with:
+          subject-path: "packages/cookie-banner/dist/**"
+          sbom-path: "packages/cookie-banner/sbom.json"
+      - uses: "actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32" # v4
+        if: steps.check.outputs.skip != 'true'
+        with:
+          subject-path: "packages/cookie-banner/dist/**"
+      - uses: "actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f" # v7
+        if: steps.check.outputs.skip != 'true'
+        with:
+          name: "cookie-banner-sbom"
+          path: |
+            packages/cookie-banner/sbom.json
+            packages/cookie-banner/checksums.txt
+          retention-days: 30

--- a/package-lock.json
+++ b/package-lock.json
@@ -3227,6 +3227,10 @@
       "resolved": "apps/console",
       "link": true
     },
+    "node_modules/@probo/cookie-banner": {
+      "resolved": "packages/cookie-banner",
+      "link": true
+    },
     "node_modules/@probo/coredata": {
       "resolved": "packages/coredata",
       "link": true
@@ -19579,6 +19583,499 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "packages/cookie-banner": {
+      "name": "@probo/cookie-banner",
+      "version": "0.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "esbuild": "^0.25.0",
+        "typescript": "~5.8.3"
+      }
+    },
+    "packages/cookie-banner/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cookie-banner/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cookie-banner/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cookie-banner/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cookie-banner/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cookie-banner/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cookie-banner/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cookie-banner/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cookie-banner/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cookie-banner/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cookie-banner/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cookie-banner/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cookie-banner/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cookie-banner/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cookie-banner/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cookie-banner/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cookie-banner/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cookie-banner/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cookie-banner/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cookie-banner/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cookie-banner/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cookie-banner/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cookie-banner/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cookie-banner/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cookie-banner/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cookie-banner/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cookie-banner/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "packages/coredata": {

--- a/packages/cookie-banner/LICENSE
+++ b/packages/cookie-banner/LICENSE
@@ -1,0 +1,20 @@
+Copyright 2026 Probo Inc
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/cookie-banner/build.mjs
+++ b/packages/cookie-banner/build.mjs
@@ -1,0 +1,36 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import * as esbuild from "esbuild";
+
+const shared = {
+  entryPoints: ["src/index.ts"],
+  bundle: true,
+  target: "es2020",
+};
+
+await Promise.all([
+  esbuild.build({
+    ...shared,
+    outfile: "dist/cookie-banner.iife.js",
+    format: "iife",
+    globalName: "ProboCookieBanner",
+    minify: true,
+  }),
+  esbuild.build({
+    ...shared,
+    outfile: "dist/cookie-banner.mjs",
+    format: "esm",
+  }),
+]);

--- a/packages/cookie-banner/build.mjs
+++ b/packages/cookie-banner/build.mjs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
 //
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above

--- a/packages/cookie-banner/package.json
+++ b/packages/cookie-banner/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@probo/cookie-banner",
+  "version": "0.0.0",
+  "description": "Probo cookie consent banner SDK",
+  "type": "module",
+  "main": "dist/cookie-banner.iife.js",
+  "module": "dist/cookie-banner.mjs",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "node build.mjs && tsc --emitDeclarationOnly",
+    "check": "tsc --noEmit"
+  },
+  "author": {
+    "name": "Probo Inc",
+    "email": "hello@getprobo.com"
+  },
+  "files": [
+    "dist"
+  ],
+  "license": "MIT",
+  "keywords": [
+    "cookie-banner",
+    "cookie-consent",
+    "gdpr",
+    "privacy",
+    "probo"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getprobo/probo.git",
+    "directory": "packages/cookie-banner"
+  },
+  "bugs": {
+    "url": "https://github.com/getprobo/probo/issues"
+  },
+  "homepage": "https://github.com/getprobo/probo#README",
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "esbuild": "^0.25.0",
+    "typescript": "~5.8.3"
+  }
+}

--- a/packages/cookie-banner/package.json
+++ b/packages/cookie-banner/package.json
@@ -3,9 +3,17 @@
   "version": "0.0.0",
   "description": "Probo cookie consent banner SDK",
   "type": "module",
-  "main": "dist/cookie-banner.iife.js",
+  "main": "dist/cookie-banner.mjs",
   "module": "dist/cookie-banner.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/cookie-banner.mjs",
+      "default": "./dist/cookie-banner.mjs"
+    },
+    "./iife": "./dist/cookie-banner.iife.js"
+  },
   "scripts": {
     "build": "node build.mjs && tsc --emitDeclarationOnly",
     "check": "tsc --noEmit"

--- a/packages/cookie-banner/src/activation.ts
+++ b/packages/cookie-banner/src/activation.ts
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+const ATTR_CATEGORY = "data-cookie-consent";
+const ATTR_SRC = "data-src";
+const ATTR_HREF = "data-href";
+const ATTR_ACTIVATED = "data-cookie-consent-activated";
+
+const ACTIVATABLE_TAGS = new Set([
+  "SCRIPT",
+  "IFRAME",
+  "IMG",
+  "VIDEO",
+  "AUDIO",
+  "EMBED",
+  "OBJECT",
+  "LINK",
+]);
+
+function activateScript(el: HTMLScriptElement): void {
+  const replacement = document.createElement("script");
+
+  for (const attr of el.attributes) {
+    if (attr.name === "type" || attr.name === ATTR_CATEGORY) {
+      continue;
+    }
+    if (attr.name === ATTR_SRC) {
+      replacement.setAttribute("src", attr.value);
+      continue;
+    }
+    replacement.setAttribute(attr.name, attr.value);
+  }
+
+  replacement.setAttribute("type", "text/javascript");
+  replacement.setAttribute(ATTR_ACTIVATED, "");
+
+  if (el.textContent) {
+    replacement.textContent = el.textContent;
+  }
+
+  el.parentNode!.replaceChild(replacement, el);
+}
+
+function activateElement(el: Element): void {
+  const src = el.getAttribute(ATTR_SRC);
+  if (src) {
+    el.setAttribute("src", src);
+    el.removeAttribute(ATTR_SRC);
+  }
+
+  const href = el.getAttribute(ATTR_HREF);
+  if (href) {
+    el.setAttribute("href", href);
+    el.removeAttribute(ATTR_HREF);
+  }
+
+  el.removeAttribute(ATTR_CATEGORY);
+  el.setAttribute(ATTR_ACTIVATED, "");
+}
+
+function tryActivate(
+  el: Element,
+  consentData: Record<string, boolean>,
+): void {
+  if (el.hasAttribute(ATTR_ACTIVATED)) {
+    return;
+  }
+
+  if (!ACTIVATABLE_TAGS.has(el.tagName)) {
+    return;
+  }
+
+  const category = el.getAttribute(ATTR_CATEGORY);
+  if (!category || !consentData[category]) {
+    return;
+  }
+
+  if (el instanceof HTMLScriptElement) {
+    activateScript(el);
+  } else {
+    activateElement(el);
+  }
+}
+
+export function activateElements(
+  consentData: Record<string, boolean>,
+): void {
+  const elements = document.querySelectorAll(`[${ATTR_CATEGORY}]`);
+  for (const el of elements) {
+    tryActivate(el, consentData);
+  }
+}
+
+export function observeAndActivate(
+  consentData: Record<string, boolean>,
+): MutationObserver {
+  const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      for (const node of mutation.addedNodes) {
+        if (!(node instanceof Element)) {
+          continue;
+        }
+
+        if (node.hasAttribute(ATTR_CATEGORY)) {
+          tryActivate(node, consentData);
+        }
+
+        const nested = node.querySelectorAll(`[${ATTR_CATEGORY}]`);
+        for (const el of nested) {
+          tryActivate(el, consentData);
+        }
+      }
+    }
+  });
+
+  observer.observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+  });
+
+  return observer;
+}

--- a/packages/cookie-banner/src/activation.ts
+++ b/packages/cookie-banner/src/activation.ts
@@ -30,9 +30,14 @@ const ACTIVATABLE_TAGS = new Set([
 
 function activateScript(el: HTMLScriptElement): void {
   const replacement = document.createElement("script");
+  const originalType = el.getAttribute("data-type");
 
   for (const attr of el.attributes) {
-    if (attr.name === "type" || attr.name === ATTR_CATEGORY) {
+    if (
+      attr.name === "type" ||
+      attr.name === "data-type" ||
+      attr.name === ATTR_CATEGORY
+    ) {
       continue;
     }
     if (attr.name === ATTR_SRC) {
@@ -42,7 +47,9 @@ function activateScript(el: HTMLScriptElement): void {
     replacement.setAttribute(attr.name, attr.value);
   }
 
-  replacement.setAttribute("type", "text/javascript");
+  if (originalType) {
+    replacement.setAttribute("type", originalType);
+  }
   replacement.setAttribute(ATTR_ACTIVATED, "");
 
   if (el.textContent) {

--- a/packages/cookie-banner/src/client.ts
+++ b/packages/cookie-banner/src/client.ts
@@ -233,9 +233,10 @@ export class CookieBannerClient {
 
   private activate(consentData: Record<string, boolean>): void {
     activateElements(consentData);
-    if (!this.observer) {
-      this.observer = observeAndActivate(consentData);
+    if (this.observer) {
+      this.observer.disconnect();
     }
+    this.observer = observeAndActivate(consentData);
   }
 
   destroy(): void {

--- a/packages/cookie-banner/src/client.ts
+++ b/packages/cookie-banner/src/client.ts
@@ -97,6 +97,7 @@ export class CookieBannerClient {
         created_at: "",
       };
       this.activate(cookie.data);
+      void flush(this.bannerId);
       return;
     }
 

--- a/packages/cookie-banner/src/client.ts
+++ b/packages/cookie-banner/src/client.ts
@@ -16,6 +16,7 @@ import { activateElements, observeAndActivate } from "./activation";
 import { getConsentCookie, setConsentCookie } from "./cookie";
 import { NotFoundError } from "./errors";
 import { fetchJSON } from "./http";
+import { enqueue, flush } from "./queue";
 import { getOrCreateVisitorId } from "./visitor";
 
 export interface CookieItem {
@@ -124,6 +125,8 @@ export class CookieBannerClient {
     } else {
       this.consent = null;
     }
+
+    void flush(this.bannerId);
   }
 
   get config(): BannerConfig {
@@ -182,23 +185,30 @@ export class CookieBannerClient {
   ): Promise<ConsentRecord> {
     const cfg = this.config;
     const url = `${this.baseUrl}/${this.bannerId}/consents`;
+    const body = {
+      visitor_id: this.visitorId,
+      version: cfg.version,
+      action,
+      consent_data: consentData,
+    };
 
-    const record = await fetchJSON<ConsentRecord>(url, {
-      method: "POST",
-      body: {
-        visitor_id: this.visitorId,
-        version: cfg.version,
-        action,
-        consent_data: consentData,
-      },
-    });
+    let record: ConsentRecord | null = null;
+    try {
+      record = await fetchJSON<ConsentRecord>(url, {
+        method: "POST",
+        body,
+      });
+      void flush(this.bannerId);
+    } catch {
+      enqueue(this.bannerId, url, body);
+    }
 
     this.consent = {
       visitor_id: this.visitorId,
       version: cfg.version,
       action,
       consent_data: consentData,
-      created_at: record.created_at,
+      created_at: record?.created_at ?? "",
     };
 
     setConsentCookie(
@@ -213,7 +223,12 @@ export class CookieBannerClient {
 
     this.activate(consentData);
 
-    return record;
+    return record ?? {
+      id: "",
+      visitor_id: this.visitorId,
+      action,
+      created_at: "",
+    };
   }
 
   private activate(consentData: Record<string, boolean>): void {

--- a/packages/cookie-banner/src/client.ts
+++ b/packages/cookie-banner/src/client.ts
@@ -1,0 +1,232 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { getConsentCookie, setConsentCookie } from "./cookie";
+import { NotFoundError } from "./errors";
+import { fetchJSON } from "./http";
+
+export interface CookieItem {
+  name: string;
+  duration: string;
+  description: string;
+}
+
+export interface Category {
+  name: string;
+  description: string;
+  required: boolean;
+  cookies: CookieItem[];
+}
+
+export interface BannerConfig {
+  banner_id: string;
+  version: number;
+  privacy_policy_url: string;
+  consent_expiry_days: number;
+  consent_mode: "OPT_IN" | "OPT_OUT";
+  categories: Category[];
+}
+
+export type ConsentAction = "ACCEPT_ALL" | "REJECT_ALL" | "CUSTOMIZE" | "GPC";
+
+export interface VisitorConsent {
+  visitor_id: string;
+  version: number;
+  action: ConsentAction;
+  consent_data: Record<string, boolean>;
+  created_at: string;
+}
+
+export interface ConsentRecord {
+  id: string;
+  visitor_id: string;
+  action: string;
+  created_at: string;
+}
+
+export interface CookieBannerClientOptions {
+  bannerId: string;
+  baseUrl: string;
+}
+
+const STORAGE_KEY_PREFIX = "probo_consent";
+
+function getOrCreateVisitorId(bannerId: string): string {
+  const key = `${STORAGE_KEY_PREFIX}:${bannerId}:vid`;
+
+  try {
+    const stored = localStorage.getItem(key);
+    if (stored) {
+      return stored;
+    }
+  } catch {
+    // localStorage unavailable
+  }
+
+  const id = crypto.randomUUID();
+
+  try {
+    localStorage.setItem(key, id);
+  } catch {
+    // localStorage unavailable
+  }
+
+  return id;
+}
+
+export class CookieBannerClient {
+  private readonly baseUrl: string;
+  private readonly bannerId: string;
+  private readonly visitorId: string;
+
+  private bannerConfig: BannerConfig | null = null;
+  private consent: VisitorConsent | null = null;
+
+  constructor(config: CookieBannerClientOptions) {
+    this.baseUrl = config.baseUrl.replace(/\/+$/, "");
+    this.bannerId = config.bannerId;
+    this.visitorId = getOrCreateVisitorId(config.bannerId);
+  }
+
+  async load(): Promise<void> {
+    const configUrl = `${this.baseUrl}/${this.bannerId}/config`;
+    const config = await fetchJSON<BannerConfig>(configUrl);
+    this.bannerConfig = config;
+
+    const cookie = getConsentCookie();
+    if (cookie && cookie.v === config.version && cookie.vid === this.visitorId) {
+      this.consent = {
+        visitor_id: cookie.vid,
+        version: cookie.v,
+        action: cookie.action,
+        consent_data: cookie.data,
+        created_at: "",
+      };
+      return;
+    }
+
+    const consentUrl = `${this.baseUrl}/${this.bannerId}/consents/${this.visitorId}`;
+    const apiConsent = await fetchJSON<VisitorConsent>(consentUrl).catch(
+      (err) => {
+        if (err instanceof NotFoundError) {
+          return null;
+        }
+        throw err;
+      },
+    );
+
+    if (apiConsent && apiConsent.version === config.version) {
+      this.consent = apiConsent;
+      setConsentCookie(
+        {
+          v: apiConsent.version,
+          vid: apiConsent.visitor_id,
+          action: apiConsent.action,
+          data: apiConsent.consent_data,
+        },
+        config.consent_expiry_days,
+      );
+    } else {
+      this.consent = null;
+    }
+  }
+
+  get config(): BannerConfig {
+    if (!this.bannerConfig) {
+      throw new Error("CookieBannerClient not loaded: call load() first");
+    }
+    return this.bannerConfig;
+  }
+
+  get visitorConsent(): VisitorConsent | null {
+    return this.consent;
+  }
+
+  get hasConsent(): boolean {
+    return this.consent !== null;
+  }
+
+  async acceptAll(): Promise<ConsentRecord> {
+    const cfg = this.config;
+
+    const consentData: Record<string, boolean> = {};
+    for (const cat of cfg.categories) {
+      consentData[cat.name] = true;
+    }
+
+    return this.recordConsent("ACCEPT_ALL", consentData);
+  }
+
+  async rejectAll(): Promise<ConsentRecord> {
+    const cfg = this.config;
+
+    const consentData: Record<string, boolean> = {};
+    for (const cat of cfg.categories) {
+      consentData[cat.name] = cat.required;
+    }
+
+    return this.recordConsent("REJECT_ALL", consentData);
+  }
+
+  async customize(
+    categories: Record<string, boolean>,
+  ): Promise<ConsentRecord> {
+    const cfg = this.config;
+
+    const consentData: Record<string, boolean> = {};
+    for (const cat of cfg.categories) {
+      consentData[cat.name] = cat.required || !!categories[cat.name];
+    }
+
+    return this.recordConsent("CUSTOMIZE", consentData);
+  }
+
+  private async recordConsent(
+    action: ConsentAction,
+    consentData: Record<string, boolean>,
+  ): Promise<ConsentRecord> {
+    const cfg = this.config;
+    const url = `${this.baseUrl}/${this.bannerId}/consents`;
+
+    const record = await fetchJSON<ConsentRecord>(url, {
+      method: "POST",
+      body: {
+        visitor_id: this.visitorId,
+        version: cfg.version,
+        action,
+        consent_data: consentData,
+      },
+    });
+
+    this.consent = {
+      visitor_id: this.visitorId,
+      version: cfg.version,
+      action,
+      consent_data: consentData,
+      created_at: record.created_at,
+    };
+
+    setConsentCookie(
+      {
+        v: cfg.version,
+        vid: this.visitorId,
+        action,
+        data: consentData,
+      },
+      cfg.consent_expiry_days,
+    );
+
+    return record;
+  }
+}

--- a/packages/cookie-banner/src/client.ts
+++ b/packages/cookie-banner/src/client.ts
@@ -12,6 +12,7 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
+import { activateElements, observeAndActivate } from "./activation";
 import { getConsentCookie, setConsentCookie } from "./cookie";
 import { NotFoundError } from "./errors";
 import { fetchJSON } from "./http";
@@ -68,6 +69,7 @@ export class CookieBannerClient {
 
   private bannerConfig: BannerConfig | null = null;
   private consent: VisitorConsent | null = null;
+  private observer: MutationObserver | null = null;
 
   constructor(config: CookieBannerClientOptions) {
     this.baseUrl = config.baseUrl.replace(/\/+$/, "");
@@ -89,6 +91,7 @@ export class CookieBannerClient {
         consent_data: cookie.data,
         created_at: "",
       };
+      this.activate(cookie.data);
       return;
     }
 
@@ -113,6 +116,7 @@ export class CookieBannerClient {
         },
         config.consent_expiry_days,
       );
+      this.activate(apiConsent.consent_data);
     } else {
       this.consent = null;
     }
@@ -203,6 +207,22 @@ export class CookieBannerClient {
       cfg.consent_expiry_days,
     );
 
+    this.activate(consentData);
+
     return record;
+  }
+
+  private activate(consentData: Record<string, boolean>): void {
+    activateElements(consentData);
+    if (!this.observer) {
+      this.observer = observeAndActivate(consentData);
+    }
+  }
+
+  destroy(): void {
+    if (this.observer) {
+      this.observer.disconnect();
+      this.observer = null;
+    }
   }
 }

--- a/packages/cookie-banner/src/client.ts
+++ b/packages/cookie-banner/src/client.ts
@@ -72,7 +72,11 @@ export class CookieBannerClient {
   private observer: MutationObserver | null = null;
 
   constructor(config: CookieBannerClientOptions) {
-    this.baseUrl = config.baseUrl.replace(/\/+$/, "");
+    let base = config.baseUrl;
+    while (base.endsWith("/")) {
+      base = base.slice(0, -1);
+    }
+    this.baseUrl = base;
     this.bannerId = config.bannerId;
     this.visitorId = getOrCreateVisitorId(config.bannerId);
   }

--- a/packages/cookie-banner/src/client.ts
+++ b/packages/cookie-banner/src/client.ts
@@ -15,6 +15,7 @@
 import { getConsentCookie, setConsentCookie } from "./cookie";
 import { NotFoundError } from "./errors";
 import { fetchJSON } from "./http";
+import { getOrCreateVisitorId } from "./visitor";
 
 export interface CookieItem {
   name: string;
@@ -58,31 +59,6 @@ export interface ConsentRecord {
 export interface CookieBannerClientOptions {
   bannerId: string;
   baseUrl: string;
-}
-
-const STORAGE_KEY_PREFIX = "probo_consent";
-
-function getOrCreateVisitorId(bannerId: string): string {
-  const key = `${STORAGE_KEY_PREFIX}:${bannerId}:vid`;
-
-  try {
-    const stored = localStorage.getItem(key);
-    if (stored) {
-      return stored;
-    }
-  } catch {
-    // localStorage unavailable
-  }
-
-  const id = crypto.randomUUID();
-
-  try {
-    localStorage.setItem(key, id);
-  } catch {
-    // localStorage unavailable
-  }
-
-  return id;
 }
 
 export class CookieBannerClient {

--- a/packages/cookie-banner/src/client.ts
+++ b/packages/cookie-banner/src/client.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
 //
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above

--- a/packages/cookie-banner/src/cookie.ts
+++ b/packages/cookie-banner/src/cookie.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
 //
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above

--- a/packages/cookie-banner/src/cookie.ts
+++ b/packages/cookie-banner/src/cookie.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { ConsentAction } from "./client";
+
+const COOKIE_NAME = "probo_consent";
+const SECONDS_PER_DAY = 86400;
+
+export interface ConsentCookie {
+  v: number;
+  vid: string;
+  action: ConsentAction;
+  data: Record<string, boolean>;
+}
+
+export function getConsentCookie(): ConsentCookie | null {
+  try {
+    const prefix = `${COOKIE_NAME}=`;
+    const entry = document.cookie
+      .split("; ")
+      .find((c) => c.startsWith(prefix));
+
+    if (!entry) {
+      return null;
+    }
+
+    return JSON.parse(decodeURIComponent(entry.substring(prefix.length)));
+  } catch {
+    return null;
+  }
+}
+
+export function setConsentCookie(
+  value: ConsentCookie,
+  expiryDays: number,
+): void {
+  const maxAge = expiryDays * SECONDS_PER_DAY;
+  const encoded = encodeURIComponent(JSON.stringify(value));
+
+  document.cookie = `${COOKIE_NAME}=${encoded}; path=/; max-age=${maxAge}; SameSite=Lax`;
+}
+
+export function clearConsentCookie(): void {
+  document.cookie = `${COOKIE_NAME}=; path=/; max-age=0; SameSite=Lax`;
+}

--- a/packages/cookie-banner/src/errors.ts
+++ b/packages/cookie-banner/src/errors.ts
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+export class ApiError extends Error {
+  readonly status: number;
+  readonly code: string;
+
+  constructor(status: number, code: string, message: string) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export class BadRequestError extends ApiError {
+  constructor(message: string) {
+    super(400, "bad_request", message);
+    this.name = "BadRequestError";
+  }
+}
+
+export class NotFoundError extends ApiError {
+  constructor(message: string) {
+    super(404, "not_found", message);
+    this.name = "NotFoundError";
+  }
+}
+
+export class InternalServerError extends ApiError {
+  constructor(message: string) {
+    super(500, "internal_server_error", message);
+    this.name = "InternalServerError";
+  }
+}
+
+export class NetworkError extends Error {
+  readonly cause?: unknown;
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = "NetworkError";
+    this.cause = cause;
+  }
+}
+
+export class TimeoutError extends NetworkError {
+  constructor() {
+    super("request timed out");
+    this.name = "TimeoutError";
+  }
+}

--- a/packages/cookie-banner/src/http.ts
+++ b/packages/cookie-banner/src/http.ts
@@ -22,7 +22,7 @@ import {
 } from "./errors";
 
 const DEFAULT_TIMEOUT_MS = 5_000;
-const MAX_RETRIES = 2;
+const MAX_ATTEMPTS = 3;
 const BASE_DELAY_MS = 500;
 
 export interface RequestOptions {
@@ -129,7 +129,7 @@ export async function fetchJSON<T>(
 
   let lastError: Error | undefined;
 
-  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
     if (attempt > 0) {
       await delay(jitteredBackoff(attempt - 1));
     }
@@ -138,6 +138,9 @@ export async function fetchJSON<T>(
     try {
       response = await fetchWithTimeout(url, init, timeout);
     } catch (err) {
+      if (signal?.aborted) {
+        throw err;
+      }
       if (err instanceof TimeoutError || err instanceof NetworkError) {
         lastError = err;
         continue;

--- a/packages/cookie-banner/src/http.ts
+++ b/packages/cookie-banner/src/http.ts
@@ -1,0 +1,168 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import {
+  ApiError,
+  BadRequestError,
+  InternalServerError,
+  NetworkError,
+  NotFoundError,
+  TimeoutError,
+} from "./errors";
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const MAX_RETRIES = 3;
+const BASE_DELAY_MS = 1_000;
+
+export interface RequestOptions {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+  timeout?: number;
+  signal?: AbortSignal;
+}
+
+interface ApiErrorBody {
+  error: string;
+  message: string;
+}
+
+function isRetryable(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function jitteredBackoff(attempt: number): number {
+  const base = BASE_DELAY_MS * Math.pow(2, attempt);
+  return base + Math.random() * base;
+}
+
+function throwApiError(status: number, body: ApiErrorBody): never {
+  switch (status) {
+    case 400:
+      throw new BadRequestError(body.message);
+    case 404:
+      throw new NotFoundError(body.message);
+    case 500:
+      throw new InternalServerError(body.message);
+    default:
+      throw new ApiError(status, body.error, body.message);
+  }
+}
+
+async function parseErrorBody(response: Response): Promise<ApiErrorBody> {
+  try {
+    return (await response.json()) as ApiErrorBody;
+  } catch {
+    return {
+      error: "unknown",
+      message: response.statusText || "unknown error",
+    };
+  }
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeout: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const externalSignal = init.signal;
+
+  if (externalSignal?.aborted) {
+    throw new NetworkError("request aborted", externalSignal.reason);
+  }
+
+  const onExternalAbort = () => controller.abort(externalSignal!.reason);
+  externalSignal?.addEventListener("abort", onExternalAbort, { once: true });
+
+  const timer = setTimeout(() => controller.abort("timeout"), timeout);
+
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } catch (err) {
+    if (controller.signal.aborted && controller.signal.reason === "timeout") {
+      throw new TimeoutError();
+    }
+    if (externalSignal?.aborted) {
+      throw new NetworkError("request aborted", err);
+    }
+    throw new NetworkError("network request failed", err);
+  } finally {
+    clearTimeout(timer);
+    externalSignal?.removeEventListener("abort", onExternalAbort);
+  }
+}
+
+export async function fetchJSON<T>(
+  url: string,
+  options: RequestOptions = {},
+): Promise<T> {
+  const { method = "GET", headers, body, timeout = DEFAULT_TIMEOUT_MS, signal } = options;
+
+  const init: RequestInit = {
+    method,
+    mode: "cors",
+    credentials: "omit",
+    headers: {
+      Accept: "application/json",
+      ...(body !== undefined && { "Content-Type": "application/json" }),
+      ...headers,
+    },
+    ...(body !== undefined && { body: JSON.stringify(body) }),
+    ...(signal && { signal }),
+  };
+
+  let lastError: Error | undefined;
+
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    if (attempt > 0) {
+      await delay(jitteredBackoff(attempt - 1));
+    }
+
+    let response: Response;
+    try {
+      response = await fetchWithTimeout(url, init, timeout);
+    } catch (err) {
+      if (err instanceof TimeoutError || err instanceof NetworkError) {
+        lastError = err;
+        continue;
+      }
+      throw err;
+    }
+
+    if (response.ok) {
+      if (response.status === 204) {
+        return undefined as T;
+      }
+      return (await response.json()) as T;
+    }
+
+    if (!isRetryable(response.status)) {
+      const body = await parseErrorBody(response);
+      throwApiError(response.status, body);
+    }
+
+    lastError = new ApiError(
+      response.status,
+      "server_error",
+      `server returned ${response.status}`,
+    );
+  }
+
+  throw lastError!;
+}

--- a/packages/cookie-banner/src/http.ts
+++ b/packages/cookie-banner/src/http.ts
@@ -21,9 +21,9 @@ import {
   TimeoutError,
 } from "./errors";
 
-const DEFAULT_TIMEOUT_MS = 10_000;
-const MAX_RETRIES = 3;
-const BASE_DELAY_MS = 1_000;
+const DEFAULT_TIMEOUT_MS = 5_000;
+const MAX_RETRIES = 2;
+const BASE_DELAY_MS = 500;
 
 export interface RequestOptions {
   method?: string;

--- a/packages/cookie-banner/src/index.ts
+++ b/packages/cookie-banner/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
 //
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above
@@ -13,6 +13,17 @@
 // PERFORMANCE OF THIS SOFTWARE.
 
 export const VERSION = "0.0.0";
+
+export {
+  ApiError,
+  BadRequestError,
+  InternalServerError,
+  NetworkError,
+  NotFoundError,
+  TimeoutError,
+} from "./errors";
+export { fetchJSON } from "./http";
+export type { RequestOptions } from "./http";
 
 export type CookieBannerConfig = {
   bannerId: string;

--- a/packages/cookie-banner/src/index.ts
+++ b/packages/cookie-banner/src/index.ts
@@ -14,6 +14,7 @@
 
 export const VERSION = "0.0.0";
 
+export { activateElements, observeAndActivate } from "./activation";
 export { CookieBannerClient } from "./client";
 export type {
   BannerConfig,

--- a/packages/cookie-banner/src/index.ts
+++ b/packages/cookie-banner/src/index.ts
@@ -14,6 +14,17 @@
 
 export const VERSION = "0.0.0";
 
+export { CookieBannerClient } from "./client";
+export type {
+  BannerConfig,
+  Category,
+  ConsentAction,
+  ConsentRecord,
+  CookieBannerClientOptions,
+  CookieItem,
+  VisitorConsent,
+} from "./client";
+export type { ConsentCookie } from "./cookie";
 export {
   ApiError,
   BadRequestError,
@@ -24,12 +35,3 @@ export {
 } from "./errors";
 export { fetchJSON } from "./http";
 export type { RequestOptions } from "./http";
-
-export type CookieBannerConfig = {
-  bannerId: string;
-  baseUrl: string;
-};
-
-export async function init(_config: CookieBannerConfig): Promise<void> {
-  // TODO: implement
-}

--- a/packages/cookie-banner/src/index.ts
+++ b/packages/cookie-banner/src/index.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+export const VERSION = "0.0.0";
+
+export type CookieBannerConfig = {
+  bannerId: string;
+  baseUrl: string;
+};
+
+export async function init(_config: CookieBannerConfig): Promise<void> {
+  // TODO: implement
+}

--- a/packages/cookie-banner/src/queue.ts
+++ b/packages/cookie-banner/src/queue.ts
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { fetchJSON } from "./http";
+
+const STORAGE_KEY_PREFIX = "probo_consent";
+const MAX_QUEUE_SIZE = 10;
+const MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+interface PendingConsent {
+  url: string;
+  body: unknown;
+  timestamp: number;
+}
+
+function storageKey(bannerId: string): string {
+  return `${STORAGE_KEY_PREFIX}:${bannerId}:queue`;
+}
+
+function readQueue(bannerId: string): PendingConsent[] {
+  try {
+    const raw = localStorage.getItem(storageKey(bannerId));
+    if (!raw) {
+      return [];
+    }
+    return JSON.parse(raw) as PendingConsent[];
+  } catch {
+    return [];
+  }
+}
+
+function writeQueue(bannerId: string, queue: PendingConsent[]): void {
+  try {
+    if (queue.length === 0) {
+      localStorage.removeItem(storageKey(bannerId));
+    } else {
+      localStorage.setItem(storageKey(bannerId), JSON.stringify(queue));
+    }
+  } catch {
+    // localStorage unavailable
+  }
+}
+
+export function enqueue(
+  bannerId: string,
+  url: string,
+  body: unknown,
+): void {
+  const queue = readQueue(bannerId);
+  queue.push({ url, body, timestamp: Date.now() });
+
+  if (queue.length > MAX_QUEUE_SIZE) {
+    queue.splice(0, queue.length - MAX_QUEUE_SIZE);
+  }
+
+  writeQueue(bannerId, queue);
+}
+
+export async function flush(bannerId: string): Promise<void> {
+  const now = Date.now();
+  let queue = readQueue(bannerId);
+
+  if (queue.length === 0) {
+    return;
+  }
+
+  queue = queue.filter((entry) => now - entry.timestamp < MAX_AGE_MS);
+
+  if (queue.length === 0) {
+    writeQueue(bannerId, []);
+    return;
+  }
+
+  const remaining: PendingConsent[] = [];
+
+  for (const entry of queue) {
+    try {
+      await fetchJSON(entry.url, { method: "POST", body: entry.body });
+    } catch {
+      remaining.push(entry);
+    }
+  }
+
+  writeQueue(bannerId, remaining);
+}

--- a/packages/cookie-banner/src/queue.ts
+++ b/packages/cookie-banner/src/queue.ts
@@ -82,15 +82,25 @@ export async function flush(bannerId: string): Promise<void> {
     return;
   }
 
-  const remaining: PendingConsent[] = [];
+  const sentTimestamps: number[] = [];
 
   for (const entry of queue) {
     try {
       await fetchJSON(entry.url, { method: "POST", body: entry.body });
+      sentTimestamps.push(entry.timestamp);
     } catch {
-      remaining.push(entry);
+      // will remain in queue
     }
   }
 
-  writeQueue(bannerId, remaining);
+  if (sentTimestamps.length === 0) {
+    return;
+  }
+
+  const sentSet = new Set(sentTimestamps);
+  const current = readQueue(bannerId);
+  writeQueue(
+    bannerId,
+    current.filter((entry) => !sentSet.has(entry.timestamp)),
+  );
 }

--- a/packages/cookie-banner/src/queue.ts
+++ b/packages/cookie-banner/src/queue.ts
@@ -93,14 +93,13 @@ export async function flush(bannerId: string): Promise<void> {
     }
   }
 
-  if (sentTimestamps.length === 0) {
-    return;
-  }
-
   const sentSet = new Set(sentTimestamps);
+  const cutoff = now - MAX_AGE_MS;
   const current = readQueue(bannerId);
   writeQueue(
     bannerId,
-    current.filter((entry) => !sentSet.has(entry.timestamp)),
+    current.filter(
+      (entry) => !sentSet.has(entry.timestamp) && entry.timestamp > cutoff,
+    ),
   );
 }

--- a/packages/cookie-banner/src/visitor.ts
+++ b/packages/cookie-banner/src/visitor.ts
@@ -26,7 +26,9 @@ export function getOrCreateVisitorId(bannerId: string): string {
     // localStorage unavailable
   }
 
-  const id = crypto.randomUUID();
+  const array = new Uint8Array(16);
+  crypto.getRandomValues(array);
+  const id = Array.from(array, (b) => b.toString(16).padStart(2, "0")).join("");
 
   try {
     localStorage.setItem(key, id);

--- a/packages/cookie-banner/src/visitor.ts
+++ b/packages/cookie-banner/src/visitor.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+const STORAGE_KEY_PREFIX = "probo_consent";
+
+export function getOrCreateVisitorId(bannerId: string): string {
+  const key = `${STORAGE_KEY_PREFIX}:${bannerId}:vid`;
+
+  try {
+    const stored = localStorage.getItem(key);
+    if (stored) {
+      return stored;
+    }
+  } catch {
+    // localStorage unavailable
+  }
+
+  const id = crypto.randomUUID();
+
+  try {
+    localStorage.setItem(key, id);
+  } catch {
+    // localStorage unavailable
+  }
+
+  return id;
+}

--- a/packages/cookie-banner/tsconfig.json
+++ b/packages/cookie-banner/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@probo/tsconfig/base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationDir": "dist",
+    "emitDeclarationOnly": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Closes ENG-273

Introduce the boilerplate for a new public npm package that will serve as the cookie consent banner JavaScript SDK. The package uses esbuild to produce both an IIFE bundle (for script tag embedding) and an ESM module. Versioning is independent from the monorepo: CI compares package.json against npm and only publishes when the version changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces the public cookie consent banner SDK `@probo/cookie-banner` with IIFE/ESM builds and a release workflow. Adds a `CookieBannerClient` with versioned cookie caching, persistent visitor IDs, automatic activation of consent-tagged elements, a resilient HTTP client, and a localStorage-backed consent retry queue.

- **New Features**
  - Exports: `VERSION`, `CookieBannerClient`, `fetchJSON<T>()`, typed errors, `activateElements`, `observeAndActivate`, and types.
  - Client: loads config; accept/reject/customize; caches consent by version in `probo_consent`; persistent visitor ID (crypto.getRandomValues); replays failed consent POSTs on next load.
  - Activation: unblocks consent-tagged `script`, `iframe`, `img`, `video`, `audio`, `embed`, `object`, `link`; supports `data-src`/`data-href`; observes DOM changes.
  - HTTP: JSON fetch with 5s timeout and up to 3 attempts on 429/5xx and network errors using exponential backoff with jitter; supports abort/timeout.

- **Bug Fixes**
  - Exports map fixed: `main` points to ESM; added `./iife` entry.
  - Activation: preserve original `<script>` type via `data-type`; recreate `MutationObserver` when consent changes.
  - HTTP: skip retries on caller-initiated aborts; renamed `MAX_RETRIES` to `MAX_ATTEMPTS` for clarity.
  - Queue: fix flush race by re-reading localStorage; always flush in the cookie fast-path of `load()`; prune expired entries on final write to enforce `MAX_AGE_MS`.

<sup>Written for commit d63ce1f68b18a424fb4579f9288f8cba86da10ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



