### PR TITLE
Prevent last owner from demoting themselves

### DIFF
--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -266,6 +266,18 @@ func (s *OrganizationService) UpdateMempership(
 				return NewMembershipNotFoundError(membership.ID)
 			}
 
+			if membership.Role == coredata.MembershipRoleOwner && role != coredata.MembershipRoleOwner {
+				profiles := coredata.MembershipProfiles{}
+				count, err := profiles.CountActiveOwnerByOrganizationID(ctx, tx, scope, organizationID)
+				if err != nil {
+					return fmt.Errorf("cannot count active owners: %w", err)
+				}
+
+				if count <= 1 {
+					return NewLastActiveOwnerError(membershipID)
+				}
+			}
+
 			membership.Role = role
 			membership.UpdatedAt = time.Now()
 

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -266,7 +266,12 @@ func (s *OrganizationService) UpdateMempership(
 				return NewMembershipNotFoundError(membership.ID)
 			}
 
-			if membership.Role == coredata.MembershipRoleOwner && role != coredata.MembershipRoleOwner {
+			profile := &coredata.MembershipProfile{}
+			if err := profile.LoadByIdentityIDAndOrganizationID(ctx, tx, scope, membership.IdentityID, membership.OrganizationID); err != nil {
+				return fmt.Errorf("cannot load profile: %w", err)
+			}
+
+			if membership.Role == coredata.MembershipRoleOwner && role != coredata.MembershipRoleOwner && profile.State == coredata.ProfileStateActive {
 				profiles := coredata.MembershipProfiles{}
 				count, err := profiles.CountActiveOwnerByOrganizationID(ctx, tx, scope, organizationID)
 				if err != nil {
@@ -283,11 +288,6 @@ func (s *OrganizationService) UpdateMempership(
 
 			if err := membership.Update(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot update membership: %w", err)
-			}
-
-			profile := &coredata.MembershipProfile{}
-			if err := profile.LoadByIdentityIDAndOrganizationID(ctx, tx, scope, membership.IdentityID, membership.OrganizationID); err != nil {
-				return fmt.Errorf("cannot load profile: %w", err)
 			}
 
 			if err := webhook.InsertData(ctx, tx, scope, organizationID, coredata.WebhookEventTypeUserUpdated, webhooktypes.NewUser(profile, &membership)); err != nil {


### PR DESCRIPTION
## Summary
- Add an active-owner count guard to `UpdateMembership`, mirroring the existing check in `RemoveUser`, so the sole owner of an organization cannot demote themselves and cause permanent lockout.

Closes #1071

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the sole organization owner from demoting themselves via `UpdateMembership`, avoiding permanent lockout. Closes #1071.

- **Bug Fixes**
  - Add active-owner count guard in `UpdateMembership`; only applies to active profiles. If demotion would leave zero active owners, return `NewLastActiveOwnerError`.
  - Load the profile before the guard, matching `RemoveUser`, so demoting inactive owners is not blocked.

<sup>Written for commit f743c743c1442c8b7e09ab6968015b521150307d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

