### PR TITLE
Cookie banner sdk panel fix

### DIFF
--- a/packages/cookie-banner/README.md
+++ b/packages/cookie-banner/README.md
@@ -1,28 +1,102 @@
 # @probo/cookie-banner
 
-A lightweight, GDPR-compliant cookie consent banner for the web. Works with any framework or plain HTML — zero dependencies, powered by Web Components.
+A lightweight, dependency-free cookie consent banner built on Web Components. Bundle it with your app as an ES module, use it headless with full UI control, or drop it in with a single script tag. Works with any framework or plain HTML.
+
+Supports opt-in (GDPR, ePrivacy) and opt-out (CCPA/CPRA) consent modes, per-category cookie controls, third-party resource blocking, Google Consent Mode v2, PostHog integration, and multi-language support out of the box.
 
 ## Installation
+
+There are three ways to use the SDK:
+
+### Script Tag (IIFE)
+
+No bundler required — add a single `<script>` tag:
+
+```html
+<script
+  src="https://cdn.jsdelivr.net/npm/@probo/cookie-banner/dist/cookie-banner.iife.js"
+  data-banner-id="YOUR_BANNER_ID"
+  data-base-url="https://your-probo-instance.com/api/cookie-banner/v1/"
+  data-position="bottom-left"
+></script>
+```
+
+This renders a fully styled consent dialog and a floating settings button automatically.
+
+### ES Module (Themed Banner)
+
+For bundled applications (React, Vue, Svelte, Next.js, etc.):
 
 ```bash
 npm install @probo/cookie-banner
 ```
 
-Or drop a single `<script>` tag — no bundler required:
+```js
+import { registerThemedBanner } from "@probo/cookie-banner";
+
+registerThemedBanner();
+```
 
 ```html
-<script
-  src="https://unpkg.com/@probo/cookie-banner/dist/cookie-banner.iife.js"
-  data-banner-id="YOUR_BANNER_ID"
-  data-base-url="BASE_URL"
-></script>
+<probo-cookie-banner
+  banner-id="YOUR_BANNER_ID"
+  base-url="https://your-probo-instance.com/api/cookie-banner/v1/"
+  position="bottom-left"
+></probo-cookie-banner>
 ```
+
+See [Theming](https://www.getprobo.com/docs/product/cookie-banner/theming) to customize colors, fonts, and styling with CSS custom properties.
+
+### Headless Components
+
+For complete control over the consent UI, use the unstyled Web Component building blocks:
+
+```js
+import { registerComponents } from "@probo/cookie-banner/headless";
+
+registerComponents();
+```
+
+```html
+<probo-cookie-banner-root banner-id="YOUR_BANNER_ID" base-url="BASE_URL">
+  <probo-banner>
+    <div class="my-banner">
+      <p>We use cookies to improve your experience.</p>
+      <probo-accept-button><button>Accept all</button></probo-accept-button>
+      <probo-reject-button><button>Reject all</button></probo-reject-button>
+      <probo-customize-button><button>Customize</button></probo-customize-button>
+    </div>
+  </probo-banner>
+
+  <probo-preference-panel>
+    <div class="my-preferences">
+      <probo-category-list>
+        <template>
+          <div class="category">
+            <span data-slot="name"></span>
+            <span data-slot="description"></span>
+            <probo-category-toggle><input type="checkbox" /></probo-category-toggle>
+          </div>
+        </template>
+      </probo-category-list>
+      <probo-save-button><button>Save preferences</button></probo-save-button>
+    </div>
+  </probo-preference-panel>
+</probo-cookie-banner-root>
+```
+
+## Key Features
+
+- **Multi-regulation compliance** — Supports opt-in (GDPR, ePrivacy) and opt-out (CCPA/CPRA) consent modes, Global Privacy Control (GPC) detection, and per-category cookie controls.
+- **Consent audit trail** — Every consent action is recorded server-side with anonymized IP, user agent, per-category choices, and a reference to the exact banner version the visitor saw.
+- **Third-party blocking** — Automatically prevents scripts, iframes, images, and other resources from loading until the visitor grants consent for the matching category.
+- **Built-in integrations** — Syncs consent state with Google Consent Mode v2 and PostHog automatically.
+- **Multi-language support** — Built-in translations for English, French, German, and Spanish. The SDK auto-detects the visitor's language from the page or browser.
+- **Theming** — Match your brand with CSS custom properties for colors, fonts, border radius, and more. Supports dark mode.
 
 ## Documentation
 
-Full documentation — including theming, headless components, and script blocking — is available at:
-
-**https://www.getprobo.com/docs/product/cookie-banner/overview**
+Full documentation is available at **https://www.getprobo.com/docs/product/cookie-banner/overview**
 
 ## License
 

--- a/packages/cookie-banner/package.json
+++ b/packages/cookie-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@probo/cookie-banner",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Probo cookie consent banner SDK",
   "type": "module",
   "main": "dist/cookie-banner.mjs",
@@ -10,14 +10,13 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/cookie-banner.mjs",
-      "default": "./dist/cookie-banner.mjs"
+      "default": "./dist/cookie-banner.iife.js"
     },
     "./headless": {
       "types": "./dist/headless/index.d.ts",
       "import": "./dist/cookie-banner-headless.mjs",
       "default": "./dist/cookie-banner-headless.mjs"
-    },
-    "./iife": "./dist/cookie-banner.iife.js"
+    }
   },
   "scripts": {
     "build": "node build.mjs && tsc --emitDeclarationOnly",

--- a/packages/cookie-banner/package.json
+++ b/packages/cookie-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@probo/cookie-banner",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Probo cookie consent banner SDK",
   "type": "module",
   "main": "dist/cookie-banner.mjs",

--- a/packages/cookie-banner/package.json
+++ b/packages/cookie-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@probo/cookie-banner",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Probo cookie consent banner SDK",
   "type": "module",
   "main": "dist/cookie-banner.mjs",

--- a/packages/cookie-banner/src/components/cookie-list.ts
+++ b/packages/cookie-banner/src/components/cookie-list.ts
@@ -13,7 +13,7 @@
 // PERFORMANCE OF THIS SOFTWARE.
 
 import type { CookieItem } from "../client";
-import { getCookieDetailLabels, interpolate } from "../i18n";
+import { getCookieDetailLabels } from "../i18n";
 import { ProboElement } from "./base";
 import type { ProboCategory } from "./category";
 import type { ProboCookieBannerRoot } from "./cookie-banner-root";
@@ -90,9 +90,13 @@ export class ProboCookieList extends ProboElement {
       const value = values[slotName] ?? "";
       const tpl = labels[key];
       if (tpl) {
-        el.textContent = interpolate(tpl, { value });
         const slot = el.querySelector(`[data-slot="${slotName}"]`);
-        if (slot) slot.remove();
+        const parts = tpl.split("{{value}}");
+        el.textContent = parts[0] ?? "";
+        if (slot) {
+          slot.textContent = value;
+          el.appendChild(slot);
+        }
       }
     }
   }

