### PR TITLE
Add IP-to-country geolocation service

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "pkg/validator/data/disposable-email-domains"]
 	path = pkg/validator/data/disposable-email-domains
 	url = https://github.com/disposable-email-domains/disposable-email-domains.git
+[submodule "pkg/geoloc/data/country-ip-blocks"]
+	path = pkg/geoloc/data/country-ip-blocks
+	url = https://github.com/ipverse/country-ip-blocks.git

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/consent-records/CookieBannerConsentRecordPage.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/consent-records/CookieBannerConsentRecordPage.tsx
@@ -58,6 +58,7 @@ export const cookieBannerConsentRecordPageQuery = graphql`
         userAgent
         sdkVersion
         regulation
+        countryCode
         consentData
         createdAt
       }
@@ -156,6 +157,11 @@ export default function CookieBannerConsentRecordPage({
         <PropertyRow label={__("Regulation")}>
           <span className="font-mono text-sm">
             {record.regulation || "-"}
+          </span>
+        </PropertyRow>
+        <PropertyRow label={__("Country")}>
+          <span className="font-mono text-sm">
+            {record.countryCode || "-"}
           </span>
         </PropertyRow>
         <PropertyRow label={__("Date")}>

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/consent-records/CookieBannerConsentRecordPage.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/consent-records/CookieBannerConsentRecordPage.tsx
@@ -147,7 +147,7 @@ export default function CookieBannerConsentRecordPage({
           </span>
         </PropertyRow>
         <PropertyRow label={__("User Agent")}>
-          <span className="font-mono text-sm truncate max-w-md" title={record.userAgent ?? undefined}>
+          <span className="font-mono text-sm break-all">
             {record.userAgent ?? "-"}
           </span>
         </PropertyRow>

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/consent-records/CookieBannerConsentRecordPage.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/consent-records/CookieBannerConsentRecordPage.tsx
@@ -57,6 +57,7 @@ export const cookieBannerConsentRecordPageQuery = graphql`
         ipAddress
         userAgent
         sdkVersion
+        regulation
         consentData
         createdAt
       }
