### PR TITLE
SCIM config missing surfaces

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -44,6 +44,7 @@ import (
 	processingactivity "go.probo.inc/probo/pkg/cmd/processing-activity"
 	rightsrequest "go.probo.inc/probo/pkg/cmd/rights-request"
 	"go.probo.inc/probo/pkg/cmd/risk"
+	"go.probo.inc/probo/pkg/cmd/scim"
 	"go.probo.inc/probo/pkg/cmd/soa"
 	"go.probo.inc/probo/pkg/cmd/task"
 	"go.probo.inc/probo/pkg/cmd/tia"
@@ -111,6 +112,7 @@ func NewCmdRoot(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(processingactivity.NewCmdProcessingActivity(f))
 	cmd.AddCommand(rightsrequest.NewCmdRightsRequest(f))
 	cmd.AddCommand(risk.NewCmdRisk(f))
+	cmd.AddCommand(scim.NewCmdScim(f))
 	cmd.AddCommand(soa.NewCmdSoa(f))
 	cmd.AddCommand(task.NewCmdTask(f))
 	cmd.AddCommand(tia.NewCmdTIA(f))

--- a/pkg/cmd/scim/bridge/bridge.go
+++ b/pkg/cmd/scim/bridge/bridge.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package bridge
+
+import (
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+	"go.probo.inc/probo/pkg/cmd/scim/bridge/update"
+	"go.probo.inc/probo/pkg/cmd/scim/bridge/view"
+)
+
+func NewCmdBridge(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "bridge <command>",
+		Short: "Manage SCIM bridges",
+	}
+
+	cmd.AddCommand(view.NewCmdView(f))
+	cmd.AddCommand(update.NewCmdUpdate(f))
+
+	return cmd
+}

--- a/pkg/cmd/scim/bridge/update/update.go
+++ b/pkg/cmd/scim/bridge/update/update.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package update
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const updateMutation = `
+mutation($input: UpdateSCIMBridgeInput!) {
+  updateSCIMBridge(input: $input) {
+    scimBridge {
+      id
+      state
+      excludedUserNames
+    }
+  }
+}
+`
+
+type updateResponse struct {
+	UpdateSCIMBridge struct {
+		ScimBridge struct {
+			ID                string   `json:"id"`
+			State             string   `json:"state"`
+			ExcludedUserNames []string `json:"excludedUserNames"`
+		} `json:"scimBridge"`
+	} `json:"updateSCIMBridge"`
+}
+
+func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
+	var (
+		flagOrg               string
+		flagExcludedUserNames []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update a SCIM bridge",
+		Example: `  # Set excluded user names
+  prb scim bridge update <id> --excluded-user-names admin@example.com --excluded-user-names bot@example.com
+
+  # Clear excluded user names
+  prb scim bridge update <id> --excluded-user-names ""`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !cmd.Flags().Changed("excluded-user-names") {
+				return fmt.Errorf("at least one field must be specified for update; use --excluded-user-names")
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/connect/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			if flagOrg == "" {
+				flagOrg = hc.Organization
+			}
+
+			if flagOrg == "" {
+				return fmt.Errorf("organization is required; pass --org or set a default with 'prb auth login'")
+			}
+
+			excluded := make([]string, 0, len(flagExcludedUserNames))
+			for _, name := range flagExcludedUserNames {
+				if name != "" {
+					excluded = append(excluded, name)
+				}
+			}
+
+			data, err := client.Do(
+				updateMutation,
+				map[string]any{
+					"input": map[string]any{
+						"organizationId":    flagOrg,
+						"scimBridgeId":      args[0],
+						"excludedUserNames": excluded,
+					},
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			var resp updateResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return fmt.Errorf("cannot parse response: %w", err)
+			}
+
+			_, _ = fmt.Fprintf(
+				f.IOStreams.Out,
+				"Updated SCIM bridge %s\n",
+				resp.UpdateSCIMBridge.ScimBridge.ID,
+			)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&flagOrg, "org", "", "Organization ID")
+	cmd.Flags().StringSliceVar(&flagExcludedUserNames, "excluded-user-names", nil, "User names to exclude from SCIM sync (repeatable)")
+
+	return cmd
+}

--- a/pkg/cmd/scim/bridge/view/view.go
+++ b/pkg/cmd/scim/bridge/view/view.go
@@ -1,0 +1,164 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package view
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const viewQuery = `
+query($id: ID!) {
+  node(id: $id) {
+    __typename
+    ... on SCIMBridge {
+      id
+      state
+      type
+      excludedUserNames
+      scimConfiguration {
+        id
+      }
+      connector {
+        id
+        provider
+      }
+      createdAt
+      updatedAt
+    }
+  }
+}
+`
+
+type (
+	connector struct {
+		ID       string `json:"id"`
+		Provider string `json:"provider"`
+	}
+
+	viewResponse struct {
+		Node *struct {
+			Typename          string   `json:"__typename"`
+			ID                string   `json:"id"`
+			State             string   `json:"state"`
+			Type              string   `json:"type"`
+			ExcludedUserNames []string `json:"excludedUserNames"`
+			ScimConfiguration *struct {
+				ID string `json:"id"`
+			} `json:"scimConfiguration"`
+			Connector *connector `json:"connector"`
+			CreatedAt string     `json:"createdAt"`
+			UpdatedAt string     `json:"updatedAt"`
+		} `json:"node"`
+	}
+)
+
+func NewCmdView(f *cmdutil.Factory) *cobra.Command {
+	var flagOutput *string
+
+	cmd := &cobra.Command{
+		Use:   "view <id>",
+		Short: "View a SCIM bridge",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmdutil.ValidateOutputFlag(flagOutput); err != nil {
+				return err
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/connect/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			data, err := client.Do(
+				viewQuery,
+				map[string]any{"id": args[0]},
+			)
+			if err != nil {
+				return err
+			}
+
+			var resp viewResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return fmt.Errorf("cannot parse response: %w", err)
+			}
+
+			if resp.Node == nil {
+				return fmt.Errorf("SCIM bridge %s not found", args[0])
+			}
+
+			if resp.Node.Typename != "SCIMBridge" {
+				return fmt.Errorf("expected SCIMBridge node, got %s", resp.Node.Typename)
+			}
+
+			if *flagOutput == cmdutil.OutputJSON {
+				return cmdutil.PrintJSON(f.IOStreams.Out, resp.Node)
+			}
+
+			b := resp.Node
+			out := f.IOStreams.Out
+			bold := lipgloss.NewStyle().Bold(true)
+			label := lipgloss.NewStyle().Foreground(lipgloss.Color("242")).Width(22)
+
+			_, _ = fmt.Fprintf(out, "%s\n\n", bold.Render("SCIM Bridge"))
+
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("ID:"), b.ID)
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("State:"), b.State)
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Type:"), b.Type)
+
+			if b.ScimConfiguration != nil {
+				_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Configuration ID:"), b.ScimConfiguration.ID)
+			}
+
+			if b.Connector != nil {
+				_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Connector ID:"), b.Connector.ID)
+				_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Connector Provider:"), b.Connector.Provider)
+			}
+
+			if len(b.ExcludedUserNames) > 0 {
+				_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Excluded Users:"), strings.Join(b.ExcludedUserNames, ", "))
+			}
+
+			_, _ = fmt.Fprintln(out)
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Created:"), cmdutil.FormatTime(b.CreatedAt))
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Updated:"), cmdutil.FormatTime(b.UpdatedAt))
+
+			return nil
+		},
+	}
+
+	flagOutput = cmdutil.AddOutputFlag(cmd)
+
+	return cmd
+}

