### PR TITLE
Serialize gqlgen codegen to fix build cache race

### DIFF
--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -216,12 +216,10 @@ jobs:
           echo dev-server > packages/emails/dist/placeholder
       - name: "Generate Go code"
         run: |
-          pids=()
-          go generate ./pkg/server/api/connect/v1 & pids+=($!)
-          go generate ./pkg/server/api/console/v1 & pids+=($!)
-          go generate ./pkg/server/api/trust/v1 & pids+=($!)
-          go generate ./pkg/server/api/mcp/v1 & pids+=($!)
-          for pid in "${pids[@]}"; do wait "$pid"; done
+          go generate ./pkg/server/api/connect/v1
+          go generate ./pkg/server/api/console/v1
+          go generate ./pkg/server/api/trust/v1
+          go generate ./pkg/server/api/mcp/v1
       - name: "Build binaries"
         env:
           CGO_ENABLED: "0"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -269,12 +269,14 @@ pkg/server/api/connect/v1/schema/schema.go \
 pkg/server/api/connect/v1/types/types.go: pkg/server/api/connect/v1/gqlgen.yaml pkg/server/api/connect/v1/graphql $(CONNECT_GQL)
 	$(GO_GENERATE) ./pkg/server/api/connect/v1
 
+# gqlgen instances must run sequentially: parallel runs race on the Go build
+# cache and cause gqlgen's Rewriter.getSource() to panic with empty source.
 pkg/server/api/console/v1/schema/schema.go \
-pkg/server/api/console/v1/types/types.go: pkg/server/api/console/v1/gqlgen.yaml pkg/server/api/console/v1/graphql $(CONSOLE_GQL)
+pkg/server/api/console/v1/types/types.go: pkg/server/api/console/v1/gqlgen.yaml pkg/server/api/console/v1/graphql $(CONSOLE_GQL) | pkg/server/api/connect/v1/types/types.go
 	$(GO_GENERATE) ./pkg/server/api/console/v1
 
 pkg/server/api/trust/v1/schema/schema.go \
-pkg/server/api/trust/v1/types/types.go: pkg/server/api/trust/v1/gqlgen.yaml pkg/server/api/trust/v1/graphql $(TRUST_GQL)
+pkg/server/api/trust/v1/types/types.go: pkg/server/api/trust/v1/gqlgen.yaml pkg/server/api/trust/v1/graphql $(TRUST_GQL) | pkg/server/api/console/v1/types/types.go
 	$(GO_GENERATE) ./pkg/server/api/trust/v1
 
 pkg/server/api/mcp/v1/server/server.go \

--- a/pkg/server/api/console/v1/resolver.go
+++ b/pkg/server/api/console/v1/resolver.go
@@ -14,20 +14,6 @@
 
 //go:generate go tool github.com/99designs/gqlgen generate
 
-// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
-//
-// Permission to use, copy, modify, and/or distribute this software for any
-// purpose with or without fee is hereby granted, provided that the above
-// copyright notice and this permission notice appear in all copies.
-//
-// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
-// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
-// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
-// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-// PERFORMANCE OF THIS SOFTWARE.
-
 package console_v1
 
 import (


### PR DESCRIPTION
Parallel gqlgen instances race on the Go build cache, causing Rewriter.getSource() to panic with "slice bounds out of range" when go/packages returns empty source. Chain gqlgen targets with order-only prerequisites in the Makefile and switch the CI build job to sequential generation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize `gqlgen` code generation to stop Go build cache races that caused `Rewriter.getSource()` panics from `go/packages`. CI and local builds now generate schemas sequentially for stability.

- **Bug Fixes**
  - Makefile: chain codegen targets with order-only prerequisites to enforce `connect` → `console` → `trust`.
  - CI: replace parallel `go generate` with sequential runs for `connect`, `console`, `trust`, and `mcp`.

<sup>Written for commit f7070c43a43c628fafd22a2ab922e0e6caa9acdd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

