### PR TITLE
Preserve shared connector on SCIM disconnect

### DIFF
--- a/apps/console/src/pages/iam/organizations/settings/_components/GoogleWorkspaceConnector.tsx
+++ b/apps/console/src/pages/iam/organizations/settings/_components/GoogleWorkspaceConnector.tsx
@@ -54,7 +54,7 @@ const deleteSCIMConfigurationMutation = graphql`
     $input: DeleteSCIMConfigurationInput!
   ) {
     deleteSCIMConfiguration(input: $input) {
-      deletedScimConfigurationId
+      deletedScimConfigurationId @deleteRecord
     }
   }
 `;
@@ -146,12 +146,6 @@ export function GoogleWorkspaceConnector(props: {
           description: error.message,
           variant: "error",
         });
-      },
-      updater: (store) => {
-        const organizationRecord = store.get(organizationId);
-        if (organizationRecord) {
-          organizationRecord.setValue(null, "scimConfiguration");
-        }
       },
     });
   };

--- a/pkg/coredata/access_source.go
+++ b/pkg/coredata/access_source.go
@@ -307,6 +307,32 @@ WHERE
 	return count, nil
 }
 
+func (sources *AccessSources) CountByConnectorID(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	connectorID gid.GID,
+) (int, error) {
+	q := `
+SELECT COUNT(id)
+FROM access_sources
+WHERE
+    %s
+    AND connector_id = @connector_id;
+`
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"connector_id": connectorID}
+	maps.Copy(args, scope.SQLArguments())
+
+	var count int
+	if err := conn.QueryRow(ctx, q, args).Scan(&count); err != nil {
+		return 0, fmt.Errorf("cannot count access_sources by connector ID: %w", err)
+	}
+
+	return count, nil
+}
+
 // LoadScopeSourcesByCampaignID loads the campaign scope sources in deterministic
 // name order. Only explicitly scoped sources are returned.
 func (sources *AccessSources) LoadScopeSourcesByCampaignID(

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -1580,12 +1580,23 @@ func (s OrganizationService) DeleteSCIMConfiguration(
 			}
 
 			if err == nil {
-				// Bridge exists, delete connector if it has one
+				// Bridge exists. Only delete the underlying connector if nothing
+				// else references it (e.g. access_sources). Otherwise leave it in
+				// place — the bridge's FK is ON DELETE SET NULL, so deleting the
+				// bridge alone is sufficient to unbind SCIM from the connector.
 				if bridge.ConnectorID != nil {
-					connector := &coredata.Connector{ID: *bridge.ConnectorID}
-					err = connector.Delete(ctx, tx, scope)
-					if err != nil && err != coredata.ErrResourceNotFound {
-						return fmt.Errorf("cannot delete connector: %w", err)
+					accessSources := &coredata.AccessSources{}
+					count, err := accessSources.CountByConnectorID(ctx, tx, scope, *bridge.ConnectorID)
+					if err != nil {
+						return fmt.Errorf("cannot count access sources for connector: %w", err)
+					}
+
+					if count == 0 {
+						connector := &coredata.Connector{ID: *bridge.ConnectorID}
+						err = connector.Delete(ctx, tx, scope)
+						if err != nil && err != coredata.ErrResourceNotFound {
+							return fmt.Errorf("cannot delete connector: %w", err)
+						}
 					}
 				}
 


### PR DESCRIPTION
## Summary

`deleteSCIMConfiguration` unconditionally deleted the underlying OAuth2 connector together with the SCIM bridge and config. When the same Google Workspace connector was also referenced from `access_sources` (the case when Google Workspace is configured for both SCIM and Access Reviews), the `access_sources.connector_id` foreign key rejected the DELETE, aborting the whole transaction. Nothing was deleted and the resolver returned an INTERNAL error — but the frontend `updater` ran regardless and optimistically cleared `organization.scimConfiguration`, showing the user a false "disconnected" UI until the next refresh revealed the state had not changed.

## Changes

- **`feat(coredata)`** add `AccessSources.CountByConnectorID` — helper used to gate the disconnect flow on remaining references.
- **`fix(iam)`** `DeleteSCIMConfiguration` now skips the connector delete when any access source still references it. The bridge's own `connector_id` FK is `ON DELETE SET NULL`, so dropping the bridge alone is sufficient to unbind SCIM.
- **`fix(console)`** replace the custom `updater` on the Google Workspace disconnect mutation with a `@deleteRecord` directive on `deletedScimConfigurationId` (matching the idiom already used in `SCIMConfiguration.tsx`). `@deleteRecord` is a no-op when the returned id is null, so error responses no longer flip the UI.

## Test plan

- [x] Reproduce the original bug locally: click Disconnect on an org that has both a Google Workspace SCIM bridge and a Google Workspace access source referencing the same connector → mutation returns `INTERNAL`, DB rows untouched, UI shows false "disconnected" state until refresh restores "Connected".
- [x] `go vet ./pkg/coredata/... ./pkg/iam/...` → clean.
- [x] `make test MODULE=./pkg/coredata/...` → 70 tests pass.
- [x] `make test MODULE=./pkg/iam/...` → 111 tests pass.
- [x] `npm run relay` → regenerates `GoogleWorkspaceConnectorDeleteMutation.graphql.ts` with `"handle": "deleteRecord"`.
- [x] `cd apps/console && npx eslint` on the modified file → 0 errors; `npm run build` → no type errors.
- [x] End-to-end smoke in the dev environment after the fix:
    - shared-connector disconnect → mutation returns `{"data":{"deleteSCIMConfiguration":{"deletedScimConfigurationId":"…"}}}`; DB state: `scim_config=0`, `scim_bridge=0`, `connector=1` (preserved), `access_source=1` (connector_id unchanged); UI after refresh shows **Connect**.

## Notes

- No automated regression test is added. `pkg/coredata` / `pkg/iam` have no DB-backed test harness in the repo, and the e2e testutil has no SCIM/connector/access-source seeder. The sibling helper `CountByOrganizationID` this one mirrors is also untested. Adding a DB harness is scope creep for a bugfix — flagged as a follow-up for when e2e testutil gains the missing factories.
- No GraphQL schema change, no MCP/CLI change, no DB migration.
- Full plan: `docs/plans/2026-04-16-fix-scim-disconnect-shared-connector.md` on the branch (not committed in this PR).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SCIM disconnect when a connector is shared with Access Reviews. We keep the shared connector and prevent the console from showing a false “disconnected” state.

- **Bug Fixes**
  - `pkg/coredata`: Add `AccessSources.CountByConnectorID` to detect connector usage.
  - `pkg/iam`: `DeleteSCIMConfiguration` now deletes the bridge/config and only deletes the connector if unused.
  - `apps/console`: Use `@deleteRecord` on `deletedScimConfigurationId` and remove the custom updater to avoid incorrect UI updates on errors.

<sup>Written for commit 763f80730f75aefaab4fd2c4f9c35f73278ee503. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

