### PR TITLE
Address code review findings in relay fetch and iam

### DIFF
--- a/packages/relay/src/fetch.ts
+++ b/packages/relay/src/fetch.ts
@@ -24,19 +24,19 @@ import {
 import { GraphQLError } from "graphql";
 
 const hasUnauthenticatedError = (error: GraphQLError) =>
-    error.extensions?.code == "UNAUTHENTICATED";
+    error.extensions?.code === "UNAUTHENTICATED";
 
 const hasFullNameRequiredError = (error: GraphQLError) =>
-    error.extensions?.code == "FULL_NAME_REQUIRED";
+    error.extensions?.code === "FULL_NAME_REQUIRED";
 
 const hasAssumptionRequiredError = (error: GraphQLError) =>
-    error.extensions?.code == "ASSUMPTION_REQUIRED";
+    error.extensions?.code === "ASSUMPTION_REQUIRED";
 
 const hasNDASignatureRequiredError = (error: GraphQLError) =>
-    error.extensions?.code == "NDA_SIGNATURE_REQUIRED";
+    error.extensions?.code === "NDA_SIGNATURE_REQUIRED";
 
 const hasForbiddenError = (error: GraphQLError) =>
-    error.extensions?.code == "FORBIDDEN";
+    error.extensions?.code === "FORBIDDEN";
 
 export const makeFetchQuery = (endpoint: string): FetchFunction => {
     return async (request, variables, _, uploadables) => {

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -241,7 +241,7 @@ func NewOrganizationService(svc *Service) *OrganizationService {
 	return &OrganizationService{Service: svc}
 }
 
-func (s *OrganizationService) UpdateMempership(
+func (s *OrganizationService) UpdateMembership(
 	ctx context.Context,
 	organizationID gid.GID,
 	membershipID gid.GID,
@@ -792,10 +792,6 @@ func (s *OrganizationService) UpdateOrganization(ctx context.Context, organizati
 			}
 
 			organization.UpdatedAt = now
-
-			if req.Name != nil {
-				organization.Name = *req.Name
-			}
 
 			if req.Name != nil {
 				organization.Name = *req.Name

--- a/pkg/server/api/connect/v1/membership_resolvers.go
+++ b/pkg/server/api/connect/v1/membership_resolvers.go
@@ -61,7 +61,7 @@ func (r *mutationResolver) UpdateMembership(ctx context.Context, input types.Upd
 		}
 	}
 
-	membership, err := r.iam.OrganizationService.UpdateMempership(ctx, input.OrganizationID, input.MembershipID, input.Role)
+	membership, err := r.iam.OrganizationService.UpdateMembership(ctx, input.OrganizationID, input.MembershipID, input.Role)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot update membership", log.Error(err))
 		return nil, gqlutils.Internal(ctx)

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -2494,7 +2494,7 @@ func (r *Resolver) UpdateMembershipTool(ctx context.Context, req *mcp.CallToolRe
 		r.MustAuthorize(ctx, input.MembershipID, iam.ActionMembershipRoleSetOwner)
 	}
 
-	membership, err := r.iamSvc.OrganizationService.UpdateMempership(ctx, input.OrganizationID, input.MembershipID, input.Role)
+	membership, err := r.iamSvc.OrganizationService.UpdateMembership(ctx, input.OrganizationID, input.MembershipID, input.Role)
 	if err != nil {
 		return nil, types.UpdateMembershipOutput{}, fmt.Errorf("update membership: %w", err)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Tightened GraphQL error handling in `packages/relay` by using strict equality checks, and fixed a typo in IAM membership update with aligned call sites. Also removed a redundant field assignment in organization updates.

- **Bug Fixes**
  - Use `===` for GraphQL error code checks in `packages/relay/src/fetch.ts`.
  - Rename `UpdateMempership` to `UpdateMembership` in `pkg/iam`, and update calls in `connect` and `mcp` resolvers.
  - Remove duplicate `Name` assignment in `UpdateOrganization` to avoid unnecessary writes.

<sup>Written for commit a67f2433b11c91bbbb877a6ee8db4fa0c7a2643d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

