### PR TITLE
Add e2e, mcp, prb surfaces to cookiebanner

### DIFF
--- a/apps/console/src/pages/organizations/cookie-banners/overview/CookieBannersOverviewPage.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/overview/CookieBannersOverviewPage.tsx
@@ -174,7 +174,7 @@ export function CookieBannersOverviewPage({ queryRef }: CookieBannersOverviewPag
           <Button to={newBannerHref}>{__("Create Banner")}</Button>
         </div>
 
-        <Card className="divide-y divide-border rounded-lg border">
+        <Card className="divide-y divide-border-low rounded-lg">
           {banners.map(banner => (
             <Link
               key={banner.id}

--- a/e2e/console/cookie_banner_test.go
+++ b/e2e/console/cookie_banner_test.go
@@ -1,0 +1,924 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package console_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/e2e/internal/factory"
+	"go.probo.inc/probo/e2e/internal/testutil"
+)
+
+func TestCookieBanner_Create(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with required fields", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		const query = `
+			mutation CreateCookieBanner($input: CreateCookieBannerInput!) {
+				createCookieBanner(input: $input) {
+					cookieBannerEdge {
+						node {
+							id
+							name
+							origin
+							state
+							cookiePolicyUrl
+							consentExpiryDays
+							consentMode
+							showBranding
+							defaultLanguage
+							createdAt
+							updatedAt
+						}
+					}
+				}
+			}
+		`
+
+		name := factory.SafeName("Banner")
+		origin := factory.SafeOrigin()
+
+		var result struct {
+			CreateCookieBanner struct {
+				CookieBannerEdge struct {
+					Node struct {
+						ID                string `json:"id"`
+						Name              string `json:"name"`
+						Origin            string `json:"origin"`
+						State             string `json:"state"`
+						CookiePolicyUrl   string `json:"cookiePolicyUrl"`
+						ConsentExpiryDays int    `json:"consentExpiryDays"`
+						ConsentMode       string `json:"consentMode"`
+						ShowBranding      bool   `json:"showBranding"`
+						DefaultLanguage   string `json:"defaultLanguage"`
+						CreatedAt         string `json:"createdAt"`
+						UpdatedAt         string `json:"updatedAt"`
+					} `json:"node"`
+				} `json:"cookieBannerEdge"`
+			} `json:"createCookieBanner"`
+		}
+
+		err := owner.Execute(query, map[string]any{
+			"input": map[string]any{
+				"organizationId":    owner.GetOrganizationID().String(),
+				"name":              name,
+				"origin":            origin,
+				"cookiePolicyUrl":   "https://example.com/cookies",
+				"consentExpiryDays": 365,
+				"consentMode":       "OPT_IN",
+			},
+		}, &result)
+
+		require.NoError(t, err)
+		node := result.CreateCookieBanner.CookieBannerEdge.Node
+		assert.NotEmpty(t, node.ID)
+		assert.Equal(t, name, node.Name)
+		assert.Equal(t, "ACTIVE", node.State)
+		assert.Equal(t, "https://example.com/cookies", node.CookiePolicyUrl)
+		assert.Equal(t, 365, node.ConsentExpiryDays)
+		assert.Equal(t, "OPT_IN", node.ConsentMode)
+		assert.Equal(t, "en", node.DefaultLanguage)
+		assert.NotEmpty(t, node.CreatedAt)
+		assert.NotEmpty(t, node.UpdatedAt)
+	})
+
+	t.Run("with all fields including privacyPolicyUrl", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		const query = `
+			mutation CreateCookieBanner($input: CreateCookieBannerInput!) {
+				createCookieBanner(input: $input) {
+					cookieBannerEdge {
+						node {
+							id
+							privacyPolicyUrl
+							consentMode
+						}
+					}
+				}
+			}
+		`
+
+		var result struct {
+			CreateCookieBanner struct {
+				CookieBannerEdge struct {
+					Node struct {
+						ID               string  `json:"id"`
+						PrivacyPolicyUrl *string `json:"privacyPolicyUrl"`
+						ConsentMode      string  `json:"consentMode"`
+					} `json:"node"`
+				} `json:"cookieBannerEdge"`
+			} `json:"createCookieBanner"`
+		}
+
+		err := owner.Execute(query, map[string]any{
+			"input": map[string]any{
+				"organizationId":    owner.GetOrganizationID().String(),
+				"name":              factory.SafeName("Banner"),
+				"origin":            factory.SafeOrigin(),
+				"cookiePolicyUrl":   "https://example.com/cookies",
+				"privacyPolicyUrl":  "https://example.com/privacy",
+				"consentExpiryDays": 180,
+				"consentMode":       "OPT_OUT",
+			},
+		}, &result)
+
+		require.NoError(t, err)
+		node := result.CreateCookieBanner.CookieBannerEdge.Node
+		assert.NotEmpty(t, node.ID)
+		require.NotNil(t, node.PrivacyPolicyUrl)
+		assert.Equal(t, "https://example.com/privacy", *node.PrivacyPolicyUrl)
+		assert.Equal(t, "OPT_OUT", node.ConsentMode)
+	})
+
+	t.Run("creates default categories", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+
+		const query = `
+			query($id: ID!) {
+				node(id: $id) {
+					... on CookieBanner {
+						categories(first: 10) {
+							totalCount
+							edges {
+								node {
+									id
+									name
+									kind
+								}
+							}
+						}
+					}
+				}
+			}
+		`
+
+		var result struct {
+			Node struct {
+				Categories struct {
+					TotalCount int `json:"totalCount"`
+					Edges      []struct {
+						Node struct {
+							ID   string `json:"id"`
+							Name string `json:"name"`
+							Kind string `json:"kind"`
+						} `json:"node"`
+					} `json:"edges"`
+				} `json:"categories"`
+			} `json:"node"`
+		}
+
+		err := owner.Execute(query, map[string]any{"id": bannerID}, &result)
+		require.NoError(t, err)
+		assert.Greater(t, result.Node.Categories.TotalCount, 0)
+
+		kinds := make(map[string]bool)
+		for _, e := range result.Node.Categories.Edges {
+			kinds[e.Node.Kind] = true
+		}
+		assert.True(t, kinds["NECESSARY"], "should have a NECESSARY category")
+		assert.True(t, kinds["UNCATEGORISED"], "should have an UNCATEGORISED category")
+	})
+
+	t.Run("duplicate origin conflict", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		origin := factory.SafeOrigin()
+		factory.NewCookieBanner(owner).WithOrigin(origin).Create()
+
+		_, err := owner.Do(`
+			mutation CreateCookieBanner($input: CreateCookieBannerInput!) {
+				createCookieBanner(input: $input) {
+					cookieBannerEdge { node { id } }
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{
+				"organizationId":    owner.GetOrganizationID().String(),
+				"name":              factory.SafeName("Banner"),
+				"origin":            origin,
+				"cookiePolicyUrl":   "https://example.com/cookies",
+				"consentExpiryDays": 365,
+				"consentMode":       "OPT_IN",
+			},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("validation error on missing name", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		_, err := owner.Do(`
+			mutation CreateCookieBanner($input: CreateCookieBannerInput!) {
+				createCookieBanner(input: $input) {
+					cookieBannerEdge { node { id } }
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{
+				"organizationId":    owner.GetOrganizationID().String(),
+				"name":              "",
+				"origin":            factory.SafeOrigin(),
+				"cookiePolicyUrl":   "https://example.com/cookies",
+				"consentExpiryDays": 365,
+				"consentMode":       "OPT_IN",
+			},
+		})
+		require.Error(t, err)
+	})
+}
+
+func TestCookieBanner_Update(t *testing.T) {
+	t.Parallel()
+
+	t.Run("partial update name only", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+
+		const query = `
+			mutation UpdateCookieBanner($input: UpdateCookieBannerInput!) {
+				updateCookieBanner(input: $input) {
+					cookieBanner {
+						id
+						name
+						consentExpiryDays
+					}
+				}
+			}
+		`
+
+		newName := factory.SafeName("Updated")
+		var result struct {
+			UpdateCookieBanner struct {
+				CookieBanner struct {
+					ID                string `json:"id"`
+					Name              string `json:"name"`
+					ConsentExpiryDays int    `json:"consentExpiryDays"`
+				} `json:"cookieBanner"`
+			} `json:"updateCookieBanner"`
+		}
+
+		err := owner.Execute(query, map[string]any{
+			"input": map[string]any{
+				"cookieBannerId": bannerID,
+				"name":           newName,
+			},
+		}, &result)
+
+		require.NoError(t, err)
+		assert.Equal(t, bannerID, result.UpdateCookieBanner.CookieBanner.ID)
+		assert.Equal(t, newName, result.UpdateCookieBanner.CookieBanner.Name)
+		assert.Equal(t, 365, result.UpdateCookieBanner.CookieBanner.ConsentExpiryDays)
+	})
+
+	t.Run("update consent settings", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+
+		const query = `
+			mutation UpdateCookieBanner($input: UpdateCookieBannerInput!) {
+				updateCookieBanner(input: $input) {
+					cookieBanner {
+						consentExpiryDays
+						consentMode
+						defaultLanguage
+					}
+				}
+			}
+		`
+
+		var result struct {
+			UpdateCookieBanner struct {
+				CookieBanner struct {
+					ConsentExpiryDays int    `json:"consentExpiryDays"`
+					ConsentMode       string `json:"consentMode"`
+					DefaultLanguage   string `json:"defaultLanguage"`
+				} `json:"cookieBanner"`
+			} `json:"updateCookieBanner"`
+		}
+
+		err := owner.Execute(query, map[string]any{
+			"input": map[string]any{
+				"cookieBannerId":    bannerID,
+				"consentExpiryDays": 90,
+				"consentMode":       "OPT_OUT",
+				"defaultLanguage":   "fr",
+			},
+		}, &result)
+
+		require.NoError(t, err)
+		assert.Equal(t, 90, result.UpdateCookieBanner.CookieBanner.ConsentExpiryDays)
+		assert.Equal(t, "OPT_OUT", result.UpdateCookieBanner.CookieBanner.ConsentMode)
+		assert.Equal(t, "fr", result.UpdateCookieBanner.CookieBanner.DefaultLanguage)
+	})
+}
+
+func TestCookieBanner_Delete(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+
+		const query = `
+			mutation DeleteCookieBanner($input: DeleteCookieBannerInput!) {
+				deleteCookieBanner(input: $input) {
+					deletedCookieBannerId
+				}
+			}
+		`
+
+		var result struct {
+			DeleteCookieBanner struct {
+				DeletedCookieBannerID string `json:"deletedCookieBannerId"`
+			} `json:"deleteCookieBanner"`
+		}
+
+		err := owner.Execute(query, map[string]any{
+			"input": map[string]any{
+				"cookieBannerId": bannerID,
+			},
+		}, &result)
+
+		require.NoError(t, err)
+		assert.Equal(t, bannerID, result.DeleteCookieBanner.DeletedCookieBannerID)
+	})
+}
+
+func TestCookieBanner_ActivateDeactivate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("deactivate active banner", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+
+		const query = `
+			mutation DeactivateCookieBanner($input: DeactivateCookieBannerInput!) {
+				deactivateCookieBanner(input: $input) {
+					cookieBanner {
+						id
+						state
+					}
+				}
+			}
+		`
+
+		var result struct {
+			DeactivateCookieBanner struct {
+				CookieBanner struct {
+					ID    string `json:"id"`
+					State string `json:"state"`
+				} `json:"cookieBanner"`
+			} `json:"deactivateCookieBanner"`
+		}
+
+		err := owner.Execute(query, map[string]any{
+			"input": map[string]any{"cookieBannerId": bannerID},
+		}, &result)
+
+		require.NoError(t, err)
+		assert.Equal(t, "INACTIVE", result.DeactivateCookieBanner.CookieBanner.State)
+	})
+
+	t.Run("activate inactive banner", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+
+		// Deactivate first
+		var deactivateResult struct {
+			DeactivateCookieBanner struct {
+				CookieBanner struct {
+					State string `json:"state"`
+				} `json:"cookieBanner"`
+			} `json:"deactivateCookieBanner"`
+		}
+		err := owner.Execute(`
+			mutation($input: DeactivateCookieBannerInput!) {
+				deactivateCookieBanner(input: $input) {
+					cookieBanner { state }
+				}
+			}
+		`, map[string]any{"input": map[string]any{"cookieBannerId": bannerID}}, &deactivateResult)
+		require.NoError(t, err)
+		require.Equal(t, "INACTIVE", deactivateResult.DeactivateCookieBanner.CookieBanner.State)
+
+		// Activate
+		const query = `
+			mutation ActivateCookieBanner($input: ActivateCookieBannerInput!) {
+				activateCookieBanner(input: $input) {
+					cookieBanner {
+						id
+						state
+					}
+				}
+			}
+		`
+
+		var result struct {
+			ActivateCookieBanner struct {
+				CookieBanner struct {
+					ID    string `json:"id"`
+					State string `json:"state"`
+				} `json:"cookieBanner"`
+			} `json:"activateCookieBanner"`
+		}
+
+		err = owner.Execute(query, map[string]any{
+			"input": map[string]any{"cookieBannerId": bannerID},
+		}, &result)
+
+		require.NoError(t, err)
+		assert.Equal(t, "ACTIVE", result.ActivateCookieBanner.CookieBanner.State)
+	})
+
+	t.Run("deactivate already inactive returns error", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+
+		deactivateQuery := `
+			mutation($input: DeactivateCookieBannerInput!) {
+				deactivateCookieBanner(input: $input) {
+					cookieBanner { state }
+				}
+			}
+		`
+
+		var result struct {
+			DeactivateCookieBanner struct {
+				CookieBanner struct {
+					State string `json:"state"`
+				} `json:"cookieBanner"`
+			} `json:"deactivateCookieBanner"`
+		}
+
+		err := owner.Execute(deactivateQuery, map[string]any{
+			"input": map[string]any{"cookieBannerId": bannerID},
+		}, &result)
+		require.NoError(t, err)
+
+		_, err = owner.Do(deactivateQuery, map[string]any{
+			"input": map[string]any{"cookieBannerId": bannerID},
+		})
+		require.Error(t, err)
+	})
+}
+
+func TestCookieBanner_List(t *testing.T) {
+	t.Parallel()
+
+	t.Run("lists banners via organization", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		factory.CreateCookieBanner(owner)
+		factory.CreateCookieBanner(owner)
+
+		const query = `
+			query($id: ID!) {
+				node(id: $id) {
+					... on Organization {
+						cookieBanners(first: 10) {
+							totalCount
+							edges {
+								node {
+									id
+									name
+								}
+							}
+							pageInfo {
+								hasNextPage
+								hasPreviousPage
+							}
+						}
+					}
+				}
+			}
+		`
+
+		var result struct {
+			Node struct {
+				CookieBanners struct {
+					TotalCount int `json:"totalCount"`
+					Edges      []struct {
+						Node struct {
+							ID   string `json:"id"`
+							Name string `json:"name"`
+						} `json:"node"`
+					} `json:"edges"`
+					PageInfo struct {
+						HasNextPage     bool `json:"hasNextPage"`
+						HasPreviousPage bool `json:"hasPreviousPage"`
+					} `json:"pageInfo"`
+				} `json:"cookieBanners"`
+			} `json:"node"`
+		}
+
+		err := owner.Execute(query, map[string]any{
+			"id": owner.GetOrganizationID().String(),
+		}, &result)
+
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, result.Node.CookieBanners.TotalCount, 2)
+		assert.GreaterOrEqual(t, len(result.Node.CookieBanners.Edges), 2)
+	})
+}
+
+func TestCookieBanner_Node(t *testing.T) {
+	t.Parallel()
+
+	t.Run("fetch by ID", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+
+		const query = `
+			query($id: ID!) {
+				node(id: $id) {
+					... on CookieBanner {
+						id
+						name
+						origin
+						state
+						consentMode
+					}
+				}
+			}
+		`
+
+		var result struct {
+			Node struct {
+				ID          string `json:"id"`
+				Name        string `json:"name"`
+				Origin      string `json:"origin"`
+				State       string `json:"state"`
+				ConsentMode string `json:"consentMode"`
+			} `json:"node"`
+		}
+
+		err := owner.Execute(query, map[string]any{"id": bannerID}, &result)
+		require.NoError(t, err)
+		assert.Equal(t, bannerID, result.Node.ID)
+		assert.NotEmpty(t, result.Node.Name)
+		assert.Equal(t, "ACTIVE", result.Node.State)
+	})
+}
+
+func TestCookieBanner_PublishVersion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("publish draft version", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+
+		const publishQuery = `
+			mutation PublishCookieBannerVersion($input: PublishCookieBannerVersionInput!) {
+				publishCookieBannerVersion(input: $input) {
+					cookieBannerVersion {
+						id
+						version
+						state
+					}
+					cookieBanner {
+						id
+					}
+				}
+			}
+		`
+
+		var publishResult struct {
+			PublishCookieBannerVersion struct {
+				CookieBannerVersion struct {
+					ID      string `json:"id"`
+					Version int    `json:"version"`
+					State   string `json:"state"`
+				} `json:"cookieBannerVersion"`
+				CookieBanner struct {
+					ID string `json:"id"`
+				} `json:"cookieBanner"`
+			} `json:"publishCookieBannerVersion"`
+		}
+
+		err := owner.Execute(publishQuery, map[string]any{
+			"input": map[string]any{"cookieBannerId": bannerID},
+		}, &publishResult)
+
+		require.NoError(t, err)
+		assert.Equal(t, 1, publishResult.PublishCookieBannerVersion.CookieBannerVersion.Version)
+		assert.Equal(t, "published", publishResult.PublishCookieBannerVersion.CookieBannerVersion.State)
+		assert.Equal(t, bannerID, publishResult.PublishCookieBannerVersion.CookieBanner.ID)
+	})
+
+	t.Run("latestVersion resolver", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+
+		const query = `
+			query($id: ID!) {
+				node(id: $id) {
+					... on CookieBanner {
+						latestVersion {
+							id
+							version
+							state
+						}
+					}
+				}
+			}
+		`
+
+		var result struct {
+			Node struct {
+				LatestVersion *struct {
+					ID      string `json:"id"`
+					Version int    `json:"version"`
+					State   string `json:"state"`
+				} `json:"latestVersion"`
+			} `json:"node"`
+		}
+
+		err := owner.Execute(query, map[string]any{"id": bannerID}, &result)
+		require.NoError(t, err)
+		require.NotNil(t, result.Node.LatestVersion)
+		assert.Equal(t, "draft", result.Node.LatestVersion.State)
+		assert.Equal(t, 1, result.Node.LatestVersion.Version)
+	})
+}
+
+func TestCookieBanner_UpsertTranslation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("insert new language", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+
+		const query = `
+			mutation UpsertCookieBannerTranslation($input: UpsertCookieBannerTranslationInput!) {
+				upsertCookieBannerTranslation(input: $input) {
+					cookieBannerTranslation {
+						id
+						language
+						translations
+					}
+					cookieBanner {
+						id
+					}
+				}
+			}
+		`
+
+		var result struct {
+			UpsertCookieBannerTranslation struct {
+				CookieBannerTranslation struct {
+					ID           string `json:"id"`
+					Language     string `json:"language"`
+					Translations string `json:"translations"`
+				} `json:"cookieBannerTranslation"`
+				CookieBanner struct {
+					ID string `json:"id"`
+				} `json:"cookieBanner"`
+			} `json:"upsertCookieBannerTranslation"`
+		}
+
+		err := owner.Execute(query, map[string]any{
+			"input": map[string]any{
+				"cookieBannerId": bannerID,
+				"language":       "de",
+				"translations":   `{"title":"Cookie Einstellungen","description":"Wir verwenden Cookies"}`,
+			},
+		}, &result)
+
+		require.NoError(t, err)
+		assert.NotEmpty(t, result.UpsertCookieBannerTranslation.CookieBannerTranslation.ID)
+		assert.Equal(t, "de", result.UpsertCookieBannerTranslation.CookieBannerTranslation.Language)
+		assert.Equal(t, bannerID, result.UpsertCookieBannerTranslation.CookieBanner.ID)
+	})
+
+	t.Run("update existing language", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+
+		const query = `
+			mutation UpsertCookieBannerTranslation($input: UpsertCookieBannerTranslationInput!) {
+				upsertCookieBannerTranslation(input: $input) {
+					cookieBannerTranslation {
+						id
+						language
+						translations
+					}
+				}
+			}
+		`
+
+		input := map[string]any{
+			"input": map[string]any{
+				"cookieBannerId": bannerID,
+				"language":       "es",
+				"translations":   `{"title":"Configuracion de cookies"}`,
+			},
+		}
+
+		var result1 struct {
+			UpsertCookieBannerTranslation struct {
+				CookieBannerTranslation struct {
+					ID string `json:"id"`
+				} `json:"cookieBannerTranslation"`
+			} `json:"upsertCookieBannerTranslation"`
+		}
+		err := owner.Execute(query, input, &result1)
+		require.NoError(t, err)
+		firstID := result1.UpsertCookieBannerTranslation.CookieBannerTranslation.ID
+
+		input["input"].(map[string]any)["translations"] = `{"title":"Ajustes de cookies"}`
+
+		var result2 struct {
+			UpsertCookieBannerTranslation struct {
+				CookieBannerTranslation struct {
+					ID           string `json:"id"`
+					Translations string `json:"translations"`
+				} `json:"cookieBannerTranslation"`
+			} `json:"upsertCookieBannerTranslation"`
+		}
+		err = owner.Execute(query, input, &result2)
+		require.NoError(t, err)
+		assert.Equal(t, firstID, result2.UpsertCookieBannerTranslation.CookieBannerTranslation.ID)
+		assert.Contains(t, result2.UpsertCookieBannerTranslation.CookieBannerTranslation.Translations, "Ajustes de cookies")
+	})
+
+	t.Run("translations resolver on banner", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+
+		const query = `
+			query($id: ID!) {
+				node(id: $id) {
+					... on CookieBanner {
+						translations {
+							id
+							language
+						}
+					}
+				}
+			}
+		`
+
+		var result struct {
+			Node struct {
+				Translations []struct {
+					ID       string `json:"id"`
+					Language string `json:"language"`
+				} `json:"translations"`
+			} `json:"node"`
+		}
+
+		err := owner.Execute(query, map[string]any{"id": bannerID}, &result)
+		require.NoError(t, err)
+		assert.NotEmpty(t, result.Node.Translations)
+	})
+}
+
+func TestCookieBanner_RBAC(t *testing.T) {
+	t.Parallel()
+
+	t.Run("viewer cannot create", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+
+		_, err := viewer.Do(`
+			mutation CreateCookieBanner($input: CreateCookieBannerInput!) {
+				createCookieBanner(input: $input) {
+					cookieBannerEdge { node { id } }
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{
+				"organizationId":    viewer.GetOrganizationID().String(),
+				"name":              factory.SafeName("Banner"),
+				"origin":            factory.SafeOrigin(),
+				"cookiePolicyUrl":   "https://example.com/cookies",
+				"consentExpiryDays": 365,
+				"consentMode":       "OPT_IN",
+			},
+		})
+		testutil.RequireForbiddenError(t, err, "viewer should not be able to create cookie banner")
+	})
+
+	t.Run("viewer cannot update", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+
+		_, err := viewer.Do(`
+			mutation UpdateCookieBanner($input: UpdateCookieBannerInput!) {
+				updateCookieBanner(input: $input) {
+					cookieBanner { id }
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{
+				"cookieBannerId": bannerID,
+				"name":           "Updated",
+			},
+		})
+		testutil.RequireForbiddenError(t, err, "viewer should not be able to update cookie banner")
+	})
+
+	t.Run("viewer cannot delete", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+
+		_, err := viewer.Do(`
+			mutation DeleteCookieBanner($input: DeleteCookieBannerInput!) {
+				deleteCookieBanner(input: $input) {
+					deletedCookieBannerId
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{"cookieBannerId": bannerID},
+		})
+		testutil.RequireForbiddenError(t, err, "viewer should not be able to delete cookie banner")
+	})
+}
+
+func TestCookieBanner_TenantIsolation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("other org cannot access banner", func(t *testing.T) {
+		t.Parallel()
+		owner1 := testutil.NewClient(t, testutil.RoleOwner)
+		owner2 := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner1)
+
+		const query = `
+			query($id: ID!) {
+				node(id: $id) {
+					... on CookieBanner {
+						id
+						name
+					}
+				}
+			}
+		`
+
+		var result struct {
+			Node *struct {
+				ID string `json:"id"`
+			} `json:"node"`
+		}
+
+		err := owner2.Execute(query, map[string]any{"id": bannerID}, &result)
+		testutil.AssertNodeNotAccessible(t, err, result.Node == nil, "cookie banner")
+	})
+}

--- a/e2e/console/cookie_banner_test.go
+++ b/e2e/console/cookie_banner_test.go
@@ -642,7 +642,7 @@ func TestCookieBanner_PublishVersion(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, 1, publishResult.PublishCookieBannerVersion.CookieBannerVersion.Version)
-		assert.Equal(t, "published", publishResult.PublishCookieBannerVersion.CookieBannerVersion.State)
+		assert.Equal(t, "PUBLISHED", publishResult.PublishCookieBannerVersion.CookieBannerVersion.State)
 		assert.Equal(t, bannerID, publishResult.PublishCookieBannerVersion.CookieBanner.ID)
 	})
 
@@ -679,7 +679,7 @@ func TestCookieBanner_PublishVersion(t *testing.T) {
 		err := owner.Execute(query, map[string]any{"id": bannerID}, &result)
 		require.NoError(t, err)
 		require.NotNil(t, result.Node.LatestVersion)
-		assert.Equal(t, "draft", result.Node.LatestVersion.State)
+		assert.Equal(t, "DRAFT", result.Node.LatestVersion.State)
 		assert.Equal(t, 1, result.Node.LatestVersion.Version)
 	})
 }

