### PR TITLE
Cookie banner integrations - GCM & posthog

### DIFF
--- a/apps/console/src/pages/organizations/cookie-banners/configuration/cookies/_components/CategorySection.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/cookies/_components/CategorySection.tsx
@@ -490,6 +490,7 @@ export function CategorySection({ categoryKey, onDelete }: CategorySectionProps)
                 name={category.name}
                 slug={category.slug}
                 description={category.description}
+                kind={category.kind}
                 gcmConsentTypes={[...category.gcmConsentTypes]}
                 posthogConsent={category.posthogConsent}
                 isUpdating={isUpdating}

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/cookies/_components/CategorySection.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/cookies/_components/CategorySection.tsx
@@ -59,6 +59,7 @@ export const categorySectionFragment = graphql`
     slug
     description
     kind
+    gcmConsentTypes
     cookies(first: 100, orderBy: { field: CREATED_AT, direction: ASC })
       @connection(key: "CategorySection_cookies", filters: [])
       @required(action: THROW) {
@@ -97,6 +98,7 @@ const updateCategoryMutation = graphql`
         slug
         description
         rank
+        gcmConsentTypes
         updatedAt
       }
       cookieBanner {
@@ -237,7 +239,7 @@ export function CategorySection({ categoryKey, onDelete }: CategorySectionProps)
   const cookies = category.cookies.edges.map(e => e.node);
   const isMutating = isUpdating || isCreating || isUpdatingCookie;
 
-  const handleSaveCategory = (name: string, slug: string, description: string) => {
+  const handleSaveCategory = (name: string, slug: string, description: string, gcmConsentTypes: string[]) => {
     updateCategory({
       variables: {
         input: {
@@ -245,6 +247,7 @@ export function CategorySection({ categoryKey, onDelete }: CategorySectionProps)
           name,
           slug,
           description,
+          gcmConsentTypes,
         },
       },
       onCompleted(_response, errors) {
@@ -481,6 +484,7 @@ export function CategorySection({ categoryKey, onDelete }: CategorySectionProps)
                 name={category.name}
                 slug={category.slug}
                 description={category.description}
+                gcmConsentTypes={[...category.gcmConsentTypes]}
                 isUpdating={isUpdating}
                 onSave={handleSaveCategory}
                 onCancel={() => setIsEditingCategory(false)}
@@ -525,6 +529,18 @@ export function CategorySection({ categoryKey, onDelete }: CategorySectionProps)
                 &quot;
               </code>
             </p>
+            {category.gcmConsentTypes.length > 0 && (
+              <div className="mt-2 flex items-center gap-1.5">
+                <span className="text-xs text-txt-secondary/70">
+                  {__("Google Consent Mode:")}
+                </span>
+                {category.gcmConsentTypes.map(type => (
+                  <Badge key={type} variant="neutral">
+                    {type}
+                  </Badge>
+                ))}
+              </div>
+            )}
           </>
         )}
       </div>

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/cookies/_components/CategorySection.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/cookies/_components/CategorySection.tsx
@@ -60,6 +60,7 @@ export const categorySectionFragment = graphql`
     description
     kind
     gcmConsentTypes
+    posthogConsent
     cookies(first: 100, orderBy: { field: CREATED_AT, direction: ASC })
       @connection(key: "CategorySection_cookies", filters: [])
       @required(action: THROW) {
@@ -99,6 +100,7 @@ const updateCategoryMutation = graphql`
         description
         rank
         gcmConsentTypes
+        posthogConsent
         updatedAt
       }
       cookieBanner {
@@ -239,7 +241,10 @@ export function CategorySection({ categoryKey, onDelete }: CategorySectionProps)
   const cookies = category.cookies.edges.map(e => e.node);
   const isMutating = isUpdating || isCreating || isUpdatingCookie;
 
-  const handleSaveCategory = (name: string, slug: string, description: string, gcmConsentTypes: string[]) => {
+  const handleSaveCategory = (
+    name: string, slug: string, description: string,
+    gcmConsentTypes: string[], posthogConsent: boolean,
+  ) => {
     updateCategory({
       variables: {
         input: {
@@ -248,6 +253,7 @@ export function CategorySection({ categoryKey, onDelete }: CategorySectionProps)
           slug,
           description,
           gcmConsentTypes,
+          posthogConsent,
         },
       },
       onCompleted(_response, errors) {
@@ -485,6 +491,7 @@ export function CategorySection({ categoryKey, onDelete }: CategorySectionProps)
                 slug={category.slug}
                 description={category.description}
                 gcmConsentTypes={[...category.gcmConsentTypes]}
+                posthogConsent={category.posthogConsent}
                 isUpdating={isUpdating}
                 onSave={handleSaveCategory}
                 onCancel={() => setIsEditingCategory(false)}
@@ -539,6 +546,16 @@ export function CategorySection({ categoryKey, onDelete }: CategorySectionProps)
                     {type}
                   </Badge>
                 ))}
+              </div>
+            )}
+            {category.posthogConsent && (
+              <div className="mt-2 flex items-center gap-1.5">
+                <span className="text-xs text-txt-secondary/70">
+                  {__("PostHog:")}
+                </span>
+                <Badge variant="neutral">
+                  {__("Tracking consent")}
+                </Badge>
               </div>
             )}
           </>

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/cookies/_components/EditCategoryForm.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/cookies/_components/EditCategoryForm.tsx
@@ -30,6 +30,7 @@ interface EditCategoryFormProps {
   name: string;
   slug: string;
   description: string;
+  kind: string;
   gcmConsentTypes: string[];
   posthogConsent: boolean;
   isUpdating: boolean;
@@ -41,6 +42,7 @@ export function EditCategoryForm({
   name,
   slug,
   description,
+  kind,
   gcmConsentTypes,
   posthogConsent,
   isUpdating,
@@ -105,23 +107,25 @@ export function EditCategoryForm({
           ))}
         </div>
       </div>
-      <div>
-        <label className="text-sm font-medium">
-          {__("PostHog")}
-        </label>
-        <p className="text-xs text-muted-foreground mb-2">
-          {__("Control PostHog tracking consent based on this category.")}
-        </p>
-        <label className="flex items-center gap-1.5 text-xs cursor-pointer">
-          <input
-            type="checkbox"
-            checked={editPosthogConsent}
-            onChange={() => setEditPosthogConsent(prev => !prev)}
-            className="rounded"
-          />
-          <span>{__("Opt in/out of PostHog tracking")}</span>
-        </label>
-      </div>
+      {kind === "NORMAL" && (
+        <div>
+          <label className="text-sm font-medium">
+            {__("PostHog")}
+          </label>
+          <p className="text-xs text-muted-foreground mb-2">
+            {__("Control PostHog tracking consent based on this category.")}
+          </p>
+          <label className="flex items-center gap-1.5 text-xs cursor-pointer">
+            <input
+              type="checkbox"
+              checked={editPosthogConsent}
+              onChange={() => setEditPosthogConsent(prev => !prev)}
+              className="rounded"
+            />
+            <span>{__("Opt in/out of PostHog tracking")}</span>
+          </label>
+        </div>
+      )}
       <div className="flex items-center gap-2">
         <Button
           onClick={() => {

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/cookies/_components/EditCategoryForm.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/cookies/_components/EditCategoryForm.tsx
@@ -31,8 +31,9 @@ interface EditCategoryFormProps {
   slug: string;
   description: string;
   gcmConsentTypes: string[];
+  posthogConsent: boolean;
   isUpdating: boolean;
-  onSave: (name: string, slug: string, description: string, gcmConsentTypes: string[]) => void;
+  onSave: (name: string, slug: string, description: string, gcmConsentTypes: string[], posthogConsent: boolean) => void;
   onCancel: () => void;
 }
 
@@ -41,6 +42,7 @@ export function EditCategoryForm({
   slug,
   description,
   gcmConsentTypes,
+  posthogConsent,
   isUpdating,
   onSave,
   onCancel,
@@ -50,6 +52,7 @@ export function EditCategoryForm({
   const [editSlug, setEditSlug] = useState(slug);
   const [editDescription, setEditDescription] = useState(description);
   const [editGcmTypes, setEditGcmTypes] = useState<string[]>(gcmConsentTypes);
+  const [editPosthogConsent, setEditPosthogConsent] = useState(posthogConsent);
 
   const toggleGcmType = (type: string) => {
     setEditGcmTypes(prev =>
@@ -102,11 +105,28 @@ export function EditCategoryForm({
           ))}
         </div>
       </div>
+      <div>
+        <label className="text-sm font-medium">
+          {__("PostHog")}
+        </label>
+        <p className="text-xs text-muted-foreground mb-2">
+          {__("Control PostHog tracking consent based on this category.")}
+        </p>
+        <label className="flex items-center gap-1.5 text-xs cursor-pointer">
+          <input
+            type="checkbox"
+            checked={editPosthogConsent}
+            onChange={() => setEditPosthogConsent(prev => !prev)}
+            className="rounded"
+          />
+          <span>{__("Opt in/out of PostHog tracking")}</span>
+        </label>
+      </div>
       <div className="flex items-center gap-2">
         <Button
           onClick={() => {
             if (!/^[a-z0-9]+(-[a-z0-9]+)*$/.test(editSlug)) return;
-            onSave(editName, editSlug, editDescription, editGcmTypes);
+            onSave(editName, editSlug, editDescription, editGcmTypes, editPosthogConsent);
           }}
           disabled={isUpdating}
         >

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/cookies/_components/EditCategoryForm.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/cookies/_components/EditCategoryForm.tsx
@@ -16,12 +16,23 @@ import { useTranslate } from "@probo/i18n";
 import { Button, Input, Textarea } from "@probo/ui";
 import { useState } from "react";
 
+const GCM_CONSENT_TYPES = [
+  "analytics_storage",
+  "ad_storage",
+  "ad_user_data",
+  "ad_personalization",
+  "functionality_storage",
+  "personalization_storage",
+  "security_storage",
+] as const;
+
 interface EditCategoryFormProps {
   name: string;
   slug: string;
   description: string;
+  gcmConsentTypes: string[];
   isUpdating: boolean;
-  onSave: (name: string, slug: string, description: string) => void;
+  onSave: (name: string, slug: string, description: string, gcmConsentTypes: string[]) => void;
   onCancel: () => void;
 }
 
@@ -29,6 +40,7 @@ export function EditCategoryForm({
   name,
   slug,
   description,
+  gcmConsentTypes,
   isUpdating,
   onSave,
   onCancel,
@@ -37,6 +49,15 @@ export function EditCategoryForm({
   const [editName, setEditName] = useState(name);
   const [editSlug, setEditSlug] = useState(slug);
   const [editDescription, setEditDescription] = useState(description);
+  const [editGcmTypes, setEditGcmTypes] = useState<string[]>(gcmConsentTypes);
+
+  const toggleGcmType = (type: string) => {
+    setEditGcmTypes(prev =>
+      prev.includes(type)
+        ? prev.filter(t => t !== type)
+        : [...prev, type],
+    );
+  };
 
   return (
     <div className="space-y-3">
@@ -57,11 +78,35 @@ export function EditCategoryForm({
         placeholder={__("Category description")}
         rows={2}
       />
+      <div>
+        <label className="text-sm font-medium">
+          {__("Google Consent Mode")}
+        </label>
+        <p className="text-xs text-muted-foreground mb-2">
+          {__("Select the Google Consent Mode signals this category controls.")}
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {GCM_CONSENT_TYPES.map(type => (
+            <label
+              key={type}
+              className="flex items-center gap-1.5 text-xs cursor-pointer"
+            >
+              <input
+                type="checkbox"
+                checked={editGcmTypes.includes(type)}
+                onChange={() => toggleGcmType(type)}
+                className="rounded"
+              />
+              <code className="font-mono">{type}</code>
+            </label>
+          ))}
+        </div>
+      </div>
       <div className="flex items-center gap-2">
         <Button
           onClick={() => {
             if (!/^[a-z0-9]+(-[a-z0-9]+)*$/.test(editSlug)) return;
-            onSave(editName, editSlug, editDescription);
+            onSave(editName, editSlug, editDescription, editGcmTypes);
           }}
           disabled={isUpdating}
         >

--- a/packages/cookie-banner/src/client.ts
+++ b/packages/cookie-banner/src/client.ts
@@ -39,6 +39,7 @@ export interface Category {
   description: string;
   kind: string;
   cookies: CookieItem[];
+  gcm_consent_types: string[];
 }
 
 export interface BannerConfig {
@@ -108,6 +109,7 @@ export class CookieBannerClient {
     const config = await fetchJSON<BannerConfig>(configUrl);
     this.bannerConfig = config;
 
+    this.setGoogleConsentDefaults();
     this.startDetector(config);
 
     const cookie = getConsentCookie();
@@ -272,6 +274,8 @@ export class CookieBannerClient {
   }
 
   private activate(consentData: Record<string, boolean>): void {
+    this.updateGoogleConsentMode(consentData);
+
     const categoryCookies: Record<string, string[]> = {};
     const categoryLabels: Record<string, string> = {};
     for (const cat of this.config.categories) {
@@ -287,6 +291,55 @@ export class CookieBannerClient {
       this.observer.disconnect();
     }
     this.observer = observeAndActivate(consentData, categoryLabels, texts);
+  }
+
+  private hasGCMMapping(): boolean {
+    return this.config.categories.some(
+      (cat) => cat.gcm_consent_types && cat.gcm_consent_types.length > 0,
+    );
+  }
+
+  private setGoogleConsentDefaults(): void {
+    if (!this.hasGCMMapping()) return;
+
+    const w = window as unknown as Record<string, unknown>;
+    const gtag = w.gtag as ((...args: unknown[]) => void) | undefined;
+    if (typeof gtag !== "function") return;
+
+    const defaults: Record<string, string> = {};
+    for (const cat of this.config.categories) {
+      if (!cat.gcm_consent_types) continue;
+      for (const gcmType of cat.gcm_consent_types) {
+        defaults[gcmType] = "denied";
+      }
+    }
+
+    if (Object.keys(defaults).length > 0) {
+      gtag("consent", "default", defaults);
+    }
+  }
+
+  private updateGoogleConsentMode(
+    consentData: Record<string, boolean>,
+  ): void {
+    if (!this.hasGCMMapping()) return;
+
+    const w = window as unknown as Record<string, unknown>;
+    const gtag = w.gtag as ((...args: unknown[]) => void) | undefined;
+    if (typeof gtag !== "function") return;
+
+    const update: Record<string, string> = {};
+    for (const cat of this.config.categories) {
+      if (!cat.gcm_consent_types) continue;
+      const granted = !!consentData[cat.slug];
+      for (const gcmType of cat.gcm_consent_types) {
+        update[gcmType] = granted ? "granted" : "denied";
+      }
+    }
+
+    if (Object.keys(update).length > 0) {
+      gtag("consent", "update", update);
+    }
   }
 
   private startDetector(config: BannerConfig): void {

--- a/packages/cookie-banner/src/client.ts
+++ b/packages/cookie-banner/src/client.ts
@@ -24,6 +24,8 @@ import { NotFoundError } from "./errors";
 import { fetchJSON } from "./http";
 import type { BannerTexts } from "./i18n";
 import { detectLanguage } from "./i18n";
+import type { ConsentIntegration } from "./integrations";
+import { createDefaultIntegrations } from "./integrations";
 import { enqueue, flush } from "./queue";
 import { getOrCreateVisitorId } from "./visitor";
 
@@ -40,6 +42,7 @@ export interface Category {
   kind: string;
   cookies: CookieItem[];
   gcm_consent_types: string[];
+  posthog_consent: boolean;
 }
 
 export interface BannerConfig {
@@ -84,6 +87,8 @@ export class CookieBannerClient {
   private readonly visitorId: string;
   private readonly lang: string;
 
+  private readonly integrations: ConsentIntegration[];
+
   private bannerConfig: BannerConfig | null = null;
   private consent: VisitorConsent | null = null;
   private observer: MutationObserver | null = null;
@@ -99,6 +104,7 @@ export class CookieBannerClient {
     this.bannerId = config.bannerId;
     this.visitorId = getOrCreateVisitorId(config.bannerId);
     this.lang = detectLanguage(config.lang);
+    this.integrations = createDefaultIntegrations();
   }
 
   async load(): Promise<void> {
@@ -109,7 +115,9 @@ export class CookieBannerClient {
     const config = await fetchJSON<BannerConfig>(configUrl);
     this.bannerConfig = config;
 
-    this.setGoogleConsentDefaults();
+    for (const integration of this.integrations) {
+      integration.setDefaults(config.categories);
+    }
     this.startDetector(config);
 
     const cookie = getConsentCookie();
@@ -274,7 +282,9 @@ export class CookieBannerClient {
   }
 
   private activate(consentData: Record<string, boolean>): void {
-    this.updateGoogleConsentMode(consentData);
+    for (const integration of this.integrations) {
+      integration.update(this.config.categories, consentData);
+    }
 
     const categoryCookies: Record<string, string[]> = {};
     const categoryLabels: Record<string, string> = {};
@@ -291,55 +301,6 @@ export class CookieBannerClient {
       this.observer.disconnect();
     }
     this.observer = observeAndActivate(consentData, categoryLabels, texts);
-  }
-
-  private hasGCMMapping(): boolean {
-    return this.config.categories.some(
-      (cat) => cat.gcm_consent_types && cat.gcm_consent_types.length > 0,
-    );
-  }
-
-  private setGoogleConsentDefaults(): void {
-    if (!this.hasGCMMapping()) return;
-
-    const w = window as unknown as Record<string, unknown>;
-    const gtag = w.gtag as ((...args: unknown[]) => void) | undefined;
-    if (typeof gtag !== "function") return;
-
-    const defaults: Record<string, string> = {};
-    for (const cat of this.config.categories) {
-      if (!cat.gcm_consent_types) continue;
-      for (const gcmType of cat.gcm_consent_types) {
-        defaults[gcmType] = "denied";
-      }
-    }
-
-    if (Object.keys(defaults).length > 0) {
-      gtag("consent", "default", defaults);
-    }
-  }
-
-  private updateGoogleConsentMode(
-    consentData: Record<string, boolean>,
-  ): void {
-    if (!this.hasGCMMapping()) return;
-
-    const w = window as unknown as Record<string, unknown>;
-    const gtag = w.gtag as ((...args: unknown[]) => void) | undefined;
-    if (typeof gtag !== "function") return;
-
-    const update: Record<string, string> = {};
-    for (const cat of this.config.categories) {
-      if (!cat.gcm_consent_types) continue;
-      const granted = !!consentData[cat.slug];
-      for (const gcmType of cat.gcm_consent_types) {
-        update[gcmType] = granted ? "granted" : "denied";
-      }
-    }
-
-    if (Object.keys(update).length > 0) {
-      gtag("consent", "update", update);
-    }
   }
 
   private startDetector(config: BannerConfig): void {

--- a/packages/cookie-banner/src/integrations/gcm.ts
+++ b/packages/cookie-banner/src/integrations/gcm.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { Category } from "../client";
+import type { ConsentIntegration } from "./integration";
+
+export class GoogleConsentModeIntegration implements ConsentIntegration {
+  private hasMapping(categories: Category[]): boolean {
+    return categories.some(
+      (cat) => cat.gcm_consent_types && cat.gcm_consent_types.length > 0,
+    );
+  }
+
+  private getGtag(): ((...args: unknown[]) => void) | null {
+    const w = window as unknown as Record<string, unknown>;
+    const gtag = w.gtag as ((...args: unknown[]) => void) | undefined;
+    if (typeof gtag !== "function") return null;
+    return gtag;
+  }
+
+  setDefaults(categories: Category[]): void {
+    if (!this.hasMapping(categories)) return;
+
+    const gtag = this.getGtag();
+    if (!gtag) return;
+
+    const defaults: Record<string, string> = {};
+    for (const cat of categories) {
+      if (!cat.gcm_consent_types) continue;
+      for (const gcmType of cat.gcm_consent_types) {
+        defaults[gcmType] = "denied";
+      }
+    }
+
+    if (Object.keys(defaults).length > 0) {
+      gtag("consent", "default", defaults);
+    }
+  }
+
+  update(
+    categories: Category[],
+    consentData: Record<string, boolean>,
+  ): void {
+    if (!this.hasMapping(categories)) return;
+
+    const gtag = this.getGtag();
+    if (!gtag) return;
+
+    const update: Record<string, string> = {};
+    for (const cat of categories) {
+      if (!cat.gcm_consent_types) continue;
+      const granted = !!consentData[cat.slug];
+      for (const gcmType of cat.gcm_consent_types) {
+        update[gcmType] = granted ? "granted" : "denied";
+      }
+    }
+
+    if (Object.keys(update).length > 0) {
+      gtag("consent", "update", update);
+    }
+  }
+}

--- a/packages/cookie-banner/src/integrations/gcm.ts
+++ b/packages/cookie-banner/src/integrations/gcm.ts
@@ -22,18 +22,26 @@ export class GoogleConsentModeIntegration implements ConsentIntegration {
     );
   }
 
-  private getGtag(): ((...args: unknown[]) => void) | null {
+  private getConsentFn(): ((...args: unknown[]) => void) | null {
     const w = window as unknown as Record<string, unknown>;
-    const gtag = w.gtag as ((...args: unknown[]) => void) | undefined;
-    if (typeof gtag !== "function") return null;
-    return gtag;
+
+    if (typeof w.gtag === "function") {
+      return w.gtag as (...args: unknown[]) => void;
+    }
+
+    if (!Array.isArray(w.dataLayer)) return null;
+
+    const dataLayer = w.dataLayer as unknown[];
+    return function () {
+      dataLayer.push(arguments);
+    };
   }
 
   setDefaults(categories: Category[]): void {
     if (!this.hasMapping(categories)) return;
 
-    const gtag = this.getGtag();
-    if (!gtag) return;
+    const consentFn = this.getConsentFn();
+    if (!consentFn) return;
 
     const defaults: Record<string, string> = {};
     for (const cat of categories) {
@@ -44,7 +52,7 @@ export class GoogleConsentModeIntegration implements ConsentIntegration {
     }
 
     if (Object.keys(defaults).length > 0) {
-      gtag("consent", "default", defaults);
+      consentFn("consent", "default", defaults);
     }
   }
 
@@ -54,8 +62,8 @@ export class GoogleConsentModeIntegration implements ConsentIntegration {
   ): void {
     if (!this.hasMapping(categories)) return;
 
-    const gtag = this.getGtag();
-    if (!gtag) return;
+    const consentFn = this.getConsentFn();
+    if (!consentFn) return;
 
     const update: Record<string, string> = {};
     for (const cat of categories) {
@@ -67,7 +75,7 @@ export class GoogleConsentModeIntegration implements ConsentIntegration {
     }
 
     if (Object.keys(update).length > 0) {
-      gtag("consent", "update", update);
+      consentFn("consent", "update", update);
     }
   }
 }

--- a/packages/cookie-banner/src/integrations/index.ts
+++ b/packages/cookie-banner/src/integrations/index.ts
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+export type { ConsentIntegration } from "./integration";
+export { GoogleConsentModeIntegration } from "./gcm";
+export { PostHogIntegration } from "./posthog";
+
+import type { ConsentIntegration } from "./integration";
+import { GoogleConsentModeIntegration } from "./gcm";
+import { PostHogIntegration } from "./posthog";
+
+export function createDefaultIntegrations(): ConsentIntegration[] {
+  return [
+    new GoogleConsentModeIntegration(),
+    new PostHogIntegration(),
+  ];
+}

--- a/packages/cookie-banner/src/integrations/integration.ts
+++ b/packages/cookie-banner/src/integrations/integration.ts
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { Category } from "../client";
+
+export interface ConsentIntegration {
+  /** Called once after config is loaded, before any consent is applied. */
+  setDefaults(categories: Category[]): void;
+
+  /** Called whenever consent changes (accept, reject, customize, GPC). */
+  update(categories: Category[], consentData: Record<string, boolean>): void;
+}

--- a/packages/cookie-banner/src/integrations/posthog.ts
+++ b/packages/cookie-banner/src/integrations/posthog.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { Category } from "../client";
+import type { ConsentIntegration } from "./integration";
+
+interface PostHogInstance {
+  opt_in_capturing: () => void;
+  opt_out_capturing: () => void;
+}
+
+export class PostHogIntegration implements ConsentIntegration {
+  private hasMapping(categories: Category[]): boolean {
+    return categories.some((cat) => cat.posthog_consent);
+  }
+
+  private getPostHog(): PostHogInstance | null {
+    const w = window as unknown as Record<string, unknown>;
+    const posthog = w.posthog as (PostHogInstance & Record<string, unknown>) | undefined;
+    if (
+      !posthog ||
+      typeof posthog.opt_in_capturing !== "function" ||
+      typeof posthog.opt_out_capturing !== "function"
+    ) {
+      return null;
+    }
+    return posthog;
+  }
+
+  setDefaults(categories: Category[]): void {
+    if (!this.hasMapping(categories)) return;
+
+    const posthog = this.getPostHog();
+    if (!posthog) return;
+
+    posthog.opt_out_capturing();
+  }
+
+  update(
+    categories: Category[],
+    consentData: Record<string, boolean>,
+  ): void {
+    if (!this.hasMapping(categories)) return;
+
+    const posthog = this.getPostHog();
+    if (!posthog) return;
+
+    const granted = categories
+      .filter((cat) => cat.posthog_consent)
+      .every((cat) => !!consentData[cat.slug]);
+
+    if (granted) {
+      posthog.opt_in_capturing();
+    } else {
+      posthog.opt_out_capturing();
+    }
+  }
+}

--- a/pkg/cookiebanner/defaults.go
+++ b/pkg/cookiebanner/defaults.go
@@ -25,12 +25,53 @@ var defaultCategories = []struct {
 	Kind            coredata.CookieCategoryKind
 	Rank            int
 	GCMConsentTypes []string
+	PostHogConsent  bool
 }{
-	{"Necessary", "necessary", "Essential cookies required for the website to function properly.", coredata.CookieCategoryKindNecessary, 0, []string{"security_storage"}},
-	{"Analytics", "analytics", "Cookies that help understand how visitors interact with the website.", coredata.CookieCategoryKindNormal, 1, []string{"analytics_storage"}},
-	{"Advertising", "advertising", "Cookies used to deliver relevant advertisements and track campaigns.", coredata.CookieCategoryKindNormal, 2, []string{"ad_storage", "ad_user_data", "ad_personalization"}},
-	{"Functional", "functional", "Cookies that enable enhanced functionality and personalization.", coredata.CookieCategoryKindNormal, 3, []string{"functionality_storage", "personalization_storage"}},
-	{"Uncategorised", "uncategorised", "Cookies that have not been assigned to a category yet.", coredata.CookieCategoryKindUncategorised, 4, nil},
+	{
+		Name:            "Necessary",
+		Slug:            "necessary",
+		Description:     "Essential cookies required for the website to function properly.",
+		Kind:            coredata.CookieCategoryKindNecessary,
+		Rank:            0,
+		GCMConsentTypes: []string{"security_storage"},
+		PostHogConsent:  false,
+	},
+	{
+		Name:            "Analytics",
+		Slug:            "analytics",
+		Description:     "Cookies that help understand how visitors interact with the website.",
+		Kind:            coredata.CookieCategoryKindNormal,
+		Rank:            1,
+		GCMConsentTypes: []string{"analytics_storage"},
+		PostHogConsent:  true,
+	},
+	{
+		Name:            "Advertising",
+		Slug:            "advertising",
+		Description:     "Cookies used to deliver relevant advertisements and track campaigns.",
+		Kind:            coredata.CookieCategoryKindNormal,
+		Rank:            2,
+		GCMConsentTypes: []string{"ad_storage", "ad_user_data", "ad_personalization"},
+		PostHogConsent:  false,
+	},
+	{
+		Name:            "Functional",
+		Slug:            "functional",
+		Description:     "Cookies that enable enhanced functionality and personalization.",
+		Kind:            coredata.CookieCategoryKindNormal,
+		Rank:            3,
+		GCMConsentTypes: []string{"functionality_storage", "personalization_storage"},
+		PostHogConsent:  false,
+	},
+	{
+		Name:            "Uncategorised",
+		Slug:            "uncategorised",
+		Description:     "Cookies that have not been assigned to a category yet.",
+		Kind:            coredata.CookieCategoryKindUncategorised,
+		Rank:            4,
+		GCMConsentTypes: nil,
+		PostHogConsent:  false,
+	},
 }
 
 var defaultCategoryTranslationsByLanguage = map[string]map[string]struct {

--- a/pkg/cookiebanner/defaults.go
+++ b/pkg/cookiebanner/defaults.go
@@ -19,17 +19,18 @@ import "go.probo.inc/probo/pkg/coredata"
 var SupportedLanguages = []string{"en", "fr", "de", "es"}
 
 var defaultCategories = []struct {
-	Name        string
-	Slug        string
-	Description string
-	Kind        coredata.CookieCategoryKind
-	Rank        int
+	Name            string
+	Slug            string
+	Description     string
+	Kind            coredata.CookieCategoryKind
+	Rank            int
+	GCMConsentTypes []string
 }{
-	{"Necessary", "necessary", "Essential cookies required for the website to function properly.", coredata.CookieCategoryKindNecessary, 0},
-	{"Analytics", "analytics", "Cookies that help understand how visitors interact with the website.", coredata.CookieCategoryKindNormal, 1},
-	{"Advertising", "advertising", "Cookies used to deliver relevant advertisements and track campaigns.", coredata.CookieCategoryKindNormal, 2},
-	{"Functional", "functional", "Cookies that enable enhanced functionality and personalization.", coredata.CookieCategoryKindNormal, 3},
-	{"Uncategorised", "uncategorised", "Cookies that have not been assigned to a category yet.", coredata.CookieCategoryKindUncategorised, 4},
+	{"Necessary", "necessary", "Essential cookies required for the website to function properly.", coredata.CookieCategoryKindNecessary, 0, []string{"security_storage"}},
+	{"Analytics", "analytics", "Cookies that help understand how visitors interact with the website.", coredata.CookieCategoryKindNormal, 1, []string{"analytics_storage"}},
+	{"Advertising", "advertising", "Cookies used to deliver relevant advertisements and track campaigns.", coredata.CookieCategoryKindNormal, 2, []string{"ad_storage", "ad_user_data", "ad_personalization"}},
+	{"Functional", "functional", "Cookies that enable enhanced functionality and personalization.", coredata.CookieCategoryKindNormal, 3, []string{"functionality_storage", "personalization_storage"}},
+	{"Uncategorised", "uncategorised", "Cookies that have not been assigned to a category yet.", coredata.CookieCategoryKindUncategorised, 4, nil},
 }
 
 var defaultCategoryTranslationsByLanguage = map[string]map[string]struct {

--- a/pkg/cookiebanner/errors.go
+++ b/pkg/cookiebanner/errors.go
@@ -33,4 +33,5 @@ var (
 	ErrCookieNameAlreadyExists    = errors.New("a cookie with this name already exists in this banner")
 	ErrCategoriesBannerMismatch   = errors.New("source and target categories belong to different banners")
 	ErrSameCategoryMove           = errors.New("source and target cookie categories must be different")
+	ErrPostHogConsentKindInvalid  = errors.New("PostHog consent can only be enabled on normal categories")
 )

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -73,6 +73,7 @@ type (
 		Name             *string
 		Slug             *string
 		Description      *string
+		GCMConsentTypes  *[]string
 	}
 
 	CreateCookieRequest struct {
@@ -557,17 +558,22 @@ func (s *Service) CreateCookieBanner(
 
 			slugToGID := make(map[string]gid.GID, len(defaultCategories))
 			for _, dc := range defaultCategories {
+				gcmConsentTypes := dc.GCMConsentTypes
+				if gcmConsentTypes == nil {
+					gcmConsentTypes = []string{}
+				}
 				category := &coredata.CookieCategory{
-					ID:             gid.New(scope.GetTenantID(), coredata.CookieCategoryEntityType),
-					OrganizationID: banner.OrganizationID,
-					CookieBannerID: banner.ID,
-					Name:           dc.Name,
-					Slug:           dc.Slug,
-					Description:    dc.Description,
-					Kind:           dc.Kind,
-					Rank:           dc.Rank,
-					CreatedAt:      now,
-					UpdatedAt:      now,
+					ID:              gid.New(scope.GetTenantID(), coredata.CookieCategoryEntityType),
+					OrganizationID:  banner.OrganizationID,
+					CookieBannerID:  banner.ID,
+					Name:            dc.Name,
+					Slug:            dc.Slug,
+					Description:     dc.Description,
+					Kind:            dc.Kind,
+					Rank:            dc.Rank,
+					GCMConsentTypes: gcmConsentTypes,
+					CreatedAt:       now,
+					UpdatedAt:       now,
 				}
 
 				if err := category.Insert(ctx, tx, scope); err != nil {
@@ -974,16 +980,17 @@ func (s *Service) CreateCookieCategory(
 			now := time.Now()
 
 			category = &coredata.CookieCategory{
-				ID:             gid.New(scope.GetTenantID(), coredata.CookieCategoryEntityType),
-				OrganizationID: banner.OrganizationID,
-				CookieBannerID: req.CookieBannerID,
-				Name:           req.Name,
-				Slug:           req.Slug,
-				Description:    req.Description,
-				Kind:           coredata.CookieCategoryKindNormal,
-				Rank:           req.Rank,
-				CreatedAt:      now,
-				UpdatedAt:      now,
+				ID:              gid.New(scope.GetTenantID(), coredata.CookieCategoryEntityType),
+				OrganizationID:  banner.OrganizationID,
+				CookieBannerID:  req.CookieBannerID,
+				Name:            req.Name,
+				Slug:            req.Slug,
+				Description:     req.Description,
+				Kind:            coredata.CookieCategoryKindNormal,
+				Rank:            req.Rank,
+				GCMConsentTypes: []string{},
+				CreatedAt:       now,
+				UpdatedAt:       now,
 			}
 
 			if err := category.Insert(ctx, tx, scope); err != nil {
@@ -1336,6 +1343,9 @@ func (s *Service) UpdateCookieCategory(
 			}
 			if req.Description != nil {
 				category.Description = *req.Description
+			}
+			if req.GCMConsentTypes != nil {
+				category.GCMConsentTypes = *req.GCMConsentTypes
 			}
 
 			category.UpdatedAt = time.Now()

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -74,6 +74,7 @@ type (
 		Slug             *string
 		Description      *string
 		GCMConsentTypes  *[]string
+		PostHogConsent   *bool
 	}
 
 	CreateCookieRequest struct {
@@ -360,6 +361,7 @@ func buildSnapshot(
 			Kind:            c.Kind,
 			Cookies:         cookies,
 			GCMConsentTypes: gcmConsentTypes,
+			PostHogConsent:  c.PostHogConsent,
 		}
 	}
 
@@ -1346,6 +1348,9 @@ func (s *Service) UpdateCookieCategory(
 			}
 			if req.GCMConsentTypes != nil {
 				category.GCMConsentTypes = *req.GCMConsentTypes
+			}
+			if req.PostHogConsent != nil {
+				category.PostHogConsent = *req.PostHogConsent
 			}
 
 			category.UpdatedAt = time.Now()

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -574,6 +574,7 @@ func (s *Service) CreateCookieBanner(
 					Kind:            dc.Kind,
 					Rank:            dc.Rank,
 					GCMConsentTypes: gcmConsentTypes,
+					PostHogConsent:  dc.PostHogConsent,
 					CreatedAt:       now,
 					UpdatedAt:       now,
 				}
@@ -1350,6 +1351,15 @@ func (s *Service) UpdateCookieCategory(
 				category.GCMConsentTypes = *req.GCMConsentTypes
 			}
 			if req.PostHogConsent != nil {
+				if *req.PostHogConsent && category.Kind != coredata.CookieCategoryKindNormal {
+					return ErrPostHogConsentKindInvalid
+				}
+				if *req.PostHogConsent {
+					var categories coredata.CookieCategories
+				if err := categories.ClearPostHogConsentByBannerID(ctx, tx, scope, category.CookieBannerID); err != nil {
+						return fmt.Errorf("cannot clear posthog consent: %w", err)
+					}
+				}
 				category.PostHogConsent = *req.PostHogConsent
 			}
 
@@ -2091,13 +2101,13 @@ func (s *Service) ReportDetectedCookies(
 					UpdatedAt:        now,
 				}
 
-				if err := cookie.Insert(ctx, tx, scope); err != nil {
-					if errors.Is(err, coredata.ErrResourceAlreadyExists) {
-						continue
-					}
+				ok, err := cookie.InsertIfNotExists(ctx, tx, scope)
+				if err != nil {
 					return fmt.Errorf("cannot insert detected cookie: %w", err)
 				}
-				inserted++
+				if ok {
+					inserted++
+				}
 			}
 
 			if inserted > 0 {

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -1356,7 +1356,7 @@ func (s *Service) UpdateCookieCategory(
 				}
 				if *req.PostHogConsent {
 					var categories coredata.CookieCategories
-				if err := categories.ClearPostHogConsentByBannerID(ctx, tx, scope, category.CookieBannerID); err != nil {
+					if err := categories.ClearPostHogConsentByBannerID(ctx, tx, scope, category.CookieBannerID); err != nil {
 						return fmt.Errorf("cannot clear posthog consent: %w", err)
 					}
 				}

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -348,12 +348,17 @@ func buildSnapshot(
 		if cookies == nil {
 			cookies = coredata.CookieItems{}
 		}
+		gcmConsentTypes := c.GCMConsentTypes
+		if gcmConsentTypes == nil {
+			gcmConsentTypes = []string{}
+		}
 		snapshotCategories[i] = coredata.CookieBannerVersionSnapshotCategory{
-			Name:        c.Name,
-			Slug:        c.Slug,
-			Description: c.Description,
-			Kind:        c.Kind,
-			Cookies:     cookies,
+			Name:            c.Name,
+			Slug:            c.Slug,
+			Description:     c.Description,
+			Kind:            c.Kind,
+			Cookies:         cookies,
+			GCMConsentTypes: gcmConsentTypes,
 		}
 	}
 

--- a/pkg/coredata/cookie.go
+++ b/pkg/coredata/cookie.go
@@ -297,6 +297,59 @@ INSERT INTO cookies (
 	return nil
 }
 
+func (c *Cookie) InsertIfNotExists(
+	ctx context.Context,
+	tx pg.Tx,
+	scope Scoper,
+) (bool, error) {
+	q := `
+INSERT INTO cookies (
+	id,
+	tenant_id,
+	organization_id,
+	cookie_banner_id,
+	cookie_category_id,
+	name,
+	duration,
+	description,
+	created_at,
+	updated_at
+) VALUES (
+	@id,
+	@tenant_id,
+	@organization_id,
+	@cookie_banner_id,
+	@cookie_category_id,
+	@name,
+	@duration,
+	@description,
+	@created_at,
+	@updated_at
+)
+ON CONFLICT (cookie_banner_id, name) DO NOTHING
+`
+
+	args := pgx.StrictNamedArgs{
+		"id":                 c.ID,
+		"tenant_id":          scope.GetTenantID(),
+		"organization_id":    c.OrganizationID,
+		"cookie_banner_id":   c.CookieBannerID,
+		"cookie_category_id": c.CookieCategoryID,
+		"name":               c.Name,
+		"duration":           c.Duration,
+		"description":        c.Description,
+		"created_at":         c.CreatedAt,
+		"updated_at":         c.UpdatedAt,
+	}
+
+	result, err := tx.Exec(ctx, q, args)
+	if err != nil {
+		return false, fmt.Errorf("cannot insert cookie: %w", err)
+	}
+
+	return result.RowsAffected() > 0, nil
+}
+
 func (c *Cookie) Update(
 	ctx context.Context,
 	tx pg.Tx,

--- a/pkg/coredata/cookie_banner_version.go
+++ b/pkg/coredata/cookie_banner_version.go
@@ -55,6 +55,7 @@ type (
 		Kind            CookieCategoryKind `json:"kind"`
 		Cookies         CookieItems        `json:"cookies"`
 		GCMConsentTypes []string           `json:"gcm_consent_types"`
+		PostHogConsent  bool               `json:"posthog_consent"`
 	}
 
 	CookieBannerVersion struct {

--- a/pkg/coredata/cookie_banner_version.go
+++ b/pkg/coredata/cookie_banner_version.go
@@ -49,11 +49,12 @@ type (
 	}
 
 	CookieBannerVersionSnapshotCategory struct {
-		Name        string             `json:"name"`
-		Slug        string             `json:"slug"`
-		Description string             `json:"description"`
-		Kind        CookieCategoryKind `json:"kind"`
-		Cookies     CookieItems        `json:"cookies"`
+		Name            string             `json:"name"`
+		Slug            string             `json:"slug"`
+		Description     string             `json:"description"`
+		Kind            CookieCategoryKind `json:"kind"`
+		Cookies         CookieItems        `json:"cookies"`
+		GCMConsentTypes []string           `json:"gcm_consent_types"`
 	}
 
 	CookieBannerVersion struct {

--- a/pkg/coredata/cookie_category.go
+++ b/pkg/coredata/cookie_category.go
@@ -39,16 +39,17 @@ type (
 	CookieItems []CookieItem
 
 	CookieCategory struct {
-		ID             gid.GID            `db:"id"`
-		OrganizationID gid.GID            `db:"organization_id"`
-		CookieBannerID gid.GID            `db:"cookie_banner_id"`
-		Name           string             `db:"name"`
-		Slug           string             `db:"slug"`
-		Description    string             `db:"description"`
-		Kind           CookieCategoryKind `db:"kind"`
-		Rank           int                `db:"rank"`
-		CreatedAt      time.Time          `db:"created_at"`
-		UpdatedAt      time.Time          `db:"updated_at"`
+		ID              gid.GID            `db:"id"`
+		OrganizationID  gid.GID            `db:"organization_id"`
+		CookieBannerID  gid.GID            `db:"cookie_banner_id"`
+		Name            string             `db:"name"`
+		Slug            string             `db:"slug"`
+		Description     string             `db:"description"`
+		Kind            CookieCategoryKind `db:"kind"`
+		Rank            int                `db:"rank"`
+		GCMConsentTypes []string           `db:"gcm_consent_types"`
+		CreatedAt       time.Time          `db:"created_at"`
+		UpdatedAt       time.Time          `db:"updated_at"`
 	}
 
 	CookieCategories []*CookieCategory
@@ -109,6 +110,7 @@ SELECT
 	description,
 	kind,
 	rank,
+	gcm_consent_types,
 	created_at,
 	updated_at
 FROM
@@ -159,6 +161,7 @@ SELECT
 	description,
 	kind,
 	rank,
+	gcm_consent_types,
 	created_at,
 	updated_at
 FROM
@@ -237,6 +240,7 @@ SELECT
 	description,
 	kind,
 	rank,
+	gcm_consent_types,
 	created_at,
 	updated_at
 FROM
@@ -284,6 +288,7 @@ INSERT INTO cookie_categories (
 	description,
 	kind,
 	rank,
+	gcm_consent_types,
 	created_at,
 	updated_at
 ) VALUES (
@@ -296,23 +301,25 @@ INSERT INTO cookie_categories (
 	@description,
 	@kind,
 	@rank,
+	@gcm_consent_types,
 	@created_at,
 	@updated_at
 )
 `
 
 	args := pgx.StrictNamedArgs{
-		"id":               c.ID,
-		"tenant_id":        scope.GetTenantID(),
-		"organization_id":  c.OrganizationID,
-		"cookie_banner_id": c.CookieBannerID,
-		"name":             c.Name,
-		"slug":             c.Slug,
-		"description":      c.Description,
-		"kind":             c.Kind,
-		"rank":             c.Rank,
-		"created_at":       c.CreatedAt,
-		"updated_at":       c.UpdatedAt,
+		"id":                c.ID,
+		"tenant_id":         scope.GetTenantID(),
+		"organization_id":   c.OrganizationID,
+		"cookie_banner_id":  c.CookieBannerID,
+		"name":              c.Name,
+		"slug":              c.Slug,
+		"description":       c.Description,
+		"kind":              c.Kind,
+		"rank":              c.Rank,
+		"gcm_consent_types": c.GCMConsentTypes,
+		"created_at":        c.CreatedAt,
+		"updated_at":        c.UpdatedAt,
 	}
 
 	_, err := tx.Exec(ctx, q, args)
@@ -339,6 +346,7 @@ SET
 	name = @name,
 	slug = @slug,
 	description = @description,
+	gcm_consent_types = @gcm_consent_types,
 	updated_at = @updated_at
 WHERE
 	%s
@@ -348,11 +356,12 @@ WHERE
 	q = fmt.Sprintf(q, scope.SQLFragment())
 
 	args := pgx.StrictNamedArgs{
-		"id":          c.ID,
-		"name":        c.Name,
-		"slug":        c.Slug,
-		"description": c.Description,
-		"updated_at":  c.UpdatedAt,
+		"id":                c.ID,
+		"name":              c.Name,
+		"slug":              c.Slug,
+		"description":       c.Description,
+		"gcm_consent_types": c.GCMConsentTypes,
+		"updated_at":        c.UpdatedAt,
 	}
 	maps.Copy(args, scope.SQLArguments())
 
@@ -467,6 +476,7 @@ SELECT
 	description,
 	kind,
 	rank,
+	gcm_consent_types,
 	created_at,
 	updated_at
 FROM

--- a/pkg/coredata/cookie_category.go
+++ b/pkg/coredata/cookie_category.go
@@ -469,6 +469,39 @@ WHERE
 	return nil
 }
 
+func (c *CookieCategories) ClearPostHogConsentByBannerID(
+	ctx context.Context,
+	tx pg.Tx,
+	scope Scoper,
+	cookieBannerID gid.GID,
+) error {
+	q := `
+UPDATE cookie_categories
+SET
+	posthog_consent = false,
+	updated_at = @updated_at
+WHERE
+	%s
+	AND cookie_banner_id = @cookie_banner_id
+	AND posthog_consent = true
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"cookie_banner_id": cookieBannerID,
+		"updated_at":       time.Now(),
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := tx.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot clear posthog consent: %w", err)
+	}
+
+	return nil
+}
+
 func (c *CookieCategory) LoadUncategorisedByCookieBannerID(
 	ctx context.Context,
 	conn pg.Querier,

--- a/pkg/coredata/cookie_category.go
+++ b/pkg/coredata/cookie_category.go
@@ -48,6 +48,7 @@ type (
 		Kind            CookieCategoryKind `db:"kind"`
 		Rank            int                `db:"rank"`
 		GCMConsentTypes []string           `db:"gcm_consent_types"`
+		PostHogConsent  bool               `db:"posthog_consent"`
 		CreatedAt       time.Time          `db:"created_at"`
 		UpdatedAt       time.Time          `db:"updated_at"`
 	}
@@ -111,6 +112,7 @@ SELECT
 	kind,
 	rank,
 	gcm_consent_types,
+	posthog_consent,
 	created_at,
 	updated_at
 FROM
@@ -162,6 +164,7 @@ SELECT
 	kind,
 	rank,
 	gcm_consent_types,
+	posthog_consent,
 	created_at,
 	updated_at
 FROM
@@ -241,6 +244,7 @@ SELECT
 	kind,
 	rank,
 	gcm_consent_types,
+	posthog_consent,
 	created_at,
 	updated_at
 FROM
@@ -289,6 +293,7 @@ INSERT INTO cookie_categories (
 	kind,
 	rank,
 	gcm_consent_types,
+	posthog_consent,
 	created_at,
 	updated_at
 ) VALUES (
@@ -302,6 +307,7 @@ INSERT INTO cookie_categories (
 	@kind,
 	@rank,
 	@gcm_consent_types,
+	@posthog_consent,
 	@created_at,
 	@updated_at
 )
@@ -318,6 +324,7 @@ INSERT INTO cookie_categories (
 		"kind":              c.Kind,
 		"rank":              c.Rank,
 		"gcm_consent_types": c.GCMConsentTypes,
+		"posthog_consent":   c.PostHogConsent,
 		"created_at":        c.CreatedAt,
 		"updated_at":        c.UpdatedAt,
 	}
@@ -347,6 +354,7 @@ SET
 	slug = @slug,
 	description = @description,
 	gcm_consent_types = @gcm_consent_types,
+	posthog_consent = @posthog_consent,
 	updated_at = @updated_at
 WHERE
 	%s
@@ -361,6 +369,7 @@ WHERE
 		"slug":              c.Slug,
 		"description":       c.Description,
 		"gcm_consent_types": c.GCMConsentTypes,
+		"posthog_consent":   c.PostHogConsent,
 		"updated_at":        c.UpdatedAt,
 	}
 	maps.Copy(args, scope.SQLArguments())
@@ -477,6 +486,7 @@ SELECT
 	kind,
 	rank,
 	gcm_consent_types,
+	posthog_consent,
 	created_at,
 	updated_at
 FROM

--- a/pkg/coredata/migrations/20260424T093655Z.sql
+++ b/pkg/coredata/migrations/20260424T093655Z.sql
@@ -1,0 +1,16 @@
+-- Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+--
+-- Permission to use, copy, modify, and/or distribute this software for any
+-- purpose with or without fee is hereby granted, provided that the above
+-- copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+-- REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+-- INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+-- LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+-- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+ALTER TABLE cookie_categories ADD COLUMN gcm_consent_types TEXT[] NOT NULL DEFAULT '{}';
+ALTER TABLE cookie_categories ALTER COLUMN gcm_consent_types DROP DEFAULT;

--- a/pkg/coredata/migrations/20260424T112802Z.sql
+++ b/pkg/coredata/migrations/20260424T112802Z.sql
@@ -1,0 +1,16 @@
+-- Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+--
+-- Permission to use, copy, modify, and/or distribute this software for any
+-- purpose with or without fee is hereby granted, provided that the above
+-- copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+-- REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+-- INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+-- LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+-- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+ALTER TABLE cookie_categories ADD COLUMN posthog_consent BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE cookie_categories ALTER COLUMN posthog_consent DROP DEFAULT;

--- a/pkg/coredata/migrations/20260424T122219Z.sql
+++ b/pkg/coredata/migrations/20260424T122219Z.sql
@@ -1,0 +1,17 @@
+-- Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+--
+-- Permission to use, copy, modify, and/or distribute this software for any
+-- purpose with or without fee is hereby granted, provided that the above
+-- copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+-- REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+-- INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+-- LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+-- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+CREATE UNIQUE INDEX idx_cookie_categories_unique_posthog_per_banner
+  ON cookie_categories (cookie_banner_id)
+  WHERE posthog_consent = true;

--- a/pkg/server/api/console/v1/cookie_banner_resolvers.go
+++ b/pkg/server/api/console/v1/cookie_banner_resolvers.go
@@ -458,6 +458,11 @@ func (r *mutationResolver) UpdateCookieCategory(ctx context.Context, input types
 
 	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
 
+	var gcmConsentTypes *[]string
+	if input.GcmConsentTypes != nil {
+		gcmConsentTypes = &input.GcmConsentTypes
+	}
+
 	category, err := r.cookieBanner.UpdateCookieCategory(
 		ctx,
 		scope,
@@ -466,6 +471,7 @@ func (r *mutationResolver) UpdateCookieCategory(ctx context.Context, input types
 			Name:             input.Name,
 			Slug:             input.Slug,
 			Description:      input.Description,
+			GCMConsentTypes:  gcmConsentTypes,
 		},
 	)
 	if err != nil {

--- a/pkg/server/api/console/v1/cookie_banner_resolvers.go
+++ b/pkg/server/api/console/v1/cookie_banner_resolvers.go
@@ -472,6 +472,7 @@ func (r *mutationResolver) UpdateCookieCategory(ctx context.Context, input types
 			Slug:             input.Slug,
 			Description:      input.Description,
 			GCMConsentTypes:  gcmConsentTypes,
+			PostHogConsent:   input.PosthogConsent,
 		},
 	)
 	if err != nil {

--- a/pkg/server/api/console/v1/cookie_banner_resolvers.go
+++ b/pkg/server/api/console/v1/cookie_banner_resolvers.go
@@ -482,6 +482,9 @@ func (r *mutationResolver) UpdateCookieCategory(ctx context.Context, input types
 		if errors.Is(err, cookiebanner.ErrCategorySlugAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
 		}
+		if errors.Is(err, cookiebanner.ErrPostHogConsentKindInvalid) {
+			return nil, gqlutils.Invalid(ctx, err)
+		}
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
 		}

--- a/pkg/server/api/console/v1/graphql/cookie_banner.graphql
+++ b/pkg/server/api/console/v1/graphql/cookie_banner.graphql
@@ -123,6 +123,7 @@ type CookieCategory implements Node {
     description: String!
     kind: CookieCategoryKind!
     rank: Int!
+    gcmConsentTypes: [String!]!
 
     cookies(
         first: Int
@@ -308,6 +309,7 @@ input UpdateCookieCategoryInput {
     name: String
     slug: String
     description: String
+    gcmConsentTypes: [String!]
 }
 
 input DeleteCookieCategoryInput {

--- a/pkg/server/api/console/v1/graphql/cookie_banner.graphql
+++ b/pkg/server/api/console/v1/graphql/cookie_banner.graphql
@@ -124,6 +124,7 @@ type CookieCategory implements Node {
     kind: CookieCategoryKind!
     rank: Int!
     gcmConsentTypes: [String!]!
+    posthogConsent: Boolean!
 
     cookies(
         first: Int
@@ -310,6 +311,7 @@ input UpdateCookieCategoryInput {
     slug: String
     description: String
     gcmConsentTypes: [String!]
+    posthogConsent: Boolean
 }
 
 input DeleteCookieCategoryInput {

--- a/pkg/server/api/console/v1/types/cookie_category.go
+++ b/pkg/server/api/console/v1/types/cookie_category.go
@@ -76,6 +76,7 @@ func NewCookieCategory(c *coredata.CookieCategory) *CookieCategory {
 		Kind:            c.Kind,
 		Rank:            c.Rank,
 		GcmConsentTypes: gcmConsentTypes,
+		PosthogConsent:  c.PostHogConsent,
 		CreatedAt:       c.CreatedAt,
 		UpdatedAt:       c.UpdatedAt,
 	}

--- a/pkg/server/api/console/v1/types/cookie_category.go
+++ b/pkg/server/api/console/v1/types/cookie_category.go
@@ -61,17 +61,22 @@ func NewCookieCategoryEdge(c *coredata.CookieCategory, orderBy coredata.CookieCa
 }
 
 func NewCookieCategory(c *coredata.CookieCategory) *CookieCategory {
+	gcmConsentTypes := c.GCMConsentTypes
+	if gcmConsentTypes == nil {
+		gcmConsentTypes = []string{}
+	}
 	return &CookieCategory{
 		ID: c.ID,
 		CookieBanner: &CookieBanner{
 			ID: c.CookieBannerID,
 		},
-		Name:        c.Name,
-		Slug:        c.Slug,
-		Description: c.Description,
-		Kind:        c.Kind,
-		Rank:        c.Rank,
-		CreatedAt:   c.CreatedAt,
-		UpdatedAt:   c.UpdatedAt,
+		Name:            c.Name,
+		Slug:            c.Slug,
+		Description:     c.Description,
+		Kind:            c.Kind,
+		Rank:            c.Rank,
+		GcmConsentTypes: gcmConsentTypes,
+		CreatedAt:       c.CreatedAt,
+		UpdatedAt:       c.UpdatedAt,
 	}
 }


### PR DESCRIPTION
Closes ENG-287


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Google Consent Mode v2 and PostHog consent integrations to the cookie banner with UI controls, GraphQL fields, DB schema updates, and an SDK plugin system. Categories map to GCM signals and can control PostHog; defaults apply on load and updates propagate automatically (via `gtag` or `window.dataLayer`).

- **New Features**
  - Google Consent Mode v2
    - Store mappings per category in `gcm_consent_types`; included in the published config, exposed via GraphQL; editable in the console with checkboxes and shown as badges.
    - Seed default mappings on banner creation (Analytics → `analytics_storage`, Advertising → `ad_storage`/`ad_user_data`/`ad_personalization`, Necessary → `security_storage`, Functional → `functionality_storage`/`personalization_storage`).
    - SDK sets defaults to denied and pushes updates via `gtag('consent', ...)` or `window.dataLayer`.
  - PostHog
    - `posthog_consent` per category with a partial unique index to allow only one per banner; enforced in the service and exposed via GraphQL; console toggle (NORMAL categories only).
    - Defaults to Analytics on banner creation; SDK opts out on load, then opts in/out based on consent.
  - SDK refactor
    - Introduced `ConsentIntegration` plugin API; default integrations: GCM and PostHog.
  - Minor improvements
    - Avoid duplicate detected cookies with `InsertIfNotExists`.

- **Migration**
  - Run the new DB migrations.
  - Confirm category GCM mappings and which category controls PostHog (default: Analytics). Only one NORMAL category per banner can enable `posthog_consent`.

<sup>Written for commit e48da4dc993fc29511543fd212953eb08f539c77. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



