### PR TITLE
Apply coredata rules: idempotent deletes and constraint checks

### DIFF
--- a/.cursor/rules/go-pg-constraint-check.mdc
+++ b/.cursor/rules/go-pg-constraint-check.mdc
@@ -38,3 +38,21 @@ if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
 This applies to all PostgreSQL error codes mapped to sentinel errors:
 - `"23505"` (unique violation) → `ErrResourceAlreadyExists`
 - `"23503"` (foreign key violation) → `ErrResourceInUse`
+
+# Primary key constraint handling
+
+**Do not** add a 23505 check for a single-column GID primary key (`id TEXT PRIMARY KEY`). GIDs are generated and cannot realistically collide; such a check is dead code.
+
+**Do** check the composite primary key on junction tables where the PK represents a business uniqueness constraint (e.g. a link between two entities).
+
+```go
+// GOOD — composite PK on a junction table (real business constraint)
+if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" && pgErr.ConstraintName == "risk_assessment_scenario_threats_pkey" {
+	return ErrResourceAlreadyExists
+}
+
+// BAD — single GID PK (can never collide, dead code)
+if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" && pgErr.ConstraintName == "risk_assessments_pkey" {
+	return ErrResourceAlreadyExists
+}
+```

--- a/contrib/claude/coredata.md
+++ b/contrib/claude/coredata.md
@@ -249,6 +249,20 @@ if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
 
 The same applies to foreign key violations (`"23503"`) mapped to `ErrResourceInUse` — always verify the constraint name.
 
+**Primary key handling:** Do not add a 23505 check for a single-column GID primary key (`id TEXT PRIMARY KEY`). GIDs are generated and cannot realistically collide — such a check is dead code. Only check the primary key constraint on **composite-PK junction tables** where the PK represents a business uniqueness constraint (e.g. linking a scenario to a threat).
+
+```go
+// Good — composite PK on junction table (real business constraint)
+if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" && pgErr.ConstraintName == "risk_assessment_scenario_threats_pkey" {
+    return ErrResourceAlreadyExists
+}
+
+// Bad — single GID PK (cannot collide, dead code)
+if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" && pgErr.ConstraintName == "risk_assessments_pkey" {
+    return ErrResourceAlreadyExists
+}
+```
+
 ## Filters
 
 Filters implement `SQLFragment() string` and `SQLArguments() pgx.NamedArgs`. Use double pointers for three-state filtering: `nil` = no filter, `*nil` = IS NULL, `*val` = equals.

--- a/pkg/coredata/access_review_campaign.go
+++ b/pkg/coredata/access_review_campaign.go
@@ -233,13 +233,9 @@ WHERE %s AND id = @id
 	args := pgx.StrictNamedArgs{"id": c.ID}
 	maps.Copy(args, scope.SQLArguments())
 
-	result, err := conn.Exec(ctx, q, args)
+	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
 		return fmt.Errorf("cannot delete access_review_campaign: %w", err)
-	}
-
-	if result.RowsAffected() == 0 {
-		return ErrResourceNotFound
 	}
 
 	return nil

--- a/pkg/coredata/applicability_statement.go
+++ b/pkg/coredata/applicability_statement.go
@@ -250,9 +250,8 @@ VALUES (
 
 	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) {
-			if pgErr.Code == "23505" {
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
+			if pgErr.Code == "23505" && pgErr.ConstraintName == "states_of_applicability_contr_state_of_applicability_id_con_key" {
 				return ErrResourceAlreadyExists
 			}
 		}
@@ -382,13 +381,9 @@ WHERE
 	args := pgx.StrictNamedArgs{"id": applicabilityStatementID}
 	maps.Copy(args, scope.SQLArguments())
 
-	result, err := conn.Exec(ctx, q, args)
+	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
 		return fmt.Errorf("cannot delete applicability statement: %w", err)
-	}
-
-	if result.RowsAffected() == 0 {
-		return ErrResourceNotFound
 	}
 
 	return nil

