### PR TITLE
yjs protocol support for collaborative editing

### DIFF
--- a/pkg/collab/lib0/bytes.go
+++ b/pkg/collab/lib0/bytes.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package lib0
+
+// WriteVarUint8Array writes a byte slice prefixed by its length encoded as
+// a varuint. This matches lib0's `writeVarUint8Array`.
+func WriteVarUint8Array(e *Encoder, b []byte) {
+	WriteVarUint(e, uint64(len(b)))
+	_, _ = e.Write(b)
+}
+
+// ReadVarUint8Array reads a byte slice written by WriteVarUint8Array.
+// The returned slice is a copy: callers may mutate it without affecting
+// the decoder's underlying buffer.
+func ReadVarUint8Array(d *Decoder) ([]byte, error) {
+	n, err := ReadVarUint(d)
+	if err != nil {
+		return nil, err
+	}
+	if n > uint64(d.Remaining()) {
+		return nil, ErrUnexpectedEOF
+	}
+
+	return d.ReadBytes(int(n))
+}

--- a/pkg/collab/lib0/bytes_test.go
+++ b/pkg/collab/lib0/bytes_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package lib0_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/collab/lib0"
+)
+
+func TestWriteVarUint8Array_GoldenFixtures(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		value []byte
+		want  []byte
+	}{
+		{"empty", []byte{}, []byte{0x00}},
+		{"single-byte", []byte{0xab}, []byte{0x01, 0xab}},
+		{"deadbeef", []byte{0xde, 0xad, 0xbe, 0xef}, []byte{0x04, 0xde, 0xad, 0xbe, 0xef}},
+		{"length-127", bytes.Repeat([]byte{0x42}, 127), append([]byte{0x7f}, bytes.Repeat([]byte{0x42}, 127)...)},
+		{"length-128", bytes.Repeat([]byte{0x42}, 128), append([]byte{0x80, 0x01}, bytes.Repeat([]byte{0x42}, 128)...)},
+	}
+
+	for _, tc := range cases {
+		t.Run(
+			tc.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				enc := lib0.NewEncoder()
+				lib0.WriteVarUint8Array(enc, tc.value)
+				assert.Equal(t, tc.want, enc.Bytes())
+			},
+		)
+	}
+}
+
+func TestVarUint8Array_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	values := [][]byte{
+		nil,
+		{},
+		{0x00},
+		{0xde, 0xad, 0xbe, 0xef},
+		bytes.Repeat([]byte{0x55}, 1024),
+	}
+
+	for _, v := range values {
+		v := v
+		enc := lib0.NewEncoder()
+		lib0.WriteVarUint8Array(enc, v)
+
+		dec := lib0.NewDecoder(enc.Bytes())
+		got, err := lib0.ReadVarUint8Array(dec)
+		require.NoError(t, err)
+		if v == nil {
+			assert.Empty(t, got)
+		} else {
+			assert.Equal(t, v, got)
+		}
+		assert.Equal(t, 0, dec.Remaining())
+	}
+}
+
+func TestReadVarUint8Array_ReturnsCopy(t *testing.T) {
+	t.Parallel()
+
+	src := []byte{0x04, 0xde, 0xad, 0xbe, 0xef}
+	dec := lib0.NewDecoder(src)
+
+	got, err := lib0.ReadVarUint8Array(dec)
+	require.NoError(t, err)
+	require.Equal(t, []byte{0xde, 0xad, 0xbe, 0xef}, got)
+
+	got[0] = 0x00
+	assert.Equal(t, byte(0xde), src[1], "mutation of returned slice must not affect decoder buffer")
+}
+
+func TestReadVarUint8Array_TruncatedBody(t *testing.T) {
+	t.Parallel()
+
+	dec := lib0.NewDecoder([]byte{0x04, 0xde, 0xad}) // claims 4 bytes, only 2 available
+	_, err := lib0.ReadVarUint8Array(dec)
+	require.ErrorIs(t, err, lib0.ErrUnexpectedEOF)
+}
+
+func TestReadVarUint8Array_TruncatedLength(t *testing.T) {
+	t.Parallel()
+
+	dec := lib0.NewDecoder([]byte{0x80}) // varuint continuation, no follow-up byte
+	_, err := lib0.ReadVarUint8Array(dec)
+	require.ErrorIs(t, err, lib0.ErrUnexpectedEOF)
+}

--- a/pkg/collab/lib0/decoder.go
+++ b/pkg/collab/lib0/decoder.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package lib0
+
+import "errors"
+
+var (
+	ErrUnexpectedEOF   = errors.New("lib0: unexpected end of input")
+	ErrVarUintOverflow = errors.New("lib0: varuint overflow")
+	ErrVarIntOverflow  = errors.New("lib0: varint overflow")
+)
+
+type (
+	Decoder struct {
+		buf []byte
+		pos int
+	}
+)
+
+func NewDecoder(buf []byte) *Decoder {
+	return &Decoder{buf: buf}
+}
+
+func (d *Decoder) Pos() int {
+	return d.pos
+}
+
+func (d *Decoder) Remaining() int {
+	return len(d.buf) - d.pos
+}
+
+func (d *Decoder) HasMore() bool {
+	return d.pos < len(d.buf)
+}
+
+func (d *Decoder) ReadByte() (byte, error) {
+	if d.pos >= len(d.buf) {
+		return 0, ErrUnexpectedEOF
+	}
+	b := d.buf[d.pos]
+	d.pos++
+	return b, nil
+}
+
+// ReadBytes copies and returns the next n bytes from the underlying buffer.
+// A copy is returned so callers cannot accidentally mutate the decoder's
+// backing storage.
+func (d *Decoder) ReadBytes(n int) ([]byte, error) {
+	if n < 0 || n > d.Remaining() {
+		return nil, ErrUnexpectedEOF
+	}
+
+	out := make([]byte, n)
+	copy(out, d.buf[d.pos:d.pos+n])
+	d.pos += n
+	return out, nil
+}

