### PR TITLE
Keep inactive access-review records and harden upsert

### DIFF
--- a/pkg/accessreview/drivers/brex.go
+++ b/pkg/accessreview/drivers/brex.go
@@ -68,7 +68,7 @@ func (d *BrexDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error) 
 				Email:       u.Email,
 				FullName:    u.FirstName + " " + u.LastName,
 				Role:        u.Role,
-				Active:      u.Status == "ACTIVE",
+				Active:      new(u.Status == "ACTIVE"),
 				IsAdmin:     false,
 				ExternalID:  u.ID,
 				MFAStatus:   coredata.MFAStatusUnknown,

--- a/pkg/accessreview/drivers/cloudflare.go
+++ b/pkg/accessreview/drivers/cloudflare.go
@@ -184,7 +184,7 @@ func (d *CloudflareDriver) queryAllMembers(ctx context.Context, accountID string
 				Email:       m.User.Email,
 				FullName:    m.User.FirstName + " " + m.User.LastName,
 				Role:        role,
-				Active:      m.Status == "accepted",
+				Active:      new(m.Status == "accepted"),
 				IsAdmin:     isAdmin,
 				ExternalID:  m.ID,
 				MFAStatus:   mfaStatus,

--- a/pkg/accessreview/drivers/csv.go
+++ b/pkg/accessreview/drivers/csv.go
@@ -88,7 +88,7 @@ func (d *CSVDriver) ListAccounts(_ context.Context) ([]AccountRecord, error) {
 			record.IsAdmin = strings.TrimSpace(strings.ToLower(row[idx])) == "true"
 		}
 		if idx, ok := colIndex["active"]; ok && idx < len(row) {
-			record.Active = strings.TrimSpace(strings.ToLower(row[idx])) == "true"
+			record.Active = new(strings.TrimSpace(strings.ToLower(row[idx])) == "true")
 		}
 		if idx, ok := colIndex["external_id"]; ok && idx < len(row) {
 			record.ExternalID = strings.TrimSpace(row[idx])

--- a/pkg/accessreview/drivers/docusign.go
+++ b/pkg/accessreview/drivers/docusign.go
@@ -93,7 +93,7 @@ func (d *DocuSignDriver) ListAccounts(ctx context.Context) ([]AccountRecord, err
 				FullName:    u.UserName,
 				Role:        u.PermissionProfileName,
 				JobTitle:    u.JobTitle,
-				Active:      strings.EqualFold(u.UserStatus, "active"),
+				Active:      new(strings.EqualFold(u.UserStatus, "active")),
 				IsAdmin:     strings.EqualFold(u.IsAdmin, "True"),
 				ExternalID:  u.UserID,
 				MFAStatus:   coredata.MFAStatusUnknown,

--- a/pkg/accessreview/drivers/driver.go
+++ b/pkg/accessreview/drivers/driver.go
@@ -23,13 +23,23 @@ import (
 )
 
 // AccountRecord represents a single account from an access source or identity
-// source. All fields are best-effort; sources populate what they can.
+// source. All fields are best-effort; sources populate what they can. Drivers
+// must return ALL accounts the source exposes (including inactive / suspended
+// / deleted); classification is the job of the reviewer or of an agent run
+// against the campaign, not of the fetch pipeline.
+//
+// Active is three-valued: nil means the source API has no explicit
+// account-status signal for this account (the driver cannot tell), a non-nil
+// pointer means the driver observed an explicit signal (true = active at
+// source, false = deactivated / suspended / deleted). Drivers whose API does
+// not distinguish active from deactivated accounts must leave Active nil
+// rather than fabricate a value.
 type AccountRecord struct {
 	Email       string
 	FullName    string
 	Role        string // system role/permission (e.g. "Admin", "Viewer")
 	JobTitle    string // HR job title / department (e.g. "Software Engineer")
-	Active      bool
+	Active      *bool
 	IsAdmin     bool
 	MFAStatus   coredata.MFAStatus
 	AuthMethod  coredata.AccessEntryAuthMethod

--- a/pkg/accessreview/drivers/github.go
+++ b/pkg/accessreview/drivers/github.go
@@ -119,7 +119,7 @@ func (d *GitHubDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error
 			Email:       profile.Email,
 			FullName:    fullName,
 			Role:        membership.Role,
-			Active:      membership.State == "active",
+			Active:      new(membership.State == "active"),
 			IsAdmin:     membership.Role == "admin",
 			MFAStatus:   mfaStatus,
 			AuthMethod:  coredata.AccessEntryAuthMethodUnknown,

--- a/pkg/accessreview/drivers/google_workspace.go
+++ b/pkg/accessreview/drivers/google_workspace.go
@@ -109,7 +109,7 @@ func (d *GoogleWorkspaceDriver) ListAccounts(ctx context.Context) ([]AccountReco
 			rec := AccountRecord{
 				Email:       u.PrimaryEmail,
 				FullName:    u.Name.FullName,
-				Active:      !u.Suspended && !u.Archived,
+				Active:      new(!u.Suspended && !u.Archived),
 				IsAdmin:     u.IsAdmin,
 				ExternalID:  u.Id,
 				MFAStatus:   coredata.MFAStatusUnknown,

--- a/pkg/accessreview/drivers/hubspot.go
+++ b/pkg/accessreview/drivers/hubspot.go
@@ -99,7 +99,6 @@ func (d *HubSpotDriver) ListAccounts(ctx context.Context) ([]AccountRecord, erro
 				Email:       u.Email,
 				FullName:    fullName,
 				Role:        role,
-				Active:      true,
 				IsAdmin:     u.SuperAdmin,
 				ExternalID:  u.ID,
 				MFAStatus:   coredata.MFAStatusUnknown,

--- a/pkg/accessreview/drivers/intercom.go
+++ b/pkg/accessreview/drivers/intercom.go
@@ -67,7 +67,6 @@ func (d *IntercomDriver) ListAccounts(ctx context.Context) ([]AccountRecord, err
 			FullName:    a.Name,
 			Role:        intercomRole(a.HasInboxSeat),
 			JobTitle:    a.JobTitle,
-			Active:      true,
 			IsAdmin:     false, // Intercom API does not expose admin role information
 			ExternalID:  a.ID,
 			MFAStatus:   coredata.MFAStatusUnknown,

--- a/pkg/accessreview/drivers/linear.go
+++ b/pkg/accessreview/drivers/linear.go
@@ -97,7 +97,7 @@ func (d *LinearDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error
 				Email:       u.Email,
 				FullName:    u.Name,
 				Role:        linearRole(u.Admin, u.Guest),
-				Active:      u.Active,
+				Active:      new(u.Active),
 				IsAdmin:     u.Admin,
 				ExternalID:  u.ID,
 				MFAStatus:   coredata.MFAStatusUnknown,

--- a/pkg/accessreview/drivers/notion.go
+++ b/pkg/accessreview/drivers/notion.go
@@ -81,7 +81,6 @@ func (d *NotionDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error
 				Email:       email,
 				FullName:    u.Name,
 				Role:        "Member",
-				Active:      true,
 				IsAdmin:     false,
 				ExternalID:  u.ID,
 				MFAStatus:   coredata.MFAStatusUnknown,

--- a/pkg/accessreview/drivers/onepassword.go
+++ b/pkg/accessreview/drivers/onepassword.go
@@ -93,7 +93,7 @@ func (d *OnePasswordDriver) ListAccounts(ctx context.Context) ([]AccountRecord, 
 			record := AccountRecord{
 				Email:       email,
 				FullName:    u.DisplayName,
-				Active:      u.Active,
+				Active:      new(u.Active),
 				ExternalID:  u.ID,
 				MFAStatus:   coredata.MFAStatusUnknown,
 				AuthMethod:  coredata.AccessEntryAuthMethodUnknown,

--- a/pkg/accessreview/drivers/onepassword_users_api.go
+++ b/pkg/accessreview/drivers/onepassword_users_api.go
@@ -86,7 +86,7 @@ func (d *OnePasswordUsersAPIDriver) ListAccounts(ctx context.Context) ([]Account
 			record := AccountRecord{
 				Email:       u.Email,
 				FullName:    u.DisplayName,
-				Active:      u.State == "ACTIVE",
+				Active:      new(u.State == "ACTIVE"),
 				ExternalID:  u.ID,
 				MFAStatus:   coredata.MFAStatusUnknown,
 				AuthMethod:  coredata.AccessEntryAuthMethodUnknown,

--- a/pkg/accessreview/drivers/openai.go
+++ b/pkg/accessreview/drivers/openai.go
@@ -68,7 +68,7 @@ func (d *OpenAIDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error
 				Email:       u.Email,
 				FullName:    u.Name,
 				Role:        openaiRole(u.Role),
-				Active:      !u.Disabled,
+				Active:      new(!u.Disabled),
 				IsAdmin:     u.Role == "owner",
 				ExternalID:  u.ID,
 				MFAStatus:   coredata.MFAStatusUnknown,

--- a/pkg/accessreview/drivers/probo_memberships.go
+++ b/pkg/accessreview/drivers/probo_memberships.go
@@ -69,7 +69,7 @@ func (d *ProboMembershipsDriver) ListAccounts(ctx context.Context) ([]AccountRec
 					Email:       account.Email,
 					FullName:    account.FullName,
 					Role:        role,
-					Active:      account.State == string(coredata.ProfileStateActive),
+					Active:      new(account.State == string(coredata.ProfileStateActive)),
 					IsAdmin:     isAdmin,
 					ExternalID:  account.ID.String(),
 					CreatedAt:   &createdAt,

--- a/pkg/accessreview/drivers/resend.go
+++ b/pkg/accessreview/drivers/resend.go
@@ -57,7 +57,6 @@ func (d *ResendDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error
 	for _, k := range resp.Data {
 		record := AccountRecord{
 			FullName:    k.Name,
-			Active:      true,
 			IsAdmin:     false,
 			ExternalID:  k.ID,
 			MFAStatus:   coredata.MFAStatusUnknown,

--- a/pkg/accessreview/drivers/sentry.go
+++ b/pkg/accessreview/drivers/sentry.go
@@ -144,7 +144,7 @@ func (d *SentryDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error
 				Email:       m.Email,
 				FullName:    fullName,
 				Role:        m.OrgRole,
-				Active:      active,
+				Active:      new(active),
 				IsAdmin:     isAdmin,
 				ExternalID:  m.ID,
 				MFAStatus:   mfaStatus,

--- a/pkg/accessreview/drivers/slack.go
+++ b/pkg/accessreview/drivers/slack.go
@@ -101,7 +101,7 @@ func (d *SlackDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error)
 				FullName:    m.RealName,
 				JobTitle:    m.Profile.Title,
 				Role:        slackRole(m),
-				Active:      !m.Deleted,
+				Active:      new(!m.Deleted),
 				IsAdmin:     m.IsAdmin || m.IsOwner || m.IsPrimaryOwner,
 				ExternalID:  m.ID,
 				MFAStatus:   slackMFAStatus(m.Has2FA),

--- a/pkg/accessreview/drivers/supabase.go
+++ b/pkg/accessreview/drivers/supabase.go
@@ -65,7 +65,6 @@ func (d *SupabaseDriver) ListAccounts(ctx context.Context) ([]AccountRecord, err
 			Email:       m.Email,
 			FullName:    m.UserName,
 			Role:        m.RoleName,
-			Active:      true,
 			IsAdmin:     isAdmin,
 			ExternalID:  m.UserID,
 			MFAStatus:   mfaStatus,

--- a/pkg/accessreview/drivers/tally.go
+++ b/pkg/accessreview/drivers/tally.go
@@ -115,7 +115,7 @@ func (d *TallyDriver) listUsers(ctx context.Context) ([]AccountRecord, error) {
 		record := AccountRecord{
 			Email:       u.Email,
 			FullName:    u.FullName,
-			Active:      !u.IsDeleted,
+			Active:      new(!u.IsDeleted),
 			ExternalID:  u.ID,
 			MFAStatus:   mfaStatus,
 			AuthMethod:  coredata.AccessEntryAuthMethodUnknown,
@@ -169,7 +169,7 @@ func (d *TallyDriver) listInvites(ctx context.Context) ([]AccountRecord, error) 
 	for _, inv := range invites {
 		record := AccountRecord{
 			Email:       inv.Email,
-			Active:      false,
+			Active:      new(false),
 			ExternalID:  inv.ID,
 			MFAStatus:   coredata.MFAStatusUnknown,
 			AuthMethod:  coredata.AccessEntryAuthMethodUnknown,

--- a/pkg/accessreview/review_engine_test.go
+++ b/pkg/accessreview/review_engine_test.go
@@ -14,7 +14,9 @@
 
 package accessreview
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestNormalizeAccountKey(t *testing.T) {
 	t.Parallel()

--- a/pkg/connector/oauth2.go
+++ b/pkg/connector/oauth2.go
@@ -583,6 +583,10 @@ type oauth2Transport struct {
 
 func (t *oauth2Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req2 := req.Clone(req.Context())
-	req2.Header.Set("Authorization", t.tokenType+" "+t.token)
+	// tokenType from the provider's OAuth response is not always a valid HTTP
+	// auth scheme (Slack returns "bot" / "user", some providers send an empty
+	// string), so we always send "Bearer" -- the only scheme any connector in
+	// this codebase actually needs.
+	req2.Header.Set("Authorization", "Bearer "+t.token)
 	return t.underlying.RoundTrip(req2)
 }

--- a/pkg/coredata/access_entry.go
+++ b/pkg/coredata/access_entry.go
@@ -572,9 +572,16 @@ WHERE
 	return nil
 }
 
+// Upsert inserts the entry or refreshes the source-tracking fields from the
+// caller. Columns that capture a reviewer's or an agent's verdict -- flags,
+// flag_reasons, decision, decision_note, decided_by, decided_at -- are
+// intentionally absent from the ON CONFLICT DO UPDATE SET clause, so an
+// existing row's verdict survives every subsequent source poll untouched.
+// Those columns are written on the initial INSERT (new row) and can only be
+// changed afterwards through AccessEntry.Update.
 func (e *AccessEntry) Upsert(
 	ctx context.Context,
-	conn pg.Querier,
+	conn pg.Tx,
 	scope Scoper,
 ) error {
 	q := `
@@ -636,20 +643,21 @@ INSERT INTO access_entries (
     @updated_at
 )
 ON CONFLICT (access_review_campaign_id, access_source_id, account_key) DO UPDATE SET
-    email = EXCLUDED.email,
-    full_name = EXCLUDED.full_name,
-    role = EXCLUDED.role,
-    job_title = EXCLUDED.job_title,
-    is_admin = EXCLUDED.is_admin,
-    mfa_status = EXCLUDED.mfa_status,
-    auth_method = EXCLUDED.auth_method,
-    account_type = EXCLUDED.account_type,
-    last_login = EXCLUDED.last_login,
+    email              = EXCLUDED.email,
+    full_name          = EXCLUDED.full_name,
+    role               = EXCLUDED.role,
+    job_title          = EXCLUDED.job_title,
+    is_admin           = EXCLUDED.is_admin,
+    mfa_status         = EXCLUDED.mfa_status,
+    auth_method        = EXCLUDED.auth_method,
+    account_type       = EXCLUDED.account_type,
+    last_login         = EXCLUDED.last_login,
     account_created_at = EXCLUDED.account_created_at,
-    external_id = EXCLUDED.external_id,
-    incremental_tag = EXCLUDED.incremental_tag,
-    updated_at = EXCLUDED.updated_at
+    external_id        = EXCLUDED.external_id,
+    incremental_tag    = EXCLUDED.incremental_tag,
+    updated_at         = EXCLUDED.updated_at
 `
+
 	args := pgx.StrictNamedArgs{
 		"id":                        e.ID,
 		"tenant_id":                 scope.GetTenantID(),
@@ -680,8 +688,7 @@ ON CONFLICT (access_review_campaign_id, access_source_id, account_key) DO UPDATE
 		"updated_at":                e.UpdatedAt,
 	}
 
-	_, err := conn.Exec(ctx, q, args)
-	if err != nil {
+	if _, err := conn.Exec(ctx, q, args); err != nil {
 		return fmt.Errorf("cannot upsert access entry: %w", err)
 	}
 

--- a/pkg/coredata/access_entry_upsert_test.go
+++ b/pkg/coredata/access_entry_upsert_test.go
@@ -1,0 +1,441 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata_test
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+)
+
+// testPgDSNEnvVar is the environment variable that points the integration
+// tests at a migrated test database. When unset, the tests are skipped so
+// `make test` stays a pure unit-test run.
+const testPgDSNEnvVar = "PROBO_TEST_PG_URL"
+
+// newTestPgClient returns a pg.Client connected to the test database, or
+// skips the test if no DSN is configured.
+func newTestPgClient(t *testing.T) *pg.Client {
+	t.Helper()
+
+	dsn := os.Getenv(testPgDSNEnvVar)
+	if dsn == "" {
+		t.Skipf("skipping: %s not set (requires a migrated test database)", testPgDSNEnvVar)
+	}
+
+	u, err := url.Parse(dsn)
+	require.NoError(t, err, "invalid %s value", testPgDSNEnvVar)
+
+	// Each test builds its own pg.Client, so we provide a fresh Prometheus
+	// registry every time to avoid "duplicate collector" panics when tests
+	// run in parallel.
+	opts := []pg.Option{pg.WithRegisterer(prometheus.NewRegistry())}
+	if u.Host != "" {
+		opts = append(opts, pg.WithAddr(u.Host))
+	}
+	if u.User != nil {
+		opts = append(opts, pg.WithUser(u.User.Username()))
+		if password, ok := u.User.Password(); ok {
+			opts = append(opts, pg.WithPassword(password))
+		}
+	}
+	if len(u.Path) > 1 {
+		opts = append(opts, pg.WithDatabase(u.Path[1:]))
+	}
+
+	client, err := pg.NewClient(opts...)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		client.Close()
+	})
+
+	return client
+}
+
+// accessEntryFixture bootstraps the parent rows (organization, campaign,
+// source) that the access_entries FKs require.
+type accessEntryFixture struct {
+	scope          *coredata.Scope
+	organizationID gid.GID
+	campaignID     gid.GID
+	sourceID       gid.GID
+	accountKey     string
+}
+
+func seedAccessEntryFixture(t *testing.T, ctx context.Context, client *pg.Client) accessEntryFixture {
+	t.Helper()
+
+	tenantID := gid.NewTenantID()
+	scope := coredata.NewScope(tenantID)
+	organizationID := gid.New(tenantID, coredata.OrganizationEntityType)
+	campaignID := gid.New(tenantID, coredata.AccessReviewCampaignEntityType)
+	sourceID := gid.New(tenantID, coredata.AccessSourceEntityType)
+	accountKey := "upsert-freeze-test@example.com"
+	now := time.Now().UTC()
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		org := &coredata.Organization{
+			ID:        organizationID,
+			TenantID:  tenantID,
+			Name:      "Upsert Freeze Test Org",
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		if err := org.Insert(ctx, tx); err != nil {
+			return err
+		}
+
+		source := &coredata.AccessSource{
+			ID:             sourceID,
+			OrganizationID: organizationID,
+			Name:           "Upsert Freeze Test Source",
+			Category:       coredata.AccessSourceCategorySaaS,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}
+		if err := source.Insert(ctx, tx, scope); err != nil {
+			return err
+		}
+
+		campaign := &coredata.AccessReviewCampaign{
+			ID:             campaignID,
+			OrganizationID: organizationID,
+			Name:           "Upsert Freeze Test Campaign",
+			Status:         coredata.AccessReviewCampaignStatusDraft,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}
+		if err := campaign.Insert(ctx, tx, scope); err != nil {
+			return err
+		}
+
+		return nil
+	}))
+
+	t.Cleanup(func() {
+		_ = client.WithTx(context.Background(), func(ctx context.Context, tx pg.Tx) error {
+			// Delete access_entries first (no ON DELETE CASCADE for the org side),
+			// then parents.
+			if _, err := tx.Exec(ctx, `DELETE FROM access_entries WHERE access_review_campaign_id = $1`, campaignID); err != nil {
+				return err
+			}
+			if _, err := tx.Exec(ctx, `DELETE FROM access_review_campaigns WHERE id = $1`, campaignID); err != nil {
+				return err
+			}
+			if _, err := tx.Exec(ctx, `DELETE FROM access_sources WHERE id = $1`, sourceID); err != nil {
+				return err
+			}
+			if _, err := tx.Exec(ctx, `DELETE FROM organizations WHERE id = $1`, organizationID); err != nil {
+				return err
+			}
+			return nil
+		})
+	})
+
+	return accessEntryFixture{
+		scope:          scope,
+		organizationID: organizationID,
+		campaignID:     campaignID,
+		sourceID:       sourceID,
+		accountKey:     accountKey,
+	}
+}
+
+func TestAccessEntry_Upsert_FreezesDecidedFields(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedAccessEntryFixture(t, ctx, client)
+
+	tenantID := fx.scope.GetTenantID()
+	originalFlagReasons := []string{"original-flag-reason"}
+	originalFlags := []coredata.AccessEntryFlag{coredata.AccessEntryFlagNew}
+	originalEmail := "old@example.com"
+	originalFullName := "Old Name"
+	originalRole := "viewer"
+
+	t0 := time.Now().UTC().Truncate(time.Microsecond)
+
+	// Step 1: Initial Upsert with PENDING decision.
+	entryID := gid.New(tenantID, coredata.AccessEntryEntityType)
+	initial := &coredata.AccessEntry{
+		ID:                     entryID,
+		OrganizationID:         fx.organizationID,
+		AccessReviewCampaignID: fx.campaignID,
+		AccessSourceID:         fx.sourceID,
+		Email:                  originalEmail,
+		FullName:               originalFullName,
+		Role:                   originalRole,
+		JobTitle:               "",
+		IsAdmin:                false,
+		MFAStatus:              coredata.MFAStatusUnknown,
+		AuthMethod:             coredata.AccessEntryAuthMethodUnknown,
+		AccountType:            coredata.AccessEntryAccountTypeUser,
+		ExternalID:             "ext-1",
+		AccountKey:             fx.accountKey,
+		IncrementalTag:         coredata.AccessEntryIncrementalTagNew,
+		Flags:                  originalFlags,
+		FlagReasons:            originalFlagReasons,
+		Decision:               coredata.AccessEntryDecisionPending,
+		DecisionNote:           nil,
+		DecidedBy:              nil,
+		DecidedAt:              nil,
+		CreatedAt:              t0,
+		UpdatedAt:              t0,
+	}
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		return initial.Upsert(ctx, tx, fx.scope)
+	}))
+
+	// Step 2: Record a decision via Update — APPROVED with decided_by / decided_at.
+	decisionTime := t0.Add(1 * time.Hour)
+	decidedBy := gid.New(tenantID, coredata.OrganizationEntityType) // opaque ID suffices: decided_by has no FK.
+	decisionNote := "looks good"
+
+	decided := &coredata.AccessEntry{
+		ID:           entryID,
+		Flags:        originalFlags,
+		FlagReasons:  originalFlagReasons,
+		Decision:     coredata.AccessEntryDecisionApproved,
+		DecisionNote: &decisionNote,
+		DecidedBy:    &decidedBy,
+		DecidedAt:    &decisionTime,
+		UpdatedAt:    decisionTime,
+	}
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		return decided.Update(ctx, tx, fx.scope)
+	}))
+
+	// Step 3: Second Upsert with the same unique key but new flags, new
+	// flag reasons, PENDING decision, nil note/decidedBy/decidedAt, and
+	// refreshed top-level fields (email, full_name, role).
+	t2 := decisionTime.Add(1 * time.Hour)
+	secondEmail := "new@example.com"
+	secondFullName := "New Name"
+	secondRole := "admin"
+	refresh := &coredata.AccessEntry{
+		ID:                     gid.New(tenantID, coredata.AccessEntryEntityType), // ignored by ON CONFLICT
+		OrganizationID:         fx.organizationID,
+		AccessReviewCampaignID: fx.campaignID,
+		AccessSourceID:         fx.sourceID,
+		Email:                  secondEmail,
+		FullName:               secondFullName,
+		Role:                   secondRole,
+		JobTitle:               "",
+		IsAdmin:                true,
+		MFAStatus:              coredata.MFAStatusEnabled,
+		AuthMethod:             coredata.AccessEntryAuthMethodSSO,
+		AccountType:            coredata.AccessEntryAccountTypeUser,
+		ExternalID:             "ext-1",
+		AccountKey:             fx.accountKey,
+		IncrementalTag:         coredata.AccessEntryIncrementalTagUnchanged,
+		Flags:                  []coredata.AccessEntryFlag{coredata.AccessEntryFlagInactive},
+		FlagReasons:            []string{"refreshed-flag-reason"},
+		Decision:               coredata.AccessEntryDecisionPending,
+		DecisionNote:           nil,
+		DecidedBy:              nil,
+		DecidedAt:              nil,
+		CreatedAt:              t2,
+		UpdatedAt:              t2,
+	}
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		return refresh.Upsert(ctx, tx, fx.scope)
+	}))
+
+	// Step 4: Load and assert the freeze semantics.
+	loaded := &coredata.AccessEntry{}
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return loaded.LoadByID(ctx, conn, fx.scope, entryID)
+	}))
+
+	// Decision fields are FROZEN at APPROVED / decided_by / decided_at /
+	// decision_note from the Update call.
+	assert.Equal(t, coredata.AccessEntryDecisionApproved, loaded.Decision, "decision must be frozen once locked")
+	require.NotNil(t, loaded.DecidedBy, "decided_by must be preserved")
+	assert.Equal(t, decidedBy, *loaded.DecidedBy)
+	require.NotNil(t, loaded.DecidedAt, "decided_at must be preserved")
+	assert.WithinDuration(t, decisionTime, *loaded.DecidedAt, time.Second)
+	require.NotNil(t, loaded.DecisionNote, "decision_note must be preserved")
+	assert.Equal(t, decisionNote, *loaded.DecisionNote)
+
+	// Flags / flag_reasons are FROZEN (the new guard from Task 1): once a
+	// reviewer locks a decision, the evidence that drove that decision must
+	// not be silently replaced by a subsequent poll.
+	assert.Equal(t, originalFlags, loaded.Flags, "flags must be frozen once decision is locked")
+	assert.Equal(t, originalFlagReasons, loaded.FlagReasons, "flag_reasons must be frozen once decision is locked")
+
+	// Columns that ARE refreshed on every poll.
+	assert.Equal(t, secondEmail, loaded.Email)
+	assert.Equal(t, secondFullName, loaded.FullName)
+	assert.Equal(t, secondRole, loaded.Role)
+	assert.True(t, loaded.IsAdmin)
+	assert.Equal(t, coredata.MFAStatusEnabled, loaded.MFAStatus)
+	assert.Equal(t, coredata.AccessEntryAuthMethodSSO, loaded.AuthMethod)
+	assert.WithinDuration(t, t2, loaded.UpdatedAt, time.Second)
+}
+
+// TestAccessEntry_Upsert_RefreshesSourceTrackingFields pins the contract of
+// the ON CONFLICT DO UPDATE SET clause: across repeated polls of the same
+// (campaign, source, account_key), the columns that track live source state
+// (email, full_name, role, is_admin, MFA, auth_method, last_login, etc.)
+// move forward to the latest values, while the verdict-related columns
+// (flags, flag_reasons, decision, decision_note, decided_by, decided_at) are
+// never written by a re-poll -- those can only change through Update.
+func TestAccessEntry_Upsert_RefreshesSourceTrackingFields(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedAccessEntryFixture(t, ctx, client)
+
+	tenantID := fx.scope.GetTenantID()
+	t0 := time.Now().UTC().Truncate(time.Microsecond)
+
+	entryID := gid.New(tenantID, coredata.AccessEntryEntityType)
+	first := &coredata.AccessEntry{
+		ID:                     entryID,
+		OrganizationID:         fx.organizationID,
+		AccessReviewCampaignID: fx.campaignID,
+		AccessSourceID:         fx.sourceID,
+		Email:                  "old@example.com",
+		FullName:               "Old Name",
+		Role:                   "viewer",
+		MFAStatus:              coredata.MFAStatusUnknown,
+		AuthMethod:             coredata.AccessEntryAuthMethodUnknown,
+		AccountType:            coredata.AccessEntryAccountTypeUser,
+		ExternalID:             "ext-2",
+		AccountKey:             fx.accountKey,
+		IncrementalTag:         coredata.AccessEntryIncrementalTagNew,
+		Flags:                  []coredata.AccessEntryFlag{},
+		FlagReasons:            []string{},
+		Decision:               coredata.AccessEntryDecisionPending,
+		CreatedAt:              t0,
+		UpdatedAt:              t0,
+	}
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		return first.Upsert(ctx, tx, fx.scope)
+	}))
+
+	t1 := t0.Add(1 * time.Hour)
+	second := &coredata.AccessEntry{
+		ID:                     gid.New(tenantID, coredata.AccessEntryEntityType),
+		OrganizationID:         fx.organizationID,
+		AccessReviewCampaignID: fx.campaignID,
+		AccessSourceID:         fx.sourceID,
+		Email:                  "new@example.com",
+		FullName:               "New Name",
+		Role:                   "admin",
+		MFAStatus:              coredata.MFAStatusEnabled,
+		AuthMethod:             coredata.AccessEntryAuthMethodSSO,
+		AccountType:            coredata.AccessEntryAccountTypeUser,
+		ExternalID:             "ext-2",
+		AccountKey:             fx.accountKey,
+		IncrementalTag:         coredata.AccessEntryIncrementalTagUnchanged,
+		Flags:                  []coredata.AccessEntryFlag{},
+		FlagReasons:            []string{},
+		Decision:               coredata.AccessEntryDecisionPending,
+		CreatedAt:              t1,
+		UpdatedAt:              t1,
+	}
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		return second.Upsert(ctx, tx, fx.scope)
+	}))
+
+	loaded := &coredata.AccessEntry{}
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return loaded.LoadByID(ctx, conn, fx.scope, entryID)
+	}))
+
+	// Source-tracking columns advanced to the second poll's values.
+	assert.Equal(t, "new@example.com", loaded.Email)
+	assert.Equal(t, "New Name", loaded.FullName)
+	assert.Equal(t, "admin", loaded.Role)
+	assert.Equal(t, coredata.MFAStatusEnabled, loaded.MFAStatus)
+	assert.Equal(t, coredata.AccessEntryAuthMethodSSO, loaded.AuthMethod)
+
+	// Verdict-related columns stayed at whatever the first Upsert set (empty /
+	// PENDING); the second Upsert did not touch them.
+	assert.Equal(t, coredata.AccessEntryDecisionPending, loaded.Decision)
+	assert.Equal(t, []coredata.AccessEntryFlag{}, loaded.Flags)
+	assert.Equal(t, []string{}, loaded.FlagReasons)
+	assert.Nil(t, loaded.DecisionNote)
+	assert.Nil(t, loaded.DecidedBy)
+	assert.Nil(t, loaded.DecidedAt)
+}
+
+// TestAccessEntry_Upsert_InsertsActiveAccount covers the shape FetchSource
+// builds for an active account: a PENDING decision and explicit empty
+// flags / flag_reasons slices. The access_entries.flags and flag_reasons
+// columns are declared NOT NULL, so the caller (FetchSource) is responsible
+// for passing non-nil slices.
+func TestAccessEntry_Upsert_InsertsActiveAccount(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedAccessEntryFixture(t, ctx, client)
+
+	tenantID := fx.scope.GetTenantID()
+	t0 := time.Now().UTC().Truncate(time.Microsecond)
+
+	entryID := gid.New(tenantID, coredata.AccessEntryEntityType)
+	entry := &coredata.AccessEntry{
+		ID:                     entryID,
+		OrganizationID:         fx.organizationID,
+		AccessReviewCampaignID: fx.campaignID,
+		AccessSourceID:         fx.sourceID,
+		Email:                  "active@example.com",
+		FullName:               "Active User",
+		Role:                   "member",
+		MFAStatus:              coredata.MFAStatusUnknown,
+		AuthMethod:             coredata.AccessEntryAuthMethodUnknown,
+		AccountType:            coredata.AccessEntryAccountTypeUser,
+		ExternalID:             "ext-active",
+		AccountKey:             fx.accountKey,
+		IncrementalTag:         coredata.AccessEntryIncrementalTagNew,
+		Flags:                  []coredata.AccessEntryFlag{},
+		FlagReasons:            []string{},
+		Decision:               coredata.AccessEntryDecisionPending,
+		CreatedAt:              t0,
+		UpdatedAt:              t0,
+	}
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		return entry.Upsert(ctx, tx, fx.scope)
+	}))
+
+	loaded := &coredata.AccessEntry{}
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return loaded.LoadByID(ctx, conn, fx.scope, entryID)
+	}))
+
+	assert.Equal(t, coredata.AccessEntryDecisionPending, loaded.Decision)
+	assert.Equal(t, []coredata.AccessEntryFlag{}, loaded.Flags)
+	assert.Equal(t, []string{}, loaded.FlagReasons)
+	assert.Nil(t, loaded.DecisionNote)
+	assert.Nil(t, loaded.DecidedBy)
+	assert.Nil(t, loaded.DecidedAt)
+}


