### PR TITLE
Add user activate and deactivate operations

### DIFF
--- a/apps/console/src/pages/iam/organizations/people/PersonPage.tsx
+++ b/apps/console/src/pages/iam/organizations/people/PersonPage.tsx
@@ -14,7 +14,18 @@
 
 import { sprintf } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
-import { ActionDropdown, Avatar, Badge, Breadcrumb, Card, DropdownItem, IconTrashCan, useConfirm } from "@probo/ui";
+import {
+  ActionDropdown,
+  Avatar,
+  Badge,
+  Breadcrumb,
+  Card,
+  DropdownItem,
+  IconCircleCheck,
+  IconCircleX,
+  IconTrashCan,
+  useConfirm,
+} from "@probo/ui";
 import { type PreloadedQuery, usePreloadedQuery } from "react-relay";
 import { useNavigate } from "react-router";
 import { graphql } from "relay-runtime";
@@ -34,7 +45,10 @@ export const personPageQuery = graphql`
         fullName
         emailAddress
         source
+        state
         canDelete: permission(action: "iam:membership-profile:delete")
+        canActivate: permission(action: "iam:membership-profile:activate")
+        canDeactivate: permission(action: "iam:membership-profile:deactivate")
         ...PersonFormFragment
       }
     }
@@ -47,6 +61,28 @@ const removeUserMutation = graphql`
   ) {
     removeUser(input: $input) {
       deletedProfileId
+    }
+  }
+`;
+
+const activateUserMutation = graphql`
+  mutation PersonPage_activateMutation($input: ActivateUserInput!) {
+    activateUser(input: $input) {
+      profile {
+        id
+        state
+      }
+    }
+  }
+`;
+
+const deactivateUserMutation = graphql`
+  mutation PersonPage_deactivateMutation($input: DeactivateUserInput!) {
+    deactivateUser(input: $input) {
+      profile {
+        id
+        state
+      }
     }
   }
 `;
@@ -71,6 +107,20 @@ export function PersonPage(props: { queryRef: PreloadedQuery<PersonPageQuery> })
       errorMessage: __("Failed to remove person"),
     },
   );
+  const [activateUser, isActivating] = useMutationWithToasts(
+    activateUserMutation,
+    {
+      successMessage: __("Person activated successfully"),
+      errorMessage: __("Failed to activate person"),
+    },
+  );
+  const [deactivateUser, isDeactivating] = useMutationWithToasts(
+    deactivateUserMutation,
+    {
+      successMessage: __("Person deactivated successfully"),
+      errorMessage: __("Failed to deactivate person"),
+    },
+  );
 
   const handleRemove = () => {
     confirm(
@@ -90,6 +140,49 @@ export function PersonPage(props: { queryRef: PreloadedQuery<PersonPageQuery> })
       {
         message: sprintf(
           __("Are you sure you want to remove %s?"),
+          person.fullName,
+        ),
+      },
+    );
+  };
+  const handleDeactivate = () => {
+    confirm(
+      () => {
+        return deactivateUser({
+          variables: {
+            input: {
+              profileId: person.id,
+              organizationId: organizationId,
+            },
+          },
+        });
+      },
+      {
+        label: __("Deactivate"),
+        message: sprintf(
+          __("Deactivate %s? They will keep their profile but lose access until reactivated."),
+          person.fullName,
+        ),
+      },
+    );
+  };
+  const handleActivate = () => {
+    confirm(
+      () => {
+        return activateUser({
+          variables: {
+            input: {
+              profileId: person.id,
+              organizationId: organizationId,
+            },
+          },
+        });
+      },
+      {
+        label: __("Activate"),
+        variant: "primary",
+        message: sprintf(
+          __("Reactivate %s? They will regain access to the organization."),
           person.fullName,
         ),
       },
@@ -120,18 +213,48 @@ export function PersonPage(props: { queryRef: PreloadedQuery<PersonPageQuery> })
             <div className="text-lg text-txt-secondary">{person.emailAddress}</div>
           </div>
         </div>
-        {person.canDelete && person.source !== "SCIM" && (
-          <ActionDropdown variant="secondary">
-            <DropdownItem
-              variant="danger"
-              icon={IconTrashCan}
-              onClick={handleRemove}
-              disabled={isRemoving}
-            >
-              {__("Delete")}
-            </DropdownItem>
-          </ActionDropdown>
-        )}
+        {person.source !== "SCIM" && (() => {
+          const isInactive = person.state === "INACTIVE";
+          const showActivate = isInactive && person.canActivate;
+          const showDeactivate = !isInactive && person.canDeactivate;
+          const showDelete = person.canDelete;
+          const isMutating = isRemoving || isActivating || isDeactivating;
+          if (!showActivate && !showDeactivate && !showDelete) {
+            return null;
+          }
+          return (
+            <ActionDropdown variant="secondary">
+              {showActivate && (
+                <DropdownItem
+                  icon={IconCircleCheck}
+                  onClick={handleActivate}
+                  disabled={isMutating}
+                >
+                  {__("Activate")}
+                </DropdownItem>
+              )}
+              {showDeactivate && (
+                <DropdownItem
+                  icon={IconCircleX}
+                  onClick={handleDeactivate}
+                  disabled={isMutating}
+                >
+                  {__("Deactivate")}
+                </DropdownItem>
+              )}
+              {showDelete && (
+                <DropdownItem
+                  variant="danger"
+                  icon={IconTrashCan}
+                  onClick={handleRemove}
+                  disabled={isMutating}
+                >
+                  {__("Delete")}
+                </DropdownItem>
+              )}
+            </ActionDropdown>
+          );
+        })()}
       </div>
 
       <Card padded className="space-y-4">

--- a/apps/console/src/pages/iam/organizations/people/_components/PeopleListItem.tsx
+++ b/apps/console/src/pages/iam/organizations/people/_components/PeopleListItem.tsx
@@ -18,6 +18,8 @@ import {
   ActionDropdown,
   Badge,
   DropdownItem,
+  IconCircleCheck,
+  IconCircleX,
   IconMail,
   IconTrashCan,
   Option,
@@ -64,6 +66,8 @@ const fragment = graphql`
     canUpdate: permission(action: "iam:membership-profile:update")
     canInvite: permission(action: "iam:invitation:create")
     canDelete: permission(action: "iam:membership-profile:delete")
