### PR TITLE
@probo/cookie-banner - add components + themed banner

### DIFF
--- a/packages/cookie-banner/README.md
+++ b/packages/cookie-banner/README.md
@@ -1,0 +1,225 @@
+# @probo/cookie-banner
+
+A lightweight, GDPR-compliant cookie consent banner for the web. Works with any framework or plain HTML — zero dependencies, powered by Web Components.
+
+## Installation
+
+```bash
+npm install @probo/cookie-banner
+```
+
+## Quick Start (Script Tag)
+
+The fastest way to add a cookie banner to any website. Drop a single `<script>` tag into your HTML — no bundler required:
+
+```html
+<script
+  src="https://unpkg.com/@probo/cookie-banner/dist/cookie-banner.iife.js"
+  data-banner-id="YOUR_BANNER_ID"
+  data-base-url="BASE_URL"
+  data-position="bottom-left"
+></script>
+```
+
+This automatically renders a fully styled consent dialog and a floating settings button so visitors can change their preferences at any time.
+
+| Attribute        | Required | Description                                                       |
+| ---------------- | -------- | ----------------------------------------------------------------- |
+| `data-banner-id` | Yes      | Your banner ID from the Probo dashboard                           |
+| `data-base-url`  | Yes      | The Probo cookie-banner API base URL                              |
+| `data-position`  | No       | Settings button position: `bottom-left` (default), `bottom-right` |
+
+## Themed Banner (ES Module)
+
+Import the pre-built themed banner as an ES module for use in bundled applications (React, Vue, Svelte, etc.):
+
+```js
+import { registerThemedBanner } from "@probo/cookie-banner/themed-banner";
+
+registerThemedBanner();
+```
+
+Then use the `<probo-cookie-banner>` custom element anywhere in your HTML or templates:
+
+```html
+<probo-cookie-banner
+  banner-id="YOUR_BANNER_ID"
+  base-url="BASE_URL"
+  position="bottom-left"
+></probo-cookie-banner>
+```
+
+### Theming with CSS Custom Properties
+
+The themed banner renders inside a Shadow DOM and exposes CSS custom properties for styling:
+
+```css
+probo-cookie-banner {
+  --probo-font-family: "Inter", sans-serif;
+  --probo-bg: #ffffff;
+  --probo-text: #1a1a1a;
+  --probo-text-secondary: #555555;
+  --probo-border: #e0e0e0;
+  --probo-radius: 12px;
+  --probo-shadow: 0 4px 24px rgba(0, 0, 0, 0.12);
+  --probo-accent: #1a1a1a;
+  --probo-accent-text: #ffffff;
+  --probo-overlay: rgba(0, 0, 0, 0.4);
+  --probo-z-index: 2147483646;
+}
+```
+
+Dark mode example:
+
+```css
+@media (prefers-color-scheme: dark) {
+  probo-cookie-banner {
+    --probo-bg: #1a1a1a;
+    --probo-text: #f0f0f0;
+    --probo-text-secondary: #a0a0a0;
+    --probo-border: #333333;
+    --probo-accent: #f0f0f0;
+    --probo-accent-text: #1a1a1a;
+    --probo-overlay: rgba(0, 0, 0, 0.6);
+  }
+}
+```
+
+## Headless Components (Full Control)
+
+For complete control over the UI, import the headless Web Components directly. This entrypoint gives you unstyled building blocks that you compose and style yourself:
+
+```js
+import { registerComponents } from "@probo/cookie-banner";
+
+registerComponents();
+```
+
+Then build your own banner layout using the provided custom elements:
+
+```html
+<probo-cookie-banner-root banner-id="YOUR_BANNER_ID" base-url="BASE_URL">
+  <!-- Shown when no consent is recorded -->
+  <probo-banner>
+    <div class="my-banner">
+      <p>We use cookies to improve your experience.</p>
+      <probo-accept-button>
+        <button>Accept all</button>
+      </probo-accept-button>
+      <probo-reject-button>
+        <button>Reject all</button>
+      </probo-reject-button>
+      <probo-customize-button>
+        <button>Customize</button>
+      </probo-customize-button>
+    </div>
+  </probo-banner>
+
+  <!-- Shown when visitor clicks "Customize" -->
+  <probo-preference-panel>
+    <div class="my-preferences">
+      <probo-category-list>
+        <template>
+          <div class="category">
+            <span data-slot="name"></span>
+            <span data-slot="description"></span>
+            <probo-category-toggle>
+              <input type="checkbox" />
+            </probo-category-toggle>
+          </div>
+          <probo-cookie-list>
+            <template>
+              <div class="cookie">
+                <span data-slot="name"></span>
+                <span data-slot="duration"></span>
+              </div>
+            </template>
+          </probo-cookie-list>
+        </template>
+      </probo-category-list>
+      <probo-save-button>
+        <button>Save preferences</button>
+      </probo-save-button>
+    </div>
+  </probo-preference-panel>
+
+  <!-- Floating button to re-open preferences after consent -->
+  <probo-settings-button position="bottom-left"></probo-settings-button>
+</probo-cookie-banner-root>
+```
+
+### Available Components
+
+| Component                    | Description                                                                                                  |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `<probo-cookie-banner-root>` | Root element. Requires `banner-id` and `base-url` attributes. Manages client lifecycle and state.            |
+| `<probo-banner>`             | Container shown when consent has not been given yet.                                                         |
+| `<probo-accept-button>`      | Wraps a button that records "accept all" consent.                                                            |
+| `<probo-reject-button>`      | Wraps a button that records "reject all" consent.                                                            |
+| `<probo-customize-button>`   | Wraps a button that opens the preference panel.                                                              |
+| `<probo-preference-panel>`   | Container for per-category consent toggles.                                                                  |
+| `<probo-category-list>`      | Renders a `<template>` once per cookie category. Fills `data-slot="name"` and `data-slot="description"`.     |
+| `<probo-category-toggle>`    | Binds the checkbox inside it to the category's consent state.                                                |
+| `<probo-cookie-list>`        | Renders a `<template>` once per cookie in the category. Fills `data-slot="name"` and `data-slot="duration"`. |
+| `<probo-save-button>`        | Wraps a button that saves the current preference draft.                                                      |
+| `<probo-settings-button>`    | Floating button to re-open preferences. Accepts a `position` attribute.                                      |
+
+## Blocking Third-Party Scripts and Elements
+
+Tag any element with `data-cookie-consent="<category>"` to block it until the visitor consents to that category. The SDK will activate matching elements automatically after consent is recorded.
+
+### Scripts
+
+Replace `src` with `data-src` and set `type="text/plain"` to prevent execution:
+
+```html
+<script
+  type="text/plain"
+  data-cookie-consent="analytics"
+  data-src="https://example.com/analytics.js"
+></script>
+```
+
+If the script had a meaningful `type` attribute, preserve it with `data-type`:
+
+```html
+<script
+  type="text/plain"
+  data-type="module"
+  data-cookie-consent="analytics"
+  data-src="https://example.com/analytics.mjs"
+></script>
+```
+
+Inline scripts work too:
+
+```html
+<script type="text/plain" data-cookie-consent="analytics">
+  console.log("This runs only after analytics consent");
+</script>
+```
+
+### Iframes, Images, and Other Elements
+
+Replace `src` with `data-src` (or `href` with `data-href` for `<link>` tags):
+
+```html
+<iframe
+  data-cookie-consent="marketing"
+  data-src="https://www.youtube.com/embed/dQw4w9WgXcQ"
+  width="560"
+  height="315"
+></iframe>
+
+<img data-cookie-consent="analytics" data-src="https://example.com/pixel.gif" />
+
+<link data-cookie-consent="analytics" data-href="https://example.com/tracker.css" rel="stylesheet" />
+```
+
+Supported tags: `<script>`, `<iframe>`, `<img>`, `<video>`, `<audio>`, `<embed>`, `<object>`, `<link>`.
+
+Elements added dynamically after consent is recorded are also activated automatically via a `MutationObserver`.
+
+## License
+
+MIT