--- a/pkg/coredata/compliance_framework.go
+++ b/pkg/coredata/compliance_framework.go
@@ -212,9 +212,8 @@ RETURNING rank;
 
 	err := conn.QueryRow(ctx, q, args).Scan(&c.Rank)
 	if err != nil {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) {
-			if pgErr.Code == "23505" {
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
+			if pgErr.Code == "23505" && pgErr.ConstraintName == "compliance_frameworks_trust_center_id_framework_id_key" {
 				return ErrResourceAlreadyExists
 			}
 		}

--- a/pkg/coredata/connector.go
+++ b/pkg/coredata/connector.go
@@ -294,13 +294,9 @@ WHERE %s AND id = @id
 	args := pgx.StrictNamedArgs{"id": c.ID}
 	maps.Copy(args, scope.SQLArguments())
 
-	result, err := conn.Exec(ctx, q, args)
+	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
 		return fmt.Errorf("cannot delete connector: %w", err)
-	}
-
-	if result.RowsAffected() == 0 {
-		return ErrResourceNotFound
 	}
 
 	return nil

--- a/pkg/coredata/document_version_approval_decision.go
+++ b/pkg/coredata/document_version_approval_decision.go
@@ -305,9 +305,8 @@ INSERT INTO document_version_approval_decisions (
 
 	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) {
-			if pgErr.Code == "23505" {
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
+			if pgErr.Code == "23505" && pgErr.ConstraintName == "document_version_approval_decisions_quorum_id_approver_id_key" {
 				return ErrResourceAlreadyExists
 			}
 		}

--- a/pkg/coredata/document_version_approval_quorum.go
+++ b/pkg/coredata/document_version_approval_quorum.go
@@ -290,9 +290,8 @@ INSERT INTO document_version_approval_quorums (
 
 	_, err := conn.Exec(ctx, query, args)
 	if err != nil {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) {
-			if pgErr.Code == "23505" {
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
+			if pgErr.Code == "23505" && pgErr.ConstraintName == "document_one_pending_quorum_idx" {
 				return ErrResourceAlreadyExists
 			}
 		}

--- a/pkg/coredata/mailing_list_subscriber.go
+++ b/pkg/coredata/mailing_list_subscriber.go
@@ -214,7 +214,7 @@ VALUES (
 	}
 
 	if _, err := conn.Exec(ctx, q, args); err != nil {
-		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" {
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" && pgErr.ConstraintName == "mailing_list_subscribers_mailing_list_id_email_key" {
 			return ErrResourceAlreadyExists
 		}
 
@@ -278,13 +278,9 @@ WHERE
 	args := pgx.StrictNamedArgs{"mailing_list_subscriber_id": cns.ID}
 	maps.Copy(args, scope.SQLArguments())
 
-	tag, err := conn.Exec(ctx, q, args)
+	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
 		return fmt.Errorf("cannot delete mailing list subscriber: %w", err)
-	}
-
-	if tag.RowsAffected() == 0 {
-		return ErrResourceNotFound
 	}
 
 	return nil

--- a/pkg/coredata/mailing_list_update.go
+++ b/pkg/coredata/mailing_list_update.go
@@ -158,13 +158,9 @@ WHERE
 	}
 	maps.Copy(args, scope.SQLArguments())
 
-	tag, err := conn.Exec(ctx, q, args)
+	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
 		return fmt.Errorf("cannot delete mailing list update: %w", err)
-	}
-
-	if tag.RowsAffected() == 0 {
-		return ErrResourceNotFound
 	}
 
 	return nil

--- a/pkg/coredata/membership.go
+++ b/pkg/coredata/membership.go
@@ -138,8 +138,7 @@ VALUES (
 
 	result, err := conn.Exec(ctx, query, args)
 	if err != nil {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" && pgErr.ConstraintName == "authz_memberships_user_id_organization_id_key" {
 			return ErrResourceAlreadyExists
 		}
 
@@ -339,13 +338,9 @@ WHERE
 	}
 	maps.Copy(args, scope.SQLArguments())
 
-	result, err := conn.Exec(ctx, query, args)
+	_, err := conn.Exec(ctx, query, args)
 	if err != nil {
 		return fmt.Errorf("cannot delete membership: %w", err)
-	}
-
-	if result.RowsAffected() == 0 {
-		return ErrResourceNotFound
 	}
 
 	return nil

--- a/pkg/coredata/membership_profile.go
+++ b/pkg/coredata/membership_profile.go
@@ -1219,7 +1219,7 @@ VALUES (
 
 	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
-		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" {
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" && pgErr.ConstraintName == "idx_profiles_identity_id_organization_id" {
 			return ErrResourceAlreadyExists
 		}
 
@@ -1409,13 +1409,9 @@ WHERE
 	args := pgx.StrictNamedArgs{"profile_id": profileID}
 	maps.Copy(args, scope.SQLArguments())
 
-	result, err := conn.Exec(ctx, q, args)
+	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
 		return fmt.Errorf("cannot delete profile: %w", err)
