### PR TITLE
Surface tracker pattern changes

### DIFF
--- a/.cursor/rules/relay-connection-item-components.mdc
+++ b/.cursor/rules/relay-connection-item-components.mdc
@@ -1,0 +1,72 @@
+---
+description: Extract connection list items (table rows, list entries) into their own fragment component
+globs: "**/*.tsx"
+alwaysApply: false
+---
+
+# Extract connection items into fragment components
+
+When rendering items from a Relay connection (e.g. `edges.map(…)`), each item
+MUST be rendered by a dedicated component that owns its own fragment — never
+inline the rendering of node fields directly in the parent's `.map()` body.
+
+This ensures:
+- Data requirements are colocated with the rendering component
+- Adding/removing fields in a row doesn't bloat the parent's fragment
+- The row component is independently testable and reusable
+
+## Pattern
+
+```tsx
+// _components/ThingRow.tsx — owns its fragment
+const thingRowFragment = graphql`
+  fragment ThingRow_thing on Thing {
+    id
+    name
+    status
+  }
+`;
+
+interface ThingRowProps {
+  thingKey: ThingRow_thing$key;
+}
+
+export function ThingRow({ thingKey }: ThingRowProps) {
+  const thing = useFragment(thingRowFragment, thingKey);
+  return (
+    <Tr>
+      <Td>{thing.name}</Td>
+      <Td>{thing.status}</Td>
+    </Tr>
+  );
+}
+```
+
+```tsx
+// Parent — spreads the row fragment in its connection and renders the component
+const parentFragment = graphql`
+  fragment ParentPage_things on Query
+  @refetchable(queryName: "ParentPageRefetchQuery") {
+    things(first: $first, after: $after) @connection(key: "ParentPage_things") {
+      edges {
+        node {
+          id
+          ...ThingRow_thing
+        }
+      }
+    }
+  }
+`;
+
+// In JSX:
+{things.map(thing => (
+  <ThingRow key={thing.id} thingKey={thing} />
+))}
+```
+
+## Naming
+
+- File: `_components/<NodeType>Row.tsx` (for table rows) or
+  `_components/<NodeType>Card.tsx` (for card lists)
+- Fragment: `<ComponentName>_<typeName>` (e.g. `ThingRow_thing`)
+- Prop: `<typeName>Key` (e.g. `thingKey`)

