### PR TITLE
Sandbox fix

### DIFF
--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -395,7 +395,7 @@ jobs:
         run: |
           make stack-up &
           STACK_PID=$!
-          SKIP_APPS=1 make bin/probod
+          make bin/probod
           wait $STACK_PID
       - run: "make stack-ps"
       - name: "Run e2e tests"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,7 @@ Signed-off-by: John Doe <john.doe@example.org>
 4. Build the project:
 
    ```bash
+   make generate WITH_APPS=1
    make build
    ```
 
@@ -105,7 +106,7 @@ Signed-off-by: John Doe <john.doe@example.org>
    npm -w @probo/console run dev
    ```
 
-The application should now be running at `http://localhost:3000`
+The application should now be running at `http://localhost:5173`
 
 For detailed information about all Docker services in the development stack, see [Docker Services Documentation](docs/DOCKER_SERVICES.md).
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -240,8 +240,8 @@ $(PROBOD_BIN): $(PROBOD_BIN_DEPS) $(PROBOD_BIN_EXTRA_DEPS)
 bin/prb:
 	$(GO_BUILD) -o $(PRB_BIN) $(PRB_SRC)
 
-.PHONY: bin/probod-bootstrap
-bin/probod-bootstrap:
+.PHONY: $(PROBOD_BOOTSTRAP_BIN)
+$(PROBOD_BOOTSTRAP_BIN):
 	$(GO_BUILD) -o $(PROBOD_BOOTSTRAP_BIN) $(PROBOD_BOOTSTRAP_SRC)
 
 .PHONY: @probo/emails

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -44,7 +44,7 @@ E2E_COVER_DIR ?= $(CURDIR)/coverage/e2e
 DOCKER_IMAGE_NAME=	ghcr.io/getprobo/probo
 DOCKER_TAG_NAME?=	latest
 
-PROBOD_BIN_DEPS= pkg/server/api/connect/v1/schema/schema.go \
+GENERATED= pkg/server/api/connect/v1/schema/schema.go \
 	pkg/server/api/connect/v1/types/types.go \
 	pkg/server/api/console/v1/schema/schema.go \
 	pkg/server/api/console/v1/types/types.go \
@@ -52,7 +52,8 @@ PROBOD_BIN_DEPS= pkg/server/api/connect/v1/schema/schema.go \
 	pkg/server/api/trust/v1/types/types.go \
 	pkg/server/api/mcp/v1/server/server.go \
 	pkg/server/api/mcp/v1/types/types.go \
-	apps/console/dist/index.html \
+
+EMBEDDED= apps/console/dist/index.html \
 	apps/trust/dist/index.html \
 	@probo/emails
 
@@ -66,8 +67,9 @@ PRB_SRC=	cmd/prb/main.go
 PROBOD_BOOTSTRAP_BIN=	bin/probod-bootstrap
 PROBOD_BOOTSTRAP_SRC=	cmd/probod-bootstrap/main.go
 
-ifndef SKIP_APPS
-PROBOD_BIN_EXTRA_DEPS += \
+ifdef WITH_APPS
+GENERATED += relay
+EMBEDDED += \
 	@probo/console \
 	@probo/trust
 endif
@@ -85,7 +87,7 @@ lint-go: vet go-fmt go-fix go-lint
 lint-js: npm-lint
 
 .PHONY: vet
-vet: generate apps/console/dist/index.html apps/trust/dist/index.html @probo/emails
+vet: generate embed
 	$(GO_VET) ./...
 
 .PHONY: npm-lint
@@ -102,7 +104,7 @@ go-fmt:
 	fi
 
 .PHONY: go-fix
-go-fix: generate apps/console/dist/index.html apps/trust/dist/index.html @probo/emails
+go-fix: generate embed
 	@output="$$($(GO_BASE) fix -diff -omitzero=false ./apps/... ./cmd/... ./packages/... ./pkg/... ./e2e/...)"; \
 	if [ -n "$$output" ]; then \
 		echo "error: 'go fix' suggests changes; please apply them"; \
@@ -233,7 +235,7 @@ docker-build:
 	$(DOCKER_BUILD) --tag $(DOCKER_IMAGE_NAME):$(DOCKER_TAG_NAME) --file Dockerfile .
 
 .PHONY: $(PROBOD_BIN)
-$(PROBOD_BIN): $(PROBOD_BIN_DEPS) $(PROBOD_BIN_EXTRA_DEPS)
+$(PROBOD_BIN): generate embed
 	$(GO_BUILD) -o $(PROBOD_BIN) $(PROBOD_SRC)
 
 .PHONY: bin/prb
