### PR TITLE
Include external ID in SCIM bridge user creation error

### DIFF
--- a/pkg/iam/scim/bridge/bridge.go
+++ b/pkg/iam/scim/bridge/bridge.go
@@ -83,7 +83,7 @@ func (s *Bridge) Run(ctx context.Context) (created, updated, deleted, deactivate
 		existingSCIM, exists := scimUsersByEmail[email]
 		if !exists {
 			if err := s.scimClient.CreateUser(ctx, &pu); err != nil {
-				errs = append(errs, fmt.Errorf("cannot create user %q: %w", pu.UserName, err))
+				errs = append(errs, fmt.Errorf("cannot create user %q %q: %w", pu.ExternalID, pu.UserName, err))
 				continue
 			}
 			created++


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add the user's external ID to the SCIM bridge user-creation error message. This makes failures easier to trace and map to upstream directory records.

<sup>Written for commit dfde600e5c48b3bafe3dbf3afe18aab954ae4127. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

