### PR TITLE
Treat OIDC and magic link sessions as password-equivalent when assuming an org

### DIFF
--- a/pkg/iam/session_service.go
+++ b/pkg/iam/session_service.go
@@ -566,14 +566,25 @@ func (s SessionService) AssumeOrganizationSession(
 						return NewSAMLAuthenticationRequiredError("policy_requirement")
 					}
 				case coredata.SAMLEnforcementPolicyOptional:
-					// SAML is optional: both PASSWORD and SAML root sessions are allowed.
+					// SAML is optional: any password-equivalent (PASSWORD, OIDC,
+					// MAGIC_LINK) or SAML root session is allowed.
 				}
 			} else {
 				switch rootSession.AuthMethod {
-				case coredata.AuthMethodPassword:
+				case coredata.AuthMethodPassword,
+					coredata.AuthMethodOIDC,
+					coredata.AuthMethodMagicLink:
+					// No SAML configuration for this org+domain: any
+					// password-equivalent root session is allowed. OIDC
+					// (Google / Microsoft) and magic-link logins are treated
+					// as password logins because the user has authenticated
+					// against the platform itself rather than a third-party
+					// IdP federated with this organization.
 				case coredata.AuthMethodSAML:
-					// No (or non-required) SAML configuration: require a password-authenticated or magic-link root session
-					// (eg. when switching into a password-based org from a SAML login)
+					// SAML root sessions are bound to a different organization's
+					// IdP, so they cannot be used to access an organization that
+					// does not federate with that IdP. Force re-authentication
+					// with a password-equivalent method.
 					return NewPasswordAuthenticationRequiredError("password_authentication_required")
 				}
 			}


### PR DESCRIPTION
## Summary
- Make `AssumeOrganizationSession` explicitly accept `PASSWORD`, `OIDC`, and `MAGIC_LINK` root sessions when an organization has no SAML configuration for the user's email domain.
- Fixes the loop on the login page for users without a password (e.g. signed in via Google or Microsoft Auth) trying to access a password-only organization.
- `SAML` root sessions still require re-authentication, since they are bound to a different organization's IdP.

## Test plan
- [ ] Sign in with Google/Microsoft OIDC and access a password-only organization — should land on the org without being redirected to `/auth/password-login`.
- [ ] Sign in with password and access a password-only org — still works.
- [ ] Sign in with SAML and access a different org with no SAML config — still prompted for password (unchanged).
- [ ] Sign in with magic link and access a password-only org — works.