### PR TITLE
Block sign-in for unverified email addresses

### DIFF
--- a/apps/console/src/pages/iam/auth/ResendVerificationEmailPage.tsx
+++ b/apps/console/src/pages/iam/auth/ResendVerificationEmailPage.tsx
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { formatError } from "@probo/helpers";
+import { usePageTitle } from "@probo/hooks";
+import { useTranslate } from "@probo/i18n";
+import { Button, Field, useToast } from "@probo/ui";
+import { useState } from "react";
+import { useMutation } from "react-relay";
+import { Link, useSearchParams } from "react-router";
+import { graphql } from "relay-runtime";
+import { z } from "zod";
+
+import type { ResendVerificationEmailPageMutation } from "#/__generated__/iam/ResendVerificationEmailPageMutation.graphql";
+import { useFormWithSchema } from "#/hooks/useFormWithSchema";
+
+const resendVerificationEmailMutation = graphql`
+  mutation ResendVerificationEmailPageMutation(
+    $input: ResendVerificationEmailInput!
+  ) {
+    resendVerificationEmail(input: $input) {
+      success
+    }
+  }
+`;
+
+const schema = z.object({
+  email: z.string().email(),
+});
+
+export default function ResendVerificationEmailPage() {
+  const { toast } = useToast();
+  const { __ } = useTranslate();
+  const [searchParams] = useSearchParams();
+
+  usePageTitle(__("Verify Email"));
+
+  const [emailSent, setEmailSent] = useState<boolean>(false);
+  const { register, handleSubmit, formState } = useFormWithSchema(schema, {
+    defaultValues: {
+      email: searchParams.get("email") ?? "",
+    },
+  });
+
+  const [resendVerificationEmail]
+    = useMutation<ResendVerificationEmailPageMutation>(
+      resendVerificationEmailMutation,
+    );
+
+  const onSubmit = handleSubmit(({ email }) => {
+    resendVerificationEmail({
+      variables: {
+        input: { email },
+      },
+      onError: (e: Error) => {
+        toast({
+          title: __("Request failed"),
+          description: e.message,
+          variant: "error",
+        });
+      },
+      onCompleted: (_, e) => {
+        if (e) {
+          toast({
+            title: __("Request failed"),
+            description: formatError(
+              __("Failed to send verification email"),
+              e,
+            ),
+            variant: "error",
+          });
+          return;
+        }
+
+        toast({
+          title: __("Success"),
+          description: __("Verification email sent"),
+          variant: "success",
+        });
+        setEmailSent(true);
+      },
+    });
+  });
+
+  return emailSent
+    ? (
+        <div className="space-y-6 w-full max-w-md mx-auto pt-8">
+          <div className="space-y-2 text-center">
+            <h1 className="text-3xl font-bold">{__("Check your email")}</h1>
+            <p className="text-txt-tertiary">
+              {__(
+                "We've sent a verification link to your email address. Please check your inbox and click the link to verify your account.",
+              )}
+            </p>
+          </div>
+
+          <div className="text-center">
+            <p className="text-sm text-txt-tertiary">
+              {__("Didn't receive the email?")}
+              {" "}
+              <button
+                onClick={() => setEmailSent(false)}
+                className="underline text-txt-primary hover:text-txt-secondary"
+              >
+                {__("Try again")}
+              </button>
+            </p>
+          </div>
+
+          <div className="text-center">
+            <p className="text-sm text-txt-tertiary">
+              {__("Already verified?")}
+              {" "}
+              <Link
+                to="/auth/login"
+                className="underline text-txt-primary hover:text-txt-secondary"
+              >
+                {__("Back to login")}
+              </Link>
+            </p>
+          </div>
+        </div>
+      )
+    : (
+        <div className="space-y-6 w-full max-w-md mx-auto pt-8">
+          <div className="space-y-2 text-center">
+            <h1 className="text-3xl font-bold">
+              {__("Verify your email")}
+            </h1>
+            <p className="text-txt-tertiary">
+              {__(
+                "Your email address has not been verified yet. Enter your email below and we'll send you a verification link.",
+              )}
+            </p>
+          </div>
+
+          <form onSubmit={e => void onSubmit(e)} className="space-y-4">
+            <Field
+              label={__("Email")}
+              type="email"
+              placeholder={__("name@example.com")}
+              {...register("email")}
+              required
+              error={formState.errors.email?.message}
+            />
+
+            <Button
+              type="submit"
+              className="w-xs h-10 mx-auto mt-6"
+              disabled={formState.isSubmitting}
+            >
+              {formState.isSubmitting
+                ? __("Sending...")
+                : __("Send verification email")}
+            </Button>
+          </form>
+
+          <div className="text-center">
+            <p className="text-sm text-txt-tertiary">
+              {__("Already verified?")}
+              {" "}
+              <Link
+                to="/auth/login"
+                className="underline text-txt-primary hover:text-txt-secondary"
+              >
+                {__("Back to login")}
+              </Link>
+            </p>
+          </div>
+        </div>
+      );
+}