--- a/packages/cookie-banner/README.md
+++ b/packages/cookie-banner/README.md
@@ -66,6 +66,8 @@ probo-cookie-banner {
   --probo-accent-text: #ffffff;
   --probo-overlay: rgba(0, 0, 0, 0.4);
   --probo-z-index: 2147483646;
+  --probo-btn-radius: 8px;
+  --probo-font-size: 14px;
 }
 ```
 

--- a/packages/cookie-banner/package.json
+++ b/packages/cookie-banner/package.json
@@ -12,6 +12,11 @@
       "import": "./dist/cookie-banner.mjs",
       "default": "./dist/cookie-banner.mjs"
     },
+    "./themed-banner": {
+      "types": "./dist/themed-banner/index.d.ts",
+      "import": "./dist/cookie-banner-themed.mjs",
+      "default": "./dist/cookie-banner-themed.mjs"
+    },
     "./iife": "./dist/cookie-banner.iife.js"
   },
   "scripts": {

--- a/packages/cookie-banner/src/client.ts
+++ b/packages/cookie-banner/src/client.ts
@@ -64,7 +64,7 @@ export interface CookieBannerClientOptions {
 }
 
 export class CookieBannerClient {
-  private readonly baseUrl: string;
+  private readonly baseUrl: URL;
   private readonly bannerId: string;
   private readonly visitorId: string;
 
@@ -74,16 +74,16 @@ export class CookieBannerClient {
 
   constructor(config: CookieBannerClientOptions) {
     let base = config.baseUrl;
-    while (base.endsWith("/")) {
-      base = base.slice(0, -1);
+    if (!base.endsWith("/")) {
+      base += "/";
     }
-    this.baseUrl = base;
+    this.baseUrl = new URL(base);
     this.bannerId = config.bannerId;
     this.visitorId = getOrCreateVisitorId(config.bannerId);
   }
 
   async load(): Promise<void> {
-    const configUrl = `${this.baseUrl}/${this.bannerId}/config`;
+    const configUrl = new URL(`${this.bannerId}/config`, this.baseUrl);
     const config = await fetchJSON<BannerConfig>(configUrl);
     this.bannerConfig = config;
 
@@ -101,7 +101,10 @@ export class CookieBannerClient {
       return;
     }
 
-    const consentUrl = `${this.baseUrl}/${this.bannerId}/consents/${this.visitorId}`;
+    const consentUrl = new URL(
+      `${this.bannerId}/consents/${this.visitorId}`,
+      this.baseUrl,
+    );
     const apiConsent = await fetchJSON<VisitorConsent>(consentUrl).catch(
       (err) => {
         if (err instanceof NotFoundError) {
@@ -185,7 +188,7 @@ export class CookieBannerClient {
     consentData: Record<string, boolean>,
   ): Promise<ConsentRecord> {
     const cfg = this.config;
-    const url = `${this.baseUrl}/${this.bannerId}/consents`;
+    const url = new URL(`${this.bannerId}/consents`, this.baseUrl);
     const body = {
       visitor_id: this.visitorId,
       version: cfg.version,
@@ -201,7 +204,7 @@ export class CookieBannerClient {
       });
       void flush(this.bannerId);
     } catch {
-      enqueue(this.bannerId, url, body);
+      enqueue(this.bannerId, url.href, body);
     }
 
     this.consent = {

--- a/packages/cookie-banner/src/components/banner.ts
+++ b/packages/cookie-banner/src/components/banner.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { ProboElement } from "./base";
+import type { ProboRootElement } from "./base";
+import type { ProboCookieBannerRoot } from "./cookie-banner-root";
+
+const REQUIRED_BUTTONS = [
+  "probo-accept-button",
+  "probo-reject-button",
+  "probo-customize-button",
+] as const;
+
+export class ProboBanner extends ProboElement {
+  private root: ProboRootElement | null = null;
+  private onStateChange = (e: Event): void => {
+    const { state } = (e as CustomEvent).detail;
+    this.hidden = state !== "banner";
+  };
+
+  connectedCallback(): void {
+    this.shadow.innerHTML = `
+      <style>
+        :host { display: block; }
+        :host([hidden]) { display: none; }
+      </style>
+      <slot></slot>
+    `;
+
+    this.hidden = true;
+    this.root = this.findAncestor<ProboCookieBannerRoot>("probo-cookie-banner-root");
+
+    if (this.root) {
+      this.root.addEventListener("probo-state", this.onStateChange);
+      if (this.root.state === "banner") {
+        this.hidden = false;
+      }
+    }
+
+    this.scheduleValidation(() => this.validate());
+  }
+
+  disconnectedCallback(): void {
+    if (this.root) {
+      this.root.removeEventListener("probo-state", this.onStateChange);
+    }
+  }
+
+  private validate(): void {
+    const missing: string[] = [];
+    for (const tag of REQUIRED_BUTTONS) {
+      if (!this.querySelector(tag)) {
+        missing.push(tag);
+      }
+    }
+    if (missing.length > 0) {
+      this.warn(`<probo-banner> is missing required children: ${missing.join(", ")}`);
+      this.emitValidation(missing);
+    }
+  }
+}

--- a/packages/cookie-banner/src/components/banner.ts
+++ b/packages/cookie-banner/src/components/banner.ts
@@ -30,14 +30,6 @@ export class ProboBanner extends ProboElement {
   };
 
   connectedCallback(): void {
-    this.shadow.innerHTML = `
-      <style>
-        :host { display: block; }
-        :host([hidden]) { display: none; }
-      </style>
-      <slot></slot>
-    `;
-
     this.hidden = true;
     this.root = this.findAncestor<ProboCookieBannerRoot>("probo-cookie-banner-root");
 

--- a/packages/cookie-banner/src/components/base.ts
+++ b/packages/cookie-banner/src/components/base.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { CookieBannerClient, BannerConfig } from "../client";
+
+export type ProboState = "loading" | "banner" | "panel" | "hidden";
+
+export interface ConsentDraft {
+  [category: string]: boolean;
+}
+
+export class ProboElement extends HTMLElement {
+  protected shadow: ShadowRoot;
+
+  constructor() {
+    super();
+    this.shadow = this.attachShadow({ mode: "open" });
+  }
+
+  protected findAncestor<T extends HTMLElement>(tagName: string): T | null {
+    let node: Node | null = this as Node;
+    while (node) {
+      const root = node.getRootNode();
+      if (root instanceof ShadowRoot) {
+        node = root.host;
+      } else {
+        node = (node as HTMLElement).parentElement;
+      }
+      if (node instanceof HTMLElement && node.tagName.toLowerCase() === tagName) {
+        return node as T;
+      }
+    }
+    return null;
+  }
+
+  protected scheduleValidation(fn: () => void): void {
+    queueMicrotask(fn);
+  }
+
+  protected warn(message: string): void {
+    console.warn(`[probo] ${message}`);
+  }
+
+  protected emitValidation(missing: string[]): void {
+    this.dispatchEvent(
+      new CustomEvent("probo-validation", {
+        bubbles: true,
+        composed: true,
+        detail: { missing },
+      }),
+    );
+  }
+}
+
+export interface ProboRootElement extends ProboElement {
+  readonly client: CookieBannerClient;
+  readonly bannerConfig: BannerConfig;
+  readonly state: ProboState;
+  readonly consentDraft: ConsentDraft;
+  setState(state: ProboState): void;
+  updateDraft(category: string, value: boolean): void;
+}

--- a/packages/cookie-banner/src/components/base.ts
+++ b/packages/cookie-banner/src/components/base.ts
@@ -21,25 +21,13 @@ export interface ConsentDraft {
 }
 
 export class ProboElement extends HTMLElement {
-  protected shadow: ShadowRoot;
-
-  constructor() {
-    super();
-    this.shadow = this.attachShadow({ mode: "open" });
-  }
-
   protected findAncestor<T extends HTMLElement>(tagName: string): T | null {
-    let node: Node | null = this as Node;
-    while (node) {
-      const root = node.getRootNode();
-      if (root instanceof ShadowRoot) {
-        node = root.host;
-      } else {
-        node = (node as HTMLElement).parentElement;
+    let el: HTMLElement | null = this.parentElement;
+    while (el) {
+      if (el.tagName.toLowerCase() === tagName) {
+        return el as T;
       }
-      if (node instanceof HTMLElement && node.tagName.toLowerCase() === tagName) {
-        return node as T;
-      }
+      el = el.parentElement;
     }
     return null;
   }

--- a/packages/cookie-banner/src/components/buttons.ts
+++ b/packages/cookie-banner/src/components/buttons.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { ProboElement } from "./base";
+import type { ProboRootElement } from "./base";
+import type { ProboCookieBannerRoot } from "./cookie-banner-root";
+
+class ProboActionButton extends ProboElement {
+  protected root: ProboRootElement | null = null;
+
+  connectedCallback(): void {
+    this.shadow.innerHTML = `
+      <style>:host { display: contents; }</style>
+      <slot></slot>
+    `;
+    this.root = this.findAncestor<ProboCookieBannerRoot>("probo-cookie-banner-root");
+    this.addEventListener("click", this.handleClick);
+  }
+
+  disconnectedCallback(): void {
+    this.removeEventListener("click", this.handleClick);
+  }
+
+  protected handleClick = (_e: Event): void => {};
+}
+
+export class ProboAcceptButton extends ProboActionButton {
+  protected handleClick = (): void => {
+    if (!this.root) return;
+    void this.root.client.acceptAll().then(() => {
+      this.root!.setState("hidden");
+      this.root!.dispatchEvent(
+        new CustomEvent("probo-consent", {
+          bubbles: true,
+          composed: true,
+          detail: { action: "ACCEPT_ALL" },
+        }),
+      );
+    });
+  };
+}
+
+export class ProboRejectButton extends ProboActionButton {
+  protected handleClick = (): void => {
+    if (!this.root) return;
+    void this.root.client.rejectAll().then(() => {
+      this.root!.setState("hidden");
+      this.root!.dispatchEvent(
+        new CustomEvent("probo-consent", {
+          bubbles: true,
+          composed: true,
+          detail: { action: "REJECT_ALL" },
+        }),
+      );
+    });
+  };
+}
+
+export class ProboCustomizeButton extends ProboActionButton {
+  protected handleClick = (): void => {
+    if (!this.root) return;
+    this.root.setState("panel");
+  };
+}

--- a/packages/cookie-banner/src/components/buttons.ts
+++ b/packages/cookie-banner/src/components/buttons.ts
@@ -20,10 +20,6 @@ class ProboActionButton extends ProboElement {
   protected root: ProboRootElement | null = null;
 
   connectedCallback(): void {
-    this.shadow.innerHTML = `
-      <style>:host { display: contents; }</style>
-      <slot></slot>
-    `;
     this.root = this.findAncestor<ProboCookieBannerRoot>("probo-cookie-banner-root");
     this.addEventListener("click", this.handleClick);
   }

--- a/packages/cookie-banner/src/components/category-list.ts
+++ b/packages/cookie-banner/src/components/category-list.ts
@@ -26,11 +26,6 @@ export class ProboCategoryList extends ProboElement {
   };
 
   connectedCallback(): void {
-    this.shadow.innerHTML = `
-      <style>:host { display: contents; }</style>
-      <slot name="items"></slot>
-    `;
-
     this.template = this.querySelector("template");
     if (!this.template) {
       this.warn("<probo-category-list> requires a <template> child");
@@ -62,7 +57,6 @@ export class ProboCategoryList extends ProboElement {
     for (const cat of categories) {
       const wrapper = document.createElement("probo-category");
       wrapper.setAttribute("name", cat.name);
-      wrapper.setAttribute("slot", "items");
       if (cat.required) {
         wrapper.setAttribute("required", "");
       }

--- a/packages/cookie-banner/src/components/category-list.ts
+++ b/packages/cookie-banner/src/components/category-list.ts
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { Category } from "../client";
+import { ProboElement } from "./base";
+import type { ProboRootElement } from "./base";
+import type { ProboCookieBannerRoot } from "./cookie-banner-root";
+
+export class ProboCategoryList extends ProboElement {
+  private root: ProboRootElement | null = null;
+  private template: HTMLTemplateElement | null = null;
+  private onReady = (e: Event): void => {
+    const { config } = (e as CustomEvent).detail;
+    this.stamp(config.categories);
+  };
+
+  connectedCallback(): void {
+    this.shadow.innerHTML = `
+      <style>:host { display: contents; }</style>
+      <slot name="items"></slot>
+    `;
+
+    this.template = this.querySelector("template");
+    if (!this.template) {
+      this.warn("<probo-category-list> requires a <template> child");
+      return;
+    }
+
+    this.root = this.findAncestor<ProboCookieBannerRoot>("-root");
+    if (!this.root) return;
+
+    try {
+      const config = this.root.bannerConfig;
+      this.stamp(config.categories);
+    } catch {
+      this.root.addEventListener("probo-ready", this.onReady, { once: true });
+    }
+  }
+
+  disconnectedCallback(): void {
+    if (this.root) {
+      this.root.removeEventListener("probo-ready", this.onReady);
+    }
+  }
+
+  private stamp(categories: Category[]): void {
+    if (!this.template) return;
+
+    for (const cat of categories) {
+      const wrapper = document.createElement("probo-category");
+      wrapper.setAttribute("name", cat.name);
+      wrapper.setAttribute("slot", "items");
+      if (cat.required) {
+        wrapper.setAttribute("required", "");
+      }
+      wrapper.setAttribute("description", cat.description);
+      wrapper.setAttribute("cookies", JSON.stringify(cat.cookies));
+
+      const clone = this.template.content.cloneNode(true) as DocumentFragment;
+      this.fillSlots(clone, {
+        name: cat.name,
+        description: cat.description,
+      });
+
+      wrapper.appendChild(clone);
+      this.appendChild(wrapper);
+    }
+  }
+
+  private fillSlots(
+    fragment: DocumentFragment,
+    data: Record<string, string>,
+  ): void {
+    for (const [key, value] of Object.entries(data)) {
+      const els = fragment.querySelectorAll(`[data-slot="${key}"]`);
+      for (const el of els) {
+        el.textContent = value;
+      }
+    }
+  }
+}

--- a/packages/cookie-banner/src/components/category-list.ts
+++ b/packages/cookie-banner/src/components/category-list.ts
@@ -37,8 +37,10 @@ export class ProboCategoryList extends ProboElement {
       return;
     }
 
-    this.root = this.findAncestor<ProboCookieBannerRoot>("-root");
+    this.root = this.findAncestor<ProboCookieBannerRoot>("probo-cookie-banner-root");
     if (!this.root) return;
+
+    this.validateTemplate();
 
     try {
       const config = this.root.bannerConfig;
@@ -75,6 +77,22 @@ export class ProboCategoryList extends ProboElement {
 
       wrapper.appendChild(clone);
       this.appendChild(wrapper);
+    }
+  }
+
+  private validateTemplate(): void {
+    if (!this.template) return;
+    const content = this.template.content;
+    const missing: string[] = [];
+    if (!content.querySelector("probo-category-toggle")) {
+      missing.push("probo-category-toggle");
+    }
+    if (!content.querySelector("probo-cookie-list")) {
+      missing.push("probo-cookie-list");
+    }
+    if (missing.length > 0) {
+      this.warn(`<probo-category-list> template is missing required elements: ${missing.join(", ")}`);
+      this.emitValidation(missing);
     }
   }
 

--- a/packages/cookie-banner/src/components/category-toggle.ts
+++ b/packages/cookie-banner/src/components/category-toggle.ts
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { ProboElement } from "./base";
+import type { ProboRootElement } from "./base";
+import type { ProboCategory } from "./category";
+import type { ProboCookieBannerRoot } from "./cookie-banner-root";
+
+export class ProboCategoryToggle extends ProboElement {
+  private root: ProboRootElement | null = null;
+  private category: ProboCategory | null = null;
+  private checkbox: HTMLInputElement | null = null;
+
+  connectedCallback(): void {
+    this.shadow.innerHTML = `
+      <style>
+        :host { display: inline-block; }
+      </style>
+      <slot></slot>
+    `;
+
+    this.root = this.findAncestor<ProboCookieBannerRoot>("probo-cookie-banner-root");
+    this.category = this.findAncestor<ProboCategory>("probo-category");
+
+    this.scheduleValidation(() => this.setup());
+  }
+
+  disconnectedCallback(): void {
+    if (this.checkbox) {
+      this.checkbox.removeEventListener("change", this.handleChange);
+    }
+  }
+
+  private setup(): void {
+    this.checkbox = this.querySelector<HTMLInputElement>("input[type=checkbox]");
+
+    if (!this.checkbox) {
+      const input = document.createElement("input");
+      input.type = "checkbox";
+      input.part.add("toggle");
+      this.appendChild(input);
+      this.checkbox = input;
+    }
+
+    if (!this.category || !this.root) return;
+
+    const name = this.category.categoryName;
+    const isRequired = this.category.required;
+
+    if (isRequired) {
+      this.checkbox.checked = true;
+      this.checkbox.disabled = true;
+      return;
+    }
+
+    const draft = this.root.consentDraft;
+    this.checkbox.checked = !!draft[name];
+    this.checkbox.addEventListener("change", this.handleChange);
+
+    if (this.root) {
+      this.root.addEventListener("probo-state", (e: Event) => {
+        const { state } = (e as CustomEvent).detail;
+        if (state === "panel" && this.checkbox && this.category && this.root) {
+          this.checkbox.checked = !!this.root.consentDraft[this.category.categoryName];
+        }
+      });
+    }
+  }
+
+  private handleChange = (): void => {
+    if (!this.checkbox || !this.category || !this.root) return;
+    this.root.updateDraft(this.category.categoryName, this.checkbox.checked);
+  };
+}

--- a/packages/cookie-banner/src/components/category-toggle.ts
+++ b/packages/cookie-banner/src/components/category-toggle.ts
@@ -23,13 +23,6 @@ export class ProboCategoryToggle extends ProboElement {
   private checkbox: HTMLInputElement | null = null;
 
   connectedCallback(): void {
-    this.shadow.innerHTML = `
-      <style>
-        :host { display: inline-block; }
-      </style>
-      <slot></slot>
-    `;
-
     this.root = this.findAncestor<ProboCookieBannerRoot>("probo-cookie-banner-root");
     this.category = this.findAncestor<ProboCategory>("probo-category");
 

--- a/packages/cookie-banner/src/components/category.ts
+++ b/packages/cookie-banner/src/components/category.ts
@@ -16,12 +16,6 @@ import type { CookieItem } from "../client";
 import { ProboElement } from "./base";
 
 export class ProboCategory extends ProboElement {
-  connectedCallback(): void {
-    this.shadow.innerHTML = `
-      <style>:host { display: contents; }</style>
-      <slot></slot>
-    `;
-  }
 
   get categoryName(): string {
     return this.getAttribute("name") ?? "";

--- a/packages/cookie-banner/src/components/category.ts
+++ b/packages/cookie-banner/src/components/category.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { CookieItem } from "../client";
+import { ProboElement } from "./base";
+
+export class ProboCategory extends ProboElement {
+  connectedCallback(): void {
+    this.shadow.innerHTML = `
+      <style>:host { display: contents; }</style>
+      <slot></slot>
+    `;
+  }
+
+  get categoryName(): string {
+    return this.getAttribute("name") ?? "";
+  }
+
+  get required(): boolean {
+    return this.hasAttribute("required");
+  }
+
+  get cookies(): CookieItem[] {
+    try {
+      return JSON.parse(this.getAttribute("cookies") ?? "[]");
+    } catch {
+      return [];
+    }
+  }
+}

--- a/packages/cookie-banner/src/components/category.ts
+++ b/packages/cookie-banner/src/components/category.ts
@@ -18,7 +18,7 @@ import { ProboElement } from "./base";
 export class ProboCategory extends ProboElement {
 
   get categoryName(): string {
-    return this.getAttribute("name") ?? "";
+    return this.getAttribute("name") ?? "Other";
   }
 
   get required(): boolean {

--- a/packages/cookie-banner/src/components/cookie-banner-root.ts
+++ b/packages/cookie-banner/src/components/cookie-banner-root.ts
@@ -53,6 +53,13 @@ export class ProboCookieBannerRoot extends ProboElement implements ProboRootElem
     this.initClient();
   }
 
+  disconnectedCallback(): void {
+    if (this._client) {
+      this._client.destroy();
+      this._client = null;
+    }
+  }
+
   setState(state: ProboState): void {
     const prev = this._state;
     this._state = state;

--- a/packages/cookie-banner/src/components/cookie-banner-root.ts
+++ b/packages/cookie-banner/src/components/cookie-banner-root.ts
@@ -50,7 +50,6 @@ export class ProboCookieBannerRoot extends ProboElement implements ProboRootElem
   }
 
   connectedCallback(): void {
-    this.shadow.innerHTML = `<style>:host { display: contents; }</style><slot></slot>`;
     this.initClient();
   }
 

--- a/packages/cookie-banner/src/components/cookie-banner-root.ts
+++ b/packages/cookie-banner/src/components/cookie-banner-root.ts
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { CookieBannerClient } from "../client";
+import type { BannerConfig } from "../client";
+import { ProboElement } from "./base";
+import type { ProboState, ProboRootElement, ConsentDraft } from "./base";
+
+export class ProboCookieBannerRoot extends ProboElement implements ProboRootElement {
+  private _client: CookieBannerClient | null = null;
+  private _config: BannerConfig | null = null;
+  private _state: ProboState = "loading";
+  private _draft: ConsentDraft = {};
+
+  static get observedAttributes(): string[] {
+    return ["banner-id", "base-url"];
+  }
+
+  get client(): CookieBannerClient {
+    if (!this._client) {
+      throw new Error("<probo-cookie-banner-root> not loaded yet");
+    }
+    return this._client;
+  }
+
+  get bannerConfig(): BannerConfig {
+    if (!this._config) {
+      throw new Error("<probo-cookie-banner-root> not loaded yet");
+    }
+    return this._config;
+  }
+
+  get state(): ProboState {
+    return this._state;
+  }
+
+  get consentDraft(): ConsentDraft {
+    return this._draft;
+  }
+
+  connectedCallback(): void {
+    this.shadow.innerHTML = `<style>:host { display: contents; }</style><slot></slot>`;
+    this.initClient();
+  }
+
+  setState(state: ProboState): void {
+    const prev = this._state;
+    this._state = state;
+    this.dispatchEvent(
+      new CustomEvent("probo-state", {
+        bubbles: true,
+        composed: true,
+        detail: { state, prev },
+      }),
+    );
+  }
+
+  updateDraft(category: string, value: boolean): void {
+    this._draft[category] = value;
+  }
+
+  resetDraft(): void {
+    if (!this._config) return;
+    this._draft = this.buildDraft(this._config);
+  }
+
+  private buildDraft(config: BannerConfig): ConsentDraft {
+    const draft: ConsentDraft = {};
+    const existing = this._client?.visitorConsent?.consent_data;
+
+    for (const cat of config.categories) {
+      if (cat.required) {
+        draft[cat.name] = true;
+      } else if (existing && cat.name in existing) {
+        draft[cat.name] = existing[cat.name];
+      } else {
+        draft[cat.name] = config.consent_mode === "OPT_OUT";
+      }
+    }
+
+    return draft;
+  }
+
+  private async initClient(): Promise<void> {
+    const bannerId = this.getAttribute("banner-id");
+    const baseUrl = this.getAttribute("base-url");
+
+    if (!bannerId || !baseUrl) {
+      this.warn("<probo-cookie-banner-root> requires banner-id and base-url attributes");
+      return;
+    }
+
+    this._client = new CookieBannerClient({ bannerId, baseUrl });
+
+    try {
+      await this._client.load();
+    } catch (err) {
+      this.warn(`failed to load banner config: ${err}`);
+      return;
+    }
+
+    this._config = this._client.config;
+    this._draft = this.buildDraft(this._config);
+
+    this.dispatchEvent(
+      new CustomEvent("probo-ready", {
+        bubbles: true,
+        composed: true,
+        detail: { config: this._config },
+      }),
+    );
+
+    if (this._client.hasConsent) {
+      this.setState("hidden");
+    } else {
+      this.setState("banner");
+    }
+  }
+}

--- a/packages/cookie-banner/src/components/cookie-banner-root.ts
+++ b/packages/cookie-banner/src/components/cookie-banner-root.ts
@@ -116,6 +116,9 @@ export class ProboCookieBannerRoot extends ProboElement implements ProboRootElem
       return;
     }
 
+    // Element was disconnected while load() was in-flight.
+    if (!this._client) return;
+
     this._config = this._client.config;
     this._draft = this.buildDraft(this._config);
 

--- a/packages/cookie-banner/src/components/cookie-list.ts
+++ b/packages/cookie-banner/src/components/cookie-list.ts
@@ -21,11 +21,6 @@ export class ProboCookieList extends ProboElement {
   private template: HTMLTemplateElement | null = null;
 
   connectedCallback(): void {
-    this.shadow.innerHTML = `
-      <style>:host { display: contents; }</style>
-      <slot name="items"></slot>
-    `;
-
     this.template = this.querySelector("template");
     if (!this.template) {
       this.warn("<probo-cookie-list> requires a <template> child");
@@ -51,8 +46,6 @@ export class ProboCookieList extends ProboElement {
 
     const wrapper = document.createElement("probo-cookie");
     wrapper.setAttribute("name", cookie.name);
-    wrapper.setAttribute("slot", "items");
-
     const clone = this.template.content.cloneNode(true) as DocumentFragment;
     this.fillSlots(clone, {
       name: cookie.name,
@@ -77,11 +70,4 @@ export class ProboCookieList extends ProboElement {
   }
 }
 
-export class ProboCookie extends ProboElement {
-  connectedCallback(): void {
-    this.shadow.innerHTML = `
-      <style>:host { display: contents; }</style>
-      <slot></slot>
-    `;
-  }
-}
+export class ProboCookie extends ProboElement {}

--- a/packages/cookie-banner/src/components/cookie-list.ts
+++ b/packages/cookie-banner/src/components/cookie-list.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { CookieItem } from "../client";
+import { ProboElement } from "./base";
+import type { ProboCategory } from "./category";
+
+export class ProboCookieList extends ProboElement {
+  private category: ProboCategory | null = null;
+  private template: HTMLTemplateElement | null = null;
+
+  connectedCallback(): void {
+    this.shadow.innerHTML = `
+      <style>:host { display: contents; }</style>
+      <slot name="items"></slot>
+    `;
+
+    this.template = this.querySelector("template");
+    if (!this.template) {
+      this.warn("<probo-cookie-list> requires a <template> child");
+      return;
+    }
+
+    this.category = this.findAncestor<ProboCategory>("probo-category");
+
+    this.scheduleValidation(() => this.stamp());
+  }
+
+  private stamp(): void {
+    if (!this.template || !this.category) return;
+
+    const cookies = this.category.cookies;
+    for (const cookie of cookies) {
+      this.stampCookie(cookie);
+    }
+  }
+
+  private stampCookie(cookie: CookieItem): void {
+    if (!this.template) return;
+
+    const wrapper = document.createElement("probo-cookie");
+    wrapper.setAttribute("name", cookie.name);
+    wrapper.setAttribute("slot", "items");
+
+    const clone = this.template.content.cloneNode(true) as DocumentFragment;
+    this.fillSlots(clone, {
+      name: cookie.name,
+      duration: cookie.duration,
+      description: cookie.description,
+    });
+
+    wrapper.appendChild(clone);
+    this.appendChild(wrapper);
+  }
+
+  private fillSlots(
+    fragment: DocumentFragment,
+    data: Record<string, string>,
+  ): void {
+    for (const [key, value] of Object.entries(data)) {
+      const els = fragment.querySelectorAll(`[data-slot="${key}"]`);
+      for (const el of els) {
+        el.textContent = value;
+      }
+    }
+  }
+}
+
+export class ProboCookie extends ProboElement {
+  connectedCallback(): void {
+    this.shadow.innerHTML = `
+      <style>:host { display: contents; }</style>
+      <slot></slot>
+    `;
+  }
+}

--- a/packages/cookie-banner/src/components/index.ts
+++ b/packages/cookie-banner/src/components/index.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+export { ProboElement } from "./base";
+export type { ProboState, ProboRootElement, ConsentDraft } from "./base";
+export { ProboBanner } from "./banner";
+export {
+  ProboAcceptButton,
+  ProboCustomizeButton,
+  ProboRejectButton,
+} from "./buttons";
+export { ProboCategory } from "./category";
+export { ProboCategoryList } from "./category-list";
+export { ProboCategoryToggle } from "./category-toggle";
+export { ProboCookieBannerRoot } from "./cookie-banner-root";
+export { ProboCookie, ProboCookieList } from "./cookie-list";
+export { ProboPreferencePanel, ProboSaveButton } from "./preference-panel";
+export { ProboSettingsButton } from "./settings-button";
+export { registerComponents } from "./register";

--- a/packages/cookie-banner/src/components/preference-panel.ts
+++ b/packages/cookie-banner/src/components/preference-panel.ts
@@ -29,14 +29,6 @@ export class ProboPreferencePanel extends ProboElement {
   };
 
   connectedCallback(): void {
-    this.shadow.innerHTML = `
-      <style>
-        :host { display: block; }
-        :host([hidden]) { display: none; }
-      </style>
-      <slot></slot>
-    `;
-
     this.hidden = true;
     this.root = this.findAncestor<ProboCookieBannerRoot>("probo-cookie-banner-root");
 
@@ -77,10 +69,6 @@ export class ProboSaveButton extends ProboElement {
   private root: ProboRootElement | null = null;
 
   connectedCallback(): void {
-    this.shadow.innerHTML = `
-      <style>:host { display: contents; }</style>
-      <slot></slot>
-    `;
     this.root = this.findAncestor<ProboCookieBannerRoot>("probo-cookie-banner-root");
     this.addEventListener("click", this.handleClick);
   }

--- a/packages/cookie-banner/src/components/preference-panel.ts
+++ b/packages/cookie-banner/src/components/preference-panel.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { ProboElement } from "./base";
+import type { ProboRootElement } from "./base";
+import type { ProboCookieBannerRoot } from "./cookie-banner-root";
+
+export class ProboPreferencePanel extends ProboElement {
+  private root: ProboRootElement | null = null;
+  private onStateChange = (e: Event): void => {
+    const { state } = (e as CustomEvent).detail;
+    this.hidden = state !== "panel";
+  };
+
+  connectedCallback(): void {
+    this.shadow.innerHTML = `
+      <style>
+        :host { display: block; }
+        :host([hidden]) { display: none; }
+      </style>
+      <slot></slot>
+    `;
+
+    this.hidden = true;
+    this.root = this.findAncestor<ProboCookieBannerRoot>("probo-cookie-banner-root");
+
+    if (this.root) {
+      this.root.addEventListener("probo-state", this.onStateChange);
+      this.root.addEventListener("probo-state", (e: Event) => {
+        const { state } = (e as CustomEvent).detail;
+        if (state === "panel") {
+          (this.root as ProboCookieBannerRoot).resetDraft();
+        }
+      });
+    }
+  }
+
+  disconnectedCallback(): void {
+    if (this.root) {
+      this.root.removeEventListener("probo-state", this.onStateChange);
+    }
+  }
+}
+
+export class ProboSaveButton extends ProboElement {
+  private root: ProboRootElement | null = null;
+
+  connectedCallback(): void {
+    this.shadow.innerHTML = `
+      <style>:host { display: contents; }</style>
+      <slot></slot>
+    `;
+    this.root = this.findAncestor<ProboCookieBannerRoot>("probo-cookie-banner-root");
+    this.addEventListener("click", this.handleClick);
+  }
+
+  disconnectedCallback(): void {
+    this.removeEventListener("click", this.handleClick);
+  }
+
+  private handleClick = (): void => {
+    if (!this.root) return;
+    const draft = { ...this.root.consentDraft };
+    void this.root.client.customize(draft).then(() => {
+      this.root!.setState("hidden");
+      this.root!.dispatchEvent(
+        new CustomEvent("probo-consent", {
+          bubbles: true,
+          composed: true,
+          detail: { action: "CUSTOMIZE", consent_data: draft },
+        }),
+      );
+    });
+  };
+}

--- a/packages/cookie-banner/src/components/preference-panel.ts
+++ b/packages/cookie-banner/src/components/preference-panel.ts
@@ -16,6 +16,11 @@ import { ProboElement } from "./base";
 import type { ProboRootElement } from "./base";
 import type { ProboCookieBannerRoot } from "./cookie-banner-root";
 
+const REQUIRED_CHILDREN = [
+  "probo-category-list",
+  "probo-save-button",
+] as const;
+
 export class ProboPreferencePanel extends ProboElement {
   private root: ProboRootElement | null = null;
   private onStateChange = (e: Event): void => {
@@ -44,11 +49,26 @@ export class ProboPreferencePanel extends ProboElement {
         }
       });
     }
+
+    this.scheduleValidation(() => this.validate());
   }
 
   disconnectedCallback(): void {
     if (this.root) {
       this.root.removeEventListener("probo-state", this.onStateChange);
+    }
+  }
+
+  private validate(): void {
+    const missing: string[] = [];
+    for (const tag of REQUIRED_CHILDREN) {
+      if (!this.querySelector(tag)) {
+        missing.push(tag);
+      }
+    }
+    if (missing.length > 0) {
+      this.warn(`<probo-preference-panel> is missing required children: ${missing.join(", ")}`);
+      this.emitValidation(missing);
     }
   }
 }

--- a/packages/cookie-banner/src/components/preference-panel.ts
+++ b/packages/cookie-banner/src/components/preference-panel.ts
@@ -26,6 +26,9 @@ export class ProboPreferencePanel extends ProboElement {
   private onStateChange = (e: Event): void => {
     const { state } = (e as CustomEvent).detail;
     this.hidden = state !== "panel";
+    if (state === "panel") {
+      (this.root as ProboCookieBannerRoot).resetDraft();
+    }
   };
 
   connectedCallback(): void {
@@ -34,12 +37,6 @@ export class ProboPreferencePanel extends ProboElement {
 
     if (this.root) {
       this.root.addEventListener("probo-state", this.onStateChange);
-      this.root.addEventListener("probo-state", (e: Event) => {
-        const { state } = (e as CustomEvent).detail;
-        if (state === "panel") {
-          (this.root as ProboCookieBannerRoot).resetDraft();
-        }
-      });
     }
 
     this.scheduleValidation(() => this.validate());

--- a/packages/cookie-banner/src/components/register.ts
+++ b/packages/cookie-banner/src/components/register.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { ProboBanner } from "./banner";
+import {
+  ProboAcceptButton,
+  ProboCustomizeButton,
+  ProboRejectButton,
+} from "./buttons";
+import { ProboCategory } from "./category";
+import { ProboCategoryList } from "./category-list";
+import { ProboCategoryToggle } from "./category-toggle";
+import { ProboCookieBannerRoot } from "./cookie-banner-root";
+import { ProboCookie, ProboCookieList } from "./cookie-list";
+import { ProboPreferencePanel, ProboSaveButton } from "./preference-panel";
+import { ProboSettingsButton } from "./settings-button";
+
+const elements: [string, CustomElementConstructor][] = [
+  ["probo-cookie-banner-root", ProboCookieBannerRoot],
+  ["probo-banner", ProboBanner],
+  ["probo-accept-button", ProboAcceptButton],
+  ["probo-reject-button", ProboRejectButton],
+  ["probo-customize-button", ProboCustomizeButton],
+  ["probo-preference-panel", ProboPreferencePanel],
+  ["probo-category-list", ProboCategoryList],
+  ["probo-category", ProboCategory],
+  ["probo-category-toggle", ProboCategoryToggle],
+  ["probo-cookie-list", ProboCookieList],
+  ["probo-cookie", ProboCookie],
+  ["probo-save-button", ProboSaveButton],
+  ["probo-settings-button", ProboSettingsButton],
+];
+
+export function registerComponents(): void {
+  for (const [name, ctor] of elements) {
+    if (!customElements.get(name)) {
+      customElements.define(name, ctor);
+    }
+  }
+}

--- a/packages/cookie-banner/src/components/settings-button.ts
+++ b/packages/cookie-banner/src/components/settings-button.ts
@@ -12,14 +12,19 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import { ProboElement } from "./base";
 import type { ProboRootElement } from "./base";
 import type { ProboCookieBannerRoot } from "./cookie-banner-root";
 
 const COOKIE_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><circle cx="8" cy="9" r="1" fill="currentColor"/><circle cx="15" cy="11" r="1" fill="currentColor"/><circle cx="10" cy="15" r="1" fill="currentColor"/><circle cx="13" cy="7" r="1" fill="currentColor"/></svg>`;
 
