### PR TITLE
Use a single page-level scroll and pin the sidebar toggle

### DIFF
--- a/packages/ui/src/Atoms/Sidebar/Sidebar.tsx
+++ b/packages/ui/src/Atoms/Sidebar/Sidebar.tsx
@@ -46,17 +46,30 @@ export function Sidebar({ children }: PropsWithChildren) {
     <sidebarContext.Provider value={{ open }}>
       <aside
         className={clsx(
-          "border-r border-border-solid relative pt-16 flex-none",
-          open ? "px-4 w-[280px]" : "px-2",
+          "border-r border-border-solid pt-16 flex-none flex flex-col",
+          open && "w-[280px]",
         )}
       >
-        {children}
-        <Button
-          variant="tertiary"
-          icon={open ? IconCollapse : IconExpand}
-          onClick={() => setOpen(!open)}
-          className="absolute bottom-4 left-4"
-        />
+        <div
+          className={clsx(
+            "flex-1 pb-2",
+            open ? "px-4" : "px-2",
+          )}
+        >
+          {children}
+        </div>
+        <div
+          className={clsx(
+            "sticky bottom-0 flex-none border-t border-border-solid bg-level-0 py-2",
+            open ? "px-4" : "px-2",
+          )}
+        >
+          <Button
+            variant="tertiary"
+            icon={open ? IconCollapse : IconExpand}
+            onClick={() => setOpen(!open)}
+          />
+        </div>
       </aside>
     </sidebarContext.Provider>
   );

--- a/packages/ui/src/Layouts/Layout.tsx
+++ b/packages/ui/src/Layouts/Layout.tsx
@@ -55,8 +55,8 @@ export function Layout({
   );
   return (
     <LayoutContext value={layoutContext}>
-      <div className="text-txt-primary bg-level-0">
-        <header className="absolute z-2 left-0 right-0 px-4 flex items-center border-b border-border-solid h-12 bg-level-0">
+      <div className="text-txt-primary bg-level-0 min-h-screen">
+        <header className="fixed top-0 z-2 left-0 right-0 px-4 flex items-center border-b border-border-solid h-12 bg-level-0">
           <Link to="/">
             <Logo className="w-12 h-5" />
           </Link>
@@ -77,11 +77,11 @@ export function Layout({
           )}
           <div className="ml-auto">{headerTrailing}</div>
         </header>
-        <div className="flex h-screen" id="main">
+        <div className="flex min-h-screen" id="main">
           {sidebar && <Sidebar>{sidebar}</Sidebar>}
           <main
             className={clsx(
-              "overflow-y-auto w-full mt-12 transition-all duration-300 h-[calc(100vh-48px)]",
+              "w-full mt-12 transition-all duration-300",
               hasDrawer && "pr-105",
             )}
           >
@@ -111,7 +111,7 @@ export function Drawer({
   return createPortal(
     <aside
       className={clsx(
-        "absolute pt-20 top-0 right-0 w-105 px-6 pb-8 border-border-solid border-l h-screen",
+        "fixed pt-20 top-0 right-0 w-105 px-6 pb-8 border-border-solid border-l h-screen bg-level-0",
         className,
       )}
     >


### PR DESCRIPTION
## Summary
- Previously the layout nested two scroll regions (sidebar and main) inside a fixed `h-screen` flex container. When the sidebar nav exceeded the viewport height, the overflow spilled past the `bg-level-0` wrapper and exposed the browser's default white background -- a visible white strip at the bottom of the viewport in dark mode.
- The `absolute bottom-4` collapse button also overlapped the last nav items whenever the nav was taller than the sidebar.

## Changes
- `Layout.tsx`: switch to a single page-level scroll. Pin the header with `fixed`, grow the wrapper with `min-h-screen`, drop `main`'s internal `overflow-y-auto`. Promote the drawer from `absolute` to `fixed` (with `bg-level-0`) so it stays pinned while the page scrolls.
- `Sidebar.tsx`: restructure the aside as a flex column. Nav list in a `flex-1` region, collapse button in a `sticky bottom-0` container with a `border-t` separator. The button pins to the viewport bottom while scrolling and no longer overlaps the items above.

## Test plan
- [ ] Load a page with a tall sidebar (e.g. `/organizations/:id/people`) in dark mode -- confirm no white strip at the bottom
- [ ] Scroll the page -- confirm the header and the collapse toggle stay pinned
- [ ] Collapse/expand the sidebar -- confirm the toggle works and is always reachable
- [ ] Open a drawer (e.g. risk or measure detail page) -- confirm it stays pinned while the page scrolls and its background covers content behind it
- [ ] Verify only a single page-level scrollbar is visible

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the app to a single page-level scroll and fixes sidebar overflow. Removes the dark-mode white strip and keeps the header, drawer, and collapse button pinned.

- **Bug Fixes**
  - Layout: header is `fixed` (top-0), wrapper and main container use `min-h-screen`, and `main` no longer scrolls.
  - Drawer: `fixed` with `bg-level-0` so it stays pinned and covers content while the page scrolls.
  - Sidebar: column layout with nav in `flex-1`; collapse button in a `sticky bottom-0` container with a `border-t` separator.

<sup>Written for commit 6f0e150a06505dfb9bd989f149810f511d3c9d9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

