### PR TITLE
Use forwarded headers for SCIM event client IP

### DIFF
--- a/pkg/server/api/connect/v1/scim_handler.go
+++ b/pkg/server/api/connect/v1/scim_handler.go
@@ -32,6 +32,7 @@ import (
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/iam"
 	scimservice "go.probo.inc/probo/pkg/iam/scim"
+	"go.probo.inc/probo/pkg/server/api/clientip"
 )
 
 type (
@@ -337,12 +338,7 @@ func (h *scimResourceHandler) Delete(r *http.Request, id string) error {
 }
 
 func getIPAddress(r *http.Request) net.IP {
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		host = r.RemoteAddr
-	}
-
-	if ip := net.ParseIP(host); ip != nil {
+	if ip := net.ParseIP(clientip.Extract(r)); ip != nil {
 		return ip
 	}
 


### PR DESCRIPTION
## Summary
- The SCIM event handler built `ipAddress` from `r.RemoteAddr` only, so when probod runs behind an HTTP load balancer every `coredata.SCIMEvent` row recorded the LB's internal IP.
- Switch `getIPAddress` in `pkg/server/api/connect/v1/scim_handler.go` to `clientip.Extract`, which honors `Forwarded` / `X-Forwarded-For` (already gated by `trustedproxy.NewMiddleware` so they are only trusted from configured proxies) and falls back to `r.RemoteAddr`.

## Test plan
- [ ] Send a SCIM request through a deployment configured with `Api.ProxyProtocol.TrustedProxies` and confirm the recorded `ipAddress` matches the upstream client IP rather than the LB IP.
- [ ] Send a SCIM request without forwarded headers and confirm `r.RemoteAddr` is still recorded.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `clientip.Extract` to record the real client IP for SCIM events, honoring `Forwarded`/`X-Forwarded-For` trusted by `trustedproxy.NewMiddleware`. Falls back to `r.RemoteAddr` when no proxy headers are present to avoid logging the load balancer IP.

<sup>Written for commit 34d8bf10a29361d9071638264c1e0d97bab10366. Summary will update on new commits. <a href="https://cubic.dev/pr/getprobo/probo/pull/1118?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes audit attribution logic by trusting proxy headers, so incorrect trusted-proxy configuration could lead to spoofed client IPs; code change is small and localized.
> 
> **Overview**
> SCIM request logging now derives `ipAddress` via `clientip.Extract(r)` (honoring `Forwarded`/`X-Forwarded-For` with fallback to `RemoteAddr`) instead of parsing only `r.RemoteAddr`, improving the accuracy of stored `coredata.SCIMEvent` client IPs when running behind proxies/load balancers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34d8bf10a29361d9071638264c1e0d97bab10366. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->