### PR TITLE
Cookie banner cookie detection

### DIFF
--- a/packages/cookie-banner/src/activation.ts
+++ b/packages/cookie-banner/src/activation.ts
@@ -12,6 +12,7 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
+import { removeCookies } from "./cookie-utils";
 import { LOCK_ICON } from "./html";
 
 const ATTR_CATEGORY = "data-cookie-consent";
@@ -315,31 +316,6 @@ function deactivateElement(el: Element, label?: string): void {
   }
 }
 
-function getCandidateDomains(hostname: string): string[] {
-  const parts = hostname.split(".");
-  if (parts.length <= 1) return [];
-
-  const candidates: string[] = [];
-  // Try progressively broader parent domains. The browser silently
-  // ignores attempts to clear cookies on public suffixes, so
-  // over-trying is safe and avoids maintaining a TLD list.
-  for (let i = 0; i < parts.length - 1; i++) {
-    candidates.push("." + parts.slice(i).join("."));
-  }
-
-  return candidates;
-}
-
-function removeCookies(names: string[]): void {
-  const domains = getCandidateDomains(location.hostname);
-
-  for (const name of names) {
-    document.cookie = `${name}=; path=/; max-age=0`;
-    for (const domain of domains) {
-      document.cookie = `${name}=; path=/; domain=${domain}; max-age=0`;
-    }
-  }
-}
 
 export function deactivateElements(
   consentData: Record<string, boolean>,

--- a/packages/cookie-banner/src/client.ts
+++ b/packages/cookie-banner/src/client.ts
@@ -255,6 +255,9 @@ export class CookieBannerClient {
       }
     }
 
+    if (this.detector) {
+      this.detector.stop();
+    }
     this.detector = new CookieDetector(this.baseUrl, this.bannerId, knownNames);
     this.detector.start();
   }

--- a/packages/cookie-banner/src/client.ts
+++ b/packages/cookie-banner/src/client.ts
@@ -18,7 +18,8 @@ import {
   deactivateElements,
   observeAndActivate,
 } from "./activation";
-import { getConsentCookie, setConsentCookie } from "./cookie";
+import { COOKIE_NAME, getConsentCookie, setConsentCookie } from "./cookie";
+import { CookieDetector } from "./detector";
 import { NotFoundError } from "./errors";
 import { fetchJSON } from "./http";
 import { enqueue, flush } from "./queue";
