### PR TITLE
Fix contract end date calendar cut off in Add Person dialog

### DIFF
--- a/apps/console/src/pages/iam/organizations/people/_components/AddPersonDialog.tsx
+++ b/apps/console/src/pages/iam/organizations/people/_components/AddPersonDialog.tsx
@@ -13,7 +13,7 @@
 // PERFORMANCE OF THIS SOFTWARE.
 
 import { useTranslate } from "@probo/i18n";
-import { Dialog, useDialogRef } from "@probo/ui";
+import { Dialog, DialogContent, useDialogRef } from "@probo/ui";
 import { type PropsWithChildren } from "react";
 import type { DataID } from "relay-runtime";
 
@@ -33,9 +33,9 @@ export function AddPersonDialog(props: PropsWithChildren<{
       className="max-w-xl"
       ref={dialogRef}
     >
-      <div className="p-4">
+      <DialogContent padded>
         <PersonForm connectionId={connectionId} onSubmit={() => dialogRef.current?.close()} />
-      </div>
+      </DialogContent>
     </Dialog>
   );
 }


### PR DESCRIPTION
Closes #1064 

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When adding a person to an organisation, the **Contract end date** calendar popup gets cut off at the bottom of the viewport. The dialog content extends beyond the screen with no way to scroll, so later dates cannot be seen or selected.

Resolves ENG-338.

## Root Cause

The `AddPersonDialog` wrapped its form content in a plain `<div className="p-4">` instead of using the `DialogContent` component. Unlike `DialogContent`, a raw `<div>` does not provide:
- `overflow-y-auto` for scrollability
- A `maxHeight` constraint (`min(640px, calc(100vh - 140px))`) to keep content within the viewport

Since the person form has many fields (name, email, role, type, position, emails, contract start date, contract end date), the dialog easily exceeds the viewport height.

## Fix

Replaced the raw `<div>` with `<DialogContent padded>`, which is the standard pattern used by all other dialogs in the codebase (e.g., `CreateVendorDialog`, `FormRiskDialog`, `CreateFindingDialog`, etc.). This ensures the form body scrolls when it exceeds the available space.

## Changes

- `apps/console/src/pages/iam/organizations/people/_components/AddPersonDialog.tsx` — swap `<div className="p-4">` for `<DialogContent padded>` and import `DialogContent` from `@probo/ui`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-338](https://linear.app/probo/issue/ENG-338/contract-end-date-calendar-gets-cut-off)

<div><a href="https://cursor.com/agents/bc-879ca5f1-fa15-4df6-9f35-f7b17e2eaf5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-879ca5f1-fa15-4df6-9f35-f7b17e2eaf5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

