### PR TITLE
Remove unused loadLatestVersion method

### DIFF
--- a/pkg/probo/document_approval_service.go
+++ b/pkg/probo/document_approval_service.go
@@ -746,19 +746,6 @@ func (s *DocumentApprovalService) GetViewerDecision(
 	return decision, nil
 }
 
-func (s *DocumentApprovalService) loadLatestVersion(
-	ctx context.Context,
-	conn pg.Querier,
-	documentID gid.GID,
-) (*coredata.DocumentVersion, error) {
-	version := &coredata.DocumentVersion{}
-	if err := version.LoadLatestVersion(ctx, conn, s.svc.scope, documentID); err != nil {
-		return nil, fmt.Errorf("cannot load latest version for document %q: %w", documentID, err)
-	}
-
-	return version, nil
-}
-
 func (s *DocumentApprovalService) loadQuorumAndProfile(
 	ctx context.Context,
 	conn pg.Querier,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the unused loadLatestVersion method from DocumentApprovalService to clean up dead code and simplify maintenance. No functional or runtime behavior changes.

<sup>Written for commit 0aaee9ef73ef086f20cc6ba06b48ded2a96dfbf9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

