### PR TITLE
Pin tempo digest and set pull_policy: missing on compose services

### DIFF
--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -129,6 +129,10 @@ jobs:
       - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6
       - uses: "runs-on/action@742bf56072eb4845a0f94b3394673e4903c90ff0" # v2
       - uses: "docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd" # v4.0.0
+      - uses: "docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2" # v4.0.0
+        with:
+          username: "gearnode"
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - uses: "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" # v8
         with:
           name: "binary-linux-${{ matrix.arch }}"
@@ -369,6 +373,10 @@ jobs:
       - uses: "runs-on/action@742bf56072eb4845a0f94b3394673e4903c90ff0" # v2
       - uses: "./.github/actions/setup"
       - uses: "docker/setup-compose-action@8cccb8c14b6500aaffebff1aa49c502c34d2e5e6" # v2.1.0
+      - uses: "docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2" # v4.0.0
+        with:
+          username: "gearnode"
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - name: "Install mkcert"
         run: |
           go install filippo.io/mkcert@latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -171,6 +171,10 @@ jobs:
       - uses: "docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd" # v4.0.0
       - uses: "docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2" # v4.0.0
         with:
+          username: "gearnode"
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - uses: "docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2" # v4.0.0
+        with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,7 @@
 services:
   postgres:
     image: "postgres:18.3@sha256:52e6ffd11fddd081ae63880b635b2a61c14008c17fc98cdc7ce5472265516dd0"
+    pull_policy: missing
     shm_size: "1g"
     command: >
       postgres -c "shared_buffers=1GB"
@@ -22,6 +23,7 @@ services:
 
   seaweedfs:
     image: "chrislusf/seaweedfs:4.20@sha256:cea8339d21dad1b200adce581dd7434d254b8f5975f142c3b4c930ba78647eef"
+    pull_policy: missing
     command: >
       server
       -s3
@@ -40,6 +42,7 @@ services:
 
   grafana:
     image: "grafana/grafana:13.0.0@sha256:a03d9e604e4dba58c5e64458a879701f46ef64af1f596058aacfad9aacdcab34"
+    pull_policy: missing
     ports:
       - "3001:3000"
     volumes:
@@ -53,6 +56,7 @@ services:
 
   prometheus:
     image: "prom/prometheus:v3.11.2@sha256:5550dc63da361dc30f6fe02ac0e4dfc736ededfef3c8d12a634db04a67824d78"
+    pull_policy: missing
     volumes:
       - "./compose/prometheus/prometheus.yaml:/etc/prometheus/prometheus.yml"
       - "prometheus-data:/prometheus"
@@ -69,13 +73,15 @@ services:
 
   loki:
     image: "grafana/loki:3.7.1@sha256:73e905b51a7f917f7a1075e4be68759df30226e03dcb3cd2213b989cc0dc8eb4"
+    pull_policy: missing
     ports:
       - "3100:3100"
     command:
       - "-config.file=/etc/loki/local-config.yaml"
 
   tempo:
-    image: "grafana/tempo:2.10.4"
+    image: "grafana/tempo:2.10.4@sha256:a6616c9d224770c883a67b50e4941e99c5df81b076ef05f516bb7cce5a96cec0"
+    pull_policy: missing
     command:
       - "-config.file=/etc/tempo.yaml"
     ports:
@@ -88,6 +94,7 @@ services:
 
   mailpit:
     image: "axllent/mailpit:v1.29.6@sha256:0b5c5f7ffd3c93474baa7fd3869c1462e5a3d03256ed0933dfc0e7d81d794036"
+    pull_policy: missing
     ports:
       - "1025:1025" # SMTP server
       - "8025:8025" # Web UI
@@ -100,6 +107,7 @@ services:
 
   chrome:
     image: "chromedp/headless-shell:149.0.7779.3@sha256:b24482ae166e2c67135f5a8ba9575c257efdd8e2fd6b2e931f9d88ede3d72f3b"
+    pull_policy: missing
     ports:
       - "9222:9222"
     command:
@@ -116,6 +124,7 @@ services:
 
   pebble:
     image: "ghcr.io/letsencrypt/pebble:2.10.0@sha256:68cf1ec8a8db96f64244d5f559c448bc8e54f2934e0dd53a414eabffda7a6f22"
+    pull_policy: missing
     ports:
       - "14000:14000" # ACME server
       - "15000:15000" # Management interface
@@ -129,6 +138,7 @@ services:
 
   pebble-challtestsrv:
     image: "ghcr.io/letsencrypt/pebble-challtestsrv:2.10.0@sha256:df85447c39114cd2b3da971e751682ad2db19a996034b47d5392cd4a0f43406a"
+    pull_policy: missing
     ports:
       - "8055:8055" # HTTP-01 challenge test server
       - "8053:8053" # DNS server
@@ -137,6 +147,7 @@ services:
 
   keycloak:
     image: "quay.io/keycloak/keycloak:26.6.1@sha256:26ae26445475f7fac5f90ee138b1bdb64324f5815fb16133ffdbdb122d97c4d8"
+    pull_policy: missing
     user: root
     environment:
       KC_HOSTNAME: localhost


### PR DESCRIPTION
## Summary
- Pin the `grafana/tempo` image to its sha256 digest for reproducibility, consistent with all other services in `compose.yaml`.
- Add `pull_policy: missing` to all 11 compose services to skip Docker registry checks when images already exist locally, avoiding Docker Hub rate limit errors during `make stack-up`.

## Test plan
- [ ] Run `make stack-up` and verify no "Pulling" output for already-cached images
- [ ] Run `make stack-down && make stack-up` to confirm services start correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned the `grafana/tempo` image to a SHA256 digest and set `pull_policy: missing` on all services in `compose.yaml`. Added Docker Hub authentication in CI via `docker/login-action` to avoid unauthenticated pull limits, making `make stack-up` and CI builds/tests faster and more reliable.

<sup>Written for commit 1d539f8cc94fabc26e4588112ac0c8d430f4aa17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