--- a/e2e/console/cookie_category_test.go
+++ b/e2e/console/cookie_category_test.go
@@ -106,7 +106,7 @@ func TestCookieCategory_Create(t *testing.T) {
 		owner := testutil.NewClient(t, testutil.RoleOwner)
 
 		bannerID := factory.CreateCookieBanner(owner)
-		factory.CreateCookieCategory(owner, bannerID, factory.Attrs{"slug": "analytics"})
+		factory.CreateCookieCategory(owner, bannerID, factory.Attrs{"slug": "custom-slug-dup"})
 
 		_, err := owner.Do(`
 			mutation CreateCookieCategory($input: CreateCookieCategoryInput!) {
@@ -118,8 +118,8 @@ func TestCookieCategory_Create(t *testing.T) {
 		`, map[string]any{
 			"input": map[string]any{
 				"cookieBannerId": bannerID,
-				"name":           "Another Analytics",
-				"slug":           "analytics",
+				"name":           "Duplicate Category",
+				"slug":           "custom-slug-dup",
 				"description":    "Duplicate slug",
 				"rank":           10,
 			},

--- a/e2e/console/cookie_category_test.go
+++ b/e2e/console/cookie_category_test.go
@@ -1,0 +1,548 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package console_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/e2e/internal/factory"
+	"go.probo.inc/probo/e2e/internal/testutil"
+)
+
+func TestCookieCategory_Create(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+
+		const query = `
+			mutation CreateCookieCategory($input: CreateCookieCategoryInput!) {
+				createCookieCategory(input: $input) {
+					cookieCategoryEdge {
+						node {
+							id
+							name
+							slug
+							description
+							kind
+							rank
+							gcmConsentTypes
+							posthogConsent
+							createdAt
+							updatedAt
+						}
+					}
+					cookieBanner {
+						id
+					}
+				}
+			}
+		`
+
+		var result struct {
+			CreateCookieCategory struct {
+				CookieCategoryEdge struct {
+					Node struct {
+						ID              string   `json:"id"`
+						Name            string   `json:"name"`
+						Slug            string   `json:"slug"`
+						Description     string   `json:"description"`
+						Kind            string   `json:"kind"`
+						Rank            int      `json:"rank"`
+						GcmConsentTypes []string `json:"gcmConsentTypes"`
+						PosthogConsent  bool     `json:"posthogConsent"`
+						CreatedAt       string   `json:"createdAt"`
+						UpdatedAt       string   `json:"updatedAt"`
+					} `json:"node"`
+				} `json:"cookieCategoryEdge"`
+				CookieBanner struct {
+					ID string `json:"id"`
+				} `json:"cookieBanner"`
+			} `json:"createCookieCategory"`
+		}
+
+		err := owner.Execute(query, map[string]any{
+			"input": map[string]any{
+				"cookieBannerId": bannerID,
+				"name":           "Marketing",
+				"slug":           "marketing",
+				"description":    "Marketing cookies for tracking",
+				"rank":           5,
+			},
+		}, &result)
+
+		require.NoError(t, err)
+		node := result.CreateCookieCategory.CookieCategoryEdge.Node
+		assert.NotEmpty(t, node.ID)
+		assert.Equal(t, "Marketing", node.Name)
+		assert.Equal(t, "marketing", node.Slug)
+		assert.Equal(t, "Marketing cookies for tracking", node.Description)
+		assert.Equal(t, "NORMAL", node.Kind)
+		assert.Equal(t, 5, node.Rank)
+		assert.Empty(t, node.GcmConsentTypes)
+		assert.False(t, node.PosthogConsent)
+		assert.Equal(t, bannerID, result.CreateCookieCategory.CookieBanner.ID)
+	})
+
+	t.Run("duplicate slug conflict", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+		factory.CreateCookieCategory(owner, bannerID, factory.Attrs{"slug": "analytics"})
+
+		_, err := owner.Do(`
+			mutation CreateCookieCategory($input: CreateCookieCategoryInput!) {
+				createCookieCategory(input: $input) {
+					cookieCategoryEdge { node { id } }
+					cookieBanner { id }
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{
+				"cookieBannerId": bannerID,
+				"name":           "Another Analytics",
+				"slug":           "analytics",
+				"description":    "Duplicate slug",
+				"rank":           10,
+			},
+		})
+		require.Error(t, err)
+	})
+}
+
+func TestCookieCategory_Update(t *testing.T) {
+	t.Parallel()
+
+	t.Run("partial update", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+		categoryID := factory.CreateCookieCategory(owner, bannerID, factory.Attrs{
+			"name":        "Analytics",
+			"slug":        "analytics-update",
+			"description": "Original description",
+		})
+
+		const query = `
+			mutation UpdateCookieCategory($input: UpdateCookieCategoryInput!) {
+				updateCookieCategory(input: $input) {
+					cookieCategory {
+						id
+						name
+						description
+						slug
+					}
+					cookieBanner {
+						id
+					}
+				}
+			}
+		`
+
+		var result struct {
+			UpdateCookieCategory struct {
+				CookieCategory struct {
+					ID          string `json:"id"`
+					Name        string `json:"name"`
+					Description string `json:"description"`
+					Slug        string `json:"slug"`
+				} `json:"cookieCategory"`
+				CookieBanner struct {
+					ID string `json:"id"`
+				} `json:"cookieBanner"`
+			} `json:"updateCookieCategory"`
+		}
+
+		err := owner.Execute(query, map[string]any{
+			"input": map[string]any{
+				"cookieCategoryId": categoryID,
+				"name":             "Updated Analytics",
+			},
+		}, &result)
+
+		require.NoError(t, err)
+		assert.Equal(t, categoryID, result.UpdateCookieCategory.CookieCategory.ID)
+		assert.Equal(t, "Updated Analytics", result.UpdateCookieCategory.CookieCategory.Name)
+		assert.Equal(t, "Original description", result.UpdateCookieCategory.CookieCategory.Description)
+		assert.Equal(t, bannerID, result.UpdateCookieCategory.CookieBanner.ID)
+	})
+
+	t.Run("update gcmConsentTypes", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+		categoryID := factory.CreateCookieCategory(owner, bannerID)
+
+		const query = `
+			mutation UpdateCookieCategory($input: UpdateCookieCategoryInput!) {
+				updateCookieCategory(input: $input) {
+					cookieCategory {
+						id
+						gcmConsentTypes
+					}
+				}
+			}
+		`
+
+		var result struct {
+			UpdateCookieCategory struct {
+				CookieCategory struct {
+					ID              string   `json:"id"`
+					GcmConsentTypes []string `json:"gcmConsentTypes"`
+				} `json:"cookieCategory"`
+			} `json:"updateCookieCategory"`
+		}
+
+		err := owner.Execute(query, map[string]any{
+			"input": map[string]any{
+				"cookieCategoryId": categoryID,
+				"gcmConsentTypes":  []string{"ad_storage", "analytics_storage"},
+			},
+		}, &result)
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"ad_storage", "analytics_storage"}, result.UpdateCookieCategory.CookieCategory.GcmConsentTypes)
+	})
+
+	t.Run("update posthogConsent", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+		categoryID := factory.CreateCookieCategory(owner, bannerID)
+
+		const query = `
+			mutation UpdateCookieCategory($input: UpdateCookieCategoryInput!) {
+				updateCookieCategory(input: $input) {
+					cookieCategory {
+						id
+						posthogConsent
+					}
+				}
+			}
+		`
+
+		var result struct {
+			UpdateCookieCategory struct {
+				CookieCategory struct {
+					ID             string `json:"id"`
+					PosthogConsent bool   `json:"posthogConsent"`
+				} `json:"cookieCategory"`
+			} `json:"updateCookieCategory"`
+		}
+
+		err := owner.Execute(query, map[string]any{
+			"input": map[string]any{
+				"cookieCategoryId": categoryID,
+				"posthogConsent":   true,
+			},
+		}, &result)
+
+		require.NoError(t, err)
+		assert.True(t, result.UpdateCookieCategory.CookieCategory.PosthogConsent)
+	})
+}
+
+func TestCookieCategory_Delete(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success for normal category", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+		categoryID := factory.CreateCookieCategory(owner, bannerID)
+
+		const query = `
+			mutation DeleteCookieCategory($input: DeleteCookieCategoryInput!) {
+				deleteCookieCategory(input: $input) {
+					deletedCookieCategoryId
+					cookieBanner {
+						id
+					}
+				}
+			}
+		`
+
+		var result struct {
+			DeleteCookieCategory struct {
+				DeletedCookieCategoryID string `json:"deletedCookieCategoryId"`
+				CookieBanner            struct {
+					ID string `json:"id"`
+				} `json:"cookieBanner"`
+			} `json:"deleteCookieCategory"`
+		}
+
+		err := owner.Execute(query, map[string]any{
+			"input": map[string]any{"cookieCategoryId": categoryID},
+		}, &result)
+
+		require.NoError(t, err)
+		assert.Equal(t, categoryID, result.DeleteCookieCategory.DeletedCookieCategoryID)
+		assert.Equal(t, bannerID, result.DeleteCookieCategory.CookieBanner.ID)
+	})
+
+	t.Run("cannot delete system category", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+
+		// Fetch the NECESSARY category
+		const listQuery = `
+			query($id: ID!) {
+				node(id: $id) {
+					... on CookieBanner {
+						categories(first: 20) {
+							edges {
+								node {
+									id
+									kind
+								}
+							}
+						}
+					}
+				}
+			}
+		`
+
+		var listResult struct {
+			Node struct {
+				Categories struct {
+					Edges []struct {
+						Node struct {
+							ID   string `json:"id"`
+							Kind string `json:"kind"`
+						} `json:"node"`
+					} `json:"edges"`
+				} `json:"categories"`
+			} `json:"node"`
+		}
+
+		err := owner.Execute(listQuery, map[string]any{"id": bannerID}, &listResult)
+		require.NoError(t, err)
+
+		var necessaryCategoryID string
+		for _, e := range listResult.Node.Categories.Edges {
+			if e.Node.Kind == "NECESSARY" {
+				necessaryCategoryID = e.Node.ID
+				break
+			}
+		}
+		require.NotEmpty(t, necessaryCategoryID, "should find a NECESSARY category")
+
+		_, err = owner.Do(`
+			mutation DeleteCookieCategory($input: DeleteCookieCategoryInput!) {
+				deleteCookieCategory(input: $input) {
+					deletedCookieCategoryId
+					cookieBanner { id }
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{"cookieCategoryId": necessaryCategoryID},
+		})
+		require.Error(t, err)
+	})
+}
+
+func TestCookieCategory_Reorder(t *testing.T) {
+	t.Parallel()
+
+	t.Run("change rank", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+		categoryID := factory.CreateCookieCategory(owner, bannerID, factory.Attrs{"rank": 5})
+
+		const query = `
+			mutation ReorderCookieCategory($input: ReorderCookieCategoryInput!) {
+				reorderCookieCategory(input: $input) {
+					cookieBanner {
+						id
+					}
+				}
+			}
+		`
+
+		var result struct {
+			ReorderCookieCategory struct {
+				CookieBanner struct {
+					ID string `json:"id"`
+				} `json:"cookieBanner"`
+			} `json:"reorderCookieCategory"`
+		}
+
+		err := owner.Execute(query, map[string]any{
+			"input": map[string]any{
+				"cookieCategoryId": categoryID,
+				"rank":             1,
+			},
+		}, &result)
+
+		require.NoError(t, err)
+		assert.Equal(t, bannerID, result.ReorderCookieCategory.CookieBanner.ID)
+	})
+}
+
+func TestCookieCategory_List(t *testing.T) {
+	t.Parallel()
+
+	t.Run("via banner categories connection", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+		factory.CreateCookieCategory(owner, bannerID, factory.Attrs{"rank": 20})
+		factory.CreateCookieCategory(owner, bannerID, factory.Attrs{"rank": 30})
+
+		const query = `
+			query($id: ID!) {
+				node(id: $id) {
+					... on CookieBanner {
+						categories(first: 20, orderBy: {field: RANK, direction: ASC}) {
+							totalCount
+							edges {
+								node {
+									id
+									rank
+								}
+							}
+							pageInfo {
+								hasNextPage
+								hasPreviousPage
+							}
+						}
+					}
+				}
+			}
+		`
+
+		var result struct {
+			Node struct {
+				Categories struct {
+					TotalCount int `json:"totalCount"`
+					Edges      []struct {
+						Node struct {
+							ID   string `json:"id"`
+							Rank int    `json:"rank"`
+						} `json:"node"`
+					} `json:"edges"`
+					PageInfo struct {
+						HasNextPage     bool `json:"hasNextPage"`
+						HasPreviousPage bool `json:"hasPreviousPage"`
+					} `json:"pageInfo"`
+				} `json:"categories"`
+			} `json:"node"`
+		}
+
+		err := owner.Execute(query, map[string]any{"id": bannerID}, &result)
+		require.NoError(t, err)
+
+		// Default categories + 2 custom ones
+		assert.GreaterOrEqual(t, result.Node.Categories.TotalCount, 4)
+
+		// Verify ordering (ranks should be ascending)
+		for i := 1; i < len(result.Node.Categories.Edges); i++ {
+			assert.GreaterOrEqual(t,
+				result.Node.Categories.Edges[i].Node.Rank,
+				result.Node.Categories.Edges[i-1].Node.Rank,
+			)
+		}
+	})
+}
+
+func TestCookieCategory_RBAC(t *testing.T) {
+	t.Parallel()
+
+	t.Run("viewer cannot create category", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+
+		_, err := viewer.Do(`
+			mutation CreateCookieCategory($input: CreateCookieCategoryInput!) {
+				createCookieCategory(input: $input) {
+					cookieCategoryEdge { node { id } }
+					cookieBanner { id }
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{
+				"cookieBannerId": bannerID,
+				"name":           "Test",
+				"slug":           "test-rbac",
+				"description":    "Test category",
+				"rank":           10,
+			},
+		})
+		testutil.RequireForbiddenError(t, err, "viewer should not be able to create cookie category")
+	})
+
+	t.Run("viewer cannot update category", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+		categoryID := factory.CreateCookieCategory(owner, bannerID)
+
+		_, err := viewer.Do(`
+			mutation UpdateCookieCategory($input: UpdateCookieCategoryInput!) {
+				updateCookieCategory(input: $input) {
+					cookieCategory { id }
+					cookieBanner { id }
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{
+				"cookieCategoryId": categoryID,
+				"name":             "Updated",
+			},
+		})
+		testutil.RequireForbiddenError(t, err, "viewer should not be able to update cookie category")
+	})
+
+	t.Run("viewer cannot delete category", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+		categoryID := factory.CreateCookieCategory(owner, bannerID)
+
+		_, err := viewer.Do(`
+			mutation DeleteCookieCategory($input: DeleteCookieCategoryInput!) {
+				deleteCookieCategory(input: $input) {
+					deletedCookieCategoryId
+					cookieBanner { id }
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{"cookieCategoryId": categoryID},
+		})
+		testutil.RequireForbiddenError(t, err, "viewer should not be able to delete cookie category")
+	})
+}

--- a/e2e/console/cookie_pattern_test.go
+++ b/e2e/console/cookie_pattern_test.go
@@ -1,0 +1,575 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package console_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/e2e/internal/factory"
+	"go.probo.inc/probo/e2e/internal/testutil"
+)
+
+func TestCookiePattern_Create(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with EXACT match type", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+		categoryID := factory.CreateCookieCategory(owner, bannerID)
+
+		const query = `
+			mutation CreateCookiePattern($input: CreateCookiePatternInput!) {
+				createCookiePattern(input: $input) {
+					cookiePatternEdge {
+						node {
+							id
+							pattern
+							matchType
+							displayName
+							maxAgeSeconds
+							description
+							source
+							createdAt
+							updatedAt
+						}
+					}
+					cookieBanner {
+						id
+					}
+				}
+			}
+		`
+
+		var result struct {
+			CreateCookiePattern struct {
+				CookiePatternEdge struct {
+					Node struct {
+						ID            string `json:"id"`
+						Pattern       string `json:"pattern"`
+						MatchType     string `json:"matchType"`
+						DisplayName   string `json:"displayName"`
+						MaxAgeSeconds *int   `json:"maxAgeSeconds"`
+						Description   string `json:"description"`
+						Source        string `json:"source"`
+						CreatedAt     string `json:"createdAt"`
+						UpdatedAt     string `json:"updatedAt"`
+					} `json:"node"`
+				} `json:"cookiePatternEdge"`
+				CookieBanner struct {
+					ID string `json:"id"`
+				} `json:"cookieBanner"`
+			} `json:"createCookiePattern"`
+		}
+
+		maxAge := 86400
+		err := owner.Execute(query, map[string]any{
+			"input": map[string]any{
+				"cookieCategoryId": categoryID,
+				"pattern":          "_ga",
+				"matchType":        "EXACT",
+				"displayName":      "Google Analytics",
+				"maxAgeSeconds":    maxAge,
+				"description":      "Google Analytics tracking cookie",
+			},
+		}, &result)
+
+		require.NoError(t, err)
+		node := result.CreateCookiePattern.CookiePatternEdge.Node
+		assert.NotEmpty(t, node.ID)
+		assert.Equal(t, "_ga", node.Pattern)
+		assert.Equal(t, "EXACT", node.MatchType)
+		assert.Equal(t, "Google Analytics", node.DisplayName)
+		require.NotNil(t, node.MaxAgeSeconds)
+		assert.Equal(t, maxAge, *node.MaxAgeSeconds)
+		assert.Equal(t, "Google Analytics tracking cookie", node.Description)
+		assert.Equal(t, "SCRIPT", node.Source)
+		assert.Equal(t, bannerID, result.CreateCookiePattern.CookieBanner.ID)
+	})
+
+	t.Run("with PREFIX match type", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+		categoryID := factory.CreateCookieCategory(owner, bannerID)
+
+		const query = `
+			mutation CreateCookiePattern($input: CreateCookiePatternInput!) {
+				createCookiePattern(input: $input) {
+					cookiePatternEdge {
+						node {
+							id
+							pattern
+							matchType
+							displayName
+							maxAgeSeconds
+						}
+					}
+				}
+			}
+		`
+
+		var result struct {
+			CreateCookiePattern struct {
+				CookiePatternEdge struct {
+					Node struct {
+						ID            string `json:"id"`
+						Pattern       string `json:"pattern"`
+						MatchType     string `json:"matchType"`
+						DisplayName   string `json:"displayName"`
+						MaxAgeSeconds *int   `json:"maxAgeSeconds"`
+					} `json:"node"`
+				} `json:"cookiePatternEdge"`
+			} `json:"createCookiePattern"`
+		}
+
+		err := owner.Execute(query, map[string]any{
+			"input": map[string]any{
+				"cookieCategoryId": categoryID,
+				"pattern":          "_gat_",
+				"matchType":        "PREFIX",
+				"displayName":      "GA Throttle",
+				"description":      "Google Analytics rate limiting",
+			},
+		}, &result)
+
+		require.NoError(t, err)
+		node := result.CreateCookiePattern.CookiePatternEdge.Node
+		assert.Equal(t, "_gat_", node.Pattern)
+		assert.Equal(t, "PREFIX", node.MatchType)
+		assert.Nil(t, node.MaxAgeSeconds)
+	})
+
+	t.Run("duplicate pattern conflict", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+		categoryID := factory.CreateCookieCategory(owner, bannerID)
+
+		factory.CreateCookiePattern(owner, categoryID, factory.Attrs{
+			"pattern":     "duplicate_cookie",
+			"displayName": "First",
+		})
+
+		_, err := owner.Do(`
+			mutation CreateCookiePattern($input: CreateCookiePatternInput!) {
+				createCookiePattern(input: $input) {
+					cookiePatternEdge { node { id } }
+					cookieBanner { id }
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{
+				"cookieCategoryId": categoryID,
+				"pattern":          "duplicate_cookie",
+				"matchType":        "EXACT",
+				"displayName":      "Second",
+				"description":      "Duplicate",
+			},
+		})
+		require.Error(t, err)
+	})
+}
+
+func TestCookiePattern_Update(t *testing.T) {
+	t.Parallel()
+
+	t.Run("update displayName and description", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+		categoryID := factory.CreateCookieCategory(owner, bannerID)
+		patternID := factory.CreateCookiePattern(owner, categoryID, factory.Attrs{
+			"displayName": "Original Name",
+			"description": "Original description",
+		})
+
+		const query = `
+			mutation UpdateCookiePattern($input: UpdateCookiePatternInput!) {
+				updateCookiePattern(input: $input) {
+					cookiePattern {
+						id
+						displayName
+						description
+					}
+					cookieBanner {
+						id
+					}
+				}
+			}
+		`
+
+		var result struct {
+			UpdateCookiePattern struct {
+				CookiePattern struct {
+					ID          string `json:"id"`
+					DisplayName string `json:"displayName"`
+					Description string `json:"description"`
+				} `json:"cookiePattern"`
+				CookieBanner struct {
+					ID string `json:"id"`
+				} `json:"cookieBanner"`
+			} `json:"updateCookiePattern"`
+		}
+
+		err := owner.Execute(query, map[string]any{
+			"input": map[string]any{
+				"cookiePatternId": patternID,
+				"displayName":     "Updated Name",
+				"description":     "Updated description",
+			},
+		}, &result)
+
+		require.NoError(t, err)
+		assert.Equal(t, patternID, result.UpdateCookiePattern.CookiePattern.ID)
+		assert.Equal(t, "Updated Name", result.UpdateCookiePattern.CookiePattern.DisplayName)
+		assert.Equal(t, "Updated description", result.UpdateCookiePattern.CookiePattern.Description)
+		assert.Equal(t, bannerID, result.UpdateCookiePattern.CookieBanner.ID)
+	})
+
+	t.Run("update maxAgeSeconds", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+		categoryID := factory.CreateCookieCategory(owner, bannerID)
+		patternID := factory.CreateCookiePattern(owner, categoryID)
+
+		const query = `
+			mutation UpdateCookiePattern($input: UpdateCookiePatternInput!) {
+				updateCookiePattern(input: $input) {
+					cookiePattern {
+						id
+						maxAgeSeconds
+					}
+				}
+			}
+		`
+
+		var result struct {
+			UpdateCookiePattern struct {
+				CookiePattern struct {
+					ID            string `json:"id"`
+					MaxAgeSeconds *int   `json:"maxAgeSeconds"`
+				} `json:"cookiePattern"`
+			} `json:"updateCookiePattern"`
+		}
+
+		err := owner.Execute(query, map[string]any{
+			"input": map[string]any{
+				"cookiePatternId": patternID,
+				"maxAgeSeconds":   7200,
+			},
+		}, &result)
+
+		require.NoError(t, err)
+		require.NotNil(t, result.UpdateCookiePattern.CookiePattern.MaxAgeSeconds)
+		assert.Equal(t, 7200, *result.UpdateCookiePattern.CookiePattern.MaxAgeSeconds)
+	})
+}
+
+func TestCookiePattern_Delete(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+		categoryID := factory.CreateCookieCategory(owner, bannerID)
+		patternID := factory.CreateCookiePattern(owner, categoryID)
+
+		const query = `
+			mutation DeleteCookiePattern($input: DeleteCookiePatternInput!) {
+				deleteCookiePattern(input: $input) {
+					deletedCookiePatternId
+					cookieBanner {
+						id
+					}
+				}
+			}
+		`
+
+		var result struct {
+			DeleteCookiePattern struct {
+				DeletedCookiePatternID string `json:"deletedCookiePatternId"`
+				CookieBanner           struct {
+					ID string `json:"id"`
+				} `json:"cookieBanner"`
+			} `json:"deleteCookiePattern"`
+		}
+
+		err := owner.Execute(query, map[string]any{
+			"input": map[string]any{"cookiePatternId": patternID},
+		}, &result)
+
+		require.NoError(t, err)
+		assert.Equal(t, patternID, result.DeleteCookiePattern.DeletedCookiePatternID)
+		assert.Equal(t, bannerID, result.DeleteCookiePattern.CookieBanner.ID)
+	})
+}
+
+func TestCookiePattern_MoveToCategory(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+		categoryA := factory.CreateCookieCategory(owner, bannerID, factory.Attrs{"slug": "cat-a-move"})
+		categoryB := factory.CreateCookieCategory(owner, bannerID, factory.Attrs{"slug": "cat-b-move"})
+		patternID := factory.CreateCookiePattern(owner, categoryA)
+
+		const query = `
+			mutation MoveCookiePatternToCategory($input: MoveCookiePatternToCategoryInput!) {
+				moveCookiePatternToCategory(input: $input) {
+					cookiePattern {
+						id
+						cookieCategory {
+							id
+						}
+					}
+					cookieBanner {
+						id
+					}
+				}
+			}
+		`
+
+		var result struct {
+			MoveCookiePatternToCategory struct {
+				CookiePattern struct {
+					ID             string `json:"id"`
+					CookieCategory struct {
+						ID string `json:"id"`
+					} `json:"cookieCategory"`
+				} `json:"cookiePattern"`
+				CookieBanner struct {
+					ID string `json:"id"`
+				} `json:"cookieBanner"`
+			} `json:"moveCookiePatternToCategory"`
+		}
+
+		err := owner.Execute(query, map[string]any{
+			"input": map[string]any{
+				"cookiePatternId":        patternID,
+				"targetCookieCategoryId": categoryB,
+			},
+		}, &result)
+
+		require.NoError(t, err)
+		assert.Equal(t, patternID, result.MoveCookiePatternToCategory.CookiePattern.ID)
+		assert.Equal(t, categoryB, result.MoveCookiePatternToCategory.CookiePattern.CookieCategory.ID)
+		assert.Equal(t, bannerID, result.MoveCookiePatternToCategory.CookieBanner.ID)
+	})
+
+	t.Run("cross-banner mismatch error", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		banner1 := factory.CreateCookieBanner(owner)
+		banner2 := factory.CreateCookieBanner(owner)
+		category1 := factory.CreateCookieCategory(owner, banner1, factory.Attrs{"slug": "cat-x-mismatch"})
+		category2 := factory.CreateCookieCategory(owner, banner2, factory.Attrs{"slug": "cat-y-mismatch"})
+		patternID := factory.CreateCookiePattern(owner, category1)
+
+		_, err := owner.Do(`
+			mutation MoveCookiePatternToCategory($input: MoveCookiePatternToCategoryInput!) {
+				moveCookiePatternToCategory(input: $input) {
+					cookiePattern { id }
+					cookieBanner { id }
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{
+				"cookiePatternId":        patternID,
+				"targetCookieCategoryId": category2,
+			},
+		})
+		require.Error(t, err)
+	})
+}
+
+func TestCookiePattern_List(t *testing.T) {
+	t.Parallel()
+
+	t.Run("via category cookiePatterns connection", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+		categoryID := factory.CreateCookieCategory(owner, bannerID)
+		factory.CreateCookiePattern(owner, categoryID)
+		factory.CreateCookiePattern(owner, categoryID)
+
+		const query = `
+			query($id: ID!) {
+				node(id: $id) {
+					... on CookieCategory {
+						cookiePatterns(first: 10) {
+							totalCount
+							edges {
+								node {
+									id
+									pattern
+									displayName
+								}
+							}
+							pageInfo {
+								hasNextPage
+								hasPreviousPage
+							}
+						}
+					}
+				}
+			}
+		`
+
+		var result struct {
+			Node struct {
+				CookiePatterns struct {
+					TotalCount int `json:"totalCount"`
+					Edges      []struct {
+						Node struct {
+							ID          string `json:"id"`
+							Pattern     string `json:"pattern"`
+							DisplayName string `json:"displayName"`
+						} `json:"node"`
+					} `json:"edges"`
+					PageInfo struct {
+						HasNextPage     bool `json:"hasNextPage"`
+						HasPreviousPage bool `json:"hasPreviousPage"`
+					} `json:"pageInfo"`
+				} `json:"cookiePatterns"`
+			} `json:"node"`
+		}
+
+		err := owner.Execute(query, map[string]any{"id": categoryID}, &result)
+		require.NoError(t, err)
+		assert.Equal(t, 2, result.Node.CookiePatterns.TotalCount)
+		assert.Len(t, result.Node.CookiePatterns.Edges, 2)
+	})
+}
+
+func TestCookiePattern_RBAC(t *testing.T) {
+	t.Parallel()
+
+	t.Run("viewer cannot create pattern", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+		categoryID := factory.CreateCookieCategory(owner, bannerID)
+
+		_, err := viewer.Do(`
+			mutation CreateCookiePattern($input: CreateCookiePatternInput!) {
+				createCookiePattern(input: $input) {
+					cookiePatternEdge { node { id } }
+					cookieBanner { id }
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{
+				"cookieCategoryId": categoryID,
+				"pattern":          "test_viewer",
+				"matchType":        "EXACT",
+				"displayName":      "Test Viewer Pattern",
+				"description":      "Should fail",
+			},
+		})
+		testutil.RequireForbiddenError(t, err, "viewer should not be able to create cookie pattern")
+	})
+
+	t.Run("viewer cannot update pattern", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+		categoryID := factory.CreateCookieCategory(owner, bannerID)
+		patternID := factory.CreateCookiePattern(owner, categoryID)
+
+		_, err := viewer.Do(`
+			mutation UpdateCookiePattern($input: UpdateCookiePatternInput!) {
+				updateCookiePattern(input: $input) {
+					cookiePattern { id }
+					cookieBanner { id }
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{
+				"cookiePatternId": patternID,
+				"displayName":     "Updated by Viewer",
+			},
+		})
+		testutil.RequireForbiddenError(t, err, "viewer should not be able to update cookie pattern")
+	})
+
+	t.Run("viewer cannot delete pattern", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+		categoryID := factory.CreateCookieCategory(owner, bannerID)
+		patternID := factory.CreateCookiePattern(owner, categoryID)
+
+		_, err := viewer.Do(`
+			mutation DeleteCookiePattern($input: DeleteCookiePatternInput!) {
+				deleteCookiePattern(input: $input) {
+					deletedCookiePatternId
+					cookieBanner { id }
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{"cookiePatternId": patternID},
+		})
+		testutil.RequireForbiddenError(t, err, "viewer should not be able to delete cookie pattern")
+	})
+
+	t.Run("viewer cannot move pattern", func(t *testing.T) {
+		t.Parallel()
+		owner := testutil.NewClient(t, testutil.RoleOwner)
+		viewer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+
+		bannerID := factory.CreateCookieBanner(owner)
+		categoryA := factory.CreateCookieCategory(owner, bannerID, factory.Attrs{"slug": "rbac-move-a"})
+		categoryB := factory.CreateCookieCategory(owner, bannerID, factory.Attrs{"slug": "rbac-move-b"})
+		patternID := factory.CreateCookiePattern(owner, categoryA)
+
+		_, err := viewer.Do(`
+			mutation MoveCookiePatternToCategory($input: MoveCookiePatternToCategoryInput!) {
+				moveCookiePatternToCategory(input: $input) {
+					cookiePattern { id }
+					cookieBanner { id }
+				}
+			}
+		`, map[string]any{
+			"input": map[string]any{
+				"cookiePatternId":        patternID,
+				"targetCookieCategoryId": categoryB,
+			},
+		})
+		testutil.RequireForbiddenError(t, err, "viewer should not be able to move cookie pattern")
+	})
+}

