### PR TITLE
Introspect OAuth2 refresh tokens

### DIFF
--- a/e2e/console/oauth2_test.go
+++ b/e2e/console/oauth2_test.go
@@ -785,6 +785,171 @@ func TestOAuth2_Introspect(t *testing.T) {
 			assert.Equal(t, http.StatusUnauthorized, raw.StatusCode)
 		},
 	)
+
+	t.Run(
+		"active refresh token",
+		func(t *testing.T) {
+			t.Parallel()
+
+			client := factory.CreateOAuth2Client(owner, nil)
+			redirectURI := "http://localhost:9999/callback"
+
+			tokens := testutil.OAuth2PerformAuthorizationCodeFlow(
+				t,
+				owner,
+				client.ClientID,
+				client.ClientSecret,
+				redirectURI,
+			)
+			require.NotEmpty(t, tokens.RefreshToken,
+				"authorization code flow must mint a refresh token")
+
+			introspect, raw, err := testutil.OAuth2Introspect(
+				owner,
+				client.ClientID,
+				client.ClientSecret,
+				tokens.RefreshToken,
+			)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, raw.StatusCode)
+
+			assert.True(t, introspect.Active,
+				"valid refresh token must introspect as active")
+			assert.Empty(t, introspect.TokenType,
+				"refresh tokens have no OAuth2 token_type per RFC 6749 §5.1")
+			assert.Equal(t, client.ClientID, introspect.ClientID)
+			assert.NotEmpty(t, introspect.Sub)
+			assert.Greater(t, introspect.Exp, int64(0))
+			assert.NotEmpty(t, introspect.Scope)
+		},
+	)
+
+	t.Run(
+		"refresh token with matching hint",
+		func(t *testing.T) {
+			t.Parallel()
+
+			client := factory.CreateOAuth2Client(owner, nil)
+			redirectURI := "http://localhost:9999/callback"
+
+			tokens := testutil.OAuth2PerformAuthorizationCodeFlow(
+				t,
+				owner,
+				client.ClientID,
+				client.ClientSecret,
+				redirectURI,
+			)
+
+			introspect, raw, err := testutil.OAuth2IntrospectWithHint(
+				owner,
+				client.ClientID,
+				client.ClientSecret,
+				tokens.RefreshToken,
+				"refresh_token",
+			)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, raw.StatusCode)
+			assert.True(t, introspect.Active)
+		},
+	)
+
+	t.Run(
+		"access token still resolves with refresh_token hint",
+		func(t *testing.T) {
+			t.Parallel()
+
+			client := factory.CreateOAuth2Client(owner, nil)
+			redirectURI := "http://localhost:9999/callback"
+
+			tokens := testutil.OAuth2PerformAuthorizationCodeFlow(
+				t,
+				owner,
+				client.ClientID,
+				client.ClientSecret,
+				redirectURI,
+			)
+
+			introspect, raw, err := testutil.OAuth2IntrospectWithHint(
+				owner,
+				client.ClientID,
+				client.ClientSecret,
+				tokens.AccessToken,
+				"refresh_token",
+			)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, raw.StatusCode)
+			assert.True(t, introspect.Active,
+				"hint is advisory, server must fall back to other token types")
+			assert.Equal(t, "Bearer", introspect.TokenType)
+		},
+	)
+
+	t.Run(
+		"revoked refresh token is inactive",
+		func(t *testing.T) {
+			t.Parallel()
+
+			client := factory.CreateOAuth2Client(owner, nil)
+			redirectURI := "http://localhost:9999/callback"
+
+			tokens := testutil.OAuth2PerformAuthorizationCodeFlow(
+				t,
+				owner,
+				client.ClientID,
+				client.ClientSecret,
+				redirectURI,
+			)
+
+			revokeRaw, err := testutil.OAuth2RevokeWithHint(
+				owner,
+				client.ClientID,
+				client.ClientSecret,
+				tokens.RefreshToken,
+				"refresh_token",
+			)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, revokeRaw.StatusCode)
+
+			introspect, _, err := testutil.OAuth2Introspect(
+				owner,
+				client.ClientID,
+				client.ClientSecret,
+				tokens.RefreshToken,
+			)
+			require.NoError(t, err)
+			assert.False(t, introspect.Active,
+				"revoked refresh token must introspect as inactive")
+		},
+	)
+
+	t.Run(
+		"refresh token from different client is inactive",
+		func(t *testing.T) {
+			t.Parallel()
+
+			clientA := factory.CreateOAuth2Client(owner, nil)
+			clientB := factory.CreateOAuth2Client(owner, nil)
+			redirectURI := "http://localhost:9999/callback"
+
+			tokens := testutil.OAuth2PerformAuthorizationCodeFlow(
+				t,
+				owner,
+				clientA.ClientID,
+				clientA.ClientSecret,
+				redirectURI,
+			)
+
+			introspect, _, err := testutil.OAuth2Introspect(
+				owner,
+				clientB.ClientID,
+				clientB.ClientSecret,
+				tokens.RefreshToken,
+			)
+			require.NoError(t, err)
+			assert.False(t, introspect.Active,
+				"refresh token must only be introspectable by its issuing client")
+		},
+	)
 }
 
 // ---------------------------------------------------------------------------