-	}
-
-	if result.RowsAffected() == 0 {
-		return ErrResourceNotFound
 	}
 
 	return nil

--- a/pkg/coredata/membership_profile.go
+++ b/pkg/coredata/membership_profile.go
@@ -1219,8 +1219,13 @@ VALUES (
 
 	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
-		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" && pgErr.ConstraintName == "idx_profiles_identity_id_organization_id" {
-			return ErrResourceAlreadyExists
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" {
+			switch pgErr.ConstraintName {
+			case "idx_profiles_identity_id_organization_id",
+				"idx_profiles_external_id_organization_id",
+				"idx_profiles_user_name_organization_id":
+				return ErrResourceAlreadyExists
+			}
 		}
 
 		return fmt.Errorf("cannot insert profile: %w", err)

--- a/pkg/coredata/oauth2_consent.go
+++ b/pkg/coredata/oauth2_consent.go
@@ -367,7 +367,7 @@ INSERT INTO iam_oauth2_consents (
 
 	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
-		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" {
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" && pgErr.ConstraintName == "iam_oauth2_consents_pkey" {
 			return ErrResourceAlreadyExists
 		}
 

--- a/pkg/coredata/oauth2_consent.go
+++ b/pkg/coredata/oauth2_consent.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/page"
@@ -367,10 +366,6 @@ INSERT INTO iam_oauth2_consents (
 
 	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
-		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" && pgErr.ConstraintName == "iam_oauth2_consents_pkey" {
-			return ErrResourceAlreadyExists
-		}
-
 		return fmt.Errorf("cannot insert oauth2_consent: %w", err)
 	}
 

--- a/pkg/coredata/risk_assessment.go
+++ b/pkg/coredata/risk_assessment.go
@@ -191,7 +191,7 @@ VALUES (@id, @tenant_id, @organization_id, @name, @description, @created_at, @up
 
 	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
-		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" {
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" && pgErr.ConstraintName == "risk_assessments_pkey" {
 			return ErrResourceAlreadyExists
 		}
 		return fmt.Errorf("cannot insert risk assessment: %w", err)

--- a/pkg/coredata/risk_assessment.go
+++ b/pkg/coredata/risk_assessment.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/page"
@@ -191,9 +190,6 @@ VALUES (@id, @tenant_id, @organization_id, @name, @description, @created_at, @up
 
 	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
-		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" && pgErr.ConstraintName == "risk_assessments_pkey" {
-			return ErrResourceAlreadyExists
-		}
 		return fmt.Errorf("cannot insert risk assessment: %w", err)
 	}
 	return nil

--- a/pkg/coredata/risk_assessment_node.go
+++ b/pkg/coredata/risk_assessment_node.go
@@ -242,7 +242,7 @@ INSERT INTO risk_assessment_nodes (
 	}
 	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
-		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" {
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" && pgErr.ConstraintName == "risk_assessment_nodes_unique_name" {
 			return ErrResourceAlreadyExists
 		}
 		return fmt.Errorf("cannot insert risk assessment node: %w", err)

--- a/pkg/coredata/risk_assessment_process.go
+++ b/pkg/coredata/risk_assessment_process.go
@@ -248,7 +248,7 @@ INSERT INTO risk_assessment_processes (
 	}
 	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
-		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" {
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" && pgErr.ConstraintName == "risk_assessment_processes_unique_name" {
 			return ErrResourceAlreadyExists
 		}
 		return fmt.Errorf("cannot insert risk assessment process: %w", err)

--- a/pkg/coredata/risk_assessment_scenario.go
+++ b/pkg/coredata/risk_assessment_scenario.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/page"
@@ -351,9 +350,6 @@ INSERT INTO risk_assessment_scenarios (
 	}
 	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
-		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" && pgErr.ConstraintName == "risk_assessment_scenarios_pkey" {
-			return ErrResourceAlreadyExists
-		}
 		return fmt.Errorf("cannot insert risk scenario: %w", err)
 	}
 	return nil

--- a/pkg/coredata/risk_assessment_scenario.go
+++ b/pkg/coredata/risk_assessment_scenario.go
@@ -351,7 +351,7 @@ INSERT INTO risk_assessment_scenarios (
 	}
 	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
-		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" {
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" && pgErr.ConstraintName == "risk_assessment_scenarios_pkey" {
 			return ErrResourceAlreadyExists
 		}
 		return fmt.Errorf("cannot insert risk scenario: %w", err)

