### PR TITLE
Allow viewing and uploading access source CSVs

### DIFF
--- a/apps/console/src/pages/organizations/access-reviews/CreateCsvAccessSourcePage.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/CreateCsvAccessSourcePage.tsx
@@ -18,10 +18,13 @@ import { useTranslate } from "@probo/i18n";
 import {
   Button,
   Card,
+  Dropzone,
   Field,
+  IconCrossLargeX,
   PageHeader,
   useToast,
 } from "@probo/ui";
+import { useCallback, useState } from "react";
 import { type PreloadedQuery, useMutation, usePreloadedQuery } from "react-relay";
 import { Link, useNavigate } from "react-router";
 import { ConnectionHandler, graphql } from "relay-runtime";
@@ -48,8 +51,14 @@ export const createCsvAccessSourcePageQuery = graphql`
 
 const csvSchema = z.object({
   name: z.string().min(1),
-  csvData: z.string().min(1),
 });
+
+const csvAccept = {
+  "text/csv": [".csv"],
+  "application/csv": [".csv"],
+};
+
+const MAX_CSV_MB = 10;
 
 export default function CreateCsvAccessSourcePage({
   queryRef,
@@ -60,11 +69,15 @@ export default function CreateCsvAccessSourcePage({
   const { toast } = useToast();
   const navigate = useNavigate();
   const organizationId = useOrganizationId();
-  const { register, handleSubmit }
+  const [csvFile, setCsvFile] = useState<File | null>(null);
+  const [csvContent, setCsvContent] = useState<string | null>(null);
+  const [csvError, setCsvError] = useState<string | null>(null);
+  const [isReadingFile, setIsReadingFile] = useState(false);
+
+  const { register, handleSubmit, setValue, getValues }
     = useFormWithSchema(csvSchema, {
       defaultValues: {
         name: "",
-        csvData: "",
       },
     });
 
@@ -85,6 +98,51 @@ export default function CreateCsvAccessSourcePage({
       createAccessSourceMutation,
     );
 
+  const handleFileDrop = useCallback(
+    (acceptedFiles: File[]) => {
+      const file = acceptedFiles[0];
+      if (!file) {
+        return;
+      }
+
+      setCsvError(null);
+      setCsvFile(file);
+      setCsvContent(null);
+      setIsReadingFile(true);
+
+      file.text()
+        .then((text) => {
+          if (text.trim().length === 0) {
+            setCsvError(__("The selected file is empty."));
+            setCsvContent(null);
+            return;
+          }
+          setCsvContent(text);
+          // Suggest a name from the file name (without extension), only if the
+          // user has not already typed something.
+          if (!getValues("name")) {
+            setValue("name", file.name.replace(/\.[^/.]+$/, ""), {
+              shouldValidate: true,
+            });
+          }
+        })
+        .catch(() => {
+          setCsvError(__("Could not read the selected file."));
+          setCsvContent(null);
+        })
+        .finally(() => {
+          setIsReadingFile(false);
+        });
+    },
+    [__, getValues, setValue],
+  );
+
+  const handleClearFile = () => {
+    setCsvFile(null);
+    setCsvContent(null);
+    setCsvError(null);
+  };
+
   if (!organization.canCreateSource) {
     return (
       <Card padded>
@@ -96,13 +154,18 @@ export default function CreateCsvAccessSourcePage({
   }
 
   const onSubmit = (data: z.infer<typeof csvSchema>) => {
+    if (!csvContent) {
+      setCsvError(__("Please select a CSV file."));
+      return;
+    }
+
     createAccessSource({
       variables: {
         input: {
           organizationId,
           connectorId: null,
           name: data.name,
-          csvData: data.csvData,
+          csvData: csvContent,
         },
         connections: connectionId ? [connectionId] : [],
       },
@@ -138,17 +201,60 @@ export default function CreateCsvAccessSourcePage({
     });
   };
 
+  const canSubmit = !!csvContent && !csvError && !isReadingFile && !isCreating;
+
   return (
     <div className="space-y-6">
       <PageHeader
         title={__("Add CSV access source")}
         description={__(
-          "Paste CSV content with a header row. This source will be saved and available in Access Reviews.",
+          "Upload a CSV file with a header row. This source will be saved and available in Access Reviews.",
         )}
       />
 
       <Card padded>
         <form onSubmit={e => void handleSubmit(onSubmit)(e)} className="space-y-4">
+          <div className="space-y-2">
+            <Dropzone
+              description={__(
+                "Drop a .csv file here or click to browse (max 10MB).",
+              )}
+              isUploading={isReadingFile}
+              onDrop={handleFileDrop}
+              accept={csvAccept}
+              maxSize={MAX_CSV_MB}
+            />
+            {csvFile && !csvError && (
+              <div className="flex items-center justify-between rounded-md border border-border-low bg-subtle px-3 py-2 text-sm">
+                <div className="flex flex-col">
+                  <span className="font-medium">{csvFile.name}</span>
+                  {csvContent && (
+                    <span className="text-txt-tertiary text-xs">
+                      {formatFileSummary(__, csvFile.size, csvContent)}
+                    </span>
+                  )}
+                </div>
+                <Button
+                  type="button"
+                  variant="quaternary"
+                  icon={IconCrossLargeX}
+                  onClick={handleClearFile}
+                  disabled={isCreating}
+                >
+                  {__("Remove")}
+                </Button>
+              </div>
+            )}
+            {csvError && (
+              <p className="text-sm text-txt-danger">{csvError}</p>
+            )}
+            <p className="text-txt-secondary text-sm">
+              {__(
+                "Supported columns: email, full_name, role, job_title, is_admin, active, external_id.",
+              )}
+            </p>
+          </div>
+
           <Field
             label={__("Name")}
             {...register("name")}
@@ -156,24 +262,13 @@ export default function CreateCsvAccessSourcePage({
             required
           />
 
-          <Field
-            label={__("CSV Data")}
-            {...register("csvData")}
-            type="textarea"
-            placeholder="email,full_name,role,job_title,is_admin,active,external_id"
-            required
-          />
-          <p className="text-txt-secondary text-sm">
-            {__("Supported columns: email, full_name, role, job_title, is_admin, active, external_id.")}
-          </p>
-
           <div className="flex items-center justify-end gap-2">
             <Button variant="secondary" asChild>
               <Link to={`/organizations/${organizationId}/access-reviews/sources`}>
                 {__("Back")}
               </Link>
             </Button>
-            <Button disabled={isCreating} type="submit">
+            <Button disabled={!canSubmit} type="submit">
               {__("Create")}
             </Button>
           </div>
@@ -181,4 +276,15 @@ export default function CreateCsvAccessSourcePage({
       </Card>
     </div>
   );
+}
+
+function formatFileSummary(
+  __: (s: string) => string,
+  bytes: number,
+  csv: string,
+): string {
+  const sizeKb = Math.max(1, Math.round(bytes / 1024));
+  const lines = csv.split(/\r?\n/).filter(line => line.length > 0).length;
+  const dataRows = Math.max(0, lines - 1);
+  return `${sizeKb} KB · ${dataRows} ${__("rows")}`;
 }

--- a/apps/console/src/pages/organizations/access-reviews/CreateCsvAccessSourcePage.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/CreateCsvAccessSourcePage.tsx
@@ -239,7 +239,7 @@ export default function CreateCsvAccessSourcePage({
                   variant="quaternary"
                   icon={IconCrossLargeX}
                   onClick={handleClearFile}
-                  disabled={isCreating}
+                  disabled={isCreating || isReadingFile}
                 >
                   {__("Remove")}
                 </Button>

--- a/apps/console/src/pages/organizations/access-reviews/_components/AccessSourceRow.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/_components/AccessSourceRow.tsx
@@ -19,6 +19,7 @@ import {
   Badge,
   Button,
   DropdownItem,
+  IconPageTextLine,
   IconTrashCan,
   Input,
   Option,
@@ -36,6 +37,8 @@ import type { AccessSourceRowConfigureMutation } from "#/__generated__/core/Acce
 import type { AccessSourceRowDeleteMutation } from "#/__generated__/core/AccessSourceRowDeleteMutation.graphql";
 import type { AccessSourceRowFragment$key } from "#/__generated__/core/AccessSourceRowFragment.graphql";
 import type { AccessSourceRowOrgsQuery } from "#/__generated__/core/AccessSourceRowOrgsQuery.graphql";
+
+import { ViewCsvAccessSourceDialog } from "./ViewCsvAccessSourceDialog";
 
 const fragment = graphql`
   fragment AccessSourceRowFragment on AccessSource {
@@ -123,6 +126,8 @@ export function AccessSourceRow({ fKey, connectionId, organizationId }: Props) {
   const { toast } = useToast();
 
   const accessSource = useFragment(fragment, fKey);
+  const isCsvSource = !accessSource.connector;
+  const [isViewCsvOpen, setIsViewCsvOpen] = useState(false);
 
   const [deleteAccessSource] = useMutation<AccessSourceRowDeleteMutation>(deleteAccessSourceMutation);
   const [configure] = useMutation<AccessSourceRowConfigureMutation>(configureMutation);
@@ -269,22 +274,43 @@ export function AccessSourceRow({ fKey, connectionId, organizationId }: Props) {
           {formatDate(accessSource.createdAt)}
         </time>
       </Td>
-      {accessSource.canDelete && (
+      {(accessSource.canDelete || isCsvSource) && (
         <Td noLink width={50} className="text-end">
           <ActionDropdown>
-            <DropdownItem
-              icon={IconTrashCan}
-              variant="danger"
-              onSelect={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                handleDelete();
-              }}
-            >
-              {__("Delete")}
-            </DropdownItem>
+            {isCsvSource && (
+              <DropdownItem
+                icon={IconPageTextLine}
+                onSelect={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setIsViewCsvOpen(true);
+                }}
+              >
+                {__("View CSV")}
+              </DropdownItem>
+            )}
+            {accessSource.canDelete && (
+              <DropdownItem
+                icon={IconTrashCan}
+                variant="danger"
+                onSelect={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  handleDelete();
+                }}
+              >
+                {__("Delete")}
+              </DropdownItem>
+            )}
           </ActionDropdown>
         </Td>
+      )}
+      {isViewCsvOpen && (
+        <ViewCsvAccessSourceDialog
+          accessSourceId={accessSource.id}
+          name={accessSource.name}
+          onClose={() => setIsViewCsvOpen(false)}
+        />
       )}
     </Tr>
   );

--- a/apps/console/src/pages/organizations/access-reviews/_components/ViewCsvAccessSourceDialog.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/_components/ViewCsvAccessSourceDialog.tsx
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { useTranslate } from "@probo/i18n";
+import {
+  Breadcrumb,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  Spinner,
+  Textarea,
+} from "@probo/ui";
+import { Suspense } from "react";
+import { graphql, useLazyLoadQuery } from "react-relay";
+
+import type { ViewCsvAccessSourceDialogQuery } from "#/__generated__/core/ViewCsvAccessSourceDialogQuery.graphql";
+
+const viewCsvAccessSourceDialogQuery = graphql`
+  query ViewCsvAccessSourceDialogQuery($accessSourceId: ID!) {
+    node(id: $accessSourceId) @required(action: THROW) {
+      ... on AccessSource {
+        id
+        name
+        csvData
+      }
+    }
+  }
+`;
+
+type Props = {
+  accessSourceId: string;
+  name: string;
+  onClose: () => void;
+};
+
+export function ViewCsvAccessSourceDialog({
+  accessSourceId,
+  name,
+  onClose,
+}: Props) {
+  const { __ } = useTranslate();
+
+  return (
+    <Dialog
+      defaultOpen
+      onClose={onClose}
+      title={
+        <Breadcrumb items={[{ label: __("CSV access source") }, { label: name }]} />
+      }
+      className="max-w-3xl"
+    >
+      <DialogContent padded>
+        <Suspense
+          fallback={
+            <div className="flex items-center justify-center py-8">
+              <Spinner />
+            </div>
+          }
+        >
+          <ViewCsvAccessSourceContent accessSourceId={accessSourceId} />
+        </Suspense>
+      </DialogContent>
+      <DialogFooter exitLabel={__("Close")} />
+    </Dialog>
+  );
+}
+
+function ViewCsvAccessSourceContent({
+  accessSourceId,
+}: {
+  accessSourceId: string;
+}) {
+  const { __ } = useTranslate();
+  const data = useLazyLoadQuery<ViewCsvAccessSourceDialogQuery>(
+    viewCsvAccessSourceDialogQuery,
+    { accessSourceId },
+    { fetchPolicy: "store-or-network" },
+  );
+
+  const csvData = data.node.csvData;
+
+  if (!csvData) {
+    return (
+      <p className="text-txt-secondary text-sm">
+        {__("This access source does not have any CSV content stored.")}
+      </p>
+    );
+  }
+
+  return (
+    <Textarea
+      readOnly
+      defaultValue={csvData}
+      rows={20}
+      className="font-mono text-xs whitespace-pre overflow-auto"
+    />
+  );
+}

--- a/apps/console/src/pages/organizations/access-reviews/_components/ViewCsvAccessSourceDialog.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/_components/ViewCsvAccessSourceDialog.tsx
@@ -30,8 +30,6 @@ const viewCsvAccessSourceDialogQuery = graphql`
   query ViewCsvAccessSourceDialogQuery($accessSourceId: ID!) {
     node(id: $accessSourceId) @required(action: THROW) {
       ... on AccessSource {
-        id
-        name
         csvData
       }
     }
@@ -62,11 +60,11 @@ export function ViewCsvAccessSourceDialog({
     >
       <DialogContent padded>
         <Suspense
-          fallback={
+          fallback={(
             <div className="flex items-center justify-center py-8">
               <Spinner />
             </div>
-          }
+          )}
         >
           <ViewCsvAccessSourceContent accessSourceId={accessSourceId} />
         </Suspense>


### PR DESCRIPTION
## Summary

Customer feedback (in French) on the Access Review feature was: *"Pouvoir voir les CSV uploadés (écrits) serait top; QUID d'upload des CSV directement"* — i.e. (1) be able to view CSVs that were submitted, and (2) upload CSV files directly instead of pasting them. This PR addresses both.

- **View CSV** — Add a *View CSV* action on each CSV access source row in `AccessReviewSourcesTab`. The action opens a read-only dialog that lazy-loads `AccessSource.csvData` (already exposed by the backend) only when clicked, so the table page payload is unchanged. The CSV is shown in a `Textarea` with `readOnly`, `font-mono`, `whitespace-pre`. The action is gated on the source not having a connector (i.e. CSV-only).
- **CSV file upload** — Replace the paste-into-textarea on `CreateCsvAccessSourcePage` with a `Dropzone` (drag-and-drop + click-to-browse), restricted to `.csv` (`text/csv` / `application/csv`) at 10MB max. The picked file is read in the browser via `file.text()` and submitted through the **existing** `csvData` string argument of `createAccessSource`, so the GraphQL schema, mutation, and worker pipeline are all unchanged.
- The page also auto-suggests the source `Name` from the file name (without extension) when the user hasn't typed one, shows a small file summary (KB and parsed row count), and exposes a *Remove* button to re-pick a file before submitting.

No backend changes — `csvData` is already a queryable field on `AccessSource` and the create/update mutations already accept it as a string. The existing `e2e/console/access_review_test.go` already exercises both paths via the GraphQL contract this PR reuses.

## Test plan

- [ ] Console → Access Reviews → Sources: click *Add source* → *Manual CSV*, drop a CSV file with the documented header columns, confirm the file name appears with row count, and submit. Source appears in the table with status *Connected*.
- [ ] Re-pick a file before submitting (Remove + drop a different one): verify the *Name* field updates only if it was empty.
- [ ] Drop an unsupported file type (e.g. `.xlsx`): verify the Dropzone shows the *not supported* error.
- [ ] Drop a file larger than 10MB: verify the *too large* error.
- [ ] Drop an empty `.csv`: verify the inline *empty file* error and that the submit button stays disabled.
- [ ] On a CSV source row, open the action dropdown → click *View CSV* and confirm the dialog opens, fetches `csvData` once, and renders it in the read-only textarea. Re-open: verify the cached payload is reused (no extra network call).
- [ ] On a connector-backed source row (e.g. Google Workspace, Linear), confirm the *View CSV* action is **not** shown.
- [ ] Permissions: verify a viewer without `core:access-source:create` cannot reach the create page; a viewer without `core:access-source:delete` still sees *View CSV* on CSV sources but no *Delete*.
- [ ] `make relay` and `npm run check --workspace=@probo/console` are clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CSV upload to the create flow and a read-only View CSV dialog, so users can upload files instead of pasting and inspect stored data. Reuses the existing `csvData` field and lazy-loads content to keep the table fast.

- **New Features**
  - CSV upload on create: replaced textarea with `Dropzone` from `@probo/ui`; accepts `.csv` up to 10MB, reads in-browser, and submits via existing `csvData`; auto-suggests name from filename; shows size/row count; includes Remove.
  - View CSV in table: new action for CSV-only sources opens a dialog that fetches `csvData` on open and displays it read-only; hidden for connector-backed sources.

- **Bug Fixes**
  - Cleaned up `ViewCsvAccessSourceDialog` lints (removed unused field, wrapped Suspense fallback).
  - Disabled Remove while a file is being read to avoid repopulating cleared content if the read resolves late.

<sup>Written for commit 2a770971b5b8c184d79c359df09437450bab9f0d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

