### PR TITLE
Add cookie banner operations to n8n node

### DIFF
--- a/packages/n8n-node/nodes/Probo/Probo.node.ts
+++ b/packages/n8n-node/nodes/Probo/Probo.node.ts
@@ -102,6 +102,26 @@ export class Probo implements INodeType {
 						description: 'Manage controls',
 					},
 					{
+						name: 'Cookie Banner',
+						value: 'cookieBanner',
+						description: 'Manage cookie banners',
+					},
+					{
+						name: 'Cookie Category',
+						value: 'cookieCategory',
+						description: 'Manage cookie categories',
+					},
+					{
+						name: 'Cookie Consent Record',
+						value: 'cookieConsentRecord',
+						description: 'View cookie consent records',
+					},
+					{
+						name: 'Cookie Pattern',
+						value: 'cookiePattern',
+						description: 'Manage cookie patterns',
+					},
+					{
 						name: 'Data',
 						value: 'datum',
 						description: 'Manage data',

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/activate.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/activate.operation.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { proboApiRequest } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Cookie Banner ID',
+		name: 'cookieBannerId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieBanner'],
+				operation: ['activate'],
+			},
+		},
+		default: '',
+		description: 'The ID of the cookie banner to activate',
+		required: true,
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const cookieBannerId = this.getNodeParameter('cookieBannerId', itemIndex) as string;
+
+	const query = `
+		mutation ActivateCookieBanner($input: ActivateCookieBannerInput!) {
+			activateCookieBanner(input: $input) {
+				cookieBanner {
+					id
+					name
+					origin
+					state
+					privacyPolicyUrl
+					cookiePolicyUrl
+					consentExpiryDays
+					consentMode
+					showBranding
+					defaultLanguage
+					createdAt
+					updatedAt
+				}
+			}
+		}
+	`;
+
+	const responseData = await proboApiRequest.call(this, query, { input: { cookieBannerId } });
+
+	return {
+		json: responseData,
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/create.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/create.operation.ts
@@ -82,6 +82,9 @@ export const description: INodeProperties[] = [
 				operation: ['create'],
 			},
 		},