--- a/pkg/collab/lib0/decoder.go
+++ b/pkg/collab/lib0/decoder.go
@@ -17,9 +17,9 @@ package lib0
 import "errors"
 
 var (
-	ErrUnexpectedEOF   = errors.New("lib0: unexpected end of input")
-	ErrVarUintOverflow = errors.New("lib0: varuint overflow")
-	ErrVarIntOverflow  = errors.New("lib0: varint overflow")
+	ErrUnexpectedEOF   = errors.New("unexpected end of input")
+	ErrVarUintOverflow = errors.New("varuint overflow")
+	ErrVarIntOverflow  = errors.New("varint overflow")
 )
 
 type (

--- a/pkg/collab/lib0/decoder_test.go
+++ b/pkg/collab/lib0/decoder_test.go
@@ -1,0 +1,151 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package lib0_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/collab/lib0"
+)
+
+func TestNewDecoder_StartsAtZero(t *testing.T) {
+	t.Parallel()
+
+	dec := lib0.NewDecoder([]byte{0x01, 0x02, 0x03})
+	assert.Equal(t, 0, dec.Pos())
+	assert.Equal(t, 3, dec.Remaining())
+	assert.True(t, dec.HasMore())
+}
+
+func TestDecoder_EmptyBuffer(t *testing.T) {
+	t.Parallel()
+
+	dec := lib0.NewDecoder(nil)
+	assert.Equal(t, 0, dec.Pos())
+	assert.Equal(t, 0, dec.Remaining())
+	assert.False(t, dec.HasMore())
+}
+
+func TestDecoder_ReadByte(t *testing.T) {
+	t.Parallel()
+
+	t.Run(
+		"advances position",
+		func(t *testing.T) {
+			t.Parallel()
+
+			dec := lib0.NewDecoder([]byte{0x01, 0x02})
+
+			got, err := dec.ReadByte()
+			require.NoError(t, err)
+			assert.Equal(t, byte(0x01), got)
+			assert.Equal(t, 1, dec.Pos())
+			assert.Equal(t, 1, dec.Remaining())
+			assert.True(t, dec.HasMore())
+
+			got, err = dec.ReadByte()
+			require.NoError(t, err)
+			assert.Equal(t, byte(0x02), got)
+			assert.Equal(t, 2, dec.Pos())
+			assert.Equal(t, 0, dec.Remaining())
+			assert.False(t, dec.HasMore())
+		},
+	)
+
+	t.Run(
+		"returns EOF when exhausted",
+		func(t *testing.T) {
+			t.Parallel()
+
+			dec := lib0.NewDecoder(nil)
+			_, err := dec.ReadByte()
+			require.ErrorIs(t, err, lib0.ErrUnexpectedEOF)
+		},
+	)
+}
+
+func TestDecoder_ReadBytes(t *testing.T) {
+	t.Parallel()
+
+	t.Run(
+		"reads requested length",
+		func(t *testing.T) {
+			t.Parallel()
+
+			dec := lib0.NewDecoder([]byte{0x01, 0x02, 0x03, 0x04})
+
+			got, err := dec.ReadBytes(3)
+			require.NoError(t, err)
+			assert.Equal(t, []byte{0x01, 0x02, 0x03}, got)
+			assert.Equal(t, 3, dec.Pos())
+			assert.Equal(t, 1, dec.Remaining())
+		},
+	)
+
+	t.Run(
+		"returns a copy",
+		func(t *testing.T) {
+			t.Parallel()
+
+			src := []byte{0xde, 0xad, 0xbe, 0xef}
+			dec := lib0.NewDecoder(src)
+
+			got, err := dec.ReadBytes(4)
+			require.NoError(t, err)
+
+			got[0] = 0x00
+			assert.Equal(t, byte(0xde), src[0], "mutating the returned slice must not affect the decoder buffer")
+		},
+	)
+
+	t.Run(
+		"zero length",
+		func(t *testing.T) {
+			t.Parallel()
+
+			dec := lib0.NewDecoder([]byte{0x01, 0x02})
+			got, err := dec.ReadBytes(0)
+			require.NoError(t, err)
+			assert.Empty(t, got)
+			assert.Equal(t, 0, dec.Pos())
+		},
+	)
+
+	t.Run(
+		"negative length is rejected",
+		func(t *testing.T) {
+			t.Parallel()
+
+			dec := lib0.NewDecoder([]byte{0x01, 0x02})
+			_, err := dec.ReadBytes(-1)
+			require.ErrorIs(t, err, lib0.ErrUnexpectedEOF)
+			assert.Equal(t, 0, dec.Pos(), "position must not advance on error")
+		},
+	)
+
+	t.Run(
+		"over-read is rejected",
+		func(t *testing.T) {
+			t.Parallel()
+
+			dec := lib0.NewDecoder([]byte{0x01, 0x02})
+			_, err := dec.ReadBytes(3)
+			require.ErrorIs(t, err, lib0.ErrUnexpectedEOF)
+			assert.Equal(t, 0, dec.Pos(), "position must not advance on error")
+		},
+	)
+}

--- a/pkg/collab/lib0/encoder.go
+++ b/pkg/collab/lib0/encoder.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+// Package lib0 implements the binary encoding primitives used by Y.js's
+// `lib0` and `y-protocols` packages: little-endian 7-bit-continuation
+// variable-length unsigned integers, lib0-flavoured signed variable-length
+// integers, length-prefixed UTF-8 strings, and length-prefixed byte arrays.
+//
+// The package is pure: it imports nothing outside of the Go standard library
+// so it can be vendored or copied verbatim into other tools without dragging
+// in the rest of the collaboration stack.
+package lib0
+
+type (
+	Encoder struct {
+		buf []byte
+	}
+)
+
+func NewEncoder() *Encoder {
+	return &Encoder{}
+}
+
+func (e *Encoder) Bytes() []byte {
+	return e.buf
+}
+
+func (e *Encoder) Len() int {
+	return len(e.buf)
+}
+
+func (e *Encoder) Reset() {
+	e.buf = e.buf[:0]
+}
+
+// WriteByte appends a single byte to the encoder. It always returns nil
+// (the signature matches io.ByteWriter so the encoder can be passed to
+// stdlib helpers expecting that interface).
+func (e *Encoder) WriteByte(b byte) error {
+	e.buf = append(e.buf, b)
+	return nil
+}
+
+// Write appends p to the encoder. It always returns len(p), nil.
+func (e *Encoder) Write(p []byte) (int, error) {
+	e.buf = append(e.buf, p...)
+	return len(p), nil
+}

