### PR TITLE
Log authentication and session lifecycle events with identity_id

### DIFF
--- a/pkg/server/api/authn/api_key_middleware.go
+++ b/pkg/server/api/authn/api_key_middleware.go
@@ -22,6 +22,7 @@ import (
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 	"go.gearno.de/kit/httpserver"
+	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/iam"
 	"go.probo.inc/probo/pkg/securetoken"
@@ -86,6 +87,13 @@ func NewAPIKeyMiddleware(svc *iam.Service, tokenSecret string) func(next http.Ha
 
 				ctx = ContextWithAPIKey(ctx, apiKey)
 				ctx = ContextWithIdentity(ctx, identity)
+
+				httpserver.LoggerFromContext(ctx).InfoCtx(
+					ctx,
+					"api key authenticated",
+					log.String("identity_id", identity.ID.String()),
+					log.String("api_key_id", apiKey.ID.String()),
+				)
 
 				next.ServeHTTP(w, r.WithContext(ctx))
 			},

--- a/pkg/server/api/authn/oauth2_access_token_middleware.go
+++ b/pkg/server/api/authn/oauth2_access_token_middleware.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"go.gearno.de/kit/httpserver"
+	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/bearertoken"
 	"go.probo.inc/probo/pkg/iam"
 )
@@ -51,6 +53,13 @@ func NewOAuth2AccessTokenMiddleware(svc *iam.Service) func(next http.Handler) ht
 				}
 
 				ctx = ContextWithIdentity(ctx, identity)
+
+				httpserver.LoggerFromContext(ctx).InfoCtx(
+					ctx,
+					"access token authenticated",
+					log.String("identity_id", identity.ID.String()),
+					log.String("access_token_id", accessToken.ID.String()),
+				)
 
 				next.ServeHTTP(w, r.WithContext(ctx))
 			},

--- a/pkg/server/api/authn/session_middleware.go
+++ b/pkg/server/api/authn/session_middleware.go
@@ -23,6 +23,7 @@ import (
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 	"go.gearno.de/kit/httpserver"
+	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/iam"
 	"go.probo.inc/probo/pkg/securecookie"
@@ -104,6 +105,13 @@ func NewSessionMiddleware(svc *iam.Service, cookieConfig securecookie.Config) fu
 
 				ctx = ContextWithSession(ctx, session)
 				ctx = ContextWithIdentity(ctx, identity)
+
+				httpserver.LoggerFromContext(ctx).InfoCtx(
+					ctx,
+					"session authenticated",
+					log.String("identity_id", identity.ID.String()),
+					log.String("session_id", session.ID.String()),
+				)
 
 				next.ServeHTTP(w, r.WithContext(ctx))
 


### PR DESCRIPTION
Add a single info log line in each authn middleware once an identity is resolved, so every authenticated request emits a record that ties the request back to its user:

- Cookie session middleware logs "session authenticated" with
  identity_id and session_id.
- API key middleware logs "api key authenticated" with identity_id.
- OAuth2 access token middleware logs "access token authenticated" with
  identity_id.

The log lines use the request-scoped logger from httpserver.LoggerFromContext so they inherit http_request_id and any other middleware-attached attributes, giving each authenticated request a self-contained, correlatable record.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add structured info logs to auth middlewares and session lifecycle. Every authenticated request now logs `identity_id` plus credential IDs (`session_id`, `api_key_id`, `access_token_id`) with request context to improve traceability across HTTP and non-HTTP paths.

- **New Features**
  - Session, API key, and OAuth2 access token middlewares log one line per authenticated request via `go.gearno.de/kit/httpserver` (inherits `http_request_id`); include `identity_id` and the credential ID (`session_id` for cookie sessions, `api_key_id`, `access_token_id`).
  - Root session opens (Password, SAML, OIDC, Magic Link) log `identity_id`, `session_id`, and `auth_method`.
  - Session close, revoke, and revoke-all log `identity_id` and `session_id`; revoke-all also logs `revoked_count`.
  - Child/organization sessions (Password, SAML) and AssumeOrganizationSession log `identity_id`, `session_id`, `root_session_id`, `organization_id`, and `auth_method`; service-layer logs use `go.gearno.de/kit/log` for non-HTTP callers.

<sup>Written for commit 9eed0d71c83cdd7e6fe6694651c72337a827e5a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





