### PR TITLE
Fix errcheck and ineffassign lint errors

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -92,7 +92,7 @@ func blockingCallLLM(ctx context.Context, agent *Agent, req *llm.ChatCompletionR
 	if sErr != nil {
 		return nil, err // return the original error
 	}
-	defer stream.Close()
+	defer func() { _ = stream.Close() }()
 
 	acc := llm.NewStreamAccumulator(stream)
 	for acc.Next() {
@@ -447,8 +447,6 @@ func coreLoop(ctx context.Context, startAgent *Agent, inputMessages []llm.Messag
 				)
 				continue
 			}
-			emptyOutputRetries = 0
-
 			if err := runOutputGuardrails(ctx, s.agent, resp.Message); err != nil {
 				return s.finishRun(ctx, nil, err)
 			}

--- a/pkg/agent/tools/browser/download_pdf.go
+++ b/pkg/agent/tools/browser/download_pdf.go
@@ -95,7 +95,7 @@ func DownloadPDFTool() agent.Tool {
 					ErrorDetail: fmt.Sprintf("cannot create temp dir: %s", err),
 				}), nil
 			}
-			defer os.RemoveAll(tmpDir)
+			defer func() { _ = os.RemoveAll(tmpDir) }()
 
 			tmpFile := filepath.Join(tmpDir, "input.pdf")
 			if err := os.WriteFile(tmpFile, body, 0o600); err != nil {

--- a/pkg/agent/tools/browser/fetch_sitemap.go
+++ b/pkg/agent/tools/browser/fetch_sitemap.go
@@ -92,7 +92,7 @@ func FetchSitemapTool() agent.Tool {
 						ErrorDetail: fmt.Sprintf("cannot decompress gzipped sitemap: %s", err),
 					}), nil
 				}
-				defer gz.Close()
+				defer func() { _ = gz.Close() }()
 				reader = gz
 			}
 

--- a/pkg/agent/tools/security/whois.go
+++ b/pkg/agent/tools/security/whois.go
@@ -130,7 +130,7 @@ func queryWhois(ctx context.Context, server, domain string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("cannot connect to %s: %w", server, err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix lint errors by making cleanup calls `errcheck`-safe and removing an unnecessary assignment in the agent loop. This keeps resource cleanup consistent and removes noisy lints.

- **Refactors**
  - Wrap `Close`/`RemoveAll` defers with `defer func() { _ = ... }()` in `pkg/agent/run.go`, `pkg/agent/tools/browser/download_pdf.go`, `pkg/agent/tools/browser/fetch_sitemap.go`, and `pkg/agent/tools/security/whois.go`.
  - Remove redundant `emptyOutputRetries = 0` assignment in `coreLoop` to satisfy `ineffassign` (no behavior change).

<sup>Written for commit ab5654f6e5bd6a46f4f81b11f203cf270b9d4d7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