--- a/apps/console/src/pages/iam/auth/sign-in/PasswordSignInPage.tsx
+++ b/apps/console/src/pages/iam/auth/sign-in/PasswordSignInPage.tsx
@@ -17,7 +17,7 @@ import { useTranslate } from "@probo/i18n";
 import { Button, Field, IconChevronLeft, useToast } from "@probo/ui";
 import type { FormEventHandler } from "react";
 import { useMutation } from "react-relay";
-import { Link, matchPath, useLocation } from "react-router";
+import { Link, matchPath, useLocation, useNavigate } from "react-router";
 import { graphql } from "relay-runtime";
 
 import type { PasswordSignInPageMutation } from "#/__generated__/iam/PasswordSignInPageMutation.graphql";
@@ -35,6 +35,7 @@ const signInMutation = graphql`
 
 export default function PasswordSignInPage() {
   const location = useLocation();
+  const navigate = useNavigate();
   const safeContinueUrl = useSafeContinueUrl();
 
   const { __ } = useTranslate();
@@ -73,10 +74,10 @@ export default function PasswordSignInPage() {
           );
 
           if (hasEmailNotVerified) {
-            toast({
-              title: __("Email not verified"),
-              description: __("Please verify your email address before signing in. A new verification email has been sent."),
-              variant: "error",
+            const search = new URLSearchParams([["email", emailValue]]);
+            void navigate({
+              pathname: "/auth/resend-verification-email",
+              search: "?" + search.toString(),
             });
             return;
           }

--- a/apps/console/src/pages/iam/auth/sign-in/PasswordSignInPage.tsx
+++ b/apps/console/src/pages/iam/auth/sign-in/PasswordSignInPage.tsx
@@ -67,6 +67,20 @@ export default function PasswordSignInPage() {
       },
       onCompleted: (_, error) => {
         if (error) {
+          const errors = error as GraphQLError[];
+          const hasEmailNotVerified = errors.some(
+            e => e.extensions?.code === "EMAIL_NOT_VERIFIED",
+          );
+
+          if (hasEmailNotVerified) {
+            toast({
+              title: __("Email not verified"),
+              description: __("Please verify your email address before signing in. A new verification email has been sent."),
+              variant: "error",
+            });
+            return;
+          }
+
           toast({
             title: __("Error"),
             description: formatError(

--- a/apps/console/src/routes.tsx
+++ b/apps/console/src/routes.tsx
@@ -80,6 +80,12 @@ const routes = [
         Component: lazy(() => import("./pages/iam/auth/VerifyEmailPage")),
       },
       {
+        path: "resend-verification-email",
+        Component: lazy(
+          () => import("./pages/iam/auth/ResendVerificationEmailPage"),
+        ),
+      },
+      {
         path: "activate-account",
         Component: lazy(
           () => import("./pages/iam/auth/ActivateAccountPage"),

--- a/pkg/iam/auth_service.go
+++ b/pkg/iam/auth_service.go
@@ -729,36 +729,49 @@ func (s AuthService) OpenSessionWithMagicLink(ctx context.Context, tokenString s
 	return identity, session, payload.Data.Continue, nil
 }
 
-func (s AuthService) SendEmailVerification(ctx context.Context, identity *coredata.Identity) error {
-	confirmationToken, err := statelesstoken.NewToken(
-		s.tokenSecret,
-		TokenTypeEmailConfirmation,
-		24*time.Hour,
-		EmailConfirmationData{IdentityID: identity.ID, Email: identity.EmailAddress},
-	)
-	if err != nil {
-		return fmt.Errorf("cannot generate confirmation token: %w", err)
-	}
-
-	emailPresenter := emails.NewPresenter(s.fm, s.bucket, s.baseURL, identity.FullName)
-
-	subject, textBody, htmlBody, err := emailPresenter.RenderConfirmEmail(ctx, "/auth/verify-email", confirmationToken)
-	if err != nil {
-		return fmt.Errorf("cannot render confirmation email: %w", err)
-	}
-
-	confirmationEmail := coredata.NewEmail(
-		identity.FullName,
-		identity.EmailAddress,
-		subject,
-		textBody,
-		htmlBody,
-		nil,
-	)
-
+func (s AuthService) SendEmailVerification(ctx context.Context, email mail.Addr) error {
 	return s.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
+			identity := &coredata.Identity{}
+			if err := identity.LoadByEmail(ctx, tx, email); err != nil {
+				if err == coredata.ErrResourceNotFound {
+					return nil
+				}
+
+				return fmt.Errorf("cannot load identity: %w", err)
+			}
+
+			if identity.EmailAddressVerified {
+				return nil
+			}
+
+			confirmationToken, err := statelesstoken.NewToken(
+				s.tokenSecret,
+				TokenTypeEmailConfirmation,
+				24*time.Hour,
+				EmailConfirmationData{IdentityID: identity.ID, Email: identity.EmailAddress},
+			)
+			if err != nil {
+				return fmt.Errorf("cannot generate confirmation token: %w", err)
+			}
+
+			emailPresenter := emails.NewPresenter(s.fm, s.bucket, s.baseURL, identity.FullName)
+
+			subject, textBody, htmlBody, err := emailPresenter.RenderConfirmEmail(ctx, "/auth/verify-email", confirmationToken)
+			if err != nil {
+				return fmt.Errorf("cannot render confirmation email: %w", err)
+			}
+
+			confirmationEmail := coredata.NewEmail(
+				identity.FullName,
+				identity.EmailAddress,
+				subject,
+				textBody,
+				htmlBody,
+				nil,
+			)
+
 			if err := confirmationEmail.Insert(ctx, tx); err != nil {
 				return fmt.Errorf("cannot insert confirmation email: %w", err)
 			}

--- a/pkg/iam/auth_service.go
+++ b/pkg/iam/auth_service.go
@@ -518,6 +518,10 @@ func (s AuthService) CheckCredentials(
 				return NewInvalidCredentialsError("invalid email or password")
 			}
 
+			if !identity.EmailAddressVerified {
+				return NewEmailNotVerifiedError()
+			}
+
 			return nil
 		},
 	)
@@ -723,6 +727,45 @@ func (s AuthService) OpenSessionWithMagicLink(ctx context.Context, tokenString s
 	}
 
 	return identity, session, payload.Data.Continue, nil
+}
+
+func (s AuthService) SendEmailVerification(ctx context.Context, identity *coredata.Identity) error {
+	confirmationToken, err := statelesstoken.NewToken(
+		s.tokenSecret,
+		TokenTypeEmailConfirmation,
+		24*time.Hour,
+		EmailConfirmationData{IdentityID: identity.ID, Email: identity.EmailAddress},
+	)
+	if err != nil {
+		return fmt.Errorf("cannot generate confirmation token: %w", err)
+	}
+
+	emailPresenter := emails.NewPresenter(s.fm, s.bucket, s.baseURL, identity.FullName)
+
+	subject, textBody, htmlBody, err := emailPresenter.RenderConfirmEmail(ctx, "/auth/verify-email", confirmationToken)
+	if err != nil {
+		return fmt.Errorf("cannot render confirmation email: %w", err)
+	}
+
+	confirmationEmail := coredata.NewEmail(
+		identity.FullName,
+		identity.EmailAddress,
+		subject,
+		textBody,
+		htmlBody,
+		nil,
+	)
+
+	return s.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			if err := confirmationEmail.Insert(ctx, tx); err != nil {
+				return fmt.Errorf("cannot insert confirmation email: %w", err)
+			}
+
+			return nil
+		},
+	)
 }
 
 func HashToken(token string) []byte {

--- a/pkg/iam/errors.go
+++ b/pkg/iam/errors.go
@@ -361,6 +361,16 @@ func (e ErrUnsupportedPrincipalType) Error() string {
 	return fmt.Sprintf("unsupported principal type: %d", e.EntityType)
 }
 
+type ErrEmailNotVerified struct{}
+
+func NewEmailNotVerifiedError() error {
+	return &ErrEmailNotVerified{}
+}
+
+func (e ErrEmailNotVerified) Error() string {
+	return "email address has not been verified"
+}
+
 type ErrSignupDisabled struct{}
 
 func NewErrSignupDisabled() error {

--- a/pkg/server/api/connect/v1/graphql/session.graphql
+++ b/pkg/server/api/connect/v1/graphql/session.graphql
@@ -17,6 +17,9 @@ extend type Mutation {
     @session(required: NONE)
   verifyEmail(input: VerifyEmailInput!): VerifyEmailPayload
     @session(required: OPTIONAL)
+  resendVerificationEmail(
+    input: ResendVerificationEmailInput!
+  ): ResendVerificationEmailPayload @session(required: NONE)
   changePassword(input: ChangePasswordInput!): ChangePasswordPayload
     @session(required: PRESENT)
   changeEmail(input: ChangeEmailInput!): ChangeEmailPayload
@@ -149,6 +152,14 @@ type ResetPasswordPayload {
 }
 
 type VerifyEmailPayload {
+  success: Boolean!
+}
+
+input ResendVerificationEmailInput {
+  email: EmailAddr!
+}
+
+type ResendVerificationEmailPayload {
   success: Boolean!
 }
 

--- a/pkg/server/api/connect/v1/session_resolvers.go
+++ b/pkg/server/api/connect/v1/session_resolvers.go
@@ -36,10 +36,6 @@ func (r *mutationResolver) SignIn(ctx context.Context, input types.SignInInput) 
 		}
 
 		if _, ok := errors.AsType[*iam.ErrEmailNotVerified](err); ok {
-			if err := r.iam.AuthService.SendEmailVerification(ctx, identity); err != nil {
-				r.logger.ErrorCtx(ctx, "cannot resend verification email", log.Error(err))
-			}
-
 			return nil, &gqlerror.Error{
 				Message: "email address has not been verified",
 				Extensions: map[string]any{
@@ -320,6 +316,19 @@ func (r *mutationResolver) VerifyEmail(ctx context.Context, input types.VerifyEm
 	}
 
 	return &types.VerifyEmailPayload{
+		Success: true,
+	}, nil
+}
+
+// ResendVerificationEmail is the resolver for the resendVerificationEmail field.
+func (r *mutationResolver) ResendVerificationEmail(ctx context.Context, input types.ResendVerificationEmailInput) (*types.ResendVerificationEmailPayload, error) {
+	err := r.iam.AuthService.SendEmailVerification(ctx, input.Email)
+	if err != nil {
+		r.logger.ErrorCtx(ctx, "cannot send verification email", log.Error(err))
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	return &types.ResendVerificationEmailPayload{
 		Success: true,
 	}, nil
 }

--- a/pkg/server/api/connect/v1/session_resolvers.go
+++ b/pkg/server/api/connect/v1/session_resolvers.go
@@ -35,6 +35,19 @@ func (r *mutationResolver) SignIn(ctx context.Context, input types.SignInInput) 
 			}
 		}
 
+		if _, ok := errors.AsType[*iam.ErrEmailNotVerified](err); ok {
+			if err := r.iam.AuthService.SendEmailVerification(ctx, identity); err != nil {
+				r.logger.ErrorCtx(ctx, "cannot resend verification email", log.Error(err))
+			}
+
+			return nil, &gqlerror.Error{
+				Message: "email address has not been verified",
+				Extensions: map[string]any{
+					"code": "EMAIL_NOT_VERIFIED",
+				},
+			}
+		}
+
 		r.logger.ErrorCtx(ctx, "cannot check credentials", log.Error(err))
 
 		return nil, gqlutils.Internal(ctx)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves **ENG-401**: Users with unverified email addresses can no longer authenticate via password sign-in. When blocked, they are redirected to a dedicated verification page where they can request a new verification email.

## Changes

### Backend

- **`pkg/iam/errors.go`** — Added `ErrEmailNotVerified` error type for the IAM package.
- **`pkg/iam/auth_service.go`** — `CheckCredentials` now checks `EmailAddressVerified` after successful password verification. If the flag is `false`, it returns `ErrEmailNotVerified`. Added `SendEmailVerification(email)` method that looks up the identity and sends a verification email (silently succeeds if identity not found or already verified, to prevent information leakage).
- **`pkg/server/api/connect/v1/graphql/session.graphql`** — Added `resendVerificationEmail` mutation (`@session(required: NONE)`), with `ResendVerificationEmailInput` and `ResendVerificationEmailPayload`.
- **`pkg/server/api/connect/v1/session_resolvers.go`** — The `SignIn` resolver catches `ErrEmailNotVerified` and returns a GraphQL error with code `EMAIL_NOT_VERIFIED`. New `ResendVerificationEmail` resolver delegates to `AuthService.SendEmailVerification`.

### Frontend

- **`apps/console/src/pages/iam/auth/ResendVerificationEmailPage.tsx`** — New page modeled after `ForgotPasswordPage`: email input (prefilled from query string), submit calls `resendVerificationEmail` mutation, then shows a "check your email" confirmation with a "try again" link.
- **`apps/console/src/pages/iam/auth/sign-in/PasswordSignInPage.tsx`** — On `EMAIL_NOT_VERIFIED`, redirects to `/auth/resend-verification-email?email=<addr>` instead of showing a toast.
- **`apps/console/src/routes.tsx`** — Added `/auth/resend-verification-email` route.

## How it works

1. User tries to sign in with email + password
2. Password is validated successfully
3. If `email_address_verified` is `false`, authentication is rejected with `EMAIL_NOT_VERIFIED`
4. The frontend redirects to `/auth/resend-verification-email?email=<addr>`
5. User sees a form with their email prefilled, submits to request a new verification email
6. After submission, a confirmation screen shows with "check your email" instructions

## Unaffected flows

SAML, OIDC, magic-link, and invitation-activation flows are unaffected because they already set `email_address_verified = true` upon identity creation or update.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-401](https://linear.app/probo/issue/ENG-401/email-address-verification)

<div><a href="https://cursor.com/agents/bc-fcc5695c-44d5-461a-a525-fff1a38d5bde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fcc5695c-44d5-461a-a525-fff1a38d5bde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks password sign-in for unverified accounts and redirects users to a dedicated verification flow. Implements ENG-401 by returning `EMAIL_NOT_VERIFIED` and adding a safe resend path; SAML, OIDC, magic-link, and invitation activation stay the same.

- **New Features**
  - Backend: `CheckCredentials` rejects unverified identities via `ErrEmailNotVerified`. Added `SendEmailVerification(ctx, email)` which no-ops if the account doesn’t exist or is already verified to avoid info leaks.
  - API: `SignIn` now only returns a GraphQL error with code `EMAIL_NOT_VERIFIED` (no auto-resend). Added `resendVerificationEmail` mutation.
  - Frontend: On `EMAIL_NOT_VERIFIED`, password sign-in redirects to `/auth/resend-verification-email?email=<addr>`. New `ResendVerificationEmailPage` lets users enter an email, call the mutation, and see a confirmation; route added in `routes.tsx`.

<sup>Written for commit bd9f6fae823477098c5e318ec6f330234eb5da31. Summary will update on new commits. <a href="https://cubic.dev/pr/getprobo/probo/pull/1192?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

