### PR TITLE
Use typed error when SCIM bridge is not found

### DIFF
--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -1670,14 +1670,14 @@ func (s OrganizationService) UpdateSCIMBridge(
 			err := bridge.LoadByID(ctx, tx, scope, bridgeID)
 			if err != nil {
 				if err == coredata.ErrResourceNotFound {
-					return fmt.Errorf("SCIM bridge not found")
+					return NewSCIMBridgeNotFoundError(bridgeID)
 				}
 
 				return fmt.Errorf("cannot load SCIM bridge: %w", err)
 			}
 
 			if bridge.OrganizationID != organizationID {
-				return fmt.Errorf("SCIM bridge not found")
+				return NewSCIMBridgeNotFoundError(bridgeID)
 			}
 
 			bridge.ExcludedUserNames = excludedUserNames


### PR DESCRIPTION
## Summary

`OrganizationService.UpdateSCIMBridge` returned bare `fmt.Errorf("SCIM bridge not found")` strings on both not-found branches (resource missing in DB, and cross-tenant mismatch). Every other call site returning the same condition uses the typed `NewSCIMBridgeNotFoundError(bridgeID)` — see `pkg/iam/organization_service.go:1962` and `:2153`.

Switch both branches to the typed error so:
- Error shape is consistent across the service.
- Callers can detect the condition with `errors.As` instead of string matching.
- The GraphQL/CLI error mapping paths that already handle `*ErrSCIMBridgeNotFound` work uniformly for this resolver too.

## Test plan

- [x] `go build ./pkg/iam/...` → clean.
- [x] `go vet ./pkg/iam/...` → clean.
- [x] No behavior change for callers that already swallow the error into `gqlutils.Internal` — the typed error still unwraps to a human-readable string.

## Notes

Spotted during review of a separate SCIM disconnect bugfix (#1053). Split into its own PR because it's a preexisting inconsistency, not caused by that change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return the typed `NewSCIMBridgeNotFoundError(bridgeID)` from `OrganizationService.UpdateSCIMBridge` in both not-found cases (bridge missing or cross-tenant mismatch). This keeps errors consistent with other call sites and lets callers and GraphQL/CLI mappers use `errors.As` to detect it.

<sup>Written for commit f5c59ba13bfba957325d8002926621f83d2acb3c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