+    canActivate: permission(action: "iam:membership-profile:activate")
+    canDeactivate: permission(action: "iam:membership-profile:deactivate")
   }
 `;
 
@@ -107,6 +111,28 @@ const removeUserMutation = graphql`
   }
 `;
 
+const activateUserMutation = graphql`
+  mutation PeopleListItem_activateMutation($input: ActivateUserInput!) {
+    activateUser(input: $input) {
+      profile {
+        id
+        state
+      }
+    }
+  }
+`;
+
+const deactivateUserMutation = graphql`
+  mutation PeopleListItem_deactivateMutation($input: DeactivateUserInput!) {
+    deactivateUser(input: $input) {
+      profile {
+        id
+        state
+      }
+    }
+  }
+`;
+
 export function PeopleListItem(props: {
   connectionId: DataID;
   fKey: PeopleListItemFragment$key;
@@ -125,9 +151,12 @@ export function PeopleListItem(props: {
   const lastInvitation = profile.lastInvitation.edges[0]?.node;
 
   const isInactive = profile.state === "INACTIVE";
+  const isManagedBySCIM = profile.source === "SCIM";
 
-  const canSendActivationMail = isInactive && profile.source !== "SCIM" && profile.canInvite;
-  const canDelete = profile.canDelete && profile.source !== "SCIM";
+  const canSendActivationMail = isInactive && !isManagedBySCIM && profile.canInvite;
+  const canDelete = profile.canDelete && !isManagedBySCIM;
+  const canDeactivate = !isInactive && profile.canDeactivate && !isManagedBySCIM;
+  const canActivate = isInactive && profile.canActivate && !isManagedBySCIM;
 
   const [inviteUser]
     = useMutationWithToasts<PeopleListItem_inviteMutation>(inviteUserMutation, {
@@ -146,6 +175,20 @@ export function PeopleListItem(props: {
     {
       successMessage: __("Person removed successfully"),
       errorMessage: __("Failed to remove person"),
+    },
+  );
+  const [activateUser, isActivating] = useMutationWithToasts(
+    activateUserMutation,
+    {
+      successMessage: __("Person activated successfully"),
+      errorMessage: __("Failed to activate person"),
+    },
+  );
+  const [deactivateUser, isDeactivating] = useMutationWithToasts(
+    deactivateUserMutation,
+    {
+      successMessage: __("Person deactivated successfully"),
+      errorMessage: __("Failed to deactivate person"),
     },
   );
 
@@ -204,11 +247,56 @@ export function PeopleListItem(props: {
       },
     );
   };
+  const handleDeactivate = () => {
+    confirm(
+      () => {
+        return deactivateUser({
+          variables: {
+            input: {
+              profileId: profile.id,
+              organizationId: organizationId,
+            },
+          },
+        });
+      },
+      {
+        label: __("Deactivate"),
+        message: sprintf(
+          __("Deactivate %s? They will keep their profile but lose access until reactivated."),
+          profile.fullName,
+        ),
+      },
+    );
+  };
+  const handleActivate = () => {
+    confirm(
+      () => {
+        return activateUser({
+          variables: {
+            input: {
+              profileId: profile.id,
+              organizationId: organizationId,
+            },
+          },
+        });
+      },
+      {
+        label: __("Activate"),
+        variant: "primary",
+        message: sprintf(
+          __("Reactivate %s? They will regain access to the organization."),
+          profile.fullName,
+        ),
+      },
+    );
+  };
+
+  const isMutating = isRemoving || isActivating || isDeactivating;
 
   return (
     <Tr to={`/organizations/${organizationId}/people/${profile.id}`}>
       <Td className={clsx(
-        isRemoving && "opacity-60 pointer-events-none",
+        isMutating && "opacity-60 pointer-events-none",
         isInactive && "opacity-50",
       )}
       >
@@ -218,7 +306,7 @@ export function PeopleListItem(props: {
         <Badge variant={profile.state === "INACTIVE" ? "neutral" : "success"}>{profile.state}</Badge>
       </Td>
       <Td className={clsx(
-        isRemoving && "opacity-60 pointer-events-none",
+        isMutating && "opacity-60 pointer-events-none",
         isInactive && "opacity-50",
       )}
       >
@@ -232,7 +320,7 @@ export function PeopleListItem(props: {
           noLink
           className={clsx(
             "pr-4",
-            isRemoving && "opacity-60 pointer-events-none",
+            isMutating && "opacity-60 pointer-events-none",
             isInactive && "opacity-50",
           )}
         >
@@ -260,14 +348,14 @@ export function PeopleListItem(props: {
         </Td>
       )}
       <Td className={clsx(
-        isRemoving && "opacity-60 pointer-events-none",
+        isMutating && "opacity-60 pointer-events-none",
         isInactive && "opacity-50",
       )}
       >
         {new Date(profile.createdAt).toLocaleDateString()}
       </Td>
       <Td noLink width={160} className="text-end">
-        {(canSendActivationMail || canDelete) && (
+        {(canSendActivationMail || canActivate || canDeactivate || canDelete) && (
           <ActionDropdown>
             {canSendActivationMail && (
               <DropdownItem
@@ -275,6 +363,22 @@ export function PeopleListItem(props: {
                 icon={IconMail}
               >
                 {lastInvitation ? __("Resend activation mail") : __("Send activation mail")}
+              </DropdownItem>
+            )}
+            {canActivate && (
+              <DropdownItem
+                onClick={handleActivate}
+                icon={IconCircleCheck}
+              >
+                {__("Activate")}
+              </DropdownItem>
+            )}
+            {canDeactivate && (
+              <DropdownItem
+                onClick={handleDeactivate}
+                icon={IconCircleX}
+              >
+                {__("Deactivate")}
               </DropdownItem>
             )}
             {canDelete && (

--- a/e2e/console/user_state_test.go
+++ b/e2e/console/user_state_test.go
@@ -1,0 +1,231 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package console_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/e2e/internal/testutil"
+)
+
+const deactivateUserMutation = `
+	mutation($input: DeactivateUserInput!) {
+		deactivateUser(input: $input) {
+			profile {
+				id
+				state
+			}
+		}
+	}
+`
+
+const activateUserMutation = `
+	mutation($input: ActivateUserInput!) {
+		activateUser(input: $input) {
+			profile {
+				id
+				state
+			}
+		}
+	}
+`
+
+type userStateMutationResult struct {
+	Profile struct {
+		ID    string `json:"id"`
+		State string `json:"state"`
+	} `json:"profile"`
+}
+
+func TestUser_DeactivateAndActivate(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	target := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+
+	// Deactivate the viewer.
+	var deactivateResp struct {
+		DeactivateUser userStateMutationResult `json:"deactivateUser"`
+	}
+	err := owner.ExecuteConnect(deactivateUserMutation, map[string]any{
+		"input": map[string]any{
+			"organizationId": owner.GetOrganizationID().String(),
+			"profileId":      target.GetProfileID().String(),
+		},
+	}, &deactivateResp)
+	require.NoError(t, err)
+	assert.Equal(t, target.GetProfileID().String(), deactivateResp.DeactivateUser.Profile.ID)
+	assert.Equal(t, "INACTIVE", deactivateResp.DeactivateUser.Profile.State)
+
+	// Reactivate the viewer.
+	var activateResp struct {
+		ActivateUser userStateMutationResult `json:"activateUser"`
+	}
+	err = owner.ExecuteConnect(activateUserMutation, map[string]any{
+		"input": map[string]any{
+			"organizationId": owner.GetOrganizationID().String(),
+			"profileId":      target.GetProfileID().String(),
+		},
+	}, &activateResp)
+	require.NoError(t, err)
+	assert.Equal(t, target.GetProfileID().String(), activateResp.ActivateUser.Profile.ID)
+	assert.Equal(t, "ACTIVE", activateResp.ActivateUser.Profile.State)
+}
+
+func TestUser_DeactivateNoop(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	target := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+
+	for i := 0; i < 2; i++ {
+		var resp struct {
+			DeactivateUser userStateMutationResult `json:"deactivateUser"`
+		}
+		err := owner.ExecuteConnect(deactivateUserMutation, map[string]any{
+			"input": map[string]any{
+				"organizationId": owner.GetOrganizationID().String(),
+				"profileId":      target.GetProfileID().String(),
+			},
+		}, &resp)
+		require.NoError(t, err)
+		assert.Equal(t, "INACTIVE", resp.DeactivateUser.Profile.State)
+	}
+}
+
+func TestUser_DeactivateLastActiveOwner(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+
+	// Find the owner's profile id.
+	const profilesQuery = `
+		query($id: ID!) {
+			node(id: $id) {
+				... on Organization {
+					profiles(first: 50) {
+						edges {
+							node {
+								id
+								identity { id }
+								membership { role }
+							}
+						}
+					}
+				}
+			}
+		}
+	`
+
+	var profilesResp struct {
+		Node struct {
+			Profiles struct {
+				Edges []struct {
+					Node struct {
+						ID       string `json:"id"`
+						Identity struct {
+							ID string `json:"id"`
+						} `json:"identity"`
+						Membership struct {
+							Role string `json:"role"`
+						} `json:"membership"`
+					} `json:"node"`
+				} `json:"edges"`
+			} `json:"profiles"`
+		} `json:"node"`
+	}
+
+	err := owner.ExecuteConnect(profilesQuery, map[string]any{
+		"id": owner.GetOrganizationID().String(),
+	}, &profilesResp)
+	require.NoError(t, err)
+
+	var ownerProfileID string
+	for _, edge := range profilesResp.Node.Profiles.Edges {
+		if edge.Node.Membership.Role == "OWNER" && edge.Node.Identity.ID == owner.GetUserID().String() {
+			ownerProfileID = edge.Node.ID
+			break
+		}
+	}
+	require.NotEmpty(t, ownerProfileID)
+
+	// Attempting to deactivate the last active owner must fail with a conflict.
+	err = owner.ExecuteConnect(deactivateUserMutation, map[string]any{
+		"input": map[string]any{
+			"organizationId": owner.GetOrganizationID().String(),
+			"profileId":      ownerProfileID,
+		},
+	}, nil)
+
+	require.Error(t, err)
+	var gqlErrors testutil.GraphQLErrors
+	require.ErrorAs(t, err, &gqlErrors)
+	require.NotEmpty(t, gqlErrors)
+	assert.Equal(t, "CONFLICT", gqlErrors[0].Code(), "got code=%q message=%q", gqlErrors[0].Code(), gqlErrors[0].Message)
+	assert.True(t,
+		strings.Contains(gqlErrors[0].Message, "last active owner"),
+		"expected last active owner message, got: %q", gqlErrors[0].Message,
+	)
+}
+
+func TestUser_DeactivateForbiddenForViewer(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+	target := testutil.NewClientInOrg(t, testutil.RoleEmployee, owner)
+
+	err := viewer.ExecuteConnect(deactivateUserMutation, map[string]any{
+		"input": map[string]any{
+			"organizationId": owner.GetOrganizationID().String(),
+			"profileId":      target.GetProfileID().String(),
+		},
+	}, nil)
+
+	require.Error(t, err)
+	var gqlErrors testutil.GraphQLErrors
+	require.ErrorAs(t, err, &gqlErrors)
+	require.NotEmpty(t, gqlErrors)
+	code := gqlErrors[0].Code()
+	msg := gqlErrors[0].Message
+	isForbidden := code == "FORBIDDEN" ||
+		(code == "" && (strings.Contains(msg, "does not have sufficient permissions") ||
+			strings.Contains(msg, "insufficient permissions")))
+	assert.True(t, isForbidden, "expected FORBIDDEN error, got code=%q message=%q", code, msg)
+}
+
+func TestUser_ActivateForbiddenForViewer(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+	target := testutil.NewClientInOrg(t, testutil.RoleEmployee, owner)
+
+	err := viewer.ExecuteConnect(activateUserMutation, map[string]any{
+		"input": map[string]any{
+			"organizationId": owner.GetOrganizationID().String(),
+			"profileId":      target.GetProfileID().String(),
+		},
+	}, nil)
+
+	require.Error(t, err)
+	var gqlErrors testutil.GraphQLErrors
+	require.ErrorAs(t, err, &gqlErrors)
+	require.NotEmpty(t, gqlErrors)
+	code := gqlErrors[0].Code()
+	msg := gqlErrors[0].Message
+	isForbidden := code == "FORBIDDEN" ||
+		(code == "" && (strings.Contains(msg, "does not have sufficient permissions") ||
+			strings.Contains(msg, "insufficient permissions")))
+	assert.True(t, isForbidden, "expected FORBIDDEN error, got code=%q message=%q", code, msg)
+}

--- a/packages/n8n-node/nodes/Probo/actions/user/activateUser.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/user/activateUser.operation.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { proboConnectApiRequest } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Organization ID',
+		name: 'organizationId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['user'],
+				operation: ['activateUser'],
+			},
+		},
+		default: '',
+		description: 'The ID of the organization',
+		required: true,
+	},
+	{
+		displayName: 'User ID',
+		name: 'userId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['user'],
+				operation: ['activateUser'],
+			},
+		},
+		default: '',
+		description: 'The ID of the user (profile) to reactivate',
+		required: true,
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const organizationId = this.getNodeParameter('organizationId', itemIndex) as string;
+	const userId = this.getNodeParameter('userId', itemIndex) as string;
+
+	const query = `
+		mutation ActivateUser($input: ActivateUserInput!) {
+			activateUser(input: $input) {
+				profile {
+					id
+					state
+				}
+			}
+		}
+	`;
+
+	const input = { organizationId, profileId: userId };
+	const responseData = await proboConnectApiRequest.call(this, query, { input });
+
+	return {
+		json: responseData,
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/user/deactivateUser.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/user/deactivateUser.operation.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { proboConnectApiRequest } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Organization ID',
+		name: 'organizationId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['user'],
+				operation: ['deactivateUser'],
+			},
+		},
+		default: '',
+		description: 'The ID of the organization',
+		required: true,
+	},
+	{
+		displayName: 'User ID',
+		name: 'userId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['user'],
+				operation: ['deactivateUser'],
+			},
+		},
+		default: '',
+		description: 'The ID of the user (profile) to mark as inactive',
+		required: true,
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const organizationId = this.getNodeParameter('organizationId', itemIndex) as string;
+	const userId = this.getNodeParameter('userId', itemIndex) as string;
+
+	const query = `
+		mutation DeactivateUser($input: DeactivateUserInput!) {
+			deactivateUser(input: $input) {
+				profile {
+					id
+					state
+				}
+			}
+		}
+	`;
+
+	const input = { organizationId, profileId: userId };
+	const responseData = await proboConnectApiRequest.call(this, query, { input });
+
+	return {
+		json: responseData,
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/user/index.ts
+++ b/packages/n8n-node/nodes/Probo/actions/user/index.ts
@@ -20,6 +20,8 @@ import * as inviteUserOp from './inviteUser.operation';
 import * as updateUserOp from './updateUser.operation';
 import * as updateMembershipOp from './updateMembership.operation';
 import * as removeUserOp from './removeUser.operation';
+import * as activateUserOp from './activateUser.operation';
+import * as deactivateUserOp from './deactivateUser.operation';
 
 export const description: INodeProperties[] = [
 	{
@@ -34,10 +36,22 @@ export const description: INodeProperties[] = [
 		},
 		options: [
 			{
+				name: 'Activate',
+				value: 'activateUser',
+				description: 'Reactivate a previously deactivated user',
+				action: 'Activate a user',
+			},
+			{
 				name: 'Create',
 				value: 'createUser',
 				description: 'Create a new user in the organization',
 				action: 'Create a user',
+			},
+			{
+				name: 'Deactivate',
+				value: 'deactivateUser',
+				description: 'Mark a user as inactive without deleting them',
+				action: 'Deactivate a user',
 			},
 			{
 				name: 'Get',
@@ -85,6 +99,8 @@ export const description: INodeProperties[] = [
 	...updateUserOp.description,
 	...updateMembershipOp.description,
 	...removeUserOp.description,
+	...activateUserOp.description,
+	...deactivateUserOp.description,
 ];
 
 export {
@@ -95,4 +111,6 @@ export {
 	updateUserOp as updateUser,
 	updateMembershipOp as updateMembership,
 	removeUserOp as removeUser,
+	activateUserOp as activateUser,
+	deactivateUserOp as deactivateUser,
 };

--- a/pkg/cmd/user/activate/activate.go
+++ b/pkg/cmd/user/activate/activate.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package activate
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const activateMutation = `
+mutation($input: ActivateUserInput!) {
+  activateUser(input: $input) {
+    profile {
+      id
+      fullName
+      state
+    }
+  }
+}
+`
+
+type activateResponse struct {
+	ActivateUser *struct {
+		Profile *struct {
+			ID       string `json:"id"`
+			FullName string `json:"fullName"`
+			State    string `json:"state"`
+		} `json:"profile"`
+	} `json:"activateUser"`
+}
+
+func NewCmdActivate(f *cmdutil.Factory) *cobra.Command {
+	var (
+		flagOrg    string
+		flagOutput *string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "activate <id>",
+		Short: "Reactivate an inactive user",
+		Args:  cobra.ExactArgs(1),
+		Example: `  # Reactivate a user in the default organization
+  prb user activate prfl_01H...
+
+  # Reactivate a user in a specific organization
+  prb user activate prfl_01H... --org org_01H...`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmdutil.ValidateOutputFlag(flagOutput); err != nil {
+				return err
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			if flagOrg == "" {
+				flagOrg = hc.Organization
+			}
+
+			if flagOrg == "" {
+				return fmt.Errorf("organization is required; pass --org or set a default with 'prb auth login'")
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/connect/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			data, err := client.Do(
+				activateMutation,
+				map[string]any{
+					"input": map[string]any{
+						"organizationId": flagOrg,
+						"profileId":      args[0],
+					},
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			var resp activateResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return fmt.Errorf("cannot parse response: %w", err)
+			}
+
+			if resp.ActivateUser == nil || resp.ActivateUser.Profile == nil {
+				return fmt.Errorf("user %s not found", args[0])
+			}
+
+			if *flagOutput == cmdutil.OutputJSON {
+				return cmdutil.PrintJSON(f.IOStreams.Out, resp.ActivateUser.Profile)
+			}
+
+			profile := resp.ActivateUser.Profile
+			_, _ = fmt.Fprintf(
+				f.IOStreams.Out,
+				"Activated user %s (%s) — state: %s\n",
+				profile.FullName,
+				profile.ID,
+				profile.State,
+			)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&flagOrg, "org", "", "Organization ID")
+	flagOutput = cmdutil.AddOutputFlag(cmd)
+
+	return cmd
+}

--- a/pkg/cmd/user/deactivate/deactivate.go
+++ b/pkg/cmd/user/deactivate/deactivate.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package deactivate
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const deactivateMutation = `
+mutation($input: DeactivateUserInput!) {
+  deactivateUser(input: $input) {
+    profile {
+      id
+      fullName
+      state
+    }
+  }
+}
+`
+
+type deactivateResponse struct {
+	DeactivateUser *struct {
+		Profile *struct {
+			ID       string `json:"id"`
+			FullName string `json:"fullName"`
+			State    string `json:"state"`
+		} `json:"profile"`
+	} `json:"deactivateUser"`
+}
+
+func NewCmdDeactivate(f *cmdutil.Factory) *cobra.Command {
+	var (
+		flagOrg    string
+		flagOutput *string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "deactivate <id>",
+		Short: "Mark a user as inactive without deleting them",
+		Args:  cobra.ExactArgs(1),
+		Example: `  # Deactivate a user in the default organization
+  prb user deactivate prfl_01H...
+
+  # Deactivate a user in a specific organization
+  prb user deactivate prfl_01H... --org org_01H...`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmdutil.ValidateOutputFlag(flagOutput); err != nil {
+				return err
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			if flagOrg == "" {
+				flagOrg = hc.Organization
+			}
+
+			if flagOrg == "" {
+				return fmt.Errorf("organization is required; pass --org or set a default with 'prb auth login'")
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/connect/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			data, err := client.Do(
+				deactivateMutation,
+				map[string]any{
+					"input": map[string]any{
+						"organizationId": flagOrg,
+						"profileId":      args[0],
+					},
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			var resp deactivateResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return fmt.Errorf("cannot parse response: %w", err)
+			}
+
+			if resp.DeactivateUser == nil || resp.DeactivateUser.Profile == nil {
+				return fmt.Errorf("user %s not found", args[0])
+			}
+
+			if *flagOutput == cmdutil.OutputJSON {
+				return cmdutil.PrintJSON(f.IOStreams.Out, resp.DeactivateUser.Profile)
+			}
+
+			profile := resp.DeactivateUser.Profile
+			_, _ = fmt.Fprintf(
+				f.IOStreams.Out,
+				"Deactivated user %s (%s) — state: %s\n",
+				profile.FullName,
+				profile.ID,
+				profile.State,
+			)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&flagOrg, "org", "", "Organization ID")
+	flagOutput = cmdutil.AddOutputFlag(cmd)
+
+	return cmd
+}

--- a/pkg/cmd/user/user.go
+++ b/pkg/cmd/user/user.go
@@ -17,6 +17,8 @@ package user
 import (
 	"github.com/spf13/cobra"
 	"go.probo.inc/probo/pkg/cmd/cmdutil"
+	"go.probo.inc/probo/pkg/cmd/user/activate"
+	"go.probo.inc/probo/pkg/cmd/user/deactivate"
 	"go.probo.inc/probo/pkg/cmd/user/list"
 	"go.probo.inc/probo/pkg/cmd/user/view"
 )
@@ -29,6 +31,8 @@ func NewCmdUser(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.AddCommand(list.NewCmdList(f))
 	cmd.AddCommand(view.NewCmdView(f))
+	cmd.AddCommand(activate.NewCmdActivate(f))
+	cmd.AddCommand(deactivate.NewCmdDeactivate(f))
 
 	return cmd
 }

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -1054,7 +1054,38 @@ func (s *OrganizationService) UpdateUserState(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			if err := profile.LoadByID(ctx, tx, scope, userID); err != nil {
+				if errors.Is(err, coredata.ErrResourceNotFound) {
+					return NewProfileNotFoundError(userID)
+				}
+
 				return fmt.Errorf("cannot load profile: %w", err)
+			}
+
+			if profile.State == state {
+				return nil
+			}
+
+			if profile.Source == coredata.ProfileSourceSCIM {
+				return NewUserManagedBySCIMError(userID)
+			}
+
+			membership := &coredata.Membership{}
+			if err := membership.LoadByIdentityIDAndOrganizationID(ctx, tx, scope, profile.IdentityID, profile.OrganizationID); err != nil {
+				return fmt.Errorf("cannot load membership: %w", err)
+			}
+
+			if state == coredata.ProfileStateInactive &&
+				membership.Role == coredata.MembershipRoleOwner &&
+				profile.State == coredata.ProfileStateActive {
+				profiles := coredata.MembershipProfiles{}
+				count, err := profiles.CountActiveOwnerByOrganizationID(ctx, tx, scope, profile.OrganizationID)
+				if err != nil {
+					return fmt.Errorf("cannot count active owners: %w", err)
+				}
+
+				if count <= 1 {
+					return NewLastActiveOwnerError(userID)
+				}
 			}
 
 			profile.State = state
@@ -1062,6 +1093,10 @@ func (s *OrganizationService) UpdateUserState(
 
 			if err := profile.Update(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot update profile: %w", err)
+			}
+
+			if err := webhook.InsertData(ctx, tx, scope, profile.OrganizationID, coredata.WebhookEventTypeUserUpdated, webhooktypes.NewUser(profile, membership)); err != nil {
+				return fmt.Errorf("cannot insert webhook event: %w", err)
 			}
 
 			return nil

--- a/pkg/server/api/connect/v1/graphql/profile.graphql
+++ b/pkg/server/api/connect/v1/graphql/profile.graphql
@@ -94,7 +94,10 @@ type ProfileEdge {
 extend type Mutation {
   createUser(input: CreateUserInput!): CreateUserPayload
     @session(required: PRESENT)
+  activateUser(input: ActivateUserInput!): ActivateUserPayload
+    @session(required: PRESENT)
   deactivateUser(input: DeactivateUserInput!): DeactivateUserPayload
+    @session(required: PRESENT)
   updateUser(input: UpdateUserInput!): UpdateUserPayload!
   removeUser(input: RemoveUserInput!): RemoveUserPayload
     @session(required: PRESENT)
@@ -141,8 +144,12 @@ type CreateUserPayload {
   profileEdge: ProfileEdge!
 }
 
+type ActivateUserPayload {
+  profile: Profile!
+}
+
 type DeactivateUserPayload {
-  success: Boolean!
+  profile: Profile!
 }
 
 type UpdateUserPayload {

--- a/pkg/server/api/connect/v1/profile_resolvers.go
+++ b/pkg/server/api/connect/v1/profile_resolvers.go
@@ -8,6 +8,7 @@ package connect_v1
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/coredata"
@@ -55,25 +56,45 @@ func (r *mutationResolver) CreateUser(ctx context.Context, input types.CreateUse
 	}, nil
 }
 
+// ActivateUser is the resolver for the activateUser field.
+func (r *mutationResolver) ActivateUser(ctx context.Context, input types.ActivateUserInput) (*types.ActivateUserPayload, error) {
+	panic(fmt.Errorf("not implemented: ActivateUser - activateUser"))
+}
+
 // DeactivateUser is the resolver for the deactivateUser field.
 func (r *mutationResolver) DeactivateUser(ctx context.Context, input types.DeactivateUserInput) (*types.DeactivateUserPayload, error) {
 	if err := r.authorize(ctx, input.ProfileID, iam.ActionMembershipProfileDeactivate); err != nil {
 		return nil, err
 	}
 
-	_, err := r.iam.OrganizationService.UpdateUserState(
+	profile, err := r.iam.OrganizationService.UpdateUserState(
 		ctx,
 		input.ProfileID,
 		coredata.ProfileStateInactive,
 	)
-
 	if err != nil {
+		var errProfileNotFound *iam.ErrProfileNotFound
+		var errManagedBySCIM *iam.ErrUserManagedBySCIM
+		var errLastActiveOwner *iam.ErrLastActiveOwner
+
+		if errors.As(err, &errProfileNotFound) {
+			return nil, gqlutils.NotFound(ctx, err)
+		}
+
+		if errors.As(err, &errManagedBySCIM) {
+			return nil, gqlutils.Conflict(ctx, err)
+		}
+
+		if errors.As(err, &errLastActiveOwner) {
+			return nil, gqlutils.Conflict(ctx, err)
+		}
+
 		r.logger.ErrorCtx(ctx, "cannot deactivate profile", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
 
 	return &types.DeactivateUserPayload{
-		Success: true,
+		Profile: types.NewProfile(profile),
 	}, nil
 }
 


### PR DESCRIPTION
Add CLI (prb user activate / deactivate) and n8n operations for toggling membership profile state. Connect API exposes the corresponding mutations and the console person page lets owners activate or deactivate users. The IAM service now guards against deactivating the last active owner, skips no-op transitions, rejects SCIM-managed profiles, and emits a UserUpdated webhook.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add activate/deactivate for organization users across Console, Connect API, `prb` CLI, and `packages/n8n-node`. Adds guardrails in IAM and emits a `UserUpdated` webhook.

- **New Features**
  - Connect API: `activateUser` and `deactivateUser` mutations return `profile { id state }`; permission checks; no-ops skipped; rejects SCIM-managed profiles; blocks deactivating the last active owner; emits `UserUpdated`.
  - Console: Person page and People list now show Activate/Deactivate actions with confirms, toasts, and permission/SCIM gating.
  - CLI: `prb user activate <profileId> [--org]` and `prb user deactivate <profileId> [--org]` with optional `--output json`.
  - `n8n`: new `activateUser` and `deactivateUser` actions under the user resource.
  - Tests: e2e coverage for activate/deactivate, no-op, forbidden access, and last-active-owner protection.

- **Migration**
  - Connect API breaking change: `DeactivateUserPayload` now returns `profile` instead of `success`. Update clients to request `profile { id state }`.

<sup>Written for commit 374095d710259b2dc0adb04d078cac11354dbbbe. Summary will update on new commits. <a href="https://cubic.dev/pr/getprobo/probo/pull/1120?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