@@ -77,6 +78,7 @@ export class CookieBannerClient {
   private bannerConfig: BannerConfig | null = null;
   private consent: VisitorConsent | null = null;
   private observer: MutationObserver | null = null;
+  private detector: CookieDetector | null = null;
 
   constructor(config: CookieBannerClientOptions) {
     let base = config.baseUrl;
@@ -92,6 +94,8 @@ export class CookieBannerClient {
     const configUrl = new URL(`${this.bannerId}/config`, this.baseUrl);
     const config = await fetchJSON<BannerConfig>(configUrl);
     this.bannerConfig = config;
+
+    this.startDetector(config);
 
     const cookie = getConsentCookie();
     if (cookie && cookie.v === config.version && cookie.vid === this.visitorId) {
@@ -242,7 +246,24 @@ export class CookieBannerClient {
     this.observer = observeAndActivate(consentData, categoryLabels);
   }
 
+  private startDetector(config: BannerConfig): void {
+    const knownNames = new Set<string>();
+    knownNames.add(COOKIE_NAME);
+    for (const cat of config.categories) {
+      for (const cookie of cat.cookies) {
+        knownNames.add(cookie.name);
+      }
+    }
+
+    this.detector = new CookieDetector(this.baseUrl, this.bannerId, knownNames);
+    this.detector.start();
+  }
+
   destroy(): void {
+    if (this.detector) {
+      this.detector.stop();
+      this.detector = null;
+    }
     if (this.observer) {
       this.observer.disconnect();
       this.observer = null;

--- a/packages/cookie-banner/src/cookie-utils.ts
+++ b/packages/cookie-banner/src/cookie-utils.ts
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+// [unitSeconds, singular, plural, snapBuffer]
+// snapBuffer: if the remainder is within this many seconds of the next
+// whole unit, round up instead of carrying into smaller units.
+const DURATION_UNITS: [number, string, string, number][] = [
+  [365 * 24 * 3600, "year", "years", 21 * 24 * 3600],
+  [30 * 24 * 3600, "month", "months", 2 * 24 * 3600],
+  [7 * 24 * 3600, "week", "weeks", 12 * 3600],
+  [24 * 3600, "day", "days", 0],
+  [3600, "hour", "hours", 5 * 60],
+  [60, "minute", "minutes", 15],
+];
+
+function humanizeDuration(seconds: number): string {
+  if (seconds <= 0) return "session";
+
+  let remaining = seconds;
+  const parts: string[] = [];
+
+  for (const [unit, singular, plural, snap] of DURATION_UNITS) {
+    if (remaining >= unit) {
+      let count = Math.floor(remaining / unit);
+      const leftover = remaining - count * unit;
+
+      if (leftover >= unit - snap) {
+        count++;
+        remaining = 0;
+      } else if (leftover <= snap) {
+        remaining = 0;
+      } else {
+        remaining = leftover;
+      }
+
+      parts.push(count === 1 ? `1 ${singular}` : `${count} ${plural}`);
+    }
+  }
+
+  return parts.length > 0 ? parts.join(", ") : "session";
+}
+
+export function parseCookieName(raw: string): string {
+  const eqIdx = raw.indexOf("=");
+  if (eqIdx === -1) return raw.trim();
+  return raw.substring(0, eqIdx).trim();
+}
+
+export function parseDuration(raw: string): string {
+  const parts = raw.split(";").map((s) => s.trim());
+
+  for (const part of parts) {
+    const lower = part.toLowerCase();
+    if (lower.startsWith("max-age=")) {
+      const val = parseInt(part.substring(8), 10);
+      if (isNaN(val) || val <= 0) return "session";
+      return humanizeDuration(val);
+    }
+  }
+
+  for (const part of parts) {
+    const lower = part.toLowerCase();
+    if (lower.startsWith("expires=")) {
+      const dateStr = part.substring(8);
+      const expires = new Date(dateStr);
+      if (isNaN(expires.getTime())) return "session";
+      const deltaSeconds = Math.round(
+        (expires.getTime() - Date.now()) / 1000,
+      );
+      if (deltaSeconds <= 0) return "session";
+      return humanizeDuration(deltaSeconds);
+    }
+  }
+
+  return "session";
+}
+
+export function isDeletion(raw: string): boolean {
+  const parts = raw.split(";").map((s) => s.trim().toLowerCase());
+
+  for (const part of parts) {
+    if (part.startsWith("max-age=")) {
+      const val = parseInt(part.substring(8), 10);
+      if (val <= 0) return true;
+    }
+    if (part.startsWith("expires=")) {
+      const dateStr = part.substring(8);
+      const expires = new Date(dateStr);
+      if (!isNaN(expires.getTime()) && expires.getTime() <= Date.now()) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function getCandidateDomains(hostname: string): string[] {
+  const parts = hostname.split(".");
+  if (parts.length <= 1) return [];
+
+  const candidates: string[] = [];
+  // Try progressively broader parent domains. The browser silently
+  // ignores attempts to clear cookies on public suffixes, so
+  // over-trying is safe and avoids maintaining a TLD list.
+  for (let i = 0; i < parts.length - 1; i++) {
+    candidates.push("." + parts.slice(i).join("."));
+  }
+
+  return candidates;
+}
+
+export function removeCookies(names: string[]): void {
+  const domains = getCandidateDomains(location.hostname);
+
+  for (const name of names) {
+    document.cookie = `${name}=; path=/; max-age=0`;
+    for (const domain of domains) {
+      document.cookie = `${name}=; path=/; domain=${domain}; max-age=0`;
+    }
+  }
+}

--- a/packages/cookie-banner/src/cookie.ts
+++ b/packages/cookie-banner/src/cookie.ts
@@ -14,7 +14,7 @@
 
 import type { ConsentAction } from "./client";
 
-const COOKIE_NAME = "probo_consent";
+export const COOKIE_NAME = "probo_consent";
 const SECONDS_PER_DAY = 86400;
 
 export interface ConsentCookie {

--- a/packages/cookie-banner/src/detector.ts
+++ b/packages/cookie-banner/src/detector.ts
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { isDeletion, parseCookieName, parseDuration } from "./cookie-utils";
+import { fetchJSON } from "./http";
+
+interface DetectedCookieEntry {
+  name: string;
+  duration: string;
+}
+
+const DEBOUNCE_MS = 2_000;
+
+export class CookieDetector {
+  private readonly reportUrl: URL;
+  private readonly knownNames: Set<string>;
+  private readonly reported: Set<string> = new Set();
+  private readonly pending: Map<string, DetectedCookieEntry> = new Map();
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private originalDescriptor: PropertyDescriptor | null = null;
+
+  constructor(baseUrl: URL, bannerId: string, knownNames: Set<string>) {
+    this.reportUrl = new URL(`${bannerId}/detected-cookies`, baseUrl);
+    this.knownNames = knownNames;
+  }
+
+  start(): void {
+    const desc =
+      Object.getOwnPropertyDescriptor(Document.prototype, "cookie") ??
+      Object.getOwnPropertyDescriptor(HTMLDocument.prototype, "cookie");
+
+    if (!desc?.set || !desc?.get) return;
+
+    this.originalDescriptor = desc;
+
+    const self = this;
+    const originalGet = desc.get;
+    const originalSet = desc.set;
+
+    Object.defineProperty(document, "cookie", {
+      configurable: true,
+      get() {
+        return originalGet.call(this);
+      },
+      set(value: string) {
+        originalSet.call(this, value);
+        self.onCookieSet(value);
+      },
+    });
+
+    this.scanExisting();
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+
+    if (this.pending.size > 0) {
+      this.flush();
+    }
+
+    if (this.originalDescriptor) {
+      Object.defineProperty(document, "cookie", this.originalDescriptor);
+      this.originalDescriptor = null;
+    }
+  }
+
+  private onCookieSet(raw: string): void {
+    if (isDeletion(raw)) return;
+
+    const name = parseCookieName(raw);
+    if (!name || this.knownNames.has(name) || this.reported.has(name)) return;
+
+    const duration = parseDuration(raw);
+
+    this.reported.add(name);
+    this.pending.set(name, { name, duration });
+    this.scheduleFlush();
+  }
+
+  private scanExisting(): void {
+    const cookieStr = document.cookie;
+    if (!cookieStr) return;
+
+    for (const pair of cookieStr.split(";")) {
+      const name = pair.split("=")[0]?.trim();
+      if (!name || this.knownNames.has(name) || this.reported.has(name)) {
+        continue;
+      }
+      this.reported.add(name);
+      this.pending.set(name, { name, duration: "session" });
+    }
+
+    if (this.pending.size > 0) {
+      this.scheduleFlush();
+    }
+  }
+
+  private scheduleFlush(): void {
+    if (this.timer) return;
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      this.flush();
+    }, DEBOUNCE_MS);
+  }
+
+  private flush(): void {
+    const entries = Array.from(this.pending.values());
+    this.pending.clear();
+    if (entries.length === 0) return;
+
+    void fetchJSON(this.reportUrl, {
+      method: "POST",
+      body: { cookies: entries },
+    }).catch(() => {});
+  }
+}

--- a/packages/cookie-banner/src/queue.ts
+++ b/packages/cookie-banner/src/queue.ts
@@ -12,9 +12,8 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
+import { COOKIE_NAME } from "./cookie";
 import { fetchJSON } from "./http";
-
-const STORAGE_KEY_PREFIX = "probo_consent";
 const MAX_QUEUE_SIZE = 10;
 const MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 
@@ -25,7 +24,7 @@ interface PendingConsent {
 }
 
 function storageKey(bannerId: string): string {
-  return `${STORAGE_KEY_PREFIX}:${bannerId}:queue`;
+  return `${COOKIE_NAME}:${bannerId}:queue`;
 }
 
 function readQueue(bannerId: string): PendingConsent[] {

--- a/packages/cookie-banner/src/visitor.ts
+++ b/packages/cookie-banner/src/visitor.ts
@@ -12,10 +12,10 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-const STORAGE_KEY_PREFIX = "probo_consent";
+import { COOKIE_NAME } from "./cookie";
 
 export function getOrCreateVisitorId(bannerId: string): string {
-  const key = `${STORAGE_KEY_PREFIX}:${bannerId}:vid`;
+  const key = `${COOKIE_NAME}:${bannerId}:vid`;
 
   try {
     const stored = localStorage.getItem(key);

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -127,6 +127,15 @@ type (
 		Action      coredata.CookieConsentAction
 	}
 
+	DetectedCookie struct {
+		Name     string
+		Duration string
+	}
+
+	ReportDetectedCookiesRequest struct {
+		Cookies []DetectedCookie
+	}
+
 	BannerConfig struct {
 		BannerID          gid.GID                                        `json:"banner_id"`
 		Version           int                                            `json:"version"`
@@ -1716,4 +1725,63 @@ func (s *Service) RecordConsent(
 	}
 
 	return record, nil
+}
+
+func (s *Service) ReportDetectedCookies(
+	ctx context.Context,
+	bannerID gid.GID,
+	req ReportDetectedCookiesRequest,
+) error {
+	return s.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			var banner coredata.CookieBanner
+			if err := banner.LoadActiveByID(ctx, tx, bannerID); err != nil {
+				if errors.Is(err, coredata.ErrResourceNotFound) {
+					return ErrBannerNotFound
+				}
+				return fmt.Errorf("cannot load active cookie banner: %w", err)
+			}
+
+			scope := coredata.NewScopeFromObjectID(banner.ID)
+
+			var uncategorised coredata.CookieCategory
+			if err := uncategorised.LoadUncategorisedByCookieBannerID(ctx, tx, scope, banner.ID); err != nil {
+				return fmt.Errorf("cannot load uncategorised category: %w", err)
+			}
+
+			inserted := 0
+			now := time.Now()
+
+			for _, dc := range req.Cookies {
+				cookie := &coredata.Cookie{
+					ID:               gid.New(scope.GetTenantID(), coredata.CookieEntityType),
+					OrganizationID:   banner.OrganizationID,
+					CookieBannerID:   banner.ID,
+					CookieCategoryID: uncategorised.ID,
+					Name:             dc.Name,
+					Duration:         dc.Duration,
+					Description:      "",
+					CreatedAt:        now,
+					UpdatedAt:        now,
+				}
+
+				if err := cookie.Insert(ctx, tx, scope); err != nil {
+					if errors.Is(err, coredata.ErrResourceAlreadyExists) {
+						continue
+					}
+					return fmt.Errorf("cannot insert detected cookie: %w", err)
+				}
+				inserted++
+			}
+
+			if inserted > 0 {
+				if _, err := s.ensureDraftVersionForBanner(ctx, tx, scope, banner.ID); err != nil {
+					return fmt.Errorf("cannot ensure draft version: %w", err)
+				}
+			}
+
+			return nil
+		},
+	)
 }

--- a/pkg/server/api/cookiebanner/v1/handler.go
+++ b/pkg/server/api/cookiebanner/v1/handler.go
@@ -222,10 +222,14 @@ func (h *Handler) handleReportDetectedCookies(w http.ResponseWriter, r *http.Req
 		if name == "" {
 			continue
 		}
-		detected = append(detected, cookiebanner.DetectedCookie{
-			Name:     name,
-			Duration: strings.TrimSpace(c.Duration),
-		})
+
+		detected = append(
+			detected,
+			cookiebanner.DetectedCookie{
+				Name:     name,
+				Duration: strings.TrimSpace(c.Duration),
+			},
+		)
 	}
 
 	if len(detected) == 0 {
@@ -242,6 +246,7 @@ func (h *Handler) handleReportDetectedCookies(w http.ResponseWriter, r *http.Req
 			jsonutil.RenderNotFound(w, fmt.Errorf("banner not found"))
 			return
 		}
+
 		h.logger.ErrorCtx(r.Context(), "cannot report detected cookies", log.Error(err))
 		jsonutil.RenderInternalServerError(w)
 		return

--- a/pkg/server/api/cookiebanner/v1/handler.go
+++ b/pkg/server/api/cookiebanner/v1/handler.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -51,6 +52,7 @@ func NewMux(
 		r.Get("/config", h.handleGetConfig)
 		r.Get("/consents/{visitorID}", h.handleGetConsent)
 		r.Post("/consents", h.handlePostConsent)
+		r.Post("/detected-cookies", h.handleReportDetectedCookies)
 	})
 
 	return r
@@ -178,4 +180,72 @@ func (h *Handler) handlePostConsent(w http.ResponseWriter, r *http.Request) {
 			CreatedAt: record.CreatedAt,
 		},
 	)
+}
+
+type detectedCookieEntry struct {
+	Name     string `json:"name"`
+	Duration string `json:"duration"`
+}
+
+type reportDetectedCookiesBody struct {
+	Cookies []detectedCookieEntry `json:"cookies"`
+}
+
+const maxDetectedCookiesPerRequest = 100
+
+func (h *Handler) handleReportDetectedCookies(w http.ResponseWriter, r *http.Request) {
+	bannerID, err := gid.ParseGID(chi.URLParam(r, "bannerID"))
+	if err != nil {
+		jsonutil.RenderBadRequest(w, fmt.Errorf("invalid banner id"))
+		return
+	}
+
+	var body reportDetectedCookiesBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		jsonutil.RenderBadRequest(w, fmt.Errorf("invalid request body"))
+		return
+	}
+
+	if len(body.Cookies) == 0 {
+		jsonutil.RenderBadRequest(w, fmt.Errorf("cookies list is empty"))
+		return
+	}
+
+	if len(body.Cookies) > maxDetectedCookiesPerRequest {
+		jsonutil.RenderBadRequest(w, fmt.Errorf("too many cookies, maximum is %d", maxDetectedCookiesPerRequest))
+		return
+	}
+
+	detected := make([]cookiebanner.DetectedCookie, 0, len(body.Cookies))
+	for _, c := range body.Cookies {
+		name := strings.TrimSpace(c.Name)
+		if name == "" {
+			continue
+		}
+		detected = append(detected, cookiebanner.DetectedCookie{
+			Name:     name,
+			Duration: strings.TrimSpace(c.Duration),
+		})
+	}
+
+	if len(detected) == 0 {
+		jsonutil.RenderBadRequest(w, fmt.Errorf("no valid cookie names provided"))
+		return
+	}
+
+	req := cookiebanner.ReportDetectedCookiesRequest{
+		Cookies: detected,
+	}
+
+	if err := h.cookieBannerSvc.ReportDetectedCookies(r.Context(), bannerID, req); err != nil {
+		if errors.Is(err, cookiebanner.ErrBannerNotFound) {
+			jsonutil.RenderNotFound(w, fmt.Errorf("banner not found"))
+			return
+		}
+		h.logger.ErrorCtx(r.Context(), "cannot report detected cookies", log.Error(err))
+		jsonutil.RenderInternalServerError(w)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }


### PR DESCRIPTION
Closes ENG-269

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds automatic cookie discovery to the SDK and backend: the client detects unknown cookies and reports them to a new POST `/{bannerID}/detected-cookies` endpoint, which saves them to Uncategorised and opens a draft (ENG-269).

- **New Features**
  - Client (`packages/cookie-banner`): Intercepts `document.cookie` to detect unknown cookies, scans existing, infers duration, debounces batches, and ignores deletions and known names (incl `probo_consent`); starts on init, restarts safely on repeated `load()`, and stops on destroy.
  - Server (`pkg/cookiebanner`, `pkg/server/api/cookiebanner/v1`): Adds POST `/{bannerID}/detected-cookies` (max 100 per request); validates input, dedupes, saves to "Uncategorised", ensures a draft version, and returns 204.

- **Refactors**
  - Extracted `cookie-utils.ts` (parse name, parse duration, deletion check, `removeCookies`) and used by `activation.ts` and the detector.
  - Exported `COOKIE_NAME` and reused it for localStorage keys in `queue.ts` and `visitor.ts`.

<sup>Written for commit b5a87818163c196a9f0f0334cc489304d8eb21e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

