### PR TITLE
Add Global Privacy Control (GPC) support to cookie banner SDK

### DIFF
--- a/packages/cookie-banner/src/client.ts
+++ b/packages/cookie-banner/src/client.ts
@@ -119,6 +119,7 @@ export class CookieBannerClient {
         consent_data: cookie.data,
         created_at: "",
       };
+      this._gpcApplied = cookie.action === "GPC";
       this.activate(cookie.data);
       void flush(this.bannerId);
       return;
@@ -139,6 +140,7 @@ export class CookieBannerClient {
 
     if (apiConsent && apiConsent.version === config.version) {
       this.consent = apiConsent;
+      this._gpcApplied = apiConsent.action === "GPC";
       setConsentCookie(
         {
           v: apiConsent.version,
@@ -154,7 +156,6 @@ export class CookieBannerClient {
     }
 
     if (!this.consent && this.gpcDetected) {
-      console.log("GPC")
       this.gpc();
       this._gpcApplied = true;
     }

--- a/packages/cookie-banner/src/client.ts
+++ b/packages/cookie-banner/src/client.ts
@@ -154,6 +154,7 @@ export class CookieBannerClient {
     }
 
     if (!this.consent && this.gpcDetected) {
+      console.log("GPC")
       this.gpc();
       this._gpcApplied = true;
     }
@@ -233,6 +234,10 @@ export class CookieBannerClient {
     action: ConsentAction,
     consentData: Record<string, boolean>,
   ): void {
+    if (action !== "GPC") {
+      this._gpcApplied = false;
+    }
+
     const cfg = this.config;
 
     this.consent = {

--- a/packages/cookie-banner/src/client.ts
+++ b/packages/cookie-banner/src/client.ts
@@ -235,9 +235,7 @@ export class CookieBannerClient {
     action: ConsentAction,
     consentData: Record<string, boolean>,
   ): void {
-    if (action !== "GPC") {
-      this._gpcApplied = false;
-    }
+    this._gpcApplied = action === "GPC";
 
     const cfg = this.config;
 

--- a/packages/cookie-banner/src/client.ts
+++ b/packages/cookie-banner/src/client.ts
@@ -87,6 +87,7 @@ export class CookieBannerClient {
   private consent: VisitorConsent | null = null;
   private observer: MutationObserver | null = null;
   private detector: CookieDetector | null = null;
+  private _gpcApplied = false;
 
   constructor(config: CookieBannerClientOptions) {
     let base = config.baseUrl;
@@ -152,6 +153,11 @@ export class CookieBannerClient {
       this.consent = null;
     }
 
+    if (!this.consent && this.gpcDetected) {
+      this.gpc();
+      this._gpcApplied = true;
+    }
+
     void flush(this.bannerId);
   }
 
@@ -168,6 +174,26 @@ export class CookieBannerClient {
 
   get hasConsent(): boolean {
     return this.consent !== null;
+  }
+
+  get gpcDetected(): boolean {
+    return typeof navigator !== "undefined" &&
+      (navigator as Navigator & { globalPrivacyControl?: boolean }).globalPrivacyControl === true;
+  }
+
+  get gpcApplied(): boolean {
+    return this._gpcApplied;
+  }
+
+  gpc(): void {
+    const cfg = this.config;
+
+    const consentData: Record<string, boolean> = {};
+    for (const cat of cfg.categories) {
+      consentData[cat.slug] = cat.kind === "NECESSARY";
+    }
+
+    this.recordConsent("GPC", consentData);
   }
 
   acceptAll(): void {

--- a/packages/cookie-banner/src/components/base.ts
+++ b/packages/cookie-banner/src/components/base.ts
@@ -66,6 +66,7 @@ export interface ProboRootElement extends ProboElement {
   readonly state: ProboState;
   readonly reopenWidget: string;
   readonly consentDraft: ConsentDraft;
+  readonly gpcApplied: boolean;
   setState(state: ProboState): void;
   updateDraft(category: string, value: boolean): void;
 }

--- a/packages/cookie-banner/src/components/cookie-banner-root.ts
+++ b/packages/cookie-banner/src/components/cookie-banner-root.ts
@@ -53,6 +53,10 @@ export class ProboCookieBannerRoot extends ProboElement implements ProboRootElem
     return this._draft;
   }
 
+  get gpcApplied(): boolean {
+    return this._client?.gpcApplied ?? false;
+  }
+
   attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null): void {
     if (name === "reopen-widget" && oldValue !== newValue) {
       this.dispatchEvent(
@@ -150,7 +154,7 @@ export class ProboCookieBannerRoot extends ProboElement implements ProboRootElem
       new CustomEvent("probo-ready", {
         bubbles: true,
         composed: true,
-        detail: { config: this._config },
+        detail: { config: this._config, gpcApplied: this.gpcApplied },
       }),
     );
 

--- a/packages/cookie-banner/src/components/settings-button.ts
+++ b/packages/cookie-banner/src/components/settings-button.ts
@@ -26,7 +26,7 @@ export class ProboSettingsButton extends HTMLElement {
   }
 
   static get observedAttributes(): string[] {
-    return ["position", "aria-settings-label"];
+    return ["position", "aria-settings-label", "gpc-label"];
   }
 
   attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null): void {
@@ -35,6 +35,9 @@ export class ProboSettingsButton extends HTMLElement {
       if (btn && newValue) {
         btn.setAttribute("aria-label", newValue);
       }
+    }
+    if (name === "gpc-label") {
+      this.updateGpcBadge(newValue);
     }
   }
 
@@ -73,10 +76,19 @@ export class ProboSettingsButton extends HTMLElement {
         }
         button:hover { opacity: 0.85; }
         .icon { display: flex; flex-shrink: 0; }
+        .gpc-badge {
+          display: none;
+          font-size: 11px;
+          line-height: 1;
+          font-weight: 600;
+          white-space: nowrap;
+        }
+        :host([gpc-label]) .gpc-badge { display: inline; }
         ::slotted(*) { display: contents; }
       </style>
       <button part="button" aria-label="Cookie settings">
         <span class="icon" part="icon" aria-hidden="true">${COOKIE_ICON}</span>
+        <span class="gpc-badge" part="gpc-badge"></span>
         <slot></slot>
       </button>
     `;
@@ -141,4 +153,11 @@ export class ProboSettingsButton extends HTMLElement {
     if (!this.root) return;
     this.root.setState("panel");
   };
+
+  private updateGpcBadge(label: string | null): void {
+    const badge = this.shadow.querySelector(".gpc-badge");
+    if (badge) {
+      badge.textContent = label ?? "";
+    }
+  }
 }

--- a/packages/cookie-banner/src/components/settings-button.ts
+++ b/packages/cookie-banner/src/components/settings-button.ts
@@ -97,7 +97,7 @@ export class ProboSettingsButton extends HTMLElement {
     this.root = this.findRoot();
 
     if (this.root) {
-      if (this.root.reopenWidget === "custom") {
+      if (this.root.reopenWidget === "custom" && !this.root.gpcApplied) {
         return;
       }
 
@@ -142,7 +142,7 @@ export class ProboSettingsButton extends HTMLElement {
 
   private onReopenWidgetChange = (e: Event): void => {
     const { value } = (e as CustomEvent).detail;
-    if (value === "custom") {
+    if (value === "custom" && !this.root?.gpcApplied) {
       this.hidden = true;
       this.root?.removeEventListener("probo-state", this.onStateChange);
       this.root?.removeEventListener("probo-reopen-widget", this.onReopenWidgetChange);

--- a/packages/cookie-banner/src/i18n.ts
+++ b/packages/cookie-banner/src/i18n.ts
@@ -52,3 +52,14 @@ const COOKIE_DETAIL_LABELS: Record<string, Record<string, string>> = {
 export function getCookieDetailLabels(lang: string): Record<string, string> {
   return COOKIE_DETAIL_LABELS[lang] ?? COOKIE_DETAIL_LABELS.en;
 }
+
+const GPC_LABELS: Record<string, string> = {
+  en: "Opt-Out Preference Signal Honored",
+  fr: "Signal de préférence de désinscription respecté",
+  de: "Opt-Out-Präferenzsignal beachtet",
+  es: "Señal de exclusión respetada",
+};
+
+export function getGpcLabel(lang: string): string {
+  return GPC_LABELS[lang] ?? GPC_LABELS.en;
+}

--- a/packages/cookie-banner/src/themed-banner/themed-banner.ts
+++ b/packages/cookie-banner/src/themed-banner/themed-banner.ts
@@ -141,6 +141,14 @@ export class ProboThemedBanner extends HTMLElement {
       }
     });
 
+    root.addEventListener("probo-consent", (e: Event) => {
+      const { action } = (e as CustomEvent).detail;
+      if (action !== "GPC") {
+        const settingsBtn = this.shadow.querySelector("probo-settings-button");
+        settingsBtn?.removeAttribute("gpc-label");
+      }
+    });
+
     this.shadow.querySelector("[data-action=back]")?.addEventListener("click", () => {
       root.setState(root.client.hasConsent ? "hidden" : "banner");
     });

--- a/packages/cookie-banner/src/themed-banner/themed-banner.ts
+++ b/packages/cookie-banner/src/themed-banner/themed-banner.ts
@@ -15,7 +15,7 @@
 import { registerComponents } from "../components";
 import type { ProboCookieBannerRoot } from "../components/cookie-banner-root";
 import type { BannerConfig } from "../client";
-import { interpolate } from "../i18n";
+import { getGpcLabel, interpolate } from "../i18n";
 import { BRANDING, CHEVRON_DOWN, CLOSE_ICON } from "../html";
 import { THEMED_STYLES } from "./styles";
 
@@ -127,12 +127,17 @@ export class ProboThemedBanner extends HTMLElement {
     const root = this.shadow.querySelector("probo-cookie-banner-root") as ProboCookieBannerRoot;
 
     root.addEventListener("probo-ready", (e: Event) => {
-      const config = (e as CustomEvent).detail.config as BannerConfig;
+      const detail = (e as CustomEvent).detail;
+      const config = detail.config as BannerConfig;
       this.applyTexts(config);
       if (!config.show_branding) {
         this.shadow.querySelectorAll("[data-branding]").forEach(el => {
           (el as HTMLElement).setAttribute("hidden", "");
         });
+      }
+      if (detail.gpcApplied) {
+        const settingsBtn = this.shadow.querySelector("probo-settings-button");
+        settingsBtn?.setAttribute("gpc-label", getGpcLabel(config.language));
       }
     });
 


### PR DESCRIPTION
Closes ENG-286

When navigator.globalPrivacyControl is true and no prior consent exists, auto-reject all non-necessary cookies with action "GPC", skip showing the banner, and display an "Opt-Out Preference Signal Honored" badge on the settings button (CPRA compliance). GPC labels are hardcoded in the SDK for en/fr/de/es. Users can still override via the preference panel.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Global Privacy Control (GPC) support to the `cookie-banner` SDK for CPRA compliance. If GPC is present and no prior consent exists, we allow only necessary cookies, skip the banner, and show a localized “Opt‑Out Preference Signal Honored” badge that clears after an explicit choice. Implements Linear ENG-286.

- **New Features**
  - Detect `navigator.globalPrivacyControl`; when true and no prior consent, record consent with action "GPC" allowing only necessary cookies and skip the banner.
  - Persist and surface `gpcApplied`: set from the consent cookie/API response, expose on the root element, and include in the `probo-ready` event detail.
  - Themed banner sets a localized badge on the settings button (`en`, `fr`, `de`, `es`) via `getGpcLabel` using a new `gpc-label` attribute and styles; the button stays visible with `reopenWidget="custom"` when GPC is applied, and the badge is removed when the user overrides consent.

<sup>Written for commit c364c3eacba30fbf05198f8ce9f0a33dd72753fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

