### PR TITLE
Fix access-review source naming for Google Workspace and Notion

### DIFF
--- a/pkg/accessreview/drivers/name_resolver.go
+++ b/pkg/accessreview/drivers/name_resolver.go
@@ -588,3 +588,42 @@ func NewResendNameResolver() NameResolver {
 func (r *resendNameResolver) ResolveInstanceName(_ context.Context) (string, error) {
 	return "Resend", nil
 }
+
+// notionNameResolver resolves the Notion workspace name via /v1/users/me.
+type notionNameResolver struct {
+	httpClient *http.Client
+}
+
+func NewNotionNameResolver(httpClient *http.Client) NameResolver {
+	return &notionNameResolver{httpClient: httpClient}
+}
+
+func (r *notionNameResolver) ResolveInstanceName(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.notion.com/v1/users/me", nil)
+	if err != nil {
+		return "", fmt.Errorf("cannot create notion users/me request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Notion-Version", notionAPIVersion)
+
+	httpResp, err := r.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("cannot execute notion users/me request: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		return "", fmt.Errorf("cannot fetch notion users/me: unexpected status %d", httpResp.StatusCode)
+	}
+
+	var resp struct {
+		Bot struct {
+			WorkspaceName string `json:"workspace_name"`
+		} `json:"bot"`
+	}
+	if err := json.NewDecoder(httpResp.Body).Decode(&resp); err != nil {
+		return "", fmt.Errorf("cannot decode notion users/me response: %w", err)
+	}
+
+	return resp.Bot.WorkspaceName, nil
+}

--- a/pkg/accessreview/drivers/name_resolver_test.go
+++ b/pkg/accessreview/drivers/name_resolver_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package drivers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// hostRewriter redirects requests to the configured target host so that
+// resolvers with hardcoded production URLs (api.notion.com, etc.) can be
+// pointed at an httptest server.
+type hostRewriter struct {
+	target string
+}
+
+func (h *hostRewriter) RoundTrip(r *http.Request) (*http.Response, error) {
+	u, err := url.Parse(h.target)
+	if err != nil {
+		return nil, err
+	}
+	r2 := r.Clone(r.Context())
+	r2.URL.Scheme = u.Scheme
+	r2.URL.Host = u.Host
+	return http.DefaultTransport.RoundTrip(r2)
+}
+
+func TestNotionNameResolver(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		status  int
+		body    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "bot with workspace_name",
+			status: http.StatusOK,
+			body:   `{"type":"bot","bot":{"workspace_name":"Acme Inc"}}`,
+			want:   "Acme Inc",
+		},
+		{
+			name:   "user token (no bot field)",
+			status: http.StatusOK,
+			body:   `{"type":"person"}`,
+			want:   "",
+		},
+		{
+			name:    "server error",
+			status:  http.StatusInternalServerError,
+			body:    `{"message":"boom"}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "/v1/users/me", r.URL.Path)
+				assert.Equal(t, notionAPIVersion, r.Header.Get("Notion-Version"))
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			client := &http.Client{Transport: &hostRewriter{target: srv.URL}}
+			got, err := NewNotionNameResolver(client).ResolveInstanceName(context.Background())
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/accessreview/drivers/oauth2_scopes.go
+++ b/pkg/accessreview/drivers/oauth2_scopes.go
@@ -33,8 +33,9 @@ var providerOAuth2Scopes = map[coredata.ConnectorProvider][]string{
 		"https://www.googleapis.com/auth/admin.directory.group.member.readonly",
 		"https://www.googleapis.com/auth/admin.directory.customer.readonly",
 	},
-	// Notion and Intercom intentionally omitted: Notion uses extra-auth-params
-	// instead of scopes, Intercom configures scopes at the app level.
+	// Notion and Intercom have no scopes here: Notion authorizes via
+	// extra-auth-params (owner=user), Intercom configures scopes at the app
+	// level.
 }
 
 // ProviderOAuth2Scopes returns the OAuth2 scopes the access review driver

--- a/pkg/accessreview/drivers/oauth2_scopes.go
+++ b/pkg/accessreview/drivers/oauth2_scopes.go
@@ -31,6 +31,7 @@ var providerOAuth2Scopes = map[coredata.ConnectorProvider][]string{
 	coredata.ConnectorProviderGoogleWorkspace: {
 		"https://www.googleapis.com/auth/admin.directory.user.readonly",
 		"https://www.googleapis.com/auth/admin.directory.group.member.readonly",
+		"https://www.googleapis.com/auth/admin.directory.customer.readonly",
 	},
 	// Notion and Intercom intentionally omitted: Notion uses extra-auth-params
 	// instead of scopes, Intercom configures scopes at the app level.

--- a/pkg/accessreview/source_name_worker.go
+++ b/pkg/accessreview/source_name_worker.go
@@ -277,6 +277,8 @@ func (h *sourceNameHandler) buildResolver(
 		return drivers.NewSupabaseNameResolver(supabaseSettings.OrganizationSlug)
 	case coredata.ConnectorProviderIntercom:
 		return drivers.NewIntercomNameResolver(httpClient)
+	case coredata.ConnectorProviderNotion:
+		return drivers.NewNotionNameResolver(httpClient)
 	case coredata.ConnectorProviderResend:
 		return drivers.NewResendNameResolver()
 	default:


### PR DESCRIPTION
Two independent fixes for the access-review source-name worker:

1. **Google Workspace** — the worker calls `Customers.Get("my_customer")` on the Admin SDK, which requires `admin.directory.customer.readonly`. The scope was only wired into the SCIM bridge, not the access-review driver, so name resolution returned 403 and the source kept the generic placeholder. Aligned the access-review scopes with the SCIM bridge.

2. **Notion** — the only wired access-review connector without a `NameResolver`, so the source stayed as the literal `"Notion"`. Added a resolver that calls `GET /v1/users/me` and reads `bot.workspace_name`, matching the pattern of the 14 other resolvers. The endpoint was already registered as Notion's probe URL; the `Notion-Version` constant was already available in the `drivers` package.

## Test plan

- [x] `go test ./pkg/accessreview/drivers/ -run TestNotionNameResolver` (new; 3 sub-tests: bot with workspace_name, user token, server error)
- [ ] Sandbox: connect a fresh Google Workspace connector, verify `access_sources.name` becomes `"Google Workspace <domain>"` within one worker poll (~10 s)
- [ ] Sandbox: connect a fresh Notion connector, verify `access_sources.name` becomes `"Notion <workspace>"` within one worker poll (~10 s)
- [ ] Existing Google Workspace connectors authorized before this change will need to reconnect to pick up the new scope — on failure the worker just re-queues the row (no data loss, just log noise)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes source naming in the `access-review` worker for Google Workspace and Notion. Adds the missing Google Admin scope and a Notion resolver so sources show the correct instance names.

- **Bug Fixes**
  - Google Workspace: request `admin.directory.customer.readonly` in the `access-review` driver so `Customers.Get("my_customer")` succeeds and the primary domain is shown.
  - Notion: add a name resolver that calls `GET /v1/users/me` and reads `bot.workspace_name`, then wire it into the worker.

- **Migration**
  - Existing Google Workspace connectors must reconnect to grant the new scope for name sync to work.

<sup>Written for commit c43445d487a64b45cfa82d9d9df108eed1acb575. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

