### PR TITLE
Fix copy paste in rich editor

### DIFF
--- a/packages/ui/src/RichEditor/MarkdownPasteExtension.ts
+++ b/packages/ui/src/RichEditor/MarkdownPasteExtension.ts
@@ -18,6 +18,10 @@ export const MarkdownPasteExtension = Extension.create({
         key: markdownPasteKey,
         props: {
           handlePaste(view, event) {
+            if (event.clipboardData?.getData("text/html")) {
+              return false;
+            }
+
             const text = event.clipboardData?.getData("text/plain") ?? "";
             if (!hasMarkdown(text)) {
               return false;


### PR DESCRIPTION
Closes ENG-306

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes paste in the rich editor so HTML isn’t converted to Markdown. Pasting from web apps preserves formatting; only plain-text Markdown is processed (ENG-306).

<sup>Written for commit e473884b31ea7a9e6820992b7f76abb2791cf3b1. Summary will update on new commits. <a href="https://cubic.dev/pr/getprobo/probo/pull/1115?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to paste handling logic; main risk is edge cases where some clipboards provide both HTML and plain text and Markdown conversion will no longer run.
> 
> **Overview**
> Updates `MarkdownPasteExtension.handlePaste` to *bail out early* when the clipboard contains `text/html`, so the editor’s native HTML paste path runs instead of converting the content to Markdown.
> 
> Markdown parsing is now only applied for plain-text pastes that contain Markdown syntax.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e473884b31ea7a9e6820992b7f76abb2791cf3b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->