### PR TITLE
Fix auditor access to processing activities

### DIFF
--- a/pkg/probo/policies.go
+++ b/pkg/probo/policies.go
@@ -150,7 +150,7 @@ var AuditorPolicy = policy.NewPolicy(
 		ActionFindingGet, ActionFindingList,
 		ActionObligationGet, ActionObligationList,
 		ActionProcessingActivityGet, ActionProcessingActivityList,
-		ActionDataProtectionImpactAssessmentGet,
+		ActionDataProtectionImpactAssessmentGet, ActionDataProtectionImpactAssessmentList,
 		ActionTransferImpactAssessmentGet, ActionTransferImpactAssessmentList,
 		ActionSnapshotGet, ActionSnapshotList,
 		ActionFileGet, ActionFileDownloadUrl,

--- a/pkg/probo/policies_test.go
+++ b/pkg/probo/policies_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package probo_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
+	"go.probo.inc/probo/pkg/probo"
+)
+
+func TestAuditorPolicy_ProcessingActivityPageReadAccess(t *testing.T) {
+	t.Parallel()
+
+	organizationID := gid.New(gid.NewTenantID(), 1)
+	evaluator := policy.NewEvaluator()
+	conditionContext := policy.ConditionContext{
+		Principal: map[string]string{
+			"organization_id": organizationID.String(),
+		},
+		Resource: map[string]string{
+			"organization_id": organizationID.String(),
+		},
+	}
+
+	tests := []struct {
+		name   string
+		action string
+	}{
+		{
+			name:   "list processing activities",
+			action: probo.ActionProcessingActivityList,
+		},
+		{
+			name:   "list data protection impact assessments",
+			action: probo.ActionDataProtectionImpactAssessmentList,
+		},
+		{
+			name:   "list transfer impact assessments",
+			action: probo.ActionTransferImpactAssessmentList,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := evaluator.Evaluate(
+				policy.AuthorizationRequest{
+					Principal:        organizationID,
+					Resource:         organizationID,
+					Action:           tt.action,
+					ConditionContext: conditionContext,
+				},
+				[]*policy.Policy{probo.AuditorPolicy},
+			)
+
+			assert.True(t, result.IsAllowed())
+		})
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Allow auditors to list Data Protection Impact Assessments so the Processing Activities page preload can resolve all tab data.
- Add focused policy coverage for Auditor read/list actions used by the Processing Activities page.

## Testing
- `go test ./pkg/iam/policy`
- Attempted `go test ./pkg/probo -run TestAuditorPolicy_ProcessingActivityPageReadAccess` (blocked: `packages/emails/emails.go:37:12: pattern dist: no matching files found`; the image also lacks `node`/`npm`, so `npm --workspace @probo/emails run build` cannot generate the missing embedded assets here).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-359](https://linear.app/probo/issue/ENG-359/auditor-role-cant-access-processing-activities)

<div><a href="https://cursor.com/agents/bc-49924d07-5761-466e-adee-825a384ce160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49924d07-5761-466e-adee-825a384ce160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