--- a/e2e/internal/factory/factory.go
+++ b/e2e/internal/factory/factory.go
@@ -1369,9 +1369,7 @@ func CreateCookiePattern(c *testutil.Client, categoryID string, attrs ...Attrs) 
 		"description":      a.getString("description", "Test cookie pattern"),
 	}
 	if _, ok := a["maxAgeSeconds"]; ok {
-		if v, ok := a["maxAgeSeconds"].(int); ok {
-			input["maxAgeSeconds"] = v
-		}
+		input["maxAgeSeconds"] = a.getInt("maxAgeSeconds", 0)
 	}
 
 	var result struct {

--- a/e2e/internal/factory/factory.go
+++ b/e2e/internal/factory/factory.go
@@ -1207,3 +1207,185 @@ func CreatePublicOAuth2Client(c *testutil.Client, attrs Attrs) OAuth2ClientResul
 		ClientSecret: resp.ClientSecret,
 	}
 }
+
+func SafeOrigin() string {
+	return fmt.Sprintf("https://%s.example.com", strings.ToLower(gofakeit.LetterN(10)))
+}
+
+func CreateCookieBanner(c *testutil.Client, attrs ...Attrs) string {
+	c.T.Helper()
+
+	var a Attrs
+	if len(attrs) > 0 {
+		a = attrs[0]
+	}
+
+	const query = `
+		mutation($input: CreateCookieBannerInput!) {
+			createCookieBanner(input: $input) {
+				cookieBannerEdge {
+					node { id }
+				}
+			}
+		}
+	`
+
+	input := map[string]any{
+		"organizationId":    c.GetOrganizationID().String(),
+		"name":              a.getString("name", SafeName("CookieBanner")),
+		"origin":            a.getString("origin", SafeOrigin()),
+		"cookiePolicyUrl":   a.getString("cookiePolicyUrl", "https://example.com/cookies"),
+		"consentExpiryDays": a.getInt("consentExpiryDays", 365),
+		"consentMode":       a.getString("consentMode", "OPT_IN"),
+	}
+	if ppURL := a.getStringPtr("privacyPolicyUrl"); ppURL != nil {
+		input["privacyPolicyUrl"] = *ppURL
+	}
+
+	var result struct {
+		CreateCookieBanner struct {
+			CookieBannerEdge struct {
+				Node struct {
+					ID string `json:"id"`
+				} `json:"node"`
+			} `json:"cookieBannerEdge"`
+		} `json:"createCookieBanner"`
+	}
+
+	err := c.Execute(query, map[string]any{"input": input}, &result)
+	require.NoError(c.T, err, "createCookieBanner mutation failed")
+
+	return result.CreateCookieBanner.CookieBannerEdge.Node.ID
+}
+
+type CookieBannerBuilder struct {
+	client *testutil.Client
+	attrs  Attrs
+}
+
+func NewCookieBanner(c *testutil.Client) *CookieBannerBuilder {
+	return &CookieBannerBuilder{client: c, attrs: Attrs{}}
+}
+
+func (b *CookieBannerBuilder) WithName(name string) *CookieBannerBuilder {
+	b.attrs["name"] = name
+	return b
+}
+
+func (b *CookieBannerBuilder) WithOrigin(origin string) *CookieBannerBuilder {
+	b.attrs["origin"] = origin
+	return b
+}
+
+func (b *CookieBannerBuilder) WithCookiePolicyUrl(url string) *CookieBannerBuilder {
+	b.attrs["cookiePolicyUrl"] = url
+	return b
+}
+
+func (b *CookieBannerBuilder) WithPrivacyPolicyUrl(url string) *CookieBannerBuilder {
+	b.attrs["privacyPolicyUrl"] = url
+	return b
+}
+
+func (b *CookieBannerBuilder) WithConsentExpiryDays(days int) *CookieBannerBuilder {
+	b.attrs["consentExpiryDays"] = days
+	return b
+}
+
+func (b *CookieBannerBuilder) WithConsentMode(mode string) *CookieBannerBuilder {
+	b.attrs["consentMode"] = mode
+	return b
+}
+
+func (b *CookieBannerBuilder) Create() string {
+	return CreateCookieBanner(b.client, b.attrs)
+}
+
+func CreateCookieCategory(c *testutil.Client, bannerID string, attrs ...Attrs) string {
+	c.T.Helper()
+
+	var a Attrs
+	if len(attrs) > 0 {
+		a = attrs[0]
+	}
+
+	const query = `
+		mutation($input: CreateCookieCategoryInput!) {
+			createCookieCategory(input: $input) {
+				cookieCategoryEdge {
+					node { id }
+				}
+			}
+		}
+	`
+
+	input := map[string]any{
+		"cookieBannerId": bannerID,
+		"name":           a.getString("name", SafeName("Category")),
+		"slug":           a.getString("slug", strings.ToLower(gofakeit.LetterN(8))),
+		"description":    a.getString("description", "Test cookie category"),
+		"rank":           a.getInt("rank", 10),
+	}
+
+	var result struct {
+		CreateCookieCategory struct {
+			CookieCategoryEdge struct {
+				Node struct {
+					ID string `json:"id"`
+				} `json:"node"`
+			} `json:"cookieCategoryEdge"`
+		} `json:"createCookieCategory"`
+	}
+
+	err := c.Execute(query, map[string]any{"input": input}, &result)
+	require.NoError(c.T, err, "createCookieCategory mutation failed")
+
+	return result.CreateCookieCategory.CookieCategoryEdge.Node.ID
+}
+
+func CreateCookiePattern(c *testutil.Client, categoryID string, attrs ...Attrs) string {
+	c.T.Helper()
+
+	var a Attrs
+	if len(attrs) > 0 {
+		a = attrs[0]
+	}
+
+	const query = `
+		mutation($input: CreateCookiePatternInput!) {
+			createCookiePattern(input: $input) {
+				cookiePatternEdge {
+					node { id }
+				}
+			}
+		}
+	`
+
+	input := map[string]any{
+		"cookieCategoryId": categoryID,
+		"pattern":          a.getString("pattern", gofakeit.LetterN(8)+"_cookie"),
+		"matchType":        a.getString("matchType", "EXACT"),
+		"displayName":      a.getString("displayName", SafeName("Pattern")),
+		"description":      a.getString("description", "Test cookie pattern"),
+	}
+	if maxAge := a.getStringPtr("maxAgeSeconds"); maxAge != nil {
+		input["maxAgeSeconds"] = a.getInt("maxAgeSeconds", 0)
+	} else if _, ok := a["maxAgeSeconds"]; ok {
+		input["maxAgeSeconds"] = a.getInt("maxAgeSeconds", 0)
+	}
+
+	var result struct {
+		CreateCookiePattern struct {
+			CookiePatternEdge struct {
+				Node struct {
+					ID string `json:"id"`
+				} `json:"node"`
+			} `json:"cookiePatternEdge"`
+		} `json:"createCookiePattern"`
+	}
+
+	err := c.Execute(query, map[string]any{"input": input}, &result)
+	require.NoError(c.T, err, "createCookiePattern mutation failed")
+
+	return result.CreateCookiePattern.CookiePatternEdge.Node.ID
+}

--- a/e2e/internal/factory/factory.go
+++ b/e2e/internal/factory/factory.go
@@ -1368,10 +1368,10 @@ func CreateCookiePattern(c *testutil.Client, categoryID string, attrs ...Attrs) 
 		"displayName":      a.getString("displayName", SafeName("Pattern")),
 		"description":      a.getString("description", "Test cookie pattern"),
 	}
-	if maxAge := a.getStringPtr("maxAgeSeconds"); maxAge != nil {
-		input["maxAgeSeconds"] = a.getInt("maxAgeSeconds", 0)
-	} else if _, ok := a["maxAgeSeconds"]; ok {
-		input["maxAgeSeconds"] = a.getInt("maxAgeSeconds", 0)
+	if _, ok := a["maxAgeSeconds"]; ok {
+		if v, ok := a["maxAgeSeconds"].(int); ok {
+			input["maxAgeSeconds"] = v
+		}
 	}
 
 	var result struct {

--- a/pkg/cmd/consent-record/consent_record.go
+++ b/pkg/cmd/consent-record/consent_record.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package consentrecord
+
+import (
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+	"go.probo.inc/probo/pkg/cmd/consent-record/list"
+	"go.probo.inc/probo/pkg/cmd/consent-record/view"
+)
+
+func NewCmdConsentRecord(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "consent-record <command>",
+		Short: "Manage cookie consent records",
+	}
+
+	cmd.AddCommand(list.NewCmdList(f))
+	cmd.AddCommand(view.NewCmdView(f))
+
+	return cmd
+}

--- a/pkg/cmd/consent-record/list/list.go
+++ b/pkg/cmd/consent-record/list/list.go
@@ -1,0 +1,173 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package list
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const listQuery = `
+query($id: ID!, $first: Int, $after: CursorKey, $filter: CookieConsentRecordFilter) {
+  node(id: $id) {
+    __typename
+    ... on CookieBanner {
+      consentRecords(first: $first, after: $after, filter: $filter) {
+        totalCount
+        edges {
+          node {
+            id
+            visitorId
+            action
+            sdkVersion
+            createdAt
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}
+`
+
+type consentRecord struct {
+	ID         string `json:"id"`
+	VisitorID  string `json:"visitorId"`
+	Action     string `json:"action"`
+	SDKVersion string `json:"sdkVersion"`
+	CreatedAt  string `json:"createdAt"`
+}
+
+func NewCmdList(f *cmdutil.Factory) *cobra.Command {
+	var (
+		flagBannerID  string
+		flagAction    string
+		flagVisitorID string
+		flagVersion   int
+		flagLimit     int
+		flagOutput    *string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List cookie consent records for a banner",
+		Aliases: []string{"ls"},
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmdutil.ValidateOutputFlag(flagOutput); err != nil {
+				return err
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			variables := map[string]any{"id": flagBannerID}
+
+			filter := map[string]any{}
+			if cmd.Flags().Changed("action") {
+				filter["action"] = flagAction
+			}
+			if cmd.Flags().Changed("visitor-id") {
+				filter["visitorId"] = flagVisitorID
+			}
+			if cmd.Flags().Changed("version") {
+				filter["version"] = flagVersion
+			}
+			if len(filter) > 0 {
+				variables["filter"] = filter
+			}
+
+			records, totalCount, err := api.Paginate(
+				client,
+				listQuery,
+				variables,
+				flagLimit,
+				func(data json.RawMessage) (*api.Connection[consentRecord], error) {
+					var resp struct {
+						Node *struct {
+							Typename       string                        `json:"__typename"`
+							ConsentRecords api.Connection[consentRecord] `json:"consentRecords"`
+						} `json:"node"`
+					}
+					if err := json.Unmarshal(data, &resp); err != nil {
+						return nil, err
+					}
+					if resp.Node == nil {
+						return nil, fmt.Errorf("cookie banner %s not found", flagBannerID)
+					}
+					return &resp.Node.ConsentRecords, nil
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			if *flagOutput == cmdutil.OutputJSON {
+				return cmdutil.PrintJSON(f.IOStreams.Out, records)
+			}
+
+			if len(records) == 0 {
+				_, _ = fmt.Fprintln(f.IOStreams.Out, "No consent records found.")
+				return nil
+			}
+
+			rows := make([][]string, 0, len(records))
+			for _, r := range records {
+				rows = append(rows, []string{r.ID, r.VisitorID, r.Action, r.SDKVersion, r.CreatedAt})
+			}
+
+			t := cmdutil.NewTable("ID", "VISITOR ID", "ACTION", "SDK VERSION", "CREATED AT").Rows(rows...)
+			_, _ = fmt.Fprintln(f.IOStreams.Out, t)
+
+			if totalCount > len(records) {
+				_, _ = fmt.Fprintf(f.IOStreams.ErrOut, "\nShowing %d of %d consent records\n", len(records), totalCount)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&flagBannerID, "banner-id", "", "Cookie banner ID (required)")
+	_ = cmd.MarkFlagRequired("banner-id")
+	cmd.Flags().StringVar(&flagAction, "action", "", "Filter by action")
+	cmd.Flags().StringVar(&flagVisitorID, "visitor-id", "", "Filter by visitor ID")
+	cmd.Flags().IntVar(&flagVersion, "version", 0, "Filter by version")
+	cmd.Flags().IntVarP(&flagLimit, "limit", "L", 30, "Maximum number of items")
+	flagOutput = cmdutil.AddOutputFlag(cmd)
+
+	return cmd
+}

--- a/pkg/cmd/consent-record/list/list.go
+++ b/pkg/cmd/consent-record/list/list.go
@@ -129,6 +129,9 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 					if resp.Node == nil {
 						return nil, fmt.Errorf("cookie banner %s not found", flagBannerID)
 					}
+					if resp.Node.Typename != "CookieBanner" {
+						return nil, fmt.Errorf("expected CookieBanner node, got %s", resp.Node.Typename)
+					}
 					return &resp.Node.ConsentRecords, nil
 				},
 			)

--- a/pkg/cmd/consent-record/view/view.go
+++ b/pkg/cmd/consent-record/view/view.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package view
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const viewQuery = `
+query($id: ID!) {
+  node(id: $id) {
+    __typename
+    ... on CookieConsentRecord {
+      id
+      visitorId
+      ipAddress
+      userAgent
+      consentData
+      action
+      sdkVersion
+      createdAt
+    }
+  }
+}
+`
+
+type viewResponse struct {
+	Node *struct {
+		Typename    string  `json:"__typename"`
+		ID          string  `json:"id"`
+		VisitorID   string  `json:"visitorId"`
+		IPAddress   *string `json:"ipAddress"`
+		UserAgent   *string `json:"userAgent"`
+		ConsentData string  `json:"consentData"`
+		Action      string  `json:"action"`
+		SdkVersion  string  `json:"sdkVersion"`
+		CreatedAt   string  `json:"createdAt"`
+	} `json:"node"`
+}
+
+func NewCmdView(f *cmdutil.Factory) *cobra.Command {
+	var flagOutput *string
+
+	cmd := &cobra.Command{
+		Use:   "view <id>",
+		Short: "View a consent record",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmdutil.ValidateOutputFlag(flagOutput); err != nil {
+				return err
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			data, err := client.Do(viewQuery, map[string]any{"id": args[0]})
+			if err != nil {
+				return err
+			}
+
+			var resp viewResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return fmt.Errorf("cannot parse response: %w", err)
+			}
+
+			if resp.Node == nil || resp.Node.Typename != "CookieConsentRecord" {
+				return fmt.Errorf("consent record %s not found", args[0])
+			}
+
+			if *flagOutput == cmdutil.OutputJSON {
+				return cmdutil.PrintJSON(f.IOStreams.Out, resp.Node)
+			}
+
+			v := resp.Node
+			out := f.IOStreams.Out
+
+			bold := lipgloss.NewStyle().Bold(true)
+			label := lipgloss.NewStyle().Foreground(lipgloss.Color("242")).Width(22)
+
+			_, _ = fmt.Fprintf(out, "%s\n\n", bold.Render("Consent Record"))
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("ID:"), v.ID)
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Visitor ID:"), v.VisitorID)
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Action:"), v.Action)
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("SDK Version:"), v.SdkVersion)
+			if v.IPAddress != nil && *v.IPAddress != "" {
+				_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("IP Address:"), *v.IPAddress)
+			}
+			if v.UserAgent != nil && *v.UserAgent != "" {
+				_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("User Agent:"), *v.UserAgent)
+			}
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Consent Data:"), v.ConsentData)
+			_, _ = fmt.Fprintln(out)
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Created:"), cmdutil.FormatTime(v.CreatedAt))
+
+			return nil
+		},
+	}
+
+	flagOutput = cmdutil.AddOutputFlag(cmd)
+
+	return cmd
+}