--- a/pkg/coredata/risk_assessment_scenario_risk.go
+++ b/pkg/coredata/risk_assessment_scenario_risk.go
@@ -60,7 +60,7 @@ INSERT INTO risk_assessment_scenario_risks (
 	}
 	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
-		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" {
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" && pgErr.ConstraintName == "risk_assessment_scenario_risks_pkey" {
 			return ErrResourceAlreadyExists
 		}
 		return fmt.Errorf("cannot insert risk scenario risk: %w", err)

--- a/pkg/coredata/risk_assessment_scenario_threat.go
+++ b/pkg/coredata/risk_assessment_scenario_threat.go
@@ -60,7 +60,7 @@ INSERT INTO risk_assessment_scenario_threats (
 	}
 	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
-		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" {
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" && pgErr.ConstraintName == "risk_assessment_scenario_threats_pkey" {
 			return ErrResourceAlreadyExists
 		}
 		return fmt.Errorf("cannot insert risk scenario threat: %w", err)

--- a/pkg/coredata/risk_assessment_scope.go
+++ b/pkg/coredata/risk_assessment_scope.go
@@ -196,7 +196,7 @@ INSERT INTO risk_assessment_scopes (
 	}
 	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
-		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" {
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" && pgErr.ConstraintName == "risk_assessment_scopes_pkey" {
 			return ErrResourceAlreadyExists
 		}
 		return fmt.Errorf("cannot insert risk assessment scope: %w", err)

--- a/pkg/coredata/risk_assessment_scope.go
+++ b/pkg/coredata/risk_assessment_scope.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/page"
@@ -196,9 +195,6 @@ INSERT INTO risk_assessment_scopes (
 	}
 	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
-		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" && pgErr.ConstraintName == "risk_assessment_scopes_pkey" {
-			return ErrResourceAlreadyExists
-		}
 		return fmt.Errorf("cannot insert risk assessment scope: %w", err)
 	}
 	return nil

--- a/pkg/coredata/risk_assessment_threat.go
+++ b/pkg/coredata/risk_assessment_threat.go
@@ -248,7 +248,7 @@ INSERT INTO risk_assessment_threats (
 	}
 	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
-		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" {
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" && pgErr.ConstraintName == "risk_assessment_threats_unique_name" {
 			return ErrResourceAlreadyExists
 		}
 		return fmt.Errorf("cannot insert risk threat: %w", err)

--- a/pkg/coredata/scim_bridge.go
+++ b/pkg/coredata/scim_bridge.go
@@ -436,13 +436,9 @@ WHERE
 	args := pgx.StrictNamedArgs{"id": s.ID}
 	maps.Copy(args, scope.SQLArguments())
 
-	result, err := conn.Exec(ctx, q, args)
+	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
 		return fmt.Errorf("cannot delete scim_bridge: %w", err)
-	}
-
-	if result.RowsAffected() == 0 {
-		return ErrResourceNotFound
 	}
 
 	return nil

