### PR TITLE
Fix Profile field name in n8n-node GraphQL queries

### DIFF
--- a/packages/n8n-node/nodes/Probo/actions/asset/create.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/asset/create.operation.ts
@@ -174,7 +174,7 @@ export async function execute(
 		? `owner {
 			id
 			fullName
-			primaryEmailAddress
+			emailAddress
 		}`
 		: '';
 

--- a/packages/n8n-node/nodes/Probo/actions/asset/get.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/asset/get.operation.ts
@@ -75,7 +75,7 @@ export async function execute(
 		? `owner {
 			id
 			fullName
-			primaryEmailAddress
+			emailAddress
 		}`
 		: '';
 

--- a/packages/n8n-node/nodes/Probo/actions/asset/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/asset/getAll.operation.ts
@@ -107,7 +107,7 @@ export async function execute(
 		? `owner {
 			id
 			fullName
-			primaryEmailAddress
+			emailAddress
 		}`
 		: '';
 

--- a/packages/n8n-node/nodes/Probo/actions/asset/update.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/asset/update.operation.ts
@@ -169,7 +169,7 @@ export async function execute(
 		? `owner {
 			id
 			fullName
-			primaryEmailAddress
+			emailAddress
 		}`
 		: '';
 

--- a/packages/n8n-node/nodes/Probo/actions/datum/create.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/datum/create.operation.ts
@@ -152,7 +152,7 @@ export async function execute(
 		? `owner {
 			id
 			fullName
-			primaryEmailAddress
+			emailAddress
 		}`
 		: '';
 

--- a/packages/n8n-node/nodes/Probo/actions/datum/get.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/datum/get.operation.ts
@@ -75,7 +75,7 @@ export async function execute(
 		? `owner {
 			id
 			fullName
-			primaryEmailAddress
+			emailAddress
 		}`
 		: '';
 

--- a/packages/n8n-node/nodes/Probo/actions/datum/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/datum/getAll.operation.ts
@@ -107,7 +107,7 @@ export async function execute(
 		? `owner {
 			id
 			fullName
-			primaryEmailAddress
+			emailAddress
 		}`
 		: '';
 

--- a/packages/n8n-node/nodes/Probo/actions/datum/update.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/datum/update.operation.ts
@@ -149,7 +149,7 @@ export async function execute(
 		? `owner {
 			id
 			fullName
-			primaryEmailAddress
+			emailAddress
 		}`
 		: '';
 

--- a/packages/n8n-node/nodes/Probo/actions/document/getAllSignatures.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/document/getAllSignatures.operation.ts
@@ -126,7 +126,7 @@ export async function execute(
 								signedBy {
 									id
 									fullName
-									primaryEmailAddress
+									emailAddress
 								}
 							}
 						}

--- a/packages/n8n-node/nodes/Probo/actions/document/getSignature.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/document/getSignature.operation.ts
@@ -51,7 +51,7 @@ export async function execute(
 					signedBy {
 						id
 						fullName
-						primaryEmailAddress
+						emailAddress
 					}
 				}
 			}

--- a/packages/n8n-node/nodes/Probo/actions/document/requestSignature.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/document/requestSignature.operation.ts
@@ -67,7 +67,7 @@ export async function execute(
 						signedBy {
 							id
 							fullName
-							primaryEmailAddress
+							emailAddress
 						}
 					}
 				}

--- a/packages/n8n-node/nodes/Probo/actions/vendor/get.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/vendor/get.operation.ts
@@ -90,7 +90,7 @@ export async function execute(
 		? `businessOwner {
 			id
 			fullName
-			primaryEmailAddress
+			emailAddress
 		}`
 		: '';
 
@@ -98,7 +98,7 @@ export async function execute(
 		? `securityOwner {
 			id
 			fullName
-			primaryEmailAddress
+			emailAddress
 		}`
 		: '';
 

--- a/packages/n8n-node/nodes/Probo/actions/vendor/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/vendor/getAll.operation.ts
@@ -122,7 +122,7 @@ export async function execute(
 		? `businessOwner {
 			id
 			fullName
-			primaryEmailAddress
+			emailAddress
 		}`
 		: '';
 
@@ -130,7 +130,7 @@ export async function execute(
 		? `securityOwner {
 			id
 			fullName
-			primaryEmailAddress
+			emailAddress
 		}`
 		: '';
 


### PR DESCRIPTION
Rename primaryEmailAddress to emailAddress to match the Profile type in the GraphQL schema.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GraphQL queries in the Probo node by renaming Profile field `primaryEmailAddress` to `emailAddress` to match the schema and prevent query errors.

- **Bug Fixes**
  - Updated Profile fragments in asset, datum, document (signatures), and vendor operations to request `emailAddress` for owner, signedBy, businessOwner, and securityOwner in `n8n-node`.

<sup>Written for commit ce1f2fa28c00ba33caba55bb3704b034731530df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