--- a/pkg/cmd/cookie-banner/activate/activate.go
+++ b/pkg/cmd/cookie-banner/activate/activate.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package activate
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const activateMutation = `
+mutation($input: ActivateCookieBannerInput!) {
+  activateCookieBanner(input: $input) {
+    cookieBanner {
+      id
+      name
+      state
+    }
+  }
+}
+`
+
+func NewCmdActivate(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "activate <id>",
+		Short: "Activate a cookie banner",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			input := map[string]any{"cookieBannerId": args[0]}
+
+			data, err := client.Do(activateMutation, map[string]any{"input": input})
+			if err != nil {
+				return err
+			}
+
+			var resp struct {
+				ActivateCookieBanner struct {
+					CookieBanner struct {
+						ID    string `json:"id"`
+						Name  string `json:"name"`
+						State string `json:"state"`
+					} `json:"cookieBanner"`
+				} `json:"activateCookieBanner"`
+			}
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return err
+			}
+
+			b := resp.ActivateCookieBanner.CookieBanner
+			_, _ = fmt.Fprintf(f.IOStreams.Out, "Activated cookie banner %s (%s)\n", b.Name, b.ID)
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/pkg/cmd/cookie-banner/cookie_banner.go
+++ b/pkg/cmd/cookie-banner/cookie_banner.go
@@ -25,7 +25,7 @@ import (
 	"go.probo.inc/probo/pkg/cmd/cookie-banner/publish"
 	"go.probo.inc/probo/pkg/cmd/cookie-banner/translate"
 	"go.probo.inc/probo/pkg/cmd/cookie-banner/update"
-	"go.probo.inc/probo/pkg/cmd/cookie-banner/versions"
+	"go.probo.inc/probo/pkg/cmd/cookie-banner/latestversion"
 	"go.probo.inc/probo/pkg/cmd/cookie-banner/view"
 )
 
@@ -44,7 +44,7 @@ func NewCmdCookieBanner(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(deactivate.NewCmdDeactivate(f))
 	cmd.AddCommand(publish.NewCmdPublish(f))
 	cmd.AddCommand(translate.NewCmdTranslate(f))
-	cmd.AddCommand(versions.NewCmdVersions(f))
+	cmd.AddCommand(latestversion.NewCmdLatestVersion(f))
 
 	return cmd
 }

--- a/pkg/cmd/cookie-banner/cookie_banner.go
+++ b/pkg/cmd/cookie-banner/cookie_banner.go
@@ -21,11 +21,11 @@ import (
 	"go.probo.inc/probo/pkg/cmd/cookie-banner/create"
 	"go.probo.inc/probo/pkg/cmd/cookie-banner/deactivate"
 	"go.probo.inc/probo/pkg/cmd/cookie-banner/delete"
+	"go.probo.inc/probo/pkg/cmd/cookie-banner/latestversion"
 	"go.probo.inc/probo/pkg/cmd/cookie-banner/list"
 	"go.probo.inc/probo/pkg/cmd/cookie-banner/publish"
 	"go.probo.inc/probo/pkg/cmd/cookie-banner/translate"
 	"go.probo.inc/probo/pkg/cmd/cookie-banner/update"
-	"go.probo.inc/probo/pkg/cmd/cookie-banner/latestversion"
 	"go.probo.inc/probo/pkg/cmd/cookie-banner/view"
 )
 

--- a/pkg/cmd/cookie-banner/cookie_banner.go
+++ b/pkg/cmd/cookie-banner/cookie_banner.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package cookiebanner
+
+import (
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+	"go.probo.inc/probo/pkg/cmd/cookie-banner/activate"
+	"go.probo.inc/probo/pkg/cmd/cookie-banner/create"
+	"go.probo.inc/probo/pkg/cmd/cookie-banner/deactivate"
+	"go.probo.inc/probo/pkg/cmd/cookie-banner/delete"
+	"go.probo.inc/probo/pkg/cmd/cookie-banner/list"
+	"go.probo.inc/probo/pkg/cmd/cookie-banner/publish"
+	"go.probo.inc/probo/pkg/cmd/cookie-banner/translate"
+	"go.probo.inc/probo/pkg/cmd/cookie-banner/update"
+	"go.probo.inc/probo/pkg/cmd/cookie-banner/versions"
+	"go.probo.inc/probo/pkg/cmd/cookie-banner/view"
+)
+
+func NewCmdCookieBanner(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cookie-banner <command>",
+		Short: "Manage cookie banners",
+	}
+
+	cmd.AddCommand(list.NewCmdList(f))
+	cmd.AddCommand(view.NewCmdView(f))
+	cmd.AddCommand(create.NewCmdCreate(f))
+	cmd.AddCommand(update.NewCmdUpdate(f))
+	cmd.AddCommand(delete.NewCmdDelete(f))
+	cmd.AddCommand(activate.NewCmdActivate(f))
+	cmd.AddCommand(deactivate.NewCmdDeactivate(f))
+	cmd.AddCommand(publish.NewCmdPublish(f))
+	cmd.AddCommand(translate.NewCmdTranslate(f))
+	cmd.AddCommand(versions.NewCmdVersions(f))
+
+	return cmd
+}

--- a/pkg/cmd/cookie-banner/create/create.go
+++ b/pkg/cmd/cookie-banner/create/create.go
@@ -1,0 +1,173 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package create
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/charmbracelet/huh"
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const createMutation = `
+mutation($input: CreateCookieBannerInput!) {
+  createCookieBanner(input: $input) {
+    cookieBannerEdge {
+      node {
+        id
+        name
+        origin
+      }
+    }
+  }
+}
+`
+
+type createResponse struct {
+	CreateCookieBanner struct {
+		CookieBannerEdge struct {
+			Node struct {
+				ID     string `json:"id"`
+				Name   string `json:"name"`
+				Origin string `json:"origin"`
+			} `json:"node"`
+		} `json:"cookieBannerEdge"`
+	} `json:"createCookieBanner"`
+}
+
+func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
+	var (
+		flagOrg              string
+		flagName             string
+		flagOrigin           string
+		flagCookiePolicyUrl  string
+		flagPrivacyPolicyUrl string
+		flagConsentExpiry    int
+		flagConsentMode      string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new cookie banner",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			if flagOrg == "" {
+				flagOrg = hc.Organization
+			}
+			if flagOrg == "" {
+				return fmt.Errorf("organization is required; pass --org or set a default with 'prb auth login'")
+			}
+
+			if f.IOStreams.IsInteractive() {
+				if flagName == "" {
+					if err := huh.NewInput().Title("Banner name").Value(&flagName).Run(); err != nil {
+						return err
+					}
+				}
+				if flagOrigin == "" {
+					if err := huh.NewInput().Title("Website origin (e.g. https://example.com)").Value(&flagOrigin).Run(); err != nil {
+						return err
+					}
+				}
+				if flagCookiePolicyUrl == "" {
+					if err := huh.NewInput().Title("Cookie policy URL").Value(&flagCookiePolicyUrl).Run(); err != nil {
+						return err
+					}
+				}
+				if flagConsentMode == "" {
+					if err := huh.NewSelect[string]().
+						Title("Consent mode").
+						Options(
+							huh.NewOption("Opt-In", "OPT_IN"),
+							huh.NewOption("Opt-Out", "OPT_OUT"),
+						).
+						Value(&flagConsentMode).Run(); err != nil {
+						return err
+					}
+				}
+			}
+
+			if flagName == "" {
+				return fmt.Errorf("name is required; pass --name or run interactively")
+			}
+			if flagOrigin == "" {
+				return fmt.Errorf("origin is required; pass --origin or run interactively")
+			}
+			if flagCookiePolicyUrl == "" {
+				return fmt.Errorf("cookie-policy-url is required; pass --cookie-policy-url or run interactively")
+			}
+			if flagConsentMode == "" {
+				return fmt.Errorf("consent-mode is required; pass --consent-mode or run interactively")
+			}
+
+			input := map[string]any{
+				"organizationId":    flagOrg,
+				"name":              flagName,
+				"origin":            flagOrigin,
+				"cookiePolicyUrl":   flagCookiePolicyUrl,
+				"consentExpiryDays": flagConsentExpiry,
+				"consentMode":       flagConsentMode,
+			}
+			if flagPrivacyPolicyUrl != "" {
+				input["privacyPolicyUrl"] = flagPrivacyPolicyUrl
+			}
+
+			data, err := client.Do(createMutation, map[string]any{"input": input})
+			if err != nil {
+				return err
+			}
+
+			var resp createResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return fmt.Errorf("cannot parse response: %w", err)
+			}
+
+			b := resp.CreateCookieBanner.CookieBannerEdge.Node
+			_, _ = fmt.Fprintf(f.IOStreams.Out, "Created cookie banner %s (%s)\n", b.ID, b.Name)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&flagOrg, "org", "", "Organization ID")
+	cmd.Flags().StringVar(&flagName, "name", "", "Banner name (required)")
+	cmd.Flags().StringVar(&flagOrigin, "origin", "", "Website origin (required)")
+	cmd.Flags().StringVar(&flagCookiePolicyUrl, "cookie-policy-url", "", "Cookie policy URL (required)")
+	cmd.Flags().StringVar(&flagPrivacyPolicyUrl, "privacy-policy-url", "", "Privacy policy URL")
+	cmd.Flags().IntVar(&flagConsentExpiry, "consent-expiry-days", 365, "Days until consent expires")
+	cmd.Flags().StringVar(&flagConsentMode, "consent-mode", "", "Consent mode: OPT_IN or OPT_OUT (required)")
+
+	return cmd
+}

--- a/pkg/cmd/cookie-banner/deactivate/deactivate.go
+++ b/pkg/cmd/cookie-banner/deactivate/deactivate.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package deactivate
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const deactivateMutation = `
+mutation($input: DeactivateCookieBannerInput!) {
+  deactivateCookieBanner(input: $input) {
+    cookieBanner {
+      id
+      name
+      state
+    }
+  }
+}
+`
+
+func NewCmdDeactivate(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "deactivate <id>",
+		Short: "Deactivate a cookie banner",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			input := map[string]any{"cookieBannerId": args[0]}
+
+			data, err := client.Do(deactivateMutation, map[string]any{"input": input})
+			if err != nil {
+				return err
+			}
+
+			var resp struct {
+				DeactivateCookieBanner struct {
+					CookieBanner struct {
+						ID    string `json:"id"`
+						Name  string `json:"name"`
+						State string `json:"state"`
+					} `json:"cookieBanner"`
+				} `json:"deactivateCookieBanner"`
+			}
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return err
+			}
+
+			b := resp.DeactivateCookieBanner.CookieBanner
+			_, _ = fmt.Fprintf(f.IOStreams.Out, "Deactivated cookie banner %s (%s)\n", b.Name, b.ID)
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/pkg/cmd/cookie-banner/delete/delete.go
+++ b/pkg/cmd/cookie-banner/delete/delete.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package delete
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/huh"
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const deleteMutation = `
+mutation($input: DeleteCookieBannerInput!) {
+  deleteCookieBanner(input: $input) {
+    deletedCookieBannerId
+  }
+}
+`
+
+func NewCmdDelete(f *cmdutil.Factory) *cobra.Command {
+	var flagYes bool
+
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a cookie banner",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !flagYes {
+				if !f.IOStreams.IsInteractive() {
+					return fmt.Errorf("cannot delete cookie banner: confirmation required, use --yes to confirm")
+				}
+				var confirmed bool
+				if err := huh.NewConfirm().Title(fmt.Sprintf("Delete cookie banner %s?", args[0])).Value(&confirmed).Run(); err != nil {
+					return err
+				}
+				if !confirmed {
+					return nil
+				}
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			_, err = client.Do(deleteMutation, map[string]any{
+				"input": map[string]any{"cookieBannerId": args[0]},
+			})
+			if err != nil {
+				return err
+			}
+
+			_, _ = fmt.Fprintf(f.IOStreams.Out, "Deleted cookie banner %s\n", args[0])
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVarP(&flagYes, "yes", "y", false, "Skip confirmation prompt")
+
+	return cmd
+}

