### PR TITLE
Cookie banner misc improvements

### DIFF
--- a/apps/console/src/pages/organizations/cookie-banners/NewCookieBannerPage.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/NewCookieBannerPage.tsx
@@ -21,10 +21,7 @@ import {
   Card,
   Field,
   Input,
-  Label,
-  Option,
   PageHeader,
-  Select,
   useToast,
 } from "@probo/ui";
 import { type FormEvent, useState } from "react";
@@ -63,7 +60,6 @@ export default function NewCookieBannerPage() {
   const [cookiePolicyUrl, setCookiePolicyUrl] = useState("");
   const [privacyPolicyUrl, setPrivacyPolicyUrl] = useState("");
   const [consentExpiryDays, setConsentExpiryDays] = useState("365");
-  const [consentMode, setConsentMode] = useState("OPT_IN");
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -77,7 +73,6 @@ export default function NewCookieBannerPage() {
           cookiePolicyUrl,
           privacyPolicyUrl: privacyPolicyUrl || undefined,
           consentExpiryDays: parseInt(consentExpiryDays, 10),
-          consentMode: consentMode as "OPT_IN" | "OPT_OUT",
         },
       },
       onCompleted(data) {
@@ -155,26 +150,15 @@ export default function NewCookieBannerPage() {
             />
           </Field>
 
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label>{__("Consent Expiry (days)")}</Label>
-              <Input
-                type="number"
-                value={consentExpiryDays}
-                onChange={e => setConsentExpiryDays(e.target.value)}
-                min="1"
-                required
-              />
-            </div>
-
-            <div className="space-y-2">
-              <Label>{__("Consent Mode")}</Label>
-              <Select value={consentMode} onValueChange={setConsentMode}>
-                <Option value="OPT_IN">{__("Opt-in")}</Option>
-                <Option value="OPT_OUT">{__("Opt-out")}</Option>
-              </Select>
-            </div>
-          </div>
+          <Field label={__("Consent Expiry (days)")}>
+            <Input
+              type="number"
+              value={consentExpiryDays}
+              onChange={e => setConsentExpiryDays(e.target.value)}
+              min="1"
+              required
+            />
+          </Field>
 
           <Button type="submit" disabled={isCreating}>
             {isCreating ? __("Creating...") : __("Create Banner")}

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/resources/_components/TrackerResourceRow.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/resources/_components/TrackerResourceRow.tsx
@@ -123,18 +123,18 @@ const updateResourceMutation = graphql`
   }
 `;
 
-function resourceTypeLabel(type: string, __: (s: string) => string): string {
+function resourceTypeBadge(type: string, __: (s: string) => string) {
   switch (type) {
-    case "SCRIPT": return __("Script");
-    case "IFRAME": return __("Iframe");
-    case "IMAGE": return __("Image");
-    case "STYLESHEET": return __("Stylesheet");
-    case "FONT": return __("Font");
-    case "BEACON": return __("Beacon");
-    case "FETCH": return __("Fetch");
-    case "MEDIA": return __("Media");
-    case "SERVICE_WORKER": return __("Service Worker");
-    default: return type;
+    case "SCRIPT": return { label: __("Script"), variant: "info" as const };
+    case "IFRAME": return { label: __("Iframe"), variant: "warning" as const };
+    case "IMAGE": return { label: __("Image"), variant: "neutral" as const };
+    case "STYLESHEET": return { label: __("Stylesheet"), variant: "highlight" as const };
+    case "FONT": return { label: __("Font"), variant: "outline" as const };
+    case "BEACON": return { label: __("Beacon"), variant: "danger" as const };
+    case "FETCH": return { label: __("Fetch"), variant: "success" as const };
+    case "MEDIA": return { label: __("Media"), variant: "neutral" as const };
+    case "SERVICE_WORKER": return { label: __("Service Worker"), variant: "warning" as const };
+    default: return { label: type, variant: "neutral" as const };
   }
 }
 
@@ -149,6 +149,7 @@ export function TrackerResourceRow({ resourceKey, connectionId }: TrackerResourc
   const confirm = useConfirm();
   const { cookieBannerId } = useParams<{ cookieBannerId: string }>();
   const resource = useFragment(trackerResourceFragment, resourceKey);
+  const typeBadge = resourceTypeBadge(resource.type, __);
 
   const [isEditing, setIsEditing] = useState(false);
   const [categoryQueryRef, loadCategoryQuery]
@@ -291,8 +292,8 @@ export function TrackerResourceRow({ resourceKey, connectionId }: TrackerResourc
   return (
     <Tr className={resource.excluded ? "bg-txt-quaternary opacity-80 line-through" : undefined}>
       <Td>
-        <Badge variant={resource.type === "SCRIPT" ? "info" : "neutral"}>
-          {resourceTypeLabel(resource.type, __)}
+        <Badge variant={typeBadge.variant}>
+          {typeBadge.label}
         </Badge>
       </Td>
       <Td>

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/settings/_components/BannerSettingsForm.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/settings/_components/BannerSettingsForm.tsx
@@ -30,7 +30,6 @@ const bannerSettingsFormFragment = graphql`
     cookiePolicyUrl
     privacyPolicyUrl
     consentExpiryDays
-    consentMode
     defaultLanguage
   }
 `;
@@ -44,7 +43,6 @@ const updateBannerMutation = graphql`
         cookiePolicyUrl
         privacyPolicyUrl
         consentExpiryDays
-        consentMode
         defaultLanguage
         latestVersion {
           id
@@ -61,7 +59,6 @@ interface BannerSettingsFormValues {
   cookiePolicyUrl: string;
   privacyPolicyUrl: string;
   consentExpiryDays: string;
-  consentMode: "OPT_IN" | "OPT_OUT";
   defaultLanguage: string;
 }
 
@@ -83,7 +80,6 @@ export function BannerSettingsForm({ cookieBannerKey }: BannerSettingsFormProps)
       cookiePolicyUrl: banner.cookiePolicyUrl,
       privacyPolicyUrl: banner.privacyPolicyUrl ?? "",
       consentExpiryDays: String(banner.consentExpiryDays),
-      consentMode: banner.consentMode,
       defaultLanguage: banner.defaultLanguage,
     },
   });
@@ -97,7 +93,6 @@ export function BannerSettingsForm({ cookieBannerKey }: BannerSettingsFormProps)
           cookiePolicyUrl: data.cookiePolicyUrl,
           privacyPolicyUrl: data.privacyPolicyUrl || undefined,
           consentExpiryDays: parseInt(data.consentExpiryDays, 10),
-          consentMode: data.consentMode,
           defaultLanguage: data.defaultLanguage,
         },
       },
@@ -131,7 +126,7 @@ export function BannerSettingsForm({ cookieBannerKey }: BannerSettingsFormProps)
             <Input {...register("privacyPolicyUrl")} />
           </Field>
 
-          <div className="grid grid-cols-3 gap-4">
+          <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
               <Label>{__("Consent Expiry (days)")}</Label>
               <Input
@@ -139,19 +134,6 @@ export function BannerSettingsForm({ cookieBannerKey }: BannerSettingsFormProps)
                 {...register("consentExpiryDays")}
                 min="1"
                 required
-              />
-            </div>
-            <div className="space-y-2">
-              <Label>{__("Consent Mode")}</Label>
-              <Controller
-                name="consentMode"
-                control={control}
-                render={({ field }) => (
-                  <Select value={field.value} onValueChange={field.onChange}>
-                    <Option value="OPT_IN">{__("Opt-in")}</Option>
-                    <Option value="OPT_OUT">{__("Opt-out")}</Option>
-                  </Select>
-                )}
               />
             </div>
             <div className="space-y-2">

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternRow.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternRow.tsx
@@ -123,24 +123,22 @@ const updatePatternMutation = graphql`
   }
 `;
 
-type BadgeVariant = "success" | "warning" | "danger" | "info" | "neutral" | "outline" | "highlight";
-
-function trackerTypeBadge(type: string, __: (s: string) => string): { label: string; variant: BadgeVariant } {
+function trackerTypeBadge(type: string, __: (s: string) => string) {
   switch (type) {
-    case "COOKIE": return { label: __("Cookie"), variant: "warning" };
-    case "LOCAL_STORAGE": return { label: __("localStorage"), variant: "info" };
-    case "SESSION_STORAGE": return { label: __("sessionStorage"), variant: "highlight" };
-    case "INDEXED_DB": return { label: __("IndexedDB"), variant: "success" };
-    case "CACHE_STORAGE": return { label: __("Cache Storage"), variant: "outline" };
-    default: return { label: type, variant: "neutral" };
+    case "COOKIE": return { label: __("Cookie"), variant: "warning" as const };
+    case "LOCAL_STORAGE": return { label: __("localStorage"), variant: "info" as const };
+    case "SESSION_STORAGE": return { label: __("sessionStorage"), variant: "highlight" as const };
+    case "INDEXED_DB": return { label: __("IndexedDB"), variant: "success" as const };
+    case "CACHE_STORAGE": return { label: __("Cache Storage"), variant: "outline" as const };
+    default: return { label: type, variant: "neutral" as const };
   }
 }
 
-function sourceBadge(source: string, __: (s: string) => string): { label: string; variant: BadgeVariant } {
+function sourceBadge(source: string, __: (s: string) => string) {
   switch (source) {
-    case "SCRIPT": return { label: __("Script"), variant: "info" };
-    case "PRE_EXISTING": return { label: __("Pre-existing"), variant: "outline" };
-    default: return { label: source, variant: "neutral" };
+    case "SCRIPT": return { label: __("Script"), variant: "info" as const };
+    case "PRE_EXISTING": return { label: __("Pre-existing"), variant: "outline" as const };
+    default: return { label: source, variant: "neutral" as const };
   }
 }
 

--- a/e2e/console/cookie_banner_test.go
+++ b/e2e/console/cookie_banner_test.go
@@ -41,7 +41,6 @@ func TestCookieBanner_Create(t *testing.T) {
 							state
 							cookiePolicyUrl
 							consentExpiryDays
-							consentMode
 							showBranding
 							defaultLanguage
 							createdAt
@@ -65,7 +64,6 @@ func TestCookieBanner_Create(t *testing.T) {
 						State             string `json:"state"`
 						CookiePolicyUrl   string `json:"cookiePolicyUrl"`
 						ConsentExpiryDays int    `json:"consentExpiryDays"`
-						ConsentMode       string `json:"consentMode"`
 						ShowBranding      bool   `json:"showBranding"`
 						DefaultLanguage   string `json:"defaultLanguage"`
 						CreatedAt         string `json:"createdAt"`
@@ -82,7 +80,6 @@ func TestCookieBanner_Create(t *testing.T) {
 				"origin":            origin,
 				"cookiePolicyUrl":   "https://example.com/cookies",
 				"consentExpiryDays": 365,
-				"consentMode":       "OPT_IN",
 			},
 		}, &result)
 
@@ -93,7 +90,6 @@ func TestCookieBanner_Create(t *testing.T) {
 		assert.Equal(t, "ACTIVE", node.State)
 		assert.Equal(t, "https://example.com/cookies", node.CookiePolicyUrl)
 		assert.Equal(t, 365, node.ConsentExpiryDays)
-		assert.Equal(t, "OPT_IN", node.ConsentMode)
 		assert.Equal(t, "en", node.DefaultLanguage)
 		assert.NotEmpty(t, node.CreatedAt)
 		assert.NotEmpty(t, node.UpdatedAt)
@@ -110,7 +106,6 @@ func TestCookieBanner_Create(t *testing.T) {
 						node {
 							id
 							privacyPolicyUrl
-							consentMode
 						}
 					}
 				}
@@ -123,7 +118,6 @@ func TestCookieBanner_Create(t *testing.T) {
 					Node struct {
 						ID               string  `json:"id"`
 						PrivacyPolicyUrl *string `json:"privacyPolicyUrl"`
-						ConsentMode      string  `json:"consentMode"`
 					} `json:"node"`
 				} `json:"cookieBannerEdge"`
 			} `json:"createCookieBanner"`
@@ -137,7 +131,6 @@ func TestCookieBanner_Create(t *testing.T) {
 				"cookiePolicyUrl":   "https://example.com/cookies",
 				"privacyPolicyUrl":  "https://example.com/privacy",
 				"consentExpiryDays": 180,
-				"consentMode":       "OPT_OUT",
 			},
 		}, &result)
 
@@ -146,7 +139,6 @@ func TestCookieBanner_Create(t *testing.T) {
 		assert.NotEmpty(t, node.ID)
 		require.NotNil(t, node.PrivacyPolicyUrl)
 		assert.Equal(t, "https://example.com/privacy", *node.PrivacyPolicyUrl)
-		assert.Equal(t, "OPT_OUT", node.ConsentMode)
 	})
 
 	t.Run("creates default categories", func(t *testing.T) {
@@ -220,7 +212,6 @@ func TestCookieBanner_Create(t *testing.T) {
 				"origin":            origin,
 				"cookiePolicyUrl":   "https://example.com/cookies",
 				"consentExpiryDays": 365,
-				"consentMode":       "OPT_IN",
 			},
 		})
 		require.Error(t, err)
@@ -243,7 +234,6 @@ func TestCookieBanner_Create(t *testing.T) {
 				"origin":            factory.SafeOrigin(),
 				"cookiePolicyUrl":   "https://example.com/cookies",
 				"consentExpiryDays": 365,
-				"consentMode":       "OPT_IN",
 			},
 		})
 		require.Error(t, err)
@@ -306,7 +296,6 @@ func TestCookieBanner_Update(t *testing.T) {
 				updateCookieBanner(input: $input) {
 					cookieBanner {
 						consentExpiryDays
-						consentMode
 						defaultLanguage
 					}
 				}
@@ -317,7 +306,6 @@ func TestCookieBanner_Update(t *testing.T) {
 			UpdateCookieBanner struct {
 				CookieBanner struct {
 					ConsentExpiryDays int    `json:"consentExpiryDays"`
-					ConsentMode       string `json:"consentMode"`
 					DefaultLanguage   string `json:"defaultLanguage"`
 				} `json:"cookieBanner"`
 			} `json:"updateCookieBanner"`
@@ -327,14 +315,12 @@ func TestCookieBanner_Update(t *testing.T) {
 			"input": map[string]any{
 				"cookieBannerId":    bannerID,
 				"consentExpiryDays": 90,
-				"consentMode":       "OPT_OUT",
 				"defaultLanguage":   "fr",
 			},
 		}, &result)
 
 		require.NoError(t, err)
 		assert.Equal(t, 90, result.UpdateCookieBanner.CookieBanner.ConsentExpiryDays)
-		assert.Equal(t, "OPT_OUT", result.UpdateCookieBanner.CookieBanner.ConsentMode)
 		assert.Equal(t, "fr", result.UpdateCookieBanner.CookieBanner.DefaultLanguage)
 	})
 }
@@ -574,7 +560,6 @@ func TestCookieBanner_Node(t *testing.T) {
 						name
 						origin
 						state
-						consentMode
 					}
 				}
 			}
@@ -582,11 +567,10 @@ func TestCookieBanner_Node(t *testing.T) {
 
 		var result struct {
 			Node struct {
-				ID          string `json:"id"`
-				Name        string `json:"name"`
-				Origin      string `json:"origin"`
-				State       string `json:"state"`
-				ConsentMode string `json:"consentMode"`
+				ID     string `json:"id"`
+				Name   string `json:"name"`
+				Origin string `json:"origin"`
+				State  string `json:"state"`
 			} `json:"node"`
 		}
 
@@ -842,7 +826,6 @@ func TestCookieBanner_RBAC(t *testing.T) {
 				"origin":            factory.SafeOrigin(),
 				"cookiePolicyUrl":   "https://example.com/cookies",
 				"consentExpiryDays": 365,
-				"consentMode":       "OPT_IN",
 			},
 		})
 		testutil.RequireForbiddenError(t, err, "viewer should not be able to create cookie banner")

--- a/e2e/console/cookie_banner_versioning_test.go
+++ b/e2e/console/cookie_banner_versioning_test.go
@@ -153,7 +153,6 @@ func TestCookieBannerVersioning_NoOpUpdates(t *testing.T) {
 		bannerID := factory.CreateCookieBanner(owner, factory.Attrs{
 			"cookiePolicyUrl":   "https://example.com/cookies",
 			"consentExpiryDays": 365,
-			"consentMode":       "OPT_IN",
 		})
 
 		published := publishBanner(t, owner, bannerID)
@@ -172,7 +171,6 @@ func TestCookieBannerVersioning_NoOpUpdates(t *testing.T) {
 				"cookieBannerId":    bannerID,
 				"cookiePolicyUrl":   "https://example.com/cookies",
 				"consentExpiryDays": 365,
-				"consentMode":       "OPT_IN",
 			},
 		}, &result)
 		require.NoError(t, err)

--- a/e2e/internal/factory/factory.go
+++ b/e2e/internal/factory/factory.go
@@ -1239,7 +1239,6 @@ func CreateCookieBanner(c *testutil.Client, attrs ...Attrs) string {
 		"origin":            a.getString("origin", SafeOrigin()),
 		"cookiePolicyUrl":   a.getString("cookiePolicyUrl", "https://example.com/cookies"),
 		"consentExpiryDays": a.getInt("consentExpiryDays", 365),
-		"consentMode":       a.getString("consentMode", "OPT_IN"),
 	}
 	if ppURL := a.getStringPtr("privacyPolicyUrl"); ppURL != nil {
 		input["privacyPolicyUrl"] = *ppURL
@@ -1292,11 +1291,6 @@ func (b *CookieBannerBuilder) WithPrivacyPolicyUrl(url string) *CookieBannerBuil
 
 func (b *CookieBannerBuilder) WithConsentExpiryDays(days int) *CookieBannerBuilder {
 	b.attrs["consentExpiryDays"] = days
-	return b
-}
-
-func (b *CookieBannerBuilder) WithConsentMode(mode string) *CookieBannerBuilder {
-	b.attrs["consentMode"] = mode
 	return b
 }
 

--- a/packages/cookie-banner/src/client.ts
+++ b/packages/cookie-banner/src/client.ts
@@ -33,7 +33,7 @@ import type {
   Regulation,
   VisitorConsent,
 } from "./types";
-import { getOrCreateVisitorId } from "./visitor";
+import { getOrCreateVisitorId, getVisitorId } from "./visitor";
 
 export type {
   BannerConfig,
@@ -49,7 +49,7 @@ export type {
 export class CookieBannerClient {
   private readonly baseUrl: URL;
   private readonly bannerId: string;
-  private readonly visitorId: string;
+  private visitorId: string | null;
   private readonly lang: string;
 
   private readonly integrations: ConsentIntegration[];
@@ -68,7 +68,7 @@ export class CookieBannerClient {
     }
     this.baseUrl = new URL(base);
     this.bannerId = config.bannerId;
-    this.visitorId = getOrCreateVisitorId(config.bannerId);
+    this.visitorId = getVisitorId(config.bannerId);
     this.lang = detectLanguage(config.lang);
     this.integrations = createDefaultIntegrations();
   }
@@ -97,50 +97,52 @@ export class CookieBannerClient {
     }
     this.startDetector(config);
 
-    const cookie = getConsentCookie();
-    if (cookie && cookie.bid === this.bannerId && cookie.v === config.version && cookie.vid === this.visitorId) {
-      this.consent = {
-        visitor_id: cookie.vid,
-        version: cookie.v,
-        action: cookie.action,
-        consent_data: cookie.data,
-        created_at: "",
-      };
-      this._gpcApplied = cookie.action === "GPC";
-      this.activate(cookie.data);
-      void flush(this.bannerId);
-      return;
-    }
+    if (this.visitorId) {
+      const cookie = getConsentCookie();
+      if (cookie && cookie.bid === this.bannerId && cookie.v === config.version && cookie.vid === this.visitorId) {
+        this.consent = {
+          visitor_id: cookie.vid,
+          version: cookie.v,
+          action: cookie.action,
+          consent_data: cookie.data,
+          created_at: "",
+        };
+        this._gpcApplied = cookie.action === "GPC";
+        this.activate(cookie.data);
+        void flush(this.bannerId);
+        return;
+      }
 
-    const consentUrl = new URL(
-      `${this.bannerId}/consents/${this.visitorId}`,
-      this.baseUrl,
-    );
-    const apiConsent = await fetchJSON<VisitorConsent>(consentUrl).catch(
-      (err) => {
-        if (err instanceof NotFoundError) {
-          return null;
-        }
-        throw err;
-      },
-    );
-
-    if (apiConsent && apiConsent.version === config.version) {
-      this.consent = apiConsent;
-      this._gpcApplied = apiConsent.action === "GPC";
-      setConsentCookie(
-        {
-          bid: this.bannerId,
-          v: apiConsent.version,
-          vid: apiConsent.visitor_id,
-          action: apiConsent.action,
-          data: apiConsent.consent_data,
-        },
-        config.consent_expiry_days,
+      const consentUrl = new URL(
+        `${this.bannerId}/consents/${this.visitorId}`,
+        this.baseUrl,
       );
-      this.activate(apiConsent.consent_data);
-    } else {
-      this.consent = null;
+      const apiConsent = await fetchJSON<VisitorConsent>(consentUrl).catch(
+        (err) => {
+          if (err instanceof NotFoundError) {
+            return null;
+          }
+          throw err;
+        },
+      );
+
+      if (apiConsent && apiConsent.version === config.version) {
+        this.consent = apiConsent;
+        this._gpcApplied = apiConsent.action === "GPC";
+        setConsentCookie(
+          {
+            bid: this.bannerId,
+            v: apiConsent.version,
+            vid: apiConsent.visitor_id,
+            action: apiConsent.action,
+            data: apiConsent.consent_data,
+          },
+          config.consent_expiry_days,
+        );
+        this.activate(apiConsent.consent_data);
+      } else {
+        this.consent = null;
+      }
     }
 
     if (!this.consent && this.gpcDetected) {
@@ -225,6 +227,13 @@ export class CookieBannerClient {
     this.recordConsent("CUSTOMIZE", consentData);
   }
 
+  private ensureVisitorId(): string {
+    if (!this.visitorId) {
+      this.visitorId = getOrCreateVisitorId(this.bannerId);
+    }
+    return this.visitorId;
+  }
+
   private recordConsent(
     action: ConsentAction,
     consentData: Record<string, boolean>,
@@ -232,9 +241,10 @@ export class CookieBannerClient {
     this._gpcApplied = action === "GPC";
 
     const cfg = this.config;
+    const visitorId = this.ensureVisitorId();
 
     this.consent = {
-      visitor_id: this.visitorId,
+      visitor_id: visitorId,
       version: cfg.version,
       action,
       consent_data: consentData,
@@ -245,7 +255,7 @@ export class CookieBannerClient {
       {
         bid: this.bannerId,
         v: cfg.version,
-        vid: this.visitorId,
+        vid: visitorId,
         action,
         data: consentData,
       },
@@ -256,7 +266,7 @@ export class CookieBannerClient {
 
     const url = new URL(`${this.bannerId}/consents`, this.baseUrl);
     const body = {
-      visitor_id: this.visitorId,
+      visitor_id: visitorId,
       version: cfg.version,
       action,
       consent_data: consentData,

--- a/packages/cookie-banner/src/visitor.ts
+++ b/packages/cookie-banner/src/visitor.ts
@@ -14,18 +14,23 @@
 
 import { COOKIE_NAME } from "./cookie";
 
-export function getOrCreateVisitorId(bannerId: string): string {
+export function getVisitorId(bannerId: string): string | null {
   const key = `${COOKIE_NAME}:${bannerId}:vid`;
 
   try {
-    const stored = localStorage.getItem(key);
-    if (stored) {
-      return stored;
-    }
+    return localStorage.getItem(key);
   } catch {
-    // localStorage unavailable
+    return null;
+  }
+}
+
+export function getOrCreateVisitorId(bannerId: string): string {
+  const existing = getVisitorId(bannerId);
+  if (existing) {
+    return existing;
   }
 
+  const key = `${COOKIE_NAME}:${bannerId}:vid`;
   const array = new Uint8Array(16);
   crypto.getRandomValues(array);
   const id = Array.from(array, (b) => b.toString(16).padStart(2, "0")).join("");

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/activate.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/activate.operation.ts
@@ -49,7 +49,6 @@ export async function execute(
 					privacyPolicyUrl
 					cookiePolicyUrl
 					consentExpiryDays
-					consentMode
 					showBranding
 					defaultLanguage
 					createdAt

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/create.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/create.operation.ts
@@ -90,30 +90,6 @@ export const description: INodeProperties[] = [
 		required: true,
 	},
 	{
-		displayName: 'Consent Mode',
-		name: 'consentMode',
-		type: 'options',
-		displayOptions: {
-			show: {
-				resource: ['cookieBanner'],
-				operation: ['create'],
-			},
-		},
-		options: [
-			{
-				name: 'Opt In',
-				value: 'OPT_IN',
-			},
-			{
-				name: 'Opt Out',
-				value: 'OPT_OUT',
-			},
-		],
-		default: 'OPT_IN',
-		description: 'The consent mode for the cookie banner',
-		required: true,
-	},
-	{
 		displayName: 'Privacy Policy URL',
 		name: 'privacyPolicyUrl',
 		type: 'string',
@@ -137,7 +113,6 @@ export async function execute(
 	const origin = this.getNodeParameter('origin', itemIndex) as string;
 	const cookiePolicyUrl = this.getNodeParameter('cookiePolicyUrl', itemIndex) as string;
 	const consentExpiryDays = this.getNodeParameter('consentExpiryDays', itemIndex) as number;
-	const consentMode = this.getNodeParameter('consentMode', itemIndex) as string;
 	const privacyPolicyUrl = this.getNodeParameter('privacyPolicyUrl', itemIndex, '') as string;
 
 	const query = `
@@ -152,7 +127,6 @@ export async function execute(
 						privacyPolicyUrl
 						cookiePolicyUrl
 						consentExpiryDays
-						consentMode
 						showBranding
 						defaultLanguage
 						createdAt
@@ -169,7 +143,6 @@ export async function execute(
 		origin,
 		cookiePolicyUrl,
 		consentExpiryDays,
-		consentMode,
 	};
 	if (privacyPolicyUrl) input.privacyPolicyUrl = privacyPolicyUrl;
 

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/deactivate.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/deactivate.operation.ts
@@ -49,7 +49,6 @@ export async function execute(
 					privacyPolicyUrl
 					cookiePolicyUrl
 					consentExpiryDays
-					consentMode
 					showBranding
 					defaultLanguage
 					createdAt

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/get.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/get.operation.ts
@@ -49,7 +49,6 @@ export async function execute(
 					privacyPolicyUrl
 					cookiePolicyUrl
 					consentExpiryDays
-					consentMode
 					showBranding
 					defaultLanguage
 					createdAt

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/getAll.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/getAll.operation.ts
@@ -84,7 +84,6 @@ export async function execute(
 								privacyPolicyUrl
 								cookiePolicyUrl
 								consentExpiryDays
-								consentMode
 								showBranding
 								defaultLanguage
 								createdAt

--- a/packages/n8n-node/nodes/Probo/actions/cookieBanner/update.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/cookieBanner/update.operation.ts
@@ -70,33 +70,6 @@ export const description: INodeProperties[] = [
 		description: 'Number of days before consent expires (0 to leave unchanged)',
 	},
 	{
-		displayName: 'Consent Mode',
-		name: 'consentMode',
-		type: 'options',
-		displayOptions: {
-			show: {
-				resource: ['cookieBanner'],
-				operation: ['update'],
-			},
-		},
-		options: [
-			{
-				name: '(Unchanged)',
-				value: '',
-			},
-			{
-				name: 'Opt In',
-				value: 'OPT_IN',
-			},
-			{
-				name: 'Opt Out',
-				value: 'OPT_OUT',
-			},
-		],
-		default: '',
-		description: 'The consent mode for the cookie banner',
-	},
-	{
 		displayName: 'Default Language',
 		name: 'defaultLanguage',
 		type: 'string',
@@ -141,7 +114,6 @@ export async function execute(
 	const name = this.getNodeParameter('name', itemIndex, '') as string;
 	const cookiePolicyUrl = this.getNodeParameter('cookiePolicyUrl', itemIndex, '') as string;
 	const consentExpiryDays = this.getNodeParameter('consentExpiryDays', itemIndex, 0) as number;
-	const consentMode = this.getNodeParameter('consentMode', itemIndex, '') as string;
 	const defaultLanguage = this.getNodeParameter('defaultLanguage', itemIndex, '') as string;
 	const additionalFields = this.getNodeParameter('additionalFields', itemIndex, {}) as {
 		privacyPolicyUrl?: string;
@@ -158,7 +130,6 @@ export async function execute(
 					privacyPolicyUrl
 					cookiePolicyUrl
 					consentExpiryDays
-					consentMode
 					showBranding
 					defaultLanguage
 					createdAt
@@ -172,7 +143,6 @@ export async function execute(
 	if (name) input.name = name;
 	if (cookiePolicyUrl) input.cookiePolicyUrl = cookiePolicyUrl;
 	if (consentExpiryDays) input.consentExpiryDays = consentExpiryDays;
-	if (consentMode) input.consentMode = consentMode;
 	if (defaultLanguage) input.defaultLanguage = defaultLanguage;
 	if (additionalFields.privacyPolicyUrl !== undefined) {
 		input.privacyPolicyUrl = additionalFields.privacyPolicyUrl === '' ? null : additionalFields.privacyPolicyUrl;

--- a/pkg/cmd/cookie-banner/create/create.go
+++ b/pkg/cmd/cookie-banner/create/create.go
@@ -58,7 +58,6 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 		flagCookiePolicyUrl  string
 		flagPrivacyPolicyUrl string
 		flagConsentExpiry    int
-		flagConsentMode      string
 	)
 
 	cmd := &cobra.Command{
@@ -106,17 +105,6 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 						return err
 					}
 				}
-				if flagConsentMode == "" {
-					if err := huh.NewSelect[string]().
-						Title("Consent mode").
-						Options(
-							huh.NewOption("Opt-In", "OPT_IN"),
-							huh.NewOption("Opt-Out", "OPT_OUT"),
-						).
-						Value(&flagConsentMode).Run(); err != nil {
-						return err
-					}
-				}
 			}
 
 			if flagName == "" {
@@ -128,9 +116,6 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 			if flagCookiePolicyUrl == "" {
 				return fmt.Errorf("cookie-policy-url is required; pass --cookie-policy-url or run interactively")
 			}
-			if flagConsentMode == "" {
-				return fmt.Errorf("consent-mode is required; pass --consent-mode or run interactively")
-			}
 
 			input := map[string]any{
 				"organizationId":    flagOrg,
@@ -138,7 +123,6 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 				"origin":            flagOrigin,
 				"cookiePolicyUrl":   flagCookiePolicyUrl,
 				"consentExpiryDays": flagConsentExpiry,
-				"consentMode":       flagConsentMode,
 			}
 			if flagPrivacyPolicyUrl != "" {
 				input["privacyPolicyUrl"] = flagPrivacyPolicyUrl
@@ -167,7 +151,6 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&flagCookiePolicyUrl, "cookie-policy-url", "", "Cookie policy URL (required)")
 	cmd.Flags().StringVar(&flagPrivacyPolicyUrl, "privacy-policy-url", "", "Privacy policy URL")
 	cmd.Flags().IntVar(&flagConsentExpiry, "consent-expiry-days", 365, "Days until consent expires")
-	cmd.Flags().StringVar(&flagConsentMode, "consent-mode", "", "Consent mode: OPT_IN or OPT_OUT (required)")
 
 	return cmd
 }

--- a/pkg/cmd/cookie-banner/list/list.go
+++ b/pkg/cmd/cookie-banner/list/list.go
@@ -36,7 +36,6 @@ query($id: ID!, $first: Int, $after: CursorKey) {
             name
             origin
             state
-            consentMode
           }
         }
         pageInfo {
@@ -50,11 +49,10 @@ query($id: ID!, $first: Int, $after: CursorKey) {
 `
 
 type banner struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Origin      string `json:"origin"`
-	State       string `json:"state"`
-	ConsentMode string `json:"consentMode"`
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Origin string `json:"origin"`
+	State  string `json:"state"`
 }
 
 func NewCmdList(f *cmdutil.Factory) *cobra.Command {
@@ -140,10 +138,10 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 
 			rows := make([][]string, 0, len(banners))
 			for _, b := range banners {
-				rows = append(rows, []string{b.ID, b.Name, b.Origin, b.State, b.ConsentMode})
+				rows = append(rows, []string{b.ID, b.Name, b.Origin, b.State})
 			}
 
-			t := cmdutil.NewTable("ID", "NAME", "ORIGIN", "STATE", "CONSENT MODE").Rows(rows...)
+			t := cmdutil.NewTable("ID", "NAME", "ORIGIN", "STATE").Rows(rows...)
 			_, _ = fmt.Fprintln(f.IOStreams.Out, t)
 
 			if totalCount > len(banners) {

--- a/pkg/cmd/cookie-banner/update/update.go
+++ b/pkg/cmd/cookie-banner/update/update.go
@@ -49,7 +49,6 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 		flagCookiePolicyUrl  string
 		flagPrivacyPolicyUrl string
 		flagConsentExpiry    int
-		flagConsentMode      string
 		flagDefaultLanguage  string
 	)
 
@@ -90,9 +89,6 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 			if cmd.Flags().Changed("consent-expiry-days") {
 				input["consentExpiryDays"] = flagConsentExpiry
 			}
-			if cmd.Flags().Changed("consent-mode") {
-				input["consentMode"] = flagConsentMode
-			}
 			if cmd.Flags().Changed("default-language") {
 				input["defaultLanguage"] = flagDefaultLanguage
 			}
@@ -122,7 +118,6 @@ func NewCmdUpdate(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&flagCookiePolicyUrl, "cookie-policy-url", "", "Cookie policy URL")
 	cmd.Flags().StringVar(&flagPrivacyPolicyUrl, "privacy-policy-url", "", "Privacy policy URL")
 	cmd.Flags().IntVar(&flagConsentExpiry, "consent-expiry-days", 0, "Days until consent expires")
-	cmd.Flags().StringVar(&flagConsentMode, "consent-mode", "", "Consent mode: OPT_IN or OPT_OUT")
 	cmd.Flags().StringVar(&flagDefaultLanguage, "default-language", "", "Default language code")
 
 	return cmd

--- a/pkg/cmd/cookie-banner/view/view.go
+++ b/pkg/cmd/cookie-banner/view/view.go
@@ -36,7 +36,6 @@ query($id: ID!) {
       cookiePolicyUrl
       privacyPolicyUrl
       consentExpiryDays
-      consentMode
       showBranding
       defaultLanguage
       createdAt
@@ -56,7 +55,6 @@ type viewResponse struct {
 		CookiePolicyUrl   string  `json:"cookiePolicyUrl"`
 		PrivacyPolicyUrl  *string `json:"privacyPolicyUrl"`
 		ConsentExpiryDays int     `json:"consentExpiryDays"`
-		ConsentMode       string  `json:"consentMode"`
 		ShowBranding      bool    `json:"showBranding"`
 		DefaultLanguage   string  `json:"defaultLanguage"`
 		CreatedAt         string  `json:"createdAt"`
@@ -122,7 +120,6 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("ID:"), v.ID)
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Origin:"), v.Origin)
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("State:"), v.State)
-			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Consent Mode:"), v.ConsentMode)
 			_, _ = fmt.Fprintf(out, "%s%d days\n", label.Render("Consent Expiry:"), v.ConsentExpiryDays)
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Default Language:"), v.DefaultLanguage)
 			_, _ = fmt.Fprintf(out, "%s%s\n", label.Render("Cookie Policy:"), v.CookiePolicyUrl)

--- a/pkg/cookiebanner/regulation.go
+++ b/pkg/cookiebanner/regulation.go
@@ -134,8 +134,8 @@ func RegulationForCountry(cc coredata.CountryCode) Regulation {
 // the visitor gives explicit consent; OPT_OUT means cookies may fire
 // immediately but the visitor must be offered a way to opt out.
 //
-// When the regulation is unknown or RegulationNone, it returns an empty
-// string so the caller can fall back to the banner's configured default.
+// When the regulation is unknown or RegulationNone, it defaults to
+// OPT_OUT (cookies may fire immediately, visitor can opt out).
 func ConsentModeForRegulation(r Regulation) string {
 	switch r {
 	case RegulationGDPR,
@@ -157,6 +157,6 @@ func ConsentModeForRegulation(r Regulation) string {
 		return ConsentModeOptOut
 
 	default:
-		return ""
+		return ConsentModeOptOut
 	}
 }

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -51,7 +51,6 @@ type (
 		PrivacyPolicyURL  *string
 		CookiePolicyURL   string
 		ConsentExpiryDays int
-		ConsentMode       coredata.CookieConsentMode
 	}
 
 	CreateCookieCategoryRequest struct {
@@ -68,7 +67,6 @@ type (
 		PrivacyPolicyURL  *string
 		CookiePolicyURL   *string
 		ConsentExpiryDays *int
-		ConsentMode       *coredata.CookieConsentMode
 		DefaultLanguage   *string
 	}
 
@@ -107,6 +105,7 @@ type (
 		SdkVersion  string
 		Regulation  *Regulation
 		CountryCode *coredata.CountryCode
+		ConsentMode *coredata.CookieConsentMode
 	}
 
 	DetectedCookie struct {
@@ -231,7 +230,6 @@ func (r *CreateCookieBannerRequest) Validate() error {
 	v.Check(r.PrivacyPolicyURL, "privacy_policy_url", validator.URL())
 	v.Check(r.CookiePolicyURL, "cookie_policy_url", validator.Required(), validator.URL())
 	v.Check(r.ConsentExpiryDays, "consent_expiry_days", validator.Required(), validator.Min(1))
-	v.Check(r.ConsentMode, "consent_mode", validator.Required(), validator.OneOfSlice(coredata.CookieConsentModes()))
 
 	return v.Error()
 }
@@ -244,7 +242,6 @@ func (r *UpdateCookieBannerRequest) Validate() error {
 	v.Check(r.PrivacyPolicyURL, "privacy_policy_url", validator.URL())
 	v.Check(r.CookiePolicyURL, "cookie_policy_url", validator.URL())
 	v.Check(r.ConsentExpiryDays, "consent_expiry_days", validator.Min(1))
-	v.Check(r.ConsentMode, "consent_mode", validator.OneOfSlice(coredata.CookieConsentModes()))
 	v.Check(r.DefaultLanguage, "default_language", validator.OneOfSlice(SupportedLanguages))
 
 	return v.Error()
@@ -581,7 +578,6 @@ func (s *Service) CreateCookieBanner(
 				PrivacyPolicyURL:  req.PrivacyPolicyURL,
 				CookiePolicyURL:   req.CookiePolicyURL,
 				ConsentExpiryDays: req.ConsentExpiryDays,
-				ConsentMode:       req.ConsentMode,
 				ShowBranding:      s.showBranding,
 				DefaultLanguage:   "en",
 				CreatedAt:         now,
@@ -857,10 +853,9 @@ func (s *Service) UpdateCookieBanner(
 			privacyChanged := req.PrivacyPolicyURL != nil && !ptrEqual(req.PrivacyPolicyURL, banner.PrivacyPolicyURL)
 			cookiePolicyChanged := req.CookiePolicyURL != nil && *req.CookiePolicyURL != banner.CookiePolicyURL
 			expiryChanged := req.ConsentExpiryDays != nil && *req.ConsentExpiryDays != banner.ConsentExpiryDays
-			consentModeChanged := req.ConsentMode != nil && *req.ConsentMode != banner.ConsentMode
 			defaultLangChanged := req.DefaultLanguage != nil && *req.DefaultLanguage != banner.DefaultLanguage
 
-			snapshotChanged := privacyChanged || cookiePolicyChanged || expiryChanged || consentModeChanged || defaultLangChanged
+			snapshotChanged := privacyChanged || cookiePolicyChanged || expiryChanged || defaultLangChanged
 
 			if !nameChanged && !snapshotChanged {
 				return nil
@@ -877,9 +872,6 @@ func (s *Service) UpdateCookieBanner(
 			}
 			if req.ConsentExpiryDays != nil {
 				banner.ConsentExpiryDays = *req.ConsentExpiryDays
-			}
-			if req.ConsentMode != nil {
-				banner.ConsentMode = *req.ConsentMode
 			}
 			if req.DefaultLanguage != nil {
 				banner.DefaultLanguage = *req.DefaultLanguage
@@ -1609,11 +1601,9 @@ func (s *Service) GetActiveBannerConfig(
 	}
 
 	config.Regulation = regulation
-	if cm := ConsentModeForRegulation(regulation); cm != "" {
-		config.ConsentMode = cm
-	}
+	config.ConsentMode = ConsentModeForRegulation(regulation)
 	if !isLegacySDK(sdkVersion) {
-		remapTextsForConsentMode(config.Texts, config.ConsentMode, regulation)
+		remapTextsForConsentMode(config.Texts, config.ConsentMode)
 	}
 
 	return config, nil
@@ -1677,7 +1667,6 @@ func buildBannerConfig(
 		PrivacyPolicyURL:  privacyPolicyURL,
 		CookiePolicyURL:   snapshot.CookiePolicyURL,
 		ConsentExpiryDays: snapshot.ConsentExpiryDays,
-		ConsentMode:       snapshot.ConsentMode,
 		ShowBranding:      banner.ShowBranding,
 		Categories:        categories,
 		Texts:             texts,
@@ -1687,24 +1676,16 @@ func buildBannerConfig(
 // remapTextsForConsentMode overrides the generic banner text keys with
 // mode-specific variants so the client renders the appropriate copy
 // without needing consent-mode awareness itself.
-func remapTextsForConsentMode(texts map[string]string, consentMode string, regulation Regulation) {
+func remapTextsForConsentMode(texts map[string]string, consentMode string) {
 	if texts == nil {
 		return
 	}
 
-	switch {
-	case consentMode == ConsentModeOptOut:
+	if consentMode == ConsentModeOptOut {
 		remapTextKey(texts, "banner_title_opt_out", "banner_title")
 		remapTextKey(texts, "banner_description_opt_out", "banner_description")
 		remapTextKey(texts, "button_acknowledge", "button_accept_all")
 		remapTextKey(texts, "button_opt_out", "button_reject_all")
-		texts["button_customize"] = ""
-
-	case regulation == RegulationNone:
-		remapTextKey(texts, "banner_title_notice", "banner_title")
-		remapTextKey(texts, "banner_description_notice", "banner_description")
-		remapTextKey(texts, "button_dismiss", "button_accept_all")
-		texts["button_reject_all"] = ""
 		texts["button_customize"] = ""
 	}
 }
@@ -1964,6 +1945,7 @@ func (s *Service) RecordConsent(
 				SdkVersion:            req.SdkVersion,
 				Regulation:            req.Regulation,
 				CountryCode:           req.CountryCode,
+				ConsentMode:           req.ConsentMode,
 				CreatedAt:             time.Now(),
 			}
 

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -2023,6 +2023,7 @@ func (s *Service) ReportDetectedTrackers(
 
 			inserted := 0
 			now := time.Now()
+			var matchedPatternIDs []gid.GID
 
 			for _, dc := range req.Cookies {
 				if err := s.reportDetectedTracker(
@@ -2040,6 +2041,7 @@ func (s *Service) ReportDetectedTrackers(
 						InitiatorURL:  dc.InitiatorURL,
 					},
 					&inserted,
+					&matchedPatternIDs,
 				); err != nil {
 					return err
 				}
@@ -2060,6 +2062,7 @@ func (s *Service) ReportDetectedTrackers(
 						InitiatorURL: ds.InitiatorURL,
 					},
 					&inserted,
+					&matchedPatternIDs,
 				); err != nil {
 					return err
 				}
@@ -2080,6 +2083,13 @@ func (s *Service) ReportDetectedTrackers(
 				}
 				if wasInserted {
 					inserted++
+				}
+			}
+
+			if len(matchedPatternIDs) > 0 {
+				var patterns coredata.TrackerPatterns
+				if err := patterns.UpdateLastMatchedAt(ctx, tx, scope, matchedPatternIDs, now); err != nil {
+					return fmt.Errorf("cannot update tracker pattern last_matched_at: %w", err)
 				}
 			}
 
@@ -2112,6 +2122,7 @@ func (s *Service) reportDetectedTracker(
 	now time.Time,
 	info detectedTrackerInfo,
 	inserted *int,
+	matchedPatternIDs *[]gid.GID,
 ) error {
 	var matchedPattern coredata.TrackerPattern
 	err := matchedPattern.FindMatchingPattern(ctx, tx, scope, banner.ID, info.TrackerType, info.Identifier)
@@ -2126,11 +2137,7 @@ func (s *Service) reportDetectedTracker(
 	var patternID *gid.GID
 	if err == nil {
 		patternID = &matchedPattern.ID
-		matchedPattern.LastMatchedAt = &now
-		matchedPattern.UpdatedAt = now
-		if updateErr := matchedPattern.Update(ctx, tx, scope); updateErr != nil {
-			return fmt.Errorf("cannot update tracker pattern last_matched_at: %w", updateErr)
-		}
+		*matchedPatternIDs = append(*matchedPatternIDs, matchedPattern.ID)
 	} else {
 		newPattern := &coredata.TrackerPattern{
 			ID:               gid.New(scope.GetTenantID(), coredata.TrackerPatternEntityType),

--- a/pkg/cookiebanner/service_test.go
+++ b/pkg/cookiebanner/service_test.go
@@ -34,7 +34,6 @@ func TestSnapshotsEqual(t *testing.T) {
 			PrivacyPolicyURL:  &policy,
 			CookiePolicyURL:   "https://example.com/cookies",
 			ConsentExpiryDays: 180,
-			ConsentMode:       "OPT_IN",
 			DefaultLanguage:   "en",
 			Categories: []coredata.CookieBannerVersionSnapshotCategory{
 				{
@@ -248,7 +247,6 @@ func TestBuildSnapshot_RankInvariant(t *testing.T) {
 		ID:                bannerID,
 		CookiePolicyURL:   "https://example.com/cookies",
 		ConsentExpiryDays: 365,
-		ConsentMode:       coredata.CookieConsentModeOptIn,
 		DefaultLanguage:   "en",
 	}
 
@@ -298,14 +296,15 @@ func TestRemapTextsForConsentMode(t *testing.T) {
 		}
 	}
 
-	t.Run("no regulation clears reject and customize", func(t *testing.T) {
+	t.Run("opt in mode keeps all buttons", func(t *testing.T) {
 		t.Parallel()
 
 		texts := baseTexts()
-		remapTextsForConsentMode(texts, ConsentModeOptIn, RegulationNone)
+		remapTextsForConsentMode(texts, ConsentModeOptIn)
 
-		assert.Empty(t, texts["button_reject_all"])
-		assert.Empty(t, texts["button_customize"])
+		assert.Equal(t, "Accept All", texts["button_accept_all"])
+		assert.Equal(t, "Reject All", texts["button_reject_all"])
+		assert.Equal(t, "Customize", texts["button_customize"])
 	})
 
 	t.Run("opt out mode maps opt out to reject and clears customize", func(t *testing.T) {
@@ -313,7 +312,7 @@ func TestRemapTextsForConsentMode(t *testing.T) {
 
 		texts := baseTexts()
 		texts["button_opt_out"] = "Do Not Sell"
-		remapTextsForConsentMode(texts, ConsentModeOptOut, RegulationCCPA)
+		remapTextsForConsentMode(texts, ConsentModeOptOut)
 
 		assert.Equal(t, "Do Not Sell", texts["button_reject_all"])
 		assert.Empty(t, texts["button_customize"])

--- a/pkg/cookiebanner/snapshot.go
+++ b/pkg/cookiebanner/snapshot.go
@@ -116,7 +116,6 @@ func buildSnapshot(
 		PrivacyPolicyURL:  banner.PrivacyPolicyURL,
 		CookiePolicyURL:   banner.CookiePolicyURL,
 		ConsentExpiryDays: banner.ConsentExpiryDays,
-		ConsentMode:       string(banner.ConsentMode),
 		DefaultLanguage:   banner.DefaultLanguage,
 		Categories:        snapshotCategories,
 	}

--- a/pkg/cookiebanner/worker.go
+++ b/pkg/cookiebanner/worker.go
@@ -349,9 +349,6 @@ func findMergeGroups(
 func heuristicTemplate(name string) (string, bool) {
 	tokens, sep := splitTokens(name)
 	if sep == 0 {
-		if looksVariable(name) {
-			return "*", true
-		}
 		return "", false
 	}
 

--- a/pkg/cookiebanner/worker_test.go
+++ b/pkg/cookiebanner/worker_test.go
@@ -200,8 +200,8 @@ func TestHeuristicTemplate(t *testing.T) {
 		{
 			name:     "no separator with variable token",
 			input:    "a1b2c3d4e5f6g7h8",
-			template: "*",
-			changed:  true,
+			template: "",
+			changed:  false,
 		},
 		{
 			name:     "no separator without variable token",

--- a/pkg/coredata/cookie_banner.go
+++ b/pkg/coredata/cookie_banner.go
@@ -38,7 +38,6 @@ type (
 		PrivacyPolicyURL           *string           `db:"privacy_policy_url"`
 		CookiePolicyURL            string            `db:"cookie_policy_url"`
 		ConsentExpiryDays          int               `db:"consent_expiry_days"`
-		ConsentMode                CookieConsentMode `db:"consent_mode"`
 		ShowBranding               bool              `db:"show_branding"`
 		DefaultLanguage            string            `db:"default_language"`
 		PatternAnalysisRequestedAt *time.Time        `db:"pattern_analysis_requested_at"`
@@ -89,7 +88,6 @@ SELECT
 	privacy_policy_url,
 	cookie_policy_url,
 	consent_expiry_days,
-	consent_mode,
 	show_branding,
 	default_language,
 	pattern_analysis_requested_at,
@@ -142,7 +140,6 @@ SELECT
 	privacy_policy_url,
 	cookie_policy_url,
 	consent_expiry_days,
-	consent_mode,
 	show_branding,
 	default_language,
 	pattern_analysis_requested_at,
@@ -196,7 +193,6 @@ SELECT
 	privacy_policy_url,
 	cookie_policy_url,
 	consent_expiry_days,
-	consent_mode,
 	show_branding,
 	default_language,
 	pattern_analysis_requested_at,
@@ -254,7 +250,6 @@ SELECT
 	privacy_policy_url,
 	cookie_policy_url,
 	consent_expiry_days,
-	consent_mode,
 	show_branding,
 	default_language,
 	pattern_analysis_requested_at,
@@ -305,7 +300,6 @@ SELECT
 	privacy_policy_url,
 	cookie_policy_url,
 	consent_expiry_days,
-	consent_mode,
 	show_branding,
 	default_language,
 	pattern_analysis_requested_at,
@@ -392,7 +386,6 @@ INSERT INTO cookie_banners (
 	privacy_policy_url,
 	cookie_policy_url,
 	consent_expiry_days,
-	consent_mode,
 	show_branding,
 	default_language,
 	pattern_analysis_requested_at,
@@ -408,7 +401,6 @@ INSERT INTO cookie_banners (
 	@privacy_policy_url,
 	@cookie_policy_url,
 	@consent_expiry_days,
-	@consent_mode,
 	@show_branding,
 	@default_language,
 	@pattern_analysis_requested_at,
@@ -427,7 +419,6 @@ INSERT INTO cookie_banners (
 		"privacy_policy_url":            b.PrivacyPolicyURL,
 		"cookie_policy_url":             b.CookiePolicyURL,
 		"consent_expiry_days":           b.ConsentExpiryDays,
-		"consent_mode":                  b.ConsentMode,
 		"show_branding":                 b.ShowBranding,
 		"default_language":              b.DefaultLanguage,
 		"pattern_analysis_requested_at": b.PatternAnalysisRequestedAt,
@@ -461,7 +452,6 @@ SET
 	privacy_policy_url = @privacy_policy_url,
 	cookie_policy_url = @cookie_policy_url,
 	consent_expiry_days = @consent_expiry_days,
-	consent_mode = @consent_mode,
 	show_branding = @show_branding,
 	default_language = @default_language,
 	updated_at = @updated_at
@@ -479,7 +469,6 @@ WHERE
 		"privacy_policy_url":  b.PrivacyPolicyURL,
 		"cookie_policy_url":   b.CookiePolicyURL,
 		"consent_expiry_days": b.ConsentExpiryDays,
-		"consent_mode":        b.ConsentMode,
 		"show_branding":       b.ShowBranding,
 		"default_language":    b.DefaultLanguage,
 		"updated_at":          b.UpdatedAt,
@@ -581,7 +570,6 @@ SELECT
 	privacy_policy_url,
 	cookie_policy_url,
 	consent_expiry_days,
-	consent_mode,
 	show_branding,
 	default_language,
 	pattern_analysis_requested_at,

--- a/pkg/coredata/cookie_banner_version.go
+++ b/pkg/coredata/cookie_banner_version.go
@@ -33,7 +33,6 @@ type (
 		PrivacyPolicyURL  *string                               `json:"privacy_policy_url,omitempty"`
 		CookiePolicyURL   string                                `json:"cookie_policy_url"`
 		ConsentExpiryDays int                                   `json:"consent_expiry_days"`
-		ConsentMode       string                                `json:"consent_mode"`
 		DefaultLanguage   string                                `json:"default_language"`
 		Categories        []CookieBannerVersionSnapshotCategory `json:"categories"`
 	}

--- a/pkg/coredata/cookie_consent_record.go
+++ b/pkg/coredata/cookie_consent_record.go
@@ -42,6 +42,7 @@ type (
 		SdkVersion            string              `db:"sdk_version"`
 		Regulation            *Regulation         `db:"regulation"`
 		CountryCode           *CountryCode        `db:"country_code"`
+		ConsentMode           *CookieConsentMode  `db:"consent_mode"`
 		CreatedAt             time.Time           `db:"created_at"`
 	}
 
@@ -94,6 +95,7 @@ SELECT
 	sdk_version,
 	regulation,
 	country_code,
+	consent_mode,
 	created_at
 FROM
 	cookie_consent_records
@@ -180,6 +182,7 @@ INSERT INTO cookie_consent_records (
 	sdk_version,
 	regulation,
 	country_code,
+	consent_mode,
 	created_at
 ) VALUES (
 	@id,
@@ -195,6 +198,7 @@ INSERT INTO cookie_consent_records (
 	@sdk_version,
 	@regulation,
 	@country_code,
+	@consent_mode,
 	@created_at
 )
 `
@@ -213,6 +217,7 @@ INSERT INTO cookie_consent_records (
 		"sdk_version":              r.SdkVersion,
 		"regulation":               r.Regulation,
 		"country_code":             r.CountryCode,
+		"consent_mode":             r.ConsentMode,
 		"created_at":               r.CreatedAt,
 	}
 
@@ -244,6 +249,7 @@ SELECT
 	sdk_version,
 	regulation,
 	country_code,
+	consent_mode,
 	created_at
 FROM
 	cookie_consent_records
@@ -297,6 +303,7 @@ SELECT
 	sdk_version,
 	regulation,
 	country_code,
+	consent_mode,
 	created_at
 FROM
 	cookie_consent_records

--- a/pkg/coredata/migrations/20260513T075812Z.sql
+++ b/pkg/coredata/migrations/20260513T075812Z.sql
@@ -1,0 +1,16 @@
+-- Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+--
+-- Permission to use, copy, modify, and/or distribute this software for any
+-- purpose with or without fee is hereby granted, provided that the above
+-- copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+-- REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+-- INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+-- LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+-- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+ALTER TABLE cookie_consent_records ADD COLUMN consent_mode cookie_consent_mode;
+ALTER TABLE cookie_banners DROP COLUMN consent_mode;

--- a/pkg/coredata/tracker_pattern.go
+++ b/pkg/coredata/tracker_pattern.go
@@ -801,6 +801,44 @@ WHERE
 	return count, nil
 }
 
+func (tps *TrackerPatterns) UpdateLastMatchedAt(
+	ctx context.Context,
+	tx pg.Tx,
+	scope Scoper,
+	patternIDs []gid.GID,
+	matchedAt time.Time,
+) error {
+	if len(patternIDs) == 0 {
+		return nil
+	}
+
+	q := `
+UPDATE tracker_patterns
+SET
+	last_matched_at = @matched_at,
+	updated_at = @updated_at
+WHERE
+	%s
+	AND id = ANY(@pattern_ids)
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"pattern_ids": patternIDs,
+		"matched_at":  matchedAt,
+		"updated_at":  matchedAt,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := tx.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot update last_matched_at for tracker patterns: %w", err)
+	}
+
+	return nil
+}
+
 func (tps *TrackerPatterns) MoveToCategoryByCookieCategoryID(
 	ctx context.Context,
 	tx pg.Tx,

--- a/pkg/server/api/console/v1/cookie_banner_resolvers.go
+++ b/pkg/server/api/console/v1/cookie_banner_resolvers.go
@@ -440,7 +440,6 @@ func (r *mutationResolver) CreateCookieBanner(ctx context.Context, input types.C
 			PrivacyPolicyURL:  input.PrivacyPolicyURL,
 			CookiePolicyURL:   input.CookiePolicyURL,
 			ConsentExpiryDays: input.ConsentExpiryDays,
-			ConsentMode:       input.ConsentMode,
 		},
 	)
 	if err != nil {
@@ -476,7 +475,6 @@ func (r *mutationResolver) UpdateCookieBanner(ctx context.Context, input types.U
 			PrivacyPolicyURL:  input.PrivacyPolicyURL,
 			CookiePolicyURL:   input.CookiePolicyURL,
 			ConsentExpiryDays: input.ConsentExpiryDays,
-			ConsentMode:       input.ConsentMode,
 			DefaultLanguage:   input.DefaultLanguage,
 		},
 	)

--- a/pkg/server/api/console/v1/graphql/cookie_banner.graphql
+++ b/pkg/server/api/console/v1/graphql/cookie_banner.graphql
@@ -120,7 +120,6 @@ type CookieBanner implements Node {
     privacyPolicyUrl: String
     cookiePolicyUrl: String!
     consentExpiryDays: Int!
-    consentMode: CookieConsentMode!
     showBranding: Boolean!
     defaultLanguage: String!
 
@@ -528,7 +527,6 @@ input CreateCookieBannerInput {
     privacyPolicyUrl: String
     cookiePolicyUrl: String!
     consentExpiryDays: Int!
-    consentMode: CookieConsentMode!
 }
 
 input UpdateCookieBannerInput {
@@ -537,7 +535,6 @@ input UpdateCookieBannerInput {
     privacyPolicyUrl: String
     cookiePolicyUrl: String
     consentExpiryDays: Int
-    consentMode: CookieConsentMode
     defaultLanguage: String
 }
 

--- a/pkg/server/api/console/v1/types/cookie_banner.go
+++ b/pkg/server/api/console/v1/types/cookie_banner.go
@@ -72,7 +72,6 @@ func NewCookieBanner(b *coredata.CookieBanner) *CookieBanner {
 		PrivacyPolicyURL:  b.PrivacyPolicyURL,
 		CookiePolicyURL:   b.CookiePolicyURL,
 		ConsentExpiryDays: b.ConsentExpiryDays,
-		ConsentMode:       b.ConsentMode,
 		ShowBranding:      b.ShowBranding,
 		DefaultLanguage:   b.DefaultLanguage,
 		CreatedAt:         b.CreatedAt,

--- a/pkg/server/api/cookiebanner/v1/handler.go
+++ b/pkg/server/api/cookiebanner/v1/handler.go
@@ -180,11 +180,16 @@ func (h *Handler) handlePostConsent(w http.ResponseWriter, r *http.Request) {
 	sdkVersion := r.Header.Get("X-SDK-Version")
 	cc := h.resolveCountryCode(r)
 
-	var regulation *cookiebanner.Regulation
+	var (
+		regulation         *cookiebanner.Regulation
+		resolvedRegulation cookiebanner.Regulation
+	)
 	if cc != nil {
-		r := cookiebanner.RegulationForCountry(*cc)
-		regulation = &r
+		resolvedRegulation = cookiebanner.RegulationForCountry(*cc)
+		regulation = &resolvedRegulation
 	}
+
+	cm := coredata.CookieConsentMode(cookiebanner.ConsentModeForRegulation(resolvedRegulation))
 
 	req := cookiebanner.RecordConsentRequest{
 		Version:     body.Version,
@@ -196,6 +201,7 @@ func (h *Handler) handlePostConsent(w http.ResponseWriter, r *http.Request) {
 		SdkVersion:  sdkVersion,
 		Regulation:  regulation,
 		CountryCode: cc,
+		ConsentMode: &cm,
 	}
 
 	record, err := h.cookieBannerSvc.RecordConsent(r.Context(), bannerID, req)

--- a/pkg/server/api/cookiebanner/v1/handler.go
+++ b/pkg/server/api/cookiebanner/v1/handler.go
@@ -54,6 +54,7 @@ func NewMux(
 
 	r := chi.NewMux()
 	r.Route("/{bannerID}", func(r chi.Router) {
+		r.Use(newSDKVersionMiddleware())
 		r.Use(newCORSMiddleware(logger, cookieBannerSvc))
 		r.Get("/config", h.handleGetConfig)
 		r.Get("/consents/{visitorID}", h.handleGetConsent)
@@ -73,7 +74,7 @@ func (h *Handler) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	lang := r.URL.Query().Get("lang")
-	sdkVersion := r.Header.Get("X-SDK-Version")
+	sdkVersion := sdkVersionFromContext(r.Context())
 	cc := h.resolveCountryCode(r)
 
 	var regulation cookiebanner.Regulation
@@ -91,7 +92,7 @@ func (h *Handler) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 			jsonutil.RenderNotFound(w, fmt.Errorf("no published version"))
 			return
 		}
-		h.logger.ErrorCtx(r.Context(), "cannot get banner config", log.Error(err))
+		h.logger.ErrorCtx(r.Context(), "cannot get banner config", log.Error(err), log.String("sdk_version", sdkVersion))
 		jsonutil.RenderInternalServerError(w)
 		return
 	}
@@ -104,7 +105,12 @@ func (h *Handler) resolveCountryCode(r *http.Request) *coredata.CountryCode {
 
 	cc, err := h.geolocSvc.LookupCountry(r.Context(), ip)
 	if err != nil {
-		h.logger.ErrorCtx(r.Context(), "cannot resolve country for IP", log.Error(err))
+		h.logger.ErrorCtx(
+			r.Context(),
+			"cannot resolve country for IP",
+			log.Error(err),
+			log.String("sdk_version", sdkVersionFromContext(r.Context())),
+		)
 		return nil
 	}
 
@@ -138,7 +144,12 @@ func (h *Handler) handleGetConsent(w http.ResponseWriter, r *http.Request) {
 			jsonutil.RenderNotFound(w, fmt.Errorf("consent not found"))
 			return
 		}
-		h.logger.ErrorCtx(r.Context(), "cannot get visitor consent", log.Error(err))
+		h.logger.ErrorCtx(
+			r.Context(),
+			"cannot get visitor consent",
+			log.Error(err),
+			log.String("sdk_version", sdkVersionFromContext(r.Context())),
+		)
 		jsonutil.RenderInternalServerError(w)
 		return
 	}
@@ -177,7 +188,7 @@ func (h *Handler) handlePostConsent(w http.ResponseWriter, r *http.Request) {
 
 	ip := clientip.Extract(r)
 	ua := r.UserAgent()
-	sdkVersion := r.Header.Get("X-SDK-Version")
+	sdkVersion := sdkVersionFromContext(r.Context())
 	cc := h.resolveCountryCode(r)
 
 	var (
@@ -214,7 +225,7 @@ func (h *Handler) handlePostConsent(w http.ResponseWriter, r *http.Request) {
 			jsonutil.RenderBadRequest(w, fmt.Errorf("invalid version"))
 			return
 		}
-		h.logger.ErrorCtx(r.Context(), "cannot record consent", log.Error(err))
+		h.logger.ErrorCtx(r.Context(), "cannot record consent", log.Error(err), log.String("sdk_version", sdkVersion))
 		jsonutil.RenderInternalServerError(w)
 		return
 	}
@@ -338,7 +349,12 @@ func (h *Handler) handleReportDetectedCookies(w http.ResponseWriter, r *http.Req
 			return
 		}
 
-		h.logger.ErrorCtx(r.Context(), "cannot report detected cookies", log.Error(err))
+		h.logger.ErrorCtx(
+			r.Context(),
+			"cannot report detected cookies",
+			log.Error(err),
+			log.String("sdk_version", sdkVersionFromContext(r.Context())),
+		)
 		jsonutil.RenderInternalServerError(w)
 		return
 	}
@@ -503,7 +519,7 @@ func (h *Handler) handleReportDetectedTrackers(w http.ResponseWriter, r *http.Re
 			return
 		}
 
-		h.logger.ErrorCtx(r.Context(), "cannot report detected trackers", log.Error(err))
+		h.logger.ErrorCtx(r.Context(), "cannot report detected trackers", log.Error(err), log.String("sdk_version", sdkVersionFromContext(r.Context())))
 		jsonutil.RenderInternalServerError(w)
 		return
 	}

--- a/pkg/server/api/cookiebanner/v1/sdk_version_middleware.go
+++ b/pkg/server/api/cookiebanner/v1/sdk_version_middleware.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package cookiebanner_v1
+
+import (
+	"context"
+	"net/http"
+)
+
+type sdkVersionCtxKey struct{}
+
+func newSDKVersionMiddleware() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			sdkVersion := r.Header.Get("X-SDK-Version")
+			ctx := context.WithValue(r.Context(), sdkVersionCtxKey{}, sdkVersion)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+func sdkVersionFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(sdkVersionCtxKey{}).(string)
+	return v
+}

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -4720,7 +4720,6 @@ func (r *Resolver) AddCookieBannerTool(ctx context.Context, req *mcp.CallToolReq
 		PrivacyPolicyURL:  input.PrivacyPolicyURL,
 		CookiePolicyURL:   input.CookiePolicyURL,
 		ConsentExpiryDays: input.ConsentExpiryDays,
-		ConsentMode:       coredata.CookieConsentMode(input.ConsentMode),
 	})
 	if err != nil {
 		return nil, types.AddCookieBannerOutput{}, fmt.Errorf("cannot create cookie banner: %w", err)
@@ -4744,10 +4743,6 @@ func (r *Resolver) UpdateCookieBannerTool(ctx context.Context, req *mcp.CallTool
 	}
 	if v := UnwrapOmittable(input.ConsentExpiryDays); v != nil && *v != nil {
 		updateReq.ConsentExpiryDays = *v
-	}
-	if v := UnwrapOmittable(input.ConsentMode); v != nil && *v != nil {
-		mode := coredata.CookieConsentMode(**v)
-		updateReq.ConsentMode = &mode
 	}
 	if v := UnwrapOmittable(input.DefaultLanguage); v != nil && *v != nil {
 		updateReq.DefaultLanguage = *v

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -9311,7 +9311,6 @@ components:
         - state
         - cookie_policy_url
         - consent_expiry_days
-        - consent_mode
         - show_branding
         - default_language
         - created_at
@@ -9344,10 +9343,6 @@ components:
         consent_expiry_days:
           type: integer
           description: Days until consent expires
-        consent_mode:
-          type: string
-          enum: [OPT_IN, OPT_OUT]
-          description: Consent mode
         show_branding:
           type: boolean
           description: Whether to show Probo branding
@@ -9726,7 +9721,6 @@ components:
         - origin
         - cookie_policy_url
         - consent_expiry_days
-        - consent_mode
       properties:
         organization_id:
           $ref: "#/components/schemas/GID"
@@ -9746,10 +9740,6 @@ components:
         consent_expiry_days:
           type: integer
           description: Days until consent expires
-        consent_mode:
-          type: string
-          enum: [OPT_IN, OPT_OUT]
-          description: Consent mode
 
     AddCookieBannerOutput:
       type: object
@@ -9785,11 +9775,6 @@ components:
         consent_expiry_days:
           type:
             - integer
-            - "null"
-          go.probo.inc/mcpgen/omittable: true
-        consent_mode:
-          type:
-            - string
             - "null"
           go.probo.inc/mcpgen/omittable: true
         default_language:

--- a/pkg/server/api/mcp/v1/types/cookie_banner.go
+++ b/pkg/server/api/mcp/v1/types/cookie_banner.go
@@ -29,7 +29,6 @@ func NewCookieBanner(b *coredata.CookieBanner) *CookieBanner {
 		PrivacyPolicyURL:  b.PrivacyPolicyURL,
 		CookiePolicyURL:   b.CookiePolicyURL,
 		ConsentExpiryDays: b.ConsentExpiryDays,
-		ConsentMode:       CookieBannerConsentMode(b.ConsentMode),
 		ShowBranding:      b.ShowBranding,
 		DefaultLanguage:   b.DefaultLanguage,
 		CreatedAt:         b.CreatedAt,


### PR DESCRIPTION
Closes ENG-396
Closes ENG-395


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives consent mode from visitor geolocation (defaults to OPT_OUT) and removes the banner-level setting across UI, APIs, and tools. Also fixes tracker pattern deadlocks and catch‑all patterns, improves badge clarity for tracker/resource types, skips consent fetch for first‑time visitors, and logs the SDK version via middleware for easier debugging.

- **Bug Fixes**
  - Avoid deadlocks by bulk-updating `last_matched_at` in `ReportDetectedTrackers`.
  - Prevent bare “*” patterns: skip separator-less variable cookie names so they stay exact-match for review.
  - Skip consent API fetch for new visitors; create visitor ID on first consent action to prevent 404s and extra requests.
  - Include `X-SDK-Version` in server logs via middleware for all cookie banner endpoints.

- **Migration**
  - Consent mode is now derived from country/regulation and stored per consent record; dropped from `cookie_banners`.
  - Removed `consentMode` from Console forms, GraphQL schema, CLI, MCP spec/tools, and `packages/n8n-node` actions.
  - Server remaps texts for opt-out; unknown regulation defaults to OPT_OUT.

<sup>Written for commit 0606416b39f508888c6de72fc807393e4776f789. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



