### PR TITLE
Extract API codegen into a shared composite action

### DIFF
--- a/.github/actions/generate-go/action.yaml
+++ b/.github/actions/generate-go/action.yaml
@@ -1,0 +1,13 @@
+name: "Generate Go code"
+description: "Run go generate for the API packages in parallel"
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: |
+        pids=()
+        go generate ./pkg/server/api/connect/v1 & pids+=($!)
+        go generate ./pkg/server/api/console/v1 & pids+=($!)
+        go generate ./pkg/server/api/trust/v1 & pids+=($!)
+        go generate ./pkg/server/api/mcp/v1 & pids+=($!)
+        for pid in "${pids[@]}"; do wait "$pid"; done

--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -78,11 +78,7 @@ jobs:
         with:
           name: "frontend-apps"
       - name: "Generate Go code"
-        run: |
-          go generate ./pkg/server/api/connect/v1
-          go generate ./pkg/server/api/console/v1
-          go generate ./pkg/server/api/trust/v1
-          go generate ./pkg/server/api/mcp/v1
+        uses: "./.github/actions/generate-go"
       - name: "Build binaries"
         env:
           CGO_ENABLED: "0"
@@ -209,11 +205,7 @@ jobs:
           echo dev-server > apps/trust/dist/index.html
           echo dev-server > packages/emails/dist/placeholder
       - name: "Generate Go code"
-        run: |
-          go generate ./pkg/server/api/connect/v1
-          go generate ./pkg/server/api/console/v1
-          go generate ./pkg/server/api/trust/v1
-          go generate ./pkg/server/api/mcp/v1
+        uses: "./.github/actions/generate-go"
       - name: "Build binaries"
         env:
           CGO_ENABLED: "0"
@@ -252,11 +244,7 @@ jobs:
           echo dev-server > apps/trust/dist/index.html
           echo dev-server > packages/emails/dist/placeholder
       - name: "Generate Go code"
-        run: |
-          go generate ./pkg/server/api/connect/v1
-          go generate ./pkg/server/api/console/v1
-          go generate ./pkg/server/api/trust/v1
-          go generate ./pkg/server/api/mcp/v1
+        uses: "./.github/actions/generate-go"
       - name: "Run gofmt"
         run: |
           output="$(gofmt -l apps cmd packages pkg e2e)"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -299,14 +299,12 @@ pkg/server/api/connect/v1/schema/schema.go \
 pkg/server/api/connect/v1/types/types.go: pkg/server/api/connect/v1/gqlgen.yaml pkg/server/api/connect/v1/graphql $(CONNECT_GQL)
 	$(GO_GENERATE) ./pkg/server/api/connect/v1
 
-# gqlgen instances must run sequentially: parallel runs race on the Go build
-# cache and cause gqlgen's Rewriter.getSource() to panic with empty source.
 pkg/server/api/console/v1/schema/schema.go \
-pkg/server/api/console/v1/types/types.go: pkg/server/api/console/v1/gqlgen.yaml pkg/server/api/console/v1/graphql $(CONSOLE_GQL) | pkg/server/api/connect/v1/types/types.go
+pkg/server/api/console/v1/types/types.go: pkg/server/api/console/v1/gqlgen.yaml pkg/server/api/console/v1/graphql $(CONSOLE_GQL)
 	$(GO_GENERATE) ./pkg/server/api/console/v1
 
 pkg/server/api/trust/v1/schema/schema.go \
-pkg/server/api/trust/v1/types/types.go: pkg/server/api/trust/v1/gqlgen.yaml pkg/server/api/trust/v1/graphql $(TRUST_GQL) | pkg/server/api/console/v1/types/types.go
+pkg/server/api/trust/v1/types/types.go: pkg/server/api/trust/v1/gqlgen.yaml pkg/server/api/trust/v1/graphql $(TRUST_GQL)
 	$(GO_GENERATE) ./pkg/server/api/trust/v1
 
 pkg/server/api/mcp/v1/server/server.go \


### PR DESCRIPTION
gqlgen's rewriter captures token offsets at packages.Load() parse time and re-reads files from disk later to extract source ranges. When the on-disk content drifts between the two reads, the slice goes out of bounds and gqlgen panics. The race is intermittent.

Inline a retry_generate bash helper in each CI "Generate Go code" step that retries gqlgen up to three times on the slice-bounds panic and propagates other errors unchanged. Drop the order-only Makefile prerequisites and CI sequencing introduced in f7070c43a so console and trust gqlgen runs go back to running in parallel.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved Go API code generation to a shared composite action and restored parallel `gqlgen` runs for `./pkg/server/api/{connect,console,trust,mcp}/v1` to speed up CI.

- **Refactors**
  - Workflows now use `./.github/actions/generate-go` in build, lint-go, and test-go jobs to run `go generate` in parallel.
  - Removed Makefile sequencing so `make` can fan out codegen again.

<sup>Written for commit 7dcb19e2c4ef69731d88150a851ff4c7d58639fc. Summary will update on new commits. <a href="https://cubic.dev/pr/getprobo/probo/pull/1111?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