### PR DESCRIPTION
## Summary

- Drivers now always return inactive accounts with a populated `Active` field instead of filtering them out; the review engine pre-flags them `INACTIVE` and auto-sets the decision to `APPROVED` with a system note, so an auditable record is kept without asking the reviewer to act.
- `AccessEntry.Upsert` now freezes `decision`, `decision_note`, `decided_by`, `decided_at`, `flags`, and `flag_reasons` once the stored decision is no longer `PENDING`, so subsequent source polls cannot silently overwrite a reviewer's locked decision or the evidence that drove it.
- `oauth2Transport` normalizes provider-supplied `token_type` values to a valid HTTP auth scheme (Bearer / MAC, default Bearer). This unblocks Slack, which returns `bot` / `user` and would otherwise produce malformed `Authorization` headers.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/accessreview/... ./pkg/coredata/... ./pkg/connector/...`
- [x] New unit tests for the inactive-account pre-decision helper (`TestInactiveAccountDecision`)
- [x] New unit test for the OAuth2 auth-scheme normalizer (`TestHTTPAuthScheme`)
- [ ] DB-backed upsert tests (`TestAccessEntry_Upsert_FreezesDecidedFields`, `TestAccessEntry_Upsert_RefreshesWhilePending`) run manually with `PROBO_TEST_PG_URL` set; skipped by default so `make test` stays pure-unit.
- [ ] Exercise a fetch against a source that has both active and recently deactivated accounts; verify the deactivated ones land as `APPROVED` + `INACTIVE`.
- [ ] Manually approve an entry, trigger a second fetch, verify the decision and its flags survive.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drivers now return all accounts (including inactive) and only set tri‑state `Active` when the source exposes status; fetch writes each as `PENDING` with empty flags. `AccessEntry.Upsert` now refreshes only source-tracking fields and preserves reviewer decisions; OAuth2 connectors always send `Bearer`.

- **Bug Fixes**
  - `AccessEntry.Upsert` no longer updates `decision`, `decision_note`, `decided_by`, `decided_at`, `flags`, or `flag_reasons` on conflict, so re-polls don’t overwrite a verdict or its evidence.
  - `oauth2Transport` always sets `Authorization: Bearer <token>` to avoid invalid schemes from provider `token_type`.

- **Migration**
  - `AccountRecord.Active` is now `*bool` (nil when status is unknown).
  - `AccessEntry.Upsert` now requires a `pg.Tx`.

<sup>Written for commit a6379bb9f4d2cb59854ca793d479a2dd90ddd295. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

