### PR TITLE
Cookie banner headless auto hide

### DIFF
--- a/packages/cookie-banner/src/components/base.ts
+++ b/packages/cookie-banner/src/components/base.ts
@@ -70,6 +70,7 @@ export interface ProboRootElement extends ProboElement {
   readonly gpcApplied: boolean;
   readonly regulation: Regulation | null;
   readonly consentMode: "OPT_IN" | "OPT_OUT" | null;
+  readonly reopenState: ProboState;
   setState(state: ProboState): void;
   updateDraft(category: string, value: boolean): void;
 }

--- a/packages/cookie-banner/src/components/buttons.ts
+++ b/packages/cookie-banner/src/components/buttons.ts
@@ -15,6 +15,7 @@
 import { ProboElement } from "./base";
 import type { ProboRootElement } from "./base";
 import type { ProboCookieBannerRoot } from "./cookie-banner-root";
+import type { BannerConfig } from "../types";
 
 class ProboActionButton extends ProboElement {
   protected root: ProboRootElement | null = null;
@@ -29,6 +30,40 @@ class ProboActionButton extends ProboElement {
   }
 
   protected handleClick = (_e: Event): void => {};
+}
+
+class ProboHideableButton extends ProboActionButton {
+  protected textKey: string = "";
+
+  private onReady = (e: Event): void => {
+    const config = (e as CustomEvent).detail.config as BannerConfig;
+    this.applyVisibility(config);
+  };
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    if (this.root) {
+      try {
+        this.applyVisibility(this.root.bannerConfig);
+      } catch {
+        this.root.addEventListener("probo-ready", this.onReady, { once: true });
+      }
+    }
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    if (this.root) {
+      this.root.removeEventListener("probo-ready", this.onReady);
+    }
+  }
+
+  private applyVisibility(config: BannerConfig): void {
+    const texts = config.texts ?? {};
+    if (!texts[this.textKey]) {
+      this.hidden = true;
+    }
+  }
 }
 
 export class ProboAcceptButton extends ProboActionButton {
@@ -46,7 +81,9 @@ export class ProboAcceptButton extends ProboActionButton {
   };
 }
 
