### PR TITLE
Surface domain provisioning errors to users

### DIFF
--- a/apps/console/src/pages/organizations/compliance-page/domain/_components/CompliancePageDomainCard.tsx
+++ b/apps/console/src/pages/organizations/compliance-page/domain/_components/CompliancePageDomainCard.tsx
@@ -30,6 +30,7 @@ const fragment = graphql`
   fragment CompliancePageDomainCardFragment on CustomDomain {
     domain
     sslStatus
+    provisioningError
     canDelete: permission(action: "core:custom-domain:delete")
     ...CompliancePageDomainDialogFragment
   }
@@ -52,7 +53,9 @@ export function CompliancePageDomainCard(props: { fKey: CompliancePageDomainCard
               <div className="text-sm text-txt-secondary">
                 {domain.sslStatus === "ACTIVE"
                   ? __("Verified")
-                  : __("Pending verification")}
+                  : domain.provisioningError
+                    ? domain.provisioningError
+                    : __("Pending verification")}
               </div>
             </div>
             <Badge

--- a/apps/console/src/pages/organizations/compliance-page/domain/_components/CompliancePageDomainDialog.tsx
+++ b/apps/console/src/pages/organizations/compliance-page/domain/_components/CompliancePageDomainDialog.tsx
@@ -35,6 +35,7 @@ const fragment = graphql`
   fragment CompliancePageDomainDialogFragment on CustomDomain {
     sslStatus
     domain
+    provisioningError
     dnsRecords {
       type
       name
@@ -115,6 +116,13 @@ export function CompliancePageDomainDialog(props: CompliancePageDomainDialogProp
             )
           : (
               <div>
+                {domain.provisioningError && (
+                  <div className="bg-danger-subtle text-danger rounded-lg p-4 mb-4">
+                    <p className="text-sm font-medium mb-1">{__("Provisioning error")}</p>
+                    <p className="text-sm">{domain.provisioningError}</p>
+                  </div>
+                )}
+
                 <h4 className="font-medium mb-3">{__("DNS Configuration")}</h4>
                 <p className="text-sm text-txt-secondary mb-4">
                   {__(

--- a/pkg/certmanager/provisioner.go
+++ b/pkg/certmanager/provisioner.go
@@ -298,6 +298,7 @@ func (p *Provisioner) resetStaleDomain(
 	fullDomain.HTTPChallengeKeyAuth = nil
 	fullDomain.HTTPChallengeURL = nil
 	fullDomain.HTTPOrderURL = nil
+	fullDomain.ProvisioningError = nil
 	fullDomain.SSLStatus = coredata.CustomDomainSSLStatusPending
 
 	if fullDomain.SSLLastAttemptAt != nil && time.Since(*fullDomain.SSLLastAttemptAt) > 24*time.Hour {
@@ -341,7 +342,13 @@ func (p *Provisioner) provisionDomainCertificate(
 				log.Error(err),
 			)
 
-			return err
+			errMsg := err.Error()
+			domain.ProvisioningError = &errMsg
+			if err := domain.Update(ctx, tx, coredata.NewNoScope()); err != nil {
+				return fmt.Errorf("cannot update domain with provisioning error: %w", err)
+			}
+
+			return nil
 		}
 
 		if err := p.checkCAARecords(domain.Domain); err != nil {
@@ -352,8 +359,16 @@ func (p *Provisioner) provisionDomainCertificate(
 				log.Error(err),
 			)
 
-			return err
+			errMsg := err.Error()
+			domain.ProvisioningError = &errMsg
+			if err := domain.Update(ctx, tx, coredata.NewNoScope()); err != nil {
+				return fmt.Errorf("cannot update domain with provisioning error: %w", err)
+			}
+
+			return nil
 		}
+
+		domain.ProvisioningError = nil
 
 		p.logger.InfoCtx(ctx, "DNS configuration verified, initiating HTTP challenge for domain", log.String("domain", domain.Domain))
 
@@ -406,6 +421,8 @@ func (p *Provisioner) provisionDomainCertificate(
 			log.Error(err),
 		)
 
+		errMsg := err.Error()
+		domain.ProvisioningError = &errMsg
 		domain.SSLRetryCount = domain.SSLRetryCount + 1
 		domain.SSLLastAttemptAt = new(time.Now())
 
@@ -445,6 +462,7 @@ func (p *Provisioner) provisionDomainCertificate(
 		log.Time("expires_at", cert.ExpiresAt),
 	)
 
+	domain.ProvisioningError = nil
 	domain.SSLCertificatePEM = cert.CertPEM
 	if err := domain.EncryptPrivateKey(cert.KeyPEM, p.encryptionKey); err != nil {
 		return fmt.Errorf("cannot encrypt private key: %w", err)

--- a/pkg/certmanager/provisioner.go
+++ b/pkg/certmanager/provisioner.go
@@ -369,6 +369,9 @@ func (p *Provisioner) provisionDomainCertificate(
 		}
 
 		domain.ProvisioningError = nil
+		if err := domain.Update(ctx, tx, coredata.NewNoScope()); err != nil {
+			return fmt.Errorf("cannot clear provisioning error: %w", err)
+		}
 
 		p.logger.InfoCtx(ctx, "DNS configuration verified, initiating HTTP challenge for domain", log.String("domain", domain.Domain))
 

--- a/pkg/coredata/custom_domain.go
+++ b/pkg/coredata/custom_domain.go
@@ -47,6 +47,7 @@ type (
 		SSLExpiresAt           *time.Time            `db:"ssl_expires_at"`
 		SSLRetryCount          int                   `db:"ssl_retry_count"`
 		SSLLastAttemptAt       *time.Time            `db:"ssl_last_attempt_at"`
+		ProvisioningError      *string               `db:"provisioning_error"`
 		CreatedAt              time.Time             `db:"created_at"`
 		UpdatedAt              time.Time             `db:"updated_at"`
 	}
@@ -171,6 +172,7 @@ SELECT
 	ssl_expires_at,
 	ssl_retry_count,
 	ssl_last_attempt_at,
+	provisioning_error,
 	created_at,
 	updated_at
 FROM
@@ -227,6 +229,7 @@ SELECT
 	ssl_expires_at,
 	ssl_retry_count,
 	ssl_last_attempt_at,
+	provisioning_error,
 	created_at,
 	updated_at
 FROM
@@ -283,6 +286,7 @@ SELECT
 	ssl_expires_at,
 	ssl_retry_count,
 	ssl_last_attempt_at,
+	provisioning_error,
 	created_at,
 	updated_at
 FROM
@@ -339,6 +343,7 @@ SELECT
 	ssl_expires_at,
 	ssl_retry_count,
 	ssl_last_attempt_at,
+	provisioning_error,
 	created_at,
 	updated_at
 FROM
@@ -401,6 +406,7 @@ INSERT INTO custom_domains (
 	ssl_expires_at,
 	ssl_retry_count,
 	ssl_last_attempt_at,
+	provisioning_error,
 	created_at,
 	updated_at
 ) VALUES (
@@ -419,6 +425,7 @@ INSERT INTO custom_domains (
 	@ssl_expires_at,
 	@ssl_retry_count,
 	@ssl_last_attempt_at,
+	@provisioning_error,
 	@created_at,
 	@updated_at
 )
@@ -440,6 +447,7 @@ INSERT INTO custom_domains (
 		"ssl_expires_at":            cd.SSLExpiresAt,
 		"ssl_retry_count":           cd.SSLRetryCount,
 		"ssl_last_attempt_at":       cd.SSLLastAttemptAt,
+		"provisioning_error":        cd.ProvisioningError,
 		"created_at":                cd.CreatedAt,
 		"updated_at":                cd.UpdatedAt,
 	}
@@ -485,6 +493,7 @@ SET
 	ssl_expires_at = @ssl_expires_at,
 	ssl_retry_count = @ssl_retry_count,
 	ssl_last_attempt_at = @ssl_last_attempt_at,
+	provisioning_error = @provisioning_error,
 	updated_at = @updated_at
 WHERE
 	%s
@@ -506,6 +515,7 @@ WHERE
 		"ssl_expires_at":            cd.SSLExpiresAt,
 		"ssl_retry_count":           cd.SSLRetryCount,
 		"ssl_last_attempt_at":       cd.SSLLastAttemptAt,
+		"provisioning_error":        cd.ProvisioningError,
 		"updated_at":                time.Now(),
 	}
 	maps.Copy(args, scope.SQLArguments())
@@ -567,6 +577,7 @@ SELECT
 	ssl_expires_at,
 	ssl_retry_count,
 	ssl_last_attempt_at,
+	provisioning_error,
 	created_at,
 	updated_at
 FROM
@@ -618,6 +629,7 @@ SELECT
 	ssl_expires_at,
 	ssl_retry_count,
 	ssl_last_attempt_at,
+	provisioning_error,
 	created_at,
 	updated_at
 FROM
@@ -670,6 +682,7 @@ SELECT
 	ssl_expires_at,
 	ssl_retry_count,
 	ssl_last_attempt_at,
+	provisioning_error,
 	created_at,
 	updated_at
 FROM
@@ -725,6 +738,7 @@ SELECT
 	ssl_expires_at,
 	ssl_retry_count,
 	ssl_last_attempt_at,
+	provisioning_error,
 	created_at,
 	updated_at
 FROM
@@ -775,6 +789,7 @@ SELECT
 	ssl_expires_at,
 	ssl_retry_count,
 	ssl_last_attempt_at,
+	provisioning_error,
 	created_at,
 	updated_at
 FROM

--- a/pkg/coredata/migrations/20260423T074540Z.sql
+++ b/pkg/coredata/migrations/20260423T074540Z.sql
@@ -1,0 +1,15 @@
+-- Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+--
+-- Permission to use, copy, modify, and/or distribute this software for any
+-- purpose with or without fee is hereby granted, provided that the above
+-- copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+-- REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+-- INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+-- LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+-- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+ALTER TABLE custom_domains ADD COLUMN provisioning_error TEXT;

--- a/pkg/server/api/console/v1/graphql/trust_center.graphql
+++ b/pkg/server/api/console/v1/graphql/trust_center.graphql
@@ -471,6 +471,7 @@ type CustomDomain implements Node {
     domain: String!
     sslStatus: SSLStatus!
     sslExpiresAt: Datetime
+    provisioningError: String
     dnsRecords: [DNSRecordInstruction!]!
     createdAt: Datetime!
     updatedAt: Datetime!

--- a/pkg/server/api/console/v1/types/custom_domain.go
+++ b/pkg/server/api/console/v1/types/custom_domain.go
@@ -24,11 +24,12 @@ func NewCustomDomain(d *coredata.CustomDomain, cnameTarget string) *CustomDomain
 		Organization: &Organization{
 			ID: d.OrganizationID,
 		},
-		Domain:       d.Domain,
-		SslStatus:    d.SSLStatus,
-		CreatedAt:    d.CreatedAt,
-		UpdatedAt:    d.UpdatedAt,
-		SslExpiresAt: d.SSLExpiresAt,
+		Domain:            d.Domain,
+		SslStatus:         d.SSLStatus,
+		CreatedAt:         d.CreatedAt,
+		UpdatedAt:         d.UpdatedAt,
+		SslExpiresAt:      d.SSLExpiresAt,
+		ProvisioningError: d.ProvisioningError,
 	}
 
 	// Convert DNS records


### PR DESCRIPTION
## Summary

- Add a `provisioning_error` column to `custom_domains` to persist certificate provisioning failures (DNS verification, CAA checks, HTTP challenge completion)
- Expose the field via GraphQL and display it in the console domain card and detail dialog
- DNS/CAA failures now save the error and return nil instead of propagating, so the provisioner continues processing other domains and retries on the next cycle
- Error is cleared automatically on successful DNS verification or certificate issuance

## Test plan

- [ ] Verify migration applies cleanly
- [ ] Configure a domain with incorrect DNS and confirm the error message appears in the card and dialog
- [ ] Fix the DNS configuration and confirm the error clears after the next provisioning cycle
- [ ] Confirm domains with valid configuration still provision successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show domain provisioning errors in the console so users can diagnose DNS/CAA/HTTP challenge issues. Errors are stored on `custom_domains.provisioning_error`, exposed via GraphQL, and cleared automatically on successful verification or issuance.

- **New Features**
  - Added `provisioning_error` column on `custom_domains`.
  - Exposed `CustomDomain.provisioningError` in GraphQL and rendered it in the compliance page domain card and dialog.
  - Provisioner now saves DNS/CAA/HTTP challenge failures, continues processing and retries; errors clear on success and stale resets, and the clear persists immediately after DNS/CAA pass to avoid stale messages.

- **Migration**
  - Apply `20260423T074540Z.sql` to add the `provisioning_error` column.
  - No manual steps required.

<sup>Written for commit bb31676697cf761c687423bfeb93767599888895. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