--- a/pkg/collab/lib0/encoder.go
+++ b/pkg/collab/lib0/encoder.go
@@ -16,10 +16,6 @@
 // `lib0` and `y-protocols` packages: little-endian 7-bit-continuation
 // variable-length unsigned integers, lib0-flavoured signed variable-length
 // integers, length-prefixed UTF-8 strings, and length-prefixed byte arrays.
-//
-// The package is pure: it imports nothing outside of the Go standard library
-// so it can be vendored or copied verbatim into other tools without dragging
-// in the rest of the collaboration stack.
 package lib0
 
 type (

--- a/pkg/collab/lib0/encoder_test.go
+++ b/pkg/collab/lib0/encoder_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package lib0_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/collab/lib0"
+)
+
+func TestNewEncoder_StartsEmpty(t *testing.T) {
+	t.Parallel()
+
+	enc := lib0.NewEncoder()
+	assert.Empty(t, enc.Bytes())
+	assert.Equal(t, 0, enc.Len())
+}
+
+func TestEncoder_WriteByte(t *testing.T) {
+	t.Parallel()
+
+	enc := lib0.NewEncoder()
+
+	require.NoError(t, enc.WriteByte(0xde))
+	require.NoError(t, enc.WriteByte(0xad))
+
+	assert.Equal(t, []byte{0xde, 0xad}, enc.Bytes())
+	assert.Equal(t, 2, enc.Len())
+}
+
+func TestEncoder_Write(t *testing.T) {
+	t.Parallel()
+
+	enc := lib0.NewEncoder()
+
+	n, err := enc.Write([]byte{0x01, 0x02, 0x03})
+	require.NoError(t, err)
+	assert.Equal(t, 3, n)
+
+	n, err = enc.Write(nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+
+	assert.Equal(t, []byte{0x01, 0x02, 0x03}, enc.Bytes())
+	assert.Equal(t, 3, enc.Len())
+}
+
+func TestEncoder_Reset(t *testing.T) {
+	t.Parallel()
+
+	t.Run(
+		"after writes",
+		func(t *testing.T) {
+			t.Parallel()
+
+			enc := lib0.NewEncoder()
+			_, err := enc.Write([]byte{0x01, 0x02, 0x03})
+			require.NoError(t, err)
+
+			enc.Reset()
+			assert.Empty(t, enc.Bytes())
+			assert.Equal(t, 0, enc.Len())
+
+			require.NoError(t, enc.WriteByte(0xff))
+			assert.Equal(t, []byte{0xff}, enc.Bytes())
+		},
+	)
+
+	t.Run(
+		"on fresh encoder",
+		func(t *testing.T) {
+			t.Parallel()
+
+			enc := lib0.NewEncoder()
+			enc.Reset()
+			assert.Empty(t, enc.Bytes())
+			assert.Equal(t, 0, enc.Len())
+		},
+	)
+}

--- a/pkg/collab/lib0/string.go
+++ b/pkg/collab/lib0/string.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package lib0
+
+// WriteVarString writes a UTF-8 string prefixed by its byte length encoded
+// as a varuint. Note that the prefix is the byte length, not the rune count
+// (matching lib0's `writeVarString`, which feeds the string through
+// TextEncoder before length-prefixing).
+func WriteVarString(e *Encoder, s string) {
+	WriteVarUint(e, uint64(len(s)))
+	_, _ = e.Write([]byte(s))
+}
+
+// ReadVarString reads a UTF-8 string written by WriteVarString.
+func ReadVarString(d *Decoder) (string, error) {
+	n, err := ReadVarUint(d)
+	if err != nil {
+		return "", err
+	}
+	if n > uint64(d.Remaining()) {
+		return "", ErrUnexpectedEOF
+	}
+
+	out := string(d.buf[d.pos : d.pos+int(n)])
+	d.pos += int(n)
+	return out, nil
+}

--- a/pkg/collab/lib0/string_test.go
+++ b/pkg/collab/lib0/string_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package lib0_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/collab/lib0"
+)
+
+func TestWriteVarString_GoldenFixtures(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		value string
+		want  []byte
+	}{
+		{"empty", "", []byte{0x00}},
+		{"ascii", "hi", []byte{0x02, 'h', 'i'}},
+		{"unicode-multibyte", "é", []byte{0x02, 0xc3, 0xa9}},
+		{"emoji", "🚀", []byte{0x04, 0xf0, 0x9f, 0x9a, 0x80}},
+	}
+
+	for _, tc := range cases {
+		t.Run(
+			tc.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				enc := lib0.NewEncoder()
+				lib0.WriteVarString(enc, tc.value)
+				assert.Equal(t, tc.want, enc.Bytes())
+			},
+		)
+	}
+}
+
+func TestVarString_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	values := []string{
+		"",
+		"a",
+		"hello world",
+		"é",
+		"🚀 to the moon",
+		strings.Repeat("x", 200),
+		strings.Repeat("é", 200),
+	}
+
+	for _, v := range values {
+		v := v
+		enc := lib0.NewEncoder()
+		lib0.WriteVarString(enc, v)
+
+		dec := lib0.NewDecoder(enc.Bytes())
+		got, err := lib0.ReadVarString(dec)
+		require.NoError(t, err)
+		assert.Equal(t, v, got)
+		assert.Equal(t, 0, dec.Remaining())
+	}
+}
+
+func TestReadVarString_TruncatedBody(t *testing.T) {
+	t.Parallel()
+
+	dec := lib0.NewDecoder([]byte{0x05, 'h', 'i'}) // claims 5 bytes, only 2 available
+	_, err := lib0.ReadVarString(dec)
+	require.ErrorIs(t, err, lib0.ErrUnexpectedEOF)
+}
+
+func TestReadVarString_TruncatedLength(t *testing.T) {
+	t.Parallel()
+
+	dec := lib0.NewDecoder([]byte{0x80}) // varuint with continuation, no follow-up
+	_, err := lib0.ReadVarString(dec)
+	require.ErrorIs(t, err, lib0.ErrUnexpectedEOF)
+}

