### PR TITLE
Bump axios override to 1.16.0 for security fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7841,14 +7841,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@langchain/community": "^1.1.25",
     "lodash": "^4.18.1",
     "lodash-es": "^4.18.1",
-    "axios": "^1.15.0"
+    "axios": "^1.16.0"
   },
   "license": "MIT",
   "packageManager": "npm@11.8.0",


### PR DESCRIPTION
Pulls fixes for the cluster of advisories filed against 1.15.0: prototype-pollution gadgets in resolveConfig/mergeConfig, CRLF injection in headers and multipart bodies, no_proxy bypass via RFC 1122 loopback subnet and IP aliases, parseReviver tampering, withXSRFToken cross-origin leakage, validateStatus auth bypass, and AxiosURLSearchParams null-byte injection. Addressed across axios 1.15.1, 1.15.2, and 1.16.0.

axios is only present as a transitive peer dep (ibm-cloud-sdk-core); the override forces a single 1.16.0 resolution.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `axios` to 1.16.0 to pull in security fixes (prototype pollution, CRLF injection, no_proxy bypass, XSRF leak, auth bypass, null-byte injection). Pin `axios` as a top-level dependency to ensure a single resolution across transitive usage from `ibm-cloud-sdk-core`.

<sup>Written for commit 23bf204ae72b383cb3674ec16423743e78981367. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

