### PR TITLE
Fix empty country code stored in consent records

### DIFF
--- a/pkg/coredata/migrations/20260511T160400Z.sql
+++ b/pkg/coredata/migrations/20260511T160400Z.sql
@@ -1,0 +1,17 @@
+-- Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+--
+-- Permission to use, copy, modify, and/or distribute this software for any
+-- purpose with or without fee is hereby granted, provided that the above
+-- copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+-- REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+-- INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+-- LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+-- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+UPDATE cookie_consent_records
+SET country_code = NULL
+WHERE country_code = '';

--- a/pkg/server/api/cookiebanner/v1/handler.go
+++ b/pkg/server/api/cookiebanner/v1/handler.go
@@ -108,6 +108,10 @@ func (h *Handler) resolveCountryCode(r *http.Request) *coredata.CountryCode {
 		return nil
 	}
 
+	if cc == "" {
+		return nil
+	}
+
 	return &cc
 }
 


### PR DESCRIPTION
When IP geolocation returned no matching CIDR block, LookupCountryByIP returned an empty string with nil error. The handler took the address of that empty string, producing a non-nil pointer to "", which was inserted into the database. Guard against this by returning nil when the resolved country code is empty, and backfill existing rows with a migration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent empty country codes from being stored in consent records. Return nil when geolocation resolves no country and backfill existing rows to NULL.

- **Bug Fixes**
  - `resolveCountryCode` now returns nil when the resolved code is empty, preventing inserts of a non-nil pointer to "".

- **Migration**
  - Backfill `cookie_consent_records` by setting `country_code` to NULL where it is ''.

<sup>Written for commit ecb9bd747e06c43d9ff189edd648f51022ed3c89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