--- a/pkg/collab/lib0/varint.go
+++ b/pkg/collab/lib0/varint.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package lib0
+
+// WriteVarUint writes x using the lib0 unsigned variable-length integer
+// encoding: little-endian 7-bit groups with the continuation bit (0x80) set
+// on every byte except the last.
+func WriteVarUint(e *Encoder, x uint64) {
+	for x >= 0x80 {
+		_ = e.WriteByte(byte(x) | 0x80)
+		x >>= 7
+	}
+	_ = e.WriteByte(byte(x))
+}
+
+// ReadVarUint reads a lib0-encoded unsigned variable-length integer.
+//
+// Returns ErrUnexpectedEOF if the input is exhausted before the
+// continuation bit is cleared, and ErrVarUintOverflow if the encoded value
+// would not fit in a uint64.
+func ReadVarUint(d *Decoder) (uint64, error) {
+	var (
+		v     uint64
+		shift uint
+	)
+
+	for {
+		b, err := d.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+
+		if shift >= 64 || (shift == 63 && b > 1) {
+			return 0, ErrVarUintOverflow
+		}
+
+		v |= uint64(b&0x7f) << shift
+		if b&0x80 == 0 {
+			return v, nil
+		}
+
+		shift += 7
+	}
+}
+
+// WriteVarInt writes x using the lib0 signed variable-length integer
+// encoding. The first byte carries the sign in bit 6 and a continuation
+// flag in bit 7; bits 0..5 hold the lowest six bits of |x|. Subsequent
+// bytes follow the unsigned varint format with 7-bit groups.
+func WriteVarInt(e *Encoder, x int64) {
+	var (
+		isNegative = x < 0
+		u          uint64
+	)
+
+	if isNegative {
+		// uint64(-x) for x = math.MinInt64 produces 1<<63 in Go, which
+		// is the correct unsigned magnitude.
+		u = uint64(-x)
+	} else {
+		u = uint64(x)
+	}
+
+	first := byte(u & 0x3f)
+	if isNegative {
+		first |= 0x40
+	}
+	if u > 0x3f {
+		first |= 0x80
+	}
+	_ = e.WriteByte(first)
+
+	u >>= 6
+	for u > 0 {
+		b := byte(u & 0x7f)
+		if u > 0x7f {
+			b |= 0x80
+		}
+		_ = e.WriteByte(b)
+		u >>= 7
+	}
+}
+
+// ReadVarInt reads a lib0-encoded signed variable-length integer.
+func ReadVarInt(d *Decoder) (int64, error) {
+	first, err := d.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+
+	var (
+		num        = uint64(first & 0x3f)
+		isNegative = first&0x40 != 0
+		hasMore    = first&0x80 != 0
+		mult       = uint64(64)
+	)
+
+	for hasMore {
+		b, err := d.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+
+		// (b&0x7f) * mult overflows uint64 once the encoded value
+		// exceeds 64 bits; the divide round-trip detects that without
+		// risking a panic (mult is always non-zero — see the shift
+		// guard below).
+		add := uint64(b&0x7f) * mult
+		if add/mult != uint64(b&0x7f) {
+			return 0, ErrVarIntOverflow
+		}
+		// num + add cannot wrap: by construction num occupies the low
+		// 6 + 7(k-1) bits before iteration k, and add only contributes
+		// bits at positions ≥ 6 + 7(k-1), so the two never collide and
+		// their sum stays within uint64 (which the previous check also
+		// guarantees).
+		num += add
+
+		hasMore = b&0x80 != 0
+		if hasMore {
+			// Compute the next multiplier (mult * 128) with an
+			// overflow guard so that mult stays strictly positive.
+			next := mult << 7
+			if next>>7 != mult {
+				return 0, ErrVarIntOverflow
+			}
+			mult = next
+		}
+	}
+
+	if isNegative {
+		// |num| can equal 1<<63, which represents math.MinInt64.
+		if num > 1<<63 {
+			return 0, ErrVarIntOverflow
+		}
+		if num == 1<<63 {
+			return -1 << 63, nil
+		}
+		return -int64(num), nil
+	}
+
+	if num > 1<<63-1 {
+		return 0, ErrVarIntOverflow
+	}
+	return int64(num), nil
+}

