### PR TITLE
Show SAML configuration ID in SSO settings

### DIFF
--- a/apps/console/src/pages/iam/organizations/settings/_components/SAMLConfigurationList.tsx
+++ b/apps/console/src/pages/iam/organizations/settings/_components/SAMLConfigurationList.tsx
@@ -14,7 +14,6 @@
 
 import { useCopy } from "@probo/hooks";
 import { useTranslate } from "@probo/i18n";
-import { useCallback, useRef, useState } from "react";
 import {
   Button,
   Card,
@@ -26,6 +25,7 @@ import {
   Tr,
   useConfirm,
 } from "@probo/ui";
+import { useCallback, useRef, useState } from "react";
 import { useFragment } from "react-relay";
 import { ConnectionHandler, graphql } from "relay-runtime";
 
@@ -84,7 +84,7 @@ export function SAMLConfigurationList(props: {
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const copiedIdTimer = useRef<ReturnType<typeof setTimeout>>();
   const copyId = useCallback((id: string) => {
-    navigator.clipboard.writeText(id);
+    void navigator.clipboard.writeText(id);
     setCopiedId(id);
     clearTimeout(copiedIdTimer.current);
     copiedIdTimer.current = setTimeout(() => setCopiedId(null), 2000);

--- a/apps/console/src/pages/iam/organizations/settings/_components/SAMLConfigurationList.tsx
+++ b/apps/console/src/pages/iam/organizations/settings/_components/SAMLConfigurationList.tsx
@@ -14,6 +14,7 @@
 
 import { useCopy } from "@probo/hooks";
 import { useTranslate } from "@probo/i18n";
+import { useCallback, useRef, useState } from "react";
 import {
   Button,
   Card,
@@ -80,7 +81,14 @@ export function SAMLConfigurationList(props: {
   const { __ } = useTranslate();
 
   const confirm = useConfirm();
-  const [isIdCopied, copyId] = useCopy();
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const copiedIdTimer = useRef<ReturnType<typeof setTimeout>>();
+  const copyId = useCallback((id: string) => {
+    navigator.clipboard.writeText(id);
+    setCopiedId(id);
+    clearTimeout(copiedIdTimer.current);
+    copiedIdTimer.current = setTimeout(() => setCopiedId(null), 2000);
+  }, []);
   const [isCopied, copy] = useCopy();
 
   const {
@@ -168,7 +176,7 @@ export function SAMLConfigurationList(props: {
                 className="font-mono text-xs text-gray-600 hover:text-gray-900"
                 title={__("Click to copy")}
               >
-                {isIdCopied ? __("Copied!") : config.id}
+                {copiedId === config.id ? __("Copied!") : config.id}
               </button>
             </Td>
             <Td>

--- a/apps/console/src/pages/iam/organizations/settings/_components/SAMLConfigurationList.tsx
+++ b/apps/console/src/pages/iam/organizations/settings/_components/SAMLConfigurationList.tsx
@@ -80,6 +80,7 @@ export function SAMLConfigurationList(props: {
   const { __ } = useTranslate();
 
   const confirm = useConfirm();
+  const [isIdCopied, copyId] = useCopy();
   const [isCopied, copy] = useCopy();
 
   const {
@@ -149,6 +150,7 @@ export function SAMLConfigurationList(props: {
     <Table>
       <Thead>
         <Tr>
+          <Th>{__("Configuration ID")}</Th>
           <Th>{__("Email Domain")}</Th>
           <Th>{__("Domain Status")}</Th>
           <Th>{__("SAML Status")}</Th>
@@ -160,6 +162,15 @@ export function SAMLConfigurationList(props: {
       <Tbody>
         {samlConfigurations.map(({ node: config }) => (
           <Tr key={config.id}>
+            <Td>
+              <button
+                onClick={() => copyId(config.id)}
+                className="font-mono text-xs text-gray-600 hover:text-gray-900"
+                title={__("Click to copy")}
+              >
+                {isIdCopied ? __("Copied!") : config.id}
+              </button>
+            </Td>
             <Td>
               <button
                 onClick={() => onEdit(config.id)}


### PR DESCRIPTION
## Summary
- Adds a "Configuration ID" column to the SAML configuration list table in the SSO settings page
- The ID is displayed in monospace font and can be clicked to copy to clipboard
- Users need this ID to configure the Start URL in their identity provider (e.g. Google Workspace)

Closes #1070

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Displays the SAML Configuration ID in the SSO settings list with click-to-copy and per-row “Copied!” feedback. Helps set the Start URL in your identity provider (e.g., Google Workspace) and includes import-order and floating-promise lint fixes.

<sup>Written for commit c7618fb7e16ba717f565b083ee29260192809bd4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

