### PR TITLE
Fix wsl_v5 lint errors and enforce lint on PR CI

### DIFF
--- a/.github/workflows/make.yaml
+++ b/.github/workflows/make.yaml
@@ -274,15 +274,14 @@ jobs:
             exit 1
           fi
       - name: "Run golangci-lint"
+        run: golangci-lint run ./...
+      - name: "Annotate PR with golangci-lint findings"
+        if: failure() && github.event_name == 'pull_request'
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            golangci-lint run --out-format=line-number ./... 2>&1 | \
-              reviewdog -f=golangci-lint -reporter=github-pr-review -filter-mode=nofilter -fail-level=error -name="golangci-lint"
-          else
-            golangci-lint run ./...
-          fi
+          golangci-lint run --out-format=line-number ./... 2>&1 | \
+            reviewdog -f=golangci-lint -reporter=github-pr-review -filter-mode=nofilter -name="golangci-lint" || true
 
   lint-js:
     name: "lint-js"
@@ -302,18 +301,16 @@ jobs:
       - name: "Generate Relay artifacts"
         run: make relay
       - name: "Run eslint"
+        run: npm run lint
+      - name: "Annotate PR with eslint findings"
+        if: failure() && github.event_name == 'pull_request'
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            for dir in apps/console apps/trust packages/ui packages/eslint-config; do
-              (cd "$dir" && npx eslint . --concurrency 4 --format stylish 2>/dev/null) | \
-                reviewdog -f=eslint -reporter=github-pr-review -filter-mode=nofilter -fail-level=error -name="eslint ($dir)"
-            done
-            (cd packages/n8n-node && npx n8n-node lint)
-          else
-            npm run lint
-          fi
+          for dir in apps/console apps/trust packages/ui packages/eslint-config; do
+            (cd "$dir" && npx eslint . --concurrency 4 --format stylish 2>/dev/null) | \
+              reviewdog -f=eslint -reporter=github-pr-review -filter-mode=nofilter -name="eslint ($dir)" || true
+          done
 
   test:
     name: "test"

--- a/pkg/coredata/membership_profile.go
+++ b/pkg/coredata/membership_profile.go
@@ -1421,6 +1421,7 @@ WHERE
 				return ErrResourceInUse
 			}
 		}
+
 		return fmt.Errorf("cannot delete profile: %w", err)
 	}
 

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -2574,6 +2574,7 @@ func (r *Resolver) RemoveUserTool(ctx context.Context, req *mcp.CallToolRequest,
 		if _, ok := errors.AsType[*iam.ErrLastActiveOwner](err); ok {
 			return nil, types.RemoveUserOutput{}, fmt.Errorf("cannot remove last active owner: %w", err)
 		}
+
 		if errors.Is(err, coredata.ErrResourceInUse) {
 			return nil, types.RemoveUserOutput{}, fmt.Errorf("cannot remove user: %w", err)
 		}


### PR DESCRIPTION
Add missing blank lines around if-block boundaries in two files to satisfy wsl_v5, and make lint-go and lint-js fail the build on pull requests (not only on push to main) by always running the strict lint and using reviewdog purely for inline annotations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix wsl_v5 blank-line lint errors in two Go files and enforce strict Go/JS linting on PRs by failing the jobs on errors, with `reviewdog` used only for inline annotations.

- **Refactors**
  - Always run `golangci-lint run ./...` and `npm run lint` on all events; jobs fail on lint errors.
  - On pull requests, send findings to `reviewdog` for inline comments without affecting job status.
  - Simplified workflow by splitting fail-fast lint steps from annotation steps.

<sup>Written for commit 3e82b64f014d85bfda2b6658171b10969cc46542. Summary will update on new commits. <a href="https://cubic.dev/pr/getprobo/probo/pull/1207?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

