### PR TITLE
Support Google Cloud Identity in SCIM bridge

### DIFF
--- a/apps/console/src/pages/iam/organizations/settings/_components/GoogleWorkspaceConnector.tsx
+++ b/apps/console/src/pages/iam/organizations/settings/_components/GoogleWorkspaceConnector.tsx
@@ -135,7 +135,7 @@ export function GoogleWorkspaceConnector(props: {
         }
         toast({
           title: __("Success"),
-          description: __("Google Workspace disconnected successfully"),
+          description: __("Google Workspace / Cloud Identity disconnected successfully"),
           variant: "success",
         });
         dialogRef.current?.close();
@@ -208,10 +208,10 @@ export function GoogleWorkspaceConnector(props: {
           <Google className="w-6 h-6" />
         </div>
         <div className="mr-auto">
-          <h3 className="font-medium">{__("Google Workspace")}</h3>
+          <h3 className="font-medium">{__("Google Workspace / Cloud Identity")}</h3>
           <p className="text-sm text-txt-secondary">
             {__(
-              "Connect Google Workspace to automatically sync users via SCIM.",
+              "Connect Google Workspace or Google Cloud Identity to automatically sync users via SCIM.",
             )}
           </p>
         </div>
@@ -229,7 +229,7 @@ export function GoogleWorkspaceConnector(props: {
         <Google className="w-6 h-6" />
       </div>
       <div className="mr-auto">
-        <h3 className="font-medium">{__("Google Workspace")}</h3>
+        <h3 className="font-medium">{__("Google Workspace / Cloud Identity")}</h3>
         <p className="text-sm text-txt-secondary">
           {sprintf(__("Connected on %s"), dateTimeFormat(connector.createdAt))}
         </p>
@@ -245,7 +245,7 @@ export function GoogleWorkspaceConnector(props: {
             {__("Settings")}
           </Button>
         )}
-        title={__("Google Workspace Settings")}
+        title={__("Google Workspace / Cloud Identity Settings")}
         className="max-w-lg"
       >
         <DialogContent padded className="space-y-6">
@@ -253,7 +253,7 @@ export function GoogleWorkspaceConnector(props: {
             <div>
               <h4 className="text-sm font-medium">{__("Excluded user names")}</h4>
               <p className="text-sm text-txt-secondary mt-1">
-                {__("Users with these user names will not be synced from Google Workspace.")}
+                {__("Users with these user names will not be synced from Google Workspace / Cloud Identity.")}
               </p>
             </div>
             <div className="flex gap-2">
@@ -297,7 +297,7 @@ export function GoogleWorkspaceConnector(props: {
 
             {currentExcludedUserNames.length === 0 && (
               <p className="text-sm text-txt-secondary text-center py-4">
-                {__("No excluded user names. All Google Workspace users will be synced.")}
+                {__("No excluded user names. All Google Workspace / Cloud Identity users will be synced.")}
               </p>
             )}
           </div>
@@ -310,13 +310,13 @@ export function GoogleWorkspaceConnector(props: {
             {__("Disconnect")}
           </Button>
         )}
-        title={__("Disconnect Google Workspace")}
+        title={__("Disconnect Google Workspace / Cloud Identity")}
         className="max-w-lg"
       >
         <DialogContent padded className="space-y-4">
           <p className="text-txt-secondary text-sm">
             {__(
-              "This will disconnect your Google Workspace integration. Users will no longer be automatically synced via SCIM.",
+              "This will disconnect your Google Workspace / Cloud Identity integration. Users will no longer be automatically synced via SCIM.",
             )}
           </p>
           <p className="text-red-600 text-sm font-medium">

--- a/pkg/iam/scim/bridge/provider/googleworkspace/oauth2_scopes.go
+++ b/pkg/iam/scim/bridge/provider/googleworkspace/oauth2_scopes.go
@@ -15,13 +15,16 @@
 package googleworkspace
 
 var (
-	// OAuth2Scopes are the Google Workspace OAuth2 scopes required by the
-	// SCIM provisioning bridge. The bridge reads users, user schemas, group
-	// members, and customer info from the Admin Directory API.
+	// OAuth2Scopes are the OAuth2 scopes required by the SCIM provisioning
+	// bridge to read users from the Admin Directory API. The scopes are
+	// intentionally limited to what the bridge actually consumes so the
+	// integration also works for Google Cloud Identity (Free or Premium)
+	// customers, not only Google Workspace customers. In particular,
+	// admin.directory.userschema is a Workspace-only entitlement (custom
+	// user fields are not available on Cloud Identity) and must not be
+	// requested here, otherwise Cloud Identity-only admins cannot complete
+	// the OAuth consent flow.
 	OAuth2Scopes = []string{
 		"https://www.googleapis.com/auth/admin.directory.user.readonly",
-		"https://www.googleapis.com/auth/admin.directory.userschema.readonly",
-		"https://www.googleapis.com/auth/admin.directory.group.member.readonly",
-		"https://www.googleapis.com/auth/admin.directory.customer.readonly",
 	}
 )

--- a/pkg/iam/scim/bridge/provider/googleworkspace/provider.go
+++ b/pkg/iam/scim/bridge/provider/googleworkspace/provider.go
@@ -68,7 +68,11 @@ func (p *Provider) ListUsers(ctx context.Context) (scimclient.Users, error) {
 	pageToken := ""
 
 	for {
-		call := adminService.Users.List().Customer("my_customer").MaxResults(500).Context(ctx)
+		call := adminService.Users.List().
+			Customer("my_customer").
+			MaxResults(500).
+			Projection("full").
+			Context(ctx)
 		if pageToken != "" {
 			call = call.PageToken(pageToken)
 		}


### PR DESCRIPTION
## Summary

- Trim the Google SCIM bridge's OAuth scopes to only `admin.directory.user.readonly`. The previous scope set requested `admin.directory.userschema.readonly`, which is a Google Workspace-only entitlement that Google Cloud Identity (Free or Premium) admins cannot grant, so they were blocked at the OAuth consent screen and never reached a sync. The dropped `userschema`, `group.member.readonly`, and `customer.readonly` scopes were also unused — the provider only calls `Users.List`.
- Switch `Users.List` to `projection=full` so standard extended user fields (`Organizations`, `ExternalIds`, `Relations`, `Languages`) are returned and the existing extractors actually populate `Title`, `Department`, `CostCenter`, `EnterpriseOrganization`, `UserType`, `EmployeeNumber`, `ManagerValue`, and `PreferredLanguage` on synced users. Full projection does not require any extra OAuth scope.
- Relabel the connector UI strings from "Google Workspace" to "Google Workspace / Cloud Identity" to reflect that both products are supported.

## Notes

- The 403 `Not Authorized to access this resource/api` from `users.list` is a separate failure mode (the consenting user lacks Workspace/Cloud Identity admin privileges, or it's a personal `@gmail.com` account) and is not addressed by this PR.
- The access-review driver (`pkg/accessreview/drivers/oauth2_scopes.go`) still lists `group.member.readonly` and `customer.readonly` despite only calling `Users.List`. Those are dead scopes too and could be trimmed in a follow-up; left untouched here to keep the diff scoped.

## Test plan

- [ ] Manually connect the SCIM bridge as a Google Cloud Identity Free admin and confirm the OAuth consent completes.
- [ ] Run a sync against a Cloud Identity tenant and confirm users land with the expected `Title` / `Department` / `EmployeeNumber` / `ManagerValue` / `PreferredLanguage` fields populated when set on the source user.
- [ ] Re-run a sync against an existing Google Workspace customer and confirm no regression in the connect flow or in the synced user fields.
- [ ] Verify the relabeled connector UI ("Google Workspace / Cloud Identity") renders correctly in the connected, disconnected, settings, and disconnect dialogs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Google Cloud Identity support to the SCIM bridge by requesting only `admin.directory.user.readonly` and fetching full user records so extended fields sync without extra scopes. Updates the console to label the connector as “Google Workspace / Cloud Identity.”

- **Bug Fixes**
  - Limit OAuth scopes to `admin.directory.user.readonly`; drop `admin.directory.userschema.readonly`, `admin.directory.group.member.readonly`, and `admin.directory.customer.readonly` so Cloud Identity tenants can connect.
  - Use `projection=full` in `Users.List` to return extended fields and populate Title, Department, EmployeeNumber, Manager, and PreferredLanguage without extra scopes.
  - Relabel connector UI to “Google Workspace / Cloud Identity” across connect, settings, and disconnect dialogs.

<sup>Written for commit fa13f61df36416ab025975854bd26e8ca76b8ce8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