-export class ProboSettingsButton extends ProboElement {
+export class ProboSettingsButton extends HTMLElement {
+  private shadow: ShadowRoot;
   private root: ProboRootElement | null = null;
+
+  constructor() {
+    super();
+    this.shadow = this.attachShadow({ mode: "open" });
+  }
 
   static get observedAttributes(): string[] {
     return ["position"];
@@ -69,7 +74,7 @@ export class ProboSettingsButton extends ProboElement {
     `;
 
     this.hidden = true;
-    this.root = this.findAncestor<ProboCookieBannerRoot>("probo-cookie-banner-root");
+    this.root = this.findRoot();
 
     if (this.root) {
       this.root.addEventListener("probo-state", this.onStateChange);
@@ -86,6 +91,17 @@ export class ProboSettingsButton extends ProboElement {
     if (this.root) {
       this.root.removeEventListener("probo-state", this.onStateChange);
     }
+  }
+
+  private findRoot(): ProboCookieBannerRoot | null {
+    let el: HTMLElement | null = this.parentElement;
+    while (el) {
+      if (el.tagName.toLowerCase() === "probo-cookie-banner-root") {
+        return el as ProboCookieBannerRoot;
+      }
+      el = el.parentElement;
+    }
+    return null;
   }
 
   private onStateChange = (e: Event): void => {

--- a/packages/cookie-banner/src/components/settings-button.ts
+++ b/packages/cookie-banner/src/components/settings-button.ts
@@ -54,8 +54,8 @@ export class ProboSettingsButton extends HTMLElement {
           gap: 6px;
           border: none;
           border-radius: var(--probo-settings-radius, 9999px);
-          background: var(--probo-settings-bg, #1a1a1a);
-          color: var(--probo-settings-color, #ffffff);
+          background: var(--probo-settings-bg, var(--probo-accent, #1a1a1a));
+          color: var(--probo-settings-color, var(--probo-accent-text, #ffffff));
           padding: var(--probo-settings-padding, 10px);
           cursor: pointer;
           font-family: inherit;

--- a/packages/cookie-banner/src/components/settings-button.ts
+++ b/packages/cookie-banner/src/components/settings-button.ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { ProboElement } from "./base";
+import type { ProboRootElement } from "./base";
+import type { ProboCookieBannerRoot } from "./cookie-banner-root";
+
+const COOKIE_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><circle cx="8" cy="9" r="1" fill="currentColor"/><circle cx="15" cy="11" r="1" fill="currentColor"/><circle cx="10" cy="15" r="1" fill="currentColor"/><circle cx="13" cy="7" r="1" fill="currentColor"/></svg>`;
+
+export class ProboSettingsButton extends ProboElement {
+  private root: ProboRootElement | null = null;
+
+  static get observedAttributes(): string[] {
+    return ["position"];
+  }
+
+  private get position(): string {
+    return this.getAttribute("position") ?? "bottom-left";
+  }
+
+  connectedCallback(): void {
+    const pos = this.position;
+    const isRight = pos === "bottom-right";
+
+    this.shadow.innerHTML = `
+      <style>
+        :host {
+          position: fixed;
+          bottom: var(--probo-settings-bottom, 16px);
+          ${isRight ? "right" : "left"}: var(--probo-settings-offset, 16px);
+          z-index: var(--probo-settings-z-index, 2147483645);
+        }
+        :host([hidden]) { display: none; }
+        button {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          gap: 6px;
+          border: none;
+          border-radius: var(--probo-settings-radius, 9999px);
+          background: var(--probo-settings-bg, #1a1a1a);
+          color: var(--probo-settings-color, #ffffff);
+          padding: var(--probo-settings-padding, 10px);
+          cursor: pointer;
+          font-family: inherit;
+          font-size: var(--probo-settings-font-size, 14px);
+          box-shadow: var(--probo-settings-shadow, 0 2px 8px rgba(0, 0, 0, 0.15));
+          transition: opacity 0.2s;
+        }
+        button:hover { opacity: 0.85; }
+        .icon { display: flex; flex-shrink: 0; }
+        ::slotted(*) { display: contents; }
+      </style>
+      <button part="button">
+        <span class="icon" part="icon">${COOKIE_ICON}</span>
+        <slot></slot>
+      </button>
+    `;
+
+    this.hidden = true;
+    this.root = this.findAncestor<ProboCookieBannerRoot>("probo-cookie-banner-root");
+
+    if (this.root) {
+      this.root.addEventListener("probo-state", this.onStateChange);
+      if (this.root.state === "hidden") {
+        this.hidden = false;
+      }
+    }
+
+    const btn = this.shadow.querySelector("button");
+    btn?.addEventListener("click", this.handleClick);
+  }
+
+  disconnectedCallback(): void {
+    if (this.root) {
+      this.root.removeEventListener("probo-state", this.onStateChange);
+    }
+  }
+
+  private onStateChange = (e: Event): void => {
+    const { state } = (e as CustomEvent).detail;
+    this.hidden = state !== "hidden";
+  };
+
+  private handleClick = (): void => {
+    if (!this.root) return;
+    this.root.setState("panel");
+  };
+}

--- a/packages/cookie-banner/src/http.ts
+++ b/packages/cookie-banner/src/http.ts
@@ -76,7 +76,7 @@ async function parseErrorBody(response: Response): Promise<ApiErrorBody> {
 }
 
 async function fetchWithTimeout(
-  url: string,
+  url: URL | string,
   init: RequestInit,
   timeout: number,
 ): Promise<Response> {
@@ -109,7 +109,7 @@ async function fetchWithTimeout(
 }
 
 export async function fetchJSON<T>(
-  url: string,
+  url: URL | string,
   options: RequestOptions = {},
 ): Promise<T> {
   const { method = "GET", headers, body, timeout = DEFAULT_TIMEOUT_MS, signal } = options;

--- a/packages/cookie-banner/src/index.ts
+++ b/packages/cookie-banner/src/index.ts
@@ -14,43 +14,4 @@
 
 export const VERSION = "0.0.0";
 
-export { activateElements, observeAndActivate } from "./activation";
-export { CookieBannerClient } from "./client";
-export type {
-  BannerConfig,
-  Category,
-  ConsentAction,
-  ConsentRecord,
-  CookieBannerClientOptions,
-  CookieItem,
-  VisitorConsent,
-} from "./client";
-export {
-  ProboElement,
-  ProboBanner,
-  ProboAcceptButton,
-  ProboRejectButton,
-  ProboCustomizeButton,
-  ProboCookieBannerRoot,
-  ProboPreferencePanel,
-  ProboSaveButton,
-  ProboCategoryList,
-  ProboCategory,
-  ProboCategoryToggle,
-  ProboCookieList,
-  ProboCookie,
-  ProboSettingsButton,
-  registerComponents,
-} from "./components";
-export type { ProboState, ProboRootElement, ConsentDraft } from "./components";
-export type { ConsentCookie } from "./cookie";
-export {
-  ApiError,
-  BadRequestError,
-  InternalServerError,
-  NetworkError,
-  NotFoundError,
-  TimeoutError,
-} from "./errors";
-export { fetchJSON } from "./http";
-export type { RequestOptions } from "./http";
+export { registerComponents } from "./components";

--- a/packages/cookie-banner/src/index.ts
+++ b/packages/cookie-banner/src/index.ts
@@ -54,6 +54,3 @@ export {
 } from "./errors";
 export { fetchJSON } from "./http";
 export type { RequestOptions } from "./http";
-
-import { registerComponents } from "./components";
-registerComponents();

--- a/packages/cookie-banner/src/index.ts
+++ b/packages/cookie-banner/src/index.ts
@@ -25,6 +25,24 @@ export type {
   CookieItem,
   VisitorConsent,
 } from "./client";
+export {
+  ProboElement,
+  ProboBanner,
+  ProboAcceptButton,
+  ProboRejectButton,
+  ProboCustomizeButton,
+  ProboCookieBannerRoot,
+  ProboPreferencePanel,
+  ProboSaveButton,
+  ProboCategoryList,
+  ProboCategory,
+  ProboCategoryToggle,
+  ProboCookieList,
+  ProboCookie,
+  ProboSettingsButton,
+  registerComponents,
+} from "./components";
+export type { ProboState, ProboRootElement, ConsentDraft } from "./components";
 export type { ConsentCookie } from "./cookie";
 export {
   ApiError,
@@ -36,3 +54,6 @@ export {
 } from "./errors";
 export { fetchJSON } from "./http";
 export type { RequestOptions } from "./http";
+
+import { registerComponents } from "./components";
+registerComponents();

--- a/packages/cookie-banner/src/themed-banner/iife.ts
+++ b/packages/cookie-banner/src/themed-banner/iife.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { registerThemedBanner } from "./index";
+
+registerThemedBanner();
+
+const script = document.currentScript as HTMLScriptElement | null;
+
+if (script) {
+  const bannerId = script.getAttribute("data-banner-id");
+  const baseUrl = script.getAttribute("data-base-url");
+
+  if (bannerId && baseUrl) {
+    const mount = (): void => {
+      const el = document.createElement("probo-cookie-banner");
+      el.setAttribute("banner-id", bannerId);
+      el.setAttribute("base-url", baseUrl);
+
+      const position = script.getAttribute("data-position");
+      if (position) {
+        el.setAttribute("position", position);
+      }
+
+      document.body.appendChild(el);
+    };
+
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", mount);
+    } else {
+      mount();
+    }
+  }
+}

--- a/packages/cookie-banner/src/themed-banner/index.ts
+++ b/packages/cookie-banner/src/themed-banner/index.ts
@@ -12,32 +12,12 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import * as esbuild from "esbuild";
+import { ProboThemedBanner } from "./themed-banner";
 
-const shared = {
-  bundle: true,
-  target: "es2020",
-};
+export { ProboThemedBanner };
 
-await Promise.all([
-  esbuild.build({
-    ...shared,
-    entryPoints: ["src/index.ts"],
-    outfile: "dist/cookie-banner.mjs",
-    format: "esm",
-  }),
-  esbuild.build({
-    ...shared,
-    entryPoints: ["src/themed-banner/index.ts"],
-    outfile: "dist/cookie-banner-themed.mjs",
-    format: "esm",
-  }),
-  esbuild.build({
-    ...shared,
-    entryPoints: ["src/themed-banner/iife.ts"],
-    outfile: "dist/cookie-banner.iife.js",
-    format: "iife",
-    globalName: "ProboCookieBanner",
-    minify: true,
-  }),
-]);
+export function registerThemedBanner(): void {
+  if (!customElements.get("probo-cookie-banner")) {
+    customElements.define("probo-cookie-banner", ProboThemedBanner);
+  }
+}

--- a/packages/cookie-banner/src/themed-banner/styles.ts
+++ b/packages/cookie-banner/src/themed-banner/styles.ts
@@ -25,11 +25,13 @@ export const THEMED_STYLES = `
     --_accent-text: var(--probo-accent-text, #ffffff);
     --_overlay: var(--probo-overlay, rgba(0, 0, 0, 0.4));
     --_z-index: var(--probo-z-index, 2147483646);
+    --_btn-radius: var(--probo-btn-radius, 8px);
+    --_font-size: var(--probo-font-size, 14px);
 
     all: initial;
     font-family: var(--_font);
     color: var(--_text);
-    font-size: 14px;
+    font-size: var(--_font-size);
     line-height: 1.5;
     box-sizing: border-box;
   }
@@ -61,7 +63,7 @@ export const THEMED_STYLES = `
   }
 
   .title {
-    font-size: 16px;
+    font-size: calc(var(--_font-size) + 2px);
     font-weight: 600;
     margin: 0 0 8px;
   }
@@ -69,7 +71,6 @@ export const THEMED_STYLES = `
   .description {
     color: var(--_text-secondary);
     margin: 0 0 20px;
-    font-size: 14px;
   }
 
   .description a {
@@ -87,12 +88,12 @@ export const THEMED_STYLES = `
     flex: 1;
     min-width: 0;
     padding: 10px 16px;
-    border-radius: 8px;
+    border-radius: var(--_btn-radius);
     border: 1px solid var(--_border);
     background: var(--_bg);
     color: var(--_text);
     font-family: var(--_font);
-    font-size: 14px;
+    font-size: var(--_font-size);
     font-weight: 500;
     cursor: pointer;
     transition: background 0.15s, border-color 0.15s;
@@ -127,7 +128,6 @@ export const THEMED_STYLES = `
     padding: 4px;
     color: var(--_text);
     font-family: var(--_font);
-    font-size: 14px;
     display: flex;
     align-items: center;
     gap: 4px;
@@ -165,17 +165,16 @@ export const THEMED_STYLES = `
 
   .category-name {
     font-weight: 500;
-    font-size: 14px;
   }
 
   .category-description {
     color: var(--_text-secondary);
-    font-size: 13px;
+    font-size: calc(var(--_font-size) - 1px);
     margin-top: 2px;
   }
 
   .category-required {
-    font-size: 12px;
+    font-size: calc(var(--_font-size) - 2px);
     color: var(--_text-secondary);
     font-style: italic;
   }
@@ -242,7 +241,7 @@ export const THEMED_STYLES = `
     display: flex;
     justify-content: space-between;
     align-items: baseline;
-    font-size: 12px;
+    font-size: calc(var(--_font-size) - 2px);
     gap: 8px;
   }
 

--- a/packages/cookie-banner/src/themed-banner/styles.ts
+++ b/packages/cookie-banner/src/themed-banner/styles.ts
@@ -1,0 +1,269 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+export const THEMED_STYLES = `
+  :host {
+    --_font: var(--probo-font-family, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif);
+    --_bg: var(--probo-bg, #ffffff);
+    --_text: var(--probo-text, #1a1a1a);
+    --_text-secondary: var(--probo-text-secondary, #555555);
+    --_border: var(--probo-border, #e0e0e0);
+    --_radius: var(--probo-radius, 12px);
+    --_shadow: var(--probo-shadow, 0 4px 24px rgba(0, 0, 0, 0.12));
+    --_accent: var(--probo-accent, #1a1a1a);
+    --_accent-text: var(--probo-accent-text, #ffffff);
+    --_overlay: var(--probo-overlay, rgba(0, 0, 0, 0.4));
+    --_z-index: var(--probo-z-index, 2147483646);
+
+    all: initial;
+    font-family: var(--_font);
+    color: var(--_text);
+    font-size: 14px;
+    line-height: 1.5;
+    box-sizing: border-box;
+  }
+
+  *, *::before, *::after {
+    box-sizing: border-box;
+  }
+
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: var(--_overlay);
+    z-index: var(--_z-index);
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    padding: 16px;
+  }
+
+  .card {
+    background: var(--_bg);
+    border-radius: var(--_radius);
+    box-shadow: var(--_shadow);
+    max-width: 520px;
+    width: 100%;
+    padding: 24px;
+    max-height: 85vh;
+    overflow-y: auto;
+  }
+
+  .title {
+    font-size: 16px;
+    font-weight: 600;
+    margin: 0 0 8px;
+  }
+
+  .description {
+    color: var(--_text-secondary);
+    margin: 0 0 20px;
+    font-size: 14px;
+  }
+
+  .description a {
+    color: var(--_accent);
+    text-decoration: underline;
+  }
+
+  .buttons {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  .btn {
+    flex: 1;
+    min-width: 0;
+    padding: 10px 16px;
+    border-radius: 8px;
+    border: 1px solid var(--_border);
+    background: var(--_bg);
+    color: var(--_text);
+    font-family: var(--_font);
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s;
+    white-space: nowrap;
+  }
+
+  .btn:hover {
+    border-color: var(--_accent);
+  }
+
+  .btn-primary {
+    background: var(--_accent);
+    color: var(--_accent-text);
+    border-color: var(--_accent);
+  }
+
+  .btn-primary:hover {
+    opacity: 0.9;
+  }
+
+  .panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 16px;
+  }
+
+  .panel-back {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 4px;
+    color: var(--_text);
+    font-family: var(--_font);
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .panel-back:hover {
+    color: var(--_accent);
+  }
+
+  probo-category-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-bottom: 20px;
+  }
+
+  probo-category {
+    display: block;
+    border: 1px solid var(--_border);
+    border-radius: 8px;
+    padding: 12px 16px;
+  }
+
+  .category-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .category-info {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .category-name {
+    font-weight: 500;
+    font-size: 14px;
+  }
+
+  .category-description {
+    color: var(--_text-secondary);
+    font-size: 13px;
+    margin-top: 2px;
+  }
+
+  .category-required {
+    font-size: 12px;
+    color: var(--_text-secondary);
+    font-style: italic;
+  }
+
+  .toggle {
+    position: relative;
+    width: 44px;
+    height: 24px;
+    flex-shrink: 0;
+  }
+
+  .toggle input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+    position: absolute;
+  }
+
+  .toggle-track {
+    position: absolute;
+    inset: 0;
+    background: var(--_border);
+    border-radius: 12px;
+    cursor: pointer;
+    transition: background 0.2s;
+  }
+
+  .toggle-track::after {
+    content: "";
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 20px;
+    height: 20px;
+    background: white;
+    border-radius: 50%;
+    transition: transform 0.2s;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  }
+
+  .toggle input:checked + .toggle-track {
+    background: var(--_accent);
+  }
+
+  .toggle input:checked + .toggle-track::after {
+    transform: translateX(20px);
+  }
+
+  .toggle input:disabled + .toggle-track {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  probo-cookie-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid var(--_border);
+  }
+
+  .cookie-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    font-size: 12px;
+    gap: 8px;
+  }
+
+  .cookie-name {
+    font-weight: 500;
+    font-family: monospace;
+    flex-shrink: 0;
+  }
+
+  .cookie-duration {
+    color: var(--_text-secondary);
+    flex-shrink: 0;
+  }
+
+  [hidden] {
+    display: none !important;
+  }
+
+  @media (min-width: 640px) {
+    .overlay {
+      align-items: center;
+    }
+  }
+`;

--- a/packages/cookie-banner/src/themed-banner/themed-banner.ts
+++ b/packages/cookie-banner/src/themed-banner/themed-banner.ts
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { registerComponents } from "../components";
+import type { ProboCookieBannerRoot } from "../components/cookie-banner-root";
+import type { BannerConfig } from "../client";
+import { THEMED_STYLES } from "./styles";
+
+const BACK_ARROW = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>`;
+
+export class ProboThemedBanner extends HTMLElement {
+  private shadow: ShadowRoot;
+
+  constructor() {
+    super();
+    this.shadow = this.attachShadow({ mode: "open" });
+  }
+
+  static get observedAttributes(): string[] {
+    return ["banner-id", "base-url"];
+  }
+
+  connectedCallback(): void {
+    registerComponents();
+
+    const bannerId = this.getAttribute("banner-id");
+    const baseUrl = this.getAttribute("base-url");
+
+    if (!bannerId || !baseUrl) {
+      console.warn("[probo] <probo-cookie-banner> requires banner-id and base-url attributes");
+      return;
+    }
+
+    const position = this.getAttribute("position") ?? "bottom-left";
+
+    this.shadow.innerHTML = `
+      <style>${THEMED_STYLES}</style>
+      <probo-cookie-banner-root banner-id="${this.esc(bannerId)}" base-url="${this.esc(baseUrl)}">
+        <probo-banner>
+          <div class="overlay">
+            <div class="card" role="dialog" aria-label="Cookie consent">
+              <p class="title">Cookie Preferences</p>
+              <p class="description" data-description>
+                We use cookies to improve your experience and analyze site traffic.
+              </p>
+              <div class="buttons">
+                <probo-reject-button><button class="btn">Reject all</button></probo-reject-button>
+                <probo-customize-button><button class="btn">Customize</button></probo-customize-button>
+                <probo-accept-button><button class="btn btn-primary">Accept all</button></probo-accept-button>
+              </div>
+            </div>
+          </div>
+        </probo-banner>
+
+        <probo-preference-panel>
+          <div class="overlay">
+            <div class="card" role="dialog" aria-label="Cookie preferences">
+              <div class="panel-header">
+                <button class="panel-back" data-action="back">
+                  ${BACK_ARROW} Back
+                </button>
+                <p class="title" style="margin:0">Preferences</p>
+                <div style="width:60px"></div>
+              </div>
+              <probo-category-list>
+                <template>
+                  <div class="category-header">
+                    <div class="category-info">
+                      <div class="category-name" data-slot="name"></div>
+                      <div class="category-description" data-slot="description"></div>
+                    </div>
+                    <probo-category-toggle>
+                      <label class="toggle">
+                        <input type="checkbox">
+                        <span class="toggle-track"></span>
+                      </label>
+                    </probo-category-toggle>
+                  </div>
+                  <probo-cookie-list>
+                    <template>
+                      <div class="cookie-item">
+                        <span class="cookie-name" data-slot="name"></span>
+                        <span class="cookie-duration" data-slot="duration"></span>
+                      </div>
+                    </template>
+                  </probo-cookie-list>
+                </template>
+              </probo-category-list>
+              <div class="buttons">
+                <probo-save-button>
+                  <button class="btn btn-primary" style="flex:1">Save preferences</button>
+                </probo-save-button>
+              </div>
+            </div>
+          </div>
+        </probo-preference-panel>
+
+        <probo-settings-button position="${this.esc(position)}"></probo-settings-button>
+      </probo-cookie-banner-root>
+    `;
+
+    const root = this.shadow.querySelector("probo-cookie-banner-root") as ProboCookieBannerRoot;
+
+    root.addEventListener("probo-ready", (e: Event) => {
+      const config = (e as CustomEvent).detail.config as BannerConfig;
+      this.updateDescription(config);
+    });
+
+    this.shadow.querySelector("[data-action=back]")?.addEventListener("click", () => {
+      root.setState("banner");
+    });
+  }
+
+  private updateDescription(config: BannerConfig): void {
+    const el = this.shadow.querySelector("[data-description]");
+    if (!el) return;
+
+    let html = "We use cookies to improve your experience and analyze site traffic.";
+    if (config.privacy_policy_url) {
+      html += ` <a href="${this.esc(config.privacy_policy_url)}" target="_blank" rel="noopener">Privacy Policy</a>`;
+    }
+    el.innerHTML = html;
+  }
+
+  private esc(str: string): string {
+    return str.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
+}


### PR DESCRIPTION
Closes ENG-270


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds headless, light‑DOM Web Components for a customizable cookie banner and preferences panel, plus a themed banner with built‑in UI in `@probo/cookie-banner`. Also narrows the public API, builds API URLs with `URL`, adds a `./themed-banner` ESM entry and IIFE auto‑mount, fixes event/observer leaks, addresses an init/unmount race, and adds `--probo-font-size`/`--probo-btn-radius` with the settings button following `--probo-accent`. Closes ENG-270.

- **New Features**
  - Headless elements: `<probo-cookie-banner-root>` loads config via `banner-id`/`base-url`, manages `loading|banner|panel|hidden`, and emits `probo-ready`/`probo-state`. `<probo-banner>`/`<probo-preference-panel>` auto show/hide; buttons `<probo-accept-button>`, `<probo-reject-button>`, `<probo-customize-button>`, `<probo-save-button>`; floating `<probo-settings-button position="bottom-left|bottom-right">` (Shadow DOM); others use light DOM.
  - Data + validation: `<probo-category-list>` and `<probo-cookie-list>` render from config; `<probo-category-toggle>` updates a consent draft. Validates required children/templates and emits `probo-validation`. `probo-consent` fires on accept/reject/customize (includes `consent_data` for CUSTOMIZE).
  - Themed banner: `<probo-cookie-banner>` (Shadow DOM) provides styled UI. Register via `registerThemedBanner()` or auto‑mount via the IIFE `<script … data-banner-id … data-base-url … [data-position]>`. Adds CSS vars `--probo-font-size` and `--probo-btn-radius`; settings button now follows `--probo-accent`.
  - Builds/exports + networking: main ESM at `dist/cookie-banner.mjs` (exports only `registerComponents`); new `./themed-banner` ESM at `dist/cookie-banner-themed.mjs`; IIFE remains `./iife`. Client stores base as `URL`, builds endpoints with `new URL()`, and `fetchJSON` accepts `URL | string`.

- **Migration**
  - Call `registerComponents()` once to define the headless elements (auto‑register removed).
  - Compose your UI with `<probo-cookie-banner-root banner-id="…" base-url="…">`, `<probo-banner>` (with accept/reject/customize), and `<probo-preference-panel>` with `<probo-category-list>` + `<probo-category-toggle>` + `<probo-cookie-list>`, plus `<probo-save-button>`.
  - Or use the themed banner: import from `./themed-banner` and use `<probo-cookie-banner …>`, or include the IIFE and set `data-banner-id`/`data-base-url` (optional `data-position`).

<sup>Written for commit 80a4d44e6d78d72e584d4430e9da6f4413d49741. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



