### PR TITLE
Fix access-review tab crash after deleting a campaign

### DIFF
--- a/apps/console/src/pages/organizations/access-reviews/campaigns/CampaignDetailPage.tsx
+++ b/apps/console/src/pages/organizations/access-reviews/campaigns/CampaignDetailPage.tsx
@@ -45,7 +45,7 @@ import * as Popover from "@radix-ui/react-popover";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { type PreloadedQuery, useMutation, usePreloadedQuery, useRelayEnvironment } from "react-relay";
 import { useNavigate } from "react-router";
-import { fetchQuery, graphql } from "relay-runtime";
+import { ConnectionHandler, fetchQuery, graphql } from "relay-runtime";
 
 import type { AccessEntryDecision, CampaignDetailPageBulkDecisionMutation } from "#/__generated__/core/CampaignDetailPageBulkDecisionMutation.graphql";
 import type { AccessEntryFlag, CampaignDetailPageBulkFlagMutation } from "#/__generated__/core/CampaignDetailPageBulkFlagMutation.graphql";
@@ -101,9 +101,10 @@ const closeCampaignMutation = graphql`
 const deleteCampaignMutation = graphql`
   mutation CampaignDetailPageDeleteMutation(
     $input: DeleteAccessReviewCampaignInput!
+    $connections: [ID!]!
   ) {
     deleteAccessReviewCampaign(input: $input) {
-      deletedAccessReviewCampaignId @deleteRecord
+      deletedAccessReviewCampaignId @deleteEdge(connections: $connections)
     }
   }
 `;
@@ -283,12 +284,19 @@ export default function CampaignDetailPage({ queryRef }: Props) {
   };
 
   const handleDelete = () => {
+    const connections = [
+      ConnectionHandler.getConnectionID(
+        organizationId,
+        "AccessReviewCampaignsTab_accessReviewCampaigns",
+      ),
+    ];
     confirm(
       () =>
         new Promise<void>((resolve) => {
           deleteCampaign({
             variables: {
               input: { accessReviewCampaignId: campaign.id },
+              connections,
             },
             onCompleted(_, errors) {
               if (errors?.length) {

--- a/e2e/console/access_review_test.go
+++ b/e2e/console/access_review_test.go
@@ -466,6 +466,103 @@ func TestAccessReviewCampaign_Delete(t *testing.T) {
 	assert.Equal(t, campaignID, result.DeleteAccessReviewCampaign.DeletedAccessReviewCampaignID)
 }
 
+// TestAccessReviewCampaign_DeleteRemovesFromListAndNode guards the contract
+// the console frontend relies on after deleting a campaign: the campaign must
+// disappear from the organization's `accessReviewCampaigns` connection, and a
+// `node(id:)` lookup on the deleted GID must surface a NOT_FOUND error rather
+// than partial data. Without this contract the cached Relay query in the
+// access-reviews tab would render edges pointing to a vanished record and
+// crash with "Unexpected error :(".
+func TestAccessReviewCampaign_DeleteRemovesFromListAndNode(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	orgID := owner.GetOrganizationID().String()
+
+	sourceID := factory.NewAccessSource(owner, orgID).
+		WithName("Source for Delete").
+		WithCsvData(testCsvData).
+		Create()
+	campaignID := factory.NewAccessReviewCampaign(owner, orgID).
+		WithName("Campaign to Cascade Delete").
+		WithAccessSourceIDs([]string{sourceID}).
+		Create()
+
+	const deleteMutation = `
+		mutation($input: DeleteAccessReviewCampaignInput!) {
+			deleteAccessReviewCampaign(input: $input) {
+				deletedAccessReviewCampaignId
+			}
+		}
+	`
+
+	var deleteResult struct {
+		DeleteAccessReviewCampaign struct {
+			DeletedAccessReviewCampaignID string `json:"deletedAccessReviewCampaignId"`
+		} `json:"deleteAccessReviewCampaign"`
+	}
+
+	err := owner.Execute(deleteMutation, map[string]any{
+		"input": map[string]any{
+			"accessReviewCampaignId": campaignID,
+		},
+	}, &deleteResult)
+	require.NoError(t, err)
+	assert.Equal(t, campaignID, deleteResult.DeleteAccessReviewCampaign.DeletedAccessReviewCampaignID)
+
+	// The campaign must no longer appear in the organization's campaign
+	// connection -- mirrors the AccessReviewCampaignsTabQuery the FE fires
+	// when the user navigates back to the access-reviews tab.
+	const listQuery = `
+		query($id: ID!) {
+			node(id: $id) {
+				... on Organization {
+					accessReviewCampaigns(first: 50) {
+						edges {
+							node { id }
+						}
+					}
+				}
+			}
+		}
+	`
+
+	var listResult struct {
+		Node struct {
+			AccessReviewCampaigns struct {
+				Edges []struct {
+					Node struct {
+						ID string `json:"id"`
+					} `json:"node"`
+				} `json:"edges"`
+			} `json:"accessReviewCampaigns"`
+		} `json:"node"`
+	}
+
+	err = owner.Execute(listQuery, map[string]any{"id": orgID}, &listResult)
+	require.NoError(t, err)
+	for _, edge := range listResult.Node.AccessReviewCampaigns.Edges {
+		assert.NotEqual(t, campaignID, edge.Node.ID, "deleted campaign must not appear in the connection")
+	}
+
+	// Resolving the deleted GID via `node(id:)` must error with NOT_FOUND so
+	// the cached Relay store can't keep serving a tombstoned record.
+	const nodeQuery = `
+		query($id: ID!) {
+			node(id: $id) {
+				... on AccessReviewCampaign {
+					id
+				}
+			}
+		}
+	`
+
+	_, err = owner.Do(nodeQuery, map[string]any{"id": campaignID})
+	var gqlErrors testutil.GraphQLErrors
+	require.ErrorAs(t, err, &gqlErrors)
+	require.Len(t, gqlErrors, 1)
+	assert.Equal(t, "NOT_FOUND", gqlErrors[0].Code())
+}
+
 func TestAccessReviewCampaign_List(t *testing.T) {
 	t.Parallel()
 	owner := testutil.NewClient(t, testutil.RoleOwner)


### PR DESCRIPTION
## Summary

- Switch the campaign detail delete mutation from `@deleteRecord` to `@deleteEdge(connections: $connections)` on the `AccessReviewCampaignsTab_accessReviewCampaigns` connection, mirroring the audit and statement-of-applicability detail page pattern.
- Add an e2e test that locks the contract the console relies on after deletion: the campaign is gone from the org's `accessReviewCampaigns` connection, and `node(id:)` on the deleted GID returns `NOT_FOUND`.

## Why

After deleting a draft access-review campaign from the detail page, opening the access-reviews tab rendered "Unexpected error :(" on every subsequent navigation. Root cause: `@deleteRecord` (introduced in f26bd8b0b) wiped the campaign from the Relay store but left the cached `AccessReviewCampaignsTabQuery` connection holding an edge pointing to the missing record. Reading that edge raised a missing-data error in Relay, which the `OrganizationErrorBoundary` caught and replaced the whole org layout with `PageError` -- matching the screenshot exactly.

`@deleteEdge` removes the stale edge from the cached connection so the list query renders cleanly when the user comes back. The record itself stays alive until Relay GC's it, which is the same behavior the audits and statement-of-applicability detail pages already rely on.

## Test plan

- [x] `npm run check --workspace=apps/console`
- [x] `npm run lint --workspace=apps/console`
- [x] `make relay`
- [x] `go vet ./e2e/console/...`
- [ ] `go test -run TestAccessReviewCampaign_DeleteRemovesFromListAndNode ./e2e/console/...` (CI)
- [ ] Manual: create a draft campaign on staging, open the detail page, delete, open the access-reviews tab -- no error

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in the Access Reviews tab after deleting a campaign by removing stale edges from the cached Relay connection. Switches the delete flow to `@deleteEdge` and adds an e2e test to lock the expected behavior.

- **Bug Fixes**
  - Use `@deleteEdge(connections: $connections)` in `CampaignDetailPage` and compute the connection ID with `ConnectionHandler.getConnectionID(...)` for `AccessReviewCampaignsTab_accessReviewCampaigns`, replacing `@deleteRecord`. This removes the stale edge and prevents Relay missing-data errors, matching the audits and statement-of-applicability pages.
  - Add e2e test to ensure the deleted campaign is gone from the org’s `accessReviewCampaigns` and that `node(id:)` on the deleted GID returns `NOT_FOUND`.

<sup>Written for commit ea22de7ced10b768b068379edeace2279fae6441. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

