### PR TITLE
Clean up CodeQL findings

### DIFF
--- a/packages/emails/src/TrustCenterAccess.tsx
+++ b/packages/emails/src/TrustCenterAccess.tsx
@@ -18,7 +18,6 @@ import EmailLayout, {
   bodyText,
   button,
   buttonContainer,
-  footerText,
 } from "./components/EmailLayout";
 
 export const TrustCenterAccess = () => {

--- a/packages/helpers/src/file.test.ts
+++ b/packages/helpers/src/file.test.ts
@@ -13,7 +13,6 @@
 // PERFORMANCE OF THIS SOFTWARE.
 
 import { describe, it, expect } from "vitest";
-import { isEmpty } from "./array";
 import { fileSize } from "./file";
 
 describe("file", () => {

--- a/packages/relay/src/fetch.ts
+++ b/packages/relay/src/fetch.ts
@@ -108,7 +108,7 @@ export const makeFetchQuery = (endpoint: string): FetchFunction => {
 
             const assumptionRequiredError = errors.find(hasAssumptionRequiredError);
             if (assumptionRequiredError) {
-                throw new AssumptionRequiredError(assumptionRequiredError.message)
+                throw new AssumptionRequiredError(assumptionRequiredError.message);
             }
 
             const ndaSignatureRequiredError = errors.find(hasNDASignatureRequiredError);

--- a/packages/ui/src/Molecules/DurationPicker/DurationPicker.tsx
+++ b/packages/ui/src/Molecules/DurationPicker/DurationPicker.tsx
@@ -42,7 +42,7 @@ const stringify = (value: number | null, unit: string): string | null => {
   }
 };
 
-const parse = (value: string): { amount: number; unit: string } | null => {
+const parse = (value: string): { amount: number; unit: string } => {
   const match = value.match(/PT?(\d+)([MDWH])/);
   if (!match) return { amount: 0, unit: "D" };
   const amount = parseInt(match[1], 10) || 0;
@@ -67,7 +67,7 @@ export function DurationPicker({ value, onValueChange, ...props }: Props) {
     );
   }
 
-  const { amount, unit } = parse(value || "") || { amount: 0, unit: "D" };
+  const { amount, unit } = parse(value);
 
   return (
     <div className="flex gap-2 w-max">

--- a/packages/vendors/scripts/build-md.mjs
+++ b/packages/vendors/scripts/build-md.mjs
@@ -1,11 +1,11 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import { createWriteStream } from "node:fs";
 import path from "node:path";
 
 const data = await readFile(path.join(import.meta.dirname, '../data.json'), 'utf8');
 const vendors = JSON.parse(data);
 
-const output = path.join(import.meta.dirname, '../VENDORS.md')
+const output = path.join(import.meta.dirname, '../VENDORS.md');
 const file = createWriteStream(output);
 
 const formatAsList = (array) => {


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up CodeQL findings across the repo to reduce noise and tighten types. Removed unused imports, added missing semicolons, and simplified DurationPicker parsing to remove a dead null path.

- **Refactors**
  - `packages/emails` and `packages/helpers`: removed unused imports.
  - `packages/relay/src/fetch.ts`: added a missing semicolon in `makeFetchQuery`.
  - `packages/ui/src/Molecules/DurationPicker/DurationPicker.tsx`: `parse` now always returns `{ amount, unit }`; removed nullable return and fallback; updated call site.
  - `packages/vendors/scripts/build-md.mjs`: removed unused `writeFile` import and added a semicolon for the output path.

<sup>Written for commit ee22e9f964c7bc05e83d5e637876ca0d3da36ea2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