--- a/pkg/cmd/cookie-banner/latestversion/latest_version.go
+++ b/pkg/cmd/cookie-banner/latestversion/latest_version.go
@@ -12,7 +12,7 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-package versions
+package latestversion
 
 import (
 	"encoding/json"
@@ -48,13 +48,12 @@ type versionInfo struct {
 	UpdatedAt string `json:"updatedAt"`
 }
 
-func NewCmdVersions(f *cmdutil.Factory) *cobra.Command {
+func NewCmdLatestVersion(f *cmdutil.Factory) *cobra.Command {
 	var flagOutput *string
 
 	cmd := &cobra.Command{
-		Use:     "versions <id>",
-		Short:   "List versions for a cookie banner",
-		Aliases: []string{"ver"},
+		Use:   "latest-version <id>",
+		Short: "Show the latest version of a cookie banner",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := cmdutil.ValidateOutputFlag(flagOutput); err != nil {

--- a/pkg/cmd/cookie-banner/latestversion/latest_version.go
+++ b/pkg/cmd/cookie-banner/latestversion/latest_version.go
@@ -54,7 +54,7 @@ func NewCmdLatestVersion(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "latest-version <id>",
 		Short: "Show the latest version of a cookie banner",
-		Args:    cobra.ExactArgs(1),
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := cmdutil.ValidateOutputFlag(flagOutput); err != nil {
 				return err

--- a/pkg/cmd/cookie-banner/list/list.go
+++ b/pkg/cmd/cookie-banner/list/list.go
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package list
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const listQuery = `
+query($id: ID!, $first: Int, $after: CursorKey) {
+  node(id: $id) {
+    __typename
+    ... on Organization {
+      cookieBanners(first: $first, after: $after) {
+        totalCount
+        edges {
+          node {
+            id
+            name
+            origin
+            state
+            consentMode
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}
+`
+
+type banner struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Origin      string `json:"origin"`
+	State       string `json:"state"`
+	ConsentMode string `json:"consentMode"`
+}
+
+func NewCmdList(f *cmdutil.Factory) *cobra.Command {
+	var (
+		flagOrg    string
+		flagLimit  int
+		flagOutput *string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List cookie banners in an organization",
+		Aliases: []string{"ls"},
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmdutil.ValidateOutputFlag(flagOutput); err != nil {
+				return err
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			if flagOrg == "" {
+				flagOrg = hc.Organization
+			}
+			if flagOrg == "" {
+				return fmt.Errorf("organization is required; pass --org or set a default with 'prb auth login'")
+			}
+
+			variables := map[string]any{"id": flagOrg}
+
+			banners, totalCount, err := api.Paginate(
+				client,
+				listQuery,
+				variables,
+				flagLimit,
+				func(data json.RawMessage) (*api.Connection[banner], error) {
+					var resp struct {
+						Node *struct {
+							Typename      string                 `json:"__typename"`
+							CookieBanners api.Connection[banner] `json:"cookieBanners"`
+						} `json:"node"`
+					}
+					if err := json.Unmarshal(data, &resp); err != nil {
+						return nil, err
+					}
+					if resp.Node == nil {
+						return nil, fmt.Errorf("organization %s not found", flagOrg)
+					}
+					return &resp.Node.CookieBanners, nil
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			if *flagOutput == cmdutil.OutputJSON {
+				return cmdutil.PrintJSON(f.IOStreams.Out, banners)
+			}
+
+			if len(banners) == 0 {
+				_, _ = fmt.Fprintln(f.IOStreams.Out, "No cookie banners found.")
+				return nil
+			}
+
+			rows := make([][]string, 0, len(banners))
+			for _, b := range banners {
+				rows = append(rows, []string{b.ID, b.Name, b.Origin, b.State, b.ConsentMode})
+			}
+
+			t := cmdutil.NewTable("ID", "NAME", "ORIGIN", "STATE", "CONSENT MODE").Rows(rows...)
+			_, _ = fmt.Fprintln(f.IOStreams.Out, t)
+
+			if totalCount > len(banners) {
+				_, _ = fmt.Fprintf(f.IOStreams.ErrOut, "\nShowing %d of %d cookie banners\n", len(banners), totalCount)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&flagOrg, "org", "", "Organization ID")
+	cmd.Flags().IntVarP(&flagLimit, "limit", "L", 30, "Maximum number of items")
+	flagOutput = cmdutil.AddOutputFlag(cmd)
+
+	return cmd
+}

--- a/pkg/cmd/cookie-banner/list/list.go
+++ b/pkg/cmd/cookie-banner/list/list.go
@@ -119,6 +119,9 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 					if resp.Node == nil {
 						return nil, fmt.Errorf("organization %s not found", flagOrg)
 					}
+					if resp.Node.Typename != "Organization" {
+						return nil, fmt.Errorf("expected Organization node, got %s", resp.Node.Typename)
+					}
 					return &resp.Node.CookieBanners, nil
 				},
 			)

--- a/pkg/cmd/cookie-banner/publish/publish.go
+++ b/pkg/cmd/cookie-banner/publish/publish.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package publish
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const publishMutation = `
+mutation($input: PublishCookieBannerVersionInput!) {
+  publishCookieBannerVersion(input: $input) {
+    cookieBannerVersion {
+      id
+      version
+      state
+    }
+  }
+}
+`
+
+func NewCmdPublish(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "publish <id>",
+		Short: "Publish the current draft version",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			input := map[string]any{"cookieBannerId": args[0]}
+
+			data, err := client.Do(publishMutation, map[string]any{"input": input})
+			if err != nil {
+				return err
+			}
+
+			var resp struct {
+				PublishCookieBannerVersion struct {
+					CookieBannerVersion struct {
+						ID      string `json:"id"`
+						Version int    `json:"version"`
+						State   string `json:"state"`
+					} `json:"cookieBannerVersion"`
+				} `json:"publishCookieBannerVersion"`
+			}
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return err
+			}
+
+			v := resp.PublishCookieBannerVersion.CookieBannerVersion
+			_, _ = fmt.Fprintf(f.IOStreams.Out, "Published version %d for cookie banner %s\n", v.Version, args[0])
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/pkg/cmd/cookie-banner/translate/translate.go
+++ b/pkg/cmd/cookie-banner/translate/translate.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package translate
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const translateMutation = `
+mutation($input: UpsertCookieBannerTranslationInput!) {
+  upsertCookieBannerTranslation(input: $input) {
+    cookieBannerTranslation {
+      id
+      language
+    }
+  }
+}
+`
+
+func NewCmdTranslate(f *cmdutil.Factory) *cobra.Command {
+	var (
+		flagLanguage     string
+		flagTranslations string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "translate <id>",
+		Short: "Upsert a translation for a language",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if flagLanguage == "" {
+				return fmt.Errorf("--language is required")
+			}
+			if flagTranslations == "" {
+				return fmt.Errorf("--translations is required")
+			}
+
+			var translations json.RawMessage
+			if err := json.Unmarshal([]byte(flagTranslations), &translations); err != nil {
+				return fmt.Errorf("invalid JSON for --translations: %w", err)
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			input := map[string]any{
+				"cookieBannerId": args[0],
+				"language":       flagLanguage,
+				"translations":   translations,
+			}
+
+			_, err = client.Do(translateMutation, map[string]any{"input": input})
+			if err != nil {
+				return err
+			}
+
+			_, _ = fmt.Fprintf(f.IOStreams.Out, "Upserted translation for language %q on cookie banner %s\n", flagLanguage, args[0])
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&flagLanguage, "language", "", "Language code (e.g. fr, de, es)")
+	cmd.Flags().StringVar(&flagTranslations, "translations", "", "Translations JSON")
+	_ = cmd.MarkFlagRequired("language")
+	_ = cmd.MarkFlagRequired("translations")
+
+	return cmd
+}

--- a/pkg/cmd/cookie-banner/update/update.go
+++ b/pkg/cmd/cookie-banner/update/update.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package update
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const updateMutation = `
+mutation($input: UpdateCookieBannerInput!) {
+  updateCookieBanner(input: $input) {
+    cookieBanner {
+      id
+      name
+    }
+  }
+}
+`
+
+type updateResponse struct {
+	UpdateCookieBanner struct {
+		CookieBanner struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"cookieBanner"`
+	} `json:"updateCookieBanner"`
+}
+
+func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
+	var (
+		flagName             string
+		flagCookiePolicyUrl  string
+		flagPrivacyPolicyUrl string
+		flagConsentExpiry    int
+		flagConsentMode      string
+		flagDefaultLanguage  string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update a cookie banner",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			input := map[string]any{"cookieBannerId": args[0]}
+
+			if cmd.Flags().Changed("name") {
+				input["name"] = flagName
+			}
+			if cmd.Flags().Changed("cookie-policy-url") {
+				input["cookiePolicyUrl"] = flagCookiePolicyUrl
+			}
+			if cmd.Flags().Changed("privacy-policy-url") {
+				input["privacyPolicyUrl"] = flagPrivacyPolicyUrl
+			}
+			if cmd.Flags().Changed("consent-expiry-days") {
+				input["consentExpiryDays"] = flagConsentExpiry
+			}
+			if cmd.Flags().Changed("consent-mode") {
+				input["consentMode"] = flagConsentMode
+			}
+			if cmd.Flags().Changed("default-language") {
+				input["defaultLanguage"] = flagDefaultLanguage
+			}
+
+			if len(input) == 1 {
+				return fmt.Errorf("at least one field must be specified for update")
+			}
+
+			data, err := client.Do(updateMutation, map[string]any{"input": input})
+			if err != nil {
+				return err
+			}
+
+			var resp updateResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return fmt.Errorf("cannot parse response: %w", err)
+			}
+
+			b := resp.UpdateCookieBanner.CookieBanner
+			_, _ = fmt.Fprintf(f.IOStreams.Out, "Updated cookie banner %s (%s)\n", b.ID, b.Name)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&flagName, "name", "", "Banner name")
+	cmd.Flags().StringVar(&flagCookiePolicyUrl, "cookie-policy-url", "", "Cookie policy URL")
+	cmd.Flags().StringVar(&flagPrivacyPolicyUrl, "privacy-policy-url", "", "Privacy policy URL")
+	cmd.Flags().IntVar(&flagConsentExpiry, "consent-expiry-days", 0, "Days until consent expires")
+	cmd.Flags().StringVar(&flagConsentMode, "consent-mode", "", "Consent mode: OPT_IN or OPT_OUT")
+	cmd.Flags().StringVar(&flagDefaultLanguage, "default-language", "", "Default language code")
+
+	return cmd
+}

--- a/pkg/cmd/cookie-banner/versions/versions.go
+++ b/pkg/cmd/cookie-banner/versions/versions.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package versions
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const versionsQuery = `
+query($id: ID!) {
+  node(id: $id) {
+    ... on CookieBanner {
+      latestVersion {
+        id
+        version
+        state
+        createdAt
+        updatedAt
+      }
+    }
+  }
+}
+`
+
+type versionInfo struct {
+	ID        string `json:"id"`
+	Version   int    `json:"version"`
+	State     string `json:"state"`
+	CreatedAt string `json:"createdAt"`
+	UpdatedAt string `json:"updatedAt"`
+}
+
+func NewCmdVersions(f *cmdutil.Factory) *cobra.Command {
+	var flagOutput *string
+
+	cmd := &cobra.Command{
+		Use:     "versions <id>",
+		Short:   "List versions for a cookie banner",
+		Aliases: []string{"ver"},
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmdutil.ValidateOutputFlag(flagOutput); err != nil {
+				return err
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			data, err := client.Do(versionsQuery, map[string]any{"id": args[0]})
+			if err != nil {
+				return err
+			}
+
+			var resp struct {
+				Node *struct {
+					LatestVersion *versionInfo `json:"latestVersion"`
+				} `json:"node"`
+			}
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return err
+			}
+
+			if resp.Node == nil || resp.Node.LatestVersion == nil {
+				_, _ = fmt.Fprintln(f.IOStreams.Out, "No versions found.")
+				return nil
+			}
+
+			v := resp.Node.LatestVersion
+
+			if *flagOutput == cmdutil.OutputJSON {
+				return cmdutil.PrintJSON(f.IOStreams.Out, v)
+			}
+
+			rows := [][]string{
+				{v.ID, strconv.Itoa(v.Version), v.State, cmdutil.FormatTime(v.CreatedAt)},
+			}
+			t := cmdutil.NewTable("ID", "VERSION", "STATE", "CREATED").Rows(rows...)
+			_, _ = fmt.Fprintln(f.IOStreams.Out, t)
+
+			return nil
+		},
+	}
+
+	flagOutput = cmdutil.AddOutputFlag(cmd)
+
+	return cmd
+}

--- a/pkg/cmd/cookie-banner/view/view.go
+++ b/pkg/cmd/cookie-banner/view/view.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package view
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const viewQuery = `
+query($id: ID!) {
+  node(id: $id) {
+    __typename
+    ... on CookieBanner {
+      id
+      name
+      origin
+      state
+      cookiePolicyUrl
+      privacyPolicyUrl
+      consentExpiryDays
+      consentMode
+      showBranding
+      defaultLanguage
+      createdAt
+      updatedAt
+    }
+  }
+}
+`
+
+type viewResponse struct {
+	Node *struct {
+		Typename          string  `json:"__typename"`
+		ID                string  `json:"id"`
+		Name              string  `json:"name"`
+		Origin            string  `json:"origin"`
+		State             string  `json:"state"`
+		CookiePolicyUrl   string  `json:"cookiePolicyUrl"`
+		PrivacyPolicyUrl  *string `json:"privacyPolicyUrl"`
+		ConsentExpiryDays int     `json:"consentExpiryDays"`
+		ConsentMode       string  `json:"consentMode"`
+		ShowBranding      bool    `json:"showBranding"`
+		DefaultLanguage   string  `json:"defaultLanguage"`
+		CreatedAt         string  `json:"createdAt"`
+		UpdatedAt         string  `json:"updatedAt"`
+	} `json:"node"`
+}
+
+func NewCmdView(f *cmdutil.Factory) *cobra.Command {
+	var flagOutput *string
+
+	cmd := &cobra.Command{
+		Use:   "view <id>",
+		Short: "View a cookie banner",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmdutil.ValidateOutputFlag(flagOutput); err != nil {
+				return err
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			data, err := client.Do(viewQuery, map[string]any{"id": args[0]})
+			if err != nil {
+				return err
+			}
+
+			var resp viewResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return fmt.Errorf("cannot parse response: %w", err)
+			}
+
+			if resp.Node == nil || resp.Node.Typename != "CookieBanner" {
+				return fmt.Errorf("cookie banner %s not found", args[0])
+			}
+
+			if *flagOutput == cmdutil.OutputJSON {
+				return cmdutil.PrintJSON(f.IOStreams.Out, resp.Node)
+			}
+
+			v := resp.Node
+			out := f.IOStreams.Out
+
+			bold := lipgloss.NewStyle().Bold(true)
+			label := lipgloss.NewStyle().Foreground(lipgloss.Color("242")).Width(22)
+
+			_, _ = fmt.Fprintf(out, "%s\n\n", bold.Render(v.Name))
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("ID:"), v.ID)
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Origin:"), v.Origin)
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("State:"), v.State)
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Consent Mode:"), v.ConsentMode)
+			_, _ = fmt.Fprintf(out, "%s%d days\n", label.Render("Consent Expiry:"), v.ConsentExpiryDays)
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Default Language:"), v.DefaultLanguage)
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Cookie Policy:"), v.CookiePolicyUrl)
+			if v.PrivacyPolicyUrl != nil && *v.PrivacyPolicyUrl != "" {
+				_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Privacy Policy:"), *v.PrivacyPolicyUrl)
+			}
+			_, _ = fmt.Fprintln(out)
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Created:"), cmdutil.FormatTime(v.CreatedAt))
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Updated:"), cmdutil.FormatTime(v.UpdatedAt))
+
+			return nil
+		},
+	}
+
+	flagOutput = cmdutil.AddOutputFlag(cmd)
+
+	return cmd
+}

--- a/pkg/cmd/cookie-category/cookie_category.go
+++ b/pkg/cmd/cookie-category/cookie_category.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package cookiecategory
+
+import (
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+	"go.probo.inc/probo/pkg/cmd/cookie-category/create"
+	"go.probo.inc/probo/pkg/cmd/cookie-category/delete"
+	"go.probo.inc/probo/pkg/cmd/cookie-category/list"
+	"go.probo.inc/probo/pkg/cmd/cookie-category/reorder"
+	"go.probo.inc/probo/pkg/cmd/cookie-category/update"
+	"go.probo.inc/probo/pkg/cmd/cookie-category/view"
+)
+
+func NewCmdCookieCategory(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cookie-category <command>",
+		Short: "Manage cookie categories",
+	}
+
+	cmd.AddCommand(list.NewCmdList(f))
+	cmd.AddCommand(view.NewCmdView(f))
+	cmd.AddCommand(create.NewCmdCreate(f))
+	cmd.AddCommand(update.NewCmdUpdate(f))
+	cmd.AddCommand(delete.NewCmdDelete(f))
+	cmd.AddCommand(reorder.NewCmdReorder(f))
+
+	return cmd
+}

--- a/pkg/cmd/cookie-category/create/create.go
+++ b/pkg/cmd/cookie-category/create/create.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package create
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/charmbracelet/huh"
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const createMutation = `
+mutation($input: CreateCookieCategoryInput!) {
+  createCookieCategory(input: $input) {
+    cookieCategoryEdge {
+      node {
+        id
+        name
+        slug
+      }
+    }
+    cookieBanner {
+      id
+    }
+  }
+}
+`
+
+type createResponse struct {
+	CreateCookieCategory struct {
+		CookieCategoryEdge struct {
+			Node struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+				Slug string `json:"slug"`
+			} `json:"node"`
+		} `json:"cookieCategoryEdge"`
+		CookieBanner struct {
+			ID string `json:"id"`
+		} `json:"cookieBanner"`
+	} `json:"createCookieCategory"`
+}
+
+func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
+	var (
+		flagBannerID    string
+		flagName        string
+		flagSlug        string
+		flagDescription string
+		flagRank        int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new cookie category",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			if f.IOStreams.IsInteractive() {
+				if flagName == "" {
+					if err := huh.NewInput().Title("Category name").Value(&flagName).Run(); err != nil {
+						return err
+					}
+				}
+				if flagSlug == "" {
+					if err := huh.NewInput().Title("Category slug").Value(&flagSlug).Run(); err != nil {
+						return err
+					}
+				}
+				if flagDescription == "" {
+					if err := huh.NewText().Title("Description").Value(&flagDescription).Run(); err != nil {
+						return err
+					}
+				}
+			}
+
+			if flagName == "" {
+				return fmt.Errorf("name is required; pass --name or run interactively")
+			}
+			if flagSlug == "" {
+				return fmt.Errorf("slug is required; pass --slug or run interactively")
+			}
+
+			input := map[string]any{
+				"cookieBannerId": flagBannerID,
+				"name":           flagName,
+				"slug":           flagSlug,
+				"description":    flagDescription,
+				"rank":           flagRank,
+			}
+
+			data, err := client.Do(createMutation, map[string]any{"input": input})
+			if err != nil {
+				return err
+			}
+
+			var resp createResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return fmt.Errorf("cannot parse response: %w", err)
+			}
+
+			c := resp.CreateCookieCategory.CookieCategoryEdge.Node
+			_, _ = fmt.Fprintf(f.IOStreams.Out, "Created cookie category %s (%s)\n", c.ID, c.Name)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&flagBannerID, "banner-id", "", "Cookie banner ID (required)")
+	cmd.Flags().StringVar(&flagName, "name", "", "Category name")
+	cmd.Flags().StringVar(&flagSlug, "slug", "", "Category slug")
+	cmd.Flags().StringVar(&flagDescription, "description", "", "Category description")
+	cmd.Flags().IntVar(&flagRank, "rank", 10, "Display rank")
+
+	_ = cmd.MarkFlagRequired("banner-id")
+
+	return cmd
+}

--- a/pkg/cmd/cookie-category/delete/delete.go
+++ b/pkg/cmd/cookie-category/delete/delete.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package delete
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/huh"
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const deleteMutation = `
+mutation($input: DeleteCookieCategoryInput!) {
+  deleteCookieCategory(input: $input) {
+    deletedCookieCategoryId
+    cookieBanner {
+      id
+    }
+  }
+}
+`
+
+func NewCmdDelete(f *cmdutil.Factory) *cobra.Command {
+	var flagYes bool
+
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a cookie category",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !flagYes {
+				if !f.IOStreams.IsInteractive() {
+					return fmt.Errorf("cannot delete cookie category: confirmation required, use --yes to confirm")
+				}
+				var confirmed bool
+				if err := huh.NewConfirm().Title(fmt.Sprintf("Delete cookie category %s?", args[0])).Value(&confirmed).Run(); err != nil {
+					return err
+				}
+				if !confirmed {
+					return nil
+				}
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			_, err = client.Do(deleteMutation, map[string]any{
+				"input": map[string]any{"cookieCategoryId": args[0]},
+			})
+			if err != nil {
+				return err
+			}
+
+			_, _ = fmt.Fprintf(f.IOStreams.Out, "Deleted cookie category %s\n", args[0])
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVarP(&flagYes, "yes", "y", false, "Skip confirmation prompt")
+
+	return cmd
+}

--- a/pkg/cmd/cookie-category/list/list.go
+++ b/pkg/cmd/cookie-category/list/list.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package list
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const listQuery = `
+query($id: ID!, $first: Int, $after: CursorKey) {
+  node(id: $id) {
+    __typename
+    ... on CookieBanner {
+      categories(first: $first, after: $after, orderBy: {field: RANK, direction: ASC}) {
+        totalCount
+        edges {
+          node {
+            id
+            name
+            slug
+            kind
+            rank
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}
+`
+
+type category struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Slug string `json:"slug"`
+	Kind string `json:"kind"`
+	Rank int    `json:"rank"`
+}
+
+func NewCmdList(f *cmdutil.Factory) *cobra.Command {
+	var (
+		flagBannerID string
+		flagLimit    int
+		flagOutput   *string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List cookie categories for a banner",
+		Aliases: []string{"ls"},
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmdutil.ValidateOutputFlag(flagOutput); err != nil {
+				return err
+			}
+
+			if flagBannerID == "" {
+				return fmt.Errorf("banner-id is required; pass --banner-id")
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			variables := map[string]any{"id": flagBannerID}
+
+			categories, totalCount, err := api.Paginate(
+				client,
+				listQuery,
+				variables,
+				flagLimit,
+				func(data json.RawMessage) (*api.Connection[category], error) {
+					var resp struct {
+						Node *struct {
+							Typename   string                   `json:"__typename"`
+							Categories api.Connection[category] `json:"categories"`
+						} `json:"node"`
+					}
+					if err := json.Unmarshal(data, &resp); err != nil {
+						return nil, err
+					}
+					if resp.Node == nil {
+						return nil, fmt.Errorf("cookie banner %s not found", flagBannerID)
+					}
+					return &resp.Node.Categories, nil
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			if *flagOutput == cmdutil.OutputJSON {
+				return cmdutil.PrintJSON(f.IOStreams.Out, categories)
+			}
+
+			if len(categories) == 0 {
+				_, _ = fmt.Fprintln(f.IOStreams.Out, "No cookie categories found.")
+				return nil
+			}
+
+			rows := make([][]string, 0, len(categories))
+			for _, c := range categories {
+				rows = append(rows, []string{c.ID, c.Name, c.Slug, c.Kind, fmt.Sprintf("%d", c.Rank)})
+			}
+
+			t := cmdutil.NewTable("ID", "NAME", "SLUG", "KIND", "RANK").Rows(rows...)
+			_, _ = fmt.Fprintln(f.IOStreams.Out, t)
+
+			if totalCount > len(categories) {
+				_, _ = fmt.Fprintf(f.IOStreams.ErrOut, "\nShowing %d of %d cookie categories\n", len(categories), totalCount)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&flagBannerID, "banner-id", "", "Cookie banner ID (required)")
+	cmd.Flags().IntVarP(&flagLimit, "limit", "L", 30, "Maximum number of items")
+	flagOutput = cmdutil.AddOutputFlag(cmd)
+
+	_ = cmd.MarkFlagRequired("banner-id")
+
+	return cmd
+}

--- a/pkg/cmd/cookie-category/list/list.go
+++ b/pkg/cmd/cookie-category/list/list.go
@@ -116,6 +116,9 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 					if resp.Node == nil {
 						return nil, fmt.Errorf("cookie banner %s not found", flagBannerID)
 					}
+					if resp.Node.Typename != "CookieBanner" {
+						return nil, fmt.Errorf("expected CookieBanner node, got %s", resp.Node.Typename)
+					}
 					return &resp.Node.Categories, nil
 				},
 			)

--- a/pkg/cmd/cookie-category/reorder/reorder.go
+++ b/pkg/cmd/cookie-category/reorder/reorder.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package reorder
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const reorderMutation = `
+mutation($input: ReorderCookieCategoryInput!) {
+  reorderCookieCategory(input: $input) {
+    cookieBanner {
+      id
+    }
+  }
+}
+`
+
+func NewCmdReorder(f *cmdutil.Factory) *cobra.Command {
+	var flagRank int
+
+	cmd := &cobra.Command{
+		Use:   "reorder <id>",
+		Short: "Change the rank of a cookie category",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			_, err = client.Do(reorderMutation, map[string]any{
+				"input": map[string]any{
+					"cookieCategoryId": args[0],
+					"rank":             flagRank,
+				},
+			})
+			if err != nil {
+				return err
+			}
+
+			_, _ = fmt.Fprintf(f.IOStreams.Out, "Reordered cookie category %s to rank %d\n", args[0], flagRank)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&flagRank, "rank", 0, "New rank position (required)")
+	_ = cmd.MarkFlagRequired("rank")
+
+	return cmd
+}

--- a/pkg/cmd/cookie-category/update/update.go
+++ b/pkg/cmd/cookie-category/update/update.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package update
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const updateMutation = `
+mutation($input: UpdateCookieCategoryInput!) {
+  updateCookieCategory(input: $input) {
+    cookieCategory {
+      id
+      name
+    }
+    cookieBanner {
+      id
+    }
+  }
+}
+`
+
+type updateResponse struct {
+	UpdateCookieCategory struct {
+		CookieCategory struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"cookieCategory"`
+		CookieBanner struct {
+			ID string `json:"id"`
+		} `json:"cookieBanner"`
+	} `json:"updateCookieCategory"`
+}
+
+func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
+	var (
+		flagName        string
+		flagSlug        string
+		flagDescription string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update a cookie category",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			input := map[string]any{"cookieCategoryId": args[0]}
+
+			if cmd.Flags().Changed("name") {
+				input["name"] = flagName
+			}
+			if cmd.Flags().Changed("slug") {
+				input["slug"] = flagSlug
+			}
+			if cmd.Flags().Changed("description") {
+				input["description"] = flagDescription
+			}
+
+			if len(input) == 1 {
+				return fmt.Errorf("at least one field must be specified for update")
+			}
+
+			data, err := client.Do(updateMutation, map[string]any{"input": input})
+			if err != nil {
+				return err
+			}
+
+			var resp updateResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return fmt.Errorf("cannot parse response: %w", err)
+			}
+
+			c := resp.UpdateCookieCategory.CookieCategory
+			_, _ = fmt.Fprintf(f.IOStreams.Out, "Updated cookie category %s (%s)\n", c.ID, c.Name)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&flagName, "name", "", "Category name")
+	cmd.Flags().StringVar(&flagSlug, "slug", "", "Category slug")
+	cmd.Flags().StringVar(&flagDescription, "description", "", "Category description")
+
+	return cmd
+}

--- a/pkg/cmd/cookie-category/view/view.go
+++ b/pkg/cmd/cookie-category/view/view.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package view
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const viewQuery = `
+query($id: ID!) {
+  node(id: $id) {
+    __typename
+    ... on CookieCategory {
+      id
+      name
+      slug
+      description
+      kind
+      rank
+      gcmConsentTypes
+      posthogConsent
+      createdAt
+      updatedAt
+    }
+  }
+}
+`
+
+type viewResponse struct {
+	Node *struct {
+		Typename        string   `json:"__typename"`
+		ID              string   `json:"id"`
+		Name            string   `json:"name"`
+		Slug            string   `json:"slug"`
+		Description     string   `json:"description"`
+		Kind            string   `json:"kind"`
+		Rank            int      `json:"rank"`
+		GcmConsentTypes []string `json:"gcmConsentTypes"`
+		PosthogConsent  string   `json:"posthogConsent"`
+		CreatedAt       string   `json:"createdAt"`
+		UpdatedAt       string   `json:"updatedAt"`
+	} `json:"node"`
+}
+
+func NewCmdView(f *cmdutil.Factory) *cobra.Command {
+	var flagOutput *string
+
+	cmd := &cobra.Command{
+		Use:   "view <id>",
+		Short: "View a cookie category",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmdutil.ValidateOutputFlag(flagOutput); err != nil {
+				return err
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			data, err := client.Do(viewQuery, map[string]any{"id": args[0]})
+			if err != nil {
+				return err
+			}
+
+			var resp viewResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return fmt.Errorf("cannot parse response: %w", err)
+			}
+
+			if resp.Node == nil || resp.Node.Typename != "CookieCategory" {
+				return fmt.Errorf("cookie category %s not found", args[0])
+			}
+
+			if *flagOutput == cmdutil.OutputJSON {
+				return cmdutil.PrintJSON(f.IOStreams.Out, resp.Node)
+			}
+
+			v := resp.Node
+			out := f.IOStreams.Out
+
+			bold := lipgloss.NewStyle().Bold(true)
+			label := lipgloss.NewStyle().Foreground(lipgloss.Color("242")).Width(22)
+
+			_, _ = fmt.Fprintf(out, "%s\n\n", bold.Render(v.Name))
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("ID:"), v.ID)
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Slug:"), v.Slug)
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Description:"), v.Description)
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Kind:"), v.Kind)
+			_, _ = fmt.Fprintf(out, "%s%d\n", label.Render("Rank:"), v.Rank)
+			if len(v.GcmConsentTypes) > 0 {
+				_, _ = fmt.Fprintf(out, "%s%v\n", label.Render("GCM Consent Types:"), v.GcmConsentTypes)
+			}
+			if v.PosthogConsent != "" {
+				_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("PostHog Consent:"), v.PosthogConsent)
+			}
+			_, _ = fmt.Fprintln(out)
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Created:"), cmdutil.FormatTime(v.CreatedAt))
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Updated:"), cmdutil.FormatTime(v.UpdatedAt))
+
+			return nil
+		},
+	}
+
+	flagOutput = cmdutil.AddOutputFlag(cmd)
+
+	return cmd
+}

--- a/pkg/cmd/cookie-pattern/cookie_pattern.go
+++ b/pkg/cmd/cookie-pattern/cookie_pattern.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package cookiepattern
+
+import (
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+	"go.probo.inc/probo/pkg/cmd/cookie-pattern/create"
+	"go.probo.inc/probo/pkg/cmd/cookie-pattern/delete"
+	"go.probo.inc/probo/pkg/cmd/cookie-pattern/list"
+	"go.probo.inc/probo/pkg/cmd/cookie-pattern/move"
+	"go.probo.inc/probo/pkg/cmd/cookie-pattern/update"
+	"go.probo.inc/probo/pkg/cmd/cookie-pattern/view"
+)
+
+func NewCmdCookiePattern(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cookie-pattern <command>",
+		Short: "Manage cookie patterns",
+	}
+
+	cmd.AddCommand(list.NewCmdList(f))
+	cmd.AddCommand(view.NewCmdView(f))
+	cmd.AddCommand(create.NewCmdCreate(f))
+	cmd.AddCommand(update.NewCmdUpdate(f))
+	cmd.AddCommand(delete.NewCmdDelete(f))
+	cmd.AddCommand(move.NewCmdMove(f))
+
+	return cmd
+}

--- a/pkg/cmd/cookie-pattern/create/create.go
+++ b/pkg/cmd/cookie-pattern/create/create.go
@@ -1,0 +1,161 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package create
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/charmbracelet/huh"
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const createMutation = `
+mutation($input: CreateCookiePatternInput!) {
+  createCookiePattern(input: $input) {
+    cookiePatternEdge {
+      node {
+        id
+        pattern
+        displayName
+      }
+    }
+    cookieBanner {
+      id
+    }
+  }
+}
+`
+
+type createResponse struct {
+	CreateCookiePattern struct {
+		CookiePatternEdge struct {
+			Node struct {
+				ID          string `json:"id"`
+				Pattern     string `json:"pattern"`
+				DisplayName string `json:"displayName"`
+			} `json:"node"`
+		} `json:"cookiePatternEdge"`
+	} `json:"createCookiePattern"`
+}
+
+func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
+	var (
+		flagCategoryID  string
+		flagPattern     string
+		flagMatchType   string
+		flagDisplayName string
+		flagDescription string
+		flagMaxAge      int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new cookie pattern",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			if f.IOStreams.IsInteractive() {
+				if flagPattern == "" {
+					if err := huh.NewInput().Title("Cookie pattern").Value(&flagPattern).Run(); err != nil {
+						return err
+					}
+				}
+				if flagMatchType == "" {
+					if err := huh.NewSelect[string]().
+						Title("Match type").
+						Options(
+							huh.NewOption("Exact", "EXACT"),
+							huh.NewOption("Prefix", "PREFIX"),
+						).
+						Value(&flagMatchType).Run(); err != nil {
+						return err
+					}
+				}
+				if flagDisplayName == "" {
+					if err := huh.NewInput().Title("Display name").Value(&flagDisplayName).Run(); err != nil {
+						return err
+					}
+				}
+			}
+
+			if flagPattern == "" {
+				return fmt.Errorf("pattern is required; pass --pattern or run interactively")
+			}
+			if flagMatchType == "" {
+				return fmt.Errorf("match-type is required; pass --match-type or run interactively")
+			}
+			if flagDisplayName == "" {
+				return fmt.Errorf("display-name is required; pass --display-name or run interactively")
+			}
+
+			input := map[string]any{
+				"cookieCategoryId": flagCategoryID,
+				"pattern":          flagPattern,
+				"matchType":        flagMatchType,
+				"displayName":      flagDisplayName,
+			}
+			if flagDescription != "" {
+				input["description"] = flagDescription
+			}
+			if cmd.Flags().Changed("max-age-seconds") {
+				input["maxAgeSeconds"] = flagMaxAge
+			}
+
+			data, err := client.Do(createMutation, map[string]any{"input": input})
+			if err != nil {
+				return err
+			}
+
+			var resp createResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return fmt.Errorf("cannot parse response: %w", err)
+			}
+
+			p := resp.CreateCookiePattern.CookiePatternEdge.Node
+			_, _ = fmt.Fprintf(f.IOStreams.Out, "Created cookie pattern %s (%s)\n", p.ID, p.DisplayName)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&flagCategoryID, "category-id", "", "Cookie category ID (required)")
+	_ = cmd.MarkFlagRequired("category-id")
+	cmd.Flags().StringVar(&flagPattern, "pattern", "", "Cookie pattern (required)")
+	cmd.Flags().StringVar(&flagMatchType, "match-type", "", "Match type: EXACT or PREFIX (required)")
+	cmd.Flags().StringVar(&flagDisplayName, "display-name", "", "Display name (required)")
+	cmd.Flags().StringVar(&flagDescription, "description", "", "Description")
+	cmd.Flags().IntVar(&flagMaxAge, "max-age-seconds", 0, "Maximum age in seconds")
+
+	return cmd
+}

--- a/pkg/cmd/cookie-pattern/delete/delete.go
+++ b/pkg/cmd/cookie-pattern/delete/delete.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package delete
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/huh"
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const deleteMutation = `
+mutation($input: DeleteCookiePatternInput!) {
+  deleteCookiePattern(input: $input) {
+    deletedCookiePatternId
+    cookieBanner {
+      id
+    }
+  }
+}
+`
+
+func NewCmdDelete(f *cmdutil.Factory) *cobra.Command {
+	var flagYes bool
+
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a cookie pattern",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !flagYes {
+				if !f.IOStreams.IsInteractive() {
+					return fmt.Errorf("cannot delete cookie pattern: confirmation required, use --yes to confirm")
+				}
+				var confirmed bool
+				if err := huh.NewConfirm().Title(fmt.Sprintf("Delete cookie pattern %s?", args[0])).Value(&confirmed).Run(); err != nil {
+					return err
+				}
+				if !confirmed {
+					return nil
+				}
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			_, err = client.Do(deleteMutation, map[string]any{
+				"input": map[string]any{"cookiePatternId": args[0]},
+			})
+			if err != nil {
+				return err
+			}
+
+			_, _ = fmt.Fprintf(f.IOStreams.Out, "Deleted cookie pattern %s\n", args[0])
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVarP(&flagYes, "yes", "y", false, "Skip confirmation prompt")
+
+	return cmd
+}

--- a/pkg/cmd/cookie-pattern/list/list.go
+++ b/pkg/cmd/cookie-pattern/list/list.go
@@ -112,6 +112,9 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 					if resp.Node == nil {
 						return nil, fmt.Errorf("cookie category %s not found", flagCategoryID)
 					}
+					if resp.Node.Typename != "CookieCategory" {
+						return nil, fmt.Errorf("expected CookieCategory node, got %s", resp.Node.Typename)
+					}
 					return &resp.Node.CookiePatterns, nil
 				},
 			)

--- a/pkg/cmd/cookie-pattern/list/list.go
+++ b/pkg/cmd/cookie-pattern/list/list.go
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package list
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const listQuery = `
+query($id: ID!, $first: Int, $after: CursorKey) {
+  node(id: $id) {
+    __typename
+    ... on CookieCategory {
+      cookiePatterns(first: $first, after: $after) {
+        totalCount
+        edges {
+          node {
+            id
+            pattern
+            matchType
+            displayName
+            source
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}
+`
+
+type cookiePattern struct {
+	ID          string `json:"id"`
+	Pattern     string `json:"pattern"`
+	MatchType   string `json:"matchType"`
+	DisplayName string `json:"displayName"`
+	Source      string `json:"source"`
+}
+
+func NewCmdList(f *cmdutil.Factory) *cobra.Command {
+	var (
+		flagCategoryID string
+		flagLimit      int
+		flagOutput     *string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List cookie patterns in a category",
+		Aliases: []string{"ls"},
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmdutil.ValidateOutputFlag(flagOutput); err != nil {
+				return err
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			variables := map[string]any{"id": flagCategoryID}
+
+			patterns, totalCount, err := api.Paginate(
+				client,
+				listQuery,
+				variables,
+				flagLimit,
+				func(data json.RawMessage) (*api.Connection[cookiePattern], error) {
+					var resp struct {
+						Node *struct {
+							Typename       string                        `json:"__typename"`
+							CookiePatterns api.Connection[cookiePattern] `json:"cookiePatterns"`
+						} `json:"node"`
+					}
+					if err := json.Unmarshal(data, &resp); err != nil {
+						return nil, err
+					}
+					if resp.Node == nil {
+						return nil, fmt.Errorf("cookie category %s not found", flagCategoryID)
+					}
+					return &resp.Node.CookiePatterns, nil
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			if *flagOutput == cmdutil.OutputJSON {
+				return cmdutil.PrintJSON(f.IOStreams.Out, patterns)
+			}
+
+			if len(patterns) == 0 {
+				_, _ = fmt.Fprintln(f.IOStreams.Out, "No cookie patterns found.")
+				return nil
+			}
+
+			rows := make([][]string, 0, len(patterns))
+			for _, p := range patterns {
+				rows = append(rows, []string{p.ID, p.Pattern, p.MatchType, p.DisplayName, p.Source})
+			}
+
+			t := cmdutil.NewTable("ID", "PATTERN", "MATCH TYPE", "DISPLAY NAME", "SOURCE").Rows(rows...)
+			_, _ = fmt.Fprintln(f.IOStreams.Out, t)
+
+			if totalCount > len(patterns) {
+				_, _ = fmt.Fprintf(f.IOStreams.ErrOut, "\nShowing %d of %d cookie patterns\n", len(patterns), totalCount)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&flagCategoryID, "category-id", "", "Cookie category ID (required)")
+	_ = cmd.MarkFlagRequired("category-id")
+	cmd.Flags().IntVarP(&flagLimit, "limit", "L", 30, "Maximum number of items")
+	flagOutput = cmdutil.AddOutputFlag(cmd)
+
+	return cmd
+}

--- a/pkg/cmd/cookie-pattern/move/move.go
+++ b/pkg/cmd/cookie-pattern/move/move.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package move
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const moveMutation = `
+mutation($input: MoveCookiePatternToCategoryInput!) {
+  moveCookiePatternToCategory(input: $input) {
+    cookiePattern {
+      id
+      cookieCategory {
+        id
+        name
+      }
+    }
+    cookieBanner {
+      id
+    }
+  }
+}
+`
+
+type moveResponse struct {
+	MoveCookiePatternToCategory struct {
+		CookiePattern struct {
+			ID             string `json:"id"`
+			CookieCategory struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"cookieCategory"`
+		} `json:"cookiePattern"`
+	} `json:"moveCookiePatternToCategory"`
+}
+
+func NewCmdMove(f *cmdutil.Factory) *cobra.Command {
+	var flagTargetCategoryID string
+
+	cmd := &cobra.Command{
+		Use:   "move <id>",
+		Short: "Move a cookie pattern to a different category",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			data, err := client.Do(moveMutation, map[string]any{
+				"input": map[string]any{
+					"cookiePatternId":        args[0],
+					"targetCookieCategoryId": flagTargetCategoryID,
+				},
+			})
+			if err != nil {
+				return err
+			}
+
+			var resp moveResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return fmt.Errorf("cannot parse response: %w", err)
+			}
+
+			p := resp.MoveCookiePatternToCategory.CookiePattern
+			_, _ = fmt.Fprintf(f.IOStreams.Out, "Moved cookie pattern %s to category %s\n", p.ID, p.CookieCategory.Name)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&flagTargetCategoryID, "target-category-id", "", "Target cookie category ID (required)")
+	_ = cmd.MarkFlagRequired("target-category-id")
+
+	return cmd
+}

--- a/pkg/cmd/cookie-pattern/update/update.go
+++ b/pkg/cmd/cookie-pattern/update/update.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package update
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const updateMutation = `
+mutation($input: UpdateCookiePatternInput!) {
+  updateCookiePattern(input: $input) {
+    cookiePattern {
+      id
+      displayName
+    }
+    cookieBanner {
+      id
+    }
+  }
+}
+`
+
+type updateResponse struct {
+	UpdateCookiePattern struct {
+		CookiePattern struct {
+			ID          string `json:"id"`
+			DisplayName string `json:"displayName"`
+		} `json:"cookiePattern"`
+	} `json:"updateCookiePattern"`
+}
+
+func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
+	var (
+		flagDisplayName string
+		flagDescription string
+		flagMaxAge      int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update a cookie pattern",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			input := map[string]any{"cookiePatternId": args[0]}
+
+			if cmd.Flags().Changed("display-name") {
+				input["displayName"] = flagDisplayName
+			}
+			if cmd.Flags().Changed("description") {
+				input["description"] = flagDescription
+			}
+			if cmd.Flags().Changed("max-age-seconds") {
+				input["maxAgeSeconds"] = flagMaxAge
+			}
+
+			if len(input) == 1 {
+				return fmt.Errorf("at least one field must be specified for update")
+			}
+
+			data, err := client.Do(updateMutation, map[string]any{"input": input})
+			if err != nil {
+				return err
+			}
+
+			var resp updateResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return fmt.Errorf("cannot parse response: %w", err)
+			}
+
+			p := resp.UpdateCookiePattern.CookiePattern
+			_, _ = fmt.Fprintf(f.IOStreams.Out, "Updated cookie pattern %s (%s)\n", p.ID, p.DisplayName)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&flagDisplayName, "display-name", "", "Display name")
+	cmd.Flags().StringVar(&flagDescription, "description", "", "Description")
+	cmd.Flags().IntVar(&flagMaxAge, "max-age-seconds", 0, "Maximum age in seconds")
+
+	return cmd
+}

--- a/pkg/cmd/cookie-pattern/view/view.go
+++ b/pkg/cmd/cookie-pattern/view/view.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package view
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const viewQuery = `
+query($id: ID!) {
+  node(id: $id) {
+    __typename
+    ... on CookiePattern {
+      id
+      pattern
+      matchType
+      displayName
+      maxAgeSeconds
+      description
+      source
+      createdAt
+      updatedAt
+    }
+  }
+}
+`
+
+type viewResponse struct {
+	Node *struct {
+		Typename      string  `json:"__typename"`
+		ID            string  `json:"id"`
+		Pattern       string  `json:"pattern"`
+		MatchType     string  `json:"matchType"`
+		DisplayName   string  `json:"displayName"`
+		MaxAgeSeconds *int    `json:"maxAgeSeconds"`
+		Description   *string `json:"description"`
+		Source        string  `json:"source"`
+		CreatedAt     string  `json:"createdAt"`
+		UpdatedAt     string  `json:"updatedAt"`
+	} `json:"node"`
+}
+
+func NewCmdView(f *cmdutil.Factory) *cobra.Command {
+	var flagOutput *string
+
+	cmd := &cobra.Command{
+		Use:   "view <id>",
+		Short: "View a cookie pattern",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmdutil.ValidateOutputFlag(flagOutput); err != nil {
+				return err
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/console/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			data, err := client.Do(viewQuery, map[string]any{"id": args[0]})
+			if err != nil {
+				return err
+			}
+
+			var resp viewResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return fmt.Errorf("cannot parse response: %w", err)
+			}
+
+			if resp.Node == nil || resp.Node.Typename != "CookiePattern" {
+				return fmt.Errorf("cookie pattern %s not found", args[0])
+			}
+
+			if *flagOutput == cmdutil.OutputJSON {
+				return cmdutil.PrintJSON(f.IOStreams.Out, resp.Node)
+			}
+
+			v := resp.Node
+			out := f.IOStreams.Out
+
+			bold := lipgloss.NewStyle().Bold(true)
+			label := lipgloss.NewStyle().Foreground(lipgloss.Color("242")).Width(22)
+
+			_, _ = fmt.Fprintf(out, "%s\n\n", bold.Render(v.DisplayName))
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("ID:"), v.ID)
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Pattern:"), v.Pattern)
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Match Type:"), v.MatchType)
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Source:"), v.Source)
+			if v.MaxAgeSeconds != nil {
+				_, _ = fmt.Fprintf(out, "%s%d\n", label.Render("Max Age (seconds):"), *v.MaxAgeSeconds)
+			}
+			if v.Description != nil && *v.Description != "" {
+				_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Description:"), *v.Description)
+			}
+			_, _ = fmt.Fprintln(out)
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Created:"), cmdutil.FormatTime(v.CreatedAt))
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Updated:"), cmdutil.FormatTime(v.UpdatedAt))
+
+			return nil
+		},
+	}
+
+	flagOutput = cmdutil.AddOutputFlag(cmd)
+
+	return cmd
+}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -26,8 +26,12 @@ import (
 	"go.probo.inc/probo/pkg/cmd/cmdutil"
 	"go.probo.inc/probo/pkg/cmd/completion"
 	cmdconfig "go.probo.inc/probo/pkg/cmd/config"
+	consentrecord "go.probo.inc/probo/pkg/cmd/consent-record"
 	cmdcontext "go.probo.inc/probo/pkg/cmd/context"
 	"go.probo.inc/probo/pkg/cmd/control"
+	cookiebanner "go.probo.inc/probo/pkg/cmd/cookie-banner"
+	cookiecategory "go.probo.inc/probo/pkg/cmd/cookie-category"
+	cookiepattern "go.probo.inc/probo/pkg/cmd/cookie-pattern"
 	"go.probo.inc/probo/pkg/cmd/datum"
 	"go.probo.inc/probo/pkg/cmd/document"
 	"go.probo.inc/probo/pkg/cmd/dpia"
@@ -90,8 +94,12 @@ func NewCmdRoot(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(browse.NewCmdBrowse(f))
 	cmd.AddCommand(completion.NewCmdCompletion(f))
 	cmd.AddCommand(cmdconfig.NewCmdConfig(f))
+	cmd.AddCommand(consentrecord.NewCmdConsentRecord(f))
 	cmd.AddCommand(cmdcontext.NewCmdContext(f))
 	cmd.AddCommand(control.NewCmdControl(f))
+	cmd.AddCommand(cookiebanner.NewCmdCookieBanner(f))
+	cmd.AddCommand(cookiecategory.NewCmdCookieCategory(f))
+	cmd.AddCommand(cookiepattern.NewCmdCookiePattern(f))
 	cmd.AddCommand(datum.NewCmdDatum(f))
 	cmd.AddCommand(document.NewCmdDocument(f))
 	cmd.AddCommand(dpia.NewCmdDPIA(f))

--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -202,6 +202,7 @@ func NewServer(cfg Config) (*Server, error) {
 			cfg.Probo,
 			cfg.IAM,
 			cfg.AccessReview,
+			cfg.CookieBanner,
 			cfg.TokenSecret,
 		),
 		slackHandler: slack_v1.NewMux(

--- a/pkg/server/api/mcp/v1/resolver.go
+++ b/pkg/server/api/mcp/v1/resolver.go
@@ -23,6 +23,7 @@ import (
 
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/accessreview"
+	"go.probo.inc/probo/pkg/cookiebanner"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/iam"
 	"go.probo.inc/probo/pkg/probo"
@@ -34,6 +35,7 @@ type Resolver struct {
 	proboSvc     *probo.Service
 	iamSvc       *iam.Service
 	accessReview *accessreview.Service
+	cookieBanner *cookiebanner.Service
 	logger       *log.Logger
 }
 

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -6,12 +6,14 @@ package mcp_v1
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.probo.inc/probo/pkg/accessreview"
+	"go.probo.inc/probo/pkg/cookiebanner"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/iam"
@@ -4851,4 +4853,337 @@ func (r *Resolver) PublishVendorListTool(ctx context.Context, req *mcp.CallToolR
 		DocumentID:        document.ID,
 		DocumentVersionID: documentVersion.ID,
 	}, nil
+}
+
+func (r *Resolver) ListCookieBannersTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListCookieBannersInput) (*mcp.CallToolResult, types.ListCookieBannersOutput, error) {
+	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionCookieBannerList)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieBannerOrderField]{Field: coredata.CookieBannerOrderFieldCreatedAt, Direction: page.OrderDirectionDesc})
+	banners, err := r.cookieBanner.ListCookieBannersForOrganization(ctx, scope, input.OrganizationID, cursor, coredata.NewCookieBannerFilter(nil))
+	if err != nil {
+		panic(fmt.Errorf("cannot list cookie banners: %w", err))
+	}
+	p := page.NewPage(banners, cursor)
+	return nil, types.NewListCookieBannersOutput(p), nil
+}
+
+func (r *Resolver) GetCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetCookieBannerInput) (*mcp.CallToolResult, types.GetCookieBannerOutput, error) {
+	r.MustAuthorize(ctx, input.ID, probo.ActionCookieBannerGet)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	banner, err := r.cookieBanner.GetCookieBanner(ctx, scope, input.ID)
+	if err != nil {
+		return nil, types.GetCookieBannerOutput{}, fmt.Errorf("cannot get cookie banner: %w", err)
+	}
+	return nil, types.GetCookieBannerOutput{CookieBanner: types.NewCookieBanner(banner)}, nil
+}
+
+func (r *Resolver) AddCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddCookieBannerInput) (*mcp.CallToolResult, types.AddCookieBannerOutput, error) {
+	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionCookieBannerCreate)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	banner, err := r.cookieBanner.CreateCookieBanner(ctx, scope, cookiebanner.CreateCookieBannerRequest{
+		OrganizationID:    input.OrganizationID,
+		Name:              input.Name,
+		Origin:            input.Origin,
+		PrivacyPolicyURL:  input.PrivacyPolicyURL,
+		CookiePolicyURL:   input.CookiePolicyURL,
+		ConsentExpiryDays: input.ConsentExpiryDays,
+		ConsentMode:       coredata.CookieConsentMode(input.ConsentMode),
+	})
+	if err != nil {
+		return nil, types.AddCookieBannerOutput{}, fmt.Errorf("cannot create cookie banner: %w", err)
+	}
+	return nil, types.AddCookieBannerOutput{CookieBanner: types.NewCookieBanner(banner)}, nil
+}
+
+func (r *Resolver) UpdateCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateCookieBannerInput) (*mcp.CallToolResult, types.UpdateCookieBannerOutput, error) {
+	r.MustAuthorize(ctx, input.ID, probo.ActionCookieBannerUpdate)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+
+	updateReq := cookiebanner.UpdateCookieBannerRequest{CookieBannerID: input.ID}
+	if v := UnwrapOmittable(input.Name); v != nil && *v != nil {
+		updateReq.Name = *v
+	}
+	if v := UnwrapOmittable(input.PrivacyPolicyURL); v != nil && *v != nil {
+		updateReq.PrivacyPolicyURL = *v
+	}
+	if v := UnwrapOmittable(input.CookiePolicyURL); v != nil && *v != nil {
+		updateReq.CookiePolicyURL = *v
+	}
+	if v := UnwrapOmittable(input.ConsentExpiryDays); v != nil && *v != nil {
+		updateReq.ConsentExpiryDays = *v
+	}
+	if v := UnwrapOmittable(input.ConsentMode); v != nil && *v != nil {
+		mode := coredata.CookieConsentMode(**v)
+		updateReq.ConsentMode = &mode
+	}
+	if v := UnwrapOmittable(input.DefaultLanguage); v != nil && *v != nil {
+		updateReq.DefaultLanguage = *v
+	}
+
+	banner, err := r.cookieBanner.UpdateCookieBanner(ctx, scope, updateReq)
+	if err != nil {
+		return nil, types.UpdateCookieBannerOutput{}, fmt.Errorf("cannot update cookie banner: %w", err)
+	}
+	return nil, types.UpdateCookieBannerOutput{CookieBanner: types.NewCookieBanner(banner)}, nil
+}
+
+func (r *Resolver) DeleteCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteCookieBannerInput) (*mcp.CallToolResult, types.DeleteCookieBannerOutput, error) {
+	r.MustAuthorize(ctx, input.ID, probo.ActionCookieBannerDelete)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	if err := r.cookieBanner.DeleteCookieBanner(ctx, scope, input.ID); err != nil {
+		return nil, types.DeleteCookieBannerOutput{}, fmt.Errorf("cannot delete cookie banner: %w", err)
+	}
+	return nil, types.DeleteCookieBannerOutput{DeletedID: input.ID}, nil
+}
+
+func (r *Resolver) ActivateCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ActivateCookieBannerInput) (*mcp.CallToolResult, types.ActivateCookieBannerOutput, error) {
+	r.MustAuthorize(ctx, input.ID, probo.ActionCookieBannerActivate)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	banner, err := r.cookieBanner.ActivateCookieBanner(ctx, scope, input.ID)
+	if err != nil {
+		return nil, types.ActivateCookieBannerOutput{}, fmt.Errorf("cannot activate cookie banner: %w", err)
+	}
+	return nil, types.ActivateCookieBannerOutput{CookieBanner: types.NewCookieBanner(banner)}, nil
+}
+
+func (r *Resolver) DeactivateCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeactivateCookieBannerInput) (*mcp.CallToolResult, types.DeactivateCookieBannerOutput, error) {
+	r.MustAuthorize(ctx, input.ID, probo.ActionCookieBannerDeactivate)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	banner, err := r.cookieBanner.DeactivateCookieBanner(ctx, scope, input.ID)
+	if err != nil {
+		return nil, types.DeactivateCookieBannerOutput{}, fmt.Errorf("cannot deactivate cookie banner: %w", err)
+	}
+	return nil, types.DeactivateCookieBannerOutput{CookieBanner: types.NewCookieBanner(banner)}, nil
+}
+
+func (r *Resolver) ListCookieCategoriesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListCookieCategoriesInput) (*mcp.CallToolResult, types.ListCookieCategoriesOutput, error) {
+	r.MustAuthorize(ctx, input.CookieBannerID, probo.ActionCookieCategoryList)
+	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
+	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieCategoryOrderField]{Field: coredata.CookieCategoryOrderFieldRank, Direction: page.OrderDirectionAsc})
+	categories, err := r.cookieBanner.ListCookieCategoriesForBanner(ctx, scope, input.CookieBannerID, cursor)
+	if err != nil {
+		panic(fmt.Errorf("cannot list cookie categories: %w", err))
+	}
+	p := page.NewPage(categories, cursor)
+	return nil, types.NewListCookieCategoriesOutput(p), nil
+}
+
+func (r *Resolver) GetCookieCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetCookieCategoryInput) (*mcp.CallToolResult, types.GetCookieCategoryOutput, error) {
+	r.MustAuthorize(ctx, input.ID, probo.ActionCookieCategoryGet)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	category, err := r.cookieBanner.GetCookieCategory(ctx, scope, input.ID)
+	if err != nil {
+		return nil, types.GetCookieCategoryOutput{}, fmt.Errorf("cannot get cookie category: %w", err)
+	}
+	return nil, types.GetCookieCategoryOutput{CookieCategory: types.NewCookieCategory(category)}, nil
+}
+
+func (r *Resolver) AddCookieCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddCookieCategoryInput) (*mcp.CallToolResult, types.AddCookieCategoryOutput, error) {
+	r.MustAuthorize(ctx, input.CookieBannerID, probo.ActionCookieCategoryCreate)
+	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
+	category, err := r.cookieBanner.CreateCookieCategory(ctx, scope, cookiebanner.CreateCookieCategoryRequest{
+		CookieBannerID: input.CookieBannerID,
+		Name:           input.Name,
+		Slug:           input.Slug,
+		Description:    input.Description,
+		Rank:           input.Rank,
+	})
+	if err != nil {
+		return nil, types.AddCookieCategoryOutput{}, fmt.Errorf("cannot create cookie category: %w", err)
+	}
+	return nil, types.AddCookieCategoryOutput{CookieCategory: types.NewCookieCategory(category)}, nil
+}
+
+func (r *Resolver) UpdateCookieCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateCookieCategoryInput) (*mcp.CallToolResult, types.UpdateCookieCategoryOutput, error) {
+	r.MustAuthorize(ctx, input.ID, probo.ActionCookieCategoryUpdate)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	updateReq := cookiebanner.UpdateCookieCategoryRequest{CookieCategoryID: input.ID}
+	if v := UnwrapOmittable(input.Name); v != nil && *v != nil {
+		updateReq.Name = *v
+	}
+	if v := UnwrapOmittable(input.Slug); v != nil && *v != nil {
+		updateReq.Slug = *v
+	}
+	if v := UnwrapOmittable(input.Description); v != nil && *v != nil {
+		updateReq.Description = *v
+	}
+	category, err := r.cookieBanner.UpdateCookieCategory(ctx, scope, updateReq)
+	if err != nil {
+		return nil, types.UpdateCookieCategoryOutput{}, fmt.Errorf("cannot update cookie category: %w", err)
+	}
+	return nil, types.UpdateCookieCategoryOutput{CookieCategory: types.NewCookieCategory(category)}, nil
+}
+
+func (r *Resolver) DeleteCookieCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteCookieCategoryInput) (*mcp.CallToolResult, types.DeleteCookieCategoryOutput, error) {
+	r.MustAuthorize(ctx, input.ID, probo.ActionCookieCategoryDelete)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	if err := r.cookieBanner.DeleteCookieCategory(ctx, scope, input.ID); err != nil {
+		return nil, types.DeleteCookieCategoryOutput{}, fmt.Errorf("cannot delete cookie category: %w", err)
+	}
+	return nil, types.DeleteCookieCategoryOutput{DeletedID: input.ID}, nil
+}
+
+func (r *Resolver) ReorderCookieCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ReorderCookieCategoryInput) (*mcp.CallToolResult, types.ReorderCookieCategoryOutput, error) {
+	r.MustAuthorize(ctx, input.ID, probo.ActionCookieCategoryUpdate)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	_, err := r.cookieBanner.ReorderCookieCategory(ctx, scope, cookiebanner.ReorderCookieCategoryRequest{
+		CookieCategoryID: input.ID,
+		Rank:             input.Rank,
+	})
+	if err != nil {
+		return nil, types.ReorderCookieCategoryOutput{}, fmt.Errorf("cannot reorder cookie category: %w", err)
+	}
+	category, err := r.cookieBanner.GetCookieCategory(ctx, scope, input.ID)
+	if err != nil {
+		return nil, types.ReorderCookieCategoryOutput{}, fmt.Errorf("cannot get cookie category: %w", err)
+	}
+	return nil, types.ReorderCookieCategoryOutput{CookieCategory: types.NewCookieCategory(category)}, nil
+}
+
+func (r *Resolver) ListCookiePatternsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListCookiePatternsInput) (*mcp.CallToolResult, types.ListCookiePatternsOutput, error) {
+	r.MustAuthorize(ctx, input.CookieCategoryID, probo.ActionCookiePatternList)
+	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
+	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookiePatternOrderField]{Field: coredata.CookiePatternOrderFieldCreatedAt, Direction: page.OrderDirectionAsc})
+	patterns, err := r.cookieBanner.ListCookiePatternsForCategory(ctx, scope, input.CookieCategoryID, cursor)
+	if err != nil {
+		panic(fmt.Errorf("cannot list cookie patterns: %w", err))
+	}
+	p := page.NewPage(patterns, cursor)
+	return nil, types.NewListCookiePatternsOutput(p), nil
+}
+
+func (r *Resolver) GetCookiePatternTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetCookiePatternInput) (*mcp.CallToolResult, types.GetCookiePatternOutput, error) {
+	r.MustAuthorize(ctx, input.ID, probo.ActionCookiePatternGet)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	pattern, err := r.cookieBanner.GetCookiePattern(ctx, scope, input.ID)
+	if err != nil {
+		return nil, types.GetCookiePatternOutput{}, fmt.Errorf("cannot get cookie pattern: %w", err)
+	}
+	return nil, types.GetCookiePatternOutput{CookiePattern: types.NewCookiePattern(pattern)}, nil
+}
+
+func (r *Resolver) AddCookiePatternTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddCookiePatternInput) (*mcp.CallToolResult, types.AddCookiePatternOutput, error) {
+	r.MustAuthorize(ctx, input.CookieCategoryID, probo.ActionCookiePatternCreate)
+	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
+	pattern, err := r.cookieBanner.CreateCookiePattern(ctx, scope, cookiebanner.CreateCookiePatternRequest{
+		CookieCategoryID: input.CookieCategoryID,
+		Pattern:          input.Pattern,
+		MatchType:        coredata.CookiePatternMatchType(input.MatchType),
+		DisplayName:      input.DisplayName,
+		MaxAgeSeconds:    input.MaxAgeSeconds,
+		Description:      input.Description,
+	})
+	if err != nil {
+		return nil, types.AddCookiePatternOutput{}, fmt.Errorf("cannot create cookie pattern: %w", err)
+	}
+	return nil, types.AddCookiePatternOutput{CookiePattern: types.NewCookiePattern(pattern)}, nil
+}
+
+func (r *Resolver) UpdateCookiePatternTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateCookiePatternInput) (*mcp.CallToolResult, types.UpdateCookiePatternOutput, error) {
+	r.MustAuthorize(ctx, input.ID, probo.ActionCookiePatternUpdate)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	updateReq := cookiebanner.UpdateCookiePatternRequest{CookiePatternID: input.ID}
+	if v := UnwrapOmittable(input.DisplayName); v != nil && *v != nil {
+		updateReq.DisplayName = *v
+	}
+	if input.MaxAgeSeconds.IsSet() {
+		val, _ := input.MaxAgeSeconds.Value()
+		updateReq.MaxAgeSeconds = &val
+	}
+	if v := UnwrapOmittable(input.Description); v != nil && *v != nil {
+		updateReq.Description = *v
+	}
+	pattern, err := r.cookieBanner.UpdateCookiePattern(ctx, scope, updateReq)
+	if err != nil {
+		return nil, types.UpdateCookiePatternOutput{}, fmt.Errorf("cannot update cookie pattern: %w", err)
+	}
+	return nil, types.UpdateCookiePatternOutput{CookiePattern: types.NewCookiePattern(pattern)}, nil
+}
+
+func (r *Resolver) DeleteCookiePatternTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteCookiePatternInput) (*mcp.CallToolResult, types.DeleteCookiePatternOutput, error) {
+	r.MustAuthorize(ctx, input.ID, probo.ActionCookiePatternDelete)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	if err := r.cookieBanner.DeleteCookiePattern(ctx, scope, input.ID); err != nil {
+		return nil, types.DeleteCookiePatternOutput{}, fmt.Errorf("cannot delete cookie pattern: %w", err)
+	}
+	return nil, types.DeleteCookiePatternOutput{DeletedID: input.ID}, nil
+}
+
+func (r *Resolver) MoveCookiePatternToCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.MoveCookiePatternToCategoryInput) (*mcp.CallToolResult, types.MoveCookiePatternToCategoryOutput, error) {
+	r.MustAuthorize(ctx, input.CookiePatternID, probo.ActionCookiePatternUpdate)
+	scope := coredata.NewScopeFromObjectID(input.CookiePatternID)
+	result, err := r.cookieBanner.MoveCookiePatternToCategory(ctx, scope, cookiebanner.MoveCookiePatternToCategoryRequest{
+		CookiePatternID:        input.CookiePatternID,
+		TargetCookieCategoryID: input.TargetCookieCategoryID,
+	})
+	if err != nil {
+		return nil, types.MoveCookiePatternToCategoryOutput{}, fmt.Errorf("cannot move cookie pattern: %w", err)
+	}
+	return nil, types.MoveCookiePatternToCategoryOutput{CookiePattern: types.NewCookiePattern(result.CookiePattern)}, nil
+}
+
+func (r *Resolver) PublishCookieBannerVersionTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishCookieBannerVersionInput) (*mcp.CallToolResult, types.PublishCookieBannerVersionOutput, error) {
+	r.MustAuthorize(ctx, input.CookieBannerID, probo.ActionCookieBannerVersionPublish)
+	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
+	version, err := r.cookieBanner.PublishCookieBannerVersion(ctx, scope, input.CookieBannerID)
+	if err != nil {
+		return nil, types.PublishCookieBannerVersionOutput{}, fmt.Errorf("cannot publish cookie banner version: %w", err)
+	}
+	return nil, types.PublishCookieBannerVersionOutput{CookieBannerVersion: types.NewCookieBannerVersion(version)}, nil
+}
+
+func (r *Resolver) ListCookieBannerVersionsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListCookieBannerVersionsInput) (*mcp.CallToolResult, types.ListCookieBannerVersionsOutput, error) {
+	r.MustAuthorize(ctx, input.CookieBannerID, probo.ActionCookieBannerVersionList)
+	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
+	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieBannerVersionOrderField]{Field: coredata.CookieBannerVersionOrderFieldCreatedAt, Direction: page.OrderDirectionDesc})
+	versions, err := r.cookieBanner.ListCookieBannerVersionsForBanner(ctx, scope, input.CookieBannerID, cursor)
+	if err != nil {
+		panic(fmt.Errorf("cannot list cookie banner versions: %w", err))
+	}
+	p := page.NewPage(versions, cursor)
+	return nil, types.NewListCookieBannerVersionsOutput(p), nil
+}
+
+func (r *Resolver) UpsertCookieBannerTranslationTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpsertCookieBannerTranslationInput) (*mcp.CallToolResult, types.UpsertCookieBannerTranslationOutput, error) {
+	r.MustAuthorize(ctx, input.CookieBannerID, probo.ActionCookieBannerUpdate)
+	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
+	translation, err := r.cookieBanner.UpsertCookieBannerTranslation(ctx, scope, cookiebanner.UpsertCookieBannerTranslationRequest{
+		CookieBannerID: input.CookieBannerID,
+		Language:       input.Language,
+		Translations:   json.RawMessage(input.Translations),
+	})
+	if err != nil {
+		return nil, types.UpsertCookieBannerTranslationOutput{}, fmt.Errorf("cannot upsert cookie banner translation: %w", err)
+	}
+	return nil, types.UpsertCookieBannerTranslationOutput{CookieBannerTranslation: types.NewCookieBannerTranslation(translation)}, nil
+}
+
+func (r *Resolver) ListCookieConsentRecordsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListCookieConsentRecordsInput) (*mcp.CallToolResult, types.ListCookieConsentRecordsOutput, error) {
+	r.MustAuthorize(ctx, input.CookieBannerID, probo.ActionCookieConsentRecordList)
+	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
+	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieConsentRecordOrderField]{Field: coredata.CookieConsentRecordOrderFieldCreatedAt, Direction: page.OrderDirectionDesc})
+
+	var action *coredata.CookieConsentAction
+	if input.Action != nil {
+		a := coredata.CookieConsentAction(*input.Action)
+		action = &a
+	}
+	filter := coredata.NewCookieConsentRecordFilter(action, input.VisitorID, input.Version)
+
+	records, err := r.cookieBanner.ListCookieConsentRecordsForBanner(ctx, scope, input.CookieBannerID, cursor, filter)
+	if err != nil {
+		panic(fmt.Errorf("cannot list cookie consent records: %w", err))
+	}
+	p := page.NewPage(records, cursor)
+	return nil, types.NewListCookieConsentRecordsOutput(p), nil
+}
+
+func (r *Resolver) GetCookieConsentRecordTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetCookieConsentRecordInput) (*mcp.CallToolResult, types.GetCookieConsentRecordOutput, error) {
+	r.MustAuthorize(ctx, input.ID, probo.ActionCookieConsentRecordList)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	record, err := r.cookieBanner.GetCookieConsentRecord(ctx, scope, input.ID)
+	if err != nil {
+		return nil, types.GetCookieConsentRecordOutput{}, fmt.Errorf("cannot get cookie consent record: %w", err)
+	}
+	return nil, types.GetCookieConsentRecordOutput{CookieConsentRecord: types.NewCookieConsentRecord(record)}, nil
 }

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -9190,6 +9190,862 @@ components:
         deleted_custom_domain:
           $ref: "#/components/schemas/CustomDomain"
 
+    CookieBanner:
+      type: object
+      required:
+        - id
+        - organization_id
+        - name
+        - origin
+        - state
+        - cookie_policy_url
+        - consent_expiry_days
+        - consent_mode
+        - show_branding
+        - default_language
+        - created_at
+        - updated_at
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+          description: Cookie banner ID
+        organization_id:
+          $ref: "#/components/schemas/GID"
+          description: Organization ID
+        name:
+          type: string
+          description: Banner name
+        origin:
+          type: string
+          description: Website origin (scheme + host)
+        state:
+          type: string
+          enum: [ACTIVE, INACTIVE]
+          description: Banner state
+        privacy_policy_url:
+          type:
+            - string
+            - "null"
+          description: Privacy policy URL
+        cookie_policy_url:
+          type: string
+          description: Cookie policy URL
+        consent_expiry_days:
+          type: integer
+          description: Days until consent expires
+        consent_mode:
+          type: string
+          enum: [OPT_IN, OPT_OUT]
+          description: Consent mode
+        show_branding:
+          type: boolean
+          description: Whether to show Probo branding
+        default_language:
+          type: string
+          description: Default language code
+        created_at:
+          type: string
+          format: date-time
+          description: Creation timestamp
+        updated_at:
+          type: string
+          format: date-time
+          description: Last update timestamp
+
+    CookieCategory:
+      type: object
+      required:
+        - id
+        - organization_id
+        - cookie_banner_id
+        - name
+        - slug
+        - description
+        - kind
+        - rank
+        - created_at
+        - updated_at
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+          description: Cookie category ID
+        organization_id:
+          $ref: "#/components/schemas/GID"
+          description: Organization ID
+        cookie_banner_id:
+          $ref: "#/components/schemas/GID"
+          description: Cookie banner ID
+        name:
+          type: string
+          description: Category name
+        slug:
+          type: string
+          description: Category slug
+        description:
+          type: string
+          description: Category description
+        kind:
+          type: string
+          enum: [NORMAL, NECESSARY, UNCATEGORISED]
+          description: Category kind
+        rank:
+          type: integer
+          description: Display order rank
+        gcm_consent_types:
+          type: array
+          items:
+            type: string
+          description: Google Consent Mode types
+        posthog_consent:
+          type: boolean
+          description: Whether this category controls PostHog consent
+        created_at:
+          type: string
+          format: date-time
+          description: Creation timestamp
+        updated_at:
+          type: string
+          format: date-time
+          description: Last update timestamp
+
+    CookiePattern:
+      type: object
+      required:
+        - id
+        - organization_id
+        - cookie_banner_id
+        - cookie_category_id
+        - pattern
+        - match_type
+        - display_name
+        - description
+        - source
+        - created_at
+        - updated_at
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+          description: Cookie pattern ID
+        organization_id:
+          $ref: "#/components/schemas/GID"
+          description: Organization ID
+        cookie_banner_id:
+          $ref: "#/components/schemas/GID"
+          description: Cookie banner ID
+        cookie_category_id:
+          $ref: "#/components/schemas/GID"
+          description: Cookie category ID
+        pattern:
+          type: string
+          description: Cookie name pattern
+        match_type:
+          type: string
+          enum: [EXACT, PREFIX]
+          description: Pattern match type
+        display_name:
+          type: string
+          description: Human-friendly display name
+        max_age_seconds:
+          type:
+            - integer
+            - "null"
+          description: Cookie max age in seconds
+        description:
+          type: string
+          description: Pattern description
+        source:
+          type: string
+          enum: [SCRIPT, PRE_EXISTING]
+          description: How the pattern was discovered
+        created_at:
+          type: string
+          format: date-time
+          description: Creation timestamp
+        updated_at:
+          type: string
+          format: date-time
+          description: Last update timestamp
+
+    CookieBannerVersion:
+      type: object
+      required:
+        - id
+        - cookie_banner_id
+        - version
+        - state
+        - created_at
+        - updated_at
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+          description: Version ID
+        cookie_banner_id:
+          $ref: "#/components/schemas/GID"
+          description: Cookie banner ID
+        version:
+          type: integer
+          description: Version number
+        state:
+          type: string
+          enum: [DRAFT, PUBLISHED]
+          description: Version state
+        created_at:
+          type: string
+          format: date-time
+          description: Creation timestamp
+        updated_at:
+          type: string
+          format: date-time
+          description: Last update timestamp
+
+    CookieBannerTranslation:
+      type: object
+      required:
+        - id
+        - cookie_banner_id
+        - language
+        - translations
+        - created_at
+        - updated_at
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+          description: Translation ID
+        cookie_banner_id:
+          $ref: "#/components/schemas/GID"
+          description: Cookie banner ID
+        language:
+          type: string
+          description: Language code
+        translations:
+          type: string
+          description: Translation JSON string
+        created_at:
+          type: string
+          format: date-time
+          description: Creation timestamp
+        updated_at:
+          type: string
+          format: date-time
+          description: Last update timestamp
+
+    CookieConsentRecord:
+      type: object
+      required:
+        - id
+        - cookie_banner_id
+        - cookie_banner_version_id
+        - visitor_id
+        - consent_data
+        - action
+        - sdk_version
+        - created_at
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+          description: Consent record ID
+        cookie_banner_id:
+          $ref: "#/components/schemas/GID"
+          description: Cookie banner ID
+        cookie_banner_version_id:
+          $ref: "#/components/schemas/GID"
+          description: Banner version ID
+        visitor_id:
+          type: string
+          description: Visitor identifier
+        ip_address:
+          type:
+            - string
+            - "null"
+          description: Anonymized IP address
+        user_agent:
+          type:
+            - string
+            - "null"
+          description: User agent string
+        consent_data:
+          type: string
+          description: Consent data JSON
+        action:
+          type: string
+          enum: [ACCEPT_ALL, REJECT_ALL, CUSTOMIZE, GPC]
+          description: Consent action taken
+        sdk_version:
+          type: string
+          description: SDK version
+        created_at:
+          type: string
+          format: date-time
+          description: Creation timestamp
+
+    ListCookieBannersInput:
+      type: object
+      required:
+        - organization_id
+      properties:
+        organization_id:
+          $ref: "#/components/schemas/GID"
+          description: Organization ID
+        size:
+          type: integer
+          description: Page size (default 100)
+        cursor:
+          $ref: "#/components/schemas/CursorKey"
+          description: Pagination cursor
+
+    ListCookieBannersOutput:
+      type: object
+      required:
+        - cookie_banners
+      properties:
+        next_cursor:
+          $ref: "#/components/schemas/CursorKey"
+        cookie_banners:
+          type: array
+          items:
+            $ref: "#/components/schemas/CookieBanner"
+
+    GetCookieBannerInput:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+          description: Cookie banner ID
+
+    GetCookieBannerOutput:
+      type: object
+      required:
+        - cookie_banner
+      properties:
+        cookie_banner:
+          $ref: "#/components/schemas/CookieBanner"
+
+    AddCookieBannerInput:
+      type: object
+      required:
+        - organization_id
+        - name
+        - origin
+        - cookie_policy_url
+        - consent_expiry_days
+        - consent_mode
+      properties:
+        organization_id:
+          $ref: "#/components/schemas/GID"
+          description: Organization ID
+        name:
+          type: string
+          description: Banner name
+        origin:
+          type: string
+          description: Website origin
+        privacy_policy_url:
+          type: string
+          description: Privacy policy URL
+        cookie_policy_url:
+          type: string
+          description: Cookie policy URL
+        consent_expiry_days:
+          type: integer
+          description: Days until consent expires
+        consent_mode:
+          type: string
+          enum: [OPT_IN, OPT_OUT]
+          description: Consent mode
+
+    AddCookieBannerOutput:
+      type: object
+      required:
+        - cookie_banner
+      properties:
+        cookie_banner:
+          $ref: "#/components/schemas/CookieBanner"
+
+    UpdateCookieBannerInput:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+          description: Cookie banner ID
+        name:
+          type:
+            - string
+            - "null"
+          go.probo.inc/mcpgen/omittable: true
+        privacy_policy_url:
+          type:
+            - string
+            - "null"
+          go.probo.inc/mcpgen/omittable: true
+        cookie_policy_url:
+          type:
+            - string
+            - "null"
+          go.probo.inc/mcpgen/omittable: true
+        consent_expiry_days:
+          type:
+            - integer
+            - "null"
+          go.probo.inc/mcpgen/omittable: true
+        consent_mode:
+          type:
+            - string
+            - "null"
+          go.probo.inc/mcpgen/omittable: true
+        default_language:
+          type:
+            - string
+            - "null"
+          go.probo.inc/mcpgen/omittable: true
+
+    UpdateCookieBannerOutput:
+      type: object
+      required:
+        - cookie_banner
+      properties:
+        cookie_banner:
+          $ref: "#/components/schemas/CookieBanner"
+
+    DeleteCookieBannerInput:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+          description: Cookie banner ID
+
+    DeleteCookieBannerOutput:
+      type: object
+      required:
+        - deleted_id
+      properties:
+        deleted_id:
+          $ref: "#/components/schemas/GID"
+
+    ActivateCookieBannerInput:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+          description: Cookie banner ID
+
+    ActivateCookieBannerOutput:
+      type: object
+      required:
+        - cookie_banner
+      properties:
+        cookie_banner:
+          $ref: "#/components/schemas/CookieBanner"
+
+    DeactivateCookieBannerInput:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+          description: Cookie banner ID
+
+    DeactivateCookieBannerOutput:
+      type: object
+      required:
+        - cookie_banner
+      properties:
+        cookie_banner:
+          $ref: "#/components/schemas/CookieBanner"
+
+    ListCookieCategoriesInput:
+      type: object
+      required:
+        - cookie_banner_id
+      properties:
+        cookie_banner_id:
+          $ref: "#/components/schemas/GID"
+          description: Cookie banner ID
+        size:
+          type: integer
+        cursor:
+          $ref: "#/components/schemas/CursorKey"
+
+    ListCookieCategoriesOutput:
+      type: object
+      required:
+        - cookie_categories
+      properties:
+        next_cursor:
+          $ref: "#/components/schemas/CursorKey"
+        cookie_categories:
+          type: array
+          items:
+            $ref: "#/components/schemas/CookieCategory"
+
+    GetCookieCategoryInput:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+
+    GetCookieCategoryOutput:
+      type: object
+      required:
+        - cookie_category
+      properties:
+        cookie_category:
+          $ref: "#/components/schemas/CookieCategory"
+
+    AddCookieCategoryInput:
+      type: object
+      required:
+        - cookie_banner_id
+        - name
+        - slug
+        - description
+        - rank
+      properties:
+        cookie_banner_id:
+          $ref: "#/components/schemas/GID"
+        name:
+          type: string
+        slug:
+          type: string
+        description:
+          type: string
+        rank:
+          type: integer
+
+    AddCookieCategoryOutput:
+      type: object
+      required:
+        - cookie_category
+      properties:
+        cookie_category:
+          $ref: "#/components/schemas/CookieCategory"
+
+    UpdateCookieCategoryInput:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+        name:
+          type:
+            - string
+            - "null"
+          go.probo.inc/mcpgen/omittable: true
+        slug:
+          type:
+            - string
+            - "null"
+          go.probo.inc/mcpgen/omittable: true
+        description:
+          type:
+            - string
+            - "null"
+          go.probo.inc/mcpgen/omittable: true
+
+    UpdateCookieCategoryOutput:
+      type: object
+      required:
+        - cookie_category
+      properties:
+        cookie_category:
+          $ref: "#/components/schemas/CookieCategory"
+
+    DeleteCookieCategoryInput:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+
+    DeleteCookieCategoryOutput:
+      type: object
+      required:
+        - deleted_id
+      properties:
+        deleted_id:
+          $ref: "#/components/schemas/GID"
+
+    ReorderCookieCategoryInput:
+      type: object
+      required:
+        - id
+        - rank
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+        rank:
+          type: integer
+
+    ReorderCookieCategoryOutput:
+      type: object
+      required:
+        - cookie_category
+      properties:
+        cookie_category:
+          $ref: "#/components/schemas/CookieCategory"
+
+    ListCookiePatternsInput:
+      type: object
+      required:
+        - cookie_category_id
+      properties:
+        cookie_category_id:
+          $ref: "#/components/schemas/GID"
+        size:
+          type: integer
+        cursor:
+          $ref: "#/components/schemas/CursorKey"
+
+    ListCookiePatternsOutput:
+      type: object
+      required:
+        - cookie_patterns
+      properties:
+        next_cursor:
+          $ref: "#/components/schemas/CursorKey"
+        cookie_patterns:
+          type: array
+          items:
+            $ref: "#/components/schemas/CookiePattern"
+
+    GetCookiePatternInput:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+
+    GetCookiePatternOutput:
+      type: object
+      required:
+        - cookie_pattern
+      properties:
+        cookie_pattern:
+          $ref: "#/components/schemas/CookiePattern"
+
+    AddCookiePatternInput:
+      type: object
+      required:
+        - cookie_category_id
+        - pattern
+        - match_type
+        - display_name
+        - description
+      properties:
+        cookie_category_id:
+          $ref: "#/components/schemas/GID"
+        pattern:
+          type: string
+        match_type:
+          type: string
+          enum: [EXACT, PREFIX]
+        display_name:
+          type: string
+        max_age_seconds:
+          type: integer
+        description:
+          type: string
+
+    AddCookiePatternOutput:
+      type: object
+      required:
+        - cookie_pattern
+      properties:
+        cookie_pattern:
+          $ref: "#/components/schemas/CookiePattern"
+
+    UpdateCookiePatternInput:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+        display_name:
+          type:
+            - string
+            - "null"
+          go.probo.inc/mcpgen/omittable: true
+        max_age_seconds:
+          type:
+            - integer
+            - "null"
+          go.probo.inc/mcpgen/omittable: true
+        description:
+          type:
+            - string
+            - "null"
+          go.probo.inc/mcpgen/omittable: true
+
+    UpdateCookiePatternOutput:
+      type: object
+      required:
+        - cookie_pattern
+      properties:
+        cookie_pattern:
+          $ref: "#/components/schemas/CookiePattern"
+
+    DeleteCookiePatternInput:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+
+    DeleteCookiePatternOutput:
+      type: object
+      required:
+        - deleted_id
+      properties:
+        deleted_id:
+          $ref: "#/components/schemas/GID"
+
+    MoveCookiePatternToCategoryInput:
+      type: object
+      required:
+        - cookie_pattern_id
+        - target_cookie_category_id
+      properties:
+        cookie_pattern_id:
+          $ref: "#/components/schemas/GID"
+        target_cookie_category_id:
+          $ref: "#/components/schemas/GID"
+
+    MoveCookiePatternToCategoryOutput:
+      type: object
+      required:
+        - cookie_pattern
+      properties:
+        cookie_pattern:
+          $ref: "#/components/schemas/CookiePattern"
+
+    PublishCookieBannerVersionInput:
+      type: object
+      required:
+        - cookie_banner_id
+      properties:
+        cookie_banner_id:
+          $ref: "#/components/schemas/GID"
+
+    PublishCookieBannerVersionOutput:
+      type: object
+      required:
+        - cookie_banner_version
+      properties:
+        cookie_banner_version:
+          $ref: "#/components/schemas/CookieBannerVersion"
+
+    ListCookieBannerVersionsInput:
+      type: object
+      required:
+        - cookie_banner_id
+      properties:
+        cookie_banner_id:
+          $ref: "#/components/schemas/GID"
+        size:
+          type: integer
+        cursor:
+          $ref: "#/components/schemas/CursorKey"
+
+    ListCookieBannerVersionsOutput:
+      type: object
+      required:
+        - cookie_banner_versions
+      properties:
+        next_cursor:
+          $ref: "#/components/schemas/CursorKey"
+        cookie_banner_versions:
+          type: array
+          items:
+            $ref: "#/components/schemas/CookieBannerVersion"
+
+    UpsertCookieBannerTranslationInput:
+      type: object
+      required:
+        - cookie_banner_id
+        - language
+        - translations
+      properties:
+        cookie_banner_id:
+          $ref: "#/components/schemas/GID"
+        language:
+          type: string
+        translations:
+          type: string
+          description: Translation JSON string
+
+    UpsertCookieBannerTranslationOutput:
+      type: object
+      required:
+        - cookie_banner_translation
+      properties:
+        cookie_banner_translation:
+          $ref: "#/components/schemas/CookieBannerTranslation"
+
+    ListCookieConsentRecordsInput:
+      type: object
+      required:
+        - cookie_banner_id
+      properties:
+        cookie_banner_id:
+          $ref: "#/components/schemas/GID"
+        size:
+          type: integer
+        cursor:
+          $ref: "#/components/schemas/CursorKey"
+        action:
+          type: string
+          enum: [ACCEPT_ALL, REJECT_ALL, CUSTOMIZE, GPC]
+          description: Filter by consent action
+        visitor_id:
+          type: string
+          description: Filter by visitor ID
+        version:
+          type: integer
+          description: Filter by banner version number
+
+    ListCookieConsentRecordsOutput:
+      type: object
+      required:
+        - cookie_consent_records
+      properties:
+        next_cursor:
+          $ref: "#/components/schemas/CursorKey"
+        cookie_consent_records:
+          type: array
+          items:
+            $ref: "#/components/schemas/CookieConsentRecord"
+
+    GetCookieConsentRecordInput:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+
+    GetCookieConsentRecordOutput:
+      type: object
+      required:
+        - cookie_consent_record
+      properties:
+        cookie_consent_record:
+          $ref: "#/components/schemas/CookieConsentRecord"
+
 tools:
   - name: listOrganizations
     description: List all organizations the user has access to
@@ -10903,3 +11759,207 @@ tools:
       $ref: "#/components/schemas/DeleteCustomDomainInput"
     outputSchema:
       $ref: "#/components/schemas/DeleteCustomDomainOutput"
+  - name: listCookieBanners
+    description: List all cookie banners for the organization
+    hints:
+      readonly: true
+      idempotent: true
+    inputSchema:
+      $ref: "#/components/schemas/ListCookieBannersInput"
+    outputSchema:
+      $ref: "#/components/schemas/ListCookieBannersOutput"
+  - name: getCookieBanner
+    description: Get a cookie banner by ID
+    hints:
+      readonly: true
+      idempotent: true
+    inputSchema:
+      $ref: "#/components/schemas/GetCookieBannerInput"
+    outputSchema:
+      $ref: "#/components/schemas/GetCookieBannerOutput"
+  - name: addCookieBanner
+    description: Create a new cookie banner for an organization
+    hints:
+      readonly: false
+    inputSchema:
+      $ref: "#/components/schemas/AddCookieBannerInput"
+    outputSchema:
+      $ref: "#/components/schemas/AddCookieBannerOutput"
+  - name: updateCookieBanner
+    description: Update an existing cookie banner
+    hints:
+      readonly: false
+    inputSchema:
+      $ref: "#/components/schemas/UpdateCookieBannerInput"
+    outputSchema:
+      $ref: "#/components/schemas/UpdateCookieBannerOutput"
+  - name: deleteCookieBanner
+    description: Delete a cookie banner
+    hints:
+      readonly: false
+      destructive: true
+    inputSchema:
+      $ref: "#/components/schemas/DeleteCookieBannerInput"
+    outputSchema:
+      $ref: "#/components/schemas/DeleteCookieBannerOutput"
+  - name: activateCookieBanner
+    description: Activate a cookie banner
+    hints:
+      readonly: false
+    inputSchema:
+      $ref: "#/components/schemas/ActivateCookieBannerInput"
+    outputSchema:
+      $ref: "#/components/schemas/ActivateCookieBannerOutput"
+  - name: deactivateCookieBanner
+    description: Deactivate a cookie banner
+    hints:
+      readonly: false
+    inputSchema:
+      $ref: "#/components/schemas/DeactivateCookieBannerInput"
+    outputSchema:
+      $ref: "#/components/schemas/DeactivateCookieBannerOutput"
+  - name: listCookieCategories
+    description: List all cookie categories for a banner
+    hints:
+      readonly: true
+      idempotent: true
+    inputSchema:
+      $ref: "#/components/schemas/ListCookieCategoriesInput"
+    outputSchema:
+      $ref: "#/components/schemas/ListCookieCategoriesOutput"
+  - name: getCookieCategory
+    description: Get a cookie category by ID
+    hints:
+      readonly: true
+      idempotent: true
+    inputSchema:
+      $ref: "#/components/schemas/GetCookieCategoryInput"
+    outputSchema:
+      $ref: "#/components/schemas/GetCookieCategoryOutput"
+  - name: addCookieCategory
+    description: Create a new cookie category for a banner
+    hints:
+      readonly: false
+    inputSchema:
+      $ref: "#/components/schemas/AddCookieCategoryInput"
+    outputSchema:
+      $ref: "#/components/schemas/AddCookieCategoryOutput"
+  - name: updateCookieCategory
+    description: Update an existing cookie category
+    hints:
+      readonly: false
+    inputSchema:
+      $ref: "#/components/schemas/UpdateCookieCategoryInput"
+    outputSchema:
+      $ref: "#/components/schemas/UpdateCookieCategoryOutput"
+  - name: deleteCookieCategory
+    description: Delete a cookie category
+    hints:
+      readonly: false
+      destructive: true
+    inputSchema:
+      $ref: "#/components/schemas/DeleteCookieCategoryInput"
+    outputSchema:
+      $ref: "#/components/schemas/DeleteCookieCategoryOutput"
+  - name: reorderCookieCategory
+    description: Change the display order rank of a cookie category
+    hints:
+      readonly: false
+    inputSchema:
+      $ref: "#/components/schemas/ReorderCookieCategoryInput"
+    outputSchema:
+      $ref: "#/components/schemas/ReorderCookieCategoryOutput"
+  - name: listCookiePatterns
+    description: List all cookie patterns for a category
+    hints:
+      readonly: true
+      idempotent: true
+    inputSchema:
+      $ref: "#/components/schemas/ListCookiePatternsInput"
+    outputSchema:
+      $ref: "#/components/schemas/ListCookiePatternsOutput"
+  - name: getCookiePattern
+    description: Get a cookie pattern by ID
+    hints:
+      readonly: true
+      idempotent: true
+    inputSchema:
+      $ref: "#/components/schemas/GetCookiePatternInput"
+    outputSchema:
+      $ref: "#/components/schemas/GetCookiePatternOutput"
+  - name: addCookiePattern
+    description: Create a new cookie pattern for a category
+    hints:
+      readonly: false
+    inputSchema:
+      $ref: "#/components/schemas/AddCookiePatternInput"
+    outputSchema:
+      $ref: "#/components/schemas/AddCookiePatternOutput"
+  - name: updateCookiePattern
+    description: Update an existing cookie pattern
+    hints:
+      readonly: false
+    inputSchema:
+      $ref: "#/components/schemas/UpdateCookiePatternInput"
+    outputSchema:
+      $ref: "#/components/schemas/UpdateCookiePatternOutput"
+  - name: deleteCookiePattern
+    description: Delete a cookie pattern
+    hints:
+      readonly: false
+      destructive: true
+    inputSchema:
+      $ref: "#/components/schemas/DeleteCookiePatternInput"
+    outputSchema:
+      $ref: "#/components/schemas/DeleteCookiePatternOutput"
+  - name: moveCookiePatternToCategory
+    description: Move a cookie pattern to a different category
+    hints:
+      readonly: false
+    inputSchema:
+      $ref: "#/components/schemas/MoveCookiePatternToCategoryInput"
+    outputSchema:
+      $ref: "#/components/schemas/MoveCookiePatternToCategoryOutput"
+  - name: publishCookieBannerVersion
+    description: Publish the current draft version of a cookie banner
+    hints:
+      readonly: false
+    inputSchema:
+      $ref: "#/components/schemas/PublishCookieBannerVersionInput"
+    outputSchema:
+      $ref: "#/components/schemas/PublishCookieBannerVersionOutput"
+  - name: listCookieBannerVersions
+    description: List all versions for a cookie banner
+    hints:
+      readonly: true
+      idempotent: true
+    inputSchema:
+      $ref: "#/components/schemas/ListCookieBannerVersionsInput"
+    outputSchema:
+      $ref: "#/components/schemas/ListCookieBannerVersionsOutput"
+  - name: upsertCookieBannerTranslation
+    description: Insert or update a cookie banner translation for a language
+    hints:
+      readonly: false
+    inputSchema:
+      $ref: "#/components/schemas/UpsertCookieBannerTranslationInput"
+    outputSchema:
+      $ref: "#/components/schemas/UpsertCookieBannerTranslationOutput"
+  - name: listCookieConsentRecords
+    description: List consent records for a cookie banner
+    hints:
+      readonly: true
+      idempotent: true
+    inputSchema:
+      $ref: "#/components/schemas/ListCookieConsentRecordsInput"
+    outputSchema:
+      $ref: "#/components/schemas/ListCookieConsentRecordsOutput"
+  - name: getCookieConsentRecord
+    description: Get a consent record by ID
+    hints:
+      readonly: true
+      idempotent: true
+    inputSchema:
+      $ref: "#/components/schemas/GetCookieConsentRecordInput"
+    outputSchema:
+      $ref: "#/components/schemas/GetCookieConsentRecordOutput"

--- a/pkg/server/api/mcp/v1/types/cookie_banner.go
+++ b/pkg/server/api/mcp/v1/types/cookie_banner.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package types
+
+import (
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/page"
+)
+
+func NewCookieBanner(b *coredata.CookieBanner) *CookieBanner {
+	return &CookieBanner{
+		ID:                b.ID,
+		OrganizationID:    b.OrganizationID,
+		Name:              b.Name,
+		Origin:            b.Origin,
+		State:             CookieBannerState(b.State),
+		PrivacyPolicyURL:  b.PrivacyPolicyURL,
+		CookiePolicyURL:   b.CookiePolicyURL,
+		ConsentExpiryDays: b.ConsentExpiryDays,
+		ConsentMode:       CookieBannerConsentMode(b.ConsentMode),
+		ShowBranding:      b.ShowBranding,
+		DefaultLanguage:   b.DefaultLanguage,
+		CreatedAt:         b.CreatedAt,
+		UpdatedAt:         b.UpdatedAt,
+	}
+}
+
+func NewListCookieBannersOutput(p *page.Page[*coredata.CookieBanner, coredata.CookieBannerOrderField]) ListCookieBannersOutput {
+	banners := make([]*CookieBanner, 0, len(p.Data))
+	for _, b := range p.Data {
+		banners = append(banners, NewCookieBanner(b))
+	}
+
+	var nextCursor *page.CursorKey
+	if len(p.Data) > 0 {
+		cursorKey := p.Data[len(p.Data)-1].CursorKey(p.Cursor.OrderBy.Field)
+		nextCursor = &cursorKey
+	}
+
+	return ListCookieBannersOutput{
+		NextCursor:    nextCursor,
+		CookieBanners: banners,
+	}
+}
+
+func NewCookieBannerTranslation(t *coredata.CookieBannerTranslation) *CookieBannerTranslation {
+	return &CookieBannerTranslation{
+		ID:             t.ID,
+		CookieBannerID: t.CookieBannerID,
+		Language:       t.Language,
+		Translations:   string(t.Translations),
+		CreatedAt:      t.CreatedAt,
+		UpdatedAt:      t.UpdatedAt,
+	}
+}

--- a/pkg/server/api/mcp/v1/types/cookie_banner_version.go
+++ b/pkg/server/api/mcp/v1/types/cookie_banner_version.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package types
+
+import (
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/page"
+)
+
+func NewCookieBannerVersion(v *coredata.CookieBannerVersion) *CookieBannerVersion {
+	return &CookieBannerVersion{
+		ID:             v.ID,
+		CookieBannerID: v.CookieBannerID,
+		Version:        v.Version,
+		State:          CookieBannerVersionState(v.State),
+		CreatedAt:      v.CreatedAt,
+		UpdatedAt:      v.UpdatedAt,
+	}
+}
+
+func NewListCookieBannerVersionsOutput(p *page.Page[*coredata.CookieBannerVersion, coredata.CookieBannerVersionOrderField]) ListCookieBannerVersionsOutput {
+	versions := make([]*CookieBannerVersion, 0, len(p.Data))
+	for _, v := range p.Data {
+		versions = append(versions, NewCookieBannerVersion(v))
+	}
+
+	var nextCursor *page.CursorKey
+	if len(p.Data) > 0 {
+		cursorKey := p.Data[len(p.Data)-1].CursorKey(p.Cursor.OrderBy.Field)
+		nextCursor = &cursorKey
+	}
+
+	return ListCookieBannerVersionsOutput{
+		NextCursor:           nextCursor,
+		CookieBannerVersions: versions,
+	}
+}

--- a/pkg/server/api/mcp/v1/types/cookie_category.go
+++ b/pkg/server/api/mcp/v1/types/cookie_category.go
@@ -20,11 +20,7 @@ import (
 )
 
 func NewCookieCategory(c *coredata.CookieCategory) *CookieCategory {
-	var posthogConsent *bool
-	if c.PostHogConsent {
-		v := true
-		posthogConsent = &v
-	}
+	posthogConsent := &c.PostHogConsent
 
 	return &CookieCategory{
 		ID:              c.ID,

--- a/pkg/server/api/mcp/v1/types/cookie_category.go
+++ b/pkg/server/api/mcp/v1/types/cookie_category.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package types
+
+import (
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/page"
+)
+
+func NewCookieCategory(c *coredata.CookieCategory) *CookieCategory {
+	var posthogConsent *bool
+	if c.PostHogConsent {
+		v := true
+		posthogConsent = &v
+	}
+
+	return &CookieCategory{
+		ID:              c.ID,
+		OrganizationID:  c.OrganizationID,
+		CookieBannerID:  c.CookieBannerID,
+		Name:            c.Name,
+		Slug:            c.Slug,
+		Description:     c.Description,
+		Kind:            CookieCategoryKind(c.Kind),
+		Rank:            c.Rank,
+		GcmConsentTypes: c.GCMConsentTypes,
+		PosthogConsent:  posthogConsent,
+		CreatedAt:       c.CreatedAt,
+		UpdatedAt:       c.UpdatedAt,
+	}
+}
+
+func NewListCookieCategoriesOutput(p *page.Page[*coredata.CookieCategory, coredata.CookieCategoryOrderField]) ListCookieCategoriesOutput {
+	categories := make([]*CookieCategory, 0, len(p.Data))
+	for _, c := range p.Data {
+		categories = append(categories, NewCookieCategory(c))
+	}
+
+	var nextCursor *page.CursorKey
+	if len(p.Data) > 0 {
+		cursorKey := p.Data[len(p.Data)-1].CursorKey(p.Cursor.OrderBy.Field)
+		nextCursor = &cursorKey
+	}
+
+	return ListCookieCategoriesOutput{
+		NextCursor:       nextCursor,
+		CookieCategories: categories,
+	}
+}

--- a/pkg/server/api/mcp/v1/types/cookie_consent_record.go
+++ b/pkg/server/api/mcp/v1/types/cookie_consent_record.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package types
+
+import (
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/page"
+)
+
+func NewCookieConsentRecord(r *coredata.CookieConsentRecord) *CookieConsentRecord {
+	var consentData string
+	if r.ConsentData != nil {
+		consentData = string(r.ConsentData)
+	}
+
+	return &CookieConsentRecord{
+		ID:                    r.ID,
+		CookieBannerID:        r.CookieBannerID,
+		CookieBannerVersionID: r.CookieBannerVersionID,
+		VisitorID:             r.VisitorID,
+		IPAddress:             r.IPAddress,
+		UserAgent:             r.UserAgent,
+		ConsentData:           consentData,
+		Action:                CookieConsentRecordAction(r.Action),
+		SdkVersion:            r.SdkVersion,
+		CreatedAt:             r.CreatedAt,
+	}
+}
+
+func NewListCookieConsentRecordsOutput(p *page.Page[*coredata.CookieConsentRecord, coredata.CookieConsentRecordOrderField]) ListCookieConsentRecordsOutput {
+	records := make([]*CookieConsentRecord, 0, len(p.Data))
+	for _, r := range p.Data {
+		records = append(records, NewCookieConsentRecord(r))
+	}
+
+	var nextCursor *page.CursorKey
+	if len(p.Data) > 0 {
+		cursorKey := p.Data[len(p.Data)-1].CursorKey(p.Cursor.OrderBy.Field)
+		nextCursor = &cursorKey
+	}
+
+	return ListCookieConsentRecordsOutput{
+		NextCursor:           nextCursor,
+		CookieConsentRecords: records,
+	}
+}

--- a/pkg/server/api/mcp/v1/types/cookie_pattern.go
+++ b/pkg/server/api/mcp/v1/types/cookie_pattern.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package types
+
+import (
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/page"
+)
+
+func NewCookiePattern(p *coredata.CookiePattern) *CookiePattern {
+	return &CookiePattern{
+		ID:               p.ID,
+		OrganizationID:   p.OrganizationID,
+		CookieBannerID:   p.CookieBannerID,
+		CookieCategoryID: p.CookieCategoryID,
+		Pattern:          p.Pattern,
+		MatchType:        CookiePatternMatchType(p.MatchType),
+		DisplayName:      p.DisplayName,
+		MaxAgeSeconds:    p.MaxAgeSeconds,
+		Description:      p.Description,
+		Source:           CookiePatternSource(p.Source),
+		CreatedAt:        p.CreatedAt,
+		UpdatedAt:        p.UpdatedAt,
+	}
+}
+
+func NewListCookiePatternsOutput(pg *page.Page[*coredata.CookiePattern, coredata.CookiePatternOrderField]) ListCookiePatternsOutput {
+	patterns := make([]*CookiePattern, 0, len(pg.Data))
+	for _, p := range pg.Data {
+		patterns = append(patterns, NewCookiePattern(p))
+	}
+
+	var nextCursor *page.CursorKey
+	if len(pg.Data) > 0 {
+		cursorKey := pg.Data[len(pg.Data)-1].CursorKey(pg.Cursor.OrderBy.Field)
+		nextCursor = &cursorKey
+	}
+
+	return ListCookiePatternsOutput{
+		NextCursor:     nextCursor,
+		CookiePatterns: patterns,
+	}
+}

--- a/pkg/server/api/mcp/v1/v1_handler.go
+++ b/pkg/server/api/mcp/v1/v1_handler.go
@@ -23,6 +23,7 @@ import (
 	"go.gearno.de/kit/log"
 	mcpgenmcp "go.probo.inc/mcpgen/mcp"
 	"go.probo.inc/probo/pkg/accessreview"
+	"go.probo.inc/probo/pkg/cookiebanner"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/iam"
 	"go.probo.inc/probo/pkg/probo"
@@ -35,7 +36,7 @@ func (r *Resolver) ProboService(ctx context.Context, objectID gid.GID) *probo.Te
 	return r.proboSvc.WithTenant(objectID.TenantID())
 }
 
-func NewMux(logger *log.Logger, proboSvc *probo.Service, iamSvc *iam.Service, accessReviewSvc *accessreview.Service, tokenSecret string) *chi.Mux {
+func NewMux(logger *log.Logger, proboSvc *probo.Service, iamSvc *iam.Service, accessReviewSvc *accessreview.Service, cookieBannerSvc *cookiebanner.Service, tokenSecret string) *chi.Mux {
 	logger = logger.Named("mcp.v1")
 
 	logger.Info("initializing MCP server")
@@ -45,6 +46,7 @@ func NewMux(logger *log.Logger, proboSvc *probo.Service, iamSvc *iam.Service, ac
 		proboSvc:     proboSvc,
 		iamSvc:       iamSvc,
 		accessReview: accessReviewSvc,
+		cookieBanner: cookieBannerSvc,
 		logger:       logger,
 	}
 


### PR DESCRIPTION
Closes ENG-340

### Summary of Changes

This PR introduces end-to-end testing, MCP tools, and CLI commands for the cookie banner service.

*   **E2E Testing**: Added comprehensive tests for the cookie banner GraphQL API in `e2e/console/`, covering CRUD operations, activation/versioning, translations, categories, patterns, RBAC, and tenant isolation.
*   **MCP Integration**: Added 24 new tools to the MCP resolver, exposing full management capabilities for cookie banners, categories, patterns, versions, and consent records.
*   **CLI Commands**: Expanded the `prb` CLI with new subcommands:
    *   `prb cookie-banner`: 10 commands for lifecycle and CRUD operations.
    *   `prb cookie-category` & `prb cookie-pattern`: 6 commands each for category and pattern management.
    *   `prb consent-record`: 2 commands for listing and viewing consent data.
*   **UI Tweaks**: Refined the styling of the cookie banners overview page in the console.

For more information on how Cubic handles descriptions, you can check the [AI PR Descriptions documentation](https://docs.cubic.dev/code-review-platform/ai-pr-descriptions).