+		typeOptions: {
+			minValue: 1,
+		},
 		default: 365,
 		description: 'Number of days before consent expires',
 		required: true,

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/create.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/create.operation.ts
@@ -1,0 +1,179 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { proboApiRequest } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Organization ID',
+		name: 'organizationId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieBanner'],
+				operation: ['create'],
+			},
+		},
+		default: '',
+		description: 'The ID of the organization',
+		required: true,
+	},
+	{
+		displayName: 'Name',
+		name: 'name',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieBanner'],
+				operation: ['create'],
+			},
+		},
+		default: '',
+		description: 'The name of the cookie banner',
+		required: true,
+	},
+	{
+		displayName: 'Origin',
+		name: 'origin',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieBanner'],
+				operation: ['create'],
+			},
+		},
+		default: '',
+		description: 'The origin URL for the cookie banner',
+		required: true,
+	},
+	{
+		displayName: 'Cookie Policy URL',
+		name: 'cookiePolicyUrl',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieBanner'],
+				operation: ['create'],
+			},
+		},
+		default: '',
+		description: 'The URL to the cookie policy',
+		required: true,
+	},
+	{
+		displayName: 'Consent Expiry Days',
+		name: 'consentExpiryDays',
+		type: 'number',
+		displayOptions: {
+			show: {
+				resource: ['cookieBanner'],
+				operation: ['create'],
+			},
+		},
+		default: 365,
+		description: 'Number of days before consent expires',
+		required: true,
+	},
+	{
+		displayName: 'Consent Mode',
+		name: 'consentMode',
+		type: 'options',
+		displayOptions: {
+			show: {
+				resource: ['cookieBanner'],
+				operation: ['create'],
+			},
+		},
+		options: [
+			{
+				name: 'Opt In',
+				value: 'OPT_IN',
+			},
+			{
+				name: 'Opt Out',
+				value: 'OPT_OUT',
+			},
+		],
+		default: 'OPT_IN',
+		description: 'The consent mode for the cookie banner',
+		required: true,
+	},
+	{
+		displayName: 'Privacy Policy URL',
+		name: 'privacyPolicyUrl',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieBanner'],
+				operation: ['create'],
+			},
+		},
+		default: '',
+		description: 'The URL to the privacy policy',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const organizationId = this.getNodeParameter('organizationId', itemIndex) as string;
+	const name = this.getNodeParameter('name', itemIndex) as string;
+	const origin = this.getNodeParameter('origin', itemIndex) as string;
+	const cookiePolicyUrl = this.getNodeParameter('cookiePolicyUrl', itemIndex) as string;
+	const consentExpiryDays = this.getNodeParameter('consentExpiryDays', itemIndex) as number;
+	const consentMode = this.getNodeParameter('consentMode', itemIndex) as string;
+	const privacyPolicyUrl = this.getNodeParameter('privacyPolicyUrl', itemIndex, '') as string;
+
+	const query = `
+		mutation CreateCookieBanner($input: CreateCookieBannerInput!) {
+			createCookieBanner(input: $input) {
+				cookieBannerEdge {
+					node {
+						id
+						name
+						origin
+						state
+						privacyPolicyUrl
+						cookiePolicyUrl
+						consentExpiryDays
+						consentMode
+						showBranding
+						defaultLanguage
+						createdAt
+						updatedAt
+					}
+				}
+			}
+		}
+	`;
+
+	const input: Record<string, unknown> = {
+		organizationId,
+		name,
+		origin,
+		cookiePolicyUrl,
+		consentExpiryDays,
+		consentMode,
+	};
+	if (privacyPolicyUrl) input.privacyPolicyUrl = privacyPolicyUrl;
+
+	const responseData = await proboApiRequest.call(this, query, { input });
+
+	return {
+		json: responseData,
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/deactivate.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/deactivate.operation.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { proboApiRequest } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Cookie Banner ID',
+		name: 'cookieBannerId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieBanner'],
+				operation: ['deactivate'],
+			},
+		},
+		default: '',
+		description: 'The ID of the cookie banner to deactivate',
+		required: true,
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const cookieBannerId = this.getNodeParameter('cookieBannerId', itemIndex) as string;
+
+	const query = `
+		mutation DeactivateCookieBanner($input: DeactivateCookieBannerInput!) {
+			deactivateCookieBanner(input: $input) {
+				cookieBanner {
+					id
+					name
+					origin
+					state
+					privacyPolicyUrl
+					cookiePolicyUrl
+					consentExpiryDays
+					consentMode
+					showBranding
+					defaultLanguage
+					createdAt
+					updatedAt
+				}
+			}
+		}
+	`;
+
+	const responseData = await proboApiRequest.call(this, query, { input: { cookieBannerId } });
+
+	return {
+		json: responseData,
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/delete.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/delete.operation.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { proboApiRequest } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Cookie Banner ID',
+		name: 'cookieBannerId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieBanner'],
+				operation: ['delete'],
+			},
+		},
+		default: '',
+		description: 'The ID of the cookie banner to delete',
+		required: true,
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const cookieBannerId = this.getNodeParameter('cookieBannerId', itemIndex) as string;
+
+	const query = `
+		mutation DeleteCookieBanner($input: DeleteCookieBannerInput!) {
+			deleteCookieBanner(input: $input) {
+				deletedCookieBannerId
+			}
+		}
+	`;
+
+	const responseData = await proboApiRequest.call(this, query, { input: { cookieBannerId } });
+
+	return {
+		json: responseData,
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/get.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/get.operation.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { proboApiRequest } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Cookie Banner ID',
+		name: 'cookieBannerId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieBanner'],
+				operation: ['get'],
+			},
+		},
+		default: '',
+		description: 'The ID of the cookie banner',
+		required: true,
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const cookieBannerId = this.getNodeParameter('cookieBannerId', itemIndex) as string;
+
+	const query = `
+		query GetCookieBanner($cookieBannerId: ID!) {
+			node(id: $cookieBannerId) {
+				... on CookieBanner {
+					id
+					name
+					origin
+					state
+					privacyPolicyUrl
+					cookiePolicyUrl
+					consentExpiryDays
+					consentMode
+					showBranding
+					defaultLanguage
+					createdAt
+					updatedAt
+				}
+			}
+		}
+	`;
+
+	const responseData = await proboApiRequest.call(this, query, { cookieBannerId });
+
+	return {
+		json: responseData,
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/getAll.operation.ts
@@ -1,0 +1,121 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
+import { proboApiRequestAllItems } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Organization ID',
+		name: 'organizationId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieBanner'],
+				operation: ['getAll'],
+			},
+		},
+		default: '',
+		description: 'The ID of the organization',
+		required: true,
+	},
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		displayOptions: {
+			show: {
+				resource: ['cookieBanner'],
+				operation: ['getAll'],
+			},
+		},
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		displayOptions: {
+			show: {
+				resource: ['cookieBanner'],
+				operation: ['getAll'],
+				returnAll: [false],
+			},
+		},
+		typeOptions: {
+			minValue: 1,
+		},
+		default: 50,
+		description: 'Max number of results to return',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const organizationId = this.getNodeParameter('organizationId', itemIndex) as string;
+	const returnAll = this.getNodeParameter('returnAll', itemIndex) as boolean;
+	const limit = this.getNodeParameter('limit', itemIndex, 50) as number;
+
+	const query = `
+		query GetCookieBanners($organizationId: ID!, $first: Int, $after: CursorKey) {
+			node(id: $organizationId) {
+				... on Organization {
+					cookieBanners(first: $first, after: $after) {
+						edges {
+							node {
+								id
+								name
+								origin
+								state
+								privacyPolicyUrl
+								cookiePolicyUrl
+								consentExpiryDays
+								consentMode
+								showBranding
+								defaultLanguage
+								createdAt
+								updatedAt
+							}
+						}
+						pageInfo {
+							hasNextPage
+							endCursor
+						}
+					}
+				}
+			}
+		}
+	`;
+
+	const cookieBanners = await proboApiRequestAllItems.call(
+		this,
+		query,
+		{ organizationId },
+		(response) => {
+			const data = response?.data as IDataObject | undefined;
+			const node = data?.node as IDataObject | undefined;
+			return node?.cookieBanners as IDataObject | undefined;
+		},
+		returnAll,
+		limit,
+	);
+
+	return {
+		json: { cookieBanners },
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/index.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/index.ts
@@ -1,0 +1,116 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties } from 'n8n-workflow';
+import * as createOp from './create.operation';
+import * as getOp from './get.operation';
+import * as getAllOp from './getAll.operation';
+import * as updateOp from './update.operation';
+import * as deleteOp from './delete.operation';
+import * as activateOp from './activate.operation';
+import * as deactivateOp from './deactivate.operation';
+import * as publishOp from './publish.operation';
+import * as translateOp from './translate.operation';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['cookieBanner'],
+			},
+		},
+		options: [
+			{
+				name: 'Activate',
+				value: 'activate',
+				description: 'Activate a cookie banner',
+				action: 'Activate a cookie banner',
+			},
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create a new cookie banner',
+				action: 'Create a cookie banner',
+			},
+			{
+				name: 'Deactivate',
+				value: 'deactivate',
+				description: 'Deactivate a cookie banner',
+				action: 'Deactivate a cookie banner',
+			},
+			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Delete a cookie banner',
+				action: 'Delete a cookie banner',
+			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a cookie banner',
+				action: 'Get a cookie banner',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get many cookie banners',
+				action: 'Get many cookie banners',
+			},
+			{
+				name: 'Publish',
+				value: 'publish',
+				description: 'Publish a new cookie banner version',
+				action: 'Publish a cookie banner version',
+			},
+			{
+				name: 'Translate',
+				value: 'translate',
+				description: 'Upsert a cookie banner translation',
+				action: 'Translate a cookie banner',
+			},
+			{
+				name: 'Update',
+				value: 'update',
+				description: 'Update an existing cookie banner',
+				action: 'Update a cookie banner',
+			},
+		],
+		default: 'create',
+	},
+	...createOp.description,
+	...getOp.description,
+	...getAllOp.description,
+	...updateOp.description,
+	...deleteOp.description,
+	...activateOp.description,
+	...deactivateOp.description,
+	...publishOp.description,
+	...translateOp.description,
+];
+
+export {
+	createOp as create,
+	getOp as get,
+	getAllOp as getAll,
+	updateOp as update,
+	deleteOp as delete,
+	activateOp as activate,
+	deactivateOp as deactivate,
+	publishOp as publish,
+	translateOp as translate,
+};

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/publish.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/publish.operation.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { proboApiRequest } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Cookie Banner ID',
+		name: 'cookieBannerId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieBanner'],
+				operation: ['publish'],
+			},
+		},
+		default: '',
+		description: 'The ID of the cookie banner to publish a new version for',
+		required: true,
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const cookieBannerId = this.getNodeParameter('cookieBannerId', itemIndex) as string;
+
+	const query = `
+		mutation PublishCookieBannerVersion($input: PublishCookieBannerVersionInput!) {
+			publishCookieBannerVersion(input: $input) {
+				cookieBannerVersion {
+					id
+					version
+					state
+					createdAt
+					updatedAt
+				}
+				cookieBanner {
+					id
+					name
+					origin
+					state
+					createdAt
+					updatedAt
+				}
+			}
+		}
+	`;
+
+	const responseData = await proboApiRequest.call(this, query, { input: { cookieBannerId } });
+
+	return {
+		json: responseData,
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/translate.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/translate.operation.ts
@@ -1,0 +1,101 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { proboApiRequest } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Cookie Banner ID',
+		name: 'cookieBannerId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieBanner'],
+				operation: ['translate'],
+			},
+		},
+		default: '',
+		description: 'The ID of the cookie banner',
+		required: true,
+	},
+	{
+		displayName: 'Language',
+		name: 'language',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieBanner'],
+				operation: ['translate'],
+			},
+		},
+		default: '',
+		description: 'The language code for the translation (e.g. "fr", "de")',
+		required: true,
+	},
+	{
+		displayName: 'Translations',
+		name: 'translations',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieBanner'],
+				operation: ['translate'],
+			},
+		},
+		default: '',
+		description: 'The translations as a JSON string',
+		required: true,
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const cookieBannerId = this.getNodeParameter('cookieBannerId', itemIndex) as string;
+	const language = this.getNodeParameter('language', itemIndex) as string;
+	const translations = this.getNodeParameter('translations', itemIndex) as string;
+
+	const query = `
+		mutation UpsertCookieBannerTranslation($input: UpsertCookieBannerTranslationInput!) {
+			upsertCookieBannerTranslation(input: $input) {
+				cookieBannerTranslation {
+					id
+					language
+					translations
+					createdAt
+					updatedAt
+				}
+				cookieBanner {
+					id
+					name
+					origin
+					state
+					createdAt
+					updatedAt
+				}
+			}
+		}
+	`;
+
+	const responseData = await proboApiRequest.call(this, query, {
+		input: { cookieBannerId, language, translations },
+	});
+
+	return {
+		json: responseData,
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/update.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/update.operation.ts
@@ -1,0 +1,176 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { proboApiRequest } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Cookie Banner ID',
+		name: 'cookieBannerId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieBanner'],
+				operation: ['update'],
+			},
+		},
+		default: '',
+		description: 'The ID of the cookie banner to update',
+		required: true,
+	},
+	{
+		displayName: 'Name',
+		name: 'name',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieBanner'],
+				operation: ['update'],
+			},
+		},
+		default: '',
+		description: 'The name of the cookie banner',
+	},
+	{
+		displayName: 'Privacy Policy URL',
+		name: 'privacyPolicyUrl',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieBanner'],
+				operation: ['update'],
+			},
+		},
+		default: '',
+		description: 'The URL to the privacy policy',
+	},
+	{
+		displayName: 'Cookie Policy URL',
+		name: 'cookiePolicyUrl',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieBanner'],
+				operation: ['update'],
+			},
+		},
+		default: '',
+		description: 'The URL to the cookie policy',
+	},
+	{
+		displayName: 'Consent Expiry Days',
+		name: 'consentExpiryDays',
+		type: 'number',
+		displayOptions: {
+			show: {
+				resource: ['cookieBanner'],
+				operation: ['update'],
+			},
+		},
+		default: 0,
+		description: 'Number of days before consent expires (0 to leave unchanged)',
+	},
+	{
+		displayName: 'Consent Mode',
+		name: 'consentMode',
+		type: 'options',
+		displayOptions: {
+			show: {
+				resource: ['cookieBanner'],
+				operation: ['update'],
+			},
+		},
+		options: [
+			{
+				name: '(Unchanged)',
+				value: '',
+			},
+			{
+				name: 'Opt In',
+				value: 'OPT_IN',
+			},
+			{
+				name: 'Opt Out',
+				value: 'OPT_OUT',
+			},
+		],
+		default: '',
+		description: 'The consent mode for the cookie banner',
+	},
+	{
+		displayName: 'Default Language',
+		name: 'defaultLanguage',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieBanner'],
+				operation: ['update'],
+			},
+		},
+		default: '',
+		description: 'The default language for the cookie banner',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const cookieBannerId = this.getNodeParameter('cookieBannerId', itemIndex) as string;
+	const name = this.getNodeParameter('name', itemIndex, '') as string;
+	const privacyPolicyUrl = this.getNodeParameter('privacyPolicyUrl', itemIndex, '') as string;
+	const cookiePolicyUrl = this.getNodeParameter('cookiePolicyUrl', itemIndex, '') as string;
+	const consentExpiryDays = this.getNodeParameter('consentExpiryDays', itemIndex, 0) as number;
+	const consentMode = this.getNodeParameter('consentMode', itemIndex, '') as string;
+	const defaultLanguage = this.getNodeParameter('defaultLanguage', itemIndex, '') as string;
+
+	const query = `
+		mutation UpdateCookieBanner($input: UpdateCookieBannerInput!) {
+			updateCookieBanner(input: $input) {
+				cookieBanner {
+					id
+					name
+					origin
+					state
+					privacyPolicyUrl
+					cookiePolicyUrl
+					consentExpiryDays
+					consentMode
+					showBranding
+					defaultLanguage
+					createdAt
+					updatedAt
+				}
+			}
+		}
+	`;
+
+	const input: Record<string, unknown> = { cookieBannerId };
+	if (name) input.name = name;
+	if (privacyPolicyUrl !== undefined) {
+		input.privacyPolicyUrl = privacyPolicyUrl === '' ? null : privacyPolicyUrl;
+	}
+	if (cookiePolicyUrl) input.cookiePolicyUrl = cookiePolicyUrl;
+	if (consentExpiryDays) input.consentExpiryDays = consentExpiryDays;
+	if (consentMode) input.consentMode = consentMode;
+	if (defaultLanguage) input.defaultLanguage = defaultLanguage;
+
+	const responseData = await proboApiRequest.call(this, query, { input });
+
+	return {
+		json: responseData,
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/update.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/update.operation.ts
@@ -44,19 +44,6 @@ export const description: INodeProperties[] = [
 		description: 'The name of the cookie banner',
 	},
 	{
-		displayName: 'Privacy Policy URL',
-		name: 'privacyPolicyUrl',
-		type: 'string',
-		displayOptions: {
-			show: {
-				resource: ['cookieBanner'],
-				operation: ['update'],
-			},
-		},
-		default: '',
-		description: 'The URL to the privacy policy',
-	},
-	{
 		displayName: 'Cookie Policy URL',
 		name: 'cookiePolicyUrl',
 		type: 'string',
@@ -122,6 +109,28 @@ export const description: INodeProperties[] = [
 		default: '',
 		description: 'The default language for the cookie banner',
 	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['cookieBanner'],
+				operation: ['update'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Privacy Policy URL',
+				name: 'privacyPolicyUrl',
+				type: 'string',
+				default: '',
+				description: 'The URL to the privacy policy. Leave empty to clear the existing value.',
+			},
+		],
+	},
 ];
 
 export async function execute(
@@ -130,11 +139,13 @@ export async function execute(
 ): Promise<INodeExecutionData> {
 	const cookieBannerId = this.getNodeParameter('cookieBannerId', itemIndex) as string;
 	const name = this.getNodeParameter('name', itemIndex, '') as string;
-	const privacyPolicyUrl = this.getNodeParameter('privacyPolicyUrl', itemIndex, '') as string;
 	const cookiePolicyUrl = this.getNodeParameter('cookiePolicyUrl', itemIndex, '') as string;
 	const consentExpiryDays = this.getNodeParameter('consentExpiryDays', itemIndex, 0) as number;
 	const consentMode = this.getNodeParameter('consentMode', itemIndex, '') as string;
 	const defaultLanguage = this.getNodeParameter('defaultLanguage', itemIndex, '') as string;
+	const additionalFields = this.getNodeParameter('additionalFields', itemIndex, {}) as {
+		privacyPolicyUrl?: string;
+	};
 
 	const query = `
 		mutation UpdateCookieBanner($input: UpdateCookieBannerInput!) {
@@ -159,11 +170,13 @@ export async function execute(
 
 	const input: Record<string, unknown> = { cookieBannerId };
 	if (name) input.name = name;
-	if (privacyPolicyUrl) input.privacyPolicyUrl = privacyPolicyUrl;
 	if (cookiePolicyUrl) input.cookiePolicyUrl = cookiePolicyUrl;
 	if (consentExpiryDays) input.consentExpiryDays = consentExpiryDays;
 	if (consentMode) input.consentMode = consentMode;
 	if (defaultLanguage) input.defaultLanguage = defaultLanguage;
+	if (additionalFields.privacyPolicyUrl !== undefined) {
+		input.privacyPolicyUrl = additionalFields.privacyPolicyUrl === '' ? null : additionalFields.privacyPolicyUrl;
+	}
 
 	const responseData = await proboApiRequest.call(this, query, { input });
 

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/update.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/update.operation.ts
@@ -159,9 +159,7 @@ export async function execute(
 
 	const input: Record<string, unknown> = { cookieBannerId };
 	if (name) input.name = name;
-	if (privacyPolicyUrl !== undefined) {
-		input.privacyPolicyUrl = privacyPolicyUrl === '' ? null : privacyPolicyUrl;
-	}
+	if (privacyPolicyUrl) input.privacyPolicyUrl = privacyPolicyUrl;
 	if (cookiePolicyUrl) input.cookiePolicyUrl = cookiePolicyUrl;
 	if (consentExpiryDays) input.consentExpiryDays = consentExpiryDays;
 	if (consentMode) input.consentMode = consentMode;

--- a/packages/n8n-node/nodes/Probo/actions/cookieCategory/create.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieCategory/create.operation.ts
@@ -1,0 +1,134 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { proboApiRequest } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Cookie Banner ID',
+		name: 'cookieBannerId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieCategory'],
+				operation: ['create'],
+			},
+		},
+		default: '',
+		description: 'The ID of the cookie banner',
+		required: true,
+	},
+	{
+		displayName: 'Name',
+		name: 'name',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieCategory'],
+				operation: ['create'],
+			},
+		},
+		default: '',
+		description: 'The name of the cookie category',
+		required: true,
+	},
+	{
+		displayName: 'Slug',
+		name: 'slug',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieCategory'],
+				operation: ['create'],
+			},
+		},
+		default: '',
+		description: 'The slug of the cookie category',
+		required: true,
+	},
+	{
+		displayName: 'Description',
+		name: 'description',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieCategory'],
+				operation: ['create'],
+			},
+		},
+		default: '',
+		description: 'The description of the cookie category',
+		required: true,
+	},
+	{
+		displayName: 'Rank',
+		name: 'rank',
+		type: 'number',
+		displayOptions: {
+			show: {
+				resource: ['cookieCategory'],
+				operation: ['create'],
+			},
+		},
+		default: 0,
+		description: 'The display order rank of the cookie category',
+		required: true,
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const cookieBannerId = this.getNodeParameter('cookieBannerId', itemIndex) as string;
+	const name = this.getNodeParameter('name', itemIndex) as string;
+	const slug = this.getNodeParameter('slug', itemIndex) as string;
+	const description = this.getNodeParameter('description', itemIndex) as string;
+	const rank = this.getNodeParameter('rank', itemIndex) as number;
+
+	const query = `
+		mutation CreateCookieCategory($input: CreateCookieCategoryInput!) {
+			createCookieCategory(input: $input) {
+				cookieCategoryEdge {
+					node {
+						id
+						name
+						slug
+						description
+						kind
+						rank
+						gcmConsentTypes
+						posthogConsent
+						createdAt
+						updatedAt
+					}
+				}
+				cookieBanner {
+					id
+					name
+				}
+			}
+		}
+	`;
+
+	const responseData = await proboApiRequest.call(this, query, {
+		input: { cookieBannerId, name, slug, description, rank },
+	});
+
+	return {
+		json: responseData,
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/cookieCategory/delete.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieCategory/delete.operation.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { proboApiRequest } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Cookie Category ID',
+		name: 'cookieCategoryId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieCategory'],
+				operation: ['delete'],
+			},
+		},
+		default: '',
+		description: 'The ID of the cookie category to delete',
+		required: true,
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const cookieCategoryId = this.getNodeParameter('cookieCategoryId', itemIndex) as string;
+
+	const query = `
+		mutation DeleteCookieCategory($input: DeleteCookieCategoryInput!) {
+			deleteCookieCategory(input: $input) {
+				deletedCookieCategoryId
+				cookieBanner {
+					id
+					name
+				}
+			}
+		}
+	`;
+
+	const responseData = await proboApiRequest.call(this, query, { input: { cookieCategoryId } });
+
+	return {
+		json: responseData,
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/cookieCategory/get.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieCategory/get.operation.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { proboApiRequest } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Cookie Category ID',
+		name: 'cookieCategoryId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieCategory'],
+				operation: ['get'],
+			},
+		},
+		default: '',
+		description: 'The ID of the cookie category',
+		required: true,
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const cookieCategoryId = this.getNodeParameter('cookieCategoryId', itemIndex) as string;
+
+	const query = `
+		query GetCookieCategory($cookieCategoryId: ID!) {
+			node(id: $cookieCategoryId) {
+				... on CookieCategory {
+					id
+					name
+					slug
+					description
+					kind
+					rank
+					gcmConsentTypes
+					posthogConsent
+					createdAt
+					updatedAt
+				}
+			}
+		}
+	`;
+
+	const responseData = await proboApiRequest.call(this, query, { cookieCategoryId });
+
+	return {
+		json: responseData,
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/cookieCategory/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieCategory/getAll.operation.ts
@@ -1,0 +1,119 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
+import { proboApiRequestAllItems } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Cookie Banner ID',
+		name: 'cookieBannerId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieCategory'],
+				operation: ['getAll'],
+			},
+		},
+		default: '',
+		description: 'The ID of the cookie banner',
+		required: true,
+	},
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		displayOptions: {
+			show: {
+				resource: ['cookieCategory'],
+				operation: ['getAll'],
+			},
+		},
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		displayOptions: {
+			show: {
+				resource: ['cookieCategory'],
+				operation: ['getAll'],
+				returnAll: [false],
+			},
+		},
+		typeOptions: {
+			minValue: 1,
+		},
+		default: 50,
+		description: 'Max number of results to return',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const cookieBannerId = this.getNodeParameter('cookieBannerId', itemIndex) as string;
+	const returnAll = this.getNodeParameter('returnAll', itemIndex) as boolean;
+	const limit = this.getNodeParameter('limit', itemIndex, 50) as number;
+
+	const query = `
+		query GetCookieCategories($cookieBannerId: ID!, $first: Int, $after: CursorKey) {
+			node(id: $cookieBannerId) {
+				... on CookieBanner {
+					categories(first: $first, after: $after) {
+						edges {
+							node {
+								id
+								name
+								slug
+								description
+								kind
+								rank
+								gcmConsentTypes
+								posthogConsent
+								createdAt
+								updatedAt
+							}
+						}
+						pageInfo {
+							hasNextPage
+							endCursor
+						}
+					}
+				}
+			}
+		}
+	`;
+
+	const cookieCategories = await proboApiRequestAllItems.call(
+		this,
+		query,
+		{ cookieBannerId },
+		(response) => {
+			const data = response?.data as IDataObject | undefined;
+			const node = data?.node as IDataObject | undefined;
+			return node?.categories as IDataObject | undefined;
+		},
+		returnAll,
+		limit,
+	);
+
+	return {
+		json: { cookieCategories },
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/cookieCategory/index.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieCategory/index.ts
@@ -1,0 +1,89 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties } from 'n8n-workflow';
+import * as createOp from './create.operation';
+import * as getOp from './get.operation';
+import * as getAllOp from './getAll.operation';
+import * as updateOp from './update.operation';
+import * as deleteOp from './delete.operation';
+import * as reorderOp from './reorder.operation';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['cookieCategory'],
+			},
+		},
+		options: [
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create a new cookie category',
+				action: 'Create a cookie category',
+			},
+			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Delete a cookie category',
+				action: 'Delete a cookie category',
+			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a cookie category',
+				action: 'Get a cookie category',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get many cookie categories',
+				action: 'Get many cookie categories',
+			},
+			{
+				name: 'Reorder',
+				value: 'reorder',
+				description: 'Change the rank of a cookie category',
+				action: 'Reorder a cookie category',
+			},
+			{
+				name: 'Update',
+				value: 'update',
+				description: 'Update an existing cookie category',
+				action: 'Update a cookie category',
+			},
+		],
+		default: 'create',
+	},
+	...createOp.description,
+	...getOp.description,
+	...getAllOp.description,
+	...updateOp.description,
+	...deleteOp.description,
+	...reorderOp.description,
+];
+
+export {
+	createOp as create,
+	getOp as get,
+	getAllOp as getAll,
+	updateOp as update,
+	deleteOp as delete,
+	reorderOp as reorder,
+};

--- a/packages/n8n-node/nodes/Probo/actions/cookieCategory/reorder.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieCategory/reorder.operation.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { proboApiRequest } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Cookie Category ID',
+		name: 'cookieCategoryId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieCategory'],
+				operation: ['reorder'],
+			},
+		},
+		default: '',
+		description: 'The ID of the cookie category to reorder',
+		required: true,
+	},
+	{
+		displayName: 'Rank',
+		name: 'rank',
+		type: 'number',
+		displayOptions: {
+			show: {
+				resource: ['cookieCategory'],
+				operation: ['reorder'],
+			},
+		},
+		default: 0,
+		description: 'The new rank position for the cookie category',
+		required: true,
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const cookieCategoryId = this.getNodeParameter('cookieCategoryId', itemIndex) as string;
+	const rank = this.getNodeParameter('rank', itemIndex) as number;
+
+	const query = `
+		mutation ReorderCookieCategory($input: ReorderCookieCategoryInput!) {
+			reorderCookieCategory(input: $input) {
+				cookieBanner {
+					id
+					name
+				}
+			}
+		}
+	`;
+
+	const responseData = await proboApiRequest.call(this, query, {
+		input: { cookieCategoryId, rank },
+	});
+
+	return {
+		json: responseData,
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/cookieCategory/update.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieCategory/update.operation.ts
@@ -150,7 +150,10 @@ export async function execute(
 	if (slug) input.slug = slug;
 	if (categoryDescription) input.description = categoryDescription;
 	if (gcmConsentTypes) {
-		input.gcmConsentTypes = gcmConsentTypes.split(',').map((s) => s.trim());
+		input.gcmConsentTypes = gcmConsentTypes
+			.split(',')
+			.map((s) => s.trim())
+			.filter((s) => s.length > 0);
 	}
 	if (posthogConsent) input.posthogConsent = posthogConsent === 'true';
 

--- a/packages/n8n-node/nodes/Probo/actions/cookieCategory/update.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieCategory/update.operation.ts
@@ -1,0 +1,163 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { proboApiRequest } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Cookie Category ID',
+		name: 'cookieCategoryId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieCategory'],
+				operation: ['update'],
+			},
+		},
+		default: '',
+		description: 'The ID of the cookie category to update',
+		required: true,
+	},
+	{
+		displayName: 'Name',
+		name: 'name',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieCategory'],
+				operation: ['update'],
+			},
+		},
+		default: '',
+		description: 'The name of the cookie category',
+	},
+	{
+		displayName: 'Slug',
+		name: 'slug',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieCategory'],
+				operation: ['update'],
+			},
+		},
+		default: '',
+		description: 'The slug of the cookie category',
+	},
+	{
+		displayName: 'Description',
+		name: 'categoryDescription',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieCategory'],
+				operation: ['update'],
+			},
+		},
+		default: '',
+		description: 'The description of the cookie category',
+	},
+	{
+		displayName: 'GCM Consent Types',
+		name: 'gcmConsentTypes',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieCategory'],
+				operation: ['update'],
+			},
+		},
+		default: '',
+		description: 'Comma-separated list of GCM consent types',
+	},
+	{
+		displayName: 'PostHog Consent',
+		name: 'posthogConsent',
+		type: 'options',
+		displayOptions: {
+			show: {
+				resource: ['cookieCategory'],
+				operation: ['update'],
+			},
+		},
+		options: [
+			{
+				name: '(Unchanged)',
+				value: '',
+			},
+			{
+				name: 'True',
+				value: 'true',
+			},
+			{
+				name: 'False',
+				value: 'false',
+			},
+		],
+		default: '',
+		description: 'Whether this category maps to PostHog consent',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const cookieCategoryId = this.getNodeParameter('cookieCategoryId', itemIndex) as string;
+	const name = this.getNodeParameter('name', itemIndex, '') as string;
+	const slug = this.getNodeParameter('slug', itemIndex, '') as string;
+	const categoryDescription = this.getNodeParameter('categoryDescription', itemIndex, '') as string;
+	const gcmConsentTypes = this.getNodeParameter('gcmConsentTypes', itemIndex, '') as string;
+	const posthogConsent = this.getNodeParameter('posthogConsent', itemIndex, '') as string;
+
+	const query = `
+		mutation UpdateCookieCategory($input: UpdateCookieCategoryInput!) {
+			updateCookieCategory(input: $input) {
+				cookieCategory {
+					id
+					name
+					slug
+					description
+					kind
+					rank
+					gcmConsentTypes
+					posthogConsent
+					createdAt
+					updatedAt
+				}
+				cookieBanner {
+					id
+					name
+				}
+			}
+		}
+	`;
+
+	const input: Record<string, unknown> = { cookieCategoryId };
+	if (name) input.name = name;
+	if (slug) input.slug = slug;
+	if (categoryDescription) input.description = categoryDescription;
+	if (gcmConsentTypes) {
+		input.gcmConsentTypes = gcmConsentTypes.split(',').map((s) => s.trim());
+	}
+	if (posthogConsent) input.posthogConsent = posthogConsent === 'true';
+
+	const responseData = await proboApiRequest.call(this, query, { input });
+
+	return {
+		json: responseData,
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/cookieConsentRecord/get.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieConsentRecord/get.operation.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { proboApiRequest } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Cookie Consent Record ID',
+		name: 'cookieConsentRecordId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieConsentRecord'],
+				operation: ['get'],
+			},
+		},
+		default: '',
+		description: 'The ID of the cookie consent record',
+		required: true,
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const cookieConsentRecordId = this.getNodeParameter('cookieConsentRecordId', itemIndex) as string;
+
+	const query = `
+		query GetCookieConsentRecord($cookieConsentRecordId: ID!) {
+			node(id: $cookieConsentRecordId) {
+				... on CookieConsentRecord {
+					id
+					visitorId
+					ipAddress
+					userAgent
+					consentData
+					action
+					sdkVersion
+					createdAt
+				}
+			}
+		}
+	`;
+
+	const responseData = await proboApiRequest.call(this, query, { cookieConsentRecordId });
+
+	return {
+		json: responseData,
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/cookieConsentRecord/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieConsentRecord/getAll.operation.ts
@@ -1,0 +1,194 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
+import { proboApiRequestAllItems } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Cookie Banner ID',
+		name: 'cookieBannerId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieConsentRecord'],
+				operation: ['getAll'],
+			},
+		},
+		default: '',
+		description: 'The ID of the cookie banner',
+		required: true,
+	},
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		displayOptions: {
+			show: {
+				resource: ['cookieConsentRecord'],
+				operation: ['getAll'],
+			},
+		},
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		displayOptions: {
+			show: {
+				resource: ['cookieConsentRecord'],
+				operation: ['getAll'],
+				returnAll: [false],
+			},
+		},
+		typeOptions: {
+			minValue: 1,
+		},
+		default: 50,
+		description: 'Max number of results to return',
+	},
+	{
+		displayName: 'Filter by Action',
+		name: 'filterAction',
+		type: 'options',
+		displayOptions: {
+			show: {
+				resource: ['cookieConsentRecord'],
+				operation: ['getAll'],
+			},
+		},
+		options: [
+			{
+				name: '(No Filter)',
+				value: '',
+			},
+			{
+				name: 'Accept All',
+				value: 'ACCEPT_ALL',
+			},
+			{
+				name: 'Customize',
+				value: 'CUSTOMIZE',
+			},
+			{
+				name: 'GPC',
+				value: 'GPC',
+			},
+			{
+				name: 'Reject All',
+				value: 'REJECT_ALL',
+			},
+		],
+		default: '',
+		description: 'Filter consent records by action',
+	},
+	{
+		displayName: 'Filter by Visitor ID',
+		name: 'filterVisitorId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookieConsentRecord'],
+				operation: ['getAll'],
+			},
+		},
+		default: '',
+		description: 'Filter consent records by visitor ID',
+	},
+	{
+		displayName: 'Filter by Version',
+		name: 'filterVersion',
+		type: 'number',
+		displayOptions: {
+			show: {
+				resource: ['cookieConsentRecord'],
+				operation: ['getAll'],
+			},
+		},
+		default: 0,
+		description: 'Filter consent records by banner version number (0 to skip)',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const cookieBannerId = this.getNodeParameter('cookieBannerId', itemIndex) as string;
+	const returnAll = this.getNodeParameter('returnAll', itemIndex) as boolean;
+	const limit = this.getNodeParameter('limit', itemIndex, 50) as number;
+	const filterAction = this.getNodeParameter('filterAction', itemIndex, '') as string;
+	const filterVisitorId = this.getNodeParameter('filterVisitorId', itemIndex, '') as string;
+	const filterVersion = this.getNodeParameter('filterVersion', itemIndex, 0) as number;
+
+	const hasFilter = filterAction || filterVisitorId || filterVersion;
+	const filterClause = hasFilter ? ', $filter: CookieConsentRecordFilter' : '';
+	const filterArg = hasFilter ? ', filter: $filter' : '';
+
+	const query = `
+		query GetCookieConsentRecords($cookieBannerId: ID!, $first: Int, $after: CursorKey${filterClause}) {
+			node(id: $cookieBannerId) {
+				... on CookieBanner {
+					consentRecords(first: $first, after: $after${filterArg}) {
+						edges {
+							node {
+								id
+								visitorId
+								ipAddress
+								userAgent
+								consentData
+								action
+								sdkVersion
+								createdAt
+							}
+						}
+						pageInfo {
+							hasNextPage
+							endCursor
+						}
+					}
+				}
+			}
+		}
+	`;
+
+	const variables: Record<string, unknown> = { cookieBannerId };
+	if (hasFilter) {
+		const filter: Record<string, unknown> = {};
+		if (filterAction) filter.action = filterAction;
+		if (filterVisitorId) filter.visitorId = filterVisitorId;
+		if (filterVersion) filter.version = filterVersion;
+		variables.filter = filter;
+	}
+
+	const cookieConsentRecords = await proboApiRequestAllItems.call(
+		this,
+		query,
+		variables,
+		(response) => {
+			const data = response?.data as IDataObject | undefined;
+			const node = data?.node as IDataObject | undefined;
+			return node?.consentRecords as IDataObject | undefined;
+		},
+		returnAll,
+		limit,
+	);
+
+	return {
+		json: { cookieConsentRecords },
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/cookieConsentRecord/index.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieConsentRecord/index.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties } from 'n8n-workflow';
+import * as getOp from './get.operation';
+import * as getAllOp from './getAll.operation';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['cookieConsentRecord'],
+			},
+		},
+		options: [
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a cookie consent record',
+				action: 'Get a cookie consent record',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get many cookie consent records',
+				action: 'Get many cookie consent records',
+			},
+		],
+		default: 'get',
+	},
+	...getOp.description,
+	...getAllOp.description,
+];
+
+export {
+	getOp as get,
+	getAllOp as getAll,
+};

--- a/packages/n8n-node/nodes/Probo/actions/cookiePattern/create.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookiePattern/create.operation.ts
@@ -134,6 +134,7 @@ export async function execute(
 						maxAgeSeconds
 						description
 						source
+						excluded
 						createdAt
 						updatedAt
 					}

--- a/packages/n8n-node/nodes/Probo/actions/cookiePattern/create.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookiePattern/create.operation.ts
@@ -1,0 +1,164 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { proboApiRequest } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Cookie Category ID',
+		name: 'cookieCategoryId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookiePattern'],
+				operation: ['create'],
+			},
+		},
+		default: '',
+		description: 'The ID of the cookie category',
+		required: true,
+	},
+	{
+		displayName: 'Pattern',
+		name: 'pattern',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookiePattern'],
+				operation: ['create'],
+			},
+		},
+		default: '',
+		description: 'The cookie name pattern to match',
+		required: true,
+	},
+	{
+		displayName: 'Match Type',
+		name: 'matchType',
+		type: 'options',
+		displayOptions: {
+			show: {
+				resource: ['cookiePattern'],
+				operation: ['create'],
+			},
+		},
+		options: [
+			{
+				name: 'Exact',
+				value: 'EXACT',
+			},
+			{
+				name: 'Prefix',
+				value: 'PREFIX',
+			},
+		],
+		default: 'EXACT',
+		description: 'How the pattern should be matched against cookie names',
+		required: true,
+	},
+	{
+		displayName: 'Display Name',
+		name: 'displayName',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookiePattern'],
+				operation: ['create'],
+			},
+		},
+		default: '',
+		description: 'The display name for the cookie pattern',
+		required: true,
+	},
+	{
+		displayName: 'Description',
+		name: 'description',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookiePattern'],
+				operation: ['create'],
+			},
+		},
+		default: '',
+		description: 'The description of the cookie pattern',
+		required: true,
+	},
+	{
+		displayName: 'Max Age Seconds',
+		name: 'maxAgeSeconds',
+		type: 'number',
+		displayOptions: {
+			show: {
+				resource: ['cookiePattern'],
+				operation: ['create'],
+			},
+		},
+		default: 0,
+		description: 'The maximum age of the cookie in seconds (0 to omit)',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const cookieCategoryId = this.getNodeParameter('cookieCategoryId', itemIndex) as string;
+	const pattern = this.getNodeParameter('pattern', itemIndex) as string;
+	const matchType = this.getNodeParameter('matchType', itemIndex) as string;
+	const displayName = this.getNodeParameter('displayName', itemIndex) as string;
+	const description = this.getNodeParameter('description', itemIndex) as string;
+	const maxAgeSeconds = this.getNodeParameter('maxAgeSeconds', itemIndex, 0) as number;
+
+	const query = `
+		mutation CreateCookiePattern($input: CreateCookiePatternInput!) {
+			createCookiePattern(input: $input) {
+				cookiePatternEdge {
+					node {
+						id
+						pattern
+						matchType
+						displayName
+						maxAgeSeconds
+						description
+						source
+						createdAt
+						updatedAt
+					}
+				}
+				cookieBanner {
+					id
+					name
+				}
+			}
+		}
+	`;
+
+	const input: Record<string, unknown> = {
+		cookieCategoryId,
+		pattern,
+		matchType,
+		displayName,
+		description,
+	};
+	if (maxAgeSeconds) input.maxAgeSeconds = maxAgeSeconds;
+
+	const responseData = await proboApiRequest.call(this, query, { input });
+
+	return {
+		json: responseData,
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/cookiePattern/delete.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookiePattern/delete.operation.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { proboApiRequest } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Cookie Pattern ID',
+		name: 'cookiePatternId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookiePattern'],
+				operation: ['delete'],
+			},
+		},
+		default: '',
+		description: 'The ID of the cookie pattern to delete',
+		required: true,
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const cookiePatternId = this.getNodeParameter('cookiePatternId', itemIndex) as string;
+
+	const query = `
+		mutation DeleteCookiePattern($input: DeleteCookiePatternInput!) {
+			deleteCookiePattern(input: $input) {
+				deletedCookiePatternId
+				cookieBanner {
+					id
+					name
+				}
+			}
+		}
+	`;
+
+	const responseData = await proboApiRequest.call(this, query, { input: { cookiePatternId } });
+
+	return {
+		json: responseData,
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/cookiePattern/get.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookiePattern/get.operation.ts
@@ -1,0 +1,65 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { proboApiRequest } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Cookie Pattern ID',
+		name: 'cookiePatternId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookiePattern'],
+				operation: ['get'],
+			},
+		},
+		default: '',
+		description: 'The ID of the cookie pattern',
+		required: true,
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const cookiePatternId = this.getNodeParameter('cookiePatternId', itemIndex) as string;
+
+	const query = `
+		query GetCookiePattern($cookiePatternId: ID!) {
+			node(id: $cookiePatternId) {
+				... on CookiePattern {
+					id
+					pattern
+					matchType
+					displayName
+					maxAgeSeconds
+					description
+					source
+					createdAt
+					updatedAt
+				}
+			}
+		}
+	`;
+
+	const responseData = await proboApiRequest.call(this, query, { cookiePatternId });
+
+	return {
+		json: responseData,
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/cookiePattern/get.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookiePattern/get.operation.ts
@@ -49,6 +49,7 @@ export async function execute(
 					maxAgeSeconds
 					description
 					source
+					excluded
 					createdAt
 					updatedAt
 				}

--- a/packages/n8n-node/nodes/Probo/actions/cookiePattern/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookiePattern/getAll.operation.ts
@@ -1,0 +1,118 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
+import { proboApiRequestAllItems } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Cookie Category ID',
+		name: 'cookieCategoryId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookiePattern'],
+				operation: ['getAll'],
+			},
+		},
+		default: '',
+		description: 'The ID of the cookie category',
+		required: true,
+	},
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		displayOptions: {
+			show: {
+				resource: ['cookiePattern'],
+				operation: ['getAll'],
+			},
+		},
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		displayOptions: {
+			show: {
+				resource: ['cookiePattern'],
+				operation: ['getAll'],
+				returnAll: [false],
+			},
+		},
+		typeOptions: {
+			minValue: 1,
+		},
+		default: 50,
+		description: 'Max number of results to return',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const cookieCategoryId = this.getNodeParameter('cookieCategoryId', itemIndex) as string;
+	const returnAll = this.getNodeParameter('returnAll', itemIndex) as boolean;
+	const limit = this.getNodeParameter('limit', itemIndex, 50) as number;
+
+	const query = `
+		query GetCookiePatterns($cookieCategoryId: ID!, $first: Int, $after: CursorKey) {
+			node(id: $cookieCategoryId) {
+				... on CookieCategory {
+					cookiePatterns(first: $first, after: $after) {
+						edges {
+							node {
+								id
+								pattern
+								matchType
+								displayName
+								maxAgeSeconds
+								description
+								source
+								createdAt
+								updatedAt
+							}
+						}
+						pageInfo {
+							hasNextPage
+							endCursor
+						}
+					}
+				}
+			}
+		}
+	`;
+
+	const cookiePatterns = await proboApiRequestAllItems.call(
+		this,
+		query,
+		{ cookieCategoryId },
+		(response) => {
+			const data = response?.data as IDataObject | undefined;
+			const node = data?.node as IDataObject | undefined;
+			return node?.cookiePatterns as IDataObject | undefined;
+		},
+		returnAll,
+		limit,
+	);
+
+	return {
+		json: { cookiePatterns },
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/cookiePattern/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookiePattern/getAll.operation.ts
@@ -84,6 +84,7 @@ export async function execute(
 								maxAgeSeconds
 								description
 								source
+								excluded
 								createdAt
 								updatedAt
 							}

--- a/packages/n8n-node/nodes/Probo/actions/cookiePattern/index.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookiePattern/index.ts
@@ -1,0 +1,89 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties } from 'n8n-workflow';
+import * as createOp from './create.operation';
+import * as getOp from './get.operation';
+import * as getAllOp from './getAll.operation';
+import * as updateOp from './update.operation';
+import * as deleteOp from './delete.operation';
+import * as moveOp from './move.operation';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['cookiePattern'],
+			},
+		},
+		options: [
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create a new cookie pattern',
+				action: 'Create a cookie pattern',
+			},
+			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Delete a cookie pattern',
+				action: 'Delete a cookie pattern',
+			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a cookie pattern',
+				action: 'Get a cookie pattern',
+			},
+			{
+				name: 'Get Many',
+				value: 'getAll',
+				description: 'Get many cookie patterns',
+				action: 'Get many cookie patterns',
+			},
+			{
+				name: 'Move',
+				value: 'move',
+				description: 'Move a cookie pattern to a different category',
+				action: 'Move a cookie pattern',
+			},
+			{
+				name: 'Update',
+				value: 'update',
+				description: 'Update an existing cookie pattern',
+				action: 'Update a cookie pattern',
+			},
+		],
+		default: 'create',
+	},
+	...createOp.description,
+	...getOp.description,
+	...getAllOp.description,
+	...updateOp.description,
+	...deleteOp.description,
+	...moveOp.description,
+];
+
+export {
+	createOp as create,
+	getOp as get,
+	getAllOp as getAll,
+	updateOp as update,
+	deleteOp as delete,
+	moveOp as move,
+};

--- a/packages/n8n-node/nodes/Probo/actions/cookiePattern/move.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookiePattern/move.operation.ts
@@ -64,6 +64,7 @@ export async function execute(
 					maxAgeSeconds
 					description
 					source
+					excluded
 					createdAt
 					updatedAt
 				}

--- a/packages/n8n-node/nodes/Probo/actions/cookiePattern/move.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookiePattern/move.operation.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { proboApiRequest } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Cookie Pattern ID',
+		name: 'cookiePatternId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookiePattern'],
+				operation: ['move'],
+			},
+		},
+		default: '',
+		description: 'The ID of the cookie pattern to move',
+		required: true,
+	},
+	{
+		displayName: 'Target Cookie Category ID',
+		name: 'targetCookieCategoryId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookiePattern'],
+				operation: ['move'],
+			},
+		},
+		default: '',
+		description: 'The ID of the target cookie category',
+		required: true,
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const cookiePatternId = this.getNodeParameter('cookiePatternId', itemIndex) as string;
+	const targetCookieCategoryId = this.getNodeParameter('targetCookieCategoryId', itemIndex) as string;
+
+	const query = `
+		mutation MoveCookiePatternToCategory($input: MoveCookiePatternToCategoryInput!) {
+			moveCookiePatternToCategory(input: $input) {
+				cookiePattern {
+					id
+					pattern
+					matchType
+					displayName
+					maxAgeSeconds
+					description
+					source
+					createdAt
+					updatedAt
+				}
+				cookieBanner {
+					id
+					name
+				}
+			}
+		}
+	`;
+
+	const responseData = await proboApiRequest.call(this, query, {
+		input: { cookiePatternId, targetCookieCategoryId },
+	});
+
+	return {
+		json: responseData,
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/cookiePattern/update.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookiePattern/update.operation.ts
@@ -44,19 +44,6 @@ export const description: INodeProperties[] = [
 		description: 'The display name for the cookie pattern',
 	},
 	{
-		displayName: 'Max Age Seconds',
-		name: 'maxAgeSeconds',
-		type: 'number',
-		displayOptions: {
-			show: {
-				resource: ['cookiePattern'],
-				operation: ['update'],
-			},
-		},
-		default: 0,
-		description: 'The maximum age of the cookie in seconds (leave at 0 to keep unchanged)',
-	},
-	{
 		displayName: 'Excluded',
 		name: 'excluded',
 		type: 'options',
@@ -96,6 +83,31 @@ export const description: INodeProperties[] = [
 		default: '',
 		description: 'The description of the cookie pattern',
 	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['cookiePattern'],
+				operation: ['update'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Max Age Seconds',
+				name: 'maxAgeSeconds',
+				type: 'number',
+				typeOptions: {
+					minValue: 0,
+				},
+				default: 0,
+				description: 'The maximum age of the cookie in seconds. Set to 0 to clear the existing value.',
+			},
+		],
+	},
 ];
 
 export async function execute(
@@ -104,9 +116,11 @@ export async function execute(
 ): Promise<INodeExecutionData> {
 	const cookiePatternId = this.getNodeParameter('cookiePatternId', itemIndex) as string;
 	const displayName = this.getNodeParameter('displayName', itemIndex, '') as string;
-	const maxAgeSeconds = this.getNodeParameter('maxAgeSeconds', itemIndex, 0) as number;
 	const excluded = this.getNodeParameter('excluded', itemIndex, '') as string;
 	const patternDescription = this.getNodeParameter('patternDescription', itemIndex, '') as string;
+	const additionalFields = this.getNodeParameter('additionalFields', itemIndex, {}) as {
+		maxAgeSeconds?: number;
+	};
 
 	const query = `
 		mutation UpdateCookiePattern($input: UpdateCookiePatternInput!) {
@@ -133,9 +147,11 @@ export async function execute(
 
 	const input: Record<string, unknown> = { cookiePatternId };
 	if (displayName) input.displayName = displayName;
-	if (maxAgeSeconds > 0) input.maxAgeSeconds = maxAgeSeconds;
 	if (excluded) input.excluded = excluded === 'true';
 	if (patternDescription) input.description = patternDescription;
+	if (additionalFields.maxAgeSeconds !== undefined) {
+		input.maxAgeSeconds = additionalFields.maxAgeSeconds === 0 ? null : additionalFields.maxAgeSeconds;
+	}
 
 	const responseData = await proboApiRequest.call(this, query, { input });
 

--- a/packages/n8n-node/nodes/Probo/actions/cookiePattern/update.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookiePattern/update.operation.ts
@@ -57,6 +57,33 @@ export const description: INodeProperties[] = [
 		description: 'The maximum age of the cookie in seconds (0 to clear)',
 	},
 	{
+		displayName: 'Excluded',
+		name: 'excluded',
+		type: 'options',
+		displayOptions: {
+			show: {
+				resource: ['cookiePattern'],
+				operation: ['update'],
+			},
+		},
+		options: [
+			{
+				name: '(Unchanged)',
+				value: '',
+			},
+			{
+				name: 'False',
+				value: 'false',
+			},
+			{
+				name: 'True',
+				value: 'true',
+			},
+		],
+		default: '',
+		description: 'Whether the cookie pattern is excluded from the banner',
+	},
+	{
 		displayName: 'Description',
 		name: 'patternDescription',
 		type: 'string',
@@ -78,6 +105,7 @@ export async function execute(
 	const cookiePatternId = this.getNodeParameter('cookiePatternId', itemIndex) as string;
 	const displayName = this.getNodeParameter('displayName', itemIndex, '') as string;
 	const maxAgeSeconds = this.getNodeParameter('maxAgeSeconds', itemIndex, 0) as number;
+	const excluded = this.getNodeParameter('excluded', itemIndex, '') as string;
 	const patternDescription = this.getNodeParameter('patternDescription', itemIndex, '') as string;
 
 	const query = `
@@ -91,6 +119,7 @@ export async function execute(
 					maxAgeSeconds
 					description
 					source
+					excluded
 					createdAt
 					updatedAt
 				}
@@ -107,6 +136,7 @@ export async function execute(
 	if (maxAgeSeconds !== undefined) {
 		input.maxAgeSeconds = maxAgeSeconds === 0 ? null : maxAgeSeconds;
 	}
+	if (excluded) input.excluded = excluded === 'true';
 	if (patternDescription) input.description = patternDescription;
 
 	const responseData = await proboApiRequest.call(this, query, { input });

--- a/packages/n8n-node/nodes/Probo/actions/cookiePattern/update.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookiePattern/update.operation.ts
@@ -54,7 +54,7 @@ export const description: INodeProperties[] = [
 			},
 		},
 		default: 0,
-		description: 'The maximum age of the cookie in seconds (0 to clear)',
+		description: 'The maximum age of the cookie in seconds (leave at 0 to keep unchanged)',
 	},
 	{
 		displayName: 'Excluded',
@@ -133,9 +133,7 @@ export async function execute(
 
 	const input: Record<string, unknown> = { cookiePatternId };
 	if (displayName) input.displayName = displayName;
-	if (maxAgeSeconds !== undefined) {
-		input.maxAgeSeconds = maxAgeSeconds === 0 ? null : maxAgeSeconds;
-	}
+	if (maxAgeSeconds > 0) input.maxAgeSeconds = maxAgeSeconds;
 	if (excluded) input.excluded = excluded === 'true';
 	if (patternDescription) input.description = patternDescription;
 

--- a/packages/n8n-node/nodes/Probo/actions/cookiePattern/update.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookiePattern/update.operation.ts
@@ -1,0 +1,118 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { proboApiRequest } from '../../GenericFunctions';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Cookie Pattern ID',
+		name: 'cookiePatternId',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookiePattern'],
+				operation: ['update'],
+			},
+		},
+		default: '',
+		description: 'The ID of the cookie pattern to update',
+		required: true,
+	},
+	{
+		displayName: 'Display Name',
+		name: 'displayName',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookiePattern'],
+				operation: ['update'],
+			},
+		},
+		default: '',
+		description: 'The display name for the cookie pattern',
+	},
+	{
+		displayName: 'Max Age Seconds',
+		name: 'maxAgeSeconds',
+		type: 'number',
+		displayOptions: {
+			show: {
+				resource: ['cookiePattern'],
+				operation: ['update'],
+			},
+		},
+		default: 0,
+		description: 'The maximum age of the cookie in seconds (0 to clear)',
+	},
+	{
+		displayName: 'Description',
+		name: 'patternDescription',
+		type: 'string',
+		displayOptions: {
+			show: {
+				resource: ['cookiePattern'],
+				operation: ['update'],
+			},
+		},
+		default: '',
+		description: 'The description of the cookie pattern',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	itemIndex: number,
+): Promise<INodeExecutionData> {
+	const cookiePatternId = this.getNodeParameter('cookiePatternId', itemIndex) as string;
+	const displayName = this.getNodeParameter('displayName', itemIndex, '') as string;
+	const maxAgeSeconds = this.getNodeParameter('maxAgeSeconds', itemIndex, 0) as number;
+	const patternDescription = this.getNodeParameter('patternDescription', itemIndex, '') as string;
+
+	const query = `
+		mutation UpdateCookiePattern($input: UpdateCookiePatternInput!) {
+			updateCookiePattern(input: $input) {
+				cookiePattern {
+					id
+					pattern
+					matchType
+					displayName
+					maxAgeSeconds
+					description
+					source
+					createdAt
+					updatedAt
+				}
+				cookieBanner {
+					id
+					name
+				}
+			}
+		}
+	`;
+
+	const input: Record<string, unknown> = { cookiePatternId };
+	if (displayName) input.displayName = displayName;
+	if (maxAgeSeconds !== undefined) {
+		input.maxAgeSeconds = maxAgeSeconds === 0 ? null : maxAgeSeconds;
+	}
+	if (patternDescription) input.description = patternDescription;
+
+	const responseData = await proboApiRequest.call(this, query, { input });
+
+	return {
+		json: responseData,
+		pairedItem: { item: itemIndex },
+	};
+}

--- a/packages/n8n-node/nodes/Probo/actions/index.ts
+++ b/packages/n8n-node/nodes/Probo/actions/index.ts
@@ -18,6 +18,10 @@ import * as asset from './asset';
 import * as audit from './audit';
 import * as auditLog from './auditLog';
 import * as control from './control';
+import * as cookieBanner from './cookieBanner';
+import * as cookieCategory from './cookieCategory';
+import * as cookieConsentRecord from './cookieConsentRecord';
+import * as cookiePattern from './cookiePattern';
 import * as datum from './datum';
 import * as document from './document';
 import * as dpia from './dpia';
@@ -57,6 +61,10 @@ export const resources: Record<string, ResourceModule> = {
 	audit: audit as ResourceModule,
 	auditLog: auditLog as ResourceModule,
 	control: control as ResourceModule,
+	cookieBanner: cookieBanner as ResourceModule,
+	cookieCategory: cookieCategory as ResourceModule,
+	cookieConsentRecord: cookieConsentRecord as ResourceModule,
+	cookiePattern: cookiePattern as ResourceModule,
 	datum: datum as ResourceModule,
 	document: document as ResourceModule,
 	dpia: dpia as ResourceModule,


### PR DESCRIPTION
Adds four new resources (cookieBanner, cookieCategory, cookiePattern, cookieConsentRecord) covering all mutations and queries from the cookie banner GraphQL resolvers.