### PR TITLE
Mcp users active

### DIFF
--- a/apps/console/src/components/form/PeopleMultiSelectField.tsx
+++ b/apps/console/src/components/form/PeopleMultiSelectField.tsx
@@ -65,7 +65,7 @@ function PeopleMultiSelectWithQuery<T extends FieldValues = FieldValues>(
 ) {
   const { __ } = useTranslate();
   const { name, organizationId, control, selectedPeople = [], placeholder } = props;
-  const people = usePeople(organizationId, { excludeContractEnded: true });
+  const people = usePeople(organizationId, { contractEnded: false });
   const [isOpen, setIsOpen] = useState(false);
 
   const allPeople = [...people];

--- a/apps/console/src/components/form/PeopleSelectField.tsx
+++ b/apps/console/src/components/form/PeopleSelectField.tsx
@@ -61,7 +61,7 @@ function PeopleSelectWithQuery<TFieldValues extends FieldValues = FieldValues>(
 ) {
   const { __ } = useTranslate();
   const { name, organizationId, control } = props;
-  const people = usePeople(organizationId, { excludeContractEnded: true });
+  const people = usePeople(organizationId, { contractEnded: false });
 
   return (
     <Controller

--- a/apps/console/src/components/table/PeopleCell.tsx
+++ b/apps/console/src/components/table/PeopleCell.tsx
@@ -31,7 +31,7 @@ export function PeopleCell(props: Props) {
       query={peopleQuery}
       variables={{
         organizationId: props.organizationId,
-        filter: { excludeContractEnded: true },
+        filter: { contractEnded: false },
       }}
       items={data =>
         data.organization?.profiles?.edges.map(edge => edge.node) ?? []}

--- a/apps/console/src/hooks/graph/PeopleGraph.ts
+++ b/apps/console/src/hooks/graph/PeopleGraph.ts
@@ -49,13 +49,13 @@ export const peopleQuery = graphql`
  */
 export function usePeople(
   organizationId: string,
-  { excludeContractEnded }: { excludeContractEnded?: boolean } = {},
+  { contractEnded }: { contractEnded?: boolean } = {},
 ) {
   const data = useLazyLoadQuery<PeopleGraphQuery>(
     peopleQuery,
     {
       organizationId: organizationId,
-      filter: excludeContractEnded ? { excludeContractEnded: true } : null,
+      filter: contractEnded !== undefined ? { contractEnded } : null,
     },
     { fetchPolicy: "network-only" },
   );

--- a/apps/console/src/pages/organizations/documents/_components/SignatureDocumentsDialog.tsx
+++ b/apps/console/src/pages/organizations/documents/_components/SignatureDocumentsDialog.tsx
@@ -196,7 +196,7 @@ function PeopleList({
     signatureDocumentsDialogPeopleQuery,
     {
       organizationId,
-      filter: { excludeContractEnded: true },
+      filter: { contractEnded: false },
     },
   );
   const {

--- a/apps/console/src/pages/organizations/documents/signatures/DocumentSignaturesPage.tsx
+++ b/apps/console/src/pages/organizations/documents/signatures/DocumentSignaturesPage.tsx
@@ -27,7 +27,7 @@ export const documentSignaturesPageQuery = graphql`
   query DocumentSignaturesPageQuery($documentId: ID! $organizationId: ID! $versionId: ID! $versionSpecified: Boolean!) {
     organization: node(id: $organizationId) {
       __typename
-      ...DocumentSignatureList_peopleFragment @arguments(filter: { excludeContractEnded: true })
+      ...DocumentSignatureList_peopleFragment @arguments(filter: { contractEnded: false })
     }
     # We use this on /documents/:documentId
     document: node(id: $documentId) @skip(if: $versionSpecified) {

--- a/apps/console/src/pages/organizations/findings/FindingsPage.tsx
+++ b/apps/console/src/pages/organizations/findings/FindingsPage.tsx
@@ -550,7 +550,7 @@ function OwnerFilterSelect({
   onChange,
 }: OwnerFilterSelectProps) {
   const { __ } = useTranslate();
-  const people = usePeople(organizationId, { excludeContractEnded: true });
+  const people = usePeople(organizationId, { contractEnded: false });
 
   return (
     <Select value={value ?? "ALL"} onValueChange={onChange}>

--- a/pkg/cmd/user/list/list.go
+++ b/pkg/cmd/user/list/list.go
@@ -61,13 +61,13 @@ type profile struct {
 
 func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 	var (
-		flagOrg            string
-		flagLimit          int
-		flagOrder          string
-		flagOrderDir       string
-		flagContractEnded  string
-		flagState          string
-		flagOutput         *string
+		flagOrg           string
+		flagLimit         int
+		flagOrder         string
+		flagOrderDir      string
+		flagContractEnded string
+		flagState         string
+		flagOutput        *string
 	)
 
 	cmd := &cobra.Command{

--- a/pkg/cmd/user/list/list.go
+++ b/pkg/cmd/user/list/list.go
@@ -61,12 +61,13 @@ type profile struct {
 
 func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 	var (
-		flagOrg      string
-		flagLimit    int
-		flagOrder    string
-		flagOrderDir string
-		flagActive   bool
-		flagOutput   *string
+		flagOrg            string
+		flagLimit          int
+		flagOrder          string
+		flagOrderDir       string
+		flagContractEnded  string
+		flagState          string
+		flagOutput         *string
 	)
 
 	cmd := &cobra.Command{
@@ -76,8 +77,11 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 		Example: `  # List users in the default organization
   prb user list
 
-  # List only active users as JSON
-  prb user ls --active --json`,
+  # List only active users
+  prb user ls --state ACTIVE
+
+  # List users whose contract has ended
+  prb user ls --contract-ended true`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := cmdutil.ValidateOutputFlag(flagOutput); err != nil {
@@ -124,10 +128,24 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 				}
 			}
 
-			if flagActive {
-				variables["filter"] = map[string]any{
-					"contractEnded": false,
+			filter := map[string]any{}
+
+			if flagContractEnded != "" {
+				if err := cmdutil.ValidateEnum("contract-ended", flagContractEnded, []string{"true", "false"}); err != nil {
+					return err
 				}
+				filter["contractEnded"] = flagContractEnded == "true"
+			}
+
+			if flagState != "" {
+				if err := cmdutil.ValidateEnum("state", flagState, []string{"ACTIVE", "INACTIVE"}); err != nil {
+					return err
+				}
+				filter["state"] = flagState
+			}
+
+			if len(filter) > 0 {
+				variables["filter"] = filter
 			}
 
 			profiles, totalCount, err := api.Paginate(
@@ -210,7 +228,8 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().IntVarP(&flagLimit, "limit", "L", 30, "Maximum number of users to list")
 	cmd.Flags().StringVar(&flagOrder, "order-by", "", "Order by field (FULL_NAME, CREATED_AT, KIND)")
 	cmd.Flags().StringVar(&flagOrderDir, "order-direction", "DESC", "Sort direction (ASC, DESC)")
-	cmd.Flags().BoolVar(&flagActive, "active", false, "Show only users with active or no contract")
+	cmd.Flags().StringVar(&flagContractEnded, "contract-ended", "", "Filter by contract status (true or false)")
+	cmd.Flags().StringVar(&flagState, "state", "", "Filter by profile state (ACTIVE or INACTIVE)")
 	flagOutput = cmdutil.AddOutputFlag(cmd)
 
 	return cmd

--- a/pkg/cmd/user/list/list.go
+++ b/pkg/cmd/user/list/list.go
@@ -126,7 +126,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 
 			if flagActive {
 				variables["filter"] = map[string]any{
-					"excludeContractEnded": true,
+					"contractEnded": false,
 				}
 			}
 
@@ -210,7 +210,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().IntVarP(&flagLimit, "limit", "L", 30, "Maximum number of users to list")
 	cmd.Flags().StringVar(&flagOrder, "order-by", "", "Order by field (FULL_NAME, CREATED_AT, KIND)")
 	cmd.Flags().StringVar(&flagOrderDir, "order-direction", "DESC", "Sort direction (ASC, DESC)")
-	cmd.Flags().BoolVar(&flagActive, "active", false, "Exclude users whose contract has ended")
+	cmd.Flags().BoolVar(&flagActive, "active", false, "Show only users with active or no contract")
 	flagOutput = cmdutil.AddOutputFlag(cmd)
 
 	return cmd

--- a/pkg/coredata/membership_profile_filter.go
+++ b/pkg/coredata/membership_profile_filter.go
@@ -25,7 +25,7 @@ type (
 	MembershipProfileFilter struct {
 		withMembership        *bool
 		withTrustCenterAccess *bool
-		excludeContractEnded  *bool
+		contractEnded         *bool
 		currentDate           time.Time
 		email                 *mail.Addr
 		userName              *string
@@ -35,10 +35,10 @@ type (
 	}
 )
 
-func NewMembershipProfileFilter(excludeContractEnded *bool) *MembershipProfileFilter {
+func NewMembershipProfileFilter(contractEnded *bool) *MembershipProfileFilter {
 	return &MembershipProfileFilter{
-		excludeContractEnded: excludeContractEnded,
-		currentDate:          time.Now(),
+		contractEnded: contractEnded,
+		currentDate:   time.Now(),
 	}
 }
 
@@ -96,7 +96,7 @@ func (f *MembershipProfileFilter) SQLArguments() pgx.StrictNamedArgs {
 		"filter_external_id":       f.externalID,
 		"with_membership":          f.withMembership,
 		"with_trust_center_access": f.withTrustCenterAccess,
-		"exclude_contract_ended":   f.excludeContractEnded,
+		"contract_ended":           f.contractEnded,
 		"current_date":             f.currentDate,
 		"filter_state":             f.state,
 		"filter_source":            f.source,
@@ -132,7 +132,9 @@ AND (
 )
 AND (
     CASE
-        WHEN @exclude_contract_ended::boolean IS NOT NULL AND @exclude_contract_ended::boolean = true THEN
+        WHEN @contract_ended::boolean IS NOT NULL AND @contract_ended::boolean = true THEN
+            (p.contract_end_date IS NOT NULL AND p.contract_end_date < @current_date::date)
+        WHEN @contract_ended::boolean IS NOT NULL AND @contract_ended::boolean = false THEN
             (p.contract_end_date IS NULL OR p.contract_end_date >= @current_date::date)
         ELSE TRUE
     END

--- a/pkg/server/api/connect/v1/graphql/profile.graphql
+++ b/pkg/server/api/connect/v1/graphql/profile.graphql
@@ -65,7 +65,7 @@ enum ProfileOrderField
 }
 
 input ProfileFilter {
-  excludeContractEnded: Boolean
+  contractEnded: Boolean
   state: ProfileState
 }
 

--- a/pkg/server/api/connect/v1/identity_resolvers.go
+++ b/pkg/server/api/connect/v1/identity_resolvers.go
@@ -30,7 +30,7 @@ func (r *identityResolver) Profiles(ctx context.Context, obj *types.Identity, fi
 
 	filters := coredata.NewMembershipProfileFilter(nil).WithMembership()
 	if filter != nil {
-		filters = coredata.NewMembershipProfileFilter(filter.ExcludeContractEnded).WithMembership()
+		filters = coredata.NewMembershipProfileFilter(filter.ContractEnded).WithMembership()
 		if filter.State != nil {
 			filters.WithState(*filter.State)
 		}

--- a/pkg/server/api/console/v1/graphql/organization.graphql
+++ b/pkg/server/api/console/v1/graphql/organization.graphql
@@ -52,7 +52,7 @@ input ProfileOrder
 }
 
 input ProfileFilter {
-    excludeContractEnded: Boolean
+    contractEnded: Boolean
 }
 
 type ProfileConnection

--- a/pkg/server/api/console/v1/graphql/organization.graphql
+++ b/pkg/server/api/console/v1/graphql/organization.graphql
@@ -53,6 +53,7 @@ input ProfileOrder
 
 input ProfileFilter {
     contractEnded: Boolean
+    state: ProfileState
 }
 
 type ProfileConnection

--- a/pkg/server/api/console/v1/organization_resolvers.go
+++ b/pkg/server/api/console/v1/organization_resolvers.go
@@ -123,7 +123,7 @@ func (r *organizationResolver) Profiles(ctx context.Context, obj *types.Organiza
 
 	filters := coredata.NewMembershipProfileFilter(nil).WithMembership()
 	if filter != nil {
-		filters = coredata.NewMembershipProfileFilter(filter.ExcludeContractEnded).WithMembership()
+		filters = coredata.NewMembershipProfileFilter(filter.ContractEnded).WithMembership()
 	}
 
 	pageOrderBy := page.OrderBy[coredata.MembershipProfileOrderField]{

--- a/pkg/server/api/console/v1/organization_resolvers.go
+++ b/pkg/server/api/console/v1/organization_resolvers.go
@@ -124,6 +124,9 @@ func (r *organizationResolver) Profiles(ctx context.Context, obj *types.Organiza
 	filters := coredata.NewMembershipProfileFilter(nil).WithMembership()
 	if filter != nil {
 		filters = coredata.NewMembershipProfileFilter(filter.ContractEnded).WithMembership()
+		if filter.State != nil {
+			filters.WithState(*filter.State)
+		}
 	}
 
 	pageOrderBy := page.OrderBy[coredata.MembershipProfileOrderField]{

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -2491,7 +2491,10 @@ func (r *Resolver) ListUsersTool(ctx context.Context, req *mcp.CallToolRequest, 
 
 	filter := coredata.NewMembershipProfileFilter(nil).WithMembership()
 	if input.Filter != nil {
-		filter = coredata.NewMembershipProfileFilter(input.Filter.ExcludeContractEnded).WithMembership()
+		filter = coredata.NewMembershipProfileFilter(input.Filter.ContractEnded).WithMembership()
+		if input.Filter.State != nil {
+			filter.WithState(*input.Filter.State)
+		}
 	}
 
 	pageResult, err := r.iamSvc.OrganizationService.ListProfiles(ctx, input.OrganizationID, cursor, filter)

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -180,6 +180,13 @@ components:
         - AUDITOR
       go.probo.inc/mcpgen/type: go.probo.inc/probo/pkg/coredata.MembershipRole
 
+    ProfileState:
+      type: string
+      enum:
+        - ACTIVE
+        - INACTIVE
+      go.probo.inc/mcpgen/type: go.probo.inc/probo/pkg/coredata.ProfileState
+
     Profile:
       type: object
       required:
@@ -189,6 +196,7 @@ components:
         - email_address
         - additional_email_addresses
         - kind
+        - state
         - created_at
         - updated_at
       properties:
@@ -214,6 +222,9 @@ components:
             - string
             - "null"
           description: Profile kind
+        state:
+          $ref: "#/components/schemas/ProfileState"
+          description: Profile state (ACTIVE or INACTIVE)
         position:
           type:
             - string
@@ -260,9 +271,12 @@ components:
         filter:
           type: object
           properties:
-            exclude_contract_ended:
+            contract_ended:
               type: boolean
-              description: Exclude users with ended contracts
+              description: Filter by contract status. True returns only users with ended contracts, false returns only users with active or no contract.
+            state:
+              $ref: "#/components/schemas/ProfileState"
+              description: Filter by profile state (ACTIVE or INACTIVE)
 
     ListUsersOutput:
       type: object

--- a/pkg/server/api/mcp/v1/types/profile.go
+++ b/pkg/server/api/mcp/v1/types/profile.go
@@ -24,6 +24,7 @@ func NewProfile(p *coredata.MembershipProfile) *Profile {
 		EmailAddress:             p.EmailAddress,
 		AdditionalEmailAddresses: p.AdditionalEmailAddresses,
 		Kind:                     p.Kind,
+		State:                    p.State,
 		Position:                 p.Position,
 		ContractStartDate:        p.ContractStartDate,
 		ContractEndDate:          p.ContractEndDate,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds profile state (ACTIVE/INACTIVE) and two-way filtering for state and contract status. Renames `excludeContractEnded` to `contractEnded` across MCP, GraphQL, CLI, and console.

- **New Features**
  - MCP: `Profile.state` added; `listUsers`/`getUser` return it.
  - MCP: `listUsers` supports `state` and `contractEnded` filters.
  - GraphQL (console/connect): `ProfileFilter` now has `contractEnded` and `state`.
  - CLI: new `--state` (ACTIVE|INACTIVE) and `--contract-ended` (true|false) flags.

- **Migration**
  - Replace `excludeContractEnded` with `contractEnded` in GraphQL queries, fragments, and console usages.
  - CLI: replace `--active` with `--state ACTIVE` or `--contract-ended false`.
  - MCP clients: expect `Profile.state` and use the new filter fields.

<sup>Written for commit c88c6ba8f6487d3b0734b5d12d7b14138dd86a21. Summary will update on new commits. <a href="https://cubic.dev/pr/getprobo/probo/pull/1099?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

