### PR TITLE
Merge excluded user names in MCP updateSCIMBridge

### DIFF
--- a/pkg/server/api/mcp/v1/resolver.go
+++ b/pkg/server/api/mcp/v1/resolver.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/accessreview"
@@ -67,4 +68,27 @@ func (r *Resolver) MustAuthorize(ctx context.Context, entityID gid.GID, action i
 	if err != nil {
 		panic(err)
 	}
+}
+
+func mergeExcludedUserNames(existing, incoming []string) []string {
+	seen := make(map[string]struct{}, len(existing))
+	merged := make([]string, 0, len(existing)+len(incoming))
+
+	for _, name := range existing {
+		if _, ok := seen[name]; !ok {
+			seen[name] = struct{}{}
+			merged = append(merged, name)
+		}
+	}
+
+	for _, name := range incoming {
+		if _, ok := seen[name]; !ok {
+			seen[name] = struct{}{}
+			merged = append(merged, name)
+		}
+	}
+
+	slices.Sort(merged)
+
+	return merged
 }

--- a/pkg/server/api/mcp/v1/resolver_test.go
+++ b/pkg/server/api/mcp/v1/resolver_test.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package mcp_v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeExcludedUserNames(t *testing.T) {
+	t.Parallel()
+
+	t.Run(
+		"appends new names to existing",
+		func(t *testing.T) {
+			t.Parallel()
+
+			got := mergeExcludedUserNames(
+				[]string{"alice@example.com", "bob@example.com"},
+				[]string{"charlie@example.com"},
+			)
+
+			assert.Equal(t, []string{"alice@example.com", "bob@example.com", "charlie@example.com"}, got)
+		},
+	)
+
+	t.Run(
+		"deduplicates overlapping names",
+		func(t *testing.T) {
+			t.Parallel()
+
+			got := mergeExcludedUserNames(
+				[]string{"alice@example.com", "bob@example.com"},
+				[]string{"bob@example.com", "charlie@example.com"},
+			)
+
+			assert.Equal(t, []string{"alice@example.com", "bob@example.com", "charlie@example.com"}, got)
+		},
+	)
+
+	t.Run(
+		"empty existing list",
+		func(t *testing.T) {
+			t.Parallel()
+
+			got := mergeExcludedUserNames(
+				nil,
+				[]string{"alice@example.com"},
+			)
+
+			assert.Equal(t, []string{"alice@example.com"}, got)
+		},
+	)
+
+	t.Run(
+		"empty incoming list preserves existing",
+		func(t *testing.T) {
+			t.Parallel()
+
+			got := mergeExcludedUserNames(
+				[]string{"alice@example.com", "bob@example.com"},
+				nil,
+			)
+
+			assert.Equal(t, []string{"alice@example.com", "bob@example.com"}, got)
+		},
+	)
+
+	t.Run(
+		"both lists empty",
+		func(t *testing.T) {
+			t.Parallel()
+
+			got := mergeExcludedUserNames(nil, nil)
+
+			assert.Equal(t, []string{}, got)
+		},
+	)
+
+	t.Run(
+		"result is sorted",
+		func(t *testing.T) {
+			t.Parallel()
+
+			got := mergeExcludedUserNames(
+				[]string{"charlie@example.com"},
+				[]string{"alice@example.com"},
+			)
+
+			assert.Equal(t, []string{"alice@example.com", "charlie@example.com"}, got)
+		},
+	)
+}

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -5120,7 +5120,14 @@ func (r *Resolver) GetSCIMBridgeTool(ctx context.Context, req *mcp.CallToolReque
 func (r *Resolver) UpdateSCIMBridgeTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateSCIMBridgeInput) (*mcp.CallToolResult, types.UpdateSCIMBridgeOutput, error) {
 	r.MustAuthorize(ctx, input.ScimBridgeID, iam.ActionSCIMBridgeUpdate)
 
-	bridge, err := r.iamSvc.OrganizationService.UpdateSCIMBridge(ctx, input.OrganizationID, input.ScimBridgeID, input.ExcludedUserNames)
+	existing, err := r.iamSvc.OrganizationService.GetSCIMBridgeByID(ctx, input.ScimBridgeID)
+	if err != nil {
+		return nil, types.UpdateSCIMBridgeOutput{}, fmt.Errorf("cannot get SCIM bridge: %w", err)
+	}
+
+	merged := mergeExcludedUserNames(existing.ExcludedUserNames, input.ExcludedUserNames)
+
+	bridge, err := r.iamSvc.OrganizationService.UpdateSCIMBridge(ctx, input.OrganizationID, input.ScimBridgeID, merged)
 	if err != nil {
 		return nil, types.UpdateSCIMBridgeOutput{}, fmt.Errorf("cannot update SCIM bridge: %w", err)
 	}

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -10680,7 +10680,7 @@ components:
           type: array
           items:
             type: string
-          description: User names to exclude from SCIM sync
+          description: User names to add to the exclusion list. These are merged with existing exclusions; previously excluded names are preserved.
 
     UpdateSCIMBridgeOutput:
       type: object
@@ -12690,7 +12690,7 @@ tools:
     outputSchema:
       $ref: "#/components/schemas/GetSCIMBridgeOutput"
   - name: updateSCIMBridge
-    description: Update a SCIM bridge's excluded user names
+    description: Add user names to a SCIM bridge's exclusion list. The provided names are merged with any existing exclusions; previously excluded names are preserved.
     hints:
       readonly: false
     inputSchema:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The MCP `updateSCIMBridge` tool was replacing the entire `excluded_user_names` list instead of appending to it. When an MCP client (e.g. an AI agent) called `updateSCIMBridge` with a set of user names, any previously excluded names were overwritten and lost.

## Fix

The MCP resolver now fetches the existing SCIM bridge before updating, merges the incoming names with the existing exclusion list (deduplicating and sorting), and passes the merged result to the service layer.

### Scope

- **MCP layer only** — the fix is in `UpdateSCIMBridgeTool` in `schema.resolvers.go`
- **GraphQL and CLI are unchanged** — they retain their existing set-replacement semantics, which is correct for those surfaces (the CLI even supports clearing the list with `--excluded-user-names ""`)

### Changes

- `resolver.go` — added `mergeExcludedUserNames` helper that merges two string slices with deduplication and sorting
- `schema.resolvers.go` — `UpdateSCIMBridgeTool` now loads the existing bridge first, merges excluded names, then updates
- `specification.yaml` — updated tool and field descriptions to reflect append/merge semantics
- `resolver_test.go` — unit tests for `mergeExcludedUserNames` covering append, dedup, empty inputs, and sorting
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-393](https://linear.app/probo/issue/ENG-393/scim-excluded-user-update-replaces-instead-of-appending)

<div><a href="https://cursor.com/agents/bc-c55ec72a-f679-45b6-9b20-a990ce6832e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c55ec72a-f679-45b6-9b20-a990ce6832e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP `updateSCIMBridge` so excluded user names are merged (appended) instead of replacing the list, preventing loss of existing exclusions. Addresses Linear ENG-393.

- **Bug Fixes**
  - Load the current SCIM bridge, merge incoming names with existing exclusions, and dedupe + sort before update.
  - Add `mergeExcludedUserNames` helper with unit tests.
  - Update `specification.yaml` to document merge semantics.
  - Scope is MCP tool only; GraphQL and CLI keep set-replacement behavior (CLI can clear with `--excluded-user-names ""`).

<sup>Written for commit 641d43fdf1013da08520798e5f625ee62e992e5a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