--- a/pkg/collab/lib0/varint_test.go
+++ b/pkg/collab/lib0/varint_test.go
@@ -1,0 +1,259 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package lib0_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/collab/lib0"
+)
+
+func TestWriteVarUint_GoldenFixtures(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		value uint64
+		want  []byte
+	}{
+		{"zero", 0, []byte{0x00}},
+		{"one", 1, []byte{0x01}},
+		{"max-single-byte", 127, []byte{0x7f}},
+		{"min-two-bytes", 128, []byte{0x80, 0x01}},
+		{"max-two-bytes", 16383, []byte{0xff, 0x7f}},
+		{"min-three-bytes", 16384, []byte{0x80, 0x80, 0x01}},
+		{"max-three-bytes", 2097151, []byte{0xff, 0xff, 0x7f}},
+		{"min-four-bytes", 2097152, []byte{0x80, 0x80, 0x80, 0x01}},
+		{"32-bit-value", 1 << 31, []byte{0x80, 0x80, 0x80, 0x80, 0x08}},
+		{"max-uint64", math.MaxUint64, []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01}},
+	}
+
+	for _, tc := range cases {
+		t.Run(
+			tc.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				enc := lib0.NewEncoder()
+				lib0.WriteVarUint(enc, tc.value)
+				assert.Equal(t, tc.want, enc.Bytes())
+			},
+		)
+	}
+}
+
+func TestReadVarUint_GoldenFixtures(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input []byte
+		want  uint64
+	}{
+		{"zero", []byte{0x00}, 0},
+		{"one", []byte{0x01}, 1},
+		{"max-single-byte", []byte{0x7f}, 127},
+		{"min-two-bytes", []byte{0x80, 0x01}, 128},
+		{"max-two-bytes", []byte{0xff, 0x7f}, 16383},
+		{"max-uint64", []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01}, math.MaxUint64},
+	}
+
+	for _, tc := range cases {
+		t.Run(
+			tc.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				dec := lib0.NewDecoder(tc.input)
+				got, err := lib0.ReadVarUint(dec)
+				require.NoError(t, err)
+				assert.Equal(t, tc.want, got)
+				assert.Equal(t, 0, dec.Remaining())
+			},
+		)
+	}
+}
+
+func TestVarUint_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	values := []uint64{
+		0, 1, 2, 63, 64, 127, 128, 255, 256, 16383, 16384,
+		1 << 20, 1 << 32, 1 << 53, math.MaxInt64, math.MaxUint64,
+	}
+
+	for _, v := range values {
+		v := v
+		enc := lib0.NewEncoder()
+		lib0.WriteVarUint(enc, v)
+
+		dec := lib0.NewDecoder(enc.Bytes())
+		got, err := lib0.ReadVarUint(dec)
+		require.NoError(t, err)
+		assert.Equal(t, v, got)
+		assert.Equal(t, 0, dec.Remaining())
+	}
+}
+
+func TestReadVarUint_TruncatedInput(t *testing.T) {
+	t.Parallel()
+
+	dec := lib0.NewDecoder([]byte{0x80}) // continuation bit set, no follow-up byte
+	_, err := lib0.ReadVarUint(dec)
+	require.ErrorIs(t, err, lib0.ErrUnexpectedEOF)
+}
+
+func TestReadVarUint_Overflow(t *testing.T) {
+	t.Parallel()
+
+	// 11 bytes all 0xff is well past the uint64 boundary.
+	overflow := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01}
+	dec := lib0.NewDecoder(overflow)
+	_, err := lib0.ReadVarUint(dec)
+	require.ErrorIs(t, err, lib0.ErrVarUintOverflow)
+}
+
+func TestWriteVarInt_GoldenFixtures(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		value int64
+		want  []byte
+	}{
+		{"zero", 0, []byte{0x00}},
+		{"positive-one", 1, []byte{0x01}},
+		{"negative-one", -1, []byte{0x41}},
+		{"max-single-byte-positive", 63, []byte{0x3f}},
+		{"max-single-byte-negative", -63, []byte{0x7f}},
+		{"min-two-bytes-positive", 64, []byte{0x80, 0x01}},
+		{"min-two-bytes-negative", -64, []byte{0xc0, 0x01}},
+		{"larger-positive", 8191, []byte{0xbf, 0x7f}},
+		{"larger-negative", -8191, []byte{0xff, 0x7f}},
+		{
+			"max-int64",
+			math.MaxInt64,
+			[]byte{0xbf, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01},
+		},
+		{
+			"min-int64",
+			math.MinInt64,
+			[]byte{0xc0, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(
+			tc.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				enc := lib0.NewEncoder()
+				lib0.WriteVarInt(enc, tc.value)
+				assert.Equal(t, tc.want, enc.Bytes())
+			},
+		)
+	}
+}
+
+func TestVarInt_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	values := []int64{
+		0, 1, -1, 63, -63, 64, -64, 127, -127, 128, -128,
+		8191, -8191, 1 << 20, -(1 << 20), 1 << 32, -(1 << 32),
+		1<<53 - 1, -(1<<53 - 1), math.MaxInt64, math.MinInt64,
+	}
+
+	for _, v := range values {
+		v := v
+		enc := lib0.NewEncoder()
+		lib0.WriteVarInt(enc, v)
+
+		dec := lib0.NewDecoder(enc.Bytes())
+		got, err := lib0.ReadVarInt(dec)
+		require.NoError(t, err, "value=%d", v)
+		assert.Equal(t, v, got)
+		assert.Equal(t, 0, dec.Remaining())
+	}
+}
+
+func TestReadVarInt_TruncatedInput(t *testing.T) {
+	t.Parallel()
+
+	dec := lib0.NewDecoder(nil)
+	_, err := lib0.ReadVarInt(dec)
+	require.ErrorIs(t, err, lib0.ErrUnexpectedEOF)
+
+	dec = lib0.NewDecoder([]byte{0x80}) // continuation set, no follow-up
+	_, err = lib0.ReadVarInt(dec)
+	require.ErrorIs(t, err, lib0.ErrUnexpectedEOF)
+}
+
+func TestReadVarInt_Overflow(t *testing.T) {
+	t.Parallel()
+
+	// In ReadVarInt the first byte carries 6 data bits and each
+	// continuation byte adds 7 more. The 10th byte (9th iteration of
+	// the loop) is therefore the boundary where mult reaches 2^62 and
+	// the various overflow guards become reachable.
+
+	cases := []struct {
+		name  string
+		input []byte
+	}{
+		{
+			// (b & 0x7f) * mult overflows uint64 on iter 9
+			// because mult = 2^62 and b & 0x7f = 4 yields 2^64.
+			name:  "multiply-overflow",
+			input: []byte{0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x04},
+		},
+		{
+			// mult << 7 would jump from 2^62 to 2^69; an extra
+			// continuation byte after byte 10 forces that shift.
+			name:  "mult-shift-overflow",
+			input: []byte{0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x00},
+		},
+		{
+			// Magnitude exceeds 2^63 for a negative value: sign
+			// bit on byte 0 and 0x03 on byte 10 yields num =
+			// 3 * 2^62 = 2^63 + 2^62.
+			name:  "negative-magnitude-exceeds-int64",
+			input: []byte{0xc0, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x03},
+		},
+		{
+			// Positive value exceeding MaxInt64: 0x02 on byte 10
+			// puts the value at exactly 2^63.
+			name:  "positive-exceeds-max-int64",
+			input: []byte{0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x02},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(
+			tc.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				dec := lib0.NewDecoder(tc.input)
+				_, err := lib0.ReadVarInt(dec)
+				require.ErrorIs(t, err, lib0.ErrVarIntOverflow)
+			},
+		)
+	}
+}

--- a/pkg/collab/yprotocol/awareness.go
+++ b/pkg/collab/yprotocol/awareness.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package yprotocol
+
+import "go.probo.inc/probo/pkg/collab/lib0"
+
+// WriteAwareness writes a complete awareness frame
+// (MessageAwareness + opaque update) into enc.
+func WriteAwareness(enc *lib0.Encoder, update []byte) {
+	lib0.WriteVarUint(enc, uint64(MessageAwareness))
+	lib0.WriteVarUint8Array(enc, update)
+}
+
+// EncodeAwareness returns a fresh frame containing an awareness message.
+func EncodeAwareness(update []byte) []byte {
+	enc := lib0.NewEncoder()
+	WriteAwareness(enc, update)
+	return enc.Bytes()
+}