--- a/pkg/cmd/scim/create/create.go
+++ b/pkg/cmd/scim/create/create.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package create
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const createMutation = `
+mutation($input: CreateSCIMConfigurationInput!) {
+  createSCIMConfiguration(input: $input) {
+    scimConfiguration {
+      id
+      endpointUrl
+    }
+    scimBridge {
+      id
+      state
+      type
+    }
+    token
+  }
+}
+`
+
+type createResponse struct {
+	CreateSCIMConfiguration struct {
+		ScimConfiguration struct {
+			ID          string `json:"id"`
+			EndpointURL string `json:"endpointUrl"`
+		} `json:"scimConfiguration"`
+		ScimBridge *struct {
+			ID    string `json:"id"`
+			State string `json:"state"`
+			Type  string `json:"type"`
+		} `json:"scimBridge"`
+		Token string `json:"token"`
+	} `json:"createSCIMConfiguration"`
+}
+
+func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
+	var (
+		flagOrg         string
+		flagConnectorID string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a SCIM configuration",
+		Example: `  # Create a SCIM configuration
+  prb scim create
+
+  # Create with a connector to also set up a SCIM bridge
+  prb scim create --connector-id <connector-id>`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/connect/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			if flagOrg == "" {
+				flagOrg = hc.Organization
+			}
+
+			if flagOrg == "" {
+				return fmt.Errorf("organization is required; pass --org or set a default with 'prb auth login'")
+			}
+
+			input := map[string]any{
+				"organizationId": flagOrg,
+			}
+
+			if flagConnectorID != "" {
+				input["connectorId"] = flagConnectorID
+			}
+
+			data, err := client.Do(
+				createMutation,
+				map[string]any{"input": input},
+			)
+			if err != nil {
+				return err
+			}
+
+			var resp createResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return fmt.Errorf("cannot parse response: %w", err)
+			}
+
+			out := f.IOStreams.Out
+			sc := resp.CreateSCIMConfiguration
+
+			_, _ = fmt.Fprintf(out, "Created SCIM configuration %s\n", sc.ScimConfiguration.ID)
+			_, _ = fmt.Fprintf(out, "Endpoint URL: %s\n", sc.ScimConfiguration.EndpointURL)
+
+			if sc.ScimBridge != nil {
+				_, _ = fmt.Fprintf(out, "Bridge: %s (%s, %s)\n", sc.ScimBridge.ID, sc.ScimBridge.Type, sc.ScimBridge.State)
+			}
+
+			_, _ = fmt.Fprintf(out, "\nSCIM Bearer Token (save this — it will not be shown again):\n%s\n", sc.Token)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&flagOrg, "org", "", "Organization ID")
+	cmd.Flags().StringVar(&flagConnectorID, "connector-id", "", "Connector ID to create a SCIM bridge")
+
+	return cmd
+}

