### PR TITLE
Drop legacy cookies and cookie_patterns tables

### DIFF
--- a/pkg/coredata/migrations/20260513T084412Z.sql
+++ b/pkg/coredata/migrations/20260513T084412Z.sql
@@ -1,0 +1,16 @@
+-- Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+--
+-- Permission to use, copy, modify, and/or distribute this software for any
+-- purpose with or without fee is hereby granted, provided that the above
+-- copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+-- REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+-- INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+-- LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+-- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+DROP TABLE IF EXISTS cookies;
+DROP TABLE IF EXISTS cookie_patterns;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a migration to drop the legacy `cookies` and `cookie_patterns` database tables. These tables were superseded by `tracker_patterns` and `detected_trackers` in migration `20260505T090000Z`, which backfilled all existing data into the new tables.

## What changed

- **New migration** (`20260513T084412Z.sql`): `DROP TABLE IF EXISTS cookies` followed by `DROP TABLE IF EXISTS cookie_patterns`

## What is preserved

- The `cookie_source` enum type — still used by `tracker_patterns` and `detected_trackers`
- The `cookie_pattern_match_type` enum type — still used by `tracker_patterns`

## Verification

- No Go code, GraphQL schema, MCP specification, or CLI command references the old `cookies` or `cookie_patterns` tables
- Entity types 85 (`CookieEntityType`) and 88 (`CookiePatternEntityType`) were already marked as removed in `entity_type_reg.go`
- The coredata package compiles and passes tests

Resolves ENG-392
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-392](https://linear.app/probo/issue/ENG-392/cb-remove-cookies-cookie-patterns-table)

<div><a href="https://cursor.com/agents/bc-9787bc0d-50b3-4bb0-ab0b-b4791270ad9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9787bc0d-50b3-4bb0-ab0b-b4791270ad9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops legacy `cookies` and `cookie_patterns` tables via a new migration to clean up the schema now that data lives in `tracker_patterns` and `detected_trackers`. Aligns with ENG-392.

- **Migration**
  - Adds `pkg/coredata/migrations/20260513T084412Z.sql` to drop `cookies` and `cookie_patterns`.
  - Keeps `cookie_source` and `cookie_pattern_match_type` enums used by `tracker_patterns` and `detected_trackers`.
  - No app changes needed; prior migration backfilled data and no code references remain.

<sup>Written for commit dec767c91d0bd0d16a96b11735abc379d560517a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