--- a/pkg/collab/yprotocol/awareness_test.go
+++ b/pkg/collab/yprotocol/awareness_test.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package yprotocol_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/collab/lib0"
+	"go.probo.inc/probo/pkg/collab/yprotocol"
+)
+
+func TestEncodeAwareness_GoldenFixtures(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		update []byte
+		want   []byte
+	}{
+		{"empty-update", []byte{}, []byte{0x01, 0x00}},
+		{"single-byte-update", []byte{0x42}, []byte{0x01, 0x01, 0x42}},
+		{"deadbeef-update", []byte{0xde, 0xad, 0xbe, 0xef}, []byte{0x01, 0x04, 0xde, 0xad, 0xbe, 0xef}},
+	}
+
+	for _, tc := range cases {
+		t.Run(
+			tc.name,
+			func(t *testing.T) {
+				t.Parallel()
+				assert.Equal(t, tc.want, yprotocol.EncodeAwareness(tc.update))
+			},
+		)
+	}
+}
+
+func TestReadMessage_Awareness(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		frame       []byte
+		wantPayload []byte
+	}{
+		{"empty", []byte{0x01, 0x00}, []byte{}},
+		{"deadbeef", []byte{0x01, 0x04, 0xde, 0xad, 0xbe, 0xef}, []byte{0xde, 0xad, 0xbe, 0xef}},
+	}
+
+	for _, tc := range cases {
+		t.Run(
+			tc.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				msg, err := yprotocol.ReadMessage(tc.frame)
+				require.NoError(t, err)
+				assert.Equal(t, yprotocol.MessageAwareness, msg.Type)
+				assert.Equal(t, tc.wantPayload, msg.Payload)
+				assert.NotNil(t, msg.Payload, "Payload should be non-nil even when empty")
+				assert.Equal(t, byte(0), msg.Subtype, "Subtype is not meaningful for awareness and should be left zero")
+			},
+		)
+	}
+}
+
+func TestReadMessage_AwarenessRejectsTrailing(t *testing.T) {
+	t.Parallel()
+
+	frame := []byte{0x01, 0x00, 0xff}
+	_, err := yprotocol.ReadMessage(frame)
+	require.ErrorIs(t, err, yprotocol.ErrTrailingBytes)
+}
+
+func TestReadMessage_AwarenessRejectsMissingPayload(t *testing.T) {
+	t.Parallel()
+
+	// MessageAwareness with no payload length varuint at all.
+	frame := []byte{0x01}
+	_, err := yprotocol.ReadMessage(frame)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, lib0.ErrUnexpectedEOF)
+}
+
+func TestReadMessage_AwarenessRejectsTruncatedPayload(t *testing.T) {
+	t.Parallel()
+
+	// MessageAwareness, length=4, but only 2 bytes follow.
+	frame := []byte{0x01, 0x04, 0xab, 0xcd}
+	_, err := yprotocol.ReadMessage(frame)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, lib0.ErrUnexpectedEOF)
+}
+
+func TestAwarenessRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		payload []byte
+	}{
+		{"empty", []byte{}},
+		{"single-byte", []byte{0x42}},
+		{"large", makeBytes(300)},
+	}
+
+	for _, tc := range cases {
+		t.Run(
+			tc.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				frame := yprotocol.EncodeAwareness(tc.payload)
+				msg, err := yprotocol.ReadMessage(frame)
+				require.NoError(t, err)
+				assert.Equal(t, yprotocol.MessageAwareness, msg.Type)
+				assert.Equal(t, tc.payload, msg.Payload)
+			},
+		)
+	}
+}

--- a/pkg/collab/yprotocol/message.go
+++ b/pkg/collab/yprotocol/message.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+// Package yprotocol implements the wire-format helpers from y-protocols
+// (https://github.com/yjs/y-protocols) that the collaboration relay needs.
+//
+// Two protocols are supported:
+//   - sync (messageSync = 0): SyncStep1, SyncStep2, Update sub-messages.
+//   - awareness (messageAwareness = 1): opaque awareness payload.
+package yprotocol
+
+import (
+	"errors"
+	"fmt"
+
+	"go.probo.inc/probo/pkg/collab/lib0"
+)
+
+const (
+	// MessageSync wraps a sync sub-message (SyncStep1, SyncStep2, Update).
+	MessageSync byte = 0
+
+	// MessageAwareness carries an opaque awareness update payload.
+	MessageAwareness byte = 1
+)
+
+const (
+	// SyncStep1 contains the sender's state vector. The receiver replies
+	// with a SyncStep2 carrying the missing updates.
+	SyncStep1 byte = 0
+
+	// SyncStep2 contains an update binary computed against the peer's
+	// state vector previously received in a SyncStep1.
+	SyncStep2 byte = 1
+
+	// SyncUpdate carries an unsolicited update binary that the receiver
+	// should apply directly.
+	SyncUpdate byte = 2
+)
+
+var (
+	// ErrUnknownMessageType is returned when an incoming frame has a
+	// top-level message type that this package does not understand.
+	ErrUnknownMessageType = errors.New("unknown message type")
+
+	// ErrUnknownSyncSubtype is returned when an incoming sync frame has
+	// an unknown sync sub-message tag.
+	ErrUnknownSyncSubtype = errors.New("unknown sync subtype")
+
+	// ErrTrailingBytes is returned when a frame contains data after the
+	// last expected field. The relay treats this as a hard error so a
+	// malformed peer cannot silently corrupt state.
+	ErrTrailingBytes = errors.New("trailing bytes after message")
+)
+
+type (
+	// Message is a parsed top-level wire frame.
+	Message struct {
+		// Type is the top-level message tag (MessageSync or MessageAwareness).
+		Type byte
+
+		// Subtype is the sync sub-message tag (SyncStep1, SyncStep2,
+		// SyncUpdate). Only meaningful when Type == MessageSync.
+		Subtype byte
+
+		// Payload is the opaque body bytes (state vector for SyncStep1,
+		// update bytes for SyncStep2/SyncUpdate, awareness blob for
+		// awareness). Never nil for a valid frame; may be empty.
+		Payload []byte
+	}
+)
+
+// ReadMessage parses a single y-protocol frame.
+//
+// The frame must contain exactly one message: trailing bytes are reported
+// as ErrTrailingBytes. Frames are produced by the WriteSyncStep1/2/Update
+// or WriteAwareness functions in this package, or by upstream y-protocols
+// peers.
+func ReadMessage(frame []byte) (Message, error) {
+	dec := lib0.NewDecoder(frame)
+
+	mt, err := lib0.ReadVarUint(dec)
+	if err != nil {
+		return Message{}, fmt.Errorf("cannot read message type: %w", err)
+	}
+
+	switch mt {
+	case uint64(MessageSync):
+		st, err := lib0.ReadVarUint(dec)
+		if err != nil {
+			return Message{}, fmt.Errorf("cannot read sync subtype: %w", err)
+		}
+
+		switch st {
+		case uint64(SyncStep1), uint64(SyncStep2), uint64(SyncUpdate):
+		default:
+			return Message{}, fmt.Errorf("%w: %d", ErrUnknownSyncSubtype, st)
+		}
+
+		payload, err := lib0.ReadVarUint8Array(dec)
+		if err != nil {
+			return Message{}, fmt.Errorf("cannot read sync payload: %w", err)
+		}
+
+		if dec.HasMore() {
+			return Message{}, ErrTrailingBytes
+		}
+
+		return Message{Type: MessageSync, Subtype: byte(st), Payload: payload}, nil
+
+	case uint64(MessageAwareness):
+		payload, err := lib0.ReadVarUint8Array(dec)
+		if err != nil {
+			return Message{}, fmt.Errorf("cannot read awareness payload: %w", err)
+		}
+
+		if dec.HasMore() {
+			return Message{}, ErrTrailingBytes
+		}
+
+		return Message{Type: MessageAwareness, Payload: payload}, nil
+
+	default:
+		return Message{}, fmt.Errorf("%w: %d", ErrUnknownMessageType, mt)
+	}
+}