--- a/pkg/cmd/scim/delete/delete.go
+++ b/pkg/cmd/scim/delete/delete.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package delete
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/huh"
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const deleteMutation = `
+mutation($input: DeleteSCIMConfigurationInput!) {
+  deleteSCIMConfiguration(input: $input) {
+    deletedScimConfigurationId
+  }
+}
+`
+
+func NewCmdDelete(f *cmdutil.Factory) *cobra.Command {
+	var (
+		flagOrg string
+		flagYes bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "delete <scim-configuration-id>",
+		Short: "Delete a SCIM configuration",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !flagYes {
+				if !f.IOStreams.IsInteractive() {
+					return fmt.Errorf("cannot delete SCIM configuration: confirmation required, use --yes to confirm")
+				}
+
+				var confirmed bool
+				err := huh.NewConfirm().
+					Title(fmt.Sprintf("Delete SCIM configuration %s? This will also remove the associated bridge.", args[0])).
+					Value(&confirmed).
+					Run()
+				if err != nil {
+					return err
+				}
+				if !confirmed {
+					return nil
+				}
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/connect/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			if flagOrg == "" {
+				flagOrg = hc.Organization
+			}
+
+			if flagOrg == "" {
+				return fmt.Errorf("organization is required; pass --org or set a default with 'prb auth login'")
+			}
+
+			_, err = client.Do(
+				deleteMutation,
+				map[string]any{
+					"input": map[string]any{
+						"organizationId":      flagOrg,
+						"scimConfigurationId": args[0],
+					},
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			_, _ = fmt.Fprintf(
+				f.IOStreams.Out,
+				"Deleted SCIM configuration %s\n",
+				args[0],
+			)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&flagOrg, "org", "", "Organization ID")
+	cmd.Flags().BoolVarP(&flagYes, "yes", "y", false, "Skip confirmation prompt")
+
+	return cmd
+}

--- a/pkg/cmd/scim/event/event.go
+++ b/pkg/cmd/scim/event/event.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package event
+
+import (
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+	"go.probo.inc/probo/pkg/cmd/scim/event/list"
+)
+
+func NewCmdEvent(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "event <command>",
+		Short: "Manage SCIM events",
+	}
+
+	cmd.AddCommand(list.NewCmdList(f))
+
+	return cmd
+}

--- a/pkg/cmd/scim/event/list/list.go
+++ b/pkg/cmd/scim/event/list/list.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package list
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const listQuery = `
+query($id: ID!, $first: Int, $after: CursorKey, $orderBy: SCIMEventOrder) {
+  node(id: $id) {
+    __typename
+    ... on SCIMConfiguration {
+      events(first: $first, after: $after, orderBy: $orderBy) {
+        totalCount
+        edges {
+          node {
+            id
+            method
+            path
+            statusCode
+            userName
+            ipAddress
+            createdAt
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}
+`
+
+type scimEvent struct {
+	ID         string `json:"id"`
+	Method     string `json:"method"`
+	Path       string `json:"path"`
+	StatusCode int    `json:"statusCode"`
+	UserName   string `json:"userName"`
+	IPAddress  string `json:"ipAddress"`
+	CreatedAt  string `json:"createdAt"`
+}
+
+func NewCmdList(f *cmdutil.Factory) *cobra.Command {
+	var (
+		flagLimit    int
+		flagOrderDir string
+		flagOutput   *string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list <scim-configuration-id>",
+		Short: "List SCIM events for a configuration",
+		Example: `  # List recent SCIM events
+  prb scim event list <scim-configuration-id>
+
+  # List oldest first
+  prb scim event list <scim-configuration-id> --order-direction ASC`,
+		Aliases: []string{"ls"},
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmdutil.ValidateOutputFlag(flagOutput); err != nil {
+				return err
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/connect/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			variables := map[string]any{
+				"id": args[0],
+				"orderBy": map[string]any{
+					"field":     "CREATED_AT",
+					"direction": flagOrderDir,
+				},
+			}
+
+			events, totalCount, err := api.Paginate(
+				client,
+				listQuery,
+				variables,
+				flagLimit,
+				func(data json.RawMessage) (*api.Connection[scimEvent], error) {
+					var resp struct {
+						Node *struct {
+							Typename string                    `json:"__typename"`
+							Events   api.Connection[scimEvent] `json:"events"`
+						} `json:"node"`
+					}
+					if err := json.Unmarshal(data, &resp); err != nil {
+						return nil, err
+					}
+					if resp.Node == nil {
+						return nil, fmt.Errorf("SCIM configuration %s not found", args[0])
+					}
+					if resp.Node.Typename != "SCIMConfiguration" {
+						return nil, fmt.Errorf("expected SCIMConfiguration node, got %s", resp.Node.Typename)
+					}
+					return &resp.Node.Events, nil
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			if *flagOutput == cmdutil.OutputJSON {
+				return cmdutil.PrintJSON(f.IOStreams.Out, events)
+			}
+
+			if len(events) == 0 {
+				_, _ = fmt.Fprintln(f.IOStreams.Out, "No SCIM events found.")
+				return nil
+			}
+
+			rows := make([][]string, 0, len(events))
+			for _, e := range events {
+				rows = append(rows, []string{
+					e.ID,
+					e.Method,
+					e.Path,
+					strconv.Itoa(e.StatusCode),
+					e.UserName,
+					cmdutil.FormatTime(e.CreatedAt),
+				})
+			}
+
+			t := cmdutil.NewTable("ID", "METHOD", "PATH", "STATUS", "USER", "CREATED").Rows(rows...)
+
+			_, _ = fmt.Fprintln(f.IOStreams.Out, t)
+
+			if totalCount > len(events) {
+				_, _ = fmt.Fprintf(
+					f.IOStreams.ErrOut,
+					"\nShowing %d of %d events\n",
+					len(events),
+					totalCount,
+				)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVarP(&flagLimit, "limit", "L", 30, "Maximum number of events to list")
+	cmd.Flags().StringVar(&flagOrderDir, "order-direction", "DESC", "Sort direction (ASC, DESC)")
+	flagOutput = cmdutil.AddOutputFlag(cmd)
+
+	return cmd
+}

--- a/pkg/cmd/scim/regenerate-token/regenerate_token.go
+++ b/pkg/cmd/scim/regenerate-token/regenerate_token.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package regeneratetoken
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/charmbracelet/huh"
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const regenerateMutation = `
+mutation($input: RegenerateSCIMTokenInput!) {
+  regenerateSCIMToken(input: $input) {
+    scimConfiguration {
+      id
+    }
+    token
+  }
+}
+`
+
+type regenerateResponse struct {
+	RegenerateSCIMToken struct {
+		ScimConfiguration struct {
+			ID string `json:"id"`
+		} `json:"scimConfiguration"`
+		Token string `json:"token"`
+	} `json:"regenerateSCIMToken"`
+}
+
+func NewCmdRegenerateToken(f *cmdutil.Factory) *cobra.Command {
+	var (
+		flagOrg string
+		flagYes bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "regenerate-token <scim-configuration-id>",
+		Short: "Regenerate the SCIM bearer token",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !flagYes {
+				if !f.IOStreams.IsInteractive() {
+					return fmt.Errorf("cannot regenerate SCIM token: confirmation required, use --yes to confirm")
+				}
+
+				var confirmed bool
+				err := huh.NewConfirm().
+					Title("Regenerate SCIM token? The current token will be invalidated.").
+					Value(&confirmed).
+					Run()
+				if err != nil {
+					return err
+				}
+				if !confirmed {
+					return nil
+				}
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/connect/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			if flagOrg == "" {
+				flagOrg = hc.Organization
+			}
+
+			if flagOrg == "" {
+				return fmt.Errorf("organization is required; pass --org or set a default with 'prb auth login'")
+			}
+
+			data, err := client.Do(
+				regenerateMutation,
+				map[string]any{
+					"input": map[string]any{
+						"organizationId":      flagOrg,
+						"scimConfigurationId": args[0],
+					},
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			var resp regenerateResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return fmt.Errorf("cannot parse response: %w", err)
+			}
+
+			out := f.IOStreams.Out
+			_, _ = fmt.Fprintf(out, "Regenerated SCIM token for configuration %s\n", resp.RegenerateSCIMToken.ScimConfiguration.ID)
+			_, _ = fmt.Fprintf(out, "\nSCIM Bearer Token (save this — it will not be shown again):\n%s\n", resp.RegenerateSCIMToken.Token)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&flagOrg, "org", "", "Organization ID")
+	cmd.Flags().BoolVarP(&flagYes, "yes", "y", false, "Skip confirmation prompt")
+
+	return cmd
+}

--- a/pkg/cmd/scim/scim.go
+++ b/pkg/cmd/scim/scim.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package scim
+
+import (
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+	"go.probo.inc/probo/pkg/cmd/scim/bridge"
+	"go.probo.inc/probo/pkg/cmd/scim/create"
+	"go.probo.inc/probo/pkg/cmd/scim/delete"
+	"go.probo.inc/probo/pkg/cmd/scim/event"
+	regeneratetoken "go.probo.inc/probo/pkg/cmd/scim/regenerate-token"
+	"go.probo.inc/probo/pkg/cmd/scim/view"
+)
+
+func NewCmdScim(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "scim <command>",
+		Short: "Manage SCIM provisioning",
+	}
+
+	cmd.AddCommand(view.NewCmdView(f))
+	cmd.AddCommand(create.NewCmdCreate(f))
+	cmd.AddCommand(delete.NewCmdDelete(f))
+	cmd.AddCommand(regeneratetoken.NewCmdRegenerateToken(f))
+	cmd.AddCommand(bridge.NewCmdBridge(f))
+	cmd.AddCommand(event.NewCmdEvent(f))
+
+	return cmd
+}

--- a/pkg/cmd/scim/view/view.go
+++ b/pkg/cmd/scim/view/view.go
@@ -1,0 +1,198 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package view
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+	"go.probo.inc/probo/pkg/cli/api"
+	"go.probo.inc/probo/pkg/cmd/cmdutil"
+)
+
+const viewQuery = `
+query($id: ID!) {
+  node(id: $id) {
+    __typename
+    ... on Organization {
+      scimConfiguration {
+        id
+        endpointUrl
+        bridge {
+          id
+          state
+          type
+          excludedUserNames
+          connector {
+            id
+            provider
+          }
+        }
+        createdAt
+        updatedAt
+      }
+    }
+  }
+}
+`
+
+type (
+	connector struct {
+		ID       string `json:"id"`
+		Provider string `json:"provider"`
+	}
+
+	scimBridge struct {
+		ID                string     `json:"id"`
+		State             string     `json:"state"`
+		Type              string     `json:"type"`
+		ExcludedUserNames []string   `json:"excludedUserNames"`
+		Connector         *connector `json:"connector"`
+	}
+
+	scimConfiguration struct {
+		ID          string      `json:"id"`
+		EndpointURL string      `json:"endpointUrl"`
+		Bridge      *scimBridge `json:"bridge"`
+		CreatedAt   string      `json:"createdAt"`
+		UpdatedAt   string      `json:"updatedAt"`
+	}
+
+	viewResponse struct {
+		Node *struct {
+			Typename          string             `json:"__typename"`
+			ScimConfiguration *scimConfiguration `json:"scimConfiguration"`
+		} `json:"node"`
+	}
+)
+
+func NewCmdView(f *cmdutil.Factory) *cobra.Command {
+	var (
+		flagOrg    string
+		flagOutput *string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "view",
+		Short: "View SCIM configuration for an organization",
+		Example: `  # View SCIM configuration for the default organization
+  prb scim view
+
+  # View as JSON
+  prb scim view --json`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmdutil.ValidateOutputFlag(flagOutput); err != nil {
+				return err
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			host, hc, err := cfg.DefaultHost()
+			if err != nil {
+				return err
+			}
+
+			client := api.NewClient(
+				host,
+				hc.Token,
+				"/api/connect/v1/graphql",
+				cfg.HTTPTimeoutDuration(),
+				cmdutil.TokenRefreshOption(cfg, host, hc),
+			)
+
+			if flagOrg == "" {
+				flagOrg = hc.Organization
+			}
+
+			if flagOrg == "" {
+				return fmt.Errorf("organization is required; pass --org or set a default with 'prb auth login'")
+			}
+
+			data, err := client.Do(
+				viewQuery,
+				map[string]any{"id": flagOrg},
+			)
+			if err != nil {
+				return err
+			}
+
+			var resp viewResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return fmt.Errorf("cannot parse response: %w", err)
+			}
+
+			if resp.Node == nil {
+				return fmt.Errorf("organization %s not found", flagOrg)
+			}
+
+			if resp.Node.Typename != "Organization" {
+				return fmt.Errorf("expected Organization node, got %s", resp.Node.Typename)
+			}
+
+			if resp.Node.ScimConfiguration == nil {
+				_, _ = fmt.Fprintln(f.IOStreams.Out, "No SCIM configuration found.")
+				return nil
+			}
+
+			sc := resp.Node.ScimConfiguration
+
+			if *flagOutput == cmdutil.OutputJSON {
+				return cmdutil.PrintJSON(f.IOStreams.Out, sc)
+			}
+
+			out := f.IOStreams.Out
+			bold := lipgloss.NewStyle().Bold(true)
+			label := lipgloss.NewStyle().Foreground(lipgloss.Color("242")).Width(22)
+
+			_, _ = fmt.Fprintf(out, "%s\n\n", bold.Render("SCIM Configuration"))
+
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("ID:"), sc.ID)
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Endpoint URL:"), sc.EndpointURL)
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Created:"), cmdutil.FormatTime(sc.CreatedAt))
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Updated:"), cmdutil.FormatTime(sc.UpdatedAt))
+
+			if sc.Bridge != nil {
+				_, _ = fmt.Fprintln(out)
+				_, _ = fmt.Fprintf(out, "%s\n\n", bold.Render("Bridge"))
+				_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Bridge ID:"), sc.Bridge.ID)
+				_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("State:"), sc.Bridge.State)
+				_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Type:"), sc.Bridge.Type)
+
+				if sc.Bridge.Connector != nil {
+					_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Connector ID:"), sc.Bridge.Connector.ID)
+					_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Connector Provider:"), sc.Bridge.Connector.Provider)
+				}
+
+				if len(sc.Bridge.ExcludedUserNames) > 0 {
+					_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Excluded Users:"), strings.Join(sc.Bridge.ExcludedUserNames, ", "))
+				}
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&flagOrg, "org", "", "Organization ID")
+	flagOutput = cmdutil.AddOutputFlag(cmd)
+
+	return cmd
+}

--- a/pkg/cmd/scim/view/view.go
+++ b/pkg/cmd/scim/view/view.go
@@ -149,6 +149,9 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			if resp.Node.ScimConfiguration == nil {
+				if *flagOutput == cmdutil.OutputJSON {
+					return cmdutil.PrintJSON(f.IOStreams.Out, nil)
+				}
 				_, _ = fmt.Fprintln(f.IOStreams.Out, "No SCIM configuration found.")
 				return nil
 			}

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -5107,3 +5107,117 @@ func (r *Resolver) PublishRiskListTool(ctx context.Context, req *mcp.CallToolReq
 		DocumentVersionID: documentVersion.ID,
 	}, nil
 }
+
+func (r *Resolver) GetSCIMConfigurationTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetSCIMConfigurationInput) (*mcp.CallToolResult, types.GetSCIMConfigurationOutput, error) {
+	r.MustAuthorize(ctx, input.OrganizationID, iam.ActionSCIMConfigurationGet)
+
+	config, err := r.iamSvc.OrganizationService.GetSCIMConfiguration(ctx, input.OrganizationID)
+	if err != nil {
+		var errNotFound *iam.ErrNoSCIMConfigurationFound
+		if errors.As(err, &errNotFound) {
+			return nil, types.GetSCIMConfigurationOutput{}, fmt.Errorf("SCIM configuration not found for organization %s", input.OrganizationID)
+		}
+		panic(fmt.Errorf("cannot get SCIM configuration: %w", err))
+	}
+
+	return nil, types.GetSCIMConfigurationOutput{ScimConfiguration: types.NewSCIMConfiguration(config)}, nil
+}
+
+func (r *Resolver) CreateSCIMConfigurationTool(ctx context.Context, req *mcp.CallToolRequest, input *types.CreateSCIMConfigurationInput) (*mcp.CallToolResult, types.CreateSCIMConfigurationOutput, error) {
+	r.MustAuthorize(ctx, input.OrganizationID, iam.ActionSCIMConfigurationCreate)
+
+	config, token, err := r.iamSvc.OrganizationService.CreateSCIMConfiguration(ctx, input.OrganizationID)
+	if err != nil {
+		return nil, types.CreateSCIMConfigurationOutput{}, fmt.Errorf("cannot create SCIM configuration: %w", err)
+	}
+
+	output := types.CreateSCIMConfigurationOutput{
+		ScimConfiguration: types.NewSCIMConfiguration(config),
+		Token:             token,
+	}
+
+	if input.ConnectorID != nil {
+		bridge, err := r.iamSvc.OrganizationService.CreateSCIMBridge(ctx, input.OrganizationID, config.ID, *input.ConnectorID)
+		if err != nil {
+			return nil, types.CreateSCIMConfigurationOutput{}, fmt.Errorf("cannot create SCIM bridge: %w", err)
+		}
+		output.ScimBridge = types.NewSCIMBridge(bridge)
+	}
+
+	return nil, output, nil
+}
+
+func (r *Resolver) DeleteSCIMConfigurationTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteSCIMConfigurationInput) (*mcp.CallToolResult, types.DeleteSCIMConfigurationOutput, error) {
+	r.MustAuthorize(ctx, input.OrganizationID, iam.ActionSCIMConfigurationDelete)
+
+	err := r.iamSvc.OrganizationService.DeleteSCIMConfiguration(ctx, input.OrganizationID, input.ScimConfigurationID)
+	if err != nil {
+		return nil, types.DeleteSCIMConfigurationOutput{}, fmt.Errorf("cannot delete SCIM configuration: %w", err)
+	}
+
+	return nil, types.DeleteSCIMConfigurationOutput{DeletedScimConfigurationID: input.ScimConfigurationID}, nil
+}
+
+func (r *Resolver) RegenerateSCIMTokenTool(ctx context.Context, req *mcp.CallToolRequest, input *types.RegenerateSCIMTokenInput) (*mcp.CallToolResult, types.RegenerateSCIMTokenOutput, error) {
+	r.MustAuthorize(ctx, input.ScimConfigurationID, iam.ActionSCIMConfigurationUpdate)
+
+	config, token, err := r.iamSvc.OrganizationService.RegenerateSCIMToken(ctx, input.OrganizationID, input.ScimConfigurationID)
+	if err != nil {
+		return nil, types.RegenerateSCIMTokenOutput{}, fmt.Errorf("cannot regenerate SCIM token: %w", err)
+	}
+
+	return nil, types.RegenerateSCIMTokenOutput{
+		ScimConfiguration: types.NewSCIMConfiguration(config),
+		Token:             token,
+	}, nil
+}
+
+func (r *Resolver) GetSCIMBridgeTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetSCIMBridgeInput) (*mcp.CallToolResult, types.GetSCIMBridgeOutput, error) {
+	r.MustAuthorize(ctx, input.ID, iam.ActionSCIMBridgeGet)
+
+	bridge, err := r.iamSvc.OrganizationService.GetSCIMBridgeByID(ctx, input.ID)
+	if err != nil {
+		var errNotFound *iam.ErrSCIMBridgeNotFound
+		if errors.As(err, &errNotFound) {
+			return nil, types.GetSCIMBridgeOutput{}, fmt.Errorf("SCIM bridge %s not found", input.ID)
+		}
+		panic(fmt.Errorf("cannot get SCIM bridge: %w", err))
+	}
+
+	return nil, types.GetSCIMBridgeOutput{ScimBridge: types.NewSCIMBridge(bridge)}, nil
+}
+
+func (r *Resolver) UpdateSCIMBridgeTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateSCIMBridgeInput) (*mcp.CallToolResult, types.UpdateSCIMBridgeOutput, error) {
+	r.MustAuthorize(ctx, input.ScimBridgeID, iam.ActionSCIMBridgeUpdate)
+
+	bridge, err := r.iamSvc.OrganizationService.UpdateSCIMBridge(ctx, input.OrganizationID, input.ScimBridgeID, input.ExcludedUserNames)
+	if err != nil {
+		return nil, types.UpdateSCIMBridgeOutput{}, fmt.Errorf("cannot update SCIM bridge: %w", err)
+	}
+
+	return nil, types.UpdateSCIMBridgeOutput{ScimBridge: types.NewSCIMBridge(bridge)}, nil
+}
+
+func (r *Resolver) ListSCIMEventsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListSCIMEventsInput) (*mcp.CallToolResult, types.ListSCIMEventsOutput, error) {
+	r.MustAuthorize(ctx, input.ScimConfigurationID, iam.ActionSCIMEventList)
+
+	pageOrderBy := page.OrderBy[coredata.SCIMEventOrderField]{
+		Field:     coredata.SCIMEventOrderFieldCreatedAt,
+		Direction: page.OrderDirectionDesc,
+	}
+	if input.OrderBy != nil {
+		pageOrderBy = page.OrderBy[coredata.SCIMEventOrderField]{
+			Field:     input.OrderBy.Field,
+			Direction: input.OrderBy.Direction,
+		}
+	}
+
+	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
+
+	p, err := r.iamSvc.OrganizationService.ListSCIMEventsByConfigID(ctx, input.ScimConfigurationID, cursor)
+	if err != nil {
+		panic(fmt.Errorf("cannot list SCIM events: %w", err))
+	}
+
+	return nil, types.NewListSCIMEventsOutput(p), nil
+}

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -5115,7 +5115,7 @@ func (r *Resolver) GetSCIMConfigurationTool(ctx context.Context, req *mcp.CallTo
 	if err != nil {
 		var errNotFound *iam.ErrNoSCIMConfigurationFound
 		if errors.As(err, &errNotFound) {
-			return nil, types.GetSCIMConfigurationOutput{}, fmt.Errorf("SCIM configuration not found for organization %s", input.OrganizationID)
+			return nil, types.GetSCIMConfigurationOutput{}, fmt.Errorf("SCIM configuration not found")
 		}
 		panic(fmt.Errorf("cannot get SCIM configuration: %w", err))
 	}

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -9879,6 +9879,344 @@ components:
         cookie_consent_record:
           $ref: "#/components/schemas/CookieConsentRecord"
 
+    SCIMBridgeType:
+      type: string
+      enum:
+        - GOOGLE_WORKSPACE
+      go.probo.inc/mcpgen/type: go.probo.inc/probo/pkg/coredata.SCIMBridgeType
+
+    SCIMBridgeState:
+      type: string
+      enum:
+        - PENDING
+        - ACTIVE
+        - SYNCING
+        - FAILED
+        - DISABLED
+      go.probo.inc/mcpgen/type: go.probo.inc/probo/pkg/coredata.SCIMBridgeState
+
+    SCIMEventOrderField:
+      type: string
+      enum:
+        - CREATED_AT
+      go.probo.inc/mcpgen/type: go.probo.inc/probo/pkg/coredata.SCIMEventOrderField
+
+    SCIMEventOrderBy:
+      type: object
+      required:
+        - field
+        - direction
+      properties:
+        field:
+          $ref: "#/components/schemas/SCIMEventOrderField"
+          description: SCIM event order field
+        direction:
+          $ref: "#/components/schemas/OrderDirection"
+          description: SCIM event order direction
+
+    SCIMConfiguration:
+      type: object
+      required:
+        - id
+        - organization_id
+        - created_at
+        - updated_at
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+          description: SCIM configuration ID
+        organization_id:
+          $ref: "#/components/schemas/GID"
+          description: Organization ID
+        bridge_id:
+          type:
+            - string
+            - "null"
+          description: Associated SCIM bridge ID, if any
+        created_at:
+          type: string
+          format: date-time
+          description: Creation timestamp
+        updated_at:
+          type: string
+          format: date-time
+          description: Last update timestamp
+
+    SCIMBridge:
+      type: object
+      required:
+        - id
+        - organization_id
+        - scim_configuration_id
+        - type
+        - state
+        - excluded_user_names
+        - created_at
+        - updated_at
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+          description: SCIM bridge ID
+        organization_id:
+          $ref: "#/components/schemas/GID"
+          description: Organization ID
+        scim_configuration_id:
+          $ref: "#/components/schemas/GID"
+          description: SCIM configuration ID
+        connector_id:
+          type:
+            - string
+            - "null"
+          description: Connector ID, if any
+        type:
+          $ref: "#/components/schemas/SCIMBridgeType"
+          description: Bridge type
+        state:
+          $ref: "#/components/schemas/SCIMBridgeState"
+          description: Bridge state
+        excluded_user_names:
+          type: array
+          items:
+            type: string
+          description: User names excluded from SCIM sync
+        last_synced_at:
+          type:
+            - string
+            - "null"
+          format: date-time
+          description: Last successful sync timestamp
+        created_at:
+          type: string
+          format: date-time
+          description: Creation timestamp
+        updated_at:
+          type: string
+          format: date-time
+          description: Last update timestamp
+
+    SCIMEvent:
+      type: object
+      required:
+        - id
+        - organization_id
+        - scim_configuration_id
+        - method
+        - path
+        - status_code
+        - user_name
+        - ip_address
+        - created_at
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+          description: SCIM event ID
+        organization_id:
+          $ref: "#/components/schemas/GID"
+          description: Organization ID
+        scim_configuration_id:
+          $ref: "#/components/schemas/GID"
+          description: SCIM configuration ID
+        method:
+          type: string
+          description: HTTP method
+        path:
+          type: string
+          description: Request path
+        status_code:
+          type: integer
+          description: HTTP status code
+        request_body:
+          type:
+            - string
+            - "null"
+          description: Request body
+        response_body:
+          type:
+            - string
+            - "null"
+          description: Response body
+        error_message:
+          type:
+            - string
+            - "null"
+          description: Error message, if any
+        user_name:
+          type: string
+          description: SCIM user name
+        ip_address:
+          type: string
+          description: Client IP address
+        created_at:
+          type: string
+          format: date-time
+          description: Creation timestamp
+
+    GetSCIMConfigurationInput:
+      type: object
+      required:
+        - organization_id
+      properties:
+        organization_id:
+          $ref: "#/components/schemas/GID"
+          description: Organization ID
+
+    GetSCIMConfigurationOutput:
+      type: object
+      required:
+        - scim_configuration
+      properties:
+        scim_configuration:
+          $ref: "#/components/schemas/SCIMConfiguration"
+
+    CreateSCIMConfigurationInput:
+      type: object
+      required:
+        - organization_id
+      properties:
+        organization_id:
+          $ref: "#/components/schemas/GID"
+          description: Organization ID
+        connector_id:
+          $ref: "#/components/schemas/GID"
+          description: Optional connector ID to create a SCIM bridge
+
+    CreateSCIMConfigurationOutput:
+      type: object
+      required:
+        - scim_configuration
+        - token
+      properties:
+        scim_configuration:
+          $ref: "#/components/schemas/SCIMConfiguration"
+        scim_bridge:
+          $ref: "#/components/schemas/SCIMBridge"
+          description: SCIM bridge, if a connector ID was provided
+        token:
+          type: string
+          description: Plaintext SCIM bearer token (only returned at creation time)
+
+    DeleteSCIMConfigurationInput:
+      type: object
+      required:
+        - organization_id
+        - scim_configuration_id
+      properties:
+        organization_id:
+          $ref: "#/components/schemas/GID"
+          description: Organization ID
+        scim_configuration_id:
+          $ref: "#/components/schemas/GID"
+          description: SCIM configuration ID to delete
+
+    DeleteSCIMConfigurationOutput:
+      type: object
+      required:
+        - deleted_scim_configuration_id
+      properties:
+        deleted_scim_configuration_id:
+          $ref: "#/components/schemas/GID"
+          description: Deleted SCIM configuration ID
+
+    RegenerateSCIMTokenInput:
+      type: object
+      required:
+        - organization_id
+        - scim_configuration_id
+      properties:
+        organization_id:
+          $ref: "#/components/schemas/GID"
+          description: Organization ID
+        scim_configuration_id:
+          $ref: "#/components/schemas/GID"
+          description: SCIM configuration ID
+
+    RegenerateSCIMTokenOutput:
+      type: object
+      required:
+        - scim_configuration
+        - token
+      properties:
+        scim_configuration:
+          $ref: "#/components/schemas/SCIMConfiguration"
+        token:
+          type: string
+          description: New plaintext SCIM bearer token
+
+    GetSCIMBridgeInput:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          $ref: "#/components/schemas/GID"
+          description: SCIM bridge ID
+
+    GetSCIMBridgeOutput:
+      type: object
+      required:
+        - scim_bridge
+      properties:
+        scim_bridge:
+          $ref: "#/components/schemas/SCIMBridge"
+
+    UpdateSCIMBridgeInput:
+      type: object
+      required:
+        - organization_id
+        - scim_bridge_id
+        - excluded_user_names
+      properties:
+        organization_id:
+          $ref: "#/components/schemas/GID"
+          description: Organization ID
+        scim_bridge_id:
+          $ref: "#/components/schemas/GID"
+          description: SCIM bridge ID
+        excluded_user_names:
+          type: array
+          items:
+            type: string
+          description: User names to exclude from SCIM sync
+
+    UpdateSCIMBridgeOutput:
+      type: object
+      required:
+        - scim_bridge
+      properties:
+        scim_bridge:
+          $ref: "#/components/schemas/SCIMBridge"
+
+    ListSCIMEventsInput:
+      type: object
+      required:
+        - scim_configuration_id
+      properties:
+        scim_configuration_id:
+          $ref: "#/components/schemas/GID"
+          description: SCIM configuration ID
+        order_by:
+          $ref: "#/components/schemas/SCIMEventOrderBy"
+          description: SCIM event order by
+        size:
+          type: integer
+          description: Page size
+        cursor:
+          $ref: "#/components/schemas/CursorKey"
+          description: Page cursor
+
+    ListSCIMEventsOutput:
+      type: object
+      required:
+        - scim_events
+      properties:
+        next_cursor:
+          $ref: "#/components/schemas/CursorKey"
+          description: Next cursor
+        scim_events:
+          type: array
+          items:
+            $ref: "#/components/schemas/SCIMEvent"
+
 tools:
   - name: listOrganizations
     description: List all organizations the user has access to
@@ -11769,3 +12107,63 @@ tools:
       $ref: "#/components/schemas/GetCookieConsentRecordInput"
     outputSchema:
       $ref: "#/components/schemas/GetCookieConsentRecordOutput"
+  - name: getSCIMConfiguration
+    description: Get the SCIM configuration for an organization
+    hints:
+      readonly: true
+      idempotent: true
+    inputSchema:
+      $ref: "#/components/schemas/GetSCIMConfigurationInput"
+    outputSchema:
+      $ref: "#/components/schemas/GetSCIMConfigurationOutput"
+  - name: createSCIMConfiguration
+    description: Create a SCIM configuration for an organization. Optionally provide a connector ID to also create a SCIM bridge.
+    hints:
+      readonly: false
+    inputSchema:
+      $ref: "#/components/schemas/CreateSCIMConfigurationInput"
+    outputSchema:
+      $ref: "#/components/schemas/CreateSCIMConfigurationOutput"
+  - name: deleteSCIMConfiguration
+    description: Delete a SCIM configuration and its associated bridge
+    hints:
+      readonly: false
+      destructive: true
+    inputSchema:
+      $ref: "#/components/schemas/DeleteSCIMConfigurationInput"
+    outputSchema:
+      $ref: "#/components/schemas/DeleteSCIMConfigurationOutput"
+  - name: regenerateSCIMToken
+    description: Regenerate the bearer token for a SCIM configuration
+    hints:
+      readonly: false
+    inputSchema:
+      $ref: "#/components/schemas/RegenerateSCIMTokenInput"
+    outputSchema:
+      $ref: "#/components/schemas/RegenerateSCIMTokenOutput"
+  - name: getSCIMBridge
+    description: Get a SCIM bridge by ID
+    hints:
+      readonly: true
+      idempotent: true
+    inputSchema:
+      $ref: "#/components/schemas/GetSCIMBridgeInput"
+    outputSchema:
+      $ref: "#/components/schemas/GetSCIMBridgeOutput"
+  - name: updateSCIMBridge
+    description: Update a SCIM bridge's excluded user names
+    hints:
+      readonly: false
+    inputSchema:
+      $ref: "#/components/schemas/UpdateSCIMBridgeInput"
+    outputSchema:
+      $ref: "#/components/schemas/UpdateSCIMBridgeOutput"
+  - name: listSCIMEvents
+    description: List SCIM events for a configuration
+    hints:
+      readonly: true
+      idempotent: true
+    inputSchema:
+      $ref: "#/components/schemas/ListSCIMEventsInput"
+    outputSchema:
+      $ref: "#/components/schemas/ListSCIMEventsOutput"

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -9929,9 +9929,9 @@ components:
           $ref: "#/components/schemas/GID"
           description: Organization ID
         bridge_id:
-          type:
-            - string
-            - "null"
+          anyOf:
+            - $ref: "#/components/schemas/GID"
+            - type: "null"
           description: Associated SCIM bridge ID, if any
         created_at:
           type: string
@@ -9964,9 +9964,9 @@ components:
           $ref: "#/components/schemas/GID"
           description: SCIM configuration ID
         connector_id:
-          type:
-            - string
-            - "null"
+          anyOf:
+            - $ref: "#/components/schemas/GID"
+            - type: "null"
           description: Connector ID, if any
         type:
           $ref: "#/components/schemas/SCIMBridgeType"

--- a/pkg/server/api/mcp/v1/types/scim_configuration.go
+++ b/pkg/server/api/mcp/v1/types/scim_configuration.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package types
+
+import (
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/page"
+)
+
+func NewSCIMConfiguration(c *coredata.SCIMConfiguration) *SCIMConfiguration {
+	var bridgeID *string
+	if c.BridgeID != nil {
+		s := c.BridgeID.String()
+		bridgeID = &s
+	}
+
+	return &SCIMConfiguration{
+		ID:             c.ID,
+		OrganizationID: c.OrganizationID,
+		BridgeID:       bridgeID,
+		CreatedAt:      c.CreatedAt,
+		UpdatedAt:      c.UpdatedAt,
+	}
+}
+
+func NewSCIMBridge(b *coredata.SCIMBridge) *SCIMBridge {
+	var connectorID *string
+	if b.ConnectorID != nil {
+		s := b.ConnectorID.String()
+		connectorID = &s
+	}
+
+	return &SCIMBridge{
+		ID:                  b.ID,
+		OrganizationID:      b.OrganizationID,
+		ScimConfigurationID: b.ScimConfigurationID,
+		ConnectorID:         connectorID,
+		Type:                b.Type,
+		State:               b.State,
+		ExcludedUserNames:   b.ExcludedUserNames,
+		LastSyncedAt:        b.LastSyncedAt,
+		CreatedAt:           b.CreatedAt,
+		UpdatedAt:           b.UpdatedAt,
+	}
+}
+
+func NewSCIMEvent(e *coredata.SCIMEvent) *SCIMEvent {
+	return &SCIMEvent{
+		ID:                  e.ID,
+		OrganizationID:      e.OrganizationID,
+		ScimConfigurationID: e.SCIMConfigurationID,
+		Method:              e.Method,
+		Path:                e.Path,
+		StatusCode:          e.StatusCode,
+		RequestBody:         e.RequestBody,
+		ResponseBody:        e.ResponseBody,
+		ErrorMessage:        e.ErrorMessage,
+		UserName:            e.UserName,
+		IPAddress:           e.IPAddress.String(),
+		CreatedAt:           e.CreatedAt,
+	}
+}
+
+func NewListSCIMEventsOutput(p *page.Page[*coredata.SCIMEvent, coredata.SCIMEventOrderField]) ListSCIMEventsOutput {
+	events := make([]*SCIMEvent, 0, len(p.Data))
+	for _, e := range p.Data {
+		events = append(events, NewSCIMEvent(e))
+	}
+
+	var nextCursor *page.CursorKey
+	if len(p.Data) > 0 {
+		cursorKey := p.Data[len(p.Data)-1].CursorKey(p.Cursor.OrderBy.Field)
+		nextCursor = &cursorKey
+	}
+
+	return ListSCIMEventsOutput{
+		NextCursor: nextCursor,
+		ScimEvents: events,
+	}
+}

--- a/pkg/server/api/mcp/v1/types/scim_configuration.go
+++ b/pkg/server/api/mcp/v1/types/scim_configuration.go
@@ -20,33 +20,21 @@ import (
 )
 
 func NewSCIMConfiguration(c *coredata.SCIMConfiguration) *SCIMConfiguration {
-	var bridgeID *string
-	if c.BridgeID != nil {
-		s := c.BridgeID.String()
-		bridgeID = &s
-	}
-
 	return &SCIMConfiguration{
 		ID:             c.ID,
 		OrganizationID: c.OrganizationID,
-		BridgeID:       bridgeID,
+		BridgeID:       c.BridgeID,
 		CreatedAt:      c.CreatedAt,
 		UpdatedAt:      c.UpdatedAt,
 	}
 }
 
 func NewSCIMBridge(b *coredata.SCIMBridge) *SCIMBridge {
-	var connectorID *string
-	if b.ConnectorID != nil {
-		s := b.ConnectorID.String()
-		connectorID = &s
-	}
-
 	return &SCIMBridge{
 		ID:                  b.ID,
 		OrganizationID:      b.OrganizationID,
 		ScimConfigurationID: b.ScimConfigurationID,
-		ConnectorID:         connectorID,
+		ConnectorID:         b.ConnectorID,
 		Type:                b.Type,
 		State:               b.State,
 		ExcludedUserNames:   b.ExcludedUserNames,


### PR DESCRIPTION
Closes ENG-374

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SCIM provisioning to the CLI and MCP API so teams can create/manage configurations, bridges, tokens, and events from one place. Addresses ENG-374 by adding missing surfaces for SCIM management and fixes review feedback on outputs and schema.

- **New Features**
  - CLI: `prb scim` with `view`, `create`, `delete`, `regenerate-token`, `bridge view/update`, and `event list` (uses `/api/connect/v1/graphql`).
  - MCP API: tools `getSCIMConfiguration`, `createSCIMConfiguration`, `deleteSCIMConfiguration`, `regenerateSCIMToken`, `getSCIMBridge`, `updateSCIMBridge`, and `listSCIMEvents` (schema and types added in `pkg/server/api/mcp/v1/specification.yaml` and `types`).
  - Root command registers the `scim` command.

- **Bug Fixes**
  - `prb scim view --json` returns `null` when no SCIM configuration exists (valid JSON).
  - MCP not-found errors no longer include organization IDs.
  - MCP spec uses nullable GID refs for `bridge_id` and `connector_id` to fix generated types.

<sup>Written for commit f418780dd4f94078c3018e834d8c0f1f21ee0561. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

