### PR TITLE
Add Google Workspace connector to bootstrap

### DIFF
--- a/pkg/bootstrap/builder.go
+++ b/pkg/bootstrap/builder.go
@@ -320,6 +320,17 @@ func (b *Builder) Build() (*probod.FullConfig, error) {
 		})
 	}
 
+	if googleWorkspaceClientID := b.getEnv("CONNECTOR_GOOGLE_WORKSPACE_CLIENT_ID"); googleWorkspaceClientID != "" {
+		cfg.Probod.Connectors = append(cfg.Probod.Connectors, probod.ConnectorConfig{
+			Provider: "GOOGLE_WORKSPACE",
+			Protocol: "oauth2",
+			RawConfig: probod.ConnectorConfigOAuth2{
+				ClientID:     googleWorkspaceClientID,
+				ClientSecret: b.getEnv("CONNECTOR_GOOGLE_WORKSPACE_CLIENT_SECRET"),
+			},
+		})
+	}
+
 	return cfg, nil
 }
 
@@ -365,6 +376,7 @@ func (b *Builder) validateRequired() error {
 		{"CONNECTOR_SENTRY", []string{"CLIENT_SECRET"}},
 		{"CONNECTOR_INTERCOM", []string{"CLIENT_SECRET"}},
 		{"CONNECTOR_BREX", []string{"CLIENT_SECRET"}},
+		{"CONNECTOR_GOOGLE_WORKSPACE", []string{"CLIENT_SECRET"}},
 	}
 
 	for _, p := range oauthProviders {

--- a/pkg/bootstrap/builder_test.go
+++ b/pkg/bootstrap/builder_test.go
@@ -85,6 +85,16 @@ func TestBuilder_Build_MissingRequiredEnvVars(t *testing.T) {
 			},
 			wantMissing: []string{"CONNECTOR_SLACK_CLIENT_SECRET", "CONNECTOR_SLACK_SIGNING_SECRET"},
 		},
+		{
+			name: "google workspace connector missing required fields",
+			env: map[string]string{
+				"PROBOD_ENCRYPTION_KEY":                "key",
+				"AUTH_COOKIE_SECRET":                   "secret",
+				"AUTH_PASSWORD_PEPPER":                 "pepper",
+				"CONNECTOR_GOOGLE_WORKSPACE_CLIENT_ID": "client-id",
+			},
+			wantMissing: []string{"CONNECTOR_GOOGLE_WORKSPACE_CLIENT_SECRET"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -368,6 +378,27 @@ func TestBuilder_Build_CustomValues(t *testing.T) {
 	assert.Equal(t, "http://custom.tsa.example.com", cfg.Probod.ESign.TSAURL)
 	// Branding
 	assert.False(t, cfg.Probod.Branding)
+}
+
+func TestBuilder_Build_GoogleWorkspaceConnector(t *testing.T) {
+	env := requiredEnv()
+	env["CONNECTOR_GOOGLE_WORKSPACE_CLIENT_ID"] = "gw-client-id"
+	env["CONNECTOR_GOOGLE_WORKSPACE_CLIENT_SECRET"] = "gw-client-secret"
+
+	b := NewBuilder(mockEnv(env))
+	b.samlCertificate = "test-cert"
+	b.samlPrivateKey = "test-key"
+
+	cfg, err := b.Build()
+	require.NoError(t, err)
+
+	require.Len(t, cfg.Probod.Connectors, 1)
+	connector := cfg.Probod.Connectors[0]
+	assert.Equal(t, "GOOGLE_WORKSPACE", connector.Provider)
+	assert.Equal(t, "oauth2", string(connector.Protocol))
+	rawConfig := connector.RawConfig.(probod.ConnectorConfigOAuth2)
+	assert.Equal(t, "gw-client-id", rawConfig.ClientID)
+	assert.Equal(t, "gw-client-secret", rawConfig.ClientSecret)
 }
 
 func TestBuilder_Build_SlackConnector(t *testing.T) {


### PR DESCRIPTION
## Summary
- Register the Google Workspace OAuth2 connector in probo-bootstrap so it can be configured via `CONNECTOR_GOOGLE_WORKSPACE_CLIENT_ID` and `CONNECTOR_GOOGLE_WORKSPACE_CLIENT_SECRET` environment variables
- Add validation that `CLIENT_SECRET` is required when `CLIENT_ID` is set
- Add tests for connector registration and missing required fields

Closes ENG-307

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Google Workspace OAuth2 connector to `probo-bootstrap`, configurable via CONNECTOR_GOOGLE_WORKSPACE_CLIENT_ID and CONNECTOR_GOOGLE_WORKSPACE_CLIENT_SECRET. Also validates that CLIENT_SECRET is required when CLIENT_ID is set, enabling env-based deployment of the existing Google Workspace SCIM bridge (ENG-307).

<sup>Written for commit a2f750403f60f3e9680b1fb407ae84864b17ece3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

