### PR TITLE
Invalidate sessions on password change and reset

### DIFF
--- a/pkg/coredata/session.go
+++ b/pkg/coredata/session.go
@@ -343,6 +343,30 @@ WHERE
 	return result.RowsAffected(), nil
 }
 
+func (s *Sessions) ExpireAllForIdentity(ctx context.Context, conn pg.Querier, identityID gid.GID) (int64, error) {
+	q := `
+UPDATE iam_sessions
+SET
+    expired_at = NOW(),
+    updated_at = NOW(),
+    expire_reason = 'revoked'
+WHERE
+    identity_id = @identity_id
+    AND expire_reason IS NULL
+`
+
+	args := pgx.StrictNamedArgs{
+		"identity_id": identityID,
+	}
+
+	result, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return 0, fmt.Errorf("cannot query sessions: %w", err)
+	}
+
+	return result.RowsAffected(), nil
+}
+
 func (s *Session) LoadByRootSessionIDAndMembershipID(
 	ctx context.Context,
 	conn pg.Querier,

--- a/pkg/iam/account_service.go
+++ b/pkg/iam/account_service.go
@@ -235,7 +235,7 @@ func (s *AccountService) ListPendingInvitations(
 	return page.NewPage(invitations, cursor), nil
 }
 
-func (s AccountService) ChangePassword(ctx context.Context, identityID gid.GID, req *ChangePasswordRequest) error {
+func (s AccountService) ChangePassword(ctx context.Context, identityID gid.GID, currentSessionID gid.GID, req *ChangePasswordRequest) error {
 	if err := req.Validate(); err != nil {
 		return fmt.Errorf("invalid request: %w", err)
 	}
@@ -273,6 +273,11 @@ func (s AccountService) ChangePassword(ctx context.Context, identityID gid.GID, 
 			err = identity.Update(ctx, tx)
 			if err != nil {
 				return fmt.Errorf("cannot update identity: %w", err)
+			}
+
+			sessions := coredata.Sessions{}
+			if _, err := sessions.ExpireAllForIdentityExceptOneSession(ctx, tx, identity.ID, currentSessionID); err != nil {
+				return fmt.Errorf("cannot expire other sessions: %w", err)
 			}
 
 			// TODO: email to notify identity that their password has been changed

--- a/pkg/iam/auth_service.go
+++ b/pkg/iam/auth_service.go
@@ -279,6 +279,11 @@ func (s AuthService) ResetPassword(
 				return fmt.Errorf("cannot update identity: %w", err)
 			}
 
+			sessions := coredata.Sessions{}
+			if _, err := sessions.ExpireAllForIdentity(ctx, tx, identity.ID); err != nil {
+				return fmt.Errorf("cannot expire sessions: %w", err)
+			}
+
 			return nil
 		},
 	)

--- a/pkg/server/api/connect/v1/session_resolvers.go
+++ b/pkg/server/api/connect/v1/session_resolvers.go
@@ -318,10 +318,12 @@ func (r *mutationResolver) VerifyEmail(ctx context.Context, input types.VerifyEm
 // ChangePassword is the resolver for the changePassword field.
 func (r *mutationResolver) ChangePassword(ctx context.Context, input types.ChangePasswordInput) (*types.ChangePasswordPayload, error) {
 	identity := authn.IdentityFromContext(ctx)
+	session := authn.SessionFromContext(ctx)
 
 	err := r.iam.AccountService.ChangePassword(
 		ctx,
 		identity.ID,
+		session.ID,
 		&iam.ChangePasswordRequest{
 			CurrentPassword: input.CurrentPassword,
 			NewPassword:     input.NewPassword,


### PR DESCRIPTION
## Summary

A user reported (v0.166.0) that being logged in on Browser A and Browser B, then changing their password from Browser A, did not log Browser B out. They expected credential rotation to invalidate the credential everywhere it was in use.

Confirmed: session validity was decoupled from credential rotation. The session middleware only checks the `iam_sessions` row (`expire_reason`, `expired_at`); it does not consult any password version on the identity. Neither `AccountService.ChangePassword` nor `AuthService.ResetPassword` touched the sessions table, so existing cookies stayed valid until their idle TTL after a password rotation. The same gap meant a forgot-password reset did not evict any session of the targeted identity.

This PR closes the gap by expiring sessions atomically with the password update:

- `Sessions.ExpireAllForIdentity` added in `pkg/coredata/session.go` (sibling of the existing `ExpireAllForIdentityExceptOneSession`, with no exclusion).
- `AccountService.ChangePassword` now takes the caller's `currentSessionID` and, inside the same transaction as the `iam_identities` update, revokes all other sessions for the identity. The current session is preserved so the user is not kicked out of the browser they just used.
- `AuthService.ResetPassword` (forgot-password completion, no caller session) revokes ALL of the identity's active sessions in the same transaction.
- `ChangePassword` resolver pulls the current session via `authn.SessionFromContext(ctx)` and forwards its ID to the service.

Same-transaction revocation guarantees the password is not rotated unless the eviction also succeeds. The session middleware already treats `expire_reason = 'revoked'` as expired, so Browser B is kicked out on its next request without any middleware changes.

## Test plan

- [ ] Log in on Browser A and Browser B with the same account; change password in A; confirm B is logged out on next request and A stays logged in.
- [ ] Trigger forgot-password from Browser A while logged in on Browsers B and C; complete the reset from the email link; confirm both B and C are logged out on next request.
- [ ] `revokeAllSessions` GraphQL mutation still works (regression check on shared `Sessions.ExpireAllForIdentityExceptOneSession`).
- [ ] Failed password update (e.g. wrong current password) does not revoke any session (transaction rollback).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Invalidate active sessions on password change and reset so other devices are logged out immediately. Password change keeps the current browser session; reset logs out every session.

- **Bug Fixes**
  - Added `Sessions.ExpireAllForIdentity` in `pkg/coredata` to revoke all sessions for an identity.
  - Updated `AccountService.ChangePassword` to accept `currentSessionID` and revoke other sessions in the same transaction.
  - Updated `AuthService.ResetPassword` to revoke all sessions in the same transaction.
  - Resolver in `pkg/server/api/connect/v1` now forwards the current session ID.

<sup>Written for commit 62f05b3ff2f27784709b9bb09f642fefb451c8d0. Summary will update on new commits. <a href="https://cubic.dev/pr/getprobo/probo/pull/1116?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication/session invalidation logic and changes the `ChangePassword` service signature; mistakes could incorrectly log users out or fail to revoke sessions.
> 
> **Overview**
> Ensures credential rotation immediately invalidates existing sessions. Password reset now revokes *all* active sessions for the identity in the same transaction as the password update.
> 
> Password change now preserves the caller’s current session while revoking all other sessions: `AccountService.ChangePassword` accepts `currentSessionID`, and the GraphQL `changePassword` resolver forwards it from `authn.SessionFromContext`. Adds `Sessions.ExpireAllForIdentity` to support full-session revocation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62f05b3ff2f27784709b9bb09f642fefb451c8d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->