--- a/.cursor/rules/relay-fragments-not-data-props.mdc
+++ b/.cursor/rules/relay-fragments-not-data-props.mdc
@@ -39,3 +39,6 @@ interface EditCookieRowProps {
 
 Callback props (`onSave`, `onCancel`) and configuration props (`isUpdating`,
 `variant`) are fine — only **domain data** must come from fragments.
+
+For connection items (table rows, list entries rendered in `.map()`), see the
+companion rule `relay-connection-item-components.mdc`.

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/display/CookieBannerDisplayPage.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/display/CookieBannerDisplayPage.tsx
@@ -30,8 +30,8 @@ export const cookieBannerDisplayPageQuery = graphql`
       __typename
       ... on CookieBanner {
         id
-        consentCategories(first: 50, orderBy: { field: RANK, direction: ASC })
-          @connection(key: "CookieBannerDisplayPage_consentCategories")
+        categories(first: 50, orderBy: { field: RANK, direction: ASC }, filter: { excludeKind: UNCATEGORISED })
+          @connection(key: "CookieBannerDisplayPage_categories")
           @required(action: THROW) {
           __id
           edges {
@@ -63,8 +63,8 @@ export default function CookieBannerDisplayPage({
   }
 
   const banner = data.node;
-  const connectionId = banner.consentCategories.__id;
-  const categories = banner.consentCategories.edges.map(e => e.node);
+  const connectionId = banner.categories.__id;
+  const categories = banner.categories.edges.map(e => e.node);
 
   const [showCreateDialog, setShowCreateDialog] = useState(false);
 

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/display/_components/CategorySection.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/display/_components/CategorySection.tsx
@@ -85,7 +85,7 @@ export const categorySectionFragment = graphql`
       }
     }
     cookieBanner @required(action: THROW) {
-      consentCategories(first: 50, orderBy: { field: RANK, direction: ASC }) @required(action: THROW) {
+      categories(first: 50, orderBy: { field: RANK, direction: ASC }, filter: { excludeKind: UNCATEGORISED }) @required(action: THROW) {
         edges {
           node {
             id
@@ -252,7 +252,7 @@ const reorderCategoryMutation = graphql`
     reorderCookieCategory(input: $input) {
       cookieBanner {
         id
-        consentCategories(first: 50, orderBy: { field: RANK, direction: ASC }) {
+        categories(first: 50, orderBy: { field: RANK, direction: ASC }, filter: { excludeKind: UNCATEGORISED }) {
           edges {
             node {
               id
@@ -517,7 +517,7 @@ export function CategorySection({ categoryKey, connectionId }: CategorySectionPr
     );
   };
 
-  const allCategories = category.cookieBanner.consentCategories.edges.map(e => e.node) ?? [];
+  const allCategories = category.cookieBanner.categories.edges.map(e => e.node) ?? [];
   const siblingCategories = allCategories.filter(c => c.id !== category.id);
   const selfIndex = allCategories.findIndex(c => c.id === category.id);
   const isFirst = selfIndex === 0;

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/resources/_components/TrackerResourceRow.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/resources/_components/TrackerResourceRow.tsx
@@ -307,7 +307,7 @@ export function TrackerResourceRow({ resourceKey, connectionId }: TrackerResourc
         </div>
       </Td>
       <Td>
-        <span className="font-mono text-sm">{resource.path}</span>
+        <span className="font-mono text-xs break-all max-w-xs inline-block">{resource.path}</span>
       </Td>
       <Td>
         {resource.lastDetectedAt

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/CookieBannerTrackersPage.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/CookieBannerTrackersPage.tsx
@@ -49,6 +49,15 @@ export const cookieBannerTrackersPageQuery = graphql`
       __typename
       ... on CookieBanner {
         ...CookieBannerTrackersPageFragment
+        categories(first: 50, orderBy: { field: RANK, direction: ASC })
+          @required(action: THROW) {
+          edges {
+            node {
+              id
+              name
+            }
+          }
+        }
       }
     }
   }
@@ -66,17 +75,18 @@ const trackersFragment = graphql`
     query: { type: "String", defaultValue: null }
     source: { type: "CookieSource", defaultValue: null }
     trackerType: { type: "TrackerType", defaultValue: null }
+    cookieCategoryId: { type: "ID", defaultValue: null }
   ) {
-    uncategorisedTrackerPatterns(
+    trackerPatterns(
       first: $first
       after: $after
       last: $last
       before: $before
       orderBy: $order
-      filter: { query: $query, source: $source, trackerType: $trackerType }
+      filter: { query: $query, source: $source, trackerType: $trackerType, cookieCategoryId: $cookieCategoryId }
     )
       @connection(
-        key: "CookieBannerTrackersPage_uncategorisedTrackerPatterns"
+        key: "CookieBannerTrackersPage_trackerPatterns"
         filters: ["filter", "orderBy"]
       )
       @required(action: THROW) {
@@ -109,14 +119,19 @@ export default function CookieBannerTrackersPage({
   const [queryFilter, setQueryFilter] = useState("");
   const [sourceFilter, setSourceFilter] = useState<CookieSource | null>(null);
   const [trackerTypeFilter, setTrackerTypeFilter] = useState<TrackerType | null>(null);
+  const [categoryFilter, setCategoryFilter] = useState<string | null>(null);
 
   const { data: fragmentData, ...pagination } = usePaginationFragment<
     CookieBannerTrackersPageRefetchQuery,
     CookieBannerTrackersPageFragment$key
   >(trackersFragment, data.node);
 
-  const connectionId = fragmentData.uncategorisedTrackerPatterns.__id;
-  const patterns = fragmentData.uncategorisedTrackerPatterns.edges.map(edge => edge.node) ?? [];
+  const connectionId = fragmentData.trackerPatterns.__id;
+  const patterns = fragmentData.trackerPatterns.edges.map(edge => edge.node) ?? [];
+
+  const categories = data.node.__typename === "CookieBanner"
+    ? data.node.categories.edges.map(edge => edge.node)
+    : [];
 
   const refetchFilters = (overrides: Record<string, unknown> = {}) => {
     startTransition(() => {
@@ -125,6 +140,7 @@ export default function CookieBannerTrackersPage({
           query: queryFilter || null,
           source: sourceFilter,
           trackerType: trackerTypeFilter,
+          cookieCategoryId: categoryFilter,
           ...overrides,
         },
         { fetchPolicy: "network-only" },
@@ -148,12 +164,19 @@ export default function CookieBannerTrackersPage({
     refetchFilters({ trackerType: newType });
   };
 
+  const handleCategoryFilterChange = (value: string) => {
+    const newCategory = value === "ALL" ? null : value;
+    setCategoryFilter(newCategory);
+    refetchFilters({ cookieCategoryId: newCategory });
+  };
+
   const refetchWithFilters: ComponentProps<typeof SortableTable>["refetch"] = ({ order }) => {
     pagination.refetch({
       order: { direction: order.direction, field: order.field as TrackerPatternOrderField },
       query: queryFilter || null,
       source: sourceFilter,
       trackerType: trackerTypeFilter,
+      cookieCategoryId: categoryFilter,
     });
   };
 
@@ -187,6 +210,15 @@ export default function CookieBannerTrackersPage({
           <Option value="SCRIPT">{__("Script")}</Option>
           <Option value="PRE_EXISTING">{__("Pre-existing")}</Option>
         </Select>
+        <Select
+          value={categoryFilter ?? "ALL"}
+          onValueChange={handleCategoryFilterChange}
+        >
+          <Option value="ALL">{__("All categories")}</Option>
+          {categories.map(category => (
+            <Option key={category.id} value={category.id}>{category.name}</Option>
+          ))}
+        </Select>
       </div>
 
       <div className={isPending ? "opacity-50 pointer-events-none transition-opacity" : ""}>
@@ -202,6 +234,7 @@ export default function CookieBannerTrackersPage({
                     <SortableTh field="NAME">{__("Name")}</SortableTh>
                     <Th>{__("Type")}</Th>
                     <SortableTh field="SOURCE">{__("Source")}</SortableTh>
+                    <Th>{__("Category")}</Th>
                     <SortableTh field="LAST_MATCHED_AT">{__("Last Matched")}</SortableTh>
                     <Th className="w-28" />
                   </Tr>
@@ -221,10 +254,10 @@ export default function CookieBannerTrackersPage({
               <Card padded>
                 <div className="text-center py-12">
                   <h3 className="text-lg font-semibold mb-2">
-                    {__("No uncategorised patterns")}
+                    {__("No tracker patterns")}
                   </h3>
                   <p className="text-txt-tertiary">
-                    {__("All detected cookie patterns have been categorised. New patterns will appear here when detected.")}
+                    {__("No cookie patterns have been detected yet. Patterns will appear here when detected.")}
                   </p>
                 </div>
               </Card>

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/TrackerPatternDetailPage.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/TrackerPatternDetailPage.tsx
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { useTranslate } from "@probo/i18n";
+import { Breadcrumb, PageHeader } from "@probo/ui";
+import { graphql, type PreloadedQuery, usePreloadedQuery } from "react-relay";
+
+import type { TrackerPatternDetailPageQuery } from "#/__generated__/core/TrackerPatternDetailPageQuery.graphql";
+import { useOrganizationId } from "#/hooks/useOrganizationId";
+
+import { TrackerPatternDetectedTrackersSection } from "./_components/TrackerPatternDetectedTrackersSection";
+import { TrackerPatternPropertiesSection } from "./_components/TrackerPatternPropertiesSection";
+
+export const trackerPatternDetailPageQuery = graphql`
+  query TrackerPatternDetailPageQuery(
+    $cookieBannerId: ID!
+    $trackerPatternId: ID!
+  ) {
+    cookieBanner: node(id: $cookieBannerId) @required(action: THROW) {
+      __typename
+      ... on CookieBanner {
+        id
+        name
+      }
+    }
+    node(id: $trackerPatternId) @required(action: THROW) {
+      __typename
+      ... on TrackerPattern {
+        id
+        displayName
+        ...TrackerPatternPropertiesSection_trackerPattern
+        ...TrackerPatternDetectedTrackersSection_trackerPattern
+      }
+    }
+  }
+`;
+
+interface TrackerPatternDetailPageProps {
+  queryRef: PreloadedQuery<TrackerPatternDetailPageQuery>;
+}
+
+export default function TrackerPatternDetailPage({
+  queryRef,
+}: TrackerPatternDetailPageProps) {
+  const { __ } = useTranslate();
+  const organizationId = useOrganizationId();
+  const data = usePreloadedQuery(trackerPatternDetailPageQuery, queryRef);
+
+  if (data.cookieBanner.__typename !== "CookieBanner") {
+    throw new Error("invalid type for cookieBanner node");
+  }
+  if (data.node.__typename !== "TrackerPattern") {
+    throw new Error("invalid type for node");
+  }
+
+  const cookieBanner = data.cookieBanner;
+  const pattern = data.node;
+
+  return (
+    <div className="space-y-6">
+      <Breadcrumb
+        items={[
+          {
+            label: __("Cookie Banners"),
+            to: `/organizations/${organizationId}/cookie-banners`,
+          },
+          {
+            label: cookieBanner.name,
+            to: `/organizations/${organizationId}/cookie-banners/${cookieBanner.id}/settings`,
+          },
+          {
+            label: __("Trackers"),
+            to: `/organizations/${organizationId}/cookie-banners/${cookieBanner.id}/trackers`,
+          },
+          {
+            label: pattern.displayName,
+          },
+        ]}
+      />
+
+      <PageHeader title={pattern.displayName} />
+
+      <TrackerPatternPropertiesSection trackerPatternKey={pattern} />
+
+      <TrackerPatternDetectedTrackersSection trackerPatternKey={pattern} />
+    </div>
+  );
+}

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/TrackerPatternDetailPageLoader.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/TrackerPatternDetailPageLoader.tsx
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { Suspense, useEffect } from "react";
+import { useQueryLoader } from "react-relay";
+import { useParams } from "react-router";
+
+import type { TrackerPatternDetailPageQuery } from "#/__generated__/core/TrackerPatternDetailPageQuery.graphql";
+
+import TrackerPatternDetailPage, { trackerPatternDetailPageQuery } from "./TrackerPatternDetailPage";
+import { TrackerPatternDetailPageSkeleton } from "./TrackerPatternDetailPageSkeleton";
+
+export default function TrackerPatternDetailPageLoader() {
+  const { cookieBannerId, trackerPatternId } = useParams<{
+    cookieBannerId: string;
+    trackerPatternId: string;
+  }>();
+  if (typeof cookieBannerId !== "string") {
+    throw new Error("Missing cookieBannerId parameter");
+  }
+  if (typeof trackerPatternId !== "string") {
+    throw new Error("Missing trackerPatternId parameter");
+  }
+
+  const [queryRef, loadQuery] = useQueryLoader<TrackerPatternDetailPageQuery>(
+    trackerPatternDetailPageQuery,
+  );
+
+  useEffect(() => {
+    loadQuery({ cookieBannerId, trackerPatternId });
+  }, [loadQuery, cookieBannerId, trackerPatternId]);
+
+  if (!queryRef) {
+    return <TrackerPatternDetailPageSkeleton />;
+  }
+
+  return (
+    <Suspense fallback={<TrackerPatternDetailPageSkeleton />}>
+      <TrackerPatternDetailPage queryRef={queryRef} />
+    </Suspense>
+  );
+}

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/TrackerPatternDetailPageSkeleton.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/TrackerPatternDetailPageSkeleton.tsx
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+export function TrackerPatternDetailPageSkeleton() {
+  return (
+    <div className="space-y-6 animate-pulse">
+      <div className="rounded-2xl border border-border-low p-6 space-y-4">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="flex items-center justify-between py-3 border-b border-border-low last:border-b-0">
+            <div className="h-4 w-28 rounded bg-bg-subtle" />
+            <div className="h-4 w-48 rounded bg-bg-subtle" />
+          </div>
+        ))}
+      </div>
+      <div className="rounded-2xl border border-border-low p-6 space-y-4">
+        <div className="h-5 w-48 rounded bg-bg-subtle" />
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-4 py-3 border-b border-border-low last:border-b-0">
+            <div className="h-4 w-32 rounded bg-bg-subtle" />
+            <div className="h-4 w-48 rounded bg-bg-subtle" />
+            <div className="h-4 w-16 rounded bg-bg-subtle" />
+            <div className="h-4 w-20 rounded bg-bg-subtle" />
+            <div className="h-4 w-28 rounded bg-bg-subtle" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/DetectedTrackerRow.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/DetectedTrackerRow.tsx
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { useTranslate } from "@probo/i18n";
+import { Badge, Td, Tr } from "@probo/ui";
+import { graphql, useFragment } from "react-relay";
+
+import type { DetectedTrackerRow_detectedTracker$key } from "#/__generated__/core/DetectedTrackerRow_detectedTracker.graphql";
+
+const detectedTrackerFragment = graphql`
+  fragment DetectedTrackerRow_detectedTracker on DetectedTracker {
+    id
+    identifier
+    initiatorUrl
+    maxAgeSeconds
+    source
+    lastDetectedAt
+  }
+`;
+
+function sourceBadge(source: string, __: (s: string) => string) {
+  switch (source) {
+    case "SCRIPT": return { label: __("Script"), variant: "info" as const };
+    case "PRE_EXISTING": return { label: __("Pre-existing"), variant: "outline" as const };
+    default: return { label: source, variant: "neutral" as const };
+  }
+}
+
+interface DetectedTrackerRowProps {
+  detectedTrackerKey: DetectedTrackerRow_detectedTracker$key;
+}
+
+export function DetectedTrackerRow({ detectedTrackerKey }: DetectedTrackerRowProps) {
+  const { __ } = useTranslate();
+  const tracker = useFragment(detectedTrackerFragment, detectedTrackerKey);
+
+  return (
+    <Tr>
+      <Td>
+        <span className="font-mono text-xs break-all max-w-xs inline-block">{tracker.identifier}</span>
+      </Td>
+      <Td>
+        {tracker.initiatorUrl
+          ? <span className="font-mono text-xs break-all max-w-xs inline-block">{tracker.initiatorUrl}</span>
+          : <span className="text-txt-tertiary">-</span>}
+      </Td>
+      <Td>
+        {tracker.maxAgeSeconds != null
+          ? <span className="text-sm">{tracker.maxAgeSeconds}</span>
+          : <span className="text-txt-tertiary">-</span>}
+      </Td>
+      <Td>
+        {tracker.source
+          ? (
+              <Badge variant={sourceBadge(tracker.source, __).variant}>
+                {sourceBadge(tracker.source, __).label}
+              </Badge>
+            )
+          : <span className="text-txt-tertiary">-</span>}
+      </Td>
+      <Td>
+        <time dateTime={tracker.lastDetectedAt}>
+          {new Date(tracker.lastDetectedAt).toLocaleString()}
+        </time>
+      </Td>
+    </Tr>
+  );
+}

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/MoveToCategoryDropdown.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/MoveToCategoryDropdown.tsx
@@ -23,7 +23,7 @@ export const moveToCategoryDropdownQuery = graphql`
     node(id: $cookieBannerId) @required(action: THROW) {
       __typename
       ... on CookieBanner {
-        consentCategories(first: 50, orderBy: { field: RANK, direction: ASC })
+        categories(first: 50, orderBy: { field: RANK, direction: ASC })
           @required(action: THROW) {
           edges {
             node {
@@ -53,7 +53,7 @@ export function MoveToCategoryDropdown({
     return null;
   }
 
-  const categories = data.node.consentCategories.edges.map(e => e.node);
+  const categories = data.node.categories.edges.map(e => e.node);
 
   if (categories.length === 0) {
     return (

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternDetectedTrackersSection.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternDetectedTrackersSection.tsx
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { useTranslate } from "@probo/i18n";
+import { Card, Tbody, Th, Thead, Tr } from "@probo/ui";
+import { type ComponentProps } from "react";
+import { graphql, usePaginationFragment } from "react-relay";
+
+import type { TrackerPatternDetectedTrackersSection_trackerPattern$key } from "#/__generated__/core/TrackerPatternDetectedTrackersSection_trackerPattern.graphql";
+import type {
+  DetectedTrackerOrderField,
+  TrackerPatternDetectedTrackersSectionRefetchQuery,
+} from "#/__generated__/core/TrackerPatternDetectedTrackersSectionRefetchQuery.graphql";
+import { SortableTable, SortableTh } from "#/components/SortableTable";
+
+import { DetectedTrackerRow } from "./DetectedTrackerRow";
+
+export const trackerPatternDetectedTrackersSectionFragment = graphql`
+  fragment TrackerPatternDetectedTrackersSection_trackerPattern on TrackerPattern
+  @refetchable(queryName: "TrackerPatternDetectedTrackersSectionRefetchQuery")
+  @argumentDefinitions(
+    first: { type: "Int", defaultValue: 50 }
+    order: { type: "DetectedTrackerOrder", defaultValue: { field: LAST_DETECTED_AT, direction: DESC } }
+    after: { type: "CursorKey", defaultValue: null }
+    before: { type: "CursorKey", defaultValue: null }
+    last: { type: "Int", defaultValue: null }
+  ) {
+    detectedTrackers(
+      first: $first
+      after: $after
+      last: $last
+      before: $before
+      orderBy: $order
+    ) @connection(key: "TrackerPatternDetectedTrackersSection_detectedTrackers", filters: ["orderBy"]) {
+      __id
+      edges {
+        node {
+          id
+          ...DetectedTrackerRow_detectedTracker
+        }
+      }
+    }
+  }
+`;
+
+interface TrackerPatternDetectedTrackersSectionProps {
+  trackerPatternKey: TrackerPatternDetectedTrackersSection_trackerPattern$key;
+}
+
+export function TrackerPatternDetectedTrackersSection({
+  trackerPatternKey,
+}: TrackerPatternDetectedTrackersSectionProps) {
+  const { __ } = useTranslate();
+
+  const { data, ...pagination } = usePaginationFragment<
+    TrackerPatternDetectedTrackersSectionRefetchQuery,
+    TrackerPatternDetectedTrackersSection_trackerPattern$key
+  >(trackerPatternDetectedTrackersSectionFragment, trackerPatternKey);
+
+  const trackers = data.detectedTrackers?.edges.map(edge => edge.node) ?? [];
+
+  const refetchWithOrder: ComponentProps<typeof SortableTable>["refetch"] = ({ order }) => {
+    pagination.refetch({
+      order: { direction: order.direction, field: order.field as DetectedTrackerOrderField },
+    });
+  };
+
+  return (
+    <>
+      <h3 className="text-lg font-semibold">{__("Detected Trackers")}</h3>
+
+      {trackers.length > 0
+        ? (
+            <SortableTable
+              {...pagination}
+              refetch={refetchWithOrder}
+              pageSize={50}
+            >
+              <Thead>
+                <Tr>
+                  <Th>{__("Identifier")}</Th>
+                  <SortableTh field="INITIATOR_URL">{__("Initiator URL")}</SortableTh>
+                  <Th>{__("Max Age (s)")}</Th>
+                  <Th>{__("Source")}</Th>
+                  <SortableTh field="LAST_DETECTED_AT">{__("Detection Time")}</SortableTh>
+                </Tr>
+              </Thead>
+              <Tbody>
+                {trackers.map(tracker => (
+                  <DetectedTrackerRow
+                    key={tracker.id}
+                    detectedTrackerKey={tracker}
+                  />
+                ))}
+              </Tbody>
+            </SortableTable>
+          )
+        : (
+            <Card padded>
+              <div className="text-center py-12">
+                <p className="text-txt-tertiary">
+                  {__("No detected trackers for this pattern yet.")}
+                </p>
+              </div>
+            </Card>
+          )}
+    </>
+  );
+}

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternPropertiesSection.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternPropertiesSection.tsx
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { humanizeSeconds } from "@probo/helpers";
+import { useTranslate } from "@probo/i18n";
+import { Badge, Card, PropertyRow } from "@probo/ui";
+import { graphql, useFragment } from "react-relay";
+
+import type { TrackerPatternPropertiesSection_trackerPattern$key } from "#/__generated__/core/TrackerPatternPropertiesSection_trackerPattern.graphql";
+
+const trackerPatternPropertiesSectionFragment = graphql`
+  fragment TrackerPatternPropertiesSection_trackerPattern on TrackerPattern {
+    pattern
+    matchType
+    trackerType
+    source
+    maxAgeSeconds
+    description
+    excluded
+    detectedCount
+    lastMatchedAt
+    cookieCategory {
+      name
+    }
+  }
+`;
+
+function trackerTypeBadge(type: string, __: (s: string) => string) {
+  switch (type) {
+    case "COOKIE": return { label: __("Cookie"), variant: "warning" as const };
+    case "LOCAL_STORAGE": return { label: __("localStorage"), variant: "info" as const };
+    case "SESSION_STORAGE": return { label: __("sessionStorage"), variant: "highlight" as const };
+    case "INDEXED_DB": return { label: __("IndexedDB"), variant: "success" as const };
+    case "CACHE_STORAGE": return { label: __("Cache Storage"), variant: "outline" as const };
+    default: return { label: type, variant: "neutral" as const };
+  }
+}
+
+function sourceBadge(source: string, __: (s: string) => string) {
+  switch (source) {
+    case "SCRIPT": return { label: __("Script"), variant: "info" as const };
+    case "PRE_EXISTING": return { label: __("Pre-existing"), variant: "outline" as const };
+    default: return { label: source, variant: "neutral" as const };
+  }
+}
+
+interface TrackerPatternPropertiesSectionProps {
+  trackerPatternKey: TrackerPatternPropertiesSection_trackerPattern$key;
+}
+
+export function TrackerPatternPropertiesSection({
+  trackerPatternKey,
+}: TrackerPatternPropertiesSectionProps) {
+  const { __ } = useTranslate();
+  const pattern = useFragment(
+    trackerPatternPropertiesSectionFragment,
+    trackerPatternKey,
+  );
+
+  const typeBadge = trackerTypeBadge(pattern.trackerType, __);
+
+  return (
+    <Card padded>
+      <PropertyRow label={__("Pattern")}>
+        <span className="font-mono text-sm">{pattern.pattern}</span>
+      </PropertyRow>
+      <PropertyRow label={__("Match Type")}>
+        <span className="text-sm">{pattern.matchType === "EXACT" ? __("Exact") : __("Glob")}</span>
+      </PropertyRow>
+      <PropertyRow label={__("Type")}>
+        <Badge variant={typeBadge.variant}>{typeBadge.label}</Badge>
+      </PropertyRow>
+      {pattern.source && (
+        <PropertyRow label={__("Source")}>
+          <Badge variant={sourceBadge(pattern.source, __).variant}>
+            {sourceBadge(pattern.source, __).label}
+          </Badge>
+        </PropertyRow>
+      )}
+      <PropertyRow label={__("Category")}>
+        <span className="text-sm">
+          {pattern.cookieCategory?.name ?? "-"}
+        </span>
+      </PropertyRow>
+      <PropertyRow label={__("Max Age")}>
+        <span className="text-sm">
+          {humanizeSeconds(pattern.maxAgeSeconds ?? null)}
+        </span>
+      </PropertyRow>
+      {pattern.description && (
+        <PropertyRow label={__("Description")}>
+          <span className="text-sm">{pattern.description}</span>
+        </PropertyRow>
+      )}
+      <PropertyRow label={__("Excluded")}>
+        <span className="text-sm">{pattern.excluded ? __("Yes") : __("No")}</span>
+      </PropertyRow>
+      <PropertyRow label={__("Detected Count")}>
+        <span className="text-sm">{pattern.detectedCount}</span>
+      </PropertyRow>
+      <PropertyRow label={__("Last Matched")}>
+        {pattern.lastMatchedAt
+          ? (
+              <time dateTime={pattern.lastMatchedAt}>
+                {new Date(pattern.lastMatchedAt).toLocaleString()}
+              </time>
+            )
+          : <span className="text-txt-tertiary">-</span>}
+      </PropertyRow>
+    </Card>
+  );
+}

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternRow.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternRow.tsx
@@ -300,9 +300,9 @@ export function TrackerPatternRow({ patternKey, connectionId }: TrackerPatternRo
   const srcBadge = pattern.source ? sourceBadge(pattern.source, __) : null;
 
   return (
-    <Tr className={pattern.excluded ? "bg-txt-quaternary opacity-80  line-through" : undefined}>
+    <Tr to={pattern.id} className={pattern.excluded ? "bg-txt-quaternary opacity-80  line-through" : undefined}>
       <Td>
-        <div className="flex flex-col min-w-0">
+        <div className="flex flex-col min-w-0 max-w-xs">
           <span className={pattern.excluded ? undefined : "font-medium"}>{pattern.displayName}</span>
           {pattern.description && (
             <span className="text-xs text-txt-tertiary wrap-break-word line-clamp-1">

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternRow.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternRow.tsx
@@ -53,6 +53,9 @@ const trackerPatternFragment = graphql`
     maxAgeSeconds
     excluded
     lastMatchedAt
+    cookieCategory {
+      name
+    }
   }
 `;
 
@@ -314,6 +317,11 @@ export function TrackerPatternRow({ patternKey, connectionId }: TrackerPatternRo
       <Td>
         {srcBadge
           ? <Badge variant={srcBadge.variant}>{srcBadge.label}</Badge>
+          : <span className="text-txt-tertiary">-</span>}
+      </Td>
+      <Td>
+        {pattern.cookieCategory
+          ? <span>{pattern.cookieCategory.name}</span>
           : <span className="text-txt-tertiary">-</span>}
       </Td>
       <Td>

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternRowEdit.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternRowEdit.tsx
@@ -62,6 +62,7 @@ export function TrackerPatternRowEdit({
         <span className="font-medium">{pattern}</span>
       </Td>
       <Td />
+      <Td />
       <Td className="pr-3">
         <Controller
           name="duration"

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/translations/CookieBannerTranslationsPage.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/translations/CookieBannerTranslationsPage.tsx
@@ -36,7 +36,7 @@ export const cookieBannerTranslationsPageQuery = graphql`
           language
           translations
         }
-        consentCategories(first: 50, orderBy: { field: RANK, direction: ASC }) @required(action: THROW) {
+        categories(first: 50, orderBy: { field: RANK, direction: ASC }, filter: { excludeKind: UNCATEGORISED }) @required(action: THROW) {
           edges {
             node {
               id
@@ -101,14 +101,14 @@ export default function CookieBannerTranslationsPage({
 
   const categories = useMemo(
     () =>
-      banner.consentCategories.edges.map(e => ({
+      banner.categories.edges.map(e => ({
         id: e.node.id,
         name: e.node.name,
         slug: e.node.slug,
         description: e.node.description,
         kind: e.node.kind,
       })),
-    [banner.consentCategories],
+    [banner.categories],
   );
 
   const necessaryCategoryName = useMemo(

--- a/apps/console/src/pages/organizations/cookie-banners/routes.ts
+++ b/apps/console/src/pages/organizations/cookie-banners/routes.ts
@@ -81,4 +81,9 @@ export const cookieBannerRoutes = [
     Fallback: PageSkeleton,
     Component: lazy(() => import("#/pages/organizations/cookie-banners/configuration/consent-records/CookieBannerConsentRecordPageLoader")),
   },
+  {
+    path: "cookie-banners/:cookieBannerId/trackers/:trackerPatternId",
+    Fallback: PageSkeleton,
+    Component: lazy(() => import("#/pages/organizations/cookie-banners/configuration/trackers/TrackerPatternDetailPageLoader")),
+  },
 ] satisfies AppRoute[];

--- a/contrib/claude/app-arborescence.md
+++ b/contrib/claude/app-arborescence.md
@@ -264,6 +264,51 @@ pages/organizations/third-parties/ThirdPartiesPage.tsx
 pages/organizations/third-parties/ThirdPartiesPageSkeleton.tsx
 ```
 
+## Page sections
+
+When a detail page has visually distinct sections (e.g. a properties card and a paginated list), extract each section into its own component in `_components/`. Each section owns a colocated Relay fragment (or pagination fragment) so that field additions never modify the parent page's query.
+
+The page query spreads the section fragments and passes the fragment key to each section component:
+
+```tsx
+// TrackerPatternDetailPage.tsx (page — spreads section fragments)
+export const trackerPatternDetailPageQuery = graphql`
+  query TrackerPatternDetailPageQuery($trackerPatternId: ID!) {
+    node(id: $trackerPatternId) {
+      ... on TrackerPattern {
+        id
+        displayName
+        ...TrackerPatternPropertiesSection_trackerPattern
+        ...TrackerPatternDetectedTrackersSection_trackerPattern
+      }
+    }
+  }
+`;
+
+// In JSX:
+<TrackerPatternPropertiesSection trackerPatternKey={pattern} />
+<TrackerPatternDetectedTrackersSection trackerPatternKey={pattern} />
+```
+
+```tsx
+// _components/TrackerPatternPropertiesSection.tsx — owns its fragment
+const fragment = graphql`
+  fragment TrackerPatternPropertiesSection_trackerPattern on TrackerPattern {
+    pattern
+    matchType
+    trackerType
+    // ...
+  }
+`;
+
+export function TrackerPatternPropertiesSection({ trackerPatternKey }: Props) {
+  const pattern = useFragment(fragment, trackerPatternKey);
+  return <Card padded>{/* PropertyRows */}</Card>;
+}
+```
+
+Section components follow the same naming and fragment conventions as connection item components (see below), but represent a **logical section** of a page rather than a single list item.
+
 ## `_components` folder
 
 Sub-components that are used **only** by a single page live in a `_components/` folder next to that page. The underscore prefix visually distinguishes them from route-segment folders.

--- a/contrib/claude/react-components.md
+++ b/contrib/claude/react-components.md
@@ -400,3 +400,68 @@ export function MoveToCategoryMenu({ queryRef, onMove }: Props) {
 See also the "Interaction-triggered queries" section in [`contrib/claude/relay.md`](relay.md).
 
 (Snippet names and GraphQL types are illustrative; align with real schema and fragment names in the app.)
+
+## Page sections are components
+
+When a detail page has multiple distinct sections (e.g. a properties card and a paginated list), extract each section into its own component in `_components/`. Each section owns a colocated Relay fragment so that field additions never modify the parent page's query.
+
+The page spreads the section fragments on the shared node and passes the fragment key:
+
+```tsx
+// Page query — spreads section fragments
+export const detailPageQuery = graphql`
+  query DetailPageQuery($nodeId: ID!) {
+    node(id: $nodeId) {
+      ... on MyType {
+        id
+        displayName
+        ...MyTypePropertiesSection_myType
+        ...MyTypeListSection_myType
+      }
+    }
+  }
+`;
+
+// Page JSX:
+<MyTypePropertiesSection myTypeKey={node} />
+<MyTypeListSection myTypeKey={node} />
+```
+
+```tsx
+// _components/MyTypePropertiesSection.tsx
+const fragment = graphql`
+  fragment MyTypePropertiesSection_myType on MyType {
+    field1
+    field2
+  }
+`;
+
+interface MyTypePropertiesSectionProps {
+  myTypeKey: MyTypePropertiesSection_myType$key;
+}
+
+export function MyTypePropertiesSection({ myTypeKey }: MyTypePropertiesSectionProps) {
+  const data = useFragment(fragment, myTypeKey);
+  return <Card padded>{/* PropertyRows */}</Card>;
+}
+```
+
+For sections that own a paginated connection, use `usePaginationFragment` with a `@refetchable` fragment — the same pattern as a standalone page, but scoped to a section component.
+
+## Connection items are components
+
+When rendering items from a Relay connection (e.g. table rows via `edges.map(…)`), each item **must** be a dedicated component with its own colocated fragment — never inline the rendering of node fields directly in the parent's `.map()` body.
+
+Place the item component in `_components/` adjacent to the page. Name it after the GraphQL type it renders (e.g. `DetectedTrackerRow.tsx`, `ThirdPartyCard.tsx`). The component receives a single fragment key prop (e.g. `detectedTrackerKey: DetectedTrackerRow_detectedTracker$key`) and calls `useFragment` internally.
+
+```tsx
+// Parent (page) — spreads the child fragment in the connection:
+edges { node { id ...DetectedTrackerRow_detectedTracker } }
+
+// Parent JSX:
+{trackers.map(tracker => (
+  <DetectedTrackerRow key={tracker.id} detectedTrackerKey={tracker} />
+))}
+```
+
+This ensures field additions/removals in the row never modify the parent's fragment, and keeps the item independently testable.

--- a/e2e/console/cookie_banner_test.go
+++ b/e2e/console/cookie_banner_test.go
@@ -153,7 +153,7 @@ func TestCookieBanner_Create(t *testing.T) {
 			query($id: ID!) {
 				node(id: $id) {
 					... on CookieBanner {
-						consentCategories(first: 10) {
+						categories(first: 10) {
 							totalCount
 							edges {
 								node {
@@ -170,7 +170,7 @@ func TestCookieBanner_Create(t *testing.T) {
 
 		var result struct {
 			Node struct {
-				ConsentCategories struct {
+				Categories struct {
 					TotalCount int `json:"totalCount"`
 					Edges      []struct {
 						Node struct {
@@ -179,16 +179,16 @@ func TestCookieBanner_Create(t *testing.T) {
 							Kind string `json:"kind"`
 						} `json:"node"`
 					} `json:"edges"`
-				} `json:"consentCategories"`
+				} `json:"categories"`
 			} `json:"node"`
 		}
 
 		err := owner.Execute(query, map[string]any{"id": bannerID}, &result)
 		require.NoError(t, err)
-		assert.Greater(t, result.Node.ConsentCategories.TotalCount, 0)
+		assert.Greater(t, result.Node.Categories.TotalCount, 0)
 
 		kinds := make(map[string]bool)
-		for _, e := range result.Node.ConsentCategories.Edges {
+		for _, e := range result.Node.Categories.Edges {
 			kinds[e.Node.Kind] = true
 		}
 

--- a/e2e/console/cookie_category_test.go
+++ b/e2e/console/cookie_category_test.go
@@ -314,7 +314,7 @@ func TestCookieCategory_Delete(t *testing.T) {
 			query($id: ID!) {
 				node(id: $id) {
 					... on CookieBanner {
-						consentCategories(first: 20) {
+						categories(first: 20) {
 							edges {
 								node {
 									id
@@ -329,14 +329,14 @@ func TestCookieCategory_Delete(t *testing.T) {
 
 		var listResult struct {
 			Node struct {
-				ConsentCategories struct {
+				Categories struct {
 					Edges []struct {
 						Node struct {
 							ID   string `json:"id"`
 							Kind string `json:"kind"`
 						} `json:"node"`
 					} `json:"edges"`
-				} `json:"consentCategories"`
+				} `json:"categories"`
 			} `json:"node"`
 		}
 
@@ -345,7 +345,7 @@ func TestCookieCategory_Delete(t *testing.T) {
 
 		var necessaryCategoryID string
 
-		for _, e := range listResult.Node.ConsentCategories.Edges {
+		for _, e := range listResult.Node.Categories.Edges {
 			if e.Node.Kind == "NECESSARY" {
 				necessaryCategoryID = e.Node.ID
 				break
@@ -423,7 +423,7 @@ func TestCookieCategory_List(t *testing.T) {
 			query($id: ID!) {
 				node(id: $id) {
 					... on CookieBanner {
-						consentCategories(first: 20, orderBy: {field: RANK, direction: ASC}) {
+						categories(first: 20, orderBy: {field: RANK, direction: ASC}) {
 							totalCount
 							edges {
 								node {
@@ -443,7 +443,7 @@ func TestCookieCategory_List(t *testing.T) {
 
 		var result struct {
 			Node struct {
-				ConsentCategories struct {
+				Categories struct {
 					TotalCount int `json:"totalCount"`
 					Edges      []struct {
 						Node struct {
@@ -455,7 +455,7 @@ func TestCookieCategory_List(t *testing.T) {
 						HasNextPage     bool `json:"hasNextPage"`
 						HasPreviousPage bool `json:"hasPreviousPage"`
 					} `json:"pageInfo"`
-				} `json:"consentCategories"`
+				} `json:"categories"`
 			} `json:"node"`
 		}
 
@@ -463,13 +463,13 @@ func TestCookieCategory_List(t *testing.T) {
 		require.NoError(t, err)
 
 		// Default categories + 2 custom ones
-		assert.GreaterOrEqual(t, result.Node.ConsentCategories.TotalCount, 4)
+		assert.GreaterOrEqual(t, result.Node.Categories.TotalCount, 4)
 
 		// Verify ordering (ranks should be ascending)
-		for i := 1; i < len(result.Node.ConsentCategories.Edges); i++ {
+		for i := 1; i < len(result.Node.Categories.Edges); i++ {
 			assert.GreaterOrEqual(t,
-				result.Node.ConsentCategories.Edges[i].Node.Rank,
-				result.Node.ConsentCategories.Edges[i-1].Node.Rank,
+				result.Node.Categories.Edges[i].Node.Rank,
+				result.Node.Categories.Edges[i-1].Node.Rank,
 			)
 		}
 	})

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -549,8 +549,10 @@ func (s *Service) ensureDraftVersionForBanner(
 		return nil, fmt.Errorf("cannot load cookie banner: %w", err)
 	}
 
+	consentFilter := coredata.NewCookieCategoryFilter(new(coredata.CookieCategoryKindUncategorised))
+
 	var categories coredata.CookieCategories
-	if err := categories.LoadAllConsentCategoriesByCookieBannerID(ctx, tx, scope, bannerID); err != nil {
+	if err := categories.LoadAllByCookieBannerID(ctx, tx, scope, bannerID, consentFilter); err != nil {
 		return nil, fmt.Errorf("cannot load cookie categories: %w", err)
 	}
 
@@ -1192,18 +1194,19 @@ func (s *Service) GetCookieCategoriesByIDs(
 	return categories, nil
 }
 
-func (s *Service) ListCookieCategoriesForBanner(
+func (s *Service) ListCategoriesForBanner(
 	ctx context.Context,
 	scope coredata.Scoper,
 	bannerID gid.GID,
 	cursor *page.Cursor[coredata.CookieCategoryOrderField],
+	filter *coredata.CookieCategoryFilter,
 ) (coredata.CookieCategories, error) {
 	var categories coredata.CookieCategories
 
 	err := s.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := categories.LoadConsentCategoriesByCookieBannerID(ctx, conn, scope, bannerID, cursor); err != nil {
+			if err := categories.LoadByCookieBannerID(ctx, conn, scope, bannerID, cursor, filter); err != nil {
 				return fmt.Errorf("cannot list cookie categories: %w", err)
 			}
 
@@ -1217,10 +1220,11 @@ func (s *Service) ListCookieCategoriesForBanner(
 	return categories, nil
 }
 
-func (s *Service) CountCookieCategoriesForBanner(
+func (s *Service) CountCategoriesForBanner(
 	ctx context.Context,
 	scope coredata.Scoper,
 	bannerID gid.GID,
+	filter *coredata.CookieCategoryFilter,
 ) (int, error) {
 	var count int
 
@@ -1232,7 +1236,7 @@ func (s *Service) CountCookieCategoriesForBanner(
 				err        error
 			)
 
-			count, err = categories.CountConsentCategoriesByCookieBannerID(ctx, conn, scope, bannerID)
+			count, err = categories.CountByCookieBannerID(ctx, conn, scope, bannerID, filter)
 			if err != nil {
 				return fmt.Errorf("cannot count cookie categories: %w", err)
 			}
@@ -1637,8 +1641,10 @@ func (s *Service) GetActiveBannerConfig(
 				return fmt.Errorf("cannot get version snapshot: %w", err)
 			}
 
+			consentFilter := coredata.NewCookieCategoryFilter(new(coredata.CookieCategoryKindUncategorised))
+
 			var categories coredata.CookieCategories
-			if err := categories.LoadAllConsentCategoriesByCookieBannerID(ctx, conn, scope, banner.ID); err != nil {
+			if err := categories.LoadAllByCookieBannerID(ctx, conn, scope, banner.ID, consentFilter); err != nil {
 				return fmt.Errorf("cannot load cookie categories: %w", err)
 			}
 
@@ -2621,7 +2627,7 @@ func (s *Service) MoveTrackerPatternToCategory(
 	return &result, nil
 }
 
-func (s *Service) ListUncategorisedTrackerPatterns(
+func (s *Service) ListTrackerPatternsForBanner(
 	ctx context.Context,
 	scope coredata.Scoper,
 	bannerID gid.GID,
@@ -2633,8 +2639,8 @@ func (s *Service) ListUncategorisedTrackerPatterns(
 	err := s.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := patterns.LoadUncategorisedByCookieBannerID(ctx, conn, scope, bannerID, cursor, filter); err != nil {
-				return fmt.Errorf("cannot list uncategorised tracker patterns: %w", err)
+			if err := patterns.LoadByCookieBannerID(ctx, conn, scope, bannerID, cursor, filter); err != nil {
+				return fmt.Errorf("cannot list tracker patterns for banner: %w", err)
 			}
 
 			return nil
@@ -2647,7 +2653,7 @@ func (s *Service) ListUncategorisedTrackerPatterns(
 	return patterns, nil
 }
 
-func (s *Service) CountUncategorisedTrackerPatterns(
+func (s *Service) CountTrackerPatternsForBanner(
 	ctx context.Context,
 	scope coredata.Scoper,
 	bannerID gid.GID,
@@ -2663,9 +2669,9 @@ func (s *Service) CountUncategorisedTrackerPatterns(
 				err      error
 			)
 
-			count, err = patterns.CountUncategorisedByCookieBannerID(ctx, conn, scope, bannerID, filter)
+			count, err = patterns.CountByCookieBannerID(ctx, conn, scope, bannerID, filter)
 			if err != nil {
-				return fmt.Errorf("cannot count uncategorised tracker patterns: %w", err)
+				return fmt.Errorf("cannot count tracker patterns for banner: %w", err)
 			}
 
 			return nil

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -2714,6 +2714,31 @@ func (s *Service) CountDetectedTrackersByPatternID(
 	return count, nil
 }
 
+func (s *Service) ListDetectedTrackersForPattern(
+	ctx context.Context,
+	scope coredata.Scoper,
+	trackerPatternID gid.GID,
+	cursor *page.Cursor[coredata.DetectedTrackerOrderField],
+) (coredata.DetectedTrackers, error) {
+	var trackers coredata.DetectedTrackers
+
+	err := s.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			if err := trackers.LoadByTrackerPatternID(ctx, conn, scope, trackerPatternID, cursor); err != nil {
+				return fmt.Errorf("cannot list detected trackers for pattern: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return trackers, nil
+}
+
 func (s *Service) CreateTrackerResource(
 	ctx context.Context,
 	scope coredata.Scoper,

--- a/pkg/coredata/cookie_category.go
+++ b/pkg/coredata/cookie_category.go
@@ -202,6 +202,7 @@ func (c *CookieCategories) LoadByCookieBannerID(
 	scope Scoper,
 	cookieBannerID gid.GID,
 	cursor *page.Cursor[CookieCategoryOrderField],
+	filter *CookieCategoryFilter,
 ) error {
 	q := `
 SELECT
@@ -223,12 +224,14 @@ WHERE
 	%s
 	AND cookie_banner_id = @cookie_banner_id
 	AND %s
+	AND %s
 `
 
-	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+	q = fmt.Sprintf(q, scope.SQLFragment(), filter.SQLFragment(), cursor.SQLFragment())
 
 	args := pgx.StrictNamedArgs{"cookie_banner_id": cookieBannerID}
 	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, filter.SQLArguments())
 	maps.Copy(args, cursor.SQLArguments())
 
 	rows, err := conn.Query(ctx, q, args)
@@ -251,6 +254,7 @@ func (c *CookieCategories) CountByCookieBannerID(
 	conn pg.Querier,
 	scope Scoper,
 	cookieBannerID gid.GID,
+	filter *CookieCategoryFilter,
 ) (int, error) {
 	q := `
 SELECT
@@ -260,101 +264,14 @@ FROM
 WHERE
 	%s
 	AND cookie_banner_id = @cookie_banner_id
-`
-
-	q = fmt.Sprintf(q, scope.SQLFragment())
-
-	args := pgx.StrictNamedArgs{"cookie_banner_id": cookieBannerID}
-	maps.Copy(args, scope.SQLArguments())
-
-	row := conn.QueryRow(ctx, q, args)
-
-	var count int
-	if err := row.Scan(&count); err != nil {
-		return 0, fmt.Errorf("cannot scan count: %w", err)
-	}
-
-	return count, nil
-}
-
-func (c *CookieCategories) LoadConsentCategoriesByCookieBannerID(
-	ctx context.Context,
-	conn pg.Querier,
-	scope Scoper,
-	cookieBannerID gid.GID,
-	cursor *page.Cursor[CookieCategoryOrderField],
-) error {
-	q := `
-SELECT
-	id,
-	organization_id,
-	cookie_banner_id,
-	name,
-	slug,
-	description,
-	kind,
-	rank,
-	gcm_consent_types,
-	posthog_consent,
-	created_at,
-	updated_at
-FROM
-	cookie_categories
-WHERE
-	%s
-	AND cookie_banner_id = @cookie_banner_id
-	AND kind != @excluded_kind
 	AND %s
 `
 
-	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+	q = fmt.Sprintf(q, scope.SQLFragment(), filter.SQLFragment())
 
-	args := pgx.StrictNamedArgs{
-		"cookie_banner_id": cookieBannerID,
-		"excluded_kind":    CookieCategoryKindUncategorised,
-	}
+	args := pgx.StrictNamedArgs{"cookie_banner_id": cookieBannerID}
 	maps.Copy(args, scope.SQLArguments())
-	maps.Copy(args, cursor.SQLArguments())
-
-	rows, err := conn.Query(ctx, q, args)
-	if err != nil {
-		return fmt.Errorf("cannot query consent cookie categories: %w", err)
-	}
-
-	categories, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[CookieCategory])
-	if err != nil {
-		return fmt.Errorf("cannot collect consent cookie categories: %w", err)
-	}
-
-	*c = categories
-
-	return nil
-}
-
-func (c *CookieCategories) CountConsentCategoriesByCookieBannerID(
-	ctx context.Context,
-	conn pg.Querier,
-	scope Scoper,
-	cookieBannerID gid.GID,
-) (int, error) {
-	q := `
-SELECT
-	COUNT(id)
-FROM
-	cookie_categories
-WHERE
-	%s
-	AND cookie_banner_id = @cookie_banner_id
-	AND kind != @excluded_kind
-`
-
-	q = fmt.Sprintf(q, scope.SQLFragment())
-
-	args := pgx.StrictNamedArgs{
-		"cookie_banner_id": cookieBannerID,
-		"excluded_kind":    CookieCategoryKindUncategorised,
-	}
-	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, filter.SQLArguments())
 
 	row := conn.QueryRow(ctx, q, args)
 
@@ -371,6 +288,7 @@ func (c *CookieCategories) LoadAllByCookieBannerID(
 	conn pg.Querier,
 	scope Scoper,
 	cookieBannerID gid.GID,
+	filter *CookieCategoryFilter,
 ) error {
 	q := `
 SELECT
@@ -391,14 +309,16 @@ FROM
 WHERE
 	%s
 	AND cookie_banner_id = @cookie_banner_id
+	AND %s
 ORDER BY
 	rank ASC, id ASC;
 `
 
-	q = fmt.Sprintf(q, scope.SQLFragment())
+	q = fmt.Sprintf(q, scope.SQLFragment(), filter.SQLFragment())
 
 	args := pgx.StrictNamedArgs{"cookie_banner_id": cookieBannerID}
 	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, filter.SQLArguments())
 
 	rows, err := conn.Query(ctx, q, args)
 	if err != nil {
@@ -408,61 +328,6 @@ ORDER BY
 	categories, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[CookieCategory])
 	if err != nil {
 		return fmt.Errorf("cannot collect cookie categories: %w", err)
-	}
-
-	*c = categories
-
-	return nil
-}
-
-// LoadAllConsentCategoriesByCookieBannerID loads all categories except
-// UNCATEGORISED, which is an admin-side inbox never shown to visitors.
-func (c *CookieCategories) LoadAllConsentCategoriesByCookieBannerID(
-	ctx context.Context,
-	conn pg.Querier,
-	scope Scoper,
-	cookieBannerID gid.GID,
-) error {
-	q := `
-SELECT
-	id,
-	organization_id,
-	cookie_banner_id,
-	name,
-	slug,
-	description,
-	kind,
-	rank,
-	gcm_consent_types,
-	posthog_consent,
-	created_at,
-	updated_at
-FROM
-	cookie_categories
-WHERE
-	%s
-	AND cookie_banner_id = @cookie_banner_id
-	AND kind != @excluded_kind
-ORDER BY
-	rank ASC, id ASC;
-`
-
-	q = fmt.Sprintf(q, scope.SQLFragment())
-
-	args := pgx.StrictNamedArgs{
-		"cookie_banner_id": cookieBannerID,
-		"excluded_kind":    CookieCategoryKindUncategorised,
-	}
-	maps.Copy(args, scope.SQLArguments())
-
-	rows, err := conn.Query(ctx, q, args)
-	if err != nil {
-		return fmt.Errorf("cannot query consent cookie categories: %w", err)
-	}
-
-	categories, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[CookieCategory])
-	if err != nil {
-		return fmt.Errorf("cannot collect consent cookie categories: %w", err)
 	}
 
 	*c = categories

--- a/pkg/coredata/cookie_category_filter.go
+++ b/pkg/coredata/cookie_category_filter.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"github.com/jackc/pgx/v5"
+)
+
+type CookieCategoryFilter struct {
+	excludeKind *CookieCategoryKind
+}
+
+func NewCookieCategoryFilter(excludeKind *CookieCategoryKind) *CookieCategoryFilter {
+	return &CookieCategoryFilter{excludeKind: excludeKind}
+}
+
+func (f *CookieCategoryFilter) SQLFragment() string {
+	if f == nil {
+		return "TRUE"
+	}
+
+	return `(
+	CASE
+		WHEN @has_exclude_kind_filter::boolean = false THEN TRUE
+		WHEN @has_exclude_kind_filter::boolean = true THEN
+			kind != @filter_exclude_kind::cookie_category_kind
+		ELSE TRUE
+	END
+)`
+}
+
+func (f *CookieCategoryFilter) SQLArguments() pgx.StrictNamedArgs {
+	if f == nil {
+		return pgx.StrictNamedArgs{
+			"has_exclude_kind_filter": false,
+			"filter_exclude_kind":     nil,
+		}
+	}
+
+	args := pgx.StrictNamedArgs{
+		"has_exclude_kind_filter": false,
+		"filter_exclude_kind":     nil,
+	}
+
+	if f.excludeKind != nil {
+		args["has_exclude_kind_filter"] = true
+		args["filter_exclude_kind"] = string(*f.excludeKind)
+	}
+
+	return args
+}

--- a/pkg/coredata/detected_tracker.go
+++ b/pkg/coredata/detected_tracker.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/page"
 )
 
 type (
@@ -44,6 +45,21 @@ type (
 
 	DetectedTrackers []*DetectedTracker
 )
+
+func (dt *DetectedTracker) CursorKey(field DetectedTrackerOrderField) page.CursorKey {
+	switch field {
+	case DetectedTrackerOrderFieldInitiatorURL:
+		if dt.InitiatorURL == nil {
+			return page.NewCursorKey(dt.ID, "")
+		}
+
+		return page.NewCursorKey(dt.ID, *dt.InitiatorURL)
+	case DetectedTrackerOrderFieldLastDetectedAt:
+		return page.NewCursorKey(dt.ID, dt.LastDetectedAt)
+	}
+
+	panic(fmt.Sprintf("unsupported order by: %s", field))
+}
 
 func (dt *DetectedTracker) Upsert(
 	ctx context.Context,
@@ -181,6 +197,59 @@ LIMIT @limit;
 	}
 
 	return domains, nil
+}
+
+func (dts *DetectedTrackers) LoadByTrackerPatternID(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	trackerPatternID gid.GID,
+	cursor *page.Cursor[DetectedTrackerOrderField],
+) error {
+	q := `
+SELECT
+	id,
+	cookie_banner_id,
+	tracker_pattern_id,
+	tracker_type,
+	identifier,
+	max_age_seconds,
+	source,
+	value_size,
+	initiator_url,
+	initiator_domain,
+	last_detected_at,
+	created_at,
+	updated_at
+FROM
+	detected_trackers
+WHERE
+	%s
+	AND tracker_pattern_id = @tracker_pattern_id
+	AND %s
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment(), cursor.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"tracker_pattern_id": trackerPatternID,
+	}
+	maps.Copy(args, scope.SQLArguments())
+	maps.Copy(args, cursor.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query detected trackers: %w", err)
+	}
+
+	trackers, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[DetectedTracker])
+	if err != nil {
+		return fmt.Errorf("cannot collect detected trackers: %w", err)
+	}
+
+	*dts = trackers
+
+	return nil
 }
 
 func (dts *DetectedTrackers) RelinkByTrackerPatternID(

--- a/pkg/coredata/detected_tracker_order_field.go
+++ b/pkg/coredata/detected_tracker_order_field.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"encoding"
+	"fmt"
+
+	"go.probo.inc/probo/pkg/page"
+)
+
+type DetectedTrackerOrderField string
+
+const (
+	DetectedTrackerOrderFieldInitiatorURL   DetectedTrackerOrderField = "INITIATOR_URL"
+	DetectedTrackerOrderFieldLastDetectedAt DetectedTrackerOrderField = "LAST_DETECTED_AT"
+)
+
+var (
+	_ page.OrderField          = DetectedTrackerOrderField("")
+	_ fmt.Stringer             = DetectedTrackerOrderField("")
+	_ encoding.TextMarshaler   = DetectedTrackerOrderField("")
+	_ encoding.TextUnmarshaler = (*DetectedTrackerOrderField)(nil)
+)
+
+func DetectedTrackerOrderFields() []DetectedTrackerOrderField {
+	return []DetectedTrackerOrderField{
+		DetectedTrackerOrderFieldInitiatorURL,
+		DetectedTrackerOrderFieldLastDetectedAt,
+	}
+}
+
+func (v DetectedTrackerOrderField) IsValid() bool {
+	switch v {
+	case
+		DetectedTrackerOrderFieldInitiatorURL,
+		DetectedTrackerOrderFieldLastDetectedAt:
+		return true
+	}
+
+	return false
+}
+
+func (v DetectedTrackerOrderField) String() string {
+	return string(v)
+}
+
+func (v DetectedTrackerOrderField) MarshalText() ([]byte, error) {
+	return []byte(v.String()), nil
+}
+
+func (v *DetectedTrackerOrderField) UnmarshalText(text []byte) error {
+	val := DetectedTrackerOrderField(text)
+	if !val.IsValid() {
+		return fmt.Errorf("invalid DetectedTrackerOrderField value: %q", string(text))
+	}
+
+	*v = val
+
+	return nil
+}
+
+func (p DetectedTrackerOrderField) Column() string {
+	switch p {
+	case DetectedTrackerOrderFieldInitiatorURL:
+		return "COALESCE(initiator_url, '')"
+	case DetectedTrackerOrderFieldLastDetectedAt:
+		return "last_detected_at"
+	}
+
+	panic(fmt.Sprintf("unsupported order by: %s", p))
+}

--- a/pkg/coredata/tracker_pattern.go
+++ b/pkg/coredata/tracker_pattern.go
@@ -647,7 +647,7 @@ WHERE
 	return nil
 }
 
-func (tps *TrackerPatterns) LoadUncategorisedByCookieBannerID(
+func (tps *TrackerPatterns) LoadByCookieBannerID(
 	ctx context.Context,
 	conn pg.Querier,
 	scope Scoper,
@@ -680,22 +680,14 @@ FROM
 WHERE
 	%s
 	AND cookie_banner_id = @cookie_banner_id
-	AND cookie_category_id = (
-		SELECT id FROM cookie_categories
-		WHERE cookie_banner_id = @cookie_banner_id
-			AND kind = @category_kind
-			AND %s
-		LIMIT 1
-	)
 	AND %s
 	AND %s
 `
 
-	q = fmt.Sprintf(q, scope.SQLFragment(), scope.SQLFragment(), filter.SQLFragment(), cursor.SQLFragment())
+	q = fmt.Sprintf(q, scope.SQLFragment(), filter.SQLFragment(), cursor.SQLFragment())
 
 	args := pgx.StrictNamedArgs{
 		"cookie_banner_id": cookieBannerID,
-		"category_kind":    CookieCategoryKindUncategorised,
 	}
 	maps.Copy(args, scope.SQLArguments())
 	maps.Copy(args, filter.SQLArguments())
@@ -703,12 +695,12 @@ WHERE
 
 	rows, err := conn.Query(ctx, q, args)
 	if err != nil {
-		return fmt.Errorf("cannot query uncategorised tracker patterns: %w", err)
+		return fmt.Errorf("cannot query tracker patterns: %w", err)
 	}
 
 	patterns, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[TrackerPattern])
 	if err != nil {
-		return fmt.Errorf("cannot collect uncategorised tracker patterns: %w", err)
+		return fmt.Errorf("cannot collect tracker patterns: %w", err)
 	}
 
 	*tps = patterns
@@ -716,7 +708,7 @@ WHERE
 	return nil
 }
 
-func (tps *TrackerPatterns) CountUncategorisedByCookieBannerID(
+func (tps *TrackerPatterns) CountByCookieBannerID(
 	ctx context.Context,
 	conn pg.Querier,
 	scope Scoper,
@@ -731,21 +723,13 @@ FROM
 WHERE
 	%s
 	AND cookie_banner_id = @cookie_banner_id
-	AND cookie_category_id = (
-		SELECT id FROM cookie_categories
-		WHERE cookie_banner_id = @cookie_banner_id
-			AND kind = @category_kind
-			AND %s
-		LIMIT 1
-	)
 	AND %s
 `
 
-	q = fmt.Sprintf(q, scope.SQLFragment(), scope.SQLFragment(), filter.SQLFragment())
+	q = fmt.Sprintf(q, scope.SQLFragment(), filter.SQLFragment())
 
 	args := pgx.StrictNamedArgs{
 		"cookie_banner_id": cookieBannerID,
-		"category_kind":    CookieCategoryKindUncategorised,
 	}
 	maps.Copy(args, scope.SQLArguments())
 	maps.Copy(args, filter.SQLArguments())
@@ -754,7 +738,7 @@ WHERE
 
 	var count int
 	if err := row.Scan(&count); err != nil {
-		return 0, fmt.Errorf("cannot scan count: %w", err)
+		return 0, fmt.Errorf("cannot count tracker patterns: %w", err)
 	}
 
 	return count, nil

--- a/pkg/server/api/console/v1/base_resolvers.go
+++ b/pkg/server/api/console/v1/base_resolvers.go
@@ -465,6 +465,18 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 
 			return types.NewCookieConsentRecord(record), nil
 		}
+	case coredata.TrackerPatternEntityType:
+		action = probo.ActionTrackerPatternGet
+		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+			scope := coredata.NewScopeFromObjectID(id)
+
+			pattern, err := r.cookieBanner.GetTrackerPattern(ctx, scope, id)
+			if err != nil {
+				return nil, err
+			}
+
+			return types.NewTrackerPatternNode(pattern), nil
+		}
 	case coredata.CookieBannerVersionEntityType:
 		action = probo.ActionCookieBannerVersionGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {

--- a/pkg/server/api/console/v1/cookie_banner_resolvers.go
+++ b/pkg/server/api/console/v1/cookie_banner_resolvers.go
@@ -434,6 +434,19 @@ func (r *cookieCategoryConnectionResolver) TotalCount(ctx context.Context, obj *
 	return count, nil
 }
 
+// TotalCount is the resolver for the totalCount field.
+func (r *detectedTrackerConnectionResolver) TotalCount(ctx context.Context, obj *types.DetectedTrackerConnection) (int, error) {
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+
+	count, err := r.cookieBanner.CountDetectedTrackersByPatternID(ctx, scope, obj.ParentID)
+	if err != nil {
+		r.logger.ErrorCtx(ctx, "cannot count detected trackers", log.Error(err))
+		return 0, gqlutils.Internal(ctx)
+	}
+
+	return count, nil
+}
+
 // CreateCookieBanner is the resolver for the createCookieBanner field.
 func (r *mutationResolver) CreateCookieBanner(ctx context.Context, input types.CreateCookieBannerInput) (*types.CreateCookieBannerPayload, error) {
 	if err := r.authorize(ctx, input.OrganizationID, probo.ActionCookieBannerCreate); err != nil {
@@ -1278,6 +1291,37 @@ func (r *trackerPatternResolver) DetectedCount(ctx context.Context, obj *types.T
 	return count, nil
 }
 
+// DetectedTrackers is the resolver for the detectedTrackers field.
+func (r *trackerPatternResolver) DetectedTrackers(ctx context.Context, obj *types.TrackerPattern, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DetectedTrackerOrderBy) (*types.DetectedTrackerConnection, error) {
+	if err := r.authorize(ctx, obj.ID, probo.ActionTrackerPatternGet); err != nil {
+		return nil, err
+	}
+
+	pageOrderBy := page.OrderBy[coredata.DetectedTrackerOrderField]{
+		Field:     coredata.DetectedTrackerOrderFieldLastDetectedAt,
+		Direction: page.OrderDirectionDesc,
+	}
+	if orderBy != nil {
+		pageOrderBy = page.OrderBy[coredata.DetectedTrackerOrderField]{
+			Field:     orderBy.Field,
+			Direction: orderBy.Direction,
+		}
+	}
+
+	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+
+	trackers, err := r.cookieBanner.ListDetectedTrackersForPattern(ctx, scope, obj.ID, cursor)
+	if err != nil {
+		r.logger.ErrorCtx(ctx, "cannot list detected trackers", log.Error(err))
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	p := page.NewPage(trackers, cursor)
+
+	return types.NewDetectedTrackerConnection(p, r, obj.ID), nil
+}
+
 // Permission is the resolver for the permission field.
 func (r *trackerPatternResolver) Permission(ctx context.Context, obj *types.TrackerPattern, action string) (bool, error) {
 	return r.Resolver.Permission(ctx, obj, action)
@@ -1390,6 +1434,11 @@ func (r *Resolver) CookieCategoryConnection() schema.CookieCategoryConnectionRes
 	return &cookieCategoryConnectionResolver{r}
 }
 
+// DetectedTrackerConnection returns schema.DetectedTrackerConnectionResolver implementation.
+func (r *Resolver) DetectedTrackerConnection() schema.DetectedTrackerConnectionResolver {
+	return &detectedTrackerConnectionResolver{r}
+}
+
 // TrackerPattern returns schema.TrackerPatternResolver implementation.
 func (r *Resolver) TrackerPattern() schema.TrackerPatternResolver { return &trackerPatternResolver{r} }
 
@@ -1413,6 +1462,7 @@ type cookieBannerConnectionResolver struct{ *Resolver }
 type cookieBannerVersionResolver struct{ *Resolver }
 type cookieCategoryResolver struct{ *Resolver }
 type cookieCategoryConnectionResolver struct{ *Resolver }
+type detectedTrackerConnectionResolver struct{ *Resolver }
 type trackerPatternResolver struct{ *Resolver }
 type trackerPatternConnectionResolver struct{ *Resolver }
 type trackerResourceResolver struct{ *Resolver }

--- a/pkg/server/api/console/v1/cookie_banner_resolvers.go
+++ b/pkg/server/api/console/v1/cookie_banner_resolvers.go
@@ -69,6 +69,7 @@ func (r *cookieBannerResolver) Categories(ctx context.Context, obj *types.Cookie
 	if filter != nil {
 		excludeKind = filter.ExcludeKind
 	}
+
 	cdFilter := coredata.NewCookieCategoryFilter(excludeKind)
 
 	categories, err := r.cookieBanner.ListCategoriesForBanner(ctx, scope, obj.ID, cursor, cdFilter)

--- a/pkg/server/api/console/v1/cookie_banner_resolvers.go
+++ b/pkg/server/api/console/v1/cookie_banner_resolvers.go
@@ -45,8 +45,8 @@ func (r *cookieBannerResolver) Organization(ctx context.Context, obj *types.Cook
 	return types.NewOrganization(organization), nil
 }
 
-// ConsentCategories is the resolver for the consentCategories field.
-func (r *cookieBannerResolver) ConsentCategories(ctx context.Context, obj *types.CookieBanner, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.CookieCategoryOrderBy) (*types.CookieCategoryConnection, error) {
+// Categories is the resolver for the categories field.
+func (r *cookieBannerResolver) Categories(ctx context.Context, obj *types.CookieBanner, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.CookieCategoryOrderBy, filter *types.CookieCategoryFilter) (*types.CookieCategoryConnection, error) {
 	if err := r.authorize(ctx, obj.ID, probo.ActionCookieCategoryList); err != nil {
 		return nil, err
 	}
@@ -65,7 +65,12 @@ func (r *cookieBannerResolver) ConsentCategories(ctx context.Context, obj *types
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 	scope := coredata.NewScopeFromObjectID(obj.ID)
 
-	categories, err := r.cookieBanner.ListCookieCategoriesForBanner(ctx, scope, obj.ID, cursor)
+	var cdFilter *coredata.CookieCategoryFilter
+	if filter != nil && filter.ExcludeKind != nil {
+		cdFilter = coredata.NewCookieCategoryFilter(filter.ExcludeKind)
+	}
+
+	categories, err := r.cookieBanner.ListCategoriesForBanner(ctx, scope, obj.ID, cursor, cdFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list cookie categories", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -73,7 +78,7 @@ func (r *cookieBannerResolver) ConsentCategories(ctx context.Context, obj *types
 
 	p := page.NewPage(categories, cursor)
 
-	return types.NewCookieCategoryConnection(p, r, obj.ID), nil
+	return types.NewCookieCategoryConnectionWithFilter(p, r, obj.ID, cdFilter), nil
 }
 
 // Translations is the resolver for the translations field.
@@ -180,8 +185,8 @@ func (r *cookieBannerResolver) ConsentRecords(ctx context.Context, obj *types.Co
 	return types.NewCookieConsentRecordConnection(p, r, obj.ID, coredataFilter), nil
 }
 
-// UncategorisedTrackerPatterns is the resolver for the uncategorisedTrackerPatterns field.
-func (r *cookieBannerResolver) UncategorisedTrackerPatterns(ctx context.Context, obj *types.CookieBanner, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TrackerPatternOrderBy, filter *types.TrackerPatternFilter) (*types.TrackerPatternConnection, error) {
+// TrackerPatterns is the resolver for the trackerPatterns field.
+func (r *cookieBannerResolver) TrackerPatterns(ctx context.Context, obj *types.CookieBanner, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TrackerPatternOrderBy, filter *types.TrackerPatternFilter) (*types.TrackerPatternConnection, error) {
 	if err := r.authorize(ctx, obj.ID, probo.ActionTrackerPatternList); err != nil {
 		return nil, err
 	}
@@ -202,12 +207,13 @@ func (r *cookieBannerResolver) UncategorisedTrackerPatterns(ctx context.Context,
 
 	coredataFilter := coredata.NewTrackerPatternFilter(nil, nil, nil)
 	if filter != nil {
+		coredataFilter = coredata.NewTrackerPatternFilter(nil, filter.CookieCategoryID, nil)
 		coredataFilter = coredataFilter.WithQuery(filter.Query).WithSource(filter.Source).WithTrackerType(filter.TrackerType)
 	}
 
-	patterns, err := r.cookieBanner.ListUncategorisedTrackerPatterns(ctx, scope, obj.ID, cursor, coredataFilter)
+	patterns, err := r.cookieBanner.ListTrackerPatternsForBanner(ctx, scope, obj.ID, cursor, coredataFilter)
 	if err != nil {
-		r.logger.ErrorCtx(ctx, "cannot list uncategorised tracker patterns", log.Error(err))
+		r.logger.ErrorCtx(ctx, "cannot list tracker patterns", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
 
@@ -418,7 +424,7 @@ func (r *cookieCategoryConnectionResolver) TotalCount(ctx context.Context, obj *
 
 	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 
-	count, err := r.cookieBanner.CountCookieCategoriesForBanner(ctx, scope, obj.ParentID)
+	count, err := r.cookieBanner.CountCategoriesForBanner(ctx, scope, obj.ParentID, obj.Filter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot count cookie categories", log.Error(err))
 		return 0, gqlutils.Internal(ctx)
@@ -1291,10 +1297,11 @@ func (r *trackerPatternConnectionResolver) TotalCount(ctx context.Context, obj *
 	default:
 		filter := coredata.NewTrackerPatternFilter(nil, nil, nil)
 		if obj.Filter != nil {
+			filter = coredata.NewTrackerPatternFilter(nil, obj.Filter.CookieCategoryID, nil)
 			filter = filter.WithQuery(obj.Filter.Query).WithSource(obj.Filter.Source).WithTrackerType(obj.Filter.TrackerType)
 		}
 
-		count, err = r.cookieBanner.CountUncategorisedTrackerPatterns(ctx, scope, obj.ParentID, filter)
+		count, err = r.cookieBanner.CountTrackerPatternsForBanner(ctx, scope, obj.ParentID, filter)
 	}
 
 	if err != nil {

--- a/pkg/server/api/console/v1/cookie_banner_resolvers.go
+++ b/pkg/server/api/console/v1/cookie_banner_resolvers.go
@@ -65,10 +65,11 @@ func (r *cookieBannerResolver) Categories(ctx context.Context, obj *types.Cookie
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 	scope := coredata.NewScopeFromObjectID(obj.ID)
 
-	var cdFilter *coredata.CookieCategoryFilter
-	if filter != nil && filter.ExcludeKind != nil {
-		cdFilter = coredata.NewCookieCategoryFilter(filter.ExcludeKind)
+	var excludeKind *coredata.CookieCategoryKind
+	if filter != nil {
+		excludeKind = filter.ExcludeKind
 	}
+	cdFilter := coredata.NewCookieCategoryFilter(excludeKind)
 
 	categories, err := r.cookieBanner.ListCategoriesForBanner(ctx, scope, obj.ID, cursor, cdFilter)
 	if err != nil {

--- a/pkg/server/api/console/v1/graphql/cookie_banner.graphql
+++ b/pkg/server/api/console/v1/graphql/cookie_banner.graphql
@@ -112,6 +112,13 @@ input CookieCategoryOrder
     field: CookieCategoryOrderField!
 }
 
+input CookieCategoryFilter
+    @goModel(
+        model: "go.probo.inc/probo/pkg/server/api/console/v1/types.CookieCategoryFilter"
+    ) {
+    excludeKind: CookieCategoryKind
+}
+
 type CookieBanner implements Node {
     id: ID!
     name: String!
@@ -125,12 +132,13 @@ type CookieBanner implements Node {
 
     organization: Organization @goField(forceResolver: true)
 
-    consentCategories(
+    categories(
         first: Int
         after: CursorKey
         last: Int
         before: CursorKey
         orderBy: CookieCategoryOrder
+        filter: CookieCategoryFilter
     ): CookieCategoryConnection @goField(forceResolver: true)
 
     translations: [CookieBannerTranslation!]! @goField(forceResolver: true)
@@ -146,7 +154,7 @@ type CookieBanner implements Node {
         filter: CookieConsentRecordFilter
     ): CookieConsentRecordConnection @goField(forceResolver: true)
 
-    uncategorisedTrackerPatterns(
+    trackerPatterns(
         first: Int
         after: CursorKey
         last: Int
@@ -299,6 +307,7 @@ input TrackerPatternFilter
     query: String
     source: CookieSource
     trackerType: TrackerType
+    cookieCategoryId: ID
 }
 
 enum TrackerResourceType

--- a/pkg/server/api/console/v1/graphql/cookie_banner.graphql
+++ b/pkg/server/api/console/v1/graphql/cookie_banner.graphql
@@ -275,6 +275,14 @@ type TrackerPattern implements Node {
     createdAt: Datetime!
     updatedAt: Datetime!
 
+    detectedTrackers(
+        first: Int
+        after: CursorKey
+        last: Int
+        before: CursorKey
+        orderBy: DetectedTrackerOrder
+    ): DetectedTrackerConnection @goField(forceResolver: true)
+
     permission(action: String!): Boolean! @goField(forceResolver: true)
 }
 
@@ -308,6 +316,52 @@ input TrackerPatternFilter
     source: CookieSource
     trackerType: TrackerType
     cookieCategoryId: ID
+}
+
+type DetectedTracker implements Node {
+    id: ID!
+    identifier: String!
+    initiatorUrl: String
+    maxAgeSeconds: Int
+    source: CookieSource
+    lastDetectedAt: Datetime!
+    createdAt: Datetime!
+}
+
+enum DetectedTrackerOrderField
+    @goModel(
+        model: "go.probo.inc/probo/pkg/coredata.DetectedTrackerOrderField"
+    ) {
+    INITIATOR_URL
+        @goEnum(
+            value: "go.probo.inc/probo/pkg/coredata.DetectedTrackerOrderFieldInitiatorURL"
+        )
+    LAST_DETECTED_AT
+        @goEnum(
+            value: "go.probo.inc/probo/pkg/coredata.DetectedTrackerOrderFieldLastDetectedAt"
+        )
+}
+
+input DetectedTrackerOrder
+    @goModel(
+        model: "go.probo.inc/probo/pkg/server/api/console/v1/types.DetectedTrackerOrderBy"
+    ) {
+    direction: OrderDirection!
+    field: DetectedTrackerOrderField!
+}
+
+type DetectedTrackerConnection
+    @goModel(
+        model: "go.probo.inc/probo/pkg/server/api/console/v1/types.DetectedTrackerConnection"
+    ) {
+    totalCount: Int! @goField(forceResolver: true)
+    edges: [DetectedTrackerEdge!]!
+    pageInfo: PageInfo!
+}
+
+type DetectedTrackerEdge {
+    cursor: CursorKey!
+    node: DetectedTracker!
 }
 
 enum TrackerResourceType

--- a/pkg/server/api/console/v1/types/cookie_category.go
+++ b/pkg/server/api/console/v1/types/cookie_category.go
@@ -23,6 +23,10 @@ import (
 type (
 	CookieCategoryOrderBy OrderBy[coredata.CookieCategoryOrderField]
 
+	CookieCategoryFilter struct {
+		ExcludeKind *coredata.CookieCategoryKind
+	}
+
 	CookieCategoryConnection struct {
 		TotalCount int
 		Edges      []*CookieCategoryEdge
@@ -30,6 +34,7 @@ type (
 
 		Resolver any
 		ParentID gid.GID
+		Filter   *coredata.CookieCategoryFilter
 	}
 )
 
@@ -51,6 +56,18 @@ func NewCookieCategoryConnection(
 		Resolver: parentType,
 		ParentID: parentID,
 	}
+}
+
+func NewCookieCategoryConnectionWithFilter(
+	p *page.Page[*coredata.CookieCategory, coredata.CookieCategoryOrderField],
+	parentType any,
+	parentID gid.GID,
+	filter *coredata.CookieCategoryFilter,
+) *CookieCategoryConnection {
+	conn := NewCookieCategoryConnection(p, parentType, parentID)
+	conn.Filter = filter
+
+	return conn
 }
 
 func NewCookieCategoryEdge(c *coredata.CookieCategory, orderBy coredata.CookieCategoryOrderField) *CookieCategoryEdge {

--- a/pkg/server/api/console/v1/types/detected_tracker.go
+++ b/pkg/server/api/console/v1/types/detected_tracker.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package types
+
+import (
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/page"
+)
+
+type (
+	DetectedTrackerOrderBy OrderBy[coredata.DetectedTrackerOrderField]
+
+	DetectedTrackerConnection struct {
+		TotalCount int
+		Edges      []*DetectedTrackerEdge
+		PageInfo   PageInfo
+
+		Resolver any
+		ParentID gid.GID
+	}
+)
+
+func NewDetectedTrackerConnection(
+	p *page.Page[*coredata.DetectedTracker, coredata.DetectedTrackerOrderField],
+	parentType any,
+	parentID gid.GID,
+) *DetectedTrackerConnection {
+	edges := make([]*DetectedTrackerEdge, len(p.Data))
+
+	for i := range edges {
+		edges[i] = NewDetectedTrackerEdge(p.Data[i], p.Cursor.OrderBy.Field)
+	}
+
+	return &DetectedTrackerConnection{
+		Edges:    edges,
+		PageInfo: *NewPageInfo(p),
+
+		Resolver: parentType,
+		ParentID: parentID,
+	}
+}
+
+func NewDetectedTrackerEdge(
+	dt *coredata.DetectedTracker,
+	orderBy coredata.DetectedTrackerOrderField,
+) *DetectedTrackerEdge {
+	return &DetectedTrackerEdge{
+		Cursor: dt.CursorKey(orderBy),
+		Node:   NewDetectedTrackerNode(dt),
+	}
+}
+
+func NewDetectedTrackerNode(dt *coredata.DetectedTracker) *DetectedTracker {
+	return &DetectedTracker{
+		ID:             dt.ID,
+		Identifier:     dt.Identifier,
+		InitiatorURL:   dt.InitiatorURL,
+		MaxAgeSeconds:  dt.MaxAgeSeconds,
+		Source:         dt.Source,
+		LastDetectedAt: dt.LastDetectedAt,
+		CreatedAt:      dt.CreatedAt,
+	}
+}

--- a/pkg/server/api/console/v1/types/tracker_pattern.go
+++ b/pkg/server/api/console/v1/types/tracker_pattern.go
@@ -34,9 +34,10 @@ type (
 	}
 
 	TrackerPatternFilter struct {
-		Query       *string
-		Source      *coredata.CookieSource
-		TrackerType *coredata.TrackerType
+		Query            *string
+		Source           *coredata.CookieSource
+		TrackerType      *coredata.TrackerType
+		CookieCategoryID *gid.GID
 	}
 )
 

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -5053,7 +5053,7 @@ func (r *Resolver) ListCookieCategoriesTool(ctx context.Context, req *mcp.CallTo
 	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieCategoryOrderField]{Field: coredata.CookieCategoryOrderFieldRank, Direction: page.OrderDirectionAsc})
 
-	categories, err := r.cookieBanner.ListCookieCategoriesForBanner(ctx, scope, input.CookieBannerID, cursor)
+	categories, err := r.cookieBanner.ListCategoriesForBanner(ctx, scope, input.CookieBannerID, cursor, coredata.NewCookieCategoryFilter(new(coredata.CookieCategoryKindUncategorised)))
 	if err != nil {
 		panic(fmt.Errorf("cannot list cookie categories: %w", err))
 	}


### PR DESCRIPTION
Closes ENG-390


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies cookie category queries behind a new `CookieCategoryFilter`, updates the tracker patterns UI to show and filter by category, and adds a tracker pattern detail page with properties and detected trackers. GraphQL now uses `categories` and `trackerPatterns` (with filters to exclude `UNCATEGORISED` or target a category) and adds `detectedTrackers`; the filter is always instantiated to avoid nil-pointer issues.

- New Features
  - Tracker patterns page: added Category column, category filter dropdown, and updated empty state copy.
  - Tracker pattern detail page: shows a properties card and a paginated “Detected trackers” table (sortable by initiator URL and detection time). Rows link to this page at `/organizations/:orgId/cookie-banners/:cookieBannerId/trackers/:trackerPatternId`. GraphQL: added `TrackerPattern.detectedTrackers`.

- Migration
  - Replace `consentCategories` with `categories`. Add `filter: { excludeKind: UNCATEGORISED }` where you want to hide the uncategorised inbox.
  - Replace `uncategorisedTrackerPatterns` with `trackerPatterns`. To target a category, use `filter: { cookieCategoryId: "<id>" }`.

<sup>Written for commit 03a5f6c1d4ede72a0db4b99a3b9742cae546c49e. Summary will update on new commits. <a href="https://cubic.dev/pr/getprobo/probo/pull/1203?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