--- a/pkg/coredata/statement_of_applicability.go
+++ b/pkg/coredata/statement_of_applicability.go
@@ -227,8 +227,10 @@ VALUES (
 
 	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
-		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
-			if pgErr.Code == "23505" && pgErr.ConstraintName == "statements_of_applicability_document_id_key" {
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" {
+			switch pgErr.ConstraintName {
+			case "statements_of_applicability_document_id_key",
+				"states_of_applicability_name_organization_id_uniq":
 				return ErrResourceAlreadyExists
 			}
 		}
@@ -267,8 +269,10 @@ WHERE
 
 	result, err := conn.Exec(ctx, q, args)
 	if err != nil {
-		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
-			if pgErr.Code == "23505" && pgErr.ConstraintName == "statements_of_applicability_document_id_key" {
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgErr.Code == "23505" {
+			switch pgErr.ConstraintName {
+			case "statements_of_applicability_document_id_key",
+				"states_of_applicability_name_organization_id_uniq":
 				return ErrResourceAlreadyExists
 			}
 		}

--- a/pkg/coredata/statement_of_applicability.go
+++ b/pkg/coredata/statement_of_applicability.go
@@ -227,9 +227,8 @@ VALUES (
 
 	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) {
-			if pgErr.Code == "23505" {
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
+			if pgErr.Code == "23505" && pgErr.ConstraintName == "statements_of_applicability_document_id_key" {
 				return ErrResourceAlreadyExists
 			}
 		}
@@ -268,9 +267,8 @@ WHERE
 
 	result, err := conn.Exec(ctx, q, args)
 	if err != nil {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) {
-			if pgErr.Code == "23505" {
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
+			if pgErr.Code == "23505" && pgErr.ConstraintName == "statements_of_applicability_document_id_key" {
 				return ErrResourceAlreadyExists
 			}
 		}
@@ -303,13 +301,9 @@ WHERE
 	}
 	maps.Copy(args, scope.SQLArguments())
 
-	result, err := conn.Exec(ctx, q, args)
+	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
 		return fmt.Errorf("cannot delete statement_of_applicability: %w", err)
-	}
-
-	if result.RowsAffected() == 0 {
-		return ErrResourceNotFound
 	}
 
 	return nil

--- a/pkg/coredata/webhook_subscription.go
+++ b/pkg/coredata/webhook_subscription.go
@@ -402,13 +402,9 @@ WHERE %s
 	}
 	maps.Copy(args, scope.SQLArguments())
 
-	result, err := conn.Exec(ctx, q, args)
+	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
 		return fmt.Errorf("cannot delete webhook subscription: %w", err)
-	}
-
-	if result.RowsAffected() == 0 {
-		return ErrResourceNotFound
 	}
 
 	return nil

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -1624,7 +1624,7 @@ func (s OrganizationService) DeleteSCIMConfiguration(
 						connector := &coredata.Connector{ID: *bridge.ConnectorID}
 
 						err = connector.Delete(ctx, tx, scope)
-						if err != nil && err != coredata.ErrResourceNotFound {
+						if err != nil {
 							return fmt.Errorf("cannot delete connector: %w", err)
 						}
 					}

--- a/pkg/mailman/service.go
+++ b/pkg/mailman/service.go
@@ -269,10 +269,6 @@ func (s *Service) UnsubscribeByEmail(
 			wasConfirmed := subscriber.Status == coredata.MailingListSubscriberStatusConfirmed
 
 			if err := subscriber.Delete(ctx, tx, scope); err != nil {
-				if errors.Is(err, coredata.ErrResourceNotFound) {
-					return ErrSubscriberNotFound
-				}
-
 				return fmt.Errorf("cannot delete mailing list subscriber: %w", err)
 			}
 
@@ -348,10 +344,6 @@ func (s *Service) DeleteSubscriber(
 			wasConfirmed := subscriber.Status == coredata.MailingListSubscriberStatusConfirmed
 
 			if err := subscriber.Delete(ctx, tx, scope); err != nil {
-				if errors.Is(err, coredata.ErrResourceNotFound) {
-					return ErrSubscriberNotFound
-				}
-
 				return fmt.Errorf("cannot delete mailing list subscriber: %w", err)
 			}
 
@@ -606,10 +598,6 @@ func (s *Service) DeleteMailingListUpdate(
 		func(ctx context.Context, tx pg.Tx) error {
 			mlu := coredata.MailingListUpdate{ID: id}
 			if err := mlu.Delete(ctx, tx, scope); err != nil {
-				if errors.Is(err, coredata.ErrResourceNotFound) {
-					return ErrMailingListUpdateNotFound
-				}
-
 				return fmt.Errorf("cannot delete mailing list update: %w", err)
 			}
 


### PR DESCRIPTION
Delete methods no longer check RowsAffected — deletes are idempotent. PgError handlers now check both error code and constraint name to avoid misattributing violations. Also migrated remaining errors.As patterns to errors.AsType.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make deletes idempotent and tighten Postgres constraint handling across `coredata`. Document the PK rule and remove now-redundant not-found checks in `iam` and `mailman`.

- **Bug Fixes**
  - Delete methods no longer check RowsAffected; deleting a missing row is a no-op. Removed redundant not-found handling in `pkg/mailman` and `pkg/iam`.
  - Unique-violation handling now checks both error code and constraint name. Removed dead 23505 checks on single-GID primary keys; added explicit constraint-name checks for composite PKs and specific unique constraints.

- **Refactors**
  - Replaced errors.As with errors.AsType in remaining call sites for consistent error handling.
  - Documented composite-PK vs GID-PK rule in `.cursor/rules/go-pg-constraint-check.mdc` and `contrib/claude/coredata.md`.

<sup>Written for commit 34c25c2727f8e821c6b351e6a7cdba5205bc7cb6. Summary will update on new commits. <a href="https://cubic.dev/pr/getprobo/probo/pull/1201?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