@@ -285,15 +287,10 @@ pkg/server/api/trust/v1/schema.graphql: pkg/server/api/trust/v1/graphql $(TRUST_
 	$(NPM) --workspace $@ run build
 
 .PHONY: generate
-generate: pkg/server/api/connect/v1/schema/schema.go \
-	pkg/server/api/connect/v1/types/types.go \
-	pkg/server/api/console/v1/schema/schema.go \
-	pkg/server/api/console/v1/types/types.go \
-	pkg/server/api/trust/v1/schema/schema.go \
-	pkg/server/api/trust/v1/types/types.go \
-	pkg/server/api/mcp/v1/server/server.go \
-	pkg/server/api/mcp/v1/types/types.go \
-	relay
+generate: $(GENERATED)
+
+.PHONY: embed
+embed: $(EMBEDDED)
 
 pkg/server/api/connect/v1/schema/schema.go \
 pkg/server/api/connect/v1/types/types.go: pkg/server/api/connect/v1/gqlgen.yaml pkg/server/api/connect/v1/graphql $(CONNECT_GQL)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -390,6 +390,10 @@ sandbox-create: ## Create a Lima sandbox VM for this worktree
 sandbox-start: ## Start the Lima sandbox VM
 	./contrib/lima/sandbox.sh start
 
+.PHONY: sandbox-boot-logs
+sandbox-boot-logs: ## Show the Lima sandbox VM boot logs
+	./contrib/lima/sandbox.sh boot-logs
+
 .PHONY: sandbox-stop
 sandbox-stop: ## Stop (hibernate) the Lima sandbox VM
 	./contrib/lima/sandbox.sh stop

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ For detailed setup instructions, see our [Contributing Guide](CONTRIBUTING.md).
 ## 🏗️ Current Status
 
 Probo is in early development, focusing on building a solid foundation for
-compliance management. 
+compliance management.
 
 ## 🛠️ Tech Stack
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,7 +4,7 @@ services:
     pull_policy: missing
     shm_size: "1g"
     command: >
-      postgres -c "shared_buffers=1GB"
+      postgres -c "shared_buffers=256MB"
                -c "max_connections=200"
                -c "log_statement=all"
     ports:

--- a/contrib/claude/e2e.md
+++ b/contrib/claude/e2e.md
@@ -5,8 +5,8 @@ E2E tests live in `e2e/console/` (package `console_test`) and run against a live
 ## Running tests
 
 ```bash
-SKIP_APPS=1 make build   # Build the binary (backend only)
-make test-e2e            # Run all e2e tests
+make build    # Build the binary (backend only)
+make test-e2e # Run all e2e tests
 ```
 
 ## Client setup
@@ -26,16 +26,16 @@ Each call creates a unique identity with a fresh email. Available roles: `RoleOw
 
 ## Client methods
 
-| Method | API | Purpose |
-|--------|-----|---------|
-| `c.Execute(query, vars, &result)` | Console | Execute and unmarshal into result |
-| `c.MustExecute(query, vars, &result)` | Console | Execute, fail test on error |
-| `c.ExecuteShouldFail(query, vars)` | Console | Expect error, fail if succeeds |
-| `c.Do(query, vars)` | Console | Low-level, returns raw response |
-| `c.ExecuteConnect(query, vars, &result)` | Connect | For auth operations |
-| `c.ExecuteWithFile(query, vars, path, file, &result)` | Console | Single file upload |
-| `c.GetOrganizationID()` | — | Current org GID |
-| `c.GetUserID()` | — | Current user GID |
+| Method                                                | API     | Purpose                           |
+| ----------------------------------------------------- | ------- | --------------------------------- |
+| `c.Execute(query, vars, &result)`                     | Console | Execute and unmarshal into result |
+| `c.MustExecute(query, vars, &result)`                 | Console | Execute, fail test on error       |
+| `c.ExecuteShouldFail(query, vars)`                    | Console | Expect error, fail if succeeds    |
+| `c.Do(query, vars)`                                   | Console | Low-level, returns raw response   |
+| `c.ExecuteConnect(query, vars, &result)`              | Connect | For auth operations               |
+| `c.ExecuteWithFile(query, vars, path, file, &result)` | Console | Single file upload                |
+| `c.GetOrganizationID()`                               | —       | Current org GID                   |
+| `c.GetUserID()`                                       | —       | Current user GID                  |
 
 ## Test data factories
 

--- a/contrib/claude/make.md
+++ b/contrib/claude/make.md
@@ -4,20 +4,20 @@ The project uses a `GNUmakefile` at the root. Builds run with `--jobs=$(nproc)` 
 
 ## Everyday targets
 
-| Target                       | Purpose                                                                                                        |
-| ---------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `make build`                 | Build `bin/probod`, `bin/prb`, and `bin/probod-bootstrap` (does not include frontend apps, codegen, and Relay) |
-| `make build WITH_APPS=1`     | Build `bin/probod`, `bin/prb`, and `bin/probod-bootstrap` (includes frontend apps, codegen, and Relay)         |
-| `make test`                  | Run tests with race detection and coverage                                                                     |
-| `make test MODULE=./pkg/foo` | Run tests for a single module                                                                                  |
-| `make test-verbose`          | Tests with verbose output                                                                                      |
-| `make test-short`            | Short tests only                                                                                               |
-| `make test-bench`            | Run benchmarks                                                                                                 |
-| `make test-e2e`              | Run console end-to-end tests (requires `bin/probod`)                                                           |
-| `make lint`                  | Run all linters: `vet` + `go-fmt` + `go-fix` + `go-lint` + `npm-lint`                                          |
-| `make fmt`                   | Format Go code (`go fmt ./...`)                                                                                |
-| `make clean`                 | Remove all build artifacts, `node_modules`, generated files, and coverage                                      |
-| `make help`                  | List targets with `##` doc comments                                                                            |
+| Target                       | Purpose                                                                                                |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `make build`                 | Build `bin/probod`, `bin/prb`, and `bin/probod-bootstrap` (does not include frontend apps and Relay)   |
+| `make build WITH_APPS=1`     | Build `bin/probod`, `bin/prb`, and `bin/probod-bootstrap` (includes frontend apps, codegen, and Relay) |
+| `make test`                  | Run tests with race detection and coverage                                                             |
+| `make test MODULE=./pkg/foo` | Run tests for a single module                                                                          |
+| `make test-verbose`          | Tests with verbose output                                                                              |
+| `make test-short`            | Short tests only                                                                                       |
+| `make test-bench`            | Run benchmarks                                                                                         |
+| `make test-e2e`              | Run console end-to-end tests (requires `bin/probod`)                                                   |
+| `make lint`                  | Run all linters: `vet` + `go-fmt` + `go-fix` + `go-lint` + `npm-lint`                                  |
+| `make fmt`                   | Format Go code (`go fmt ./...`)                                                                        |
+| `make clean`                 | Remove all build artifacts, `node_modules`, generated files, and coverage                              |
+| `make help`                  | List targets with `##` doc comments                                                                    |
 
 ## Infrastructure
 

--- a/contrib/claude/make.md
+++ b/contrib/claude/make.md
@@ -4,33 +4,36 @@ The project uses a `GNUmakefile` at the root. Builds run with `--jobs=$(nproc)` 
 
 ## Everyday targets
 
-| Target | Purpose |
-|---|---|
-| `make build` | Build `bin/probod`, `bin/prb`, and `bin/probod-bootstrap` (includes frontend apps, codegen, and Relay) |
-| `SKIP_APPS=1 make build` | Build without frontend apps (faster for backend-only work) |
-| `make test` | Run tests with race detection and coverage |
-| `make test MODULE=./pkg/foo` | Run tests for a single module |
-| `make test-verbose` | Tests with verbose output |
-| `make test-short` | Short tests only |
-| `make test-bench` | Run benchmarks |
-| `make test-e2e` | Run console end-to-end tests (requires `bin/probod`) |
-| `make lint` | Run all linters: `vet` + `go-fmt` + `go-fix` + `go-lint` + `npm-lint` |
-| `make fmt` | Format Go code (`go fmt ./...`) |
-| `make clean` | Remove all build artifacts, `node_modules`, generated files, and coverage |
-| `make help` | List targets with `##` doc comments |
+| Target                       | Purpose                                                                                                        |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `make build`                 | Build `bin/probod`, `bin/prb`, and `bin/probod-bootstrap` (does not include frontend apps, codegen, and Relay) |
+| `make build WITH_APPS=1`     | Build `bin/probod`, `bin/prb`, and `bin/probod-bootstrap` (includes frontend apps, codegen, and Relay)         |
+| `make test`                  | Run tests with race detection and coverage                                                                     |
+| `make test MODULE=./pkg/foo` | Run tests for a single module                                                                                  |
+| `make test-verbose`          | Tests with verbose output                                                                                      |
+| `make test-short`            | Short tests only                                                                                               |
+| `make test-bench`            | Run benchmarks                                                                                                 |
+| `make test-e2e`              | Run console end-to-end tests (requires `bin/probod`)                                                           |
+| `make lint`                  | Run all linters: `vet` + `go-fmt` + `go-fix` + `go-lint` + `npm-lint`                                          |
+| `make fmt`                   | Format Go code (`go fmt ./...`)                                                                                |
+| `make clean`                 | Remove all build artifacts, `node_modules`, generated files, and coverage                                      |
+| `make help`                  | List targets with `##` doc comments                                                                            |
 
 ## Infrastructure
 
-| Target | Purpose |
-|---|---|
-| `make stack-up` | Start Docker Compose infra (Postgres, Pebble, Keycloak, etc.) |
-| `make stack-down` | Stop Docker Compose infra |
-| `make stack-ps` | List running containers |
-| `make psql` | Open a `psql` shell to the dev Postgres database |
+| Target            | Purpose                                                       |
+| ----------------- | ------------------------------------------------------------- |
+| `make stack-up`   | Start Docker Compose infra (Postgres, Pebble, Keycloak, etc.) |
+| `make stack-down` | Stop Docker Compose infra                                     |
+| `make stack-ps`   | List running containers                                       |
+| `make psql`       | Open a `psql` shell to the dev Postgres database              |
 
 ## Codegen
 
-`make generate` runs all code generation (GraphQL + MCP + Relay). Individual codegen is driven by `go generate`:
+`make generate` runs go code generation (GraphQL + MCP without Relay).
+`make generate WITH_APPS=1` runs all code generation (GraphQL + MCP + Relay).
+
+Individual codegen is driven by `go generate`:
 
 - `go generate ./pkg/server/api/console/v1` — Console GraphQL (gqlgen)
 - `go generate ./pkg/server/api/connect/v1` — Connect GraphQL (gqlgen)
@@ -42,39 +45,39 @@ The project uses a `GNUmakefile` at the root. Builds run with `--jobs=$(nproc)` 
 
 ## Coverage
 
-| Target | Purpose |
-|---|---|
-| `make coverage-report` | Unit test HTML coverage report (`coverage.html`) |
-| `make test-e2e-coverage` | E2E coverage report (`coverage-e2e.html`) |
+| Target                   | Purpose                                               |
+| ------------------------ | ----------------------------------------------------- |
+| `make coverage-report`   | Unit test HTML coverage report (`coverage.html`)      |
+| `make test-e2e-coverage` | E2E coverage report (`coverage-e2e.html`)             |
 | `make coverage-combined` | Combined unit + e2e report (`coverage-combined.html`) |
 
 ## Docker
 
-| Target | Purpose |
-|---|---|
+| Target              | Purpose                                           |
+| ------------------- | ------------------------------------------------- |
 | `make docker-build` | Build the Docker image (`ghcr.io/getprobo/probo`) |
-| `make sbom` | Source SBOM (CycloneDX) |
-| `make sbom-docker` | Docker image SBOM |
-| `make scan` | Vulnerability scan (Grype) on source + Docker |
-| `make scan-license` | License compliance scan (Trivy) |
+| `make sbom`         | Source SBOM (CycloneDX)                           |
+| `make sbom-docker`  | Docker image SBOM                                 |
+| `make scan`         | Vulnerability scan (Grype) on source + Docker     |
+| `make scan-license` | License compliance scan (Trivy)                   |
 
 ## Sandbox (Lima)
 
-| Target | Purpose |
-|---|---|
+| Target                | Purpose                                    |
+| --------------------- | ------------------------------------------ |
 | `make sandbox-create` | Create a Lima sandbox VM for this worktree |
-| `make sandbox-start` | Start the VM |
-| `make sandbox-stop` | Stop (hibernate) the VM |
-| `make sandbox-delete` | Delete the VM |
-| `make sandbox-ssh` | Open a shell in the VM |
-| `make sandbox-status` | Show VM status and IP |
+| `make sandbox-start`  | Start the VM                               |
+| `make sandbox-stop`   | Stop (hibernate) the VM                    |
+| `make sandbox-delete` | Delete the VM                              |
+| `make sandbox-ssh`    | Open a shell in the VM                     |
+| `make sandbox-status` | Show VM status and IP                      |
 
 ## Overridable variables
 
-| Variable | Default | Purpose |
-|---|---|---|
-| `SKIP_APPS` | (unset) | Set to `1` to skip frontend app builds |
-| `CGO_ENABLED` | `0` | Enable/disable CGO |
-| `GOOS` | (host) | Cross-compile target OS |
-| `TEST_FLAGS` | `-race -cover -coverprofile=coverage.out` | Extra flags passed to `go test` |
-| `DOCKER_BUILD_FLAGS` | (empty) | Extra flags for `docker build` |
+| Variable             | Default                                   | Purpose                                    |
+| -------------------- | ----------------------------------------- | ------------------------------------------ |
+| `WITH_APPS`          | (unset)                                   | Set to `1` to generate/build frontend apps |
+| `CGO_ENABLED`        | `0`                                       | Enable/disable CGO                         |
+| `GOOS`               | (host)                                    | Cross-compile target OS                    |
+| `TEST_FLAGS`         | `-race -cover -coverprofile=coverage.out` | Extra flags passed to `go test`            |
+| `DOCKER_BUILD_FLAGS` | (empty)                                   | Extra flags for `docker build`             |

--- a/contrib/claude/sandbox.md
+++ b/contrib/claude/sandbox.md
@@ -92,26 +92,15 @@ Manage them with `systemctl`:
 
 **Start the app:**
 ```bash
-./contrib/lima/sandbox.sh exec -- make build
 ./contrib/lima/sandbox.sh exec -- sudo systemctl start probod probo-console probo-trust
 ```
 
 **Run tests:**
 ```bash
-./contrib/lima/sandbox.sh exec -- make build
 ./contrib/lima/sandbox.sh exec -- make test
 ```
 
 **Run e2e tests:**
 ```bash
 ./contrib/lima/sandbox.sh exec -- make test-e2e
-```
-
-**Restart after code changes:**
-Code changes are reflected immediately (virtiofs mount). Just rebuild and
-restart probod — no need to restart the VM.
-
-```bash
-./contrib/lima/sandbox.sh exec -- make build
-./contrib/lima/sandbox.sh exec -- sudo systemctl restart probod
 ```

--- a/contrib/claude/sandbox.md
+++ b/contrib/claude/sandbox.md
@@ -17,10 +17,6 @@ Use a sandbox when you need to:
 # Start an existing sandbox
 ./contrib/lima/sandbox.sh start
 
-# Build and start the app (probo-stack starts automatically on boot)
-./contrib/lima/sandbox.sh exec -- make build
-./contrib/lima/sandbox.sh exec -- sudo systemctl start probod probo-console probo-trust
-
 # Get the VM IP and service URLs
 ./contrib/lima/sandbox.sh status
 
@@ -38,14 +34,14 @@ Use a sandbox when you need to:
 
 After `sandbox.sh status`, use the VM IP to access services from the host:
 
-| Service | URL |
-|---|---|
-| Console | `http://<vm-ip>:5173` |
-| Trust | `http://<vm-ip>:5174` |
-| API | `http://<vm-ip>:8080` |
-| Grafana | `http://<vm-ip>:3001` |
-| Mailpit | `http://<vm-ip>:8025` |
-| Keycloak | `http://<vm-ip>:8082` |
+| Service    | URL                         |
+| ---------- | --------------------------- |
+| Console    | `http://<vm-ip>:5173`       |
+| Trust      | `http://<vm-ip>:5174`       |
+| API        | `http://<vm-ip>:8080`       |
+| Grafana    | `http://<vm-ip>:3001`       |
+| Mailpit    | `http://<vm-ip>:8025`       |
+| Keycloak   | `http://<vm-ip>:8082`       |
 | PostgreSQL | `psql -h <vm-ip> -U probod` |
 
 ## Auto-generated configuration
@@ -74,12 +70,12 @@ This file is sourced during provisioning before `probod-bootstrap` runs. Any var
 
 The sandbox provisions four systemd services:
 
-| Service | Description | Starts on boot |
-|---|---|---|
-| `probo-stack` | Docker Compose stack (Postgres, SeaweedFS, Keycloak, etc.) | Yes |
-| `probod` | Probo API server (depends on `probo-stack`) | No |
-| `probo-console` | Console frontend dev server | No |
-| `probo-trust` | Trust frontend dev server | No |
+| Service         | Description                                                | Starts on boot |
+| --------------- | ---------------------------------------------------------- | -------------- |
+| `probo-stack`   | Docker Compose stack (Postgres, SeaweedFS, Keycloak, etc.) | Yes            |
+| `probod`        | Probo API server (depends on `probo-stack`)                | No             |
+| `probo-console` | Console frontend dev server                                | No             |
+| `probo-trust`   | Trust frontend dev server                                  | No             |
 
 `probo-stack` starts automatically when the VM boots. `probod`, `probo-console`, and `probo-trust` must be started manually after building.
 

--- a/contrib/claude/sandbox.md
+++ b/contrib/claude/sandbox.md
@@ -12,27 +12,27 @@ Use a sandbox when you need to:
 
 ```bash
 # Create a sandbox (first time only)
-./contrib/lima/sandbox.sh create
+make sandbox-create
 
 # Start an existing sandbox
-./contrib/lima/sandbox.sh start
+make sandbox-start
 
 # Get the VM IP and service URLs
-./contrib/lima/sandbox.sh status
+make sandbox-status
 
 # Interactive shell
-./contrib/lima/sandbox.sh ssh
+make sandbox-ssh
 
 # Stop (shutdown — preserves disk and Docker images, but running processes are lost)
-./contrib/lima/sandbox.sh stop
+make sandbox-stop
 
 # Delete entirely
-./contrib/lima/sandbox.sh delete
+make sandbox-delete
 ```
 
 ## Accessing services
 
-After `sandbox.sh status`, use the VM IP to access services from the host:
+After `make sandbox-status`, use the VM IP to access services from the host:
 
 | Service    | URL                         |
 | ---------- | --------------------------- |
@@ -64,7 +64,7 @@ AUTH_OIDC_CLIENT_ID=my-client-id
 AUTH_OIDC_CLIENT_SECRET=s3cret
 ```
 
-This file is sourced during provisioning before `probod-bootstrap` runs. Any variable set here overrides the defaults. The sandbox must be recreated (`delete` + `create`) for changes to take effect.
+This file is sourced during provisioning before `probod-bootstrap` runs. Any variable set here overrides the defaults. The sandbox must be recreated (`sandbox-delete` + `sandbox-create`) for changes to take effect.
 
 ## Systemd services
 
@@ -89,11 +89,6 @@ Manage them with `systemctl`:
 ```
 
 ## Common workflows
-
-**Start the app:**
-```bash
-./contrib/lima/sandbox.sh exec -- sudo systemctl start probod probo-console probo-trust
-```
 
 **Run tests:**
 ```bash

--- a/contrib/lima/provision.sh
+++ b/contrib/lima/provision.sh
@@ -30,6 +30,7 @@ apt-get install -y -qq \
     ca-certificates \
     gnupg \
     lsb-release \
+    postgresql-client \
     unzip
 
 if ! command -v docker &>/dev/null; then
@@ -178,10 +179,11 @@ Requires=docker.service
 After=docker.service
 
 [Service]
-Type=simple
+Type=oneshot
+RemainAfterExit=yes
 User=root
 WorkingDirectory=/workspace
-ExecStart=/usr/bin/docker compose -f compose.yaml up
+ExecStart=/usr/bin/docker compose -f compose.yaml up -d --wait
 ExecStop=/usr/bin/docker compose -f compose.yaml down
 Restart=on-failure
 RestartSec=5s
@@ -200,6 +202,7 @@ After=probo-stack.service
 Type=simple
 User=${LIMA_USER}
 WorkingDirectory=/workspace
+ExecStartPre=/bin/bash -c 'for i in \$(seq 1 10); do pg_isready -h localhost -p 5432 -U probod -d probod -q && exit 0; sleep 1; done; echo "PostgreSQL not ready after 10s"; exit 1'
 ExecStart=/usr/local/bin/gow -r=false run ./cmd/probod -cfg-file /etc/probod/config.yml -format pretty
 Restart=on-failure
 RestartSec=3s
@@ -213,7 +216,7 @@ cat > /etc/systemd/system/probo-console.service << EOF
 [Unit]
 Description=Probo Console Dev Server
 Requires=probo-node-modules.service
-After=probo-node-modules.service
+After=probo-node-modules.service probod.service
 
 [Service]
 Type=simple
@@ -231,7 +234,7 @@ cat > /etc/systemd/system/probo-trust.service << EOF
 [Unit]
 Description=Probo Trust Dev Server
 Requires=probo-node-modules.service
-After=probo-node-modules.service
+After=probo-node-modules.service probod.service
 
 [Service]
 Type=simple

--- a/contrib/lima/provision.sh
+++ b/contrib/lima/provision.sh
@@ -249,4 +249,4 @@ EOF
 systemctl daemon-reload
 systemctl enable --now probo-node-modules.service
 systemctl enable --now probo-stack.service
-systemctl enable probod.service probo-console.service probo-trust.service
+systemctl enable --now probod.service probo-console.service probo-trust.service

--- a/contrib/lima/provision.sh
+++ b/contrib/lima/provision.sh
@@ -145,8 +145,9 @@ if [ -z "$(ls -A /var/lib/probo/node_modules 2>/dev/null)" ]; then
     su - "${LIMA_USER}" -c "cd /workspace && npm ci"
 fi
 
-# Build bin/probod to get dependencies, notably embedded files
-make -C /workspace bin/probod SKIP_APPS=1
+# Generate go and ts files for probod and apps, and create embedded files for probod
+make -C /workspace generate WITH_APPS=1
+make -C /workspace embed
 
 echo "VITE_API_URL=http://${VM_IP}:8080" > /workspace/apps/console/.env
 echo "VITE_API_URL=http://${VM_IP}:8080" > /workspace/apps/trust/.env

--- a/contrib/lima/provision.sh
+++ b/contrib/lima/provision.sh
@@ -30,8 +30,7 @@ apt-get install -y -qq \
     ca-certificates \
     gnupg \
     lsb-release \
-    postgresql-client \
-    unzip
+    postgresql-client
 
 if ! command -v docker &>/dev/null; then
     install -m 0755 -d /etc/apt/keyrings

--- a/contrib/lima/provision.sh
+++ b/contrib/lima/provision.sh
@@ -98,6 +98,8 @@ VM_IP=$(ip -4 -j addr show dev lima0 | jq -r '.[0].addr_info[0].local')
 
 su - "${LIMA_USER}" -c "export PATH=/usr/local/go/bin:\$HOME/go/bin:\$PATH && cd /workspace && make bin/probod-bootstrap"
 
+make -C /workspace compose/pebble/certs/rootCA.pem compose/keycloak/probo-realm.json
+
 mkdir -p /etc/probod
 
 OAUTH2_SIGNING_KEY_PATH=/etc/probod/oauth2-signing-key.pem
@@ -125,11 +127,26 @@ AWS_ENDPOINT="http://127.0.0.1:8333" \
 AWS_ACCESS_KEY_ID="probod" \
 AWS_SECRET_ACCESS_KEY="thisisnotasecret" \
 AWS_USE_PATH_STYLE=true \
+ACME_DIRECTORY="https://127.0.0.1:14000/dir" \
+ACME_EMAIL="admin@getprobo.com" \
+ACME_KEY_TYPE="EC256" \
+ACME_ROOT_CA="$(cat /workspace/compose/pebble/certs/rootCA.pem)" \
     /workspace/bin/probod-bootstrap -output /etc/probod/config.yml
 
 # probod runs as ${LIMA_USER} but bootstrap writes config.yml as root with 0600
 # because it contains secrets. Transfer ownership so probod can read it.
 chown "${LIMA_USER}:${LIMA_USER}" /etc/probod/config.yml "${OAUTH2_SIGNING_KEY_PATH}"
+
+# Populate VM-local node_modules with Linux-native binaries (esbuild, etc.).
+# The host's node_modules is macOS; `probo-node-modules.service` bind-mounts an
+# empty tree over /workspace/node_modules, and we install into it once here so
+# `make build` and the dev servers can run without cross-platform mismatches.
+if [ -z "$(ls -A /var/lib/probo/node_modules 2>/dev/null)" ]; then
+    su - "${LIMA_USER}" -c "cd /workspace && npm ci"
+fi
+
+# Build bin/probod to get dependencies, notably embedded files
+make -C /workspace bin/probod SKIP_APPS=1
 
 echo "VITE_API_URL=http://${VM_IP}:8080" > /workspace/apps/console/.env
 echo "VITE_API_URL=http://${VM_IP}:8080" > /workspace/apps/trust/.env
@@ -154,7 +171,7 @@ WantedBy=multi-user.target
 EOF
 
 # Install systemd services for the sandbox
-cat > /etc/systemd/system/probo-stack.service << 'EOF'
+cat > /etc/systemd/system/probo-stack.service << EOF
 [Unit]
 Description=Probo Docker Compose Stack
 Requires=docker.service
@@ -183,7 +200,7 @@ After=probo-stack.service
 Type=simple
 User=${LIMA_USER}
 WorkingDirectory=/workspace
-ExecStart=/usr/local/bin/gow -r=false run ./cmd/probod -cfg-file /etc/probod/config.yml
+ExecStart=/usr/local/bin/gow -r=false run ./cmd/probod -cfg-file /etc/probod/config.yml -format pretty
 Restart=on-failure
 RestartSec=3s
 Environment=PATH=/usr/local/go/bin:/usr/local/bin:/usr/bin:/bin
@@ -232,11 +249,3 @@ systemctl daemon-reload
 systemctl enable --now probo-node-modules.service
 systemctl enable --now probo-stack.service
 systemctl enable probod.service probo-console.service probo-trust.service
-
-# Populate VM-local node_modules with Linux-native binaries (esbuild, etc.).
-# The host's node_modules is macOS; `probo-node-modules.service` bind-mounts an
-# empty tree over /workspace/node_modules, and we install into it once here so
-# `make build` and the dev servers can run without cross-platform mismatches.
-if [ -z "$(ls -A /var/lib/probo/node_modules 2>/dev/null)" ]; then
-    su - "${LIMA_USER}" -c "cd /workspace && npm ci"
-fi

--- a/contrib/lima/provision.sh
+++ b/contrib/lima/provision.sh
@@ -11,7 +11,7 @@ export LIMA_CIDATA_USER
 
 export DEBIAN_FRONTEND=noninteractive
 
-GO_VERSION="1.26.1"
+GO_VERSION="1.26.2"
 NODE_MAJOR=24
 NPM_VERSION="11.8.0"
 
@@ -71,8 +71,6 @@ chmod +x /etc/profile.d/go.sh
 export PATH="/usr/local/go/bin:$PATH"
 export HOME="${HOME:-/root}"
 
-GOBIN=/usr/local/bin /usr/local/go/bin/go install "gotest.tools/gotestsum@${GOTESTSUM_VERSION}"
-GOBIN=/usr/local/bin /usr/local/go/bin/go install "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}"
 GOBIN=/usr/local/bin /usr/local/go/bin/go install "github.com/mitranim/gow@${GOW_VERSION}"
 
 if ! command -v node &>/dev/null || ! node --version | grep -q "v${NODE_MAJOR}"; then
@@ -137,21 +135,6 @@ ACME_ROOT_CA="$(cat /workspace/compose/pebble/certs/rootCA.pem)" \
 # because it contains secrets. Transfer ownership so probod can read it.
 chown "${LIMA_USER}:${LIMA_USER}" /etc/probod/config.yml "${OAUTH2_SIGNING_KEY_PATH}"
 
-# Populate VM-local node_modules with Linux-native binaries (esbuild, etc.).
-# The host's node_modules is macOS; `probo-node-modules.service` bind-mounts an
-# empty tree over /workspace/node_modules, and we install into it once here so
-# `make build` and the dev servers can run without cross-platform mismatches.
-if [ -z "$(ls -A /var/lib/probo/node_modules 2>/dev/null)" ]; then
-    su - "${LIMA_USER}" -c "cd /workspace && npm ci"
-fi
-
-# Generate go and ts files for probod and apps, and create embedded files for probod
-make -C /workspace generate WITH_APPS=1
-make -C /workspace embed
-
-echo "VITE_API_URL=http://${VM_IP}:8080" > /workspace/apps/console/.env
-echo "VITE_API_URL=http://${VM_IP}:8080" > /workspace/apps/trust/.env
-
 # Bind-mount VM-local node_modules over the shared workspace to avoid
 # platform conflicts between macOS host and Linux VM native binaries.
 cat > /etc/systemd/system/probo-node-modules.service << EOF
@@ -170,6 +153,22 @@ ExecStartPost=/bin/chown ${LIMA_USER}:${LIMA_USER} /var/lib/probo/node_modules
 [Install]
 WantedBy=multi-user.target
 EOF
+
+systemctl daemon-reload
+systemctl enable --now probo-node-modules.service
+
+# Populate VM-local node_modules with Linux-native binaries (esbuild, etc.).
+# The host's node_modules is macOS; `probo-node-modules.service` bind-mounts an
+# empty tree over /workspace/node_modules, and we install into it once here so
+# the dev servers can run without cross-platform mismatches.
+su - "${LIMA_USER}" -c "cd /workspace && npm ci"
+
+# Generate go and ts files for probod and apps, and create embedded files for probod
+make -C /workspace generate WITH_APPS=1
+make -C /workspace embed
+
+echo "VITE_API_URL=http://${VM_IP}:8080" > /workspace/apps/console/.env
+echo "VITE_API_URL=http://${VM_IP}:8080" > /workspace/apps/trust/.env
 
 # Install systemd services for the sandbox
 cat > /etc/systemd/system/probo-stack.service << EOF
@@ -214,7 +213,7 @@ cat > /etc/systemd/system/probo-console.service << EOF
 [Unit]
 Description=Probo Console Dev Server
 Requires=probo-node-modules.service
-After=probod.service probo-node-modules.service
+After=probo-node-modules.service
 
 [Service]
 Type=simple
@@ -232,7 +231,7 @@ cat > /etc/systemd/system/probo-trust.service << EOF
 [Unit]
 Description=Probo Trust Dev Server
 Requires=probo-node-modules.service
-After=probod.service probo-node-modules.service
+After=probo-node-modules.service
 
 [Service]
 Type=simple
@@ -247,6 +246,5 @@ WantedBy=multi-user.target
 EOF
 
 systemctl daemon-reload
-systemctl enable --now probo-node-modules.service
 systemctl enable --now probo-stack.service
 systemctl enable --now probod.service probo-console.service probo-trust.service

--- a/contrib/lima/sandbox.sh
+++ b/contrib/lima/sandbox.sh
@@ -81,7 +81,6 @@ cmd_create() {
 cmd_start() {
     echo "Starting sandbox: ${VM_NAME}"
     limactl start "${VM_NAME}"
-    cmd_exec -- sudo systemctl start probod probo-console probo-trust
     echo ""
     cmd_status
 }

--- a/contrib/lima/sandbox.sh
+++ b/contrib/lima/sandbox.sh
@@ -76,15 +76,12 @@ cmd_create() {
     fi
 
     limactl create "${create_args[@]}" "${TEMPLATE}"
-    limactl start "${VM_NAME}"
-
-    echo ""
-    cmd_status
 }
 
 cmd_start() {
     echo "Starting sandbox: ${VM_NAME}"
     limactl start "${VM_NAME}"
+    cmd_exec -- sudo systemctl start probod probo-console probo-trust
     echo ""
     cmd_status
 }

--- a/contrib/lima/sandbox.sh
+++ b/contrib/lima/sandbox.sh
@@ -61,7 +61,7 @@ cmd_create() {
     local -a create_args=(
         --name "${VM_NAME}"
         --tty=false
-        --set ".mounts = [{\"location\": \"${REPO_ROOT}\", \"mountPoint\": \"/workspace\", \"writable\": true}]"
+        --set ".mounts = [{\"location\": \"${REPO_ROOT}\", \"mountPoint\": \"/workspace\", \"writable\": true},{\"location\": \"/Users/${USER}/go\", \"mountPoint\": \"/home/${USER}.guest/go\", \"writable\": true}]"
         --mount-type virtiofs
     )
 

--- a/contrib/lima/sandbox.sh
+++ b/contrib/lima/sandbox.sh
@@ -61,7 +61,7 @@ cmd_create() {
     local -a create_args=(
         --name "${VM_NAME}"
         --tty=false
-        --set ".mounts = [{\"location\": \"${REPO_ROOT}\", \"mountPoint\": \"/workspace\", \"writable\": true},{\"location\": \"/Users/${USER}/go\", \"mountPoint\": \"/home/${USER}.guest/go\", \"writable\": true}]"
+        --set ".mounts = [{\"location\": \"${REPO_ROOT}\", \"mountPoint\": \"/workspace\", \"writable\": true},{\"location\": \"${HOME}/go\", \"mountPoint\": \"/home/${USER}.guest/go\", \"writable\": true}]"
         --mount-type virtiofs
     )
 

--- a/contrib/lima/sandbox.sh
+++ b/contrib/lima/sandbox.sh
@@ -87,7 +87,7 @@ cmd_start() {
 }
 
 cmd_boot_logs() {
-    limactl shell probo-sandbox-fix -- sudo tail -f /var/log/cloud-init-output.log
+    limactl shell "${VM_NAME}" -- sudo tail -f /var/log/cloud-init-output.log
 }
 
 cmd_stop() {

--- a/contrib/lima/sandbox.sh
+++ b/contrib/lima/sandbox.sh
@@ -18,6 +18,7 @@ Usage: $(basename "$0") <command> [options]
 Commands:
   create [--cpus C] [--memory M] [--disk D]   Create a new sandbox VM
   start                                        Start a stopped sandbox
+  boot-logs                                    Show boot logs
   stop                                         Stop the sandbox
   restart                                      Stop + start the sandbox
   delete                                       Delete the sandbox entirely
@@ -83,6 +84,10 @@ cmd_start() {
     limactl start "${VM_NAME}"
     echo ""
     cmd_status
+}
+
+cmd_boot_logs() {
+    limactl shell probo-sandbox-fix -- sudo tail -f /var/log/cloud-init-output.log
 }
 
 cmd_stop() {
@@ -157,12 +162,13 @@ command="$1"
 shift
 
 case "${command}" in
-    create)  cmd_create "$@" ;;
-    start)   cmd_start ;;
-    stop)    cmd_stop ;;
-    restart) cmd_restart ;;
-    delete)  cmd_delete ;;
-    ssh)     cmd_ssh ;;
+    create)     cmd_create "$@" ;;
+    start)      cmd_start ;;
+    boot-logs)  cmd_boot_logs ;;
+    stop)       cmd_stop ;;
+    restart)    cmd_restart ;;
+    delete)     cmd_delete ;;
+    ssh)        cmd_ssh ;;
     exec)
         if [[ "${1:-}" == "--" ]]; then shift; fi
         cmd_exec "$@"

--- a/pkg/bootstrap/builder.go
+++ b/pkg/bootstrap/builder.go
@@ -82,8 +82,8 @@ func (b *Builder) Build() (*probodconfig.FullConfig, error) {
 			},
 			Pg: probodconfig.PgConfig{
 				Addr:                   b.getEnvOrDefault("PG_ADDR", "localhost:5432"),
-				Username:               b.getEnvOrDefault("PG_USERNAME", "postgres"),
-				Password:               b.getEnvOrDefault("PG_PASSWORD", "postgres"),
+				Username:               b.getEnvOrDefault("PG_USERNAME", "probod"),
+				Password:               b.getEnvOrDefault("PG_PASSWORD", "probod"),
 				Database:               b.getEnvOrDefault("PG_DATABASE", "probod"),
 				PoolSize:               int32(b.getEnvIntOrDefault("PG_POOL_SIZE", 100)),
 				MinPoolSize:            int32(b.getEnvIntOrDefault("PG_MIN_POOL_SIZE", 10)),

--- a/pkg/bootstrap/builder.go
+++ b/pkg/bootstrap/builder.go
@@ -20,7 +20,7 @@ import (
 	"strconv"
 	"strings"
 
-	"go.probo.inc/probo/pkg/probod"
+	"go.probo.inc/probo/pkg/probodconfig"
 )
 
 type EnvGetter func(key string) string
@@ -39,7 +39,7 @@ func NewBuilder(getEnv EnvGetter) *Builder {
 	return &Builder{getEnv: getEnv}
 }
 
-func (b *Builder) Build() (*probod.FullConfig, error) {
+func (b *Builder) Build() (*probodconfig.FullConfig, error) {
 	if err := b.validateRequired(); err != nil {
 		return nil, err
 	}
@@ -53,12 +53,12 @@ func (b *Builder) Build() (*probod.FullConfig, error) {
 
 	pgCACertBundle := b.getPgCACertBundle()
 
-	cfg := &probod.FullConfig{
-		Unit: probod.UnitConfig{
-			Metrics: probod.MetricsConfig{
+	cfg := &probodconfig.FullConfig{
+		Unit: probodconfig.UnitConfig{
+			Metrics: probodconfig.MetricsConfig{
 				Addr: b.getEnvOrDefault("METRICS_ADDR", "localhost:8081"),
 			},
-			Tracing: probod.TracingConfig{
+			Tracing: probodconfig.TracingConfig{
 				Addr:          b.getEnvOrDefault("TRACING_ADDR", "localhost:4317"),
 				MaxBatchSize:  b.getEnvIntOrDefault("TRACING_MAX_BATCH_SIZE", 512),
 				BatchTimeout:  b.getEnvIntOrDefault("TRACING_BATCH_TIMEOUT", 5),
@@ -66,21 +66,21 @@ func (b *Builder) Build() (*probod.FullConfig, error) {
 				MaxQueueSize:  b.getEnvIntOrDefault("TRACING_MAX_QUEUE_SIZE", 2048),
 			},
 		},
-		Probod: probod.Config{
+		Probod: probodconfig.Config{
 			BaseURL:       b.getEnvOrDefault("PROBOD_BASE_URL", "http://localhost:8080"),
 			EncryptionKey: b.getEnv("PROBOD_ENCRYPTION_KEY"),
 			ChromeDPAddr:  b.getEnvOrDefault("CHROME_DP_ADDR", "localhost:9222"),
-			Api: probod.APIConfig{
+			Api: probodconfig.APIConfig{
 				Addr: b.getEnvOrDefault("API_ADDR", ":8080"),
-				ProxyProtocol: probod.ProxyProtocolConfig{
+				ProxyProtocol: probodconfig.ProxyProtocolConfig{
 					TrustedProxies: b.parseOriginsList(b.getEnv("API_PROXY_PROTOCOL_TRUSTED_PROXIES")),
 				},
-				Cors: probod.CorsConfig{
+				Cors: probodconfig.CorsConfig{
 					AllowedOrigins: b.parseOriginsList(b.getEnvOrDefault("API_CORS_ALLOWED_ORIGINS", "http://localhost:8080")),
 				},
 				ExtraHeaderFields: make(map[string]string),
 			},
-			Pg: probod.PgConfig{
+			Pg: probodconfig.PgConfig{
 				Addr:                   b.getEnvOrDefault("PG_ADDR", "localhost:5432"),
 				Username:               b.getEnvOrDefault("PG_USERNAME", "postgres"),
 				Password:               b.getEnvOrDefault("PG_PASSWORD", "postgres"),
@@ -92,23 +92,23 @@ func (b *Builder) Build() (*probod.FullConfig, error) {
 				CACertBundle:           pgCACertBundle,
 				Debug:                  b.getEnvBoolOrDefault("PG_DEBUG", false),
 			},
-			Auth: probod.AuthConfig{
+			Auth: probodconfig.AuthConfig{
 				DisableSignup:                       b.getEnvBoolOrDefault("AUTH_DISABLE_SIGNUP", false),
 				InvitationConfirmationTokenValidity: b.getEnvIntOrDefault("AUTH_INVITATION_TOKEN_VALIDITY", 3600),
 				PasswordResetTokenValidity:          b.getEnvIntOrDefault("AUTH_PASSWORD_RESET_TOKEN_VALIDITY", 3600),
 				MagicLinkTokenValidity:              b.getEnvIntOrDefault("AUTH_MAGIC_LINK_TOKEN_VALIDITY", 900),
-				Cookie: probod.CookieConfig{
+				Cookie: probodconfig.CookieConfig{
 					Name:     b.getEnvOrDefault("AUTH_COOKIE_NAME", "SSID"),
 					Domain:   b.getEnvOrDefault("AUTH_COOKIE_DOMAIN", "localhost"),
 					Secret:   b.getEnv("AUTH_COOKIE_SECRET"),
 					Duration: b.getEnvIntOrDefault("AUTH_COOKIE_DURATION", 24),
 					Secure:   b.getEnvBoolOrDefault("AUTH_COOKIE_SECURE", true),
 				},
-				Password: probod.PasswordConfig{
+				Password: probodconfig.PasswordConfig{
 					Pepper:     b.getEnv("AUTH_PASSWORD_PEPPER"),
 					Iterations: b.getEnvIntOrDefault("AUTH_PASSWORD_ITERATIONS", 1000000),
 				},
-				SAML: probod.SAMLConfig{
+				SAML: probodconfig.SAMLConfig{
 					SessionDuration:                   b.getEnvIntOrDefault("SAML_SESSION_DURATION", 604800),
 					CleanupIntervalSeconds:            b.getEnvIntOrDefault("SAML_CLEANUP_INTERVAL_SECONDS", 0),
 					Certificate:                       samlCert,
@@ -116,18 +116,18 @@ func (b *Builder) Build() (*probod.FullConfig, error) {
 					DomainVerificationIntervalSeconds: b.getEnvIntOrDefault("SAML_DOMAIN_VERIFICATION_INTERVAL_SECONDS", 60),
 					DomainVerificationResolverAddr:    b.getEnvOrDefault("SAML_DOMAIN_VERIFICATION_RESOLVER_ADDR", "8.8.8.8:53"),
 				},
-				Google: probod.OIDCProviderConfig{
+				Google: probodconfig.OIDCProviderConfig{
 					ClientID:     b.getEnv("AUTH_GOOGLE_CLIENT_ID"),
 					ClientSecret: b.getEnv("AUTH_GOOGLE_CLIENT_SECRET"),
 					Enabled:      b.getEnv("AUTH_GOOGLE_CLIENT_ID") != "" && b.getEnv("AUTH_GOOGLE_CLIENT_SECRET") != "",
 				},
-				Microsoft: probod.OIDCProviderConfig{
+				Microsoft: probodconfig.OIDCProviderConfig{
 					ClientID:     b.getEnv("AUTH_MICROSOFT_CLIENT_ID"),
 					ClientSecret: b.getEnv("AUTH_MICROSOFT_CLIENT_SECRET"),
 					Enabled:      b.getEnv("AUTH_MICROSOFT_CLIENT_ID") != "" && b.getEnv("AUTH_MICROSOFT_CLIENT_SECRET") != "",
 				},
-				OAuth2Server: probod.OAuth2ServerConfig{
-					SigningKeys: []probod.OAuth2SigningKeyConfig{{
+				OAuth2Server: probodconfig.OAuth2ServerConfig{
+					SigningKeys: []probodconfig.OAuth2SigningKeyConfig{{
 						PrivateKey: oauth2SigningKey,
 						KID:        b.getEnvOrDefault("OAUTH2_SERVER_SIGNING_KEY_KID", "default"),
 						Active:     true,
@@ -138,14 +138,14 @@ func (b *Builder) Build() (*probod.FullConfig, error) {
 					DeviceCodeDuration:        b.getEnvIntOrDefault("OAUTH2_SERVER_DEVICE_CODE_DURATION", 600),
 				},
 			},
-			TrustCenter: probod.TrustCenterConfig{
+			TrustCenter: probodconfig.TrustCenterConfig{
 				HTTPAddr:  b.getEnvOrDefault("TRUST_CENTER_HTTP_ADDR", ":80"),
 				HTTPSAddr: b.getEnvOrDefault("TRUST_CENTER_HTTPS_ADDR", ":443"),
-				ProxyProtocol: probod.ProxyProtocolConfig{
+				ProxyProtocol: probodconfig.ProxyProtocolConfig{
 					TrustedProxies: b.parseOriginsList(b.getEnv("TRUST_CENTER_PROXY_PROTOCOL_TRUSTED_PROXIES")),
 				},
 			},
-			AWS: probod.AWSConfig{
+			AWS: probodconfig.AWSConfig{
 				Region:          b.getEnvOrDefault("AWS_REGION", "us-east-1"),
 				Bucket:          b.getEnvOrDefault("AWS_BUCKET", "probod"),
 				AccessKeyID:     b.getEnv("AWS_ACCESS_KEY_ID"),
@@ -153,29 +153,29 @@ func (b *Builder) Build() (*probod.FullConfig, error) {
 				Endpoint:        b.getEnv("AWS_ENDPOINT"),
 				UsePathStyle:    b.getEnvBoolOrDefault("AWS_USE_PATH_STYLE", false),
 			},
-			Notifications: probod.NotificationsConfig{
-				Mailer: probod.MailerConfig{
+			Notifications: probodconfig.NotificationsConfig{
+				Mailer: probodconfig.MailerConfig{
 					SenderName:     b.getEnvOrDefault("MAILER_SENDER_NAME", "Probo"),
 					SenderEmail:    b.getEnvOrDefault("MAILER_SENDER_EMAIL", "no-reply@notification.getprobo.com"),
 					MailerInterval: b.getEnvIntOrDefault("MAILER_INTERVAL", 60),
-					SMTP: probod.SMTPConfig{
+					SMTP: probodconfig.SMTPConfig{
 						Addr:        b.getEnvOrDefault("SMTP_ADDR", "localhost:1025"),
 						User:        b.getEnv("SMTP_USER"),
 						Password:    b.getEnv("SMTP_PASSWORD"),
 						TLSRequired: b.getEnvBoolOrDefault("SMTP_TLS_REQUIRED", false),
 					},
 				},
-				Slack: probod.SlackConfig{
+				Slack: probodconfig.SlackConfig{
 					SenderInterval: b.getEnvIntOrDefault("SLACK_SENDER_INTERVAL", 60),
 					SigningSecret:  b.getEnv("CONNECTOR_SLACK_SIGNING_SECRET"),
 				},
-				Webhook: probod.WebhookConfig{
+				Webhook: probodconfig.WebhookConfig{
 					SenderInterval: b.getEnvIntOrDefault("WEBHOOK_SENDER_INTERVAL", 5),
 					CacheTTL:       b.getEnvIntOrDefault("WEBHOOK_CACHE_TTL", 86400),
 				},
 			},
-			Agents: probod.AgentsConfig{
-				Providers: map[string]probod.LLMProviderConfig{
+			Agents: probodconfig.AgentsConfig{
+				Providers: map[string]probodconfig.LLMProviderConfig{
 					"openai": {
 						Type:   "openai",
 						APIKey: b.getEnv("OPENAI_API_KEY"),
@@ -185,32 +185,32 @@ func (b *Builder) Build() (*probod.FullConfig, error) {
 						APIKey: b.getEnv("ANTHROPIC_API_KEY"),
 					},
 				},
-				Default: probod.LLMAgentConfig{
+				Default: probodconfig.LLMAgentConfig{
 					Provider:    b.getEnvOrDefault("AGENT_DEFAULT_PROVIDER", "openai"),
 					ModelName:   b.getEnvOrDefault("AGENT_DEFAULT_MODEL_NAME", "gpt-4o"),
 					Temperature: new(b.getEnvFloatOrDefault("AGENT_DEFAULT_TEMPERATURE", 0.1)),
 					MaxTokens:   new(b.getEnvIntOrDefault("AGENT_DEFAULT_MAX_TOKENS", 4096)),
 				},
-				Probo: probod.LLMAgentConfig{
+				Probo: probodconfig.LLMAgentConfig{
 					Provider:    b.getEnvOrDefault("AGENT_PROBO_PROVIDER", ""),
 					ModelName:   b.getEnvOrDefault("AGENT_PROBO_MODEL_NAME", ""),
 					Temperature: b.getEnvFloatPtr("AGENT_PROBO_TEMPERATURE"),
 					MaxTokens:   b.getEnvIntPtr("AGENT_PROBO_MAX_TOKENS"),
 				},
-				EvidenceDescriber: probod.LLMAgentConfig{
+				EvidenceDescriber: probodconfig.LLMAgentConfig{
 					Provider:    b.getEnvOrDefault("AGENT_EVIDENCE_DESCRIBER_PROVIDER", ""),
 					ModelName:   b.getEnvOrDefault("AGENT_EVIDENCE_DESCRIBER_MODEL_NAME", ""),
 					Temperature: b.getEnvFloatPtr("AGENT_EVIDENCE_DESCRIBER_TEMPERATURE"),
 					MaxTokens:   b.getEnvIntPtr("AGENT_EVIDENCE_DESCRIBER_MAX_TOKENS"),
 				},
 			},
-			CustomDomains: probod.CustomDomainsConfig{
+			CustomDomains: probodconfig.CustomDomainsConfig{
 				RenewalInterval:   b.getEnvIntOrDefault("CUSTOM_DOMAINS_RENEWAL_INTERVAL", 3600),
 				ProvisionInterval: b.getEnvIntOrDefault("CUSTOM_DOMAINS_PROVISION_INTERVAL", 30),
 				CnameTarget:       b.getEnvOrDefault("CUSTOM_DOMAINS_CNAME_TARGET", "custom.getprobo.com"),
 				ResolverAddr:      b.getEnvOrDefault("CUSTOM_DOMAINS_RESOLVER_ADDR", "8.8.8.8:53"),
 				CAAIssuerDomain:   b.getEnvOrDefault("CUSTOM_DOMAINS_CAA_ISSUER_DOMAIN", "letsencrypt.org"),
-				ACME: probod.ACMEConfig{
+				ACME: probodconfig.ACMEConfig{
 					Directory:  b.getEnvOrDefault("ACME_DIRECTORY", "https://acme-v02.api.letsencrypt.org/directory"),
 					Email:      b.getEnvOrDefault("ACME_EMAIL", "admin@getprobo.com"),
 					KeyType:    b.getEnvOrDefault("ACME_KEY_TYPE", "EC256"),
@@ -218,14 +218,14 @@ func (b *Builder) Build() (*probod.FullConfig, error) {
 					AccountKey: b.getEnv("ACME_ACCOUNT_KEY"),
 				},
 			},
-			SCIMBridge: probod.SCIMBridgeConfig{
+			SCIMBridge: probodconfig.SCIMBridgeConfig{
 				SyncInterval: b.getEnvIntOrDefault("SCIM_BRIDGE_SYNC_INTERVAL", 900),
 				PollInterval: b.getEnvIntOrDefault("SCIM_BRIDGE_POLL_INTERVAL", 30),
 			},
-			ESign: probod.ESignConfig{
+			ESign: probodconfig.ESignConfig{
 				TSAURL: b.getEnvOrDefault("ESIGN_TSA_URL", "http://timestamp.digicert.com"),
 			},
-			EvidenceDescriber: probod.EvidenceDescriberConfig{
+			EvidenceDescriber: probodconfig.EvidenceDescriberConfig{
 				Interval:       b.getEnvIntOrDefault("EVIDENCE_DESCRIBER_INTERVAL", 10),
 				StaleAfter:     b.getEnvIntOrDefault("EVIDENCE_DESCRIBER_STALE_AFTER", 300),
 				MaxConcurrency: b.getEnvIntOrDefault("EVIDENCE_DESCRIBER_MAX_CONCURRENCY", 10),
@@ -235,10 +235,10 @@ func (b *Builder) Build() (*probod.FullConfig, error) {
 	}
 
 	if slackClientID := b.getEnv("CONNECTOR_SLACK_CLIENT_ID"); slackClientID != "" {
-		cfg.Probod.Connectors = append(cfg.Probod.Connectors, probod.ConnectorConfig{
+		cfg.Probod.Connectors = append(cfg.Probod.Connectors, probodconfig.ConnectorConfig{
 			Provider: "SLACK",
 			Protocol: "oauth2",
-			RawConfig: probod.ConnectorConfigOAuth2{
+			RawConfig: probodconfig.ConnectorConfigOAuth2{
 				ClientID:     slackClientID,
 				ClientSecret: b.getEnv("CONNECTOR_SLACK_CLIENT_SECRET"),
 			},
@@ -249,10 +249,10 @@ func (b *Builder) Build() (*probod.FullConfig, error) {
 	}
 
 	if hubspotClientID := b.getEnv("CONNECTOR_HUBSPOT_CLIENT_ID"); hubspotClientID != "" {
-		cfg.Probod.Connectors = append(cfg.Probod.Connectors, probod.ConnectorConfig{
+		cfg.Probod.Connectors = append(cfg.Probod.Connectors, probodconfig.ConnectorConfig{
 			Provider: "HUBSPOT",
 			Protocol: "oauth2",
-			RawConfig: probod.ConnectorConfigOAuth2{
+			RawConfig: probodconfig.ConnectorConfigOAuth2{
 				ClientID:     hubspotClientID,
 				ClientSecret: b.getEnv("CONNECTOR_HUBSPOT_CLIENT_SECRET"),
 			},
@@ -260,10 +260,10 @@ func (b *Builder) Build() (*probod.FullConfig, error) {
 	}
 
 	if docusignClientID := b.getEnv("CONNECTOR_DOCUSIGN_CLIENT_ID"); docusignClientID != "" {
-		cfg.Probod.Connectors = append(cfg.Probod.Connectors, probod.ConnectorConfig{
+		cfg.Probod.Connectors = append(cfg.Probod.Connectors, probodconfig.ConnectorConfig{
 			Provider: "DOCUSIGN",
 			Protocol: "oauth2",
-			RawConfig: probod.ConnectorConfigOAuth2{
+			RawConfig: probodconfig.ConnectorConfigOAuth2{
 				ClientID:     docusignClientID,
 				ClientSecret: b.getEnv("CONNECTOR_DOCUSIGN_CLIENT_SECRET"),
 			},
@@ -271,10 +271,10 @@ func (b *Builder) Build() (*probod.FullConfig, error) {
 	}
 
 	if notionClientID := b.getEnv("CONNECTOR_NOTION_CLIENT_ID"); notionClientID != "" {
-		cfg.Probod.Connectors = append(cfg.Probod.Connectors, probod.ConnectorConfig{
+		cfg.Probod.Connectors = append(cfg.Probod.Connectors, probodconfig.ConnectorConfig{
 			Provider: "NOTION",
 			Protocol: "oauth2",
-			RawConfig: probod.ConnectorConfigOAuth2{
+			RawConfig: probodconfig.ConnectorConfigOAuth2{
 				ClientID:     notionClientID,
 				ClientSecret: b.getEnv("CONNECTOR_NOTION_CLIENT_SECRET"),
 			},
@@ -282,10 +282,10 @@ func (b *Builder) Build() (*probod.FullConfig, error) {
 	}
 
 	if githubClientID := b.getEnv("CONNECTOR_GITHUB_CLIENT_ID"); githubClientID != "" {
-		cfg.Probod.Connectors = append(cfg.Probod.Connectors, probod.ConnectorConfig{
+		cfg.Probod.Connectors = append(cfg.Probod.Connectors, probodconfig.ConnectorConfig{
 			Provider: "GITHUB",
 			Protocol: "oauth2",
-			RawConfig: probod.ConnectorConfigOAuth2{
+			RawConfig: probodconfig.ConnectorConfigOAuth2{
 				ClientID:     githubClientID,
 				ClientSecret: b.getEnv("CONNECTOR_GITHUB_CLIENT_SECRET"),
 			},
@@ -293,10 +293,10 @@ func (b *Builder) Build() (*probod.FullConfig, error) {
 	}
 
 	if sentryClientID := b.getEnv("CONNECTOR_SENTRY_CLIENT_ID"); sentryClientID != "" {
-		cfg.Probod.Connectors = append(cfg.Probod.Connectors, probod.ConnectorConfig{
+		cfg.Probod.Connectors = append(cfg.Probod.Connectors, probodconfig.ConnectorConfig{
 			Provider: "SENTRY",
 			Protocol: "oauth2",
-			RawConfig: probod.ConnectorConfigOAuth2{
+			RawConfig: probodconfig.ConnectorConfigOAuth2{
 				ClientID:     sentryClientID,
 				ClientSecret: b.getEnv("CONNECTOR_SENTRY_CLIENT_SECRET"),
 			},
@@ -304,10 +304,10 @@ func (b *Builder) Build() (*probod.FullConfig, error) {
 	}
 
 	if intercomClientID := b.getEnv("CONNECTOR_INTERCOM_CLIENT_ID"); intercomClientID != "" {
-		cfg.Probod.Connectors = append(cfg.Probod.Connectors, probod.ConnectorConfig{
+		cfg.Probod.Connectors = append(cfg.Probod.Connectors, probodconfig.ConnectorConfig{
 			Provider: "INTERCOM",
 			Protocol: "oauth2",
-			RawConfig: probod.ConnectorConfigOAuth2{
+			RawConfig: probodconfig.ConnectorConfigOAuth2{
 				ClientID:     intercomClientID,
 				ClientSecret: b.getEnv("CONNECTOR_INTERCOM_CLIENT_SECRET"),
 			},
@@ -315,10 +315,10 @@ func (b *Builder) Build() (*probod.FullConfig, error) {
 	}
 
 	if brexClientID := b.getEnv("CONNECTOR_BREX_CLIENT_ID"); brexClientID != "" {
-		cfg.Probod.Connectors = append(cfg.Probod.Connectors, probod.ConnectorConfig{
+		cfg.Probod.Connectors = append(cfg.Probod.Connectors, probodconfig.ConnectorConfig{
 			Provider: "BREX",
 			Protocol: "oauth2",
-			RawConfig: probod.ConnectorConfigOAuth2{
+			RawConfig: probodconfig.ConnectorConfigOAuth2{
 				ClientID:     brexClientID,
 				ClientSecret: b.getEnv("CONNECTOR_BREX_CLIENT_SECRET"),
 			},
@@ -326,10 +326,10 @@ func (b *Builder) Build() (*probod.FullConfig, error) {
 	}
 
 	if googleWorkspaceClientID := b.getEnv("CONNECTOR_GOOGLE_WORKSPACE_CLIENT_ID"); googleWorkspaceClientID != "" {
-		cfg.Probod.Connectors = append(cfg.Probod.Connectors, probod.ConnectorConfig{
+		cfg.Probod.Connectors = append(cfg.Probod.Connectors, probodconfig.ConnectorConfig{
 			Provider: "GOOGLE_WORKSPACE",
 			Protocol: "oauth2",
-			RawConfig: probod.ConnectorConfigOAuth2{
+			RawConfig: probodconfig.ConnectorConfigOAuth2{
 				ClientID:     googleWorkspaceClientID,
 				ClientSecret: b.getEnv("CONNECTOR_GOOGLE_WORKSPACE_CLIENT_SECRET"),
 			},

--- a/pkg/bootstrap/builder_test.go
+++ b/pkg/bootstrap/builder_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.probo.inc/probo/pkg/probod"
+	"go.probo.inc/probo/pkg/probodconfig"
 )
 
 func mockEnv(env map[string]string) EnvGetter {
@@ -393,7 +393,7 @@ func TestBuilder_Build_GoogleWorkspaceConnector(t *testing.T) {
 	connector := cfg.Probod.Connectors[0]
 	assert.Equal(t, "GOOGLE_WORKSPACE", connector.Provider)
 	assert.Equal(t, "oauth2", string(connector.Protocol))
-	rawConfig := connector.RawConfig.(probod.ConnectorConfigOAuth2)
+	rawConfig := connector.RawConfig.(probodconfig.ConnectorConfigOAuth2)
 	assert.Equal(t, "gw-client-id", rawConfig.ClientID)
 	assert.Equal(t, "gw-client-secret", rawConfig.ClientSecret)
 }
@@ -415,7 +415,7 @@ func TestBuilder_Build_SlackConnector(t *testing.T) {
 	connector := cfg.Probod.Connectors[0]
 	assert.Equal(t, "SLACK", connector.Provider)
 	assert.Equal(t, "oauth2", string(connector.Protocol))
-	rawConfig := connector.RawConfig.(probod.ConnectorConfigOAuth2)
+	rawConfig := connector.RawConfig.(probodconfig.ConnectorConfigOAuth2)
 	assert.Equal(t, "slack-client-id", rawConfig.ClientID)
 	assert.Equal(t, "slack-client-secret", rawConfig.ClientSecret)
 	rawSettings := connector.RawSettings.(map[string]any)

--- a/pkg/bootstrap/builder_test.go
+++ b/pkg/bootstrap/builder_test.go
@@ -137,8 +137,8 @@ func TestBuilder_Build_Defaults(t *testing.T) {
 
 	// PG config
 	assert.Equal(t, "localhost:5432", cfg.Probod.Pg.Addr)
-	assert.Equal(t, "postgres", cfg.Probod.Pg.Username)
-	assert.Equal(t, "postgres", cfg.Probod.Pg.Password)
+	assert.Equal(t, "probod", cfg.Probod.Pg.Username)
+	assert.Equal(t, "probod", cfg.Probod.Pg.Password)
 	assert.Equal(t, "probod", cfg.Probod.Pg.Database)
 	assert.Equal(t, int32(100), cfg.Probod.Pg.PoolSize)
 	assert.Equal(t, int32(10), cfg.Probod.Pg.MinPoolSize)

--- a/pkg/bootstrap/write.go
+++ b/pkg/bootstrap/write.go
@@ -19,11 +19,11 @@ import (
 	"os"
 	"path/filepath"
 
-	"go.probo.inc/probo/pkg/probod"
+	"go.probo.inc/probo/pkg/probodconfig"
 	"sigs.k8s.io/yaml"
 )
 
-func WriteConfig(cfg *probod.FullConfig, path string) error {
+func WriteConfig(cfg *probodconfig.FullConfig, path string) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("create directory %s: %w", dir, err)

--- a/pkg/bootstrap/write_test.go
+++ b/pkg/bootstrap/write_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.probo.inc/probo/pkg/probod"
+	"go.probo.inc/probo/pkg/probodconfig"
 	"sigs.k8s.io/yaml"
 )
 
@@ -29,11 +29,11 @@ func TestWriteConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "probod.yml")
 
-	cfg := &probod.FullConfig{
-		Unit: probod.UnitConfig{
-			Metrics: probod.MetricsConfig{Addr: "localhost:9090"},
+	cfg := &probodconfig.FullConfig{
+		Unit: probodconfig.UnitConfig{
+			Metrics: probodconfig.MetricsConfig{Addr: "localhost:9090"},
 		},
-		Probod: probod.Config{
+		Probod: probodconfig.Config{
 			BaseURL:       "http://localhost:8080",
 			EncryptionKey: "test-key",
 		},
@@ -45,7 +45,7 @@ func TestWriteConfig(t *testing.T) {
 	data, err := os.ReadFile(configPath)
 	require.NoError(t, err)
 
-	var loaded probod.FullConfig
+	var loaded probodconfig.FullConfig
 	err = yaml.Unmarshal(data, &loaded)
 	require.NoError(t, err)
 
@@ -58,8 +58,8 @@ func TestWriteConfig_CreatesDirectory(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "nested", "dir", "probod.yml")
 
-	cfg := &probod.FullConfig{
-		Probod: probod.Config{BaseURL: "http://localhost:8080"},
+	cfg := &probodconfig.FullConfig{
+		Probod: probodconfig.Config{BaseURL: "http://localhost:8080"},
 	}
 
 	err := WriteConfig(cfg, configPath)
@@ -73,7 +73,7 @@ func TestWriteConfig_FilePermissions(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "probod.yml")
 
-	cfg := &probod.FullConfig{}
+	cfg := &probodconfig.FullConfig{}
 
 	err := WriteConfig(cfg, configPath)
 	require.NoError(t, err)
@@ -88,10 +88,10 @@ func TestWriteConfig_CompleteConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "probod.yml")
 
-	cfg := &probod.FullConfig{
-		Unit: probod.UnitConfig{
-			Metrics: probod.MetricsConfig{Addr: "localhost:8081"},
-			Tracing: probod.TracingConfig{
+	cfg := &probodconfig.FullConfig{
+		Unit: probodconfig.UnitConfig{
+			Metrics: probodconfig.MetricsConfig{Addr: "localhost:8081"},
+			Tracing: probodconfig.TracingConfig{
 				Addr:          "localhost:4317",
 				MaxBatchSize:  512,
 				BatchTimeout:  5,
@@ -99,18 +99,18 @@ func TestWriteConfig_CompleteConfig(t *testing.T) {
 				MaxQueueSize:  2048,
 			},
 		},
-		Probod: probod.Config{
+		Probod: probodconfig.Config{
 			BaseURL:       "http://localhost:8080",
 			EncryptionKey: "test-key",
 			ChromeDPAddr:  "localhost:9222",
-			Api: probod.APIConfig{
+			Api: probodconfig.APIConfig{
 				Addr: ":8080",
-				Cors: probod.CorsConfig{
+				Cors: probodconfig.CorsConfig{
 					AllowedOrigins: []string{"http://localhost:8080"},
 				},
 				ExtraHeaderFields: map[string]string{},
 			},
-			Pg: probod.PgConfig{
+			Pg: probodconfig.PgConfig{
 				Addr:                   "localhost:5432",
 				Username:               "postgres",
 				Password:               "postgres",
@@ -120,11 +120,11 @@ func TestWriteConfig_CompleteConfig(t *testing.T) {
 				MaxConnIdleTimeSeconds: 1800,
 				MaxConnLifetimeSeconds: 3600,
 			},
-			Connectors: []probod.ConnectorConfig{
+			Connectors: []probodconfig.ConnectorConfig{
 				{
 					Provider: "slack",
 					Protocol: "oauth2",
-					RawConfig: probod.ConnectorConfigOAuth2{
+					RawConfig: probodconfig.ConnectorConfigOAuth2{
 						ClientID:     "client-id",
 						ClientSecret: "client-secret",
 					},
@@ -142,7 +142,7 @@ func TestWriteConfig_CompleteConfig(t *testing.T) {
 	data, err := os.ReadFile(configPath)
 	require.NoError(t, err)
 
-	var loaded probod.FullConfig
+	var loaded probodconfig.FullConfig
 	err = yaml.Unmarshal(data, &loaded)
 	require.NoError(t, err)
 

--- a/pkg/probod/aliases.go
+++ b/pkg/probod/aliases.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package probod
+
+import "go.probo.inc/probo/pkg/probodconfig"
+
+type (
+	FullConfig              = probodconfig.FullConfig
+	Config                  = probodconfig.Config
+	UnitConfig              = probodconfig.UnitConfig
+	MetricsConfig           = probodconfig.MetricsConfig
+	TracingConfig           = probodconfig.TracingConfig
+	ESignConfig             = probodconfig.ESignConfig
+	TrustCenterConfig       = probodconfig.TrustCenterConfig
+	APIConfig               = probodconfig.APIConfig
+	CorsConfig              = probodconfig.CorsConfig
+	ProxyProtocolConfig     = probodconfig.ProxyProtocolConfig
+	AuthConfig              = probodconfig.AuthConfig
+	OAuth2ServerConfig      = probodconfig.OAuth2ServerConfig
+	OAuth2SigningKeyConfig  = probodconfig.OAuth2SigningKeyConfig
+	CookieConfig            = probodconfig.CookieConfig
+	PasswordConfig          = probodconfig.PasswordConfig
+	AWSConfig               = probodconfig.AWSConfig
+	ConnectorConfig         = probodconfig.ConnectorConfig
+	ConnectorConfigOAuth2   = probodconfig.ConnectorConfigOAuth2
+	CustomDomainsConfig     = probodconfig.CustomDomainsConfig
+	ACMEConfig              = probodconfig.ACMEConfig
+	LLMProviderConfig       = probodconfig.LLMProviderConfig
+	LLMAgentConfig          = probodconfig.LLMAgentConfig
+	EvidenceDescriberConfig = probodconfig.EvidenceDescriberConfig
+	AgentsConfig            = probodconfig.AgentsConfig
+	MailerConfig            = probodconfig.MailerConfig
+	SMTPConfig              = probodconfig.SMTPConfig
+	NotificationsConfig     = probodconfig.NotificationsConfig
+	WebhookConfig           = probodconfig.WebhookConfig
+	OIDCProviderConfig      = probodconfig.OIDCProviderConfig
+	PgConfig                = probodconfig.PgConfig
+	SAMLConfig              = probodconfig.SAMLConfig
+	SCIMBridgeConfig        = probodconfig.SCIMBridgeConfig
+	SlackConfig             = probodconfig.SlackConfig
+)

--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -73,71 +73,9 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-type (
-	Implm struct {
-		cfg Config
-	}
-
-	// FullConfig represents the complete configuration file structure.
-	// This is used by bootstrap to generate the YAML config file.
-	FullConfig struct {
-		Unit   UnitConfig `json:"unit"`
-		Probod Config     `json:"probod"`
-	}
-
-	// UnitConfig contains unit framework configuration.
-	UnitConfig struct {
-		Metrics MetricsConfig `json:"metrics"`
-		Tracing TracingConfig `json:"tracing"`
-	}
-
-	// MetricsConfig contains metrics server configuration.
-	MetricsConfig struct {
-		Addr string `json:"addr"`
-	}
-
-	// TracingConfig contains tracing configuration.
-	TracingConfig struct {
-		Addr          string `json:"addr"`
-		MaxBatchSize  int    `json:"max-batch-size"`
-		BatchTimeout  int    `json:"batch-timeout"`
-		ExportTimeout int    `json:"export-timeout"`
-		MaxQueueSize  int    `json:"max-queue-size"`
-	}
-
-	// ESignConfig contains electronic signature configuration.
-	ESignConfig struct {
-		TSAURL string `json:"tsa-url"`
-	}
-
-	// Config represents the probod application configuration.
-	Config struct {
-		BaseURL           string                  `json:"base-url"`
-		EncryptionKey     string                  `json:"encryption-key"`
-		Pg                PgConfig                `json:"pg"`
-		Api               APIConfig               `json:"api"`
-		Auth              AuthConfig              `json:"auth"`
-		TrustCenter       TrustCenterConfig       `json:"trust-center"`
-		AWS               AWSConfig               `json:"aws"`
-		Notifications     NotificationsConfig     `json:"notifications"`
-		Connectors        []ConnectorConfig       `json:"connectors"`
-		Agents            AgentsConfig            `json:"llm"`
-		EvidenceDescriber EvidenceDescriberConfig `json:"evidence-describer"`
-		ChromeDPAddr      string                  `json:"chrome-dp-addr"`
-		SearchEndpoint    string                  `json:"search-endpoint"`
-		CustomDomains     CustomDomainsConfig     `json:"custom-domains"`
-		SCIMBridge        SCIMBridgeConfig        `json:"scim-bridge"`
-		ESign             ESignConfig             `json:"esign"`
-		Branding          bool                    `json:"branding"`
-	}
-
-	// TrustCenterConfig contains trust center server configuration.
-	TrustCenterConfig struct {
-		HTTPAddr      string              `json:"http-addr"`
-		HTTPSAddr     string              `json:"https-addr"`
-		ProxyProtocol ProxyProtocolConfig `json:"proxy-protocol"`
-	}
-)
+type Implm struct {
+	cfg Config
+}
 
 var (
 	_ unit.Configurable = (*Implm)(nil)

--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -91,8 +91,8 @@ func New() *Implm {
 			},
 			Pg: PgConfig{
 				Addr:                   "localhost:5432",
-				Username:               "postgres",
-				Password:               "postgres",
+				Username:               "probod",
+				Password:               "probod",
 				Database:               "probod",
 				PoolSize:               100,
 				MinPoolSize:            10,

--- a/pkg/probodconfig/api_config.go
+++ b/pkg/probodconfig/api_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
 //
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above
@@ -12,21 +12,19 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-package probod
+package probodconfig
 
-type CustomDomainsConfig struct {
-	RenewalInterval   int        `json:"renewal-interval"`
-	ProvisionInterval int        `json:"provision-interval"`
-	ResolverAddr      string     `json:"resolver-addr"`
-	CnameTarget       string     `json:"cname-target"`
-	CAAIssuerDomain   string     `json:"caa-issuer-domain"`
-	ACME              ACMEConfig `json:"acme"`
+type CorsConfig struct {
+	AllowedOrigins []string `json:"allowed-origins"`
 }
 
-type ACMEConfig struct {
-	Directory  string `json:"directory"`
-	Email      string `json:"email"`
-	KeyType    string `json:"key-type"`
-	AccountKey string `json:"account-key"`
-	RootCA     string `json:"root-ca"`
+type ProxyProtocolConfig struct {
+	TrustedProxies []string `json:"trusted-proxies"`
+}
+
+type APIConfig struct {
+	Addr              string              `json:"addr"`
+	ProxyProtocol     ProxyProtocolConfig `json:"proxy-protocol"`
+	Cors              CorsConfig          `json:"cors"`
+	ExtraHeaderFields map[string]string   `json:"extra-header-fields"`
 }

--- a/pkg/probodconfig/auth_config.go
+++ b/pkg/probodconfig/auth_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
 //
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above
@@ -12,7 +12,7 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-package probod
+package probodconfig
 
 import (
 	"encoding/base64"

--- a/pkg/probodconfig/aws_config.go
+++ b/pkg/probodconfig/aws_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
 //
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above
@@ -12,9 +12,13 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-package probod
+package probodconfig
 
-type SlackConfig struct {
-	SenderInterval int    `json:"sender-interval"`
-	SigningSecret  string `json:"signing-secret"`
+type AWSConfig struct {
+	Region          string `json:"region"`
+	Bucket          string `json:"bucket"`
+	AccessKeyID     string `json:"access-key-id"`
+	SecretAccessKey string `json:"secret-access-key"`
+	Endpoint        string `json:"endpoint"`
+	UsePathStyle    bool   `json:"use-path-style"`
 }

--- a/pkg/probodconfig/config.go
+++ b/pkg/probodconfig/config.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package probodconfig
+
+type (
+	// FullConfig represents the complete configuration file structure.
+	// This is used by bootstrap to generate the YAML config file.
+	FullConfig struct {
+		Unit   UnitConfig `json:"unit"`
+		Probod Config     `json:"probod"`
+	}
+
+	// UnitConfig contains unit framework configuration.
+	UnitConfig struct {
+		Metrics MetricsConfig `json:"metrics"`
+		Tracing TracingConfig `json:"tracing"`
+	}
+
+	// MetricsConfig contains metrics server configuration.
+	MetricsConfig struct {
+		Addr string `json:"addr"`
+	}
+
+	// TracingConfig contains tracing configuration.
+	TracingConfig struct {
+		Addr          string `json:"addr"`
+		MaxBatchSize  int    `json:"max-batch-size"`
+		BatchTimeout  int    `json:"batch-timeout"`
+		ExportTimeout int    `json:"export-timeout"`
+		MaxQueueSize  int    `json:"max-queue-size"`
+	}
+
+	// ESignConfig contains electronic signature configuration.
+	ESignConfig struct {
+		TSAURL string `json:"tsa-url"`
+	}
+
+	// Config represents the probod application configuration.
+	Config struct {
+		BaseURL           string                  `json:"base-url"`
+		EncryptionKey     string                  `json:"encryption-key"`
+		Pg                PgConfig                `json:"pg"`
+		Api               APIConfig               `json:"api"`
+		Auth              AuthConfig              `json:"auth"`
+		TrustCenter       TrustCenterConfig       `json:"trust-center"`
+		AWS               AWSConfig               `json:"aws"`
+		Notifications     NotificationsConfig     `json:"notifications"`
+		Connectors        []ConnectorConfig       `json:"connectors"`
+		Agents            AgentsConfig            `json:"llm"`
+		EvidenceDescriber EvidenceDescriberConfig `json:"evidence-describer"`
+		ChromeDPAddr      string                  `json:"chrome-dp-addr"`
+		SearchEndpoint    string                  `json:"search-endpoint"`
+		CustomDomains     CustomDomainsConfig     `json:"custom-domains"`
+		SCIMBridge        SCIMBridgeConfig        `json:"scim-bridge"`
+		ESign             ESignConfig             `json:"esign"`
+		Branding          bool                    `json:"branding"`
+	}
+
+	// TrustCenterConfig contains trust center server configuration.
+	TrustCenterConfig struct {
+		HTTPAddr      string              `json:"http-addr"`
+		HTTPSAddr     string              `json:"https-addr"`
+		ProxyProtocol ProxyProtocolConfig `json:"proxy-protocol"`
+	}
+)

--- a/pkg/probodconfig/connector_config.go
+++ b/pkg/probodconfig/connector_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
 //
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above
@@ -12,7 +12,7 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-package probod
+package probodconfig
 
 import (
 	"bytes"

--- a/pkg/probodconfig/custom_domains_config.go
+++ b/pkg/probodconfig/custom_domains_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
 //
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above
@@ -12,15 +12,21 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-package probod
+package probodconfig
 
-type NotificationsConfig struct {
-	Mailer  MailerConfig  `json:"mailer"`
-	Slack   SlackConfig   `json:"slack"`
-	Webhook WebhookConfig `json:"webhook"`
+type CustomDomainsConfig struct {
+	RenewalInterval   int        `json:"renewal-interval"`
+	ProvisionInterval int        `json:"provision-interval"`
+	ResolverAddr      string     `json:"resolver-addr"`
+	CnameTarget       string     `json:"cname-target"`
+	CAAIssuerDomain   string     `json:"caa-issuer-domain"`
+	ACME              ACMEConfig `json:"acme"`
 }
 
-type WebhookConfig struct {
-	SenderInterval int `json:"sender-interval"`
-	CacheTTL       int `json:"cache-ttl"`
+type ACMEConfig struct {
+	Directory  string `json:"directory"`
+	Email      string `json:"email"`
+	KeyType    string `json:"key-type"`
+	AccountKey string `json:"account-key"`
+	RootCA     string `json:"root-ca"`
 }

--- a/pkg/probodconfig/llm_config.go
+++ b/pkg/probodconfig/llm_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
 //
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above
@@ -12,7 +12,7 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-package probod
+package probodconfig
 
 type (
 	// LLMProviderConfig holds authentication and connection settings for an

--- a/pkg/probodconfig/mailer_config.go
+++ b/pkg/probodconfig/mailer_config.go
@@ -12,9 +12,18 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-package probod
+package probodconfig
 
-type SCIMBridgeConfig struct {
-	SyncInterval int `json:"sync-interval"`
-	PollInterval int `json:"poll-interval"`
+type MailerConfig struct {
+	MailerInterval int        `json:"mailer-interval"`
+	SenderName     string     `json:"sender-name"`
+	SenderEmail    string     `json:"sender-email"`
+	SMTP           SMTPConfig `json:"smtp"`
+}
+
+type SMTPConfig struct {
+	Addr        string `json:"addr"`
+	User        string `json:"user"`
+	Password    string `json:"password"`
+	TLSRequired bool   `json:"tls-required"`
 }

--- a/pkg/probodconfig/notifications_config.go
+++ b/pkg/probodconfig/notifications_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
 //
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above
@@ -12,13 +12,15 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-package probod
+package probodconfig
 
-type AWSConfig struct {
-	Region          string `json:"region"`
-	Bucket          string `json:"bucket"`
-	AccessKeyID     string `json:"access-key-id"`
-	SecretAccessKey string `json:"secret-access-key"`
-	Endpoint        string `json:"endpoint"`
-	UsePathStyle    bool   `json:"use-path-style"`
+type NotificationsConfig struct {
+	Mailer  MailerConfig  `json:"mailer"`
+	Slack   SlackConfig   `json:"slack"`
+	Webhook WebhookConfig `json:"webhook"`
+}
+
+type WebhookConfig struct {
+	SenderInterval int `json:"sender-interval"`
+	CacheTTL       int `json:"cache-ttl"`
 }

--- a/pkg/probodconfig/oidc_config.go
+++ b/pkg/probodconfig/oidc_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
 //
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above
@@ -12,19 +12,10 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-package probod
+package probodconfig
 
-type CorsConfig struct {
-	AllowedOrigins []string `json:"allowed-origins"`
-}
-
-type ProxyProtocolConfig struct {
-	TrustedProxies []string `json:"trusted-proxies"`
-}
-
-type APIConfig struct {
-	Addr              string              `json:"addr"`
-	ProxyProtocol     ProxyProtocolConfig `json:"proxy-protocol"`
-	Cors              CorsConfig          `json:"cors"`
-	ExtraHeaderFields map[string]string   `json:"extra-header-fields"`
+type OIDCProviderConfig struct {
+	ClientID     string `json:"client-id"`
+	ClientSecret string `json:"client-secret"`
+	Enabled      bool   `json:"enabled"`
 }

--- a/pkg/probodconfig/pg_config.go
+++ b/pkg/probodconfig/pg_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
 //
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above
@@ -12,7 +12,7 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-package probod
+package probodconfig
 
 import (
 	"crypto/x509"

--- a/pkg/probodconfig/saml_config.go
+++ b/pkg/probodconfig/saml_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
 //
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above
@@ -12,7 +12,7 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-package probod
+package probodconfig
 
 import (
 	"time"

--- a/pkg/probodconfig/scim_bridge_config.go
+++ b/pkg/probodconfig/scim_bridge_config.go
@@ -12,10 +12,9 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-package probod
+package probodconfig
 
-type OIDCProviderConfig struct {
-	ClientID     string `json:"client-id"`
-	ClientSecret string `json:"client-secret"`
-	Enabled      bool   `json:"enabled"`
+type SCIMBridgeConfig struct {
+	SyncInterval int `json:"sync-interval"`
+	PollInterval int `json:"poll-interval"`
 }

--- a/pkg/probodconfig/slack_config.go
+++ b/pkg/probodconfig/slack_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
 //
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above
@@ -12,18 +12,9 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-package probod
+package probodconfig
 
-type MailerConfig struct {
-	MailerInterval int        `json:"mailer-interval"`
-	SenderName     string     `json:"sender-name"`
-	SenderEmail    string     `json:"sender-email"`
-	SMTP           SMTPConfig `json:"smtp"`
-}
-
-type SMTPConfig struct {
-	Addr        string `json:"addr"`
-	User        string `json:"user"`
-	Password    string `json:"password"`
-	TLSRequired bool   `json:"tls-required"`
+type SlackConfig struct {
+	SenderInterval int    `json:"sender-interval"`
+	SigningSecret  string `json:"signing-secret"`
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the Lima sandbox and build flow by moving config structs to `pkg/probodconfig`, replacing `SKIP_APPS` with `WITH_APPS`, and automating codegen/embedding and service startup. Adds a sandbox boot logs command, improves reliability (Compose `--wait`, Postgres readiness), lowers Postgres memory, updates default PG creds, and updates sandbox docs to `make sandbox-*`.

- **Refactors**
  - Extracted all config types to `pkg/probodconfig`; re-exported via aliases in `pkg/probod` to reduce `probod-bootstrap` deps.
  - Makefile: new `generate` (Go/MCP; `WITH_APPS=1` adds Relay) and `embed` (frontend assets); `bin/probod` depends on both; `vet`/`go-fix` use them; CI/docs drop `SKIP_APPS`.
  - Sandbox provision: runs `npm ci`, `make generate WITH_APPS=1`, `make embed`; pre-generates Pebble root CA and Keycloak realm; `probo-stack` uses `up -d --wait`; `probod` waits for Postgres; auto-starts `probod`, `probo-console`, `probo-trust`; mounts host Go path; adds node_modules bind-mount; sets ACME (directory, email, key type, root CA); Console on 5173.
  - Defaults: Postgres user/password now `probod`; Compose `shared_buffers=256MB`; Go 1.26.2.
  - New `make sandbox-boot-logs` to stream cloud-init logs.

- **Migration**
  - Build with apps: `make build WITH_APPS=1`. Backend only: `make build`.
  - Codegen/embedding: `make generate` (Go/MCP), `make generate WITH_APPS=1` (incl. Relay), `make embed` (frontend).
  - Sandbox: `make sandbox-create` (first time), then `make sandbox-start` to provision and auto-start services; `make sandbox-status` shows VM IP; Console at http://<vm-ip>:5173.
  - E2E: `make build` then `make test-e2e`.
  - Debug: `make sandbox-boot-logs`.

<sup>Written for commit c0d96e662eb370bd6c413c05e182fd8f82c11e03. Summary will update on new commits. <a href="https://cubic.dev/pr/getprobo/probo/pull/1121?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

