### PR TITLE
Return clear error on user delete FK violation

### DIFF
--- a/pkg/coredata/membership_profile.go
+++ b/pkg/coredata/membership_profile.go
@@ -1416,6 +1416,11 @@ WHERE
 
 	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
+			if pgErr.Code == "23503" {
+				return ErrResourceInUse
+			}
+		}
 		return fmt.Errorf("cannot delete profile: %w", err)
 	}
 

--- a/pkg/server/api/connect/v1/profile_resolvers.go
+++ b/pkg/server/api/connect/v1/profile_resolvers.go
@@ -120,6 +120,10 @@ func (r *mutationResolver) RemoveUser(ctx context.Context, input types.RemoveUse
 			return nil, gqlutils.Conflict(ctx, err)
 		}
 
+		if errors.Is(err, coredata.ErrResourceInUse) {
+			return nil, gqlutils.Conflict(ctx, err)
+		}
+
 		r.logger.ErrorCtx(ctx, "cannot remove user from organization", log.Error(err))
 
 		return nil, gqlutils.Internal(ctx)

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -2574,6 +2574,9 @@ func (r *Resolver) RemoveUserTool(ctx context.Context, req *mcp.CallToolRequest,
 		if _, ok := errors.AsType[*iam.ErrLastActiveOwner](err); ok {
 			return nil, types.RemoveUserOutput{}, fmt.Errorf("cannot remove last active owner: %w", err)
 		}
+		if errors.Is(err, coredata.ErrResourceInUse) {
+			return nil, types.RemoveUserOutput{}, fmt.Errorf("cannot remove user: %w", err)
+		}
 
 		return nil, types.RemoveUserOutput{}, fmt.Errorf("remove user: %w", err)
 	}


### PR DESCRIPTION
Deleting a membership profile referenced by other tables (owner, approver, assignee, etc.) surfaced as a generic Internal error. Add NewResourceInUseError to wrap the sentinel with the blocking table name, return it on Postgres FK violation (23503) in the coredata Delete, and map it to a CONFLICT in the GraphQL and MCP resolvers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return a clear error when deleting a user profile that’s still referenced by other records. Postgres FK violations now map to a Conflict in GraphQL and show “cannot remove user” in MCP.

- **Bug Fixes**
  - In `pkg/coredata/membership_profile.go`, detect `pgconn.PgError` code `23503` and return `coredata.ErrResourceInUse`.
  - In `pkg/server/api/connect/v1`, map `ErrResourceInUse` to Conflict; in `pkg/server/api/mcp/v1`, surface “cannot remove user”.

<sup>Written for commit 9e61e5e1b737019e444b141c13fa7cd49b2be227. Summary will update on new commits. <a href="https://cubic.dev/pr/getprobo/probo/pull/1126?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

