### PR TITLE
Use natural sort for SOA document export rows

### DIFF
--- a/pkg/coredata/applicability_statement.go
+++ b/pkg/coredata/applicability_statement.go
@@ -493,7 +493,7 @@ WHERE
     a.%s
     AND a.statement_of_applicability_id = @statement_of_applicability_id
 ORDER BY
-    section_title ASC;
+    section_title_sort_key(f.name || ' - ' || c.section_title) ASC;
 `
 	q = fmt.Sprintf(q, scope.SQLFragment())
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch SOA document export rows to natural sorting using a key built from framework name and section title. Numbers now sort naturally (e.g., 2 before 10) across combined titles for better readability.

<sup>Written for commit 385df9ee6ac54c8674c9d86fc1e40afc24fd9bed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

