### PR TITLE
Cookie banner - Send SDK version as X-SDK-Version header

### DIFF
--- a/packages/cookie-banner/src/client.ts
+++ b/packages/cookie-banner/src/client.ts
@@ -288,7 +288,6 @@ export class CookieBannerClient {
       version: cfg.version,
       action,
       consent_data: consentData,
-      sdk_version: __SDK_VERSION__,
     };
     void fetchJSON<ConsentRecord>(url, { method: "POST", body })
       .then(() => void flush(this.bannerId))

--- a/packages/cookie-banner/src/http.ts
+++ b/packages/cookie-banner/src/http.ts
@@ -120,6 +120,7 @@ export async function fetchJSON<T>(
     credentials: "omit",
     headers: {
       Accept: "application/json",
+      "X-SDK-Version": __SDK_VERSION__,
       ...(body !== undefined && { "Content-Type": "application/json" }),
       ...headers,
     },

--- a/pkg/server/api/cookiebanner/v1/cors_middleware.go
+++ b/pkg/server/api/cookiebanner/v1/cors_middleware.go
@@ -66,7 +66,7 @@ func newCORSMiddleware(logger *log.Logger, cookieBannerSvc *cookiebanner.Service
 
 				w.Header().Set("Access-Control-Allow-Origin", origin)
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-				w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+				w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-SDK-Version")
 				w.Header().Set("Access-Control-Max-Age", "600")
 				w.Header().Set("Vary", "Origin")
 

--- a/pkg/server/api/cookiebanner/v1/handler.go
+++ b/pkg/server/api/cookiebanner/v1/handler.go
@@ -122,7 +122,6 @@ type (
 		Version     int                          `json:"version"`
 		Action      coredata.CookieConsentAction `json:"action"`
 		ConsentData json.RawMessage              `json:"consent_data"`
-		SdkVersion  string                       `json:"sdk_version"`
 	}
 
 	postConsentResponse struct {
@@ -148,6 +147,7 @@ func (h *Handler) handlePostConsent(w http.ResponseWriter, r *http.Request) {
 
 	ip := clientip.Extract(r)
 	ua := r.UserAgent()
+	sdkVersion := r.Header.Get("X-SDK-Version")
 
 	req := cookiebanner.RecordConsentRequest{
 		Version:     body.Version,
@@ -156,7 +156,7 @@ func (h *Handler) handlePostConsent(w http.ResponseWriter, r *http.Request) {
 		UserAgent:   &ua,
 		ConsentData: body.ConsentData,
 		Action:      body.Action,
-		SdkVersion:  body.SdkVersion,
+		SdkVersion:  sdkVersion,
 	}
 
 	record, err := h.cookieBannerSvc.RecordConsent(r.Context(), bannerID, req)


### PR DESCRIPTION
Closes ENG-345

Move the cookie-banner SDK version from the POST consents request body to a custom X-SDK-Version header sent on every API call. The server now reads it from the header and the CORS middleware allows it through preflight.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send the cookie-banner SDK version in an `X-SDK-Version` header on every API call and read it on the server. Removes `sdk_version` from the consents POST body and updates CORS to allow the header (ENG-345).

- **Migration**
  - SDK users: no changes; the header is sent automatically by `packages/cookie-banner`.
  - Direct API clients: send `X-SDK-Version` and stop sending `sdk_version` in the POST body.

<sup>Written for commit b7a28573f750191c77441cfada317a813e4c591a. Summary will update on new commits. <a href="https://cubic.dev/pr/getprobo/probo/pull/1109?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