-export class ProboRejectButton extends ProboActionButton {
+export class ProboRejectButton extends ProboHideableButton {
+  protected textKey = "button_reject_all";
+
   protected handleClick = (): void => {
     if (!this.root) return;
     this.root.client.rejectAll();
@@ -61,7 +98,9 @@ export class ProboRejectButton extends ProboActionButton {
   };
 }
 
-export class ProboCustomizeButton extends ProboActionButton {
+export class ProboCustomizeButton extends ProboHideableButton {
+  protected textKey = "button_customize";
+
   protected handleClick = (): void => {
     if (!this.root) return;
     this.root.setState("panel");

--- a/packages/cookie-banner/src/components/cookie-banner-root.ts
+++ b/packages/cookie-banner/src/components/cookie-banner-root.ts
@@ -67,6 +67,10 @@ export class ProboCookieBannerRoot extends ProboElement implements ProboRootElem
     return null;
   }
 
+  get reopenState(): ProboState {
+    return this.consentMode === "OPT_OUT" ? "banner" : "panel";
+  }
+
   attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null): void {
     if (name === "reopen-widget" && oldValue !== newValue) {
       this.dispatchEvent(
@@ -93,7 +97,7 @@ export class ProboCookieBannerRoot extends ProboElement implements ProboRootElem
   }
 
   private onOpenPreferences = (): void => {
-    this.setState("panel");
+    this.setState(this.reopenState);
   };
 
   setState(state: ProboState): void {

--- a/packages/cookie-banner/src/components/settings-button.ts
+++ b/packages/cookie-banner/src/components/settings-button.ts
@@ -151,7 +151,7 @@ export class ProboSettingsButton extends HTMLElement {
 
   private handleClick = (): void => {
     if (!this.root) return;
-    this.root.setState("panel");
+    this.root.setState(this.root.reopenState);
   };
 
   private updateGpcBadge(label: string | null): void {

--- a/packages/cookie-banner/src/components/settings-link.ts
+++ b/packages/cookie-banner/src/components/settings-link.ts
@@ -68,6 +68,6 @@ export class ProboSettingsLink extends HTMLElement {
   private handleClick = (e: Event): void => {
     if (!this.root) return;
     e.preventDefault();
-    this.root.setState("panel");
+    this.root.setState(this.root.reopenState);
   };
 }

--- a/packages/cookie-banner/src/themed-banner/themed-banner.ts
+++ b/packages/cookie-banner/src/themed-banner/themed-banner.ts
@@ -130,7 +130,6 @@ export class ProboThemedBanner extends HTMLElement {
       const detail = (e as CustomEvent).detail;
       const config = detail.config as BannerConfig;
       this.applyTexts(config);
-      this.applyLayout(config);
       if (!config.show_branding) {
         this.shadow.querySelectorAll("[data-branding]").forEach(el => {
           (el as HTMLElement).setAttribute("hidden", "");
@@ -223,20 +222,6 @@ export class ProboThemedBanner extends HTMLElement {
         settingsBtn.setAttribute("aria-settings-label", ariaText);
       }
     }
-  }
-
-  private applyLayout(config: BannerConfig): void {
-    const texts = config.texts ?? {};
-
-    const hideIfEmpty = (selector: string, textKey: string): void => {
-      if (texts[textKey]) return;
-      this.shadow.querySelectorAll(selector).forEach(el => {
-        (el as HTMLElement).hidden = true;
-      });
-    };
-
-    hideIfEmpty("probo-banner probo-reject-button", "button_reject_all");
-    hideIfEmpty("probo-banner probo-customize-button", "button_customize");
   }
 
   private esc(str: string): string {

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -1616,8 +1616,8 @@ func remapTextsForConsentMode(texts map[string]string, consentMode string, regul
 		remapTextKey(texts, "banner_title_opt_out", "banner_title")
 		remapTextKey(texts, "banner_description_opt_out", "banner_description")
 		remapTextKey(texts, "button_acknowledge", "button_accept_all")
-		remapTextKey(texts, "button_opt_out", "button_customize")
-		texts["button_reject_all"] = ""
+		remapTextKey(texts, "button_opt_out", "button_reject_all")
+		texts["button_customize"] = ""
 
 	case regulation == RegulationNone:
 		remapTextKey(texts, "banner_title_notice", "banner_title")

--- a/pkg/cookiebanner/service_test.go
+++ b/pkg/cookiebanner/service_test.go
@@ -308,13 +308,15 @@ func TestRemapTextsForConsentMode(t *testing.T) {
 		assert.Empty(t, texts["button_customize"])
 	})
 
-	t.Run("opt out mode clears reject", func(t *testing.T) {
+	t.Run("opt out mode maps opt out to reject and clears customize", func(t *testing.T) {
 		t.Parallel()
 
 		texts := baseTexts()
+		texts["button_opt_out"] = "Do Not Sell"
 		remapTextsForConsentMode(texts, ConsentModeOptOut, RegulationCCPA)
 
-		assert.Empty(t, texts["button_reject_all"])
+		assert.Equal(t, "Do Not Sell", texts["button_reject_all"])
+		assert.Empty(t, texts["button_customize"])
 	})
 }
 


### PR DESCRIPTION
Closes ENG-363

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Auto-hide headless Reject/Customize buttons based on server texts and reopen the correct view based on consent mode. Also fixes OPT_OUT so the “Opt out” button rejects all and the Customize button is hidden.

- **New Features**
  - Headless Reject and Customize buttons hide when their text keys are empty (`button_reject_all`, `button_customize`).
  - Settings widget reopens the banner for OPT_OUT and the panel otherwise via a new `reopenState`.

- **Bug Fixes**
  - In OPT_OUT, map `button_opt_out` to `button_reject_all` and clear `button_customize` so “Opt out” performs one-click reject instead of opening the panel.

<sup>Written for commit 16504814a884746795614af8096469119f890dc0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