--- a/e2e/internal/testutil/oauth2.go
+++ b/e2e/internal/testutil/oauth2.go
@@ -718,8 +718,21 @@ func OAuth2Introspect(
 	c *Client,
 	clientID, clientSecret, token string,
 ) (*OAuth2IntrospectResponse, *OAuth2HTTPResponse, error) {
+	return OAuth2IntrospectWithHint(c, clientID, clientSecret, token, "")
+}
+
+// OAuth2IntrospectWithHint introspects a token with an optional
+// token_type_hint per RFC 7662.
+func OAuth2IntrospectWithHint(
+	c *Client,
+	clientID, clientSecret, token, tokenTypeHint string,
+) (*OAuth2IntrospectResponse, *OAuth2HTTPResponse, error) {
 	values := url.Values{
 		"token": {token},
+	}
+
+	if tokenTypeHint != "" {
+		values.Set("token_type_hint", tokenTypeHint)
 	}
 
 	raw, err := postFormWithBasicAuth(

--- a/pkg/iam/oauth2server/service.go
+++ b/pkg/iam/oauth2server/service.go
@@ -111,6 +111,15 @@ type (
 		IDToken      string
 		Scope        string
 	}
+
+	IntrospectResult struct {
+		ClientID   gid.GID
+		IdentityID gid.GID
+		Scopes     coredata.OAuth2Scopes
+		IssuedAt   time.Time
+		ExpiresAt  time.Time
+		TokenType  string
+	}
 )
 
 func WithAccessTokenDuration(d time.Duration) Option {
@@ -1142,35 +1151,103 @@ func (s *Service) LoadAccessToken(ctx context.Context, tokenValue string) (*core
 	return &token, nil
 }
 
-func (s *Service) IntrospectToken(ctx context.Context, clientID gid.GID, tokenValue string) (*coredata.OAuth2AccessToken, error) {
+// IntrospectToken looks up the token (access or refresh) bound to clientID and
+// returns its claims when active. It supports the optional token_type_hint
+// from RFC 7662 §2.1: when set, the hinted table is searched first and the
+// other one is used as a fallback. A nil result means the token is unknown,
+// expired, revoked, or does not belong to clientID and must be reported as
+// inactive.
+func (s *Service) IntrospectToken(
+	ctx context.Context,
+	clientID gid.GID,
+	tokenValue string,
+	tokenTypeHint *coredata.OAuth2TokenTypeHint,
+) (*IntrospectResult, error) {
 	var (
-		hashedValue = hash.SHA256String(tokenValue)
-		token       = coredata.OAuth2AccessToken{}
-		now         = time.Now()
+		hashedValue  = hash.SHA256String(tokenValue)
+		now          = time.Now()
+		accessToken  = coredata.OAuth2AccessToken{}
+		refreshToken = coredata.OAuth2RefreshToken{}
+		hasAccess    bool
+		hasRefresh   bool
 	)
+
+	loadAccess := func(ctx context.Context, conn pg.Querier) error {
+		if err := accessToken.LoadByHashedValueAndClientID(ctx, conn, hashedValue, clientID); err != nil {
+			if errors.Is(err, coredata.ErrResourceNotFound) {
+				return nil
+			}
+			return fmt.Errorf("cannot load access token: %w", err)
+		}
+		hasAccess = true
+		return nil
+	}
+
+	loadRefresh := func(ctx context.Context, conn pg.Querier) error {
+		if err := refreshToken.LoadByHashedValueAndClientID(ctx, conn, hashedValue, clientID); err != nil {
+			if errors.Is(err, coredata.ErrResourceNotFound) {
+				return nil
+			}
+			return fmt.Errorf("cannot load refresh token: %w", err)
+		}
+		hasRefresh = true
+		return nil
+	}
+
+	preferRefresh := tokenTypeHint != nil && *tokenTypeHint == coredata.OAuth2TokenTypeHintRefreshToken
 
 	if err := s.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := token.LoadByHashedValueAndClientID(ctx, conn, hashedValue, clientID); err != nil {
-				if errors.Is(err, coredata.ErrResourceNotFound) {
+			if preferRefresh {
+				if err := loadRefresh(ctx, conn); err != nil {
+					return err
+				}
+				if hasRefresh {
 					return nil
 				}
-
-				return fmt.Errorf("cannot load access token: %w", err)
+				return loadAccess(ctx, conn)
 			}
 
-			return nil
+			if err := loadAccess(ctx, conn); err != nil {
+				return err
+			}
+			if hasAccess {
+				return nil
+			}
+			return loadRefresh(ctx, conn)
 		},
 	); err != nil {
 		return nil, err
 	}
 
-	if token.ID == gid.Nil || now.After(token.ExpiresAt) {
+	switch {
+	case hasAccess:
+		if now.After(accessToken.ExpiresAt) {
+			return nil, nil
+		}
+		return &IntrospectResult{
+			ClientID:   accessToken.ClientID,
+			IdentityID: accessToken.IdentityID,
+			Scopes:     accessToken.Scopes,
+			IssuedAt:   accessToken.CreatedAt,
+			ExpiresAt:  accessToken.ExpiresAt,
+			TokenType:  tokenTypeBearer,
+		}, nil
+	case hasRefresh:
+		if refreshToken.RevokedAt != nil || now.After(refreshToken.ExpiresAt) {
+			return nil, nil
+		}
+		return &IntrospectResult{
+			ClientID:   refreshToken.ClientID,
+			IdentityID: refreshToken.IdentityID,
+			Scopes:     refreshToken.Scopes,
+			IssuedAt:   refreshToken.CreatedAt,
+			ExpiresAt:  refreshToken.ExpiresAt,
+		}, nil
+	default:
 		return nil, nil
 	}
-
-	return &token, nil
 }
 
 func (s *Service) UserInfo(

--- a/pkg/iam/oauth2server/service.go
+++ b/pkg/iam/oauth2server/service.go
@@ -1151,12 +1151,6 @@ func (s *Service) LoadAccessToken(ctx context.Context, tokenValue string) (*core
 	return &token, nil
 }
 
-// IntrospectToken looks up the token (access or refresh) bound to clientID and
-// returns its claims when active. It supports the optional token_type_hint
-// from RFC 7662 §2.1: when set, the hinted table is searched first and the
-// other one is used as a fallback. A nil result means the token is unknown,
-// expired, revoked, or does not belong to clientID and must be reported as
-// inactive.
 func (s *Service) IntrospectToken(
 	ctx context.Context,
 	clientID gid.GID,

--- a/pkg/server/api/connect/v1/oauth2_handler.go
+++ b/pkg/server/api/connect/v1/oauth2_handler.go
@@ -252,6 +252,7 @@ func (h *OAuth2Handler) IntrospectHandler(w http.ResponseWriter, r *http.Request
 		r.Context(),
 		client.ID,
 		in.Token,
+		in.TokenTypeHint,
 	)
 	if err != nil || result == nil {
 		httpserver.RenderJSON(w, http.StatusOK, types.InactiveIntrospectResponse())

--- a/pkg/server/api/connect/v1/types/oauth2.go
+++ b/pkg/server/api/connect/v1/types/oauth2.go
@@ -21,6 +21,7 @@ import (
 
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/oauth2server"
 	"go.probo.inc/probo/pkg/uri"
 )
 
@@ -59,7 +60,8 @@ type (
 	}
 
 	OAuth2IntrospectInput struct {
-		Token string
+		Token         string
+		TokenTypeHint *coredata.OAuth2TokenTypeHint
 	}
 
 	OAuth2RevokeInput struct {
@@ -138,6 +140,14 @@ func (in *OAuth2IntrospectInput) DecodeForm(r *http.Request) error {
 	if in.Token == "" {
 		return fmt.Errorf("missing token parameter")
 	}
+
+	if hint := r.FormValue("token_type_hint"); hint != "" {
+		h := coredata.OAuth2TokenTypeHint(hint)
+		if h.IsValid() {
+			in.TokenTypeHint = &h
+		}
+	}
+
 	return nil
 }
 
@@ -317,14 +327,14 @@ func InactiveIntrospectResponse() *OAuth2IntrospectResponse {
 	return &OAuth2IntrospectResponse{Active: false}
 }
 
-func ActiveIntrospectResponse(token *coredata.OAuth2AccessToken) *OAuth2IntrospectResponse {
+func ActiveIntrospectResponse(result *oauth2server.IntrospectResult) *OAuth2IntrospectResponse {
 	return &OAuth2IntrospectResponse{
 		Active:    true,
-		Scope:     token.Scopes,
-		ClientID:  token.ClientID,
-		Sub:       token.IdentityID,
-		Exp:       token.ExpiresAt.Unix(),
-		Iat:       token.CreatedAt.Unix(),
-		TokenType: "Bearer",
+		Scope:     result.Scopes,
+		ClientID:  result.ClientID,
+		Sub:       result.IdentityID,
+		Exp:       result.ExpiresAt.Unix(),
+		Iat:       result.IssuedAt.Unix(),
+		TokenType: result.TokenType,
 	}
 }


### PR DESCRIPTION
## Summary

- Extend `/api/connect/v1/oauth2/introspect` to resolve refresh tokens, not just access tokens, per RFC 7662.
- Honor the optional `token_type_hint` form parameter to drive lookup order, with a fallback to the other token type when the hint misses (RFC 7662 §2.1).
- Report revoked or expired refresh tokens as `active: false`; return `client_id`, `sub`, `exp`, `iat`, and `scope` for active refresh tokens. `token_type` is omitted for refresh tokens (it's defined for access tokens in RFC 6749 §5.1).

## Implementation notes

- New `oauth2server.IntrospectResult` decouples the introspection payload from the access-token model so refresh tokens can populate the same shape.
- `OAuth2IntrospectInput` now decodes `token_type_hint` using the existing `coredata.OAuth2TokenTypeHint` parsing (mirrors `/oauth2/revoke`).

## Test plan

- [x] `go vet ./pkg/iam/oauth2server/... ./pkg/server/api/connect/v1/... ./e2e/...`
- [x] `go test ./pkg/iam/oauth2server/...`
- [ ] `make test-e2e` (covers new subtests in `TestOAuth2_Introspect`: active refresh token, matching/non-matching `token_type_hint`, revoked refresh token, cross-client refresh token)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends `/api/connect/v1/oauth2/introspect` to handle refresh tokens and honor the optional `token_type_hint`, matching RFC 7662. Returns consistent fields for active tokens and correctly marks expired, revoked, or cross-client refresh tokens as inactive.

- **New Features**
  - Introspect refresh tokens alongside access tokens.
  - Accept `token_type_hint` to prefer lookup order, with automatic fallback when the hint misses.
  - For active refresh tokens, return `client_id`, `sub`, `exp`, `iat`, and `scope`; omit `token_type` (access tokens still return `token_type: "Bearer"`). Only the issuing client can introspect a refresh token; expired or revoked refresh tokens return `active: false`.

<sup>Written for commit 79d473080646ea15a93fca6d2bdcc742c4e3cab4. Summary will update on new commits. <a href="https://cubic.dev/pr/getprobo/probo/pull/1117?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth2 token introspection logic and response shaping, including refresh-token validity and client binding, which could affect auth-related integrations if incorrect.
> 
> **Overview**
> Extends `/api/connect/v1/oauth2/introspect` to resolve **refresh tokens in addition to access tokens**, returning the same RFC 7662 fields (`client_id`, `sub`, `exp`, `iat`, `scope`) and omitting `token_type` for refresh tokens.
> 
> Adds support for the optional `token_type_hint` form parameter to prefer lookup order (with fallback when the hint misses), updates the handler/types to pass this through, and introduces `oauth2server.IntrospectResult` to unify access/refresh introspection payloads.
> 
> E2E coverage is expanded with new subtests validating active/ revocation/ cross-client behavior for refresh-token introspection and hint handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79d473080646ea15a93fca6d2bdcc742c4e3cab4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->