--- a/packages/cookie-banner/src/themed-banner/styles.ts
+++ b/packages/cookie-banner/src/themed-banner/styles.ts
@@ -43,6 +43,7 @@ export const THEMED_STYLES = `
     position: fixed;
     z-index: var(--_z-index);
     padding: 24px;
+    max-width: 100vw;
     display: flex;
     pointer-events: none;
   }
@@ -155,6 +156,7 @@ export const THEMED_STYLES = `
     border: none;
     color: var(--_accent);
     text-decoration: underline;
+    padding: 8px 0;
   }
 
   .btn-primary {
@@ -211,7 +213,7 @@ export const THEMED_STYLES = `
   probo-category {
     display: block;
     border-bottom: 1px solid var(--_border);
-    padding: 12px 40px 12px 60px;
+    padding: 12px 40px;
     position: relative;
   }
 
@@ -239,12 +241,6 @@ export const THEMED_STYLES = `
     color: var(--_text-secondary);
     font-size: calc(var(--_font-size) - 1px);
     margin-top: 2px;
-  }
-
-  .category-required {
-    font-size: calc(var(--_font-size) - 2px);
-    color: var(--_text-secondary);
-    font-style: italic;
   }
 
   .toggle {
@@ -300,7 +296,7 @@ export const THEMED_STYLES = `
 
   .cookie-toggle {
     position: absolute;
-    left: 36px;
+    left: 16px;
     top: 14px;
     background: none;
     border: none;
@@ -349,17 +345,20 @@ export const THEMED_STYLES = `
   }
 
   .cookie-name {
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
     font-weight: 500;
     font-family: monospace;
   }
 
   .cookie-detail {
-    color: var(--_text-secondary);
+    font-weight: 500;
   }
 
-  .cookie-label {
-    font-weight: 500;
-    color: var(--_text);
+  .cookie-detail > span {
+    font-weight: 400;
   }
 
   .branding {

--- a/packages/cookie-banner/src/themed-banner/styles.ts
+++ b/packages/cookie-banner/src/themed-banner/styles.ts
@@ -354,10 +354,12 @@ export const THEMED_STYLES = `
   }
 
   .cookie-detail {
+    color: var(--_text);
     font-weight: 500;
   }
 
-  .cookie-detail > span {
+  .cookie-detail > span:last-child {
+    color: var(--_text-secondary);
     font-weight: 400;
   }
 


### PR DESCRIPTION
Closes ENG-343

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes panel rendering in `@probo/cookie-banner` (ENG-343): detail labels now render with slotted values, long cookie names are truncated, and label colors are corrected. Also switches the default export to the IIFE build and expands the README with script tag, ESM, and headless usage.

- **Bug Fixes**
  - Render cookie detail templates using the slotted element; place `{{value}}` without removing the slot.
  - UI tweaks: `max-width: 100vw`, ellipsis on `.cookie-name`, adjusted link/category padding, smaller cookie toggle offset, and refined detail colors/weights.

- **Dependencies**
  - Bump `@probo/cookie-banner` to 0.0.4 and set the main default export to the IIFE bundle; remove the `./iife` subpath.

<sup>Written for commit abafd817a86ece51b094e686d22cda9c67f6ae0e. Summary will update on new commits. <a href="https://cubic.dev/pr/getprobo/probo/pull/1108?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

