### PR TITLE
Add security notes with safer password changes entry

### DIFF
--- a/SECURITY_NOTES.md
+++ b/SECURITY_NOTES.md
@@ -1,0 +1,18 @@
+# Security Notes
+
+User-facing notes on security-relevant changes to Probo. For the
+vulnerability reporting process, see [SECURITY.md](SECURITY.md).
+
+## Safer Password Changes
+
+_2026-04-29 — **IAM**_
+
+> Changing or resetting a password now revokes old sessions automatically.
+
+Changing a password should close the door behind it. Probo now revokes existing sessions when credentials change.
+
+If you change your password while signed in, every other active session is expired and your current session stays open. If your password is reset, all sessions are expired.
+
+It is a small security detail, but an important one. A password update now does what people expect: it cuts off old access immediately.
+
+Thanks to [emimoir](https://github.com/emimoir) for reporting the security issue behind this fix.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add SECURITY_NOTES.md with user-facing guidance on password changes and sessions.
Changing a password expires other sessions and keeps the current one; resets expire all sessions.

<sup>Written for commit 0a5d8a0642379b884f2703763effc82857e6f5ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