--- a/pkg/collab/yprotocol/sync.go
+++ b/pkg/collab/yprotocol/sync.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package yprotocol
+
+import "go.probo.inc/probo/pkg/collab/lib0"
+
+// WriteSyncStep1 writes a complete sync.Step1 frame
+// (MessageSync + SyncStep1 + state vector) into enc.
+func WriteSyncStep1(enc *lib0.Encoder, stateVector []byte) {
+	lib0.WriteVarUint(enc, uint64(MessageSync))
+	lib0.WriteVarUint(enc, uint64(SyncStep1))
+	lib0.WriteVarUint8Array(enc, stateVector)
+}
+
+// WriteSyncStep2 writes a complete sync.Step2 frame
+// (MessageSync + SyncStep2 + update) into enc.
+func WriteSyncStep2(enc *lib0.Encoder, update []byte) {
+	lib0.WriteVarUint(enc, uint64(MessageSync))
+	lib0.WriteVarUint(enc, uint64(SyncStep2))
+	lib0.WriteVarUint8Array(enc, update)
+}
+
+// WriteSyncUpdate writes a complete sync.Update frame
+// (MessageSync + SyncUpdate + update) into enc.
+func WriteSyncUpdate(enc *lib0.Encoder, update []byte) {
+	lib0.WriteVarUint(enc, uint64(MessageSync))
+	lib0.WriteVarUint(enc, uint64(SyncUpdate))
+	lib0.WriteVarUint8Array(enc, update)
+}
+
+// EncodeSyncStep1 returns a fresh frame containing a sync.Step1 message.
+func EncodeSyncStep1(stateVector []byte) []byte {
+	enc := lib0.NewEncoder()
+	WriteSyncStep1(enc, stateVector)
+	return enc.Bytes()
+}
+
+// EncodeSyncStep2 returns a fresh frame containing a sync.Step2 message.
+func EncodeSyncStep2(update []byte) []byte {
+	enc := lib0.NewEncoder()
+	WriteSyncStep2(enc, update)
+	return enc.Bytes()
+}
+
+// EncodeSyncUpdate returns a fresh frame containing a sync.Update message.
+func EncodeSyncUpdate(update []byte) []byte {
+	enc := lib0.NewEncoder()
+	WriteSyncUpdate(enc, update)
+	return enc.Bytes()
+}

