### PR TITLE
Update trivy-action to 0.36.0 and print findings in CI logs

### DIFF
--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -153,21 +153,15 @@ jobs:
           key: "trivy-db-${{ matrix.arch }}-${{ github.run_id }}"
           restore-keys: "trivy-db-${{ matrix.arch }}-"
       - name: "Scan Docker image with Trivy"
-        uses: "aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1" # 0.35.0
+        uses: "aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25" # 0.36.0
         with:
           image-ref: "ghcr.io/getprobo/probo:snapshot-${{ matrix.arch }}"
-          format: "sarif"
-          output: "trivy-results.sarif"
-          exit-code: 0
+          format: "table"
+          exit-code: 1
           ignore-unfixed: true
           vuln-type: "os,library"
           severity: "CRITICAL,HIGH"
           cache-dir: ~/.cache/trivy
-      - name: "Upload Trivy scan results"
-        uses: "github/codeql-action/upload-sarif@6bc82e05fd0ea64601dd4b465378bbcf57de0314" # v4.32.1
-        with:
-          sarif_file: "trivy-results.sarif"
-          category: "trivy-${{ matrix.arch }}"
 
   # ── Snapshot: SBOM & vulnerability scan ────────────────────────────
   snapshot-scan:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -315,7 +315,7 @@ jobs:
           path: "archives"
           merge-multiple: true
       - name: "Scan Docker image with Trivy"
-        uses: "aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1" # 0.35.0
+        uses: "aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25" # 0.36.0
         with:
           image-ref: "ghcr.io/getprobo/probo:${{ github.ref_name }}"
           format: "sarif"
@@ -324,6 +324,10 @@ jobs:
           ignore-unfixed: true
           vuln-type: "os,library"
           severity: "CRITICAL,HIGH"
+      - name: "Print Trivy findings"
+        if: always()
+        run: |
+          jq -r '.runs[] | (.results // [])[] | .message.text' trivy-results.sarif
       - name: "Upload Trivy scan results"
         uses: "github/codeql-action/upload-sarif@6bc82e05fd0ea64601dd4b465378bbcf57de0314" # v4.32.1
         if: always()


### PR DESCRIPTION
Bump aquasecurity/trivy-action from 0.35.0 to 0.36.0 (Trivy 0.70.0) and add a step to print CVE findings from the SARIF output so they are visible directly in CI logs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `aquasecurity/trivy-action` to 0.36.0 (Trivy 0.70.0). Print CVE messages in release logs and make the make workflow fail on critical/high findings with table output.

- **Dependencies**
  - Bump `aquasecurity/trivy-action` from 0.35.0 to 0.36.0 in `.github/workflows/make.yaml` and `.github/workflows/release.yaml`.

- **Refactors**
  - In `make.yaml`, use `format: table`, set `exit-code: 1`, and remove the SARIF upload step; set `cache-dir` to `~/.cache/trivy`.
  - In `release.yaml`, add a "Print Trivy findings" step using `jq` (runs with `if: always()`).

<sup>Written for commit b9cf93a306739cf0d1b2a59b27ab00e6f86ccc43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