@@ -151,6 +152,11 @@ export default function CookieBannerConsentRecordPage({
         </PropertyRow>
         <PropertyRow label={__("SDK Version")}>
           <span className="font-mono text-sm">{record.sdkVersion}</span>
+        </PropertyRow>
+        <PropertyRow label={__("Regulation")}>
+          <span className="font-mono text-sm">
+            {record.regulation || "-"}
+          </span>
         </PropertyRow>
         <PropertyRow label={__("Date")}>
           <time dateTime={record.createdAt}>

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/consent-records/CookieBannerConsentRecordsPage.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/consent-records/CookieBannerConsentRecordsPage.tsx
@@ -217,6 +217,7 @@ export default function CookieBannerConsentRecordsPage({
                     <Th>{__("IP Address")}</Th>
                     <Th>{__("SDK Version")}</Th>
                     <Th>{__("Regulation")}</Th>
+                    <Th>{__("Country")}</Th>
                     <SortableTh field="CREATED_AT">{__("Date")}</SortableTh>
                   </Tr>
                 </Thead>

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/consent-records/CookieBannerConsentRecordsPage.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/consent-records/CookieBannerConsentRecordsPage.tsx
@@ -216,6 +216,7 @@ export default function CookieBannerConsentRecordsPage({
                     <Th>{__("Banner Version")}</Th>
                     <Th>{__("IP Address")}</Th>
                     <Th>{__("SDK Version")}</Th>
+                    <Th>{__("Regulation")}</Th>
                     <SortableTh field="CREATED_AT">{__("Date")}</SortableTh>
                   </Tr>
                 </Thead>

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/consent-records/_components/ConsentRecordRow.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/consent-records/_components/ConsentRecordRow.tsx
@@ -36,6 +36,7 @@ const consentRecordFragment = graphql`
     ipAddress
     sdkVersion
     regulation
+    countryCode
     createdAt
   }
 `;
@@ -78,6 +79,11 @@ export function ConsentRecordRow({ recordKey }: ConsentRecordRowProps) {
       <Td>
         <span className="font-mono text-sm">
           {record.regulation || "-"}
+        </span>
+      </Td>
+      <Td>
+        <span className="font-mono text-sm">
+          {record.countryCode || "-"}
         </span>
       </Td>
       <Td>

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/consent-records/_components/ConsentRecordRow.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/consent-records/_components/ConsentRecordRow.tsx
@@ -35,6 +35,7 @@ const consentRecordFragment = graphql`
     }
     ipAddress
     sdkVersion
+    regulation
     createdAt
   }
 `;
@@ -73,6 +74,11 @@ export function ConsentRecordRow({ recordKey }: ConsentRecordRowProps) {
       </Td>
       <Td>
         <span className="font-mono text-sm">{record.sdkVersion}</span>
+      </Td>
+      <Td>
+        <span className="font-mono text-sm">
+          {record.regulation || "-"}
+        </span>
       </Td>
       <Td>
         <time dateTime={record.createdAt}>

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/detection/_components/DetectionPatternRow.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/detection/_components/DetectionPatternRow.tsx
@@ -289,10 +289,10 @@ export function DetectionPatternRow({ patternKey, connectionId }: DetectionPatte
   }
 
   return (
-    <Tr className={pattern.excluded ? "opacity-80" : undefined}>
+    <Tr className={pattern.excluded ? "bg-txt-quaternary opacity-80  line-through" : undefined}>
       <Td>
         <div className="flex flex-col min-w-0">
-          <span className="font-medium">{pattern.displayName}</span>
+          <span className={pattern.excluded ? undefined : "font-medium"}>{pattern.displayName}</span>
           {pattern.description && (
             <span className="text-xs text-txt-tertiary wrap-break-word line-clamp-1">
               {pattern.description}
@@ -318,7 +318,7 @@ export function DetectionPatternRow({ patternKey, connectionId }: DetectionPatte
         {pattern.lastMatchedAt
           ? (
               <time dateTime={pattern.lastMatchedAt}>
-                {formatDate(pattern.lastMatchedAt)}
+                {new Date(pattern.lastMatchedAt).toLocaleString()}
               </time>
             )
           : <span className="text-txt-tertiary">-</span>}

--- a/cmd/geoloc-import/main.go
+++ b/cmd/geoloc-import/main.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+// Command geoloc-import loads IP-to-country CIDR blocks from the
+// ipverse/country-ip-blocks dataset into the common_ip_country_blocks table.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/url"
+	"os"
+
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/geoloc"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	var (
+		pgDSN   string
+		dataDir string
+	)
+
+	flag.StringVar(
+		&pgDSN,
+		"pg-dsn",
+		os.Getenv("DATABASE_URL"),
+		"PostgreSQL connection URL (default: DATABASE_URL env)",
+	)
+	flag.StringVar(
+		&dataDir,
+		"data-dir",
+		"pkg/geoloc/data/country-ip-blocks",
+		"path to ipverse country-ip-blocks checkout",
+	)
+	flag.Parse()
+
+	if pgDSN == "" {
+		return fmt.Errorf("set -pg-dsn or DATABASE_URL")
+	}
+
+	ctx := context.Background()
+
+	pgClient, err := newPgClientFromDSN(pgDSN)
+	if err != nil {
+		return fmt.Errorf("cannot create pg client: %w", err)
+	}
+
+	svc := geoloc.NewService(pgClient)
+
+	fmt.Printf("importing IP country blocks from %s\n", dataDir)
+
+	if err := svc.ImportFromDir(ctx, dataDir); err != nil {
+		return fmt.Errorf("cannot import geoloc data: %w", err)
+	}
+
+	fmt.Println("done")
+	return nil
+}
+
+func newPgClientFromDSN(dsn string) (*pg.Client, error) {
+	u, err := url.Parse(dsn)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse DSN: %w", err)
+	}
+
+	var opts []pg.Option
+
+	if u.Host != "" {
+		opts = append(opts, pg.WithAddr(u.Host))
+	}
+
+	if u.User != nil {
+		opts = append(opts, pg.WithUser(u.User.Username()))
+		if password, ok := u.User.Password(); ok {
+			opts = append(opts, pg.WithPassword(password))
+		}
+	}
+
+	if len(u.Path) > 1 {
+		opts = append(opts, pg.WithDatabase(u.Path[1:]))
+	}
+
+	return pg.NewClient(opts...)
+}

--- a/cmd/geoloc-import/main.go
+++ b/cmd/geoloc-import/main.go
@@ -35,22 +35,15 @@ func main() {
 }
 
 func run() error {
-	var (
-		pgDSN   string
-		dataDir string
-	)
+	const dataDir = "pkg/geoloc/data/country-ip-blocks"
+
+	var pgDSN string
 
 	flag.StringVar(
 		&pgDSN,
 		"pg-dsn",
 		os.Getenv("DATABASE_URL"),
 		"PostgreSQL connection URL (default: DATABASE_URL env)",
-	)
-	flag.StringVar(
-		&dataDir,
-		"data-dir",
-		"pkg/geoloc/data/country-ip-blocks",
-		"path to ipverse country-ip-blocks checkout",
 	)
 	flag.Parse()
 

--- a/cmd/geoloc-import/main.go
+++ b/cmd/geoloc-import/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 
@@ -79,7 +80,11 @@ func newPgClientFromDSN(dsn string) (*pg.Client, error) {
 	var opts []pg.Option
 
 	if u.Host != "" {
-		opts = append(opts, pg.WithAddr(u.Host))
+		host := u.Host
+		if u.Port() == "" {
+			host = net.JoinHostPort(u.Hostname(), "5432")
+		}
+		opts = append(opts, pg.WithAddr(host))
 	}
 
 	if u.User != nil {

--- a/cmd/migrate-asset-snapshots-to-documents/main.go
+++ b/cmd/migrate-asset-snapshots-to-documents/main.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"strings"
@@ -416,7 +417,11 @@ func newPgClientFromDSN(dsn string) (*pg.Client, error) {
 	var opts []pg.Option
 
 	if u.Host != "" {
-		opts = append(opts, pg.WithAddr(u.Host))
+		host := u.Host
+		if u.Port() == "" {
+			host = net.JoinHostPort(u.Hostname(), "5432")
+		}
+		opts = append(opts, pg.WithAddr(host))
 	}
 
 	if u.User != nil {

--- a/cmd/migrate-data-snapshots-to-documents/main.go
+++ b/cmd/migrate-data-snapshots-to-documents/main.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"strings"
@@ -415,7 +416,11 @@ func newPgClientFromDSN(dsn string) (*pg.Client, error) {
 	var opts []pg.Option
 
 	if u.Host != "" {
-		opts = append(opts, pg.WithAddr(u.Host))
+		host := u.Host
+		if u.Port() == "" {
+			host = net.JoinHostPort(u.Hostname(), "5432")
+		}
+		opts = append(opts, pg.WithAddr(host))
 	}
 
 	if u.User != nil {

--- a/cmd/migrate-document-versions-markdown/main.go
+++ b/cmd/migrate-document-versions-markdown/main.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"time"
@@ -130,7 +131,11 @@ func newPgClientFromDSN(dsn string) (*pg.Client, error) {
 	var opts []pg.Option
 
 	if u.Host != "" {
-		opts = append(opts, pg.WithAddr(u.Host))
+		host := u.Host
+		if u.Port() == "" {
+			host = net.JoinHostPort(u.Hostname(), "5432")
+		}
+		opts = append(opts, pg.WithAddr(host))
 	}
 
 	if u.User != nil {

--- a/cmd/migrate-finding-snapshots-to-documents/main.go
+++ b/cmd/migrate-finding-snapshots-to-documents/main.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"time"
@@ -469,7 +470,11 @@ func newPgClientFromDSN(dsn string) (*pg.Client, error) {
 	var opts []pg.Option
 
 	if u.Host != "" {
-		opts = append(opts, pg.WithAddr(u.Host))
+		host := u.Host
+		if u.Port() == "" {
+			host = net.JoinHostPort(u.Hostname(), "5432")
+		}
+		opts = append(opts, pg.WithAddr(host))
 	}
 
 	if u.User != nil {

--- a/cmd/migrate-obligation-snapshots-to-documents/main.go
+++ b/cmd/migrate-obligation-snapshots-to-documents/main.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"time"
@@ -432,7 +433,11 @@ func newPgClientFromDSN(dsn string) (*pg.Client, error) {
 	var opts []pg.Option
 
 	if u.Host != "" {
-		opts = append(opts, pg.WithAddr(u.Host))
+		host := u.Host
+		if u.Port() == "" {
+			host = net.JoinHostPort(u.Hostname(), "5432")
+		}
+		opts = append(opts, pg.WithAddr(host))
 	}
 
 	if u.User != nil {

--- a/cmd/migrate-processing-activity-snapshots-to-documents/main.go
+++ b/cmd/migrate-processing-activity-snapshots-to-documents/main.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"strings"
@@ -740,7 +741,11 @@ func newPgClientFromDSN(dsn string) (*pg.Client, error) {
 	var opts []pg.Option
 
 	if u.Host != "" {
-		opts = append(opts, pg.WithAddr(u.Host))
+		host := u.Host
+		if u.Port() == "" {
+			host = net.JoinHostPort(u.Hostname(), "5432")
+		}
+		opts = append(opts, pg.WithAddr(host))
 	}
 
 	if u.User != nil {

--- a/cmd/migrate-risk-snapshots-to-documents/main.go
+++ b/cmd/migrate-risk-snapshots-to-documents/main.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"time"
@@ -507,7 +508,11 @@ func newPgClientFromDSN(dsn string) (*pg.Client, error) {
 	var opts []pg.Option
 
 	if u.Host != "" {
-		opts = append(opts, pg.WithAddr(u.Host))
+		host := u.Host
+		if u.Port() == "" {
+			host = net.JoinHostPort(u.Hostname(), "5432")
+		}
+		opts = append(opts, pg.WithAddr(host))
 	}
 
 	if u.User != nil {

--- a/cmd/migrate-soa-snapshots-to-documents/main.go
+++ b/cmd/migrate-soa-snapshots-to-documents/main.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"time"
@@ -516,7 +517,11 @@ func newPgClientFromDSN(dsn string) (*pg.Client, error) {
 	var opts []pg.Option
 
 	if u.Host != "" {
-		opts = append(opts, pg.WithAddr(u.Host))
+		host := u.Host
+		if u.Port() == "" {
+			host = net.JoinHostPort(u.Hostname(), "5432")
+		}
+		opts = append(opts, pg.WithAddr(host))
 	}
 
 	if u.User != nil {

--- a/cmd/migrate-vendor-snapshots-to-documents/main.go
+++ b/cmd/migrate-vendor-snapshots-to-documents/main.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"strings"
@@ -731,7 +732,11 @@ func newPgClientFromDSN(dsn string) (*pg.Client, error) {
 	var opts []pg.Option
 
 	if u.Host != "" {
-		opts = append(opts, pg.WithAddr(u.Host))
+		host := u.Host
+		if u.Port() == "" {
+			host = net.JoinHostPort(u.Hostname(), "5432")
+		}
+		opts = append(opts, pg.WithAddr(host))
 	}
 
 	if u.User != nil {

--- a/packages/cookie-banner/src/client.ts
+++ b/packages/cookie-banner/src/client.ts
@@ -43,6 +43,22 @@ export interface Category {
   posthog_consent: boolean;
 }
 
+export type Regulation =
+  | "GDPR"
+  | "UK_GDPR"
+  | "FADP"
+  | "CCPA"
+  | "PIPEDA"
+  | "LGPD"
+  | "LFPDPPP"
+  | "POPIA"
+  | "PDPA"
+  | "PIPL"
+  | "PIPA"
+  | "APPI"
+  | "DPDP"
+  | "PDPL";
+
 export interface BannerConfig {
   banner_id: string;
   version: number;
@@ -52,6 +68,7 @@ export interface BannerConfig {
   cookie_policy_url: string;
   consent_expiry_days: number;
   consent_mode: "OPT_IN" | "OPT_OUT";
+  regulation: Regulation | null;
   show_branding: boolean;
   categories: Category[];
   texts: BannerTexts;
@@ -208,6 +225,10 @@ export class CookieBannerClient {
 
   get gpcApplied(): boolean {
     return this._gpcApplied;
+  }
+
+  get regulation(): Regulation | null {
+    return this.bannerConfig?.regulation ?? null;
   }
 
   gpc(): void {

--- a/packages/cookie-banner/src/client.ts
+++ b/packages/cookie-banner/src/client.ts
@@ -20,82 +20,30 @@ import { COOKIE_NAME, getConsentCookie, setConsentCookie } from "./cookie";
 import { CookieDetector } from "./detector";
 import { NotFoundError } from "./errors";
 import { fetchJSON } from "./http";
-import type { BannerTexts } from "./i18n";
 import { detectLanguage } from "./i18n";
 import type { ConsentIntegration } from "./integrations";
 import { createDefaultIntegrations } from "./integrations";
 import { enqueue, flush } from "./queue";
+import type {
+  BannerConfig,
+  ConsentAction,
+  ConsentRecord,
+  CookieBannerClientOptions,
+  Regulation,
+  VisitorConsent,
+} from "./types";
 import { getOrCreateVisitorId } from "./visitor";
 
-export interface CookieItem {
-  name: string;
-  max_age_seconds: number | null;
-  description: string;
-}
-
-export interface Category {
-  name: string;
-  slug: string;
-  description: string;
-  kind: string;
-  cookies: CookieItem[];
-  gcm_consent_types: string[];
-  posthog_consent: boolean;
-}
-
-export type Regulation =
-  | "GDPR"
-  | "UK_GDPR"
-  | "FADP"
-  | "CCPA"
-  | "PIPEDA"
-  | "LGPD"
-  | "LFPDPPP"
-  | "POPIA"
-  | "PDPA"
-  | "PIPL"
-  | "PIPA"
-  | "APPI"
-  | "DPDP"
-  | "PDPL";
-
-export interface BannerConfig {
-  banner_id: string;
-  version: number;
-  language: string;
-  default_language: string;
-  privacy_policy_url?: string;
-  cookie_policy_url: string;
-  consent_expiry_days: number;
-  consent_mode: "OPT_IN" | "OPT_OUT";
-  regulation: Regulation | null;
-  show_branding: boolean;
-  categories: Category[];
-  texts: BannerTexts;
-}
-
-export type ConsentAction = "ACCEPT_ALL" | "REJECT_ALL" | "CUSTOMIZE" | "GPC";
-
-export interface VisitorConsent {
-  visitor_id: string;
-  version: number;
-  action: ConsentAction;
-  consent_data: Record<string, boolean>;
-  created_at: string;
-}
-
-export interface ConsentRecord {
-  id: string;
-  visitor_id: string;
-  action: string;
-  created_at: string;
-}
-
-export interface CookieBannerClientOptions {
-  bannerId: string;
-  baseUrl: string;
-  lang?: string;
-}
+export type {
+  BannerConfig,
+  Category,
+  ConsentAction,
+  ConsentRecord,
+  CookieBannerClientOptions,
+  CookieItem,
+  Regulation,
+  VisitorConsent,
+} from "./types";
 
 export class CookieBannerClient {
   private readonly baseUrl: URL;

--- a/packages/cookie-banner/src/components/banner.ts
+++ b/packages/cookie-banner/src/components/banner.ts
@@ -38,7 +38,11 @@ export class ProboBanner extends ProboElement {
 
     if (this.root) {
       this.root.addEventListener("probo-state", this.onStateChange);
-      this.root.addEventListener("probo-ready", this.onReady, { once: true });
+      try {
+        this.validate(this.root.bannerConfig);
+      } catch {
+        this.root.addEventListener("probo-ready", this.onReady, { once: true });
+      }
       if (this.root.state === "banner") {
         this.hidden = false;
       }

--- a/packages/cookie-banner/src/components/banner.ts
+++ b/packages/cookie-banner/src/components/banner.ts
@@ -15,12 +15,7 @@
 import { ProboElement } from "./base";
 import type { ProboRootElement } from "./base";
 import type { ProboCookieBannerRoot } from "./cookie-banner-root";
-
-const REQUIRED_BUTTONS = [
-  "probo-accept-button",
-  "probo-reject-button",
-  "probo-customize-button",
-] as const;
+import type { BannerConfig } from "../types";
 
 export class ProboBanner extends ProboElement {
   private root: ProboRootElement | null = null;
@@ -32,29 +27,39 @@ export class ProboBanner extends ProboElement {
     }
   };
 
+  private onReady = (e: Event): void => {
+    const config = (e as CustomEvent).detail.config as BannerConfig;
+    this.validate(config);
+  };
+
   connectedCallback(): void {
     this.hidden = true;
     this.root = this.findAncestor<ProboCookieBannerRoot>("probo-cookie-banner-root");
 
     if (this.root) {
       this.root.addEventListener("probo-state", this.onStateChange);
+      this.root.addEventListener("probo-ready", this.onReady, { once: true });
       if (this.root.state === "banner") {
         this.hidden = false;
       }
     }
-
-    this.scheduleValidation(() => this.validate());
   }
 
   disconnectedCallback(): void {
     if (this.root) {
       this.root.removeEventListener("probo-state", this.onStateChange);
+      this.root.removeEventListener("probo-ready", this.onReady);
     }
   }
 
-  private validate(): void {
+  private validate(config: BannerConfig): void {
+    const texts = config.texts ?? {};
+    const required: string[] = ["probo-accept-button"];
+    if (texts.button_reject_all) required.push("probo-reject-button");
+    if (texts.button_customize) required.push("probo-customize-button");
+
     const missing: string[] = [];
-    for (const tag of REQUIRED_BUTTONS) {
+    for (const tag of required) {
       if (!this.querySelector(tag)) {
         missing.push(tag);
       }

--- a/packages/cookie-banner/src/components/base.ts
+++ b/packages/cookie-banner/src/components/base.ts
@@ -13,7 +13,7 @@
 // PERFORMANCE OF THIS SOFTWARE.
 
 import type { CookieBannerClient } from "../client";
-import type { BannerConfig } from "../types";
+import type { BannerConfig, Regulation } from "../types";
 
 export type ProboState = "loading" | "banner" | "panel" | "hidden";
 
@@ -68,6 +68,8 @@ export interface ProboRootElement extends ProboElement {
   readonly reopenWidget: string;
   readonly consentDraft: ConsentDraft;
   readonly gpcApplied: boolean;
+  readonly regulation: Regulation | null;
+  readonly consentMode: "OPT_IN" | "OPT_OUT" | null;
   setState(state: ProboState): void;
   updateDraft(category: string, value: boolean): void;
 }

--- a/packages/cookie-banner/src/components/base.ts
+++ b/packages/cookie-banner/src/components/base.ts
@@ -12,7 +12,8 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import type { CookieBannerClient, BannerConfig } from "../client";
+import type { CookieBannerClient } from "../client";
+import type { BannerConfig } from "../types";
 
 export type ProboState = "loading" | "banner" | "panel" | "hidden";
 

--- a/packages/cookie-banner/src/components/category-list.ts
+++ b/packages/cookie-banner/src/components/category-list.ts
@@ -12,7 +12,7 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import type { Category } from "../client";
+import type { Category } from "../types";
 import { ProboElement } from "./base";
 import type { ProboRootElement } from "./base";
 import type { ProboCookieBannerRoot } from "./cookie-banner-root";

--- a/packages/cookie-banner/src/components/category.ts
+++ b/packages/cookie-banner/src/components/category.ts
@@ -12,7 +12,7 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import type { CookieItem } from "../client";
+import type { CookieItem } from "../types";
 import { ProboElement } from "./base";
 
 export class ProboCategory extends ProboElement {

--- a/packages/cookie-banner/src/components/cookie-banner-root.ts
+++ b/packages/cookie-banner/src/components/cookie-banner-root.ts
@@ -13,7 +13,7 @@
 // PERFORMANCE OF THIS SOFTWARE.
 
 import { CookieBannerClient } from "../client";
-import type { BannerConfig } from "../client";
+import type { BannerConfig } from "../types";
 import { ProboElement } from "./base";
 import type { ProboState, ProboRootElement, ConsentDraft } from "./base";
 

--- a/packages/cookie-banner/src/components/cookie-banner-root.ts
+++ b/packages/cookie-banner/src/components/cookie-banner-root.ts
@@ -13,7 +13,7 @@
 // PERFORMANCE OF THIS SOFTWARE.
 
 import { CookieBannerClient } from "../client";
-import type { BannerConfig } from "../types";
+import type { BannerConfig, Regulation } from "../types";
 import { ProboElement } from "./base";
 import type { ProboState, ProboRootElement, ConsentDraft } from "./base";
 
@@ -55,6 +55,16 @@ export class ProboCookieBannerRoot extends ProboElement implements ProboRootElem
 
   get gpcApplied(): boolean {
     return this._client?.gpcApplied ?? false;
+  }
+
+  get regulation(): Regulation | null {
+    return this._client?.regulation ?? null;
+  }
+
+  get consentMode(): "OPT_IN" | "OPT_OUT" | null {
+    const mode = this._config?.consent_mode;
+    if (mode === "OPT_IN" || mode === "OPT_OUT") return mode;
+    return null;
   }
 
   attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null): void {

--- a/packages/cookie-banner/src/components/cookie-banner-root.ts
+++ b/packages/cookie-banner/src/components/cookie-banner-root.ts
@@ -156,7 +156,7 @@ export class ProboCookieBannerRoot extends ProboElement implements ProboRootElem
       new CustomEvent("probo-ready", {
         bubbles: true,
         composed: true,
-        detail: { config: this._config, gpcApplied: this.gpcApplied },
+        detail: { config: this._config, gpcApplied: this.gpcApplied, regulation: this._client.regulation },
       }),
     );
 

--- a/packages/cookie-banner/src/components/cookie-list.ts
+++ b/packages/cookie-banner/src/components/cookie-list.ts
@@ -12,7 +12,7 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import type { CookieItem } from "../client";
+import type { CookieItem } from "../types";
 import { humanizeDuration } from "../cookie-utils";
 import { getCookieDetailLabels } from "../i18n";
 import { ProboElement } from "./base";

--- a/packages/cookie-banner/src/cookie.ts
+++ b/packages/cookie-banner/src/cookie.ts
@@ -12,7 +12,7 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import type { ConsentAction } from "./client";
+import type { ConsentAction } from "./types";
 
 export const COOKIE_NAME = "probo_consent";
 const SECONDS_PER_DAY = 86400;

--- a/packages/cookie-banner/src/integrations/gcm.ts
+++ b/packages/cookie-banner/src/integrations/gcm.ts
@@ -12,7 +12,7 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import type { Category } from "../client";
+import type { Category } from "../types";
 import type { ConsentIntegration } from "./integration";
 
 export class GoogleConsentModeIntegration implements ConsentIntegration {

--- a/packages/cookie-banner/src/integrations/integration.ts
+++ b/packages/cookie-banner/src/integrations/integration.ts
@@ -12,7 +12,7 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import type { Category } from "../client";
+import type { Category } from "../types";
 
 export interface ConsentIntegration {
   /** Called once after config is loaded, before any consent is applied. */

--- a/packages/cookie-banner/src/integrations/posthog.ts
+++ b/packages/cookie-banner/src/integrations/posthog.ts
@@ -12,7 +12,7 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import type { Category } from "../client";
+import type { Category } from "../types";
 import type { ConsentIntegration } from "./integration";
 
 interface PostHogInstance {

--- a/packages/cookie-banner/src/themed-banner/themed-banner.ts
+++ b/packages/cookie-banner/src/themed-banner/themed-banner.ts
@@ -14,7 +14,7 @@
 
 import { registerHeadlessComponents } from "../components";
 import type { ProboCookieBannerRoot } from "../components/cookie-banner-root";
-import type { BannerConfig } from "../client";
+import type { BannerConfig } from "../types";
 import { getGpcLabel, interpolate } from "../i18n";
 import { BRANDING, CHEVRON_DOWN, CLOSE_ICON } from "../html";
 import { THEMED_STYLES } from "./styles";

--- a/packages/cookie-banner/src/themed-banner/themed-banner.ts
+++ b/packages/cookie-banner/src/themed-banner/themed-banner.ts
@@ -130,6 +130,7 @@ export class ProboThemedBanner extends HTMLElement {
       const detail = (e as CustomEvent).detail;
       const config = detail.config as BannerConfig;
       this.applyTexts(config);
+      this.applyLayout(config);
       if (!config.show_branding) {
         this.shadow.querySelectorAll("[data-branding]").forEach(el => {
           (el as HTMLElement).setAttribute("hidden", "");
@@ -222,6 +223,20 @@ export class ProboThemedBanner extends HTMLElement {
         settingsBtn.setAttribute("aria-settings-label", ariaText);
       }
     }
+  }
+
+  private applyLayout(config: BannerConfig): void {
+    const texts = config.texts ?? {};
+
+    const hideIfEmpty = (selector: string, textKey: string): void => {
+      if (texts[textKey]) return;
+      this.shadow.querySelectorAll(selector).forEach(el => {
+        (el as HTMLElement).hidden = true;
+      });
+    };
+
+    hideIfEmpty("probo-banner probo-reject-button", "button_reject_all");
+    hideIfEmpty("probo-banner probo-customize-button", "button_customize");
   }
 
   private esc(str: string): string {

--- a/packages/cookie-banner/src/types.ts
+++ b/packages/cookie-banner/src/types.ts
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import type { BannerTexts } from "./i18n";
+
+export interface CookieItem {
+  name: string;
+  max_age_seconds: number | null;
+  description: string;
+}
+
+export interface Category {
+  name: string;
+  slug: string;
+  description: string;
+  kind: string;
+  cookies: CookieItem[];
+  gcm_consent_types: string[];
+  posthog_consent: boolean;
+}
+
+export type Regulation =
+  | "GDPR"
+  | "UK_GDPR"
+  | "FADP"
+  | "CCPA"
+  | "PIPEDA"
+  | "LGPD"
+  | "LFPDPPP"
+  | "POPIA"
+  | "PDPA"
+  | "PIPL"
+  | "PIPA"
+  | "APPI"
+  | "DPDP"
+  | "PDPL";
+
+export interface BannerConfig {
+  banner_id: string;
+  version: number;
+  language: string;
+  default_language: string;
+  privacy_policy_url?: string;
+  cookie_policy_url: string;
+  consent_expiry_days: number;
+  consent_mode: "OPT_IN" | "OPT_OUT";
+  regulation: Regulation | null;
+  show_branding: boolean;
+  categories: Category[];
+  texts: BannerTexts;
+}
+
+export type ConsentAction = "ACCEPT_ALL" | "REJECT_ALL" | "CUSTOMIZE" | "GPC";
+
+export interface VisitorConsent {
+  visitor_id: string;
+  version: number;
+  action: ConsentAction;
+  consent_data: Record<string, boolean>;
+  created_at: string;
+}
+
+export interface ConsentRecord {
+  id: string;
+  visitor_id: string;
+  action: string;
+  created_at: string;
+}
+
+export interface CookieBannerClientOptions {
+  bannerId: string;
+  baseUrl: string;
+  lang?: string;
+}

--- a/packages/n8n-node/nodes/Probo/actions/cookieConsentRecord/get.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieConsentRecord/get.operation.ts
@@ -49,6 +49,8 @@ export async function execute(
 					consentData
 					action
 					sdkVersion
+					regulation
+					countryCode
 					createdAt
 				}
 			}

--- a/packages/n8n-node/nodes/Probo/actions/cookieConsentRecord/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieConsentRecord/getAll.operation.ts
@@ -152,6 +152,8 @@ export async function execute(
 								consentData
 								action
 								sdkVersion
+								regulation
+								countryCode
 								createdAt
 							}
 						}

--- a/pkg/cmd/consent-record/list/list.go
+++ b/pkg/cmd/consent-record/list/list.go
@@ -36,6 +36,8 @@ query($id: ID!, $first: Int, $after: CursorKey, $filter: CookieConsentRecordFilt
             visitorId
             action
             sdkVersion
+            regulation
+            countryCode
             createdAt
           }
         }
@@ -50,11 +52,13 @@ query($id: ID!, $first: Int, $after: CursorKey, $filter: CookieConsentRecordFilt
 `
 
 type consentRecord struct {
-	ID         string `json:"id"`
-	VisitorID  string `json:"visitorId"`
-	Action     string `json:"action"`
-	SDKVersion string `json:"sdkVersion"`
-	CreatedAt  string `json:"createdAt"`
+	ID          string `json:"id"`
+	VisitorID   string `json:"visitorId"`
+	Action      string `json:"action"`
+	SDKVersion  string `json:"sdkVersion"`
+	Regulation  string `json:"regulation"`
+	CountryCode string `json:"countryCode"`
+	CreatedAt   string `json:"createdAt"`
 }
 
 func NewCmdList(f *cmdutil.Factory) *cobra.Command {
@@ -150,10 +154,10 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 
 			rows := make([][]string, 0, len(records))
 			for _, r := range records {
-				rows = append(rows, []string{r.ID, r.VisitorID, r.Action, r.SDKVersion, r.CreatedAt})
+				rows = append(rows, []string{r.ID, r.VisitorID, r.Action, r.SDKVersion, r.Regulation, r.CountryCode, r.CreatedAt})
 			}
 
-			t := cmdutil.NewTable("ID", "VISITOR ID", "ACTION", "SDK VERSION", "CREATED AT").Rows(rows...)
+			t := cmdutil.NewTable("ID", "VISITOR ID", "ACTION", "SDK VERSION", "REGULATION", "COUNTRY", "CREATED AT").Rows(rows...)
 			_, _ = fmt.Fprintln(f.IOStreams.Out, t)
 
 			if totalCount > len(records) {

--- a/pkg/cmd/consent-record/list/list.go
+++ b/pkg/cmd/consent-record/list/list.go
@@ -52,13 +52,13 @@ query($id: ID!, $first: Int, $after: CursorKey, $filter: CookieConsentRecordFilt
 `
 
 type consentRecord struct {
-	ID          string `json:"id"`
-	VisitorID   string `json:"visitorId"`
-	Action      string `json:"action"`
-	SDKVersion  string `json:"sdkVersion"`
-	Regulation  string `json:"regulation"`
-	CountryCode string `json:"countryCode"`
-	CreatedAt   string `json:"createdAt"`
+	ID          string  `json:"id"`
+	VisitorID   string  `json:"visitorId"`
+	Action      string  `json:"action"`
+	SDKVersion  string  `json:"sdkVersion"`
+	Regulation  *string `json:"regulation"`
+	CountryCode *string `json:"countryCode"`
+	CreatedAt   string  `json:"createdAt"`
 }
 
 func NewCmdList(f *cmdutil.Factory) *cobra.Command {
@@ -154,7 +154,15 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 
 			rows := make([][]string, 0, len(records))
 			for _, r := range records {
-				rows = append(rows, []string{r.ID, r.VisitorID, r.Action, r.SDKVersion, r.Regulation, r.CountryCode, r.CreatedAt})
+				regulation := "-"
+				if r.Regulation != nil {
+					regulation = *r.Regulation
+				}
+				countryCode := "-"
+				if r.CountryCode != nil {
+					countryCode = *r.CountryCode
+				}
+				rows = append(rows, []string{r.ID, r.VisitorID, r.Action, r.SDKVersion, regulation, countryCode, r.CreatedAt})
 			}
 
 			t := cmdutil.NewTable("ID", "VISITOR ID", "ACTION", "SDK VERSION", "REGULATION", "COUNTRY", "CREATED AT").Rows(rows...)

--- a/pkg/cmd/consent-record/view/view.go
+++ b/pkg/cmd/consent-record/view/view.go
@@ -36,6 +36,8 @@ query($id: ID!) {
       consentData
       action
       sdkVersion
+      regulation
+      countryCode
       createdAt
     }
   }
@@ -52,6 +54,8 @@ type viewResponse struct {
 		ConsentData string  `json:"consentData"`
 		Action      string  `json:"action"`
 		SdkVersion  string  `json:"sdkVersion"`
+		Regulation  string  `json:"regulation"`
+		CountryCode string  `json:"countryCode"`
 		CreatedAt   string  `json:"createdAt"`
 	} `json:"node"`
 }
@@ -115,6 +119,8 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Visitor ID:"), v.VisitorID)
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Action:"), v.Action)
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("SDK Version:"), v.SdkVersion)
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Regulation:"), v.Regulation)
+			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Country Code:"), v.CountryCode)
 			if v.IPAddress != nil && *v.IPAddress != "" {
 				_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("IP Address:"), *v.IPAddress)
 			}

--- a/pkg/cmd/consent-record/view/view.go
+++ b/pkg/cmd/consent-record/view/view.go
@@ -54,8 +54,8 @@ type viewResponse struct {
 		ConsentData string  `json:"consentData"`
 		Action      string  `json:"action"`
 		SdkVersion  string  `json:"sdkVersion"`
-		Regulation  string  `json:"regulation"`
-		CountryCode string  `json:"countryCode"`
+		Regulation  *string `json:"regulation"`
+		CountryCode *string `json:"countryCode"`
 		CreatedAt   string  `json:"createdAt"`
 	} `json:"node"`
 }
@@ -119,8 +119,12 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Visitor ID:"), v.VisitorID)
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Action:"), v.Action)
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("SDK Version:"), v.SdkVersion)
-			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Regulation:"), v.Regulation)
-			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Country Code:"), v.CountryCode)
+			if v.Regulation != nil {
+				_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Regulation:"), *v.Regulation)
+			}
+			if v.CountryCode != nil {
+				_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Country Code:"), *v.CountryCode)
+			}
 			if v.IPAddress != nil && *v.IPAddress != "" {
 				_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("IP Address:"), *v.IPAddress)
 			}

--- a/pkg/cookiebanner/defaults.go
+++ b/pkg/cookiebanner/defaults.go
@@ -119,6 +119,15 @@ var defaultUIStringsByLanguage = map[string]map[string]string{
 		"cookie_policy_link_text":  "Cookie Policy",
 		"placeholder_text":         "This content requires {{category}} cookies.",
 		"placeholder_button":       "Manage cookie preferences",
+
+		"banner_title_opt_out":       "Cookie Notice",
+		"banner_description_opt_out": "We use cookies and similar technologies. You can opt out of non-essential cookies. {{cookie_policy_link}}",
+		"button_acknowledge":         "OK",
+		"button_opt_out":             "Do Not Sell or Share My Personal Information",
+
+		"banner_title_notice":       "Cookie Notice",
+		"banner_description_notice": "This site uses cookies to enhance your experience. {{cookie_policy_link}}",
+		"button_dismiss":            "Got it",
 	},
 	"fr": {
 		"banner_title":             "Préférences de cookies",
@@ -137,6 +146,15 @@ var defaultUIStringsByLanguage = map[string]map[string]string{
 		"cookie_policy_link_text":  "Politique relative aux cookies",
 		"placeholder_text":         "Ce contenu nécessite les cookies {{category}}.",
 		"placeholder_button":       "Gérer les préférences de cookies",
+
+		"banner_title_opt_out":       "Avis sur les cookies",
+		"banner_description_opt_out": "Nous utilisons des cookies et technologies similaires. Vous pouvez refuser les cookies non essentiels. {{cookie_policy_link}}",
+		"button_acknowledge":         "OK",
+		"button_opt_out":             "Ne pas vendre ni partager mes informations personnelles",
+
+		"banner_title_notice":       "Avis sur les cookies",
+		"banner_description_notice": "Ce site utilise des cookies pour améliorer votre expérience. {{cookie_policy_link}}",
+		"button_dismiss":            "Compris",
 	},
 	"de": {
 		"banner_title":             "Cookie-Einstellungen",
@@ -155,6 +173,15 @@ var defaultUIStringsByLanguage = map[string]map[string]string{
 		"cookie_policy_link_text":  "Cookie-Richtlinie",
 		"placeholder_text":         "Dieser Inhalt erfordert {{category}}-Cookies.",
 		"placeholder_button":       "Cookie-Einstellungen verwalten",
+
+		"banner_title_opt_out":       "Cookie-Hinweis",
+		"banner_description_opt_out": "Wir verwenden Cookies und ähnliche Technologien. Sie können nicht wesentliche Cookies ablehnen. {{cookie_policy_link}}",
+		"button_acknowledge":         "OK",
+		"button_opt_out":             "Meine persönlichen Daten nicht verkaufen oder weitergeben",
+
+		"banner_title_notice":       "Cookie-Hinweis",
+		"banner_description_notice": "Diese Website verwendet Cookies, um Ihre Erfahrung zu verbessern. {{cookie_policy_link}}",
+		"button_dismiss":            "Verstanden",
 	},
 	"es": {
 		"banner_title":             "Preferencias de cookies",
@@ -173,5 +200,14 @@ var defaultUIStringsByLanguage = map[string]map[string]string{
 		"cookie_policy_link_text":  "Política de cookies",
 		"placeholder_text":         "Este contenido requiere cookies de {{category}}.",
 		"placeholder_button":       "Gestionar preferencias de cookies",
+
+		"banner_title_opt_out":       "Aviso de cookies",
+		"banner_description_opt_out": "Utilizamos cookies y tecnologías similares. Puede optar por no recibir cookies no esenciales. {{cookie_policy_link}}",
+		"button_acknowledge":         "OK",
+		"button_opt_out":             "No vender ni compartir mi información personal",
+
+		"banner_title_notice":       "Aviso de cookies",
+		"banner_description_notice": "Este sitio utiliza cookies para mejorar su experiencia. {{cookie_policy_link}}",
+		"button_dismiss":            "Entendido",
 	},
 }

--- a/pkg/cookiebanner/regulation.go
+++ b/pkg/cookiebanner/regulation.go
@@ -16,24 +16,24 @@ package cookiebanner
 
 import "go.probo.inc/probo/pkg/coredata"
 
-type Regulation string
+type Regulation = coredata.Regulation
 
 const (
-	RegulationNone    Regulation = ""
-	RegulationGDPR    Regulation = "GDPR"
-	RegulationUKGDPR  Regulation = "UK_GDPR"
-	RegulationFADP    Regulation = "FADP"
-	RegulationCCPA    Regulation = "CCPA"
-	RegulationPIPEDA  Regulation = "PIPEDA"
-	RegulationLGPD    Regulation = "LGPD"
-	RegulationLFPDPPP Regulation = "LFPDPPP"
-	RegulationPOPIA   Regulation = "POPIA"
-	RegulationPDPA    Regulation = "PDPA"
-	RegulationPIPL    Regulation = "PIPL"
-	RegulationPIPA    Regulation = "PIPA"
-	RegulationAPPI    Regulation = "APPI"
-	RegulationDPDP    Regulation = "DPDP"
-	RegulationPDPL    Regulation = "PDPL"
+	RegulationNone    = coredata.RegulationNone
+	RegulationGDPR    = coredata.RegulationGDPR
+	RegulationUKGDPR  = coredata.RegulationUKGDPR
+	RegulationFADP    = coredata.RegulationFADP
+	RegulationCCPA    = coredata.RegulationCCPA
+	RegulationPIPEDA  = coredata.RegulationPIPEDA
+	RegulationLGPD    = coredata.RegulationLGPD
+	RegulationLFPDPPP = coredata.RegulationLFPDPPP
+	RegulationPOPIA   = coredata.RegulationPOPIA
+	RegulationPDPA    = coredata.RegulationPDPA
+	RegulationPIPL    = coredata.RegulationPIPL
+	RegulationPIPA    = coredata.RegulationPIPA
+	RegulationAPPI    = coredata.RegulationAPPI
+	RegulationDPDP    = coredata.RegulationDPDP
+	RegulationPDPL    = coredata.RegulationPDPL
 )
 
 const (

--- a/pkg/cookiebanner/regulation.go
+++ b/pkg/cookiebanner/regulation.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package cookiebanner
+
+import "go.probo.inc/probo/pkg/coredata"
+
+type Regulation string
+
+const (
+	RegulationNone    Regulation = ""
+	RegulationGDPR    Regulation = "GDPR"
+	RegulationUKGDPR  Regulation = "UK_GDPR"
+	RegulationFADP    Regulation = "FADP"
+	RegulationCCPA    Regulation = "CCPA"
+	RegulationPIPEDA  Regulation = "PIPEDA"
+	RegulationLGPD    Regulation = "LGPD"
+	RegulationLFPDPPP Regulation = "LFPDPPP"
+	RegulationPOPIA   Regulation = "POPIA"
+	RegulationPDPA    Regulation = "PDPA"
+	RegulationPIPL    Regulation = "PIPL"
+	RegulationPIPA    Regulation = "PIPA"
+	RegulationAPPI    Regulation = "APPI"
+	RegulationDPDP    Regulation = "DPDP"
+	RegulationPDPL    Regulation = "PDPL"
+)
+
+const (
+	ConsentModeOptIn  = "OPT_IN"
+	ConsentModeOptOut = "OPT_OUT"
+)
+
+// RegulationForCountry maps a country code to the applicable privacy
+// regulation. For countries with no known cookie-consent regulation it
+// returns RegulationNone.
+//
+// US states (CCPA/CPRA, CPA, VCDPA, UCPA) and Canadian provinces
+// (PIPEDA, Law 25) are collapsed to the country level because IP
+// geolocation only resolves to a country code.
+func RegulationForCountry(cc coredata.CountryCode) Regulation {
+	switch cc {
+	// EU 27 member states
+	case
+		coredata.CountryCodeAT, // Austria
+		coredata.CountryCodeBE, // Belgium
+		coredata.CountryCodeBG, // Bulgaria
+		coredata.CountryCodeHR, // Croatia
+		coredata.CountryCodeCY, // Cyprus
+		coredata.CountryCodeCZ, // Czechia
+		coredata.CountryCodeDK, // Denmark
+		coredata.CountryCodeEE, // Estonia
+		coredata.CountryCodeFI, // Finland
+		coredata.CountryCodeFR, // France
+		coredata.CountryCodeDE, // Germany
+		coredata.CountryCodeGR, // Greece
+		coredata.CountryCodeHU, // Hungary
+		coredata.CountryCodeIE, // Ireland
+		coredata.CountryCodeIT, // Italy
+		coredata.CountryCodeLV, // Latvia
+		coredata.CountryCodeLT, // Lithuania
+		coredata.CountryCodeLU, // Luxembourg
+		coredata.CountryCodeMT, // Malta
+		coredata.CountryCodeNL, // Netherlands
+		coredata.CountryCodePL, // Poland
+		coredata.CountryCodePT, // Portugal
+		coredata.CountryCodeRO, // Romania
+		coredata.CountryCodeSK, // Slovakia
+		coredata.CountryCodeSI, // Slovenia
+		coredata.CountryCodeES, // Spain
+		coredata.CountryCodeSE, // Sweden
+		// EEA (non-EU)
+		coredata.CountryCodeIS, // Iceland
+		coredata.CountryCodeLI, // Liechtenstein
+		coredata.CountryCodeNO: // Norway
+		return RegulationGDPR
+
+	case coredata.CountryCodeGB:
+		return RegulationUKGDPR
+
+	case coredata.CountryCodeCH:
+		return RegulationFADP
+
+	case coredata.CountryCodeUS:
+		return RegulationCCPA
+
+	case coredata.CountryCodeCA:
+		return RegulationPIPEDA
+
+	case coredata.CountryCodeBR:
+		return RegulationLGPD
+
+	case coredata.CountryCodeMX:
+		return RegulationLFPDPPP
+
+	case coredata.CountryCodeZA:
+		return RegulationPOPIA
+
+	case coredata.CountryCodeTH:
+		return RegulationPDPA
+
+	case coredata.CountryCodeCN:
+		return RegulationPIPL
+
+	case coredata.CountryCodeKR:
+		return RegulationPIPA
+
+	case coredata.CountryCodeJP:
+		return RegulationAPPI
+
+	case coredata.CountryCodeIN:
+		return RegulationDPDP
+
+	case coredata.CountryCodeSA:
+		return RegulationPDPL
+
+	default:
+		return RegulationNone
+	}
+}
+
+// ConsentModeForRegulation returns the consent model implied by a
+// regulation. OPT_IN means non-necessary cookies must be blocked until
+// the visitor gives explicit consent; OPT_OUT means cookies may fire
+// immediately but the visitor must be offered a way to opt out.
+//
+// When the regulation is unknown or RegulationNone, it returns an empty
+// string so the caller can fall back to the banner's configured default.
+func ConsentModeForRegulation(r Regulation) string {
+	switch r {
+	case RegulationGDPR,
+		RegulationUKGDPR,
+		RegulationFADP,
+		RegulationPOPIA,
+		RegulationPDPA,
+		RegulationPIPL,
+		RegulationPIPA,
+		RegulationDPDP,
+		RegulationPDPL:
+		return ConsentModeOptIn
+
+	case RegulationCCPA,
+		RegulationPIPEDA,
+		RegulationLGPD,
+		RegulationLFPDPPP,
+		RegulationAPPI:
+		return ConsentModeOptOut
+
+	default:
+		return ""
+	}
+}

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -1387,60 +1387,6 @@ func (s *Service) CountCookieBannerVersionsForBanner(
 	return count, nil
 }
 
-func (s *Service) CreateCookieConsentRecord(
-	ctx context.Context,
-	scope coredata.Scoper,
-	req CreateCookieConsentRecordRequest,
-) (*coredata.CookieConsentRecord, error) {
-	if err := req.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid request: %w", err)
-	}
-
-	var record *coredata.CookieConsentRecord
-
-	err := s.pg.WithTx(
-		ctx,
-		func(ctx context.Context, tx pg.Tx) error {
-			var publishedVersion coredata.CookieBannerVersion
-			if err := publishedVersion.LoadByCookieBannerIDAndVersion(ctx, tx, scope, req.CookieBannerID, req.Version); err != nil {
-				if errors.Is(err, coredata.ErrResourceNotFound) {
-					return ErrVersionNotFound
-				}
-				return fmt.Errorf("cannot load cookie banner version: %w", err)
-			}
-
-			if publishedVersion.State != coredata.CookieBannerVersionStatePublished {
-				return ErrVersionNotPublished
-			}
-
-			record = &coredata.CookieConsentRecord{
-				ID:                    gid.New(scope.GetTenantID(), coredata.CookieConsentRecordEntityType),
-				OrganizationID:        publishedVersion.OrganizationID,
-				CookieBannerID:        req.CookieBannerID,
-				CookieBannerVersionID: publishedVersion.ID,
-				VisitorID:             req.VisitorID,
-				IPAddress:             req.IPAddress,
-				UserAgent:             req.UserAgent,
-				ConsentData:           req.ConsentData,
-				Action:                req.Action,
-				SdkVersion:            req.SdkVersion,
-				CreatedAt:             time.Now(),
-			}
-
-			if err := record.Insert(ctx, tx, scope); err != nil {
-				return fmt.Errorf("cannot insert consent record: %w", err)
-			}
-
-			return nil
-		},
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return record, nil
-}
-
 func (s *Service) ListCookieConsentRecordsForBanner(
 	ctx context.Context,
 	scope coredata.Scoper,

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -171,6 +171,7 @@ type (
 		CookiePolicyURL   string                                         `json:"cookie_policy_url"`
 		ConsentExpiryDays int                                            `json:"consent_expiry_days"`
 		ConsentMode       string                                         `json:"consent_mode"`
+		Regulation        Regulation                                     `json:"regulation"`
 		ShowBranding      bool                                           `json:"show_branding"`
 		Categories        []coredata.CookieBannerVersionSnapshotCategory `json:"categories"`
 		Texts             map[string]string                              `json:"texts"`
@@ -1527,6 +1528,7 @@ func (s *Service) GetActiveBannerConfig(
 	ctx context.Context,
 	bannerID gid.GID,
 	lang string,
+	regulation Regulation,
 ) (*BannerConfig, error) {
 	var config *BannerConfig
 
@@ -1575,6 +1577,12 @@ func (s *Service) GetActiveBannerConfig(
 	if err != nil {
 		return nil, err
 	}
+
+	config.Regulation = regulation
+	if cm := ConsentModeForRegulation(regulation); cm != "" {
+		config.ConsentMode = cm
+	}
+	remapTextsForConsentMode(config.Texts, config.ConsentMode, regulation)
 
 	return config, nil
 }
@@ -1641,6 +1649,37 @@ func buildBannerConfig(
 		ShowBranding:      banner.ShowBranding,
 		Categories:        categories,
 		Texts:             texts,
+	}
+}
+
+// remapTextsForConsentMode overrides the generic banner text keys with
+// mode-specific variants so the client renders the appropriate copy
+// without needing consent-mode awareness itself.
+func remapTextsForConsentMode(texts map[string]string, consentMode string, regulation Regulation) {
+	if texts == nil {
+		return
+	}
+
+	switch {
+	case consentMode == ConsentModeOptOut:
+		remapTextKey(texts, "banner_title_opt_out", "banner_title")
+		remapTextKey(texts, "banner_description_opt_out", "banner_description")
+		remapTextKey(texts, "button_acknowledge", "button_accept_all")
+		remapTextKey(texts, "button_opt_out", "button_customize")
+		texts["button_reject_all"] = ""
+
+	case regulation == RegulationNone:
+		remapTextKey(texts, "banner_title_notice", "banner_title")
+		remapTextKey(texts, "banner_description_notice", "banner_description")
+		remapTextKey(texts, "button_dismiss", "button_accept_all")
+		texts["button_reject_all"] = ""
+		texts["button_customize"] = ""
+	}
+}
+
+func remapTextKey(texts map[string]string, src, dst string) {
+	if v, ok := texts[src]; ok && v != "" {
+		texts[dst] = v
 	}
 }
 

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -103,8 +103,8 @@ type (
 		ConsentData json.RawMessage
 		Action      coredata.CookieConsentAction
 		SdkVersion  string
-		Regulation  Regulation
-		CountryCode coredata.CountryCode
+		Regulation  *Regulation
+		CountryCode *coredata.CountryCode
 	}
 
 	DetectedCookie struct {
@@ -1845,6 +1845,10 @@ func (s *Service) RecordConsent(
 				Regulation:            req.Regulation,
 				CountryCode:           req.CountryCode,
 				CreatedAt:             time.Now(),
+			}
+
+			if record.Regulation != nil && *record.Regulation == coredata.RegulationNone {
+				record.Regulation = nil
 			}
 
 			if err := record.Insert(ctx, tx, scope); err != nil {

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -104,6 +104,7 @@ type (
 		Action      coredata.CookieConsentAction
 		SdkVersion  string
 		Regulation  Regulation
+		CountryCode coredata.CountryCode
 	}
 
 	DetectedCookie struct {
@@ -1842,6 +1843,7 @@ func (s *Service) RecordConsent(
 				Action:                req.Action,
 				SdkVersion:            req.SdkVersion,
 				Regulation:            req.Regulation,
+				CountryCode:           req.CountryCode,
 				CreatedAt:             time.Now(),
 			}
 

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -1856,7 +1856,7 @@ func (s *Service) RecordConsent(
 				ConsentData:           req.ConsentData,
 				Action:                req.Action,
 				SdkVersion:            req.SdkVersion,
-				Regulation:            string(req.Regulation),
+				Regulation:            req.Regulation,
 				CreatedAt:             time.Now(),
 			}
 

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -103,6 +103,7 @@ type (
 		ConsentData json.RawMessage
 		Action      coredata.CookieConsentAction
 		SdkVersion  string
+		Regulation  Regulation
 	}
 
 	DetectedCookie struct {
@@ -1855,6 +1856,7 @@ func (s *Service) RecordConsent(
 				ConsentData:           req.ConsentData,
 				Action:                req.Action,
 				SdkVersion:            req.SdkVersion,
+				Regulation:            string(req.Regulation),
 				CreatedAt:             time.Now(),
 			}
 

--- a/pkg/coredata/access_entry_upsert_test.go
+++ b/pkg/coredata/access_entry_upsert_test.go
@@ -16,6 +16,7 @@ package coredata_test
 
 import (
 	"context"
+	"net"
 	"net/url"
 	"os"
 	"testing"
@@ -52,7 +53,11 @@ func newTestPgClient(t *testing.T) *pg.Client {
 	// run in parallel.
 	opts := []pg.Option{pg.WithRegisterer(prometheus.NewRegistry())}
 	if u.Host != "" {
-		opts = append(opts, pg.WithAddr(u.Host))
+		host := u.Host
+		if u.Port() == "" {
+			host = net.JoinHostPort(u.Hostname(), "5432")
+		}
+		opts = append(opts, pg.WithAddr(host))
 	}
 	if u.User != nil {
 		opts = append(opts, pg.WithUser(u.User.Username()))

--- a/pkg/coredata/cookie_consent_record.go
+++ b/pkg/coredata/cookie_consent_record.go
@@ -40,7 +40,7 @@ type (
 		ConsentData           json.RawMessage     `db:"consent_data"`
 		Action                CookieConsentAction `db:"action"`
 		SdkVersion            string              `db:"sdk_version"`
-		Regulation            string              `db:"regulation"`
+		Regulation            Regulation          `db:"regulation"`
 		CreatedAt             time.Time           `db:"created_at"`
 	}
 

--- a/pkg/coredata/cookie_consent_record.go
+++ b/pkg/coredata/cookie_consent_record.go
@@ -40,6 +40,7 @@ type (
 		ConsentData           json.RawMessage     `db:"consent_data"`
 		Action                CookieConsentAction `db:"action"`
 		SdkVersion            string              `db:"sdk_version"`
+		Regulation            string              `db:"regulation"`
 		CreatedAt             time.Time           `db:"created_at"`
 	}
 
@@ -90,6 +91,7 @@ SELECT
 	consent_data,
 	action,
 	sdk_version,
+	regulation,
 	created_at
 FROM
 	cookie_consent_records
@@ -174,6 +176,7 @@ INSERT INTO cookie_consent_records (
 	consent_data,
 	action,
 	sdk_version,
+	regulation,
 	created_at
 ) VALUES (
 	@id,
@@ -187,6 +190,7 @@ INSERT INTO cookie_consent_records (
 	@consent_data,
 	@action,
 	@sdk_version,
+	@regulation,
 	@created_at
 )
 `
@@ -203,6 +207,7 @@ INSERT INTO cookie_consent_records (
 		"consent_data":             r.ConsentData,
 		"action":                   r.Action,
 		"sdk_version":              r.SdkVersion,
+		"regulation":               r.Regulation,
 		"created_at":               r.CreatedAt,
 	}
 
@@ -232,6 +237,7 @@ SELECT
 	consent_data,
 	action,
 	sdk_version,
+	regulation,
 	created_at
 FROM
 	cookie_consent_records
@@ -283,6 +289,7 @@ SELECT
 	consent_data,
 	action,
 	sdk_version,
+	regulation,
 	created_at
 FROM
 	cookie_consent_records

--- a/pkg/coredata/cookie_consent_record.go
+++ b/pkg/coredata/cookie_consent_record.go
@@ -40,8 +40,8 @@ type (
 		ConsentData           json.RawMessage     `db:"consent_data"`
 		Action                CookieConsentAction `db:"action"`
 		SdkVersion            string              `db:"sdk_version"`
-		Regulation            Regulation          `db:"regulation"`
-		CountryCode           CountryCode         `db:"country_code"`
+		Regulation            *Regulation         `db:"regulation"`
+		CountryCode           *CountryCode        `db:"country_code"`
 		CreatedAt             time.Time           `db:"created_at"`
 	}
 

--- a/pkg/coredata/cookie_consent_record.go
+++ b/pkg/coredata/cookie_consent_record.go
@@ -41,6 +41,7 @@ type (
 		Action                CookieConsentAction `db:"action"`
 		SdkVersion            string              `db:"sdk_version"`
 		Regulation            Regulation          `db:"regulation"`
+		CountryCode           CountryCode         `db:"country_code"`
 		CreatedAt             time.Time           `db:"created_at"`
 	}
 
@@ -92,6 +93,7 @@ SELECT
 	action,
 	sdk_version,
 	regulation,
+	country_code,
 	created_at
 FROM
 	cookie_consent_records
@@ -177,6 +179,7 @@ INSERT INTO cookie_consent_records (
 	action,
 	sdk_version,
 	regulation,
+	country_code,
 	created_at
 ) VALUES (
 	@id,
@@ -191,6 +194,7 @@ INSERT INTO cookie_consent_records (
 	@action,
 	@sdk_version,
 	@regulation,
+	@country_code,
 	@created_at
 )
 `
@@ -208,6 +212,7 @@ INSERT INTO cookie_consent_records (
 		"action":                   r.Action,
 		"sdk_version":              r.SdkVersion,
 		"regulation":               r.Regulation,
+		"country_code":             r.CountryCode,
 		"created_at":               r.CreatedAt,
 	}
 
@@ -238,6 +243,7 @@ SELECT
 	action,
 	sdk_version,
 	regulation,
+	country_code,
 	created_at
 FROM
 	cookie_consent_records
@@ -290,6 +296,7 @@ SELECT
 	action,
 	sdk_version,
 	regulation,
+	country_code,
 	created_at
 FROM
 	cookie_consent_records

--- a/pkg/coredata/ip_country_block.go
+++ b/pkg/coredata/ip_country_block.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"go.gearno.de/kit/pg"
+)
+
+type IPCountryBlock struct {
+	CIDR        string      `db:"cidr"`
+	CountryCode CountryCode `db:"country_code"`
+}
+
+func LookupCountryByIP(ctx context.Context, conn pg.Querier, ip string) (CountryCode, error) {
+	q := `
+SELECT country_code
+FROM common_ip_country_blocks
+WHERE cidr >>= @ip::inet
+ORDER BY masklen(cidr) DESC
+LIMIT 1;
+`
+
+	args := pgx.StrictNamedArgs{"ip": ip}
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return "", fmt.Errorf("cannot query ip country blocks: %w", err)
+	}
+
+	cc, err := pgx.CollectExactlyOneRow(rows, pgx.RowTo[CountryCode])
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return "", nil
+		}
+		return "", fmt.Errorf("cannot collect ip country block row: %w", err)
+	}
+
+	return cc, nil
+}
+
+func IsIPCountryBlocksPopulated(ctx context.Context, conn pg.Querier) (bool, error) {
+	q := `SELECT EXISTS (SELECT 1 FROM common_ip_country_blocks);`
+
+	rows, err := conn.Query(ctx, q)
+	if err != nil {
+		return false, fmt.Errorf("cannot check if ip country blocks is populated: %w", err)
+	}
+
+	populated, err := pgx.CollectExactlyOneRow(rows, pgx.RowTo[bool])
+	if err != nil {
+		return false, fmt.Errorf("cannot collect populated check: %w", err)
+	}
+
+	return populated, nil
+}
+
+func TruncateIPCountryBlocks(ctx context.Context, conn pg.Querier) error {
+	_, err := conn.Exec(ctx, "TRUNCATE common_ip_country_blocks")
+	if err != nil {
+		return fmt.Errorf("cannot truncate common_ip_country_blocks: %w", err)
+	}
+	return nil
+}
+
+func CopyIPCountryBlocks(ctx context.Context, conn pg.Querier, blocks []IPCountryBlock) error {
+	rows := make([][]any, len(blocks))
+	for i, b := range blocks {
+		rows[i] = []any{b.CIDR, b.CountryCode.String()}
+	}
+
+	_, err := conn.CopyFrom(
+		ctx,
+		pgx.Identifier{"common_ip_country_blocks"},
+		[]string{"cidr", "country_code"},
+		pgx.CopyFromRows(rows),
+	)
+	if err != nil {
+		return fmt.Errorf("cannot copy rows into common_ip_country_blocks: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/coredata/ip_country_block.go
+++ b/pkg/coredata/ip_country_block.go
@@ -70,28 +70,67 @@ func IsIPCountryBlocksPopulated(ctx context.Context, conn pg.Querier) (bool, err
 	return populated, nil
 }
 
-func TruncateIPCountryBlocks(ctx context.Context, conn pg.Querier) error {
-	_, err := conn.Exec(ctx, "TRUNCATE common_ip_country_blocks")
-	if err != nil {
-		return fmt.Errorf("cannot truncate common_ip_country_blocks: %w", err)
+const ipCountryBlocksStagingTable = "common_ip_country_blocks_staging"
+
+func CreateIPCountryBlocksStaging(ctx context.Context, conn pg.Querier) error {
+	q := `
+DROP TABLE IF EXISTS common_ip_country_blocks_staging;
+CREATE TABLE common_ip_country_blocks_staging (LIKE common_ip_country_blocks INCLUDING DEFAULTS);
+`
+
+	if _, err := conn.Exec(ctx, q); err != nil {
+		return fmt.Errorf("cannot create staging table: %w", err)
 	}
+
 	return nil
 }
 
-func CopyIPCountryBlocks(ctx context.Context, conn pg.Querier, blocks []IPCountryBlock) error {
-	rows := make([][]any, len(blocks))
-	for i, b := range blocks {
-		rows[i] = []any{b.CIDR, b.CountryCode.String()}
-	}
-
+func CopyIPCountryBlocksStaging(ctx context.Context, conn pg.Querier, blocks []IPCountryBlock) error {
 	_, err := conn.CopyFrom(
 		ctx,
-		pgx.Identifier{"common_ip_country_blocks"},
+		pgx.Identifier{ipCountryBlocksStagingTable},
 		[]string{"cidr", "country_code"},
-		pgx.CopyFromRows(rows),
+		pgx.CopyFromSlice(len(blocks), func(i int) ([]any, error) {
+			return []any{blocks[i].CIDR, blocks[i].CountryCode.String()}, nil
+		}),
 	)
 	if err != nil {
-		return fmt.Errorf("cannot copy rows into common_ip_country_blocks: %w", err)
+		return fmt.Errorf("cannot copy rows into staging table: %w", err)
+	}
+
+	return nil
+}
+
+func FinalizeIPCountryBlocksStaging(ctx context.Context, conn pg.Querier) error {
+	q := `
+CREATE INDEX idx_common_ip_country_blocks_staging_cidr
+    ON common_ip_country_blocks_staging USING gist (cidr inet_ops);
+ANALYZE common_ip_country_blocks_staging;
+`
+
+	if _, err := conn.Exec(ctx, q); err != nil {
+		return fmt.Errorf("cannot finalize staging table: %w", err)
+	}
+
+	return nil
+}
+
+func SwapIPCountryBlocksStaging(ctx context.Context, conn pg.Querier) error {
+	q := `
+DROP TABLE common_ip_country_blocks;
+ALTER TABLE common_ip_country_blocks_staging RENAME TO common_ip_country_blocks;
+`
+
+	if _, err := conn.Exec(ctx, q); err != nil {
+		return fmt.Errorf("cannot swap staging table: %w", err)
+	}
+
+	return nil
+}
+
+func DropIPCountryBlocksStaging(ctx context.Context, conn pg.Querier) error {
+	if _, err := conn.Exec(ctx, "DROP TABLE IF EXISTS common_ip_country_blocks_staging"); err != nil {
+		return fmt.Errorf("cannot drop staging table: %w", err)
 	}
 
 	return nil

--- a/pkg/coredata/migrations/20260506T084741Z.sql
+++ b/pkg/coredata/migrations/20260506T084741Z.sql
@@ -1,0 +1,21 @@
+-- Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+--
+-- Permission to use, copy, modify, and/or distribute this software for any
+-- purpose with or without fee is hereby granted, provided that the above
+-- copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+-- REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+-- INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+-- LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+-- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+CREATE TABLE common_ip_country_blocks (
+    cidr         CIDR    NOT NULL,
+    country_code CHAR(2) NOT NULL
+);
+
+CREATE INDEX idx_common_ip_country_blocks_cidr
+    ON common_ip_country_blocks USING gist (cidr inet_ops);

--- a/pkg/coredata/migrations/20260506T163600Z.sql
+++ b/pkg/coredata/migrations/20260506T163600Z.sql
@@ -1,0 +1,19 @@
+-- Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+--
+-- Permission to use, copy, modify, and/or distribute this software for any
+-- purpose with or without fee is hereby granted, provided that the above
+-- copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+-- REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+-- INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+-- LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+-- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+ALTER TABLE cookie_consent_records
+    ADD COLUMN regulation TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE cookie_consent_records
+    ALTER COLUMN regulation DROP DEFAULT;

--- a/pkg/coredata/migrations/20260507T083059Z.sql
+++ b/pkg/coredata/migrations/20260507T083059Z.sql
@@ -1,0 +1,69 @@
+-- Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+--
+-- Permission to use, copy, modify, and/or distribute this software for any
+-- purpose with or without fee is hereby granted, provided that the above
+-- copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+-- REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+-- INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+-- LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+-- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+UPDATE cookie_banner_translations
+SET translations = translations || '{
+    "banner_title_opt_out": "Cookie Notice",
+    "banner_description_opt_out": "We use cookies and similar technologies. You can opt out of non-essential cookies. {{cookie_policy_link}}",
+    "button_acknowledge": "OK",
+    "button_opt_out": "Do Not Sell or Share My Personal Information",
+    "banner_title_notice": "Cookie Notice",
+    "banner_description_notice": "This site uses cookies to enhance your experience. {{cookie_policy_link}}",
+    "button_dismiss": "Got it"
+}'::jsonb,
+    updated_at = NOW()
+WHERE language = 'en'
+  AND NOT translations ? 'banner_title_opt_out';
+
+UPDATE cookie_banner_translations
+SET translations = translations || '{
+    "banner_title_opt_out": "Avis sur les cookies",
+    "banner_description_opt_out": "Nous utilisons des cookies et technologies similaires. Vous pouvez refuser les cookies non essentiels. {{cookie_policy_link}}",
+    "button_acknowledge": "OK",
+    "button_opt_out": "Ne pas vendre ni partager mes informations personnelles",
+    "banner_title_notice": "Avis sur les cookies",
+    "banner_description_notice": "Ce site utilise des cookies pour améliorer votre expérience. {{cookie_policy_link}}",
+    "button_dismiss": "Compris"
+}'::jsonb,
+    updated_at = NOW()
+WHERE language = 'fr'
+  AND NOT translations ? 'banner_title_opt_out';
+
+UPDATE cookie_banner_translations
+SET translations = translations || '{
+    "banner_title_opt_out": "Cookie-Hinweis",
+    "banner_description_opt_out": "Wir verwenden Cookies und ähnliche Technologien. Sie können nicht wesentliche Cookies ablehnen. {{cookie_policy_link}}",
+    "button_acknowledge": "OK",
+    "button_opt_out": "Meine persönlichen Daten nicht verkaufen oder weitergeben",
+    "banner_title_notice": "Cookie-Hinweis",
+    "banner_description_notice": "Diese Website verwendet Cookies, um Ihre Erfahrung zu verbessern. {{cookie_policy_link}}",
+    "button_dismiss": "Verstanden"
+}'::jsonb,
+    updated_at = NOW()
+WHERE language = 'de'
+  AND NOT translations ? 'banner_title_opt_out';
+
+UPDATE cookie_banner_translations
+SET translations = translations || '{
+    "banner_title_opt_out": "Aviso de cookies",
+    "banner_description_opt_out": "Utilizamos cookies y tecnologías similares. Puede optar por no recibir cookies no esenciales. {{cookie_policy_link}}",
+    "button_acknowledge": "OK",
+    "button_opt_out": "No vender ni compartir mi información personal",
+    "banner_title_notice": "Aviso de cookies",
+    "banner_description_notice": "Este sitio utiliza cookies para mejorar su experiencia. {{cookie_policy_link}}",
+    "button_dismiss": "Entendido"
+}'::jsonb,
+    updated_at = NOW()
+WHERE language = 'es'
+  AND NOT translations ? 'banner_title_opt_out';

--- a/pkg/coredata/migrations/20260507T131200Z.sql
+++ b/pkg/coredata/migrations/20260507T131200Z.sql
@@ -1,0 +1,19 @@
+-- Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+--
+-- Permission to use, copy, modify, and/or distribute this software for any
+-- purpose with or without fee is hereby granted, provided that the above
+-- copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+-- REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+-- INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+-- LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+-- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+ALTER TABLE cookie_consent_records
+    ADD COLUMN country_code TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE cookie_consent_records
+    ALTER COLUMN country_code DROP DEFAULT;

--- a/pkg/coredata/migrations/20260507T143000Z.sql
+++ b/pkg/coredata/migrations/20260507T143000Z.sql
@@ -1,0 +1,22 @@
+-- Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+--
+-- Permission to use, copy, modify, and/or distribute this software for any
+-- purpose with or without fee is hereby granted, provided that the above
+-- copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+-- REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+-- INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+-- LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+-- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+ALTER TABLE cookie_consent_records
+    ALTER COLUMN regulation DROP NOT NULL;
+
+ALTER TABLE cookie_consent_records
+    ALTER COLUMN country_code DROP NOT NULL;
+
+UPDATE cookie_consent_records SET regulation = NULL WHERE regulation = '';
+UPDATE cookie_consent_records SET country_code = NULL WHERE country_code = '';

--- a/pkg/coredata/regulation.go
+++ b/pkg/coredata/regulation.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+)
+
+type Regulation string
+
+const (
+	RegulationNone    Regulation = ""
+	RegulationGDPR    Regulation = "GDPR"
+	RegulationUKGDPR  Regulation = "UK_GDPR"
+	RegulationFADP    Regulation = "FADP"
+	RegulationCCPA    Regulation = "CCPA"
+	RegulationPIPEDA  Regulation = "PIPEDA"
+	RegulationLGPD    Regulation = "LGPD"
+	RegulationLFPDPPP Regulation = "LFPDPPP"
+	RegulationPOPIA   Regulation = "POPIA"
+	RegulationPDPA    Regulation = "PDPA"
+	RegulationPIPL    Regulation = "PIPL"
+	RegulationPIPA    Regulation = "PIPA"
+	RegulationAPPI    Regulation = "APPI"
+	RegulationDPDP    Regulation = "DPDP"
+	RegulationPDPL    Regulation = "PDPL"
+)
+
+func Regulations() []Regulation {
+	return []Regulation{
+		RegulationGDPR,
+		RegulationUKGDPR,
+		RegulationFADP,
+		RegulationCCPA,
+		RegulationPIPEDA,
+		RegulationLGPD,
+		RegulationLFPDPPP,
+		RegulationPOPIA,
+		RegulationPDPA,
+		RegulationPIPL,
+		RegulationPIPA,
+		RegulationAPPI,
+		RegulationDPDP,
+		RegulationPDPL,
+	}
+}
+
+func ParseRegulation(s string) (Regulation, error) {
+	switch Regulation(s) {
+	case RegulationNone:
+		return RegulationNone, nil
+	case RegulationGDPR:
+		return RegulationGDPR, nil
+	case RegulationUKGDPR:
+		return RegulationUKGDPR, nil
+	case RegulationFADP:
+		return RegulationFADP, nil
+	case RegulationCCPA:
+		return RegulationCCPA, nil
+	case RegulationPIPEDA:
+		return RegulationPIPEDA, nil
+	case RegulationLGPD:
+		return RegulationLGPD, nil
+	case RegulationLFPDPPP:
+		return RegulationLFPDPPP, nil
+	case RegulationPOPIA:
+		return RegulationPOPIA, nil
+	case RegulationPDPA:
+		return RegulationPDPA, nil
+	case RegulationPIPL:
+		return RegulationPIPL, nil
+	case RegulationPIPA:
+		return RegulationPIPA, nil
+	case RegulationAPPI:
+		return RegulationAPPI, nil
+	case RegulationDPDP:
+		return RegulationDPDP, nil
+	case RegulationPDPL:
+		return RegulationPDPL, nil
+	default:
+		return "", fmt.Errorf("invalid Regulation value: %q", s)
+	}
+}
+
+func (r Regulation) String() string {
+	return string(r)
+}
+
+func (r *Regulation) Scan(value any) error {
+	var v string
+	switch val := value.(type) {
+	case string:
+		v = val
+	case []byte:
+		v = string(val)
+	default:
+		return fmt.Errorf("unsupported type for Regulation: %T", value)
+	}
+
+	parsed, err := ParseRegulation(v)
+	if err != nil {
+		return err
+	}
+
+	*r = parsed
+	return nil
+}
+
+func (r Regulation) Value() (driver.Value, error) {
+	if r == RegulationNone {
+		return "", nil
+	}
+
+	if _, err := ParseRegulation(string(r)); err != nil {
+		return nil, fmt.Errorf("invalid Regulation: %s", r)
+	}
+
+	return string(r), nil
+}
+
+func (r Regulation) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(r))
+}
+
+func (r *Regulation) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("cannot unmarshal Regulation: %w", err)
+	}
+
+	parsed, err := ParseRegulation(s)
+	if err != nil {
+		return err
+	}
+
+	*r = parsed
+	return nil
+}

--- a/pkg/geoloc/service.go
+++ b/pkg/geoloc/service.go
@@ -100,9 +100,9 @@ func (s *Service) LookupCountry(ctx context.Context, ip string) (coredata.Countr
 	err := s.pgClient.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			var lookupErr error
-			cc, lookupErr = coredata.LookupCountryByIP(ctx, conn, ip)
-			return lookupErr
+			var err error
+			cc, err = coredata.LookupCountryByIP(ctx, conn, ip)
+			return err
 		},
 	)
 	if err != nil {
@@ -118,9 +118,9 @@ func (s *Service) IsPopulated(ctx context.Context) (bool, error) {
 	err := s.pgClient.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			var lookupErr error
-			populated, lookupErr = coredata.IsIPCountryBlocksPopulated(ctx, conn)
-			return lookupErr
+			var err error
+			populated, err = coredata.IsIPCountryBlocksPopulated(ctx, conn)
+			return err
 		},
 	)
 	if err != nil {

--- a/pkg/geoloc/service.go
+++ b/pkg/geoloc/service.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package geoloc
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+type Service struct {
+	pgClient *pg.Client
+}
+
+func NewService(pgClient *pg.Client) *Service {
+	return &Service{pgClient: pgClient}
+}
+
+func (s *Service) ImportFromDir(ctx context.Context, dataDir string) error {
+	countryDir := filepath.Join(dataDir, "country")
+
+	entries, err := os.ReadDir(countryDir)
+	if err != nil {
+		return fmt.Errorf("cannot read country directory: %w", err)
+	}
+
+	type row struct {
+		cidr        string
+		countryCode coredata.CountryCode
+	}
+
+	var rows []row
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		code := strings.ToUpper(entry.Name())
+		var cc coredata.CountryCode
+		if err := cc.Scan(code); err != nil {
+			continue
+		}
+
+		for _, filename := range []string{"ipv4-aggregated.txt", "ipv6-aggregated.txt"} {
+			path := filepath.Join(countryDir, entry.Name(), filename)
+
+			cidrs, err := parseCIDRFile(path)
+			if err != nil {
+				continue
+			}
+
+			for _, cidr := range cidrs {
+				rows = append(rows, row{cidr: cidr, countryCode: cc})
+			}
+		}
+	}
+
+	return s.pgClient.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			_, err := tx.Exec(ctx, "TRUNCATE common_ip_country_blocks")
+			if err != nil {
+				return fmt.Errorf("cannot truncate common_ip_country_blocks: %w", err)
+			}
+
+			pgxRows := make([][]any, len(rows))
+			for i, r := range rows {
+				pgxRows[i] = []any{r.cidr, r.countryCode.String()}
+			}
+
+			_, err = tx.CopyFrom(
+				ctx,
+				pgx.Identifier{"common_ip_country_blocks"},
+				[]string{"cidr", "country_code"},
+				pgx.CopyFromRows(pgxRows),
+			)
+			if err != nil {
+				return fmt.Errorf("cannot copy rows into common_ip_country_blocks: %w", err)
+			}
+
+			return nil
+		},
+	)
+}
+
+func (s *Service) LookupCountry(ctx context.Context, conn pg.Querier, ip string) (coredata.CountryCode, error) {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return "", fmt.Errorf("cannot parse IP address: %q", ip)
+	}
+
+	q := `
+SELECT country_code
+FROM common_ip_country_blocks
+WHERE cidr >>= @ip::inet
+ORDER BY masklen(cidr) DESC
+LIMIT 1;
+`
+
+	args := pgx.StrictNamedArgs{"ip": ip}
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return "", fmt.Errorf("cannot query ip country blocks: %w", err)
+	}
+
+	cc, err := pgx.CollectExactlyOneRow(rows, pgx.RowTo[coredata.CountryCode])
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return "", nil
+		}
+		return "", fmt.Errorf("cannot collect ip country block row: %w", err)
+	}
+
+	return cc, nil
+}
+
+func (s *Service) IsPopulated(ctx context.Context, conn pg.Querier) (bool, error) {
+	q := `SELECT EXISTS (SELECT 1 FROM common_ip_country_blocks);`
+
+	rows, err := conn.Query(ctx, q)
+	if err != nil {
+		return false, fmt.Errorf("cannot check if ip country blocks is populated: %w", err)
+	}
+
+	populated, err := pgx.CollectExactlyOneRow(rows, pgx.RowTo[bool])
+	if err != nil {
+		return false, fmt.Errorf("cannot collect populated check: %w", err)
+	}
+
+	return populated, nil
+}
+
+func parseCIDRFile(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var cidrs []string
+	scanner := bufio.NewScanner(f)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		_, _, err := net.ParseCIDR(line)
+		if err != nil {
+			continue
+		}
+
+		cidrs = append(cidrs, line)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("cannot scan file: %w", err)
+	}
+
+	return cidrs, nil
+}

--- a/pkg/geoloc/service.go
+++ b/pkg/geoloc/service.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/coredata"
 )
@@ -44,12 +43,7 @@ func (s *Service) ImportFromDir(ctx context.Context, dataDir string) error {
 		return fmt.Errorf("cannot read country directory: %w", err)
 	}
 
-	type row struct {
-		cidr        string
-		countryCode coredata.CountryCode
-	}
-
-	var rows []row
+	var blocks []coredata.IPCountryBlock
 
 	for _, entry := range entries {
 		if !entry.IsDir() {
@@ -71,7 +65,10 @@ func (s *Service) ImportFromDir(ctx context.Context, dataDir string) error {
 			}
 
 			for _, cidr := range cidrs {
-				rows = append(rows, row{cidr: cidr, countryCode: cc})
+				blocks = append(blocks, coredata.IPCountryBlock{
+					CIDR:        cidr,
+					CountryCode: cc,
+				})
 			}
 		}
 	}
@@ -79,24 +76,12 @@ func (s *Service) ImportFromDir(ctx context.Context, dataDir string) error {
 	return s.pgClient.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			_, err := tx.Exec(ctx, "TRUNCATE common_ip_country_blocks")
-			if err != nil {
-				return fmt.Errorf("cannot truncate common_ip_country_blocks: %w", err)
+			if err := coredata.TruncateIPCountryBlocks(ctx, tx); err != nil {
+				return err
 			}
 
-			pgxRows := make([][]any, len(rows))
-			for i, r := range rows {
-				pgxRows[i] = []any{r.cidr, r.countryCode.String()}
-			}
-
-			_, err = tx.CopyFrom(
-				ctx,
-				pgx.Identifier{"common_ip_country_blocks"},
-				[]string{"cidr", "country_code"},
-				pgx.CopyFromRows(pgxRows),
-			)
-			if err != nil {
-				return fmt.Errorf("cannot copy rows into common_ip_country_blocks: %w", err)
+			if err := coredata.CopyIPCountryBlocks(ctx, tx, blocks); err != nil {
+				return err
 			}
 
 			return nil
@@ -110,46 +95,11 @@ func (s *Service) LookupCountry(ctx context.Context, conn pg.Querier, ip string)
 		return "", fmt.Errorf("cannot parse IP address: %q", ip)
 	}
 
-	q := `
-SELECT country_code
-FROM common_ip_country_blocks
-WHERE cidr >>= @ip::inet
-ORDER BY masklen(cidr) DESC
-LIMIT 1;
-`
-
-	args := pgx.StrictNamedArgs{"ip": ip}
-
-	rows, err := conn.Query(ctx, q, args)
-	if err != nil {
-		return "", fmt.Errorf("cannot query ip country blocks: %w", err)
-	}
-
-	cc, err := pgx.CollectExactlyOneRow(rows, pgx.RowTo[coredata.CountryCode])
-	if err != nil {
-		if err == pgx.ErrNoRows {
-			return "", nil
-		}
-		return "", fmt.Errorf("cannot collect ip country block row: %w", err)
-	}
-
-	return cc, nil
+	return coredata.LookupCountryByIP(ctx, conn, ip)
 }
 
 func (s *Service) IsPopulated(ctx context.Context, conn pg.Querier) (bool, error) {
-	q := `SELECT EXISTS (SELECT 1 FROM common_ip_country_blocks);`
-
-	rows, err := conn.Query(ctx, q)
-	if err != nil {
-		return false, fmt.Errorf("cannot check if ip country blocks is populated: %w", err)
-	}
-
-	populated, err := pgx.CollectExactlyOneRow(rows, pgx.RowTo[bool])
-	if err != nil {
-		return false, fmt.Errorf("cannot collect populated check: %w", err)
-	}
-
-	return populated, nil
+	return coredata.IsIPCountryBlocksPopulated(ctx, conn)
 }
 
 func parseCIDRFile(path string) ([]string, error) {

--- a/pkg/geoloc/service.go
+++ b/pkg/geoloc/service.go
@@ -17,6 +17,7 @@ package geoloc
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -60,6 +61,9 @@ func (s *Service) ImportFromDir(ctx context.Context, dataDir string) error {
 			path := filepath.Join(countryDir, entry.Name(), filename)
 
 			cidrs, err := parseCIDRFile(path)
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
 			if err != nil {
 				return fmt.Errorf("cannot parse CIDR file %s: %w", path, err)
 			}

--- a/pkg/geoloc/service.go
+++ b/pkg/geoloc/service.go
@@ -61,7 +61,7 @@ func (s *Service) ImportFromDir(ctx context.Context, dataDir string) error {
 
 			cidrs, err := parseCIDRFile(path)
 			if err != nil {
-				continue
+				return fmt.Errorf("cannot parse CIDR file %s: %w", path, err)
 			}
 
 			for _, cidr := range cidrs {
@@ -73,20 +73,37 @@ func (s *Service) ImportFromDir(ctx context.Context, dataDir string) error {
 		}
 	}
 
-	return s.pgClient.WithTx(
-		ctx,
-		func(ctx context.Context, tx pg.Tx) error {
-			if err := coredata.TruncateIPCountryBlocks(ctx, tx); err != nil {
-				return err
-			}
+	if err := s.pgClient.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		if err := coredata.CreateIPCountryBlocksStaging(ctx, conn); err != nil {
+			return fmt.Errorf("cannot create staging table: %w", err)
+		}
 
-			if err := coredata.CopyIPCountryBlocks(ctx, tx, blocks); err != nil {
-				return err
-			}
+		if err := coredata.CopyIPCountryBlocksStaging(ctx, conn, blocks); err != nil {
+			return fmt.Errorf("cannot copy IP country blocks to staging: %w", err)
+		}
 
-			return nil
-		},
-	)
+		if err := coredata.FinalizeIPCountryBlocksStaging(ctx, conn); err != nil {
+			return fmt.Errorf("cannot finalize staging table: %w", err)
+		}
+
+		return nil
+	}); err != nil {
+		_ = s.pgClient.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+			return coredata.DropIPCountryBlocksStaging(ctx, conn)
+		})
+		return err
+	}
+
+	if err := s.pgClient.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		return coredata.SwapIPCountryBlocksStaging(ctx, tx)
+	}); err != nil {
+		_ = s.pgClient.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+			return coredata.DropIPCountryBlocksStaging(ctx, conn)
+		})
+		return fmt.Errorf("cannot swap staging table: %w", err)
+	}
+
+	return nil
 }
 
 func (s *Service) LookupCountry(ctx context.Context, ip string) (coredata.CountryCode, error) {
@@ -101,8 +118,11 @@ func (s *Service) LookupCountry(ctx context.Context, ip string) (coredata.Countr
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			var err error
-			cc, err = coredata.LookupCountryByIP(ctx, conn, ip)
-			return err
+			if cc, err = coredata.LookupCountryByIP(ctx, conn, ip); err != nil {
+				return fmt.Errorf("cannot lookup country by IP: %w", err)
+			}
+
+			return nil
 		},
 	)
 	if err != nil {
@@ -119,8 +139,11 @@ func (s *Service) IsPopulated(ctx context.Context) (bool, error) {
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			var err error
-			populated, err = coredata.IsIPCountryBlocksPopulated(ctx, conn)
-			return err
+			if populated, err = coredata.IsIPCountryBlocksPopulated(ctx, conn); err != nil {
+				return fmt.Errorf("cannot check if IP country blocks are populated: %w", err)
+			}
+
+			return nil
 		},
 	)
 	if err != nil {
@@ -148,7 +171,7 @@ func parseCIDRFile(path string) ([]string, error) {
 
 		_, _, err := net.ParseCIDR(line)
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("cannot parse file: %w", err)
 		}
 
 		cidrs = append(cidrs, line)

--- a/pkg/geoloc/service.go
+++ b/pkg/geoloc/service.go
@@ -77,34 +77,34 @@ func (s *Service) ImportFromDir(ctx context.Context, dataDir string) error {
 		}
 	}
 
-	if err := s.pgClient.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
-		if err := coredata.CreateIPCountryBlocksStaging(ctx, conn); err != nil {
-			return fmt.Errorf("cannot create staging table: %w", err)
-		}
+	if err := s.pgClient.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			if err := coredata.CreateIPCountryBlocksStaging(ctx, conn); err != nil {
+				return fmt.Errorf("cannot create staging table: %w", err)
+			}
 
-		if err := coredata.CopyIPCountryBlocksStaging(ctx, conn, blocks); err != nil {
-			return fmt.Errorf("cannot copy IP country blocks to staging: %w", err)
-		}
+			if err := coredata.CopyIPCountryBlocksStaging(ctx, conn, blocks); err != nil {
+				return fmt.Errorf("cannot copy IP country blocks to staging: %w", err)
+			}
 
-		if err := coredata.FinalizeIPCountryBlocksStaging(ctx, conn); err != nil {
-			return fmt.Errorf("cannot finalize staging table: %w", err)
-		}
+			if err := coredata.FinalizeIPCountryBlocksStaging(ctx, conn); err != nil {
+				return fmt.Errorf("cannot finalize staging table: %w", err)
+			}
 
-		return nil
-	}); err != nil {
-		_ = s.pgClient.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
-			return coredata.DropIPCountryBlocksStaging(ctx, conn)
-		})
+			return nil
+		},
+	); err != nil {
 		return err
 	}
 
-	if err := s.pgClient.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
-		return coredata.SwapIPCountryBlocksStaging(ctx, tx)
-	}); err != nil {
-		_ = s.pgClient.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
-			return coredata.DropIPCountryBlocksStaging(ctx, conn)
-		})
-		return fmt.Errorf("cannot swap staging table: %w", err)
+	if err := s.pgClient.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			return fmt.Errorf("cannot swap staging table: %w", err)
+		},
+	); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/geoloc/service.go
+++ b/pkg/geoloc/service.go
@@ -89,17 +89,45 @@ func (s *Service) ImportFromDir(ctx context.Context, dataDir string) error {
 	)
 }
 
-func (s *Service) LookupCountry(ctx context.Context, conn pg.Querier, ip string) (coredata.CountryCode, error) {
+func (s *Service) LookupCountry(ctx context.Context, ip string) (coredata.CountryCode, error) {
 	parsed := net.ParseIP(ip)
 	if parsed == nil {
 		return "", fmt.Errorf("cannot parse IP address: %q", ip)
 	}
 
-	return coredata.LookupCountryByIP(ctx, conn, ip)
+	var cc coredata.CountryCode
+
+	err := s.pgClient.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			var lookupErr error
+			cc, lookupErr = coredata.LookupCountryByIP(ctx, conn, ip)
+			return lookupErr
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+
+	return cc, nil
 }
 
-func (s *Service) IsPopulated(ctx context.Context, conn pg.Querier) (bool, error) {
-	return coredata.IsIPCountryBlocksPopulated(ctx, conn)
+func (s *Service) IsPopulated(ctx context.Context) (bool, error) {
+	var populated bool
+
+	err := s.pgClient.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			var lookupErr error
+			populated, lookupErr = coredata.IsIPCountryBlocksPopulated(ctx, conn)
+			return lookupErr
+		},
+	)
+	if err != nil {
+		return false, err
+	}
+
+	return populated, nil
 }
 
 func parseCIDRFile(path string) ([]string, error) {

--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -57,6 +57,7 @@ import (
 	"go.probo.inc/probo/pkg/evidencedescriber"
 	"go.probo.inc/probo/pkg/file"
 	"go.probo.inc/probo/pkg/filemanager"
+	"go.probo.inc/probo/pkg/geoloc"
 	"go.probo.inc/probo/pkg/html2pdf"
 	"go.probo.inc/probo/pkg/iam"
 	"go.probo.inc/probo/pkg/iam/oauth2server"
@@ -258,6 +259,24 @@ func (impl *Implm) Run(
 	err = migrator.NewMigrator(pgClient, coredata.Migrations, l.Named("migrations")).Run(ctx, "migrations")
 	if err != nil {
 		return fmt.Errorf("cannot migrate database schema: %w", err)
+	}
+
+	geolocService := geoloc.NewService(pgClient)
+	err = pgClient.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			populated, err := geolocService.IsPopulated(ctx, conn)
+			if err != nil {
+				return err
+			}
+			if !populated {
+				l.Warn("IP geolocation table is empty; run geoloc-import to populate it")
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		l.ErrorCtx(ctx, "cannot check geoloc table", log.Error(err))
 	}
 
 	hp, err := passwdhash.NewProfile(pepper, uint32(impl.cfg.Auth.Password.Iterations))

--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -262,21 +262,11 @@ func (impl *Implm) Run(
 	}
 
 	geolocService := geoloc.NewService(pgClient)
-	err = pgClient.WithConn(
-		ctx,
-		func(ctx context.Context, conn pg.Querier) error {
-			populated, err := geolocService.IsPopulated(ctx, conn)
-			if err != nil {
-				return err
-			}
-			if !populated {
-				l.Warn("IP geolocation table is empty; run geoloc-import to populate it")
-			}
-			return nil
-		},
-	)
+	populated, err := geolocService.IsPopulated(ctx)
 	if err != nil {
 		l.ErrorCtx(ctx, "cannot check geoloc table", log.Error(err))
+	} else if !populated {
+		l.Warn("IP geolocation table is empty; run geoloc-import to populate it")
 	}
 
 	hp, err := passwdhash.NewProfile(pepper, uint32(impl.cfg.Auth.Password.Iterations))
@@ -538,6 +528,7 @@ func (impl *Implm) Run(
 			AccessReview:      accessReviewService,
 			Mailman:           mailmanService,
 			CookieBanner:      cookieBannerService,
+			Geoloc:            geolocService,
 			Slack:             slackService,
 			ConnectorRegistry: defaultConnectorRegistry,
 			BaseURL:           baseURL,

--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -31,6 +31,7 @@ import (
 	"go.probo.inc/probo/pkg/cookiebanner"
 	"go.probo.inc/probo/pkg/esign"
 	"go.probo.inc/probo/pkg/file"
+	"go.probo.inc/probo/pkg/geoloc"
 	"go.probo.inc/probo/pkg/iam"
 	"go.probo.inc/probo/pkg/mailman"
 	"go.probo.inc/probo/pkg/probo"
@@ -59,6 +60,7 @@ type (
 		Slack             *slack.Service
 		Mailman           *mailman.Service
 		CookieBanner      *cookiebanner.Service
+		Geoloc            *geoloc.Service
 		Cookie            securecookie.Config
 		TokenSecret       string
 		ConnectorRegistry *connector.ConnectorRegistry
@@ -192,6 +194,7 @@ func NewServer(cfg Config) (*Server, error) {
 		cookieBannerHandler: cookiebanner_v1.NewMux(
 			cfg.Logger.Named("cookiebanner.v1"),
 			cfg.CookieBanner,
+			cfg.Geoloc,
 		),
 		filesHandler: files_v1.NewMux(
 			cfg.Logger.Named("files.v1"),

--- a/pkg/server/api/console/v1/graphql/cookie_consent_record.graphql
+++ b/pkg/server/api/console/v1/graphql/cookie_consent_record.graphql
@@ -130,8 +130,8 @@ type CookieConsentRecord implements Node {
     consentData: String!
     action: CookieConsentAction!
     sdkVersion: String!
-    regulation: Regulation!
-    countryCode: CountryCode!
+    regulation: Regulation
+    countryCode: CountryCode
     createdAt: Datetime!
 }
 

--- a/pkg/server/api/console/v1/graphql/cookie_consent_record.graphql
+++ b/pkg/server/api/console/v1/graphql/cookie_consent_record.graphql
@@ -32,6 +32,70 @@ enum CookieConsentAction
         )
 }
 
+enum Regulation
+    @goModel(model: "go.probo.inc/probo/pkg/coredata.Regulation") {
+    NONE
+        @goEnum(
+            value: "go.probo.inc/probo/pkg/coredata.RegulationNone"
+        )
+    GDPR
+        @goEnum(
+            value: "go.probo.inc/probo/pkg/coredata.RegulationGDPR"
+        )
+    UK_GDPR
+        @goEnum(
+            value: "go.probo.inc/probo/pkg/coredata.RegulationUKGDPR"
+        )
+    FADP
+        @goEnum(
+            value: "go.probo.inc/probo/pkg/coredata.RegulationFADP"
+        )
+    CCPA
+        @goEnum(
+            value: "go.probo.inc/probo/pkg/coredata.RegulationCCPA"
+        )
+    PIPEDA
+        @goEnum(
+            value: "go.probo.inc/probo/pkg/coredata.RegulationPIPEDA"
+        )
+    LGPD
+        @goEnum(
+            value: "go.probo.inc/probo/pkg/coredata.RegulationLGPD"
+        )
+    LFPDPPP
+        @goEnum(
+            value: "go.probo.inc/probo/pkg/coredata.RegulationLFPDPPP"
+        )
+    POPIA
+        @goEnum(
+            value: "go.probo.inc/probo/pkg/coredata.RegulationPOPIA"
+        )
+    PDPA
+        @goEnum(
+            value: "go.probo.inc/probo/pkg/coredata.RegulationPDPA"
+        )
+    PIPL
+        @goEnum(
+            value: "go.probo.inc/probo/pkg/coredata.RegulationPIPL"
+        )
+    PIPA
+        @goEnum(
+            value: "go.probo.inc/probo/pkg/coredata.RegulationPIPA"
+        )
+    APPI
+        @goEnum(
+            value: "go.probo.inc/probo/pkg/coredata.RegulationAPPI"
+        )
+    DPDP
+        @goEnum(
+            value: "go.probo.inc/probo/pkg/coredata.RegulationDPDP"
+        )
+    PDPL
+        @goEnum(
+            value: "go.probo.inc/probo/pkg/coredata.RegulationPDPL"
+        )
+}
+
 enum CookieConsentRecordOrderField
     @goModel(
         model: "go.probo.inc/probo/pkg/coredata.CookieConsentRecordOrderField"
@@ -66,7 +130,8 @@ type CookieConsentRecord implements Node {
     consentData: String!
     action: CookieConsentAction!
     sdkVersion: String!
-    regulation: String!
+    regulation: Regulation!
+    countryCode: CountryCode!
     createdAt: Datetime!
 }
 

--- a/pkg/server/api/console/v1/graphql/cookie_consent_record.graphql
+++ b/pkg/server/api/console/v1/graphql/cookie_consent_record.graphql
@@ -66,6 +66,7 @@ type CookieConsentRecord implements Node {
     consentData: String!
     action: CookieConsentAction!
     sdkVersion: String!
+    regulation: String!
     createdAt: Datetime!
 }
 

--- a/pkg/server/api/console/v1/types/cookie_consent_record.go
+++ b/pkg/server/api/console/v1/types/cookie_consent_record.go
@@ -81,7 +81,8 @@ func NewCookieConsentRecord(r *coredata.CookieConsentRecord) *CookieConsentRecor
 		ConsentData: string(r.ConsentData),
 		Action:      r.Action,
 		SdkVersion:  r.SdkVersion,
-		Regulation:  r.Regulation.String(),
+		Regulation:  r.Regulation,
+		CountryCode: r.CountryCode,
 		CreatedAt:   r.CreatedAt,
 	}
 }

--- a/pkg/server/api/console/v1/types/cookie_consent_record.go
+++ b/pkg/server/api/console/v1/types/cookie_consent_record.go
@@ -81,6 +81,7 @@ func NewCookieConsentRecord(r *coredata.CookieConsentRecord) *CookieConsentRecor
 		ConsentData: string(r.ConsentData),
 		Action:      r.Action,
 		SdkVersion:  r.SdkVersion,
+		Regulation:  r.Regulation.String(),
 		CreatedAt:   r.CreatedAt,
 	}
 }

--- a/pkg/server/api/cookiebanner/v1/handler.go
+++ b/pkg/server/api/cookiebanner/v1/handler.go
@@ -71,7 +71,8 @@ func (h *Handler) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	lang := r.URL.Query().Get("lang")
-	regulation := h.resolveRegulation(r)
+	cc := h.resolveCountryCode(r)
+	regulation := cookiebanner.RegulationForCountry(cc)
 
 	config, err := h.cookieBannerSvc.GetActiveBannerConfig(r.Context(), bannerID, lang, regulation)
 	if err != nil {
@@ -91,20 +92,16 @@ func (h *Handler) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 	httpserver.RenderJSON(w, http.StatusOK, config)
 }
 
-func (h *Handler) resolveRegulation(r *http.Request) cookiebanner.Regulation {
+func (h *Handler) resolveCountryCode(r *http.Request) coredata.CountryCode {
 	ip := clientip.Extract(r)
 
 	cc, err := h.geolocSvc.LookupCountry(r.Context(), ip)
 	if err != nil {
 		h.logger.ErrorCtx(r.Context(), "cannot resolve country for IP", log.Error(err))
-		return cookiebanner.RegulationNone
+		return ""
 	}
 
-	if cc == "" {
-		return cookiebanner.RegulationNone
-	}
-
-	return cookiebanner.RegulationForCountry(cc)
+	return cc
 }
 
 func (h *Handler) handleGetConsent(w http.ResponseWriter, r *http.Request) {
@@ -170,6 +167,7 @@ func (h *Handler) handlePostConsent(w http.ResponseWriter, r *http.Request) {
 	ip := clientip.Extract(r)
 	ua := r.UserAgent()
 	sdkVersion := r.Header.Get("X-SDK-Version")
+	cc := h.resolveCountryCode(r)
 
 	req := cookiebanner.RecordConsentRequest{
 		Version:     body.Version,
@@ -179,7 +177,8 @@ func (h *Handler) handlePostConsent(w http.ResponseWriter, r *http.Request) {
 		ConsentData: body.ConsentData,
 		Action:      body.Action,
 		SdkVersion:  sdkVersion,
-		Regulation:  h.resolveRegulation(r),
+		Regulation:  cookiebanner.RegulationForCountry(cc),
+		CountryCode: cc,
 	}
 
 	record, err := h.cookieBannerSvc.RecordConsent(r.Context(), bannerID, req)

--- a/pkg/server/api/cookiebanner/v1/handler.go
+++ b/pkg/server/api/cookiebanner/v1/handler.go
@@ -72,7 +72,11 @@ func (h *Handler) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 
 	lang := r.URL.Query().Get("lang")
 	cc := h.resolveCountryCode(r)
-	regulation := cookiebanner.RegulationForCountry(cc)
+
+	var regulation cookiebanner.Regulation
+	if cc != nil {
+		regulation = cookiebanner.RegulationForCountry(*cc)
+	}
 
 	config, err := h.cookieBannerSvc.GetActiveBannerConfig(r.Context(), bannerID, lang, regulation)
 	if err != nil {
@@ -92,16 +96,16 @@ func (h *Handler) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 	httpserver.RenderJSON(w, http.StatusOK, config)
 }
 
-func (h *Handler) resolveCountryCode(r *http.Request) coredata.CountryCode {
+func (h *Handler) resolveCountryCode(r *http.Request) *coredata.CountryCode {
 	ip := clientip.Extract(r)
 
 	cc, err := h.geolocSvc.LookupCountry(r.Context(), ip)
 	if err != nil {
 		h.logger.ErrorCtx(r.Context(), "cannot resolve country for IP", log.Error(err))
-		return ""
+		return nil
 	}
 
-	return cc
+	return &cc
 }
 
 func (h *Handler) handleGetConsent(w http.ResponseWriter, r *http.Request) {
@@ -169,6 +173,12 @@ func (h *Handler) handlePostConsent(w http.ResponseWriter, r *http.Request) {
 	sdkVersion := r.Header.Get("X-SDK-Version")
 	cc := h.resolveCountryCode(r)
 
+	var regulation *cookiebanner.Regulation
+	if cc != nil {
+		r := cookiebanner.RegulationForCountry(*cc)
+		regulation = &r
+	}
+
 	req := cookiebanner.RecordConsentRequest{
 		Version:     body.Version,
 		VisitorID:   body.VisitorID,
@@ -177,7 +187,7 @@ func (h *Handler) handlePostConsent(w http.ResponseWriter, r *http.Request) {
 		ConsentData: body.ConsentData,
 		Action:      body.Action,
 		SdkVersion:  sdkVersion,
-		Regulation:  cookiebanner.RegulationForCountry(cc),
+		Regulation:  regulation,
 		CountryCode: cc,
 	}
 

--- a/pkg/server/api/cookiebanner/v1/handler.go
+++ b/pkg/server/api/cookiebanner/v1/handler.go
@@ -27,6 +27,7 @@ import (
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/cookiebanner"
 	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/geoloc"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/server/api/clientip"
 	"go.probo.inc/probo/pkg/server/jsonutil"
@@ -35,15 +36,18 @@ import (
 type Handler struct {
 	logger          *log.Logger
 	cookieBannerSvc *cookiebanner.Service
+	geolocSvc       *geoloc.Service
 }
 
 func NewMux(
 	logger *log.Logger,
 	cookieBannerSvc *cookiebanner.Service,
+	geolocSvc *geoloc.Service,
 ) *chi.Mux {
 	h := &Handler{
 		logger:          logger,
 		cookieBannerSvc: cookieBannerSvc,
+		geolocSvc:       geolocSvc,
 	}
 
 	r := chi.NewMux()
@@ -57,6 +61,11 @@ func NewMux(
 	})
 
 	return r
+}
+
+type configResponse struct {
+	*cookiebanner.BannerConfig
+	Regulation cookiebanner.Regulation `json:"regulation"`
 }
 
 func (h *Handler) handleGetConfig(w http.ResponseWriter, r *http.Request) {
@@ -83,7 +92,31 @@ func (h *Handler) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httpserver.RenderJSON(w, http.StatusOK, config)
+	regulation := h.resolveRegulation(r)
+	if cm := cookiebanner.ConsentModeForRegulation(regulation); cm != "" {
+		config.ConsentMode = cm
+	}
+
+	httpserver.RenderJSON(w, http.StatusOK, configResponse{
+		BannerConfig: config,
+		Regulation:   regulation,
+	})
+}
+
+func (h *Handler) resolveRegulation(r *http.Request) cookiebanner.Regulation {
+	ip := clientip.Extract(r)
+
+	cc, err := h.geolocSvc.LookupCountry(r.Context(), ip)
+	if err != nil {
+		h.logger.ErrorCtx(r.Context(), "cannot resolve country for IP", log.Error(err))
+		return cookiebanner.RegulationNone
+	}
+
+	if cc == "" {
+		return cookiebanner.RegulationNone
+	}
+
+	return cookiebanner.RegulationForCountry(cc)
 }
 
 func (h *Handler) handleGetConsent(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/api/cookiebanner/v1/handler.go
+++ b/pkg/server/api/cookiebanner/v1/handler.go
@@ -191,6 +191,7 @@ func (h *Handler) handlePostConsent(w http.ResponseWriter, r *http.Request) {
 		ConsentData: body.ConsentData,
 		Action:      body.Action,
 		SdkVersion:  sdkVersion,
+		Regulation:  h.resolveRegulation(r),
 	}
 
 	record, err := h.cookieBannerSvc.RecordConsent(r.Context(), bannerID, req)

--- a/pkg/server/api/cookiebanner/v1/handler.go
+++ b/pkg/server/api/cookiebanner/v1/handler.go
@@ -63,11 +63,6 @@ func NewMux(
 	return r
 }
 
-type configResponse struct {
-	*cookiebanner.BannerConfig
-	Regulation cookiebanner.Regulation `json:"regulation"`
-}
-
 func (h *Handler) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 	bannerID, err := gid.ParseGID(chi.URLParam(r, "bannerID"))
 	if err != nil {
@@ -76,8 +71,9 @@ func (h *Handler) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	lang := r.URL.Query().Get("lang")
+	regulation := h.resolveRegulation(r)
 
-	config, err := h.cookieBannerSvc.GetActiveBannerConfig(r.Context(), bannerID, lang)
+	config, err := h.cookieBannerSvc.GetActiveBannerConfig(r.Context(), bannerID, lang, regulation)
 	if err != nil {
 		if errors.Is(err, cookiebanner.ErrBannerNotFound) {
 			jsonutil.RenderNotFound(w, fmt.Errorf("banner not found"))
@@ -92,15 +88,7 @@ func (h *Handler) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	regulation := h.resolveRegulation(r)
-	if cm := cookiebanner.ConsentModeForRegulation(regulation); cm != "" {
-		config.ConsentMode = cm
-	}
-
-	httpserver.RenderJSON(w, http.StatusOK, configResponse{
-		BannerConfig: config,
-		Regulation:   regulation,
-	})
+	httpserver.RenderJSON(w, http.StatusOK, config)
 }
 
 func (h *Handler) resolveRegulation(r *http.Request) cookiebanner.Regulation {

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -9565,8 +9565,6 @@ components:
         - consent_data
         - action
         - sdk_version
-        - regulation
-        - country_code
         - created_at
       properties:
         id:
@@ -9604,9 +9602,11 @@ components:
         regulation:
           $ref: "#/components/schemas/Regulation"
           description: Applicable regulation
+          nullable: true
         country_code:
           $ref: "#/components/schemas/CountryCode"
           description: Visitor country code (ISO 3166-1 alpha-2)
+          nullable: true
         created_at:
           type: string
           format: date-time

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -187,6 +187,280 @@ components:
         - INACTIVE
       go.probo.inc/mcpgen/type: go.probo.inc/probo/pkg/coredata.ProfileState
 
+    Regulation:
+      type: string
+      enum:
+        - NONE
+        - GDPR
+        - UK_GDPR
+        - FADP
+        - CCPA
+        - PIPEDA
+        - LGPD
+        - LFPDPPP
+        - POPIA
+        - PDPA
+        - PIPL
+        - PIPA
+        - APPI
+        - DPDP
+        - PDPL
+      go.probo.inc/mcpgen/type: go.probo.inc/probo/pkg/coredata.Regulation
+
+    CountryCode:
+      type: string
+      enum:
+        - AD
+        - AE
+        - AF
+        - AG
+        - AI
+        - AL
+        - AM
+        - AO
+        - AQ
+        - AR
+        - AS
+        - AT
+        - AU
+        - AW
+        - AX
+        - AZ
+        - BA
+        - BB
+        - BD
+        - BE
+        - BF
+        - BG
+        - BH
+        - BI
+        - BJ
+        - BL
+        - BM
+        - BN
+        - BO
+        - BQ
+        - BR
+        - BS
+        - BT
+        - BV
+        - BW
+        - BY
+        - BZ
+        - CA
+        - CC
+        - CD
+        - CF
+        - CG
+        - CH
+        - CI
+        - CK
+        - CL
+        - CM
+        - CN
+        - CO
+        - CR
+        - CU
+        - CV
+        - CW
+        - CX
+        - CY
+        - CZ
+        - DE
+        - DJ
+        - DK
+        - DM
+        - DO
+        - DZ
+        - EC
+        - EE
+        - EG
+        - EH
+        - ER
+        - ES
+        - ET
+        - EU
+        - FI
+        - FJ
+        - FK
+        - FM
+        - FO
+        - FR
+        - GA
+        - GB
+        - GD
+        - GE
+        - GF
+        - GG
+        - GH
+        - GI
+        - GL
+        - GM
+        - GN
+        - GP
+        - GQ
+        - GR
+        - GT
+        - GU
+        - GW
+        - GY
+        - HK
+        - HM
+        - HN
+        - HR
+        - HT
+        - HU
+        - ID
+        - IE
+        - IL
+        - IM
+        - IN
+        - IO
+        - IQ
+        - IR
+        - IS
+        - IT
+        - JE
+        - JM
+        - JO
+        - JP
+        - KE
+        - KG
+        - KH
+        - KI
+        - KM
+        - KN
+        - KP
+        - KR
+        - KW
+        - KY
+        - KZ
+        - LA
+        - LB
+        - LC
+        - LI
+        - LK
+        - LR
+        - LS
+        - LT
+        - LU
+        - LV
+        - LY
+        - MA
+        - MC
+        - MD
+        - ME
+        - MF
+        - MG
+        - MH
+        - MK
+        - ML
+        - MM
+        - MN
+        - MO
+        - MP
+        - MQ
+        - MR
+        - MS
+        - MT
+        - MU
+        - MV
+        - MW
+        - MX
+        - MY
+        - MZ
+        - NA
+        - NC
+        - NE
+        - NF
+        - NG
+        - NI
+        - NL
+        - NO
+        - NP
+        - NR
+        - NU
+        - NZ
+        - OM
+        - PA
+        - PE
+        - PF
+        - PG
+        - PH
+        - PK
+        - PL
+        - PM
+        - PN
+        - PR
+        - PS
+        - PT
+        - PW
+        - PY
+        - QA
+        - RE
+        - RO
+        - RS
+        - RU
+        - RW
+        - SA
+        - SB
+        - SC
+        - SD
+        - SE
+        - SG
+        - SH
+        - SI
+        - SJ
+        - SK
+        - SL
+        - SM
+        - SN
+        - SO
+        - SR
+        - SS
+        - ST
+        - SV
+        - SX
+        - SY
+        - SZ
+        - TC
+        - TD
+        - TF
+        - TG
+        - TH
+        - TJ
+        - TK
+        - TL
+        - TM
+        - TN
+        - TO
+        - TR
+        - TT
+        - TV
+        - TW
+        - TZ
+        - UA
+        - UG
+        - UM
+        - US
+        - UY
+        - UZ
+        - VA
+        - VC
+        - VE
+        - VG
+        - VI
+        - VN
+        - VU
+        - WF
+        - WS
+        - YE
+        - YT
+        - ZA
+        - ZM
+        - ZW
+      go.probo.inc/mcpgen/type: go.probo.inc/probo/pkg/coredata.CountryCode
+
     Profile:
       type: object
       required:
@@ -9291,6 +9565,8 @@ components:
         - consent_data
         - action
         - sdk_version
+        - regulation
+        - country_code
         - created_at
       properties:
         id:
@@ -9325,6 +9601,12 @@ components:
         sdk_version:
           type: string
           description: SDK version
+        regulation:
+          $ref: "#/components/schemas/Regulation"
+          description: Applicable regulation
+        country_code:
+          $ref: "#/components/schemas/CountryCode"
+          description: Visitor country code (ISO 3166-1 alpha-2)
         created_at:
           type: string
           format: date-time

--- a/pkg/server/api/mcp/v1/types/cookie_consent_record.go
+++ b/pkg/server/api/mcp/v1/types/cookie_consent_record.go
@@ -35,6 +35,8 @@ func NewCookieConsentRecord(r *coredata.CookieConsentRecord) *CookieConsentRecor
 		ConsentData:           consentData,
 		Action:                CookieConsentRecordAction(r.Action),
 		SdkVersion:            r.SdkVersion,
+		Regulation:            r.Regulation,
+		CountryCode:           r.CountryCode,
 		CreatedAt:             r.CreatedAt,
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -30,6 +30,7 @@ import (
 	"go.probo.inc/probo/pkg/cookiebanner"
 	"go.probo.inc/probo/pkg/esign"
 	"go.probo.inc/probo/pkg/file"
+	"go.probo.inc/probo/pkg/geoloc"
 	"go.probo.inc/probo/pkg/iam"
 	"go.probo.inc/probo/pkg/iam/oauth2server"
 	"go.probo.inc/probo/pkg/mailman"
@@ -58,6 +59,7 @@ type Config struct {
 	Slack             *slack.Service
 	Mailman           *mailman.Service
 	CookieBanner      *cookiebanner.Service
+	Geoloc            *geoloc.Service
 	Cookie            securecookie.Config
 	TokenSecret       string
 	ConnectorRegistry *connector.ConnectorRegistry
@@ -92,6 +94,7 @@ func NewServer(cfg Config) (*Server, error) {
 		Slack:             cfg.Slack,
 		Mailman:           cfg.Mailman,
 		CookieBanner:      cfg.CookieBanner,
+		Geoloc:            cfg.Geoloc,
 		Cookie:            cfg.Cookie,
 		TokenSecret:       cfg.TokenSecret,
 		ConnectorRegistry: cfg.ConnectorRegistry,


### PR DESCRIPTION
Closes ENG-363

Introduce a geoloc package that stores CIDR-to-country mappings in PostgreSQL using the native cidr type with a GiST index for fast containment lookups. Data comes from the ipverse/country-ip-blocks dataset added as a git submodule.

A standalone geoloc-import command reads the TXT files from disk and bulk-loads them via COPY. probod wires the service and logs a warning when the table is empty.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an IP-to-country geolocation service and wires it into the cookie banner to auto-detect a visitor’s privacy regulation, set consent mode, adapt copy/layout, and store the regulation and country with each consent. Import uses a shadow-table swap to keep reads non-blocking.

- New Features
  - Added `pkg/geoloc` for IP→country lookups using Postgres `cidr` + GiST; `geoloc-import` bulk-loads from `pkg/geoloc/data/country-ip-blocks` via COPY into a staging table, then swaps it in (skips missing IPv6 files).
  - Server resolves regulation from client IP and returns `regulation` in `GET /config`; it overrides `consent_mode` based on the law, remaps texts for opt-out/notice, and records `regulation` and `country_code` on consent.
  - Client/SDK: hides buttons when texts are empty so layout adapts; button validation runs on `probo-ready`; exposes `BannerConfig.regulation`, `CookieBannerClient.regulation`, root getters for `regulation` and `consentMode`, and includes `regulation` in the `probo-ready` event; shared types moved to `packages/cookie-banner/src/types.ts`.
  - Console UI, CLI, GraphQL, MCP, and `packages/n8n-node`: surface `regulation`, `country_code`, and user agent on consent records; add `Regulation` and `CountryCode` enums across APIs. Backend adds `coredata.Regulation` and country→regulation mapping; `pkg/probod` warns if the geoloc table is empty.
  - Tooling: PG DSN parsing defaults to port 5432 when missing across migration CLIs.
  - Console detection patterns: excluded rows are styled (strikethrough, muted background) and “Last matched” shows local date-time.

- Migration
  - Run DB migrations to create `common_ip_country_blocks` (with GiST index) and add `regulation` and `country_code` columns to `cookie_consent_records`.
  - Seed translations for opt-out/notice texts in `en`, `fr`, `de`, and `es`.
  - Initialize data: `git submodule update --init --recursive` then run `geoloc-import` (use `-pg-dsn` or `DATABASE_URL`).

<sup>Written for commit ac458e526f1d87813bb64466757c68d2ea111862. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