--- a/pkg/collab/yprotocol/sync_test.go
+++ b/pkg/collab/yprotocol/sync_test.go
@@ -1,0 +1,233 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package yprotocol_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/collab/lib0"
+	"go.probo.inc/probo/pkg/collab/yprotocol"
+)
+
+func TestEncodeSyncStep1_GoldenFixtures(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		stateVector []byte
+		want        []byte
+	}{
+		{"empty-state-vector", []byte{}, []byte{0x00, 0x00, 0x00}},
+		{"nil-state-vector", nil, []byte{0x00, 0x00, 0x00}},
+		{"two-byte-state-vector", []byte{0xab, 0xcd}, []byte{0x00, 0x00, 0x02, 0xab, 0xcd}},
+	}
+
+	for _, tc := range cases {
+		t.Run(
+			tc.name,
+			func(t *testing.T) {
+				t.Parallel()
+				assert.Equal(t, tc.want, yprotocol.EncodeSyncStep1(tc.stateVector))
+			},
+		)
+	}
+}
+
+func TestEncodeSyncStep2_GoldenFixtures(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		update []byte
+		want   []byte
+	}{
+		{"empty-update", []byte{}, []byte{0x00, 0x01, 0x00}},
+		{"deadbeef-update", []byte{0xde, 0xad, 0xbe, 0xef}, []byte{0x00, 0x01, 0x04, 0xde, 0xad, 0xbe, 0xef}},
+	}
+
+	for _, tc := range cases {
+		t.Run(
+			tc.name,
+			func(t *testing.T) {
+				t.Parallel()
+				assert.Equal(t, tc.want, yprotocol.EncodeSyncStep2(tc.update))
+			},
+		)
+	}
+}
+
+func TestEncodeSyncUpdate_GoldenFixtures(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		update []byte
+		want   []byte
+	}{
+		{"empty-update", []byte{}, []byte{0x00, 0x02, 0x00}},
+		{"deadbeef-update", []byte{0xde, 0xad, 0xbe, 0xef}, []byte{0x00, 0x02, 0x04, 0xde, 0xad, 0xbe, 0xef}},
+	}
+
+	for _, tc := range cases {
+		t.Run(
+			tc.name,
+			func(t *testing.T) {
+				t.Parallel()
+				assert.Equal(t, tc.want, yprotocol.EncodeSyncUpdate(tc.update))
+			},
+		)
+	}
+}
+
+func TestReadMessage_Sync(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		frame       []byte
+		wantSubtype byte
+		wantPayload []byte
+	}{
+		{"step1-empty", []byte{0x00, 0x00, 0x00}, yprotocol.SyncStep1, []byte{}},
+		{"step1-payload", []byte{0x00, 0x00, 0x02, 0xab, 0xcd}, yprotocol.SyncStep1, []byte{0xab, 0xcd}},
+		{"step2-payload", []byte{0x00, 0x01, 0x04, 0xde, 0xad, 0xbe, 0xef}, yprotocol.SyncStep2, []byte{0xde, 0xad, 0xbe, 0xef}},
+		{"update-payload", []byte{0x00, 0x02, 0x04, 0xde, 0xad, 0xbe, 0xef}, yprotocol.SyncUpdate, []byte{0xde, 0xad, 0xbe, 0xef}},
+	}
+
+	for _, tc := range cases {
+		t.Run(
+			tc.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				msg, err := yprotocol.ReadMessage(tc.frame)
+				require.NoError(t, err)
+				assert.Equal(t, yprotocol.MessageSync, msg.Type)
+				assert.Equal(t, tc.wantSubtype, msg.Subtype)
+				assert.Equal(t, tc.wantPayload, msg.Payload)
+				assert.NotNil(t, msg.Payload, "Payload should be non-nil even when empty")
+			},
+		)
+	}
+}
+
+func TestReadMessage_RejectsEmptyFrame(t *testing.T) {
+	t.Parallel()
+
+	_, err := yprotocol.ReadMessage(nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, lib0.ErrUnexpectedEOF)
+
+	_, err = yprotocol.ReadMessage([]byte{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, lib0.ErrUnexpectedEOF)
+}
+
+func TestReadMessage_RejectsSyncMissingSubtype(t *testing.T) {
+	t.Parallel()
+
+	frame := []byte{0x00}
+	_, err := yprotocol.ReadMessage(frame)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, lib0.ErrUnexpectedEOF)
+}
+
+func TestReadMessage_RejectsTruncatedSyncPayloadLength(t *testing.T) {
+	t.Parallel()
+
+	// MessageSync, SyncStep1, but no payload length varuint at all.
+	frame := []byte{0x00, 0x00}
+	_, err := yprotocol.ReadMessage(frame)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, lib0.ErrUnexpectedEOF)
+}
+
+func TestSyncRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		encode      func([]byte) []byte
+		wantSubtype byte
+		payload     []byte
+	}{
+		{"step1-empty", yprotocol.EncodeSyncStep1, yprotocol.SyncStep1, []byte{}},
+		{"step1-large", yprotocol.EncodeSyncStep1, yprotocol.SyncStep1, makeBytes(300)},
+		{"step2-empty", yprotocol.EncodeSyncStep2, yprotocol.SyncStep2, []byte{}},
+		{"step2-large", yprotocol.EncodeSyncStep2, yprotocol.SyncStep2, makeBytes(300)},
+		{"update-empty", yprotocol.EncodeSyncUpdate, yprotocol.SyncUpdate, []byte{}},
+		{"update-large", yprotocol.EncodeSyncUpdate, yprotocol.SyncUpdate, makeBytes(300)},
+	}
+
+	for _, tc := range cases {
+		t.Run(
+			tc.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				frame := tc.encode(tc.payload)
+				msg, err := yprotocol.ReadMessage(frame)
+				require.NoError(t, err)
+				assert.Equal(t, yprotocol.MessageSync, msg.Type)
+				assert.Equal(t, tc.wantSubtype, msg.Subtype)
+				assert.Equal(t, tc.payload, msg.Payload)
+			},
+		)
+	}
+}
+
+func makeBytes(n int) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte(i % 251)
+	}
+	return b
+}
+
+func TestReadMessage_RejectsTrailingBytes(t *testing.T) {
+	t.Parallel()
+
+	// Valid SyncStep1 frame followed by an extra byte.
+	frame := []byte{0x00, 0x00, 0x00, 0xff}
+	_, err := yprotocol.ReadMessage(frame)
+	require.ErrorIs(t, err, yprotocol.ErrTrailingBytes)
+}
+
+func TestReadMessage_RejectsUnknownMessageType(t *testing.T) {
+	t.Parallel()
+
+	frame := []byte{0x05, 0x00, 0x00}
+	_, err := yprotocol.ReadMessage(frame)
+	require.ErrorIs(t, err, yprotocol.ErrUnknownMessageType)
+}
+
+func TestReadMessage_RejectsUnknownSyncSubtype(t *testing.T) {
+	t.Parallel()
+
+	frame := []byte{0x00, 0x09, 0x00}
+	_, err := yprotocol.ReadMessage(frame)
+	require.ErrorIs(t, err, yprotocol.ErrUnknownSyncSubtype)
+}
+
+func TestReadMessage_RejectsTruncatedSyncFrame(t *testing.T) {
+	t.Parallel()
+
+	// MessageSync, SyncStep1, then claims a 4-byte payload but provides 0.
+	frame := []byte{0x00, 0x00, 0x04}
+	_, err := yprotocol.ReadMessage(frame)
+	require.Error(t, err)
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Y.js wire protocol support for collaborative editing. Implements `lib0` encoding and `yprotocol` sync/awareness framing so the relay can parse and emit Y frames safely.

- New Features
  - `lib0`: Byte encoder/decoder with varuint/varint, length‑prefixed strings and byte arrays. Safe reads (return copies) and clear EOF/overflow errors.
  - `yprotocol`: Sync (Step1, Step2, Update) and Awareness message framing with `Encode*` helpers. `ReadMessage` parses and validates types, rejects trailing data, and returns a structured message.
  - Comprehensive tests: golden fixtures, round‑trips, and overflow paths.

<sup>Written for commit dbeff02ff18cc1e1941d93aead02fcb2d52f2374. Summary will update on new commits. <a href="https://cubic.dev/pr/getprobo/probo/pull/1194?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

