### PR TITLE
Handle membership not found

### DIFF
--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -1021,11 +1021,25 @@ func (s *OrganizationService) UpdateUser(ctx context.Context, req *UpdateUserReq
 			}
 
 			membership := &coredata.Membership{}
+			var webhookPayload *webhooktypes.User
+
 			if err := membership.LoadByIdentityIDAndOrganizationID(ctx, conn, scope, profile.IdentityID, profile.OrganizationID); err != nil {
-				return fmt.Errorf("cannot load membership: %w", err)
+				if !errors.Is(err, coredata.ErrResourceNotFound) {
+					return fmt.Errorf("cannot load membership: %w", err)
+				}
+
+				webhookPayload = webhooktypes.NewUser(profile, nil)
+			} else {
+				webhookPayload = webhooktypes.NewUser(profile, membership)
 			}
 
-			if err := webhook.InsertData(ctx, conn, scope, profile.OrganizationID, coredata.WebhookEventTypeUserUpdated, webhooktypes.NewUser(profile, membership)); err != nil {
+			if err := webhook.InsertData(ctx,
+				conn,
+				scope,
+				profile.OrganizationID,
+				coredata.WebhookEventTypeUserUpdated,
+				webhookPayload,
+			); err != nil {
 				return fmt.Errorf("cannot insert webhook event: %w", err)
 			}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevented user updates from failing when a membership record is missing by treating it as non-fatal and still emitting the UserUpdated webhook with no membership payload.

- **Bug Fixes**
  - In `OrganizationService.UpdateUser`, handle `coredata.ErrResourceNotFound` from `membership.LoadByIdentityIDAndOrganizationID` by sending a webhook with `nil` membership via `webhook.InsertData`.
  - Preserve error handling for other load failures.

<sup>Written for commit d40e9a157b6e59275d580f59cdecfffe914598d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

