### PR TITLE
Remove tenant service pattern

### DIFF
--- a/pkg/probo/asset_service.go
+++ b/pkg/probo/asset_service.go
@@ -27,7 +27,7 @@ import (
 )
 
 type AssetService struct {
-	svc *TenantService
+	svc *Service
 }
 
 type CreateAssetRequest struct {
@@ -83,7 +83,7 @@ func (uar *UpdateAssetRequest) Validate() error {
 }
 
 func (s AssetService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	assetID gid.GID,
 ) (*coredata.Asset, error) {
 	asset := &coredata.Asset{}
@@ -91,7 +91,7 @@ func (s AssetService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return asset.LoadByID(ctx, conn, s.svc.scope, assetID)
+			return asset.LoadByID(ctx, conn, scope, assetID)
 		},
 	)
 	if err != nil {
@@ -102,7 +102,7 @@ func (s AssetService) Get(
 }
 
 func (s AssetService) GetByOwnerID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	ownerID gid.GID,
 ) (*coredata.Asset, error) {
 	asset := &coredata.Asset{OwnerID: ownerID}
@@ -110,7 +110,7 @@ func (s AssetService) GetByOwnerID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return asset.LoadByOwnerID(ctx, conn, s.svc.scope)
+			return asset.LoadByOwnerID(ctx, conn, scope)
 		},
 	)
 	if err != nil {
@@ -121,7 +121,7 @@ func (s AssetService) GetByOwnerID(
 }
 
 func (s AssetService) CountForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (int, error) {
 	var count int
@@ -131,7 +131,7 @@ func (s AssetService) CountForOrganizationID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			assets := coredata.Assets{}
 
-			count, err = assets.CountByOrganizationID(ctx, conn, s.svc.scope, organizationID)
+			count, err = assets.CountByOrganizationID(ctx, conn, scope, organizationID)
 			if err != nil {
 				return fmt.Errorf("cannot count assets: %w", err)
 			}
@@ -147,7 +147,7 @@ func (s AssetService) CountForOrganizationID(
 }
 
 func (s AssetService) ListForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.AssetOrderField],
 ) (*page.Page[*coredata.Asset, coredata.AssetOrderField], error) {
@@ -159,7 +159,7 @@ func (s AssetService) ListForOrganizationID(
 			return assets.LoadByOrganizationID(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				organizationID,
 				cursor,
 			)
@@ -173,7 +173,7 @@ func (s AssetService) ListForOrganizationID(
 }
 
 func (s AssetService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req UpdateAssetRequest,
 ) (*coredata.Asset, error) {
 	if err := req.Validate(); err != nil {
@@ -185,7 +185,7 @@ func (s AssetService) Update(
 	assetThirdParties := &coredata.AssetThirdParties{}
 
 	err := s.svc.pg.WithTx(ctx, func(ctx context.Context, conn pg.Tx) error {
-		if err := asset.LoadByID(ctx, conn, s.svc.scope, req.ID); err != nil {
+		if err := asset.LoadByID(ctx, conn, scope, req.ID); err != nil {
 			return fmt.Errorf("cannot load asset: %w", err)
 		}
 
@@ -200,7 +200,7 @@ func (s AssetService) Update(
 
 		if req.OwnerID != nil {
 			profile := &coredata.MembershipProfile{}
-			if err := profile.LoadByID(ctx, conn, s.svc.scope, *req.OwnerID); err != nil {
+			if err := profile.LoadByID(ctx, conn, scope, *req.OwnerID); err != nil {
 				return fmt.Errorf("cannot load owner profile: %w", err)
 			}
 
@@ -215,12 +215,12 @@ func (s AssetService) Update(
 			asset.DataTypesStored = *req.DataTypesStored
 		}
 
-		if err := asset.Update(ctx, conn, s.svc.scope); err != nil {
+		if err := asset.Update(ctx, conn, scope); err != nil {
 			return fmt.Errorf("cannot update asset: %w", err)
 		}
 
 		if req.ThirdPartyIDs != nil {
-			if err := assetThirdParties.Merge(ctx, conn, s.svc.scope, asset.ID, asset.OrganizationID, req.ThirdPartyIDs); err != nil {
+			if err := assetThirdParties.Merge(ctx, conn, scope, asset.ID, asset.OrganizationID, req.ThirdPartyIDs); err != nil {
 				return fmt.Errorf("cannot update asset thirdParties: %w", err)
 			}
 		}
@@ -235,7 +235,7 @@ func (s AssetService) Update(
 }
 
 func (s AssetService) Create(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req CreateAssetRequest,
 ) (*coredata.Asset, error) {
 	if err := req.Validate(); err != nil {
@@ -243,7 +243,7 @@ func (s AssetService) Create(
 	}
 
 	now := time.Now()
-	assetID := gid.New(s.svc.scope.GetTenantID(), coredata.AssetEntityType)
+	assetID := gid.New(scope.GetTenantID(), coredata.AssetEntityType)
 	assetThirdParties := &coredata.AssetThirdParties{}
 
 	asset := &coredata.Asset{
@@ -260,16 +260,16 @@ func (s AssetService) Create(
 
 	err := s.svc.pg.WithTx(ctx, func(ctx context.Context, conn pg.Tx) error {
 		profile := &coredata.MembershipProfile{}
-		if err := profile.LoadByID(ctx, conn, s.svc.scope, req.OwnerID); err != nil {
+		if err := profile.LoadByID(ctx, conn, scope, req.OwnerID); err != nil {
 			return fmt.Errorf("cannot load owner profile: %w", err)
 		}
 
-		if err := asset.Insert(ctx, conn, s.svc.scope); err != nil {
+		if err := asset.Insert(ctx, conn, scope); err != nil {
 			return fmt.Errorf("cannot insert asset: %w", err)
 		}
 
 		if len(req.ThirdPartyIDs) > 0 {
-			if err := assetThirdParties.Insert(ctx, conn, s.svc.scope, asset.ID, asset.OrganizationID, req.ThirdPartyIDs); err != nil {
+			if err := assetThirdParties.Insert(ctx, conn, scope, asset.ID, asset.OrganizationID, req.ThirdPartyIDs); err != nil {
 				return fmt.Errorf("cannot create asset thirdParties: %w", err)
 			}
 		}
@@ -284,7 +284,7 @@ func (s AssetService) Create(
 }
 
 func (s AssetService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	assetID gid.GID,
 ) error {
 	asset := &coredata.Asset{ID: assetID}
@@ -292,7 +292,7 @@ func (s AssetService) Delete(
 	return s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			return asset.Delete(ctx, tx, s.svc.scope)
+			return asset.Delete(ctx, tx, scope)
 		},
 	)
 }

--- a/pkg/probo/audit_service.go
+++ b/pkg/probo/audit_service.go
@@ -30,7 +30,7 @@ import (
 )
 
 type AuditService struct {
-	svc *TenantService
+	svc *Service
 }
 
 type (
@@ -105,7 +105,7 @@ func (uarr *UploadAuditReportRequest) Validate() error {
 }
 
 func (s AuditService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	auditID gid.GID,
 ) (*coredata.Audit, error) {
 	audit := &coredata.Audit{}
@@ -113,7 +113,7 @@ func (s AuditService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return audit.LoadByID(ctx, conn, s.svc.scope, auditID)
+			return audit.LoadByID(ctx, conn, scope, auditID)
 		},
 	)
 	if err != nil {
@@ -124,7 +124,7 @@ func (s AuditService) Get(
 }
 
 func (s AuditService) GetByReportID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	reportID gid.GID,
 ) (*coredata.Audit, error) {
 	audit := &coredata.Audit{}
@@ -132,7 +132,7 @@ func (s AuditService) GetByReportID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return audit.LoadByReportID(ctx, conn, s.svc.scope, reportID)
+			return audit.LoadByReportID(ctx, conn, scope, reportID)
 		},
 	)
 	if err != nil {
@@ -143,7 +143,7 @@ func (s AuditService) GetByReportID(
 }
 
 func (s *AuditService) Create(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *CreateAuditRequest,
 ) (*coredata.Audit, error) {
 	if err := req.Validate(); err != nil {
@@ -152,7 +152,7 @@ func (s *AuditService) Create(
 
 	now := time.Now()
 	audit := &coredata.Audit{
-		ID:                    gid.New(s.svc.scope.GetTenantID(), coredata.AuditEntityType),
+		ID:                    gid.New(scope.GetTenantID(), coredata.AuditEntityType),
 		Name:                  req.Name,
 		OrganizationID:        req.OrganizationID,
 		FrameworkID:           req.FrameworkID,
@@ -176,16 +176,16 @@ func (s *AuditService) Create(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			organization := &coredata.Organization{}
-			if err := organization.LoadByID(ctx, conn, s.svc.scope, req.OrganizationID); err != nil {
+			if err := organization.LoadByID(ctx, conn, scope, req.OrganizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
 			framework := &coredata.Framework{}
-			if err := framework.LoadByID(ctx, conn, s.svc.scope, req.FrameworkID); err != nil {
+			if err := framework.LoadByID(ctx, conn, scope, req.FrameworkID); err != nil {
 				return fmt.Errorf("cannot load framework: %w", err)
 			}
 
-			if err := audit.Insert(ctx, conn, s.svc.scope); err != nil {
+			if err := audit.Insert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot insert audit: %w", err)
 			}
 
@@ -200,7 +200,7 @@ func (s *AuditService) Create(
 }
 
 func (s *AuditService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *UpdateAuditRequest,
 ) (*coredata.Audit, error) {
 	if err := req.Validate(); err != nil {
@@ -212,7 +212,7 @@ func (s *AuditService) Update(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := audit.LoadByID(ctx, conn, s.svc.scope, req.ID); err != nil {
+			if err := audit.LoadByID(ctx, conn, scope, req.ID); err != nil {
 				return fmt.Errorf("cannot load audit: %w", err)
 			}
 
@@ -238,7 +238,7 @@ func (s *AuditService) Update(
 
 			audit.UpdatedAt = time.Now()
 
-			if err := audit.Update(ctx, conn, s.svc.scope); err != nil {
+			if err := audit.Update(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot update audit: %w", err)
 			}
 
@@ -253,7 +253,7 @@ func (s *AuditService) Update(
 }
 
 func (s AuditService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	auditID gid.GID,
 ) error {
 	audit := coredata.Audit{ID: auditID}
@@ -261,7 +261,7 @@ func (s AuditService) Delete(
 	return s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			err := audit.Delete(ctx, tx, s.svc.scope)
+			err := audit.Delete(ctx, tx, scope)
 			if err != nil {
 				return fmt.Errorf("cannot delete audit: %w", err)
 			}
@@ -272,7 +272,7 @@ func (s AuditService) Delete(
 }
 
 func (s AuditService) ListForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.AuditOrderField],
 ) (*page.Page[*coredata.Audit, coredata.AuditOrderField], error) {
@@ -283,7 +283,7 @@ func (s AuditService) ListForOrganizationID(
 		func(ctx context.Context, conn pg.Querier) error {
 			filter := coredata.NewAuditFilter()
 
-			err := audits.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID, cursor, filter)
+			err := audits.LoadByOrganizationID(ctx, conn, scope, organizationID, cursor, filter)
 			if err != nil {
 				return fmt.Errorf("cannot load audits: %w", err)
 			}
@@ -299,7 +299,7 @@ func (s AuditService) ListForOrganizationID(
 }
 
 func (s AuditService) CountForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (int, error) {
 	var count int
@@ -309,7 +309,7 @@ func (s AuditService) CountForOrganizationID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			audits := coredata.Audits{}
 
-			count, err = audits.CountByOrganizationID(ctx, conn, s.svc.scope, organizationID)
+			count, err = audits.CountByOrganizationID(ctx, conn, scope, organizationID)
 			if err != nil {
 				return fmt.Errorf("cannot count audits: %w", err)
 			}
@@ -325,7 +325,7 @@ func (s AuditService) CountForOrganizationID(
 }
 
 func (s AuditService) UploadReport(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req UploadAuditReportRequest,
 ) (*coredata.Audit, error) {
 	if err := req.Validate(); err != nil {
@@ -337,11 +337,11 @@ func (s AuditService) UploadReport(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := audit.LoadByID(ctx, conn, s.svc.scope, req.AuditID); err != nil {
+			if err := audit.LoadByID(ctx, conn, scope, req.AuditID); err != nil {
 				return fmt.Errorf("cannot load audit: %w", err)
 			}
 
-			reportID := gid.New(s.svc.scope.GetTenantID(), coredata.ReportEntityType)
+			reportID := gid.New(scope.GetTenantID(), coredata.ReportEntityType)
 			now := time.Now()
 
 			objectKey, err := uuid.NewV7()
@@ -376,14 +376,14 @@ func (s AuditService) UploadReport(
 				UpdatedAt:      now,
 			}
 
-			if err := report.Insert(ctx, conn, s.svc.scope); err != nil {
+			if err := report.Insert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot insert report: %w", err)
 			}
 
 			audit.ReportID = &report.ID
 			audit.UpdatedAt = time.Now()
 
-			if err := audit.Update(ctx, conn, s.svc.scope); err != nil {
+			if err := audit.Update(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot update audit: %w", err)
 			}
 
@@ -398,11 +398,11 @@ func (s AuditService) UploadReport(
 }
 
 func (s AuditService) GenerateReportURL(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	auditID gid.GID,
 	expiresIn time.Duration,
 ) (*string, error) {
-	audit, err := s.Get(ctx, auditID)
+	audit, err := s.Get(ctx, scope, auditID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get audit: %w", err)
 	}
@@ -411,7 +411,7 @@ func (s AuditService) GenerateReportURL(
 		return nil, fmt.Errorf("audit has no report")
 	}
 
-	url, err := s.svc.Reports.GenerateDownloadURL(ctx, *audit.ReportID, expiresIn)
+	url, err := s.svc.Reports.GenerateDownloadURL(ctx, scope, *audit.ReportID, expiresIn)
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate report download URL: %w", err)
 	}
@@ -420,7 +420,7 @@ func (s AuditService) GenerateReportURL(
 }
 
 func (s AuditService) DeleteReport(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	auditID gid.GID,
 ) (*coredata.Audit, error) {
 	audit := &coredata.Audit{}
@@ -428,21 +428,21 @@ func (s AuditService) DeleteReport(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := audit.LoadByID(ctx, conn, s.svc.scope, auditID); err != nil {
+			if err := audit.LoadByID(ctx, conn, scope, auditID); err != nil {
 				return fmt.Errorf("cannot load audit: %w", err)
 			}
 
 			if audit.ReportID != nil {
 				report := &coredata.Report{ID: *audit.ReportID}
 
-				if err := report.Delete(ctx, conn, s.svc.scope); err != nil {
+				if err := report.Delete(ctx, conn, scope); err != nil {
 					return fmt.Errorf("cannot delete report: %w", err)
 				}
 
 				audit.ReportID = nil
 				audit.UpdatedAt = time.Now()
 
-				if err := audit.Update(ctx, conn, s.svc.scope); err != nil {
+				if err := audit.Update(ctx, conn, scope); err != nil {
 					return fmt.Errorf("cannot update audit: %w", err)
 				}
 			}
@@ -458,7 +458,7 @@ func (s AuditService) DeleteReport(
 }
 
 func (s AuditService) ListForControlID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	controlID gid.GID,
 	cursor *page.Cursor[coredata.AuditOrderField],
 ) (*page.Page[*coredata.Audit, coredata.AuditOrderField], error) {
@@ -469,11 +469,11 @@ func (s AuditService) ListForControlID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := control.LoadByID(ctx, conn, s.svc.scope, controlID); err != nil {
+			if err := control.LoadByID(ctx, conn, scope, controlID); err != nil {
 				return fmt.Errorf("cannot load control: %w", err)
 			}
 
-			err := audits.LoadByControlID(ctx, conn, s.svc.scope, control.ID, cursor)
+			err := audits.LoadByControlID(ctx, conn, scope, control.ID, cursor)
 			if err != nil {
 				return fmt.Errorf("cannot load audits: %w", err)
 			}
@@ -489,7 +489,7 @@ func (s AuditService) ListForControlID(
 }
 
 func (s AuditService) CountForControlID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	controlID gid.GID,
 ) (int, error) {
 	var count int
@@ -499,7 +499,7 @@ func (s AuditService) CountForControlID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			audits := coredata.Audits{}
 
-			count, err = audits.CountByControlID(ctx, conn, s.svc.scope, controlID)
+			count, err = audits.CountByControlID(ctx, conn, scope, controlID)
 			if err != nil {
 				return fmt.Errorf("cannot count audits: %w", err)
 			}
@@ -515,7 +515,7 @@ func (s AuditService) CountForControlID(
 }
 
 func (s AuditService) CountForFindingID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	findingID gid.GID,
 ) (int, error) {
 	var count int
@@ -525,7 +525,7 @@ func (s AuditService) CountForFindingID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			audits := coredata.Audits{}
 
-			count, err = audits.CountByFindingID(ctx, conn, s.svc.scope, findingID)
+			count, err = audits.CountByFindingID(ctx, conn, scope, findingID)
 			if err != nil {
 				return fmt.Errorf("cannot count audits: %w", err)
 			}
@@ -541,7 +541,7 @@ func (s AuditService) CountForFindingID(
 }
 
 func (s AuditService) ListForFindingID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	findingID gid.GID,
 	cursor *page.Cursor[coredata.AuditOrderField],
 ) (*page.Page[*coredata.Audit, coredata.AuditOrderField], error) {
@@ -552,11 +552,11 @@ func (s AuditService) ListForFindingID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := finding.LoadByID(ctx, conn, s.svc.scope, findingID); err != nil {
+			if err := finding.LoadByID(ctx, conn, scope, findingID); err != nil {
 				return fmt.Errorf("cannot load finding: %w", err)
 			}
 
-			err := audits.LoadByFindingID(ctx, conn, s.svc.scope, finding.ID, cursor)
+			err := audits.LoadByFindingID(ctx, conn, scope, finding.ID, cursor)
 			if err != nil {
 				return fmt.Errorf("cannot load audits: %w", err)
 			}

--- a/pkg/probo/compliance_external_url_service.go
+++ b/pkg/probo/compliance_external_url_service.go
@@ -28,7 +28,7 @@ import (
 
 type (
 	ComplianceExternalURLService struct {
-		svc *TenantService
+		svc *Service
 	}
 
 	CreateComplianceExternalURLRequest struct {
@@ -74,7 +74,7 @@ func (r *DeleteComplianceExternalURLRequest) Validate() error {
 }
 
 func (s ComplianceExternalURLService) List(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	trustCenterID gid.GID,
 	cursor *page.Cursor[coredata.ComplianceExternalURLOrderField],
 ) (*page.Page[*coredata.ComplianceExternalURL, coredata.ComplianceExternalURLOrderField], error) {
@@ -83,7 +83,7 @@ func (s ComplianceExternalURLService) List(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := items.LoadByTrustCenterID(ctx, conn, s.svc.scope, trustCenterID, cursor); err != nil {
+			if err := items.LoadByTrustCenterID(ctx, conn, scope, trustCenterID, cursor); err != nil {
 				return fmt.Errorf("cannot load compliance external URLs: %w", err)
 			}
 
@@ -98,7 +98,7 @@ func (s ComplianceExternalURLService) List(
 }
 
 func (s ComplianceExternalURLService) Create(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *CreateComplianceExternalURLRequest,
 ) (*coredata.ComplianceExternalURL, error) {
 	if err := req.Validate(); err != nil {
@@ -106,7 +106,7 @@ func (s ComplianceExternalURLService) Create(
 	}
 
 	now := time.Now()
-	id := gid.New(s.svc.scope.GetTenantID(), coredata.ComplianceExternalURLEntityType)
+	id := gid.New(scope.GetTenantID(), coredata.ComplianceExternalURLEntityType)
 
 	var item *coredata.ComplianceExternalURL
 
@@ -114,7 +114,7 @@ func (s ComplianceExternalURLService) Create(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			trustCenter := &coredata.TrustCenter{}
-			if err := trustCenter.LoadByID(ctx, tx, s.svc.scope, req.TrustCenterID); err != nil {
+			if err := trustCenter.LoadByID(ctx, tx, scope, req.TrustCenterID); err != nil {
 				return fmt.Errorf("cannot load trust center: %w", err)
 			}
 
@@ -128,7 +128,7 @@ func (s ComplianceExternalURLService) Create(
 				UpdatedAt:      now,
 			}
 
-			if err := item.Insert(ctx, tx, s.svc.scope); err != nil {
+			if err := item.Insert(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot insert compliance external URL: %w", err)
 			}
 
@@ -143,7 +143,7 @@ func (s ComplianceExternalURLService) Create(
 }
 
 func (s ComplianceExternalURLService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *UpdateComplianceExternalURLRequest,
 ) (*coredata.ComplianceExternalURL, error) {
 	if err := req.Validate(); err != nil {
@@ -157,7 +157,7 @@ func (s ComplianceExternalURLService) Update(
 		func(ctx context.Context, tx pg.Tx) error {
 			item = &coredata.ComplianceExternalURL{}
 
-			if err := item.LoadByID(ctx, tx, s.svc.scope, req.ID); err != nil {
+			if err := item.LoadByID(ctx, tx, scope, req.ID); err != nil {
 				return fmt.Errorf("cannot load compliance external URL: %w", err)
 			}
 
@@ -167,12 +167,12 @@ func (s ComplianceExternalURLService) Update(
 
 			if req.Rank != nil {
 				item.Rank = *req.Rank
-				if err := item.UpdateRank(ctx, tx, s.svc.scope); err != nil {
+				if err := item.UpdateRank(ctx, tx, scope); err != nil {
 					return fmt.Errorf("cannot update compliance external URL rank: %w", err)
 				}
 			}
 
-			if err := item.Update(ctx, tx, s.svc.scope); err != nil {
+			if err := item.Update(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot update compliance external URL: %w", err)
 			}
 
@@ -187,7 +187,7 @@ func (s ComplianceExternalURLService) Update(
 }
 
 func (s ComplianceExternalURLService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *DeleteComplianceExternalURLRequest,
 ) error {
 	if err := req.Validate(); err != nil {
@@ -199,11 +199,11 @@ func (s ComplianceExternalURLService) Delete(
 		func(ctx context.Context, tx pg.Tx) error {
 			item := &coredata.ComplianceExternalURL{}
 
-			if err := item.LoadByID(ctx, tx, s.svc.scope, req.ID); err != nil {
+			if err := item.LoadByID(ctx, tx, scope, req.ID); err != nil {
 				return fmt.Errorf("cannot load compliance external URL: %w", err)
 			}
 
-			if err := item.Delete(ctx, tx, s.svc.scope); err != nil {
+			if err := item.Delete(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot delete compliance external URL: %w", err)
 			}
 

--- a/pkg/probo/compliance_framework_service.go
+++ b/pkg/probo/compliance_framework_service.go
@@ -28,7 +28,7 @@ import (
 
 type (
 	ComplianceFrameworkService struct {
-		svc *TenantService
+		svc *Service
 	}
 
 	CreateComplianceFrameworkRequest struct {
@@ -72,7 +72,7 @@ func (r *DeleteComplianceFrameworkRequest) Validate() error {
 }
 
 func (s ComplianceFrameworkService) ListWithHiddenForTrustCenterID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	trustCenterID gid.GID,
 	cursor *page.Cursor[coredata.ComplianceFrameworkOrderField],
 ) (*page.Page[*coredata.ComplianceFramework, coredata.ComplianceFrameworkOrderField], error) {
@@ -81,7 +81,7 @@ func (s ComplianceFrameworkService) ListWithHiddenForTrustCenterID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := cfs.LoadWithHiddenByTrustCenterID(ctx, conn, s.svc.scope, trustCenterID, cursor); err != nil {
+			if err := cfs.LoadWithHiddenByTrustCenterID(ctx, conn, scope, trustCenterID, cursor); err != nil {
 				return fmt.Errorf("cannot load compliance frameworks with hidden: %w", err)
 			}
 
@@ -96,7 +96,7 @@ func (s ComplianceFrameworkService) ListWithHiddenForTrustCenterID(
 }
 
 func (s ComplianceFrameworkService) Create(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *CreateComplianceFrameworkRequest,
 ) (*coredata.ComplianceFramework, error) {
 	if err := req.Validate(); err != nil {
@@ -105,7 +105,7 @@ func (s ComplianceFrameworkService) Create(
 
 	now := time.Now()
 
-	cfID := gid.New(s.svc.scope.GetTenantID(), coredata.ComplianceFrameworkEntityType)
+	cfID := gid.New(scope.GetTenantID(), coredata.ComplianceFrameworkEntityType)
 
 	var cf *coredata.ComplianceFramework
 
@@ -113,7 +113,7 @@ func (s ComplianceFrameworkService) Create(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			trustCenter := &coredata.TrustCenter{}
-			if err := trustCenter.LoadByID(ctx, tx, s.svc.scope, req.TrustCenterID); err != nil {
+			if err := trustCenter.LoadByID(ctx, tx, scope, req.TrustCenterID); err != nil {
 				return fmt.Errorf("cannot load trust center: %w", err)
 			}
 
@@ -126,7 +126,7 @@ func (s ComplianceFrameworkService) Create(
 				UpdatedAt:      now,
 			}
 
-			if err := cf.Insert(ctx, tx, s.svc.scope); err != nil {
+			if err := cf.Insert(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot insert compliance framework: %w", err)
 			}
 
@@ -141,7 +141,7 @@ func (s ComplianceFrameworkService) Create(
 }
 
 func (s ComplianceFrameworkService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *UpdateComplianceFrameworkRequest,
 ) (*coredata.ComplianceFramework, error) {
 	if err := req.Validate(); err != nil {
@@ -155,14 +155,14 @@ func (s ComplianceFrameworkService) Update(
 		func(ctx context.Context, tx pg.Tx) error {
 			cf = &coredata.ComplianceFramework{}
 
-			if err := cf.LoadByID(ctx, tx, s.svc.scope, req.ID); err != nil {
+			if err := cf.LoadByID(ctx, tx, scope, req.ID); err != nil {
 				return fmt.Errorf("cannot load compliance framework: %w", err)
 			}
 
 			cf.Rank = req.Rank
 			cf.UpdatedAt = time.Now()
 
-			if err := cf.UpdateRank(ctx, tx, s.svc.scope); err != nil {
+			if err := cf.UpdateRank(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot update compliance framework rank: %w", err)
 			}
 
@@ -177,7 +177,7 @@ func (s ComplianceFrameworkService) Update(
 }
 
 func (s ComplianceFrameworkService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *DeleteComplianceFrameworkRequest,
 ) error {
 	if err := req.Validate(); err != nil {
@@ -189,11 +189,11 @@ func (s ComplianceFrameworkService) Delete(
 		func(ctx context.Context, tx pg.Tx) error {
 			cf := &coredata.ComplianceFramework{}
 
-			if err := cf.LoadByID(ctx, tx, s.svc.scope, req.ID); err != nil {
+			if err := cf.LoadByID(ctx, tx, scope, req.ID); err != nil {
 				return fmt.Errorf("cannot load compliance framework: %w", err)
 			}
 
-			if err := cf.Delete(ctx, tx, s.svc.scope); err != nil {
+			if err := cf.Delete(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot delete compliance framework: %w", err)
 			}
 

--- a/pkg/probo/connector_service.go
+++ b/pkg/probo/connector_service.go
@@ -45,7 +45,7 @@ var (
 
 type (
 	ConnectorService struct {
-		svc *TenantService
+		svc *Service
 	}
 
 	CreateConnectorRequest struct {
@@ -92,7 +92,7 @@ func (rcr *ReconnectConnectorRequest) Validate() error {
 }
 
 func (s *ConnectorService) ListForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.ConnectorOrderField],
 	filter *coredata.ConnectorFilter,
@@ -105,7 +105,7 @@ func (s *ConnectorService) ListForOrganizationID(
 			return connectors.LoadByOrganizationIDWithoutDecryptedConnection(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				organizationID,
 				cursor,
 				filter,
@@ -120,7 +120,7 @@ func (s *ConnectorService) ListForOrganizationID(
 }
 
 func (s *ConnectorService) ListAllForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (coredata.Connectors, error) {
 	var connectors coredata.Connectors
@@ -131,7 +131,7 @@ func (s *ConnectorService) ListAllForOrganizationID(
 			return connectors.LoadAllByOrganizationIDWithoutDecryptedConnection(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				organizationID,
 			)
 		},
@@ -144,7 +144,7 @@ func (s *ConnectorService) ListAllForOrganizationID(
 }
 
 func (s *ConnectorService) GetByOrganizationIDAndProvider(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	provider coredata.ConnectorProvider,
 ) (*coredata.Connector, error) {
@@ -156,7 +156,7 @@ func (s *ConnectorService) GetByOrganizationIDAndProvider(
 			return cnnctr.LoadOneByOrganizationIDAndProvider(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				s.svc.encryptionKey,
 				organizationID,
 				provider,
@@ -177,7 +177,7 @@ func (s *ConnectorService) GetByOrganizationIDAndProvider(
 // Contrast with Get, which uses LoadMetadataByID and returns a
 // connector with Connection == nil.
 func (s *ConnectorService) GetWithConnection(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	connectorID gid.GID,
 ) (*coredata.Connector, error) {
 	cnnctr := &coredata.Connector{}
@@ -185,7 +185,7 @@ func (s *ConnectorService) GetWithConnection(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return cnnctr.LoadByID(ctx, conn, s.svc.scope, connectorID, s.svc.encryptionKey)
+			return cnnctr.LoadByID(ctx, conn, scope, connectorID, s.svc.encryptionKey)
 		},
 	)
 	if err != nil {
@@ -196,7 +196,7 @@ func (s *ConnectorService) GetWithConnection(
 }
 
 func (s *ConnectorService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	connectorID gid.GID,
 ) (*coredata.Connector, error) {
 	connector := &coredata.Connector{}
@@ -204,7 +204,7 @@ func (s *ConnectorService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return connector.LoadMetadataByID(ctx, conn, s.svc.scope, connectorID)
+			return connector.LoadMetadataByID(ctx, conn, scope, connectorID)
 		},
 	)
 	if err != nil {
@@ -215,27 +215,27 @@ func (s *ConnectorService) Get(
 }
 
 func (s *ConnectorService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	connectorID gid.GID,
 ) error {
 	return s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			cnnctr := &coredata.Connector{ID: connectorID}
-			return cnnctr.Delete(ctx, tx, s.svc.scope)
+			return cnnctr.Delete(ctx, tx, scope)
 		},
 	)
 }
 
 func (s *ConnectorService) Create(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req CreateConnectorRequest,
 ) (*coredata.Connector, error) {
 	if err := req.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid request: %w", err)
 	}
 
-	id := gid.New(s.svc.scope.GetTenantID(), coredata.ConnectorEntityType)
+	id := gid.New(scope.GetTenantID(), coredata.ConnectorEntityType)
 	now := time.Now()
 
 	newConnector := &coredata.Connector{
@@ -286,7 +286,7 @@ func (s *ConnectorService) Create(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := newConnector.Insert(ctx, tx, s.svc.scope, s.svc.encryptionKey); err != nil {
+			if err := newConnector.Insert(ctx, tx, scope, s.svc.encryptionKey); err != nil {
 				return fmt.Errorf("cannot create connector: %w", err)
 			}
 
@@ -294,7 +294,7 @@ func (s *ConnectorService) Create(
 				slackConn, ok := req.Connection.(*connector.SlackConnection)
 				if ok && slackConn.Settings.Channel != "" {
 					var organization coredata.Organization
-					if err := organization.LoadByID(ctx, tx, s.svc.scope, req.OrganizationID); err != nil {
+					if err := organization.LoadByID(ctx, tx, scope, req.OrganizationID); err != nil {
 						return fmt.Errorf("cannot load organization: %w", err)
 					}
 
@@ -316,8 +316,8 @@ func (s *ConnectorService) Create(
 						return fmt.Errorf("cannot parse template JSON: %w", err)
 					}
 
-					slackMessage := coredata.NewSlackMessage(s.svc.scope, req.OrganizationID, coredata.SlackMessageTypeWelcome, body)
-					if err := slackMessage.Insert(ctx, tx, s.svc.scope); err != nil {
+					slackMessage := coredata.NewSlackMessage(scope, req.OrganizationID, coredata.SlackMessageTypeWelcome, body)
+					if err := slackMessage.Insert(ctx, tx, scope); err != nil {
 						return fmt.Errorf("cannot insert slack message: %w", err)
 					}
 				}
@@ -340,7 +340,7 @@ func (s *ConnectorService) Create(
 // in the initiate URL. Refresh tokens and Slack webhook settings are
 // preserved from the existing connection when the new one omits them.
 func (s *ConnectorService) Reconnect(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req ReconnectConnectorRequest,
 ) (*coredata.Connector, error) {
 	if err := req.Validate(); err != nil {
@@ -352,7 +352,7 @@ func (s *ConnectorService) Reconnect(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := cnnctr.LoadByID(ctx, conn, s.svc.scope, req.ConnectorID, s.svc.encryptionKey); err != nil {
+			if err := cnnctr.LoadByID(ctx, conn, scope, req.ConnectorID, s.svc.encryptionKey); err != nil {
 				return fmt.Errorf("cannot load connector: %w", err)
 			}
 
@@ -372,7 +372,7 @@ func (s *ConnectorService) Reconnect(
 			cnnctr.Connection = req.Connection
 			cnnctr.UpdatedAt = time.Now()
 
-			return cnnctr.Update(ctx, conn, s.svc.scope, s.svc.encryptionKey)
+			return cnnctr.Update(ctx, conn, scope, s.svc.encryptionKey)
 		},
 	)
 	if err != nil {

--- a/pkg/probo/control_service.go
+++ b/pkg/probo/control_service.go
@@ -28,7 +28,7 @@ import (
 
 type (
 	ControlService struct {
-		svc *TenantService
+		svc *Service
 	}
 
 	CreateControlRequest struct {
@@ -93,7 +93,7 @@ func (ucr *UpdateControlRequest) Validate() error {
 }
 
 func (s ControlService) CountForDocumentID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentID gid.GID,
 	filter *coredata.ControlFilter,
 ) (int, error) {
@@ -104,7 +104,7 @@ func (s ControlService) CountForDocumentID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			controls := &coredata.Controls{}
 
-			count, err = controls.CountByDocumentID(ctx, conn, s.svc.scope, documentID, filter)
+			count, err = controls.CountByDocumentID(ctx, conn, scope, documentID, filter)
 			if err != nil {
 				return fmt.Errorf("cannot count controls: %w", err)
 			}
@@ -120,7 +120,7 @@ func (s ControlService) CountForDocumentID(
 }
 
 func (s ControlService) ListForDocumentID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentID gid.GID,
 	cursor *page.Cursor[coredata.ControlOrderField],
 	filter *coredata.ControlFilter,
@@ -132,11 +132,11 @@ func (s ControlService) ListForDocumentID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := document.LoadByID(ctx, conn, s.svc.scope, documentID); err != nil {
+			if err := document.LoadByID(ctx, conn, scope, documentID); err != nil {
 				return fmt.Errorf("cannot load document: %w", err)
 			}
 
-			return controls.LoadByDocumentID(ctx, conn, s.svc.scope, documentID, cursor, filter)
+			return controls.LoadByDocumentID(ctx, conn, scope, documentID, cursor, filter)
 		},
 	)
 	if err != nil {
@@ -147,7 +147,7 @@ func (s ControlService) ListForDocumentID(
 }
 
 func (s ControlService) CountForMeasureID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	measureID gid.GID,
 	filter *coredata.ControlFilter,
 ) (int, error) {
@@ -158,7 +158,7 @@ func (s ControlService) CountForMeasureID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			controls := &coredata.Controls{}
 
-			count, err = controls.CountByMeasureID(ctx, conn, s.svc.scope, measureID, filter)
+			count, err = controls.CountByMeasureID(ctx, conn, scope, measureID, filter)
 			if err != nil {
 				return fmt.Errorf("cannot count controls: %w", err)
 			}
@@ -174,7 +174,7 @@ func (s ControlService) CountForMeasureID(
 }
 
 func (s ControlService) ListForMeasureID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	measureID gid.GID,
 	cursor *page.Cursor[coredata.ControlOrderField],
 	filter *coredata.ControlFilter,
@@ -186,11 +186,11 @@ func (s ControlService) ListForMeasureID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := measure.LoadByID(ctx, conn, s.svc.scope, measureID); err != nil {
+			if err := measure.LoadByID(ctx, conn, scope, measureID); err != nil {
 				return fmt.Errorf("cannot load measure: %w", err)
 			}
 
-			return controls.LoadByMeasureID(ctx, conn, s.svc.scope, measureID, cursor, filter)
+			return controls.LoadByMeasureID(ctx, conn, scope, measureID, cursor, filter)
 		},
 	)
 	if err != nil {
@@ -201,7 +201,7 @@ func (s ControlService) ListForMeasureID(
 }
 
 func (s ControlService) CountForFrameworkID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	frameworkID gid.GID,
 	filter *coredata.ControlFilter,
 ) (int, error) {
@@ -212,7 +212,7 @@ func (s ControlService) CountForFrameworkID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			controls := &coredata.Controls{}
 
-			count, err = controls.CountByFrameworkID(ctx, conn, s.svc.scope, frameworkID, filter)
+			count, err = controls.CountByFrameworkID(ctx, conn, scope, frameworkID, filter)
 			if err != nil {
 				return fmt.Errorf("cannot count controls: %w", err)
 			}
@@ -228,7 +228,7 @@ func (s ControlService) CountForFrameworkID(
 }
 
 func (s ControlService) ListForFrameworkID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	frameworkID gid.GID,
 	cursor *page.Cursor[coredata.ControlOrderField],
 	filter *coredata.ControlFilter,
@@ -240,14 +240,14 @@ func (s ControlService) ListForFrameworkID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := framework.LoadByID(ctx, conn, s.svc.scope, frameworkID); err != nil {
+			if err := framework.LoadByID(ctx, conn, scope, frameworkID); err != nil {
 				return fmt.Errorf("cannot load framework: %w", err)
 			}
 
 			return controls.LoadByFrameworkID(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				framework.ID,
 				cursor,
 				filter,
@@ -262,7 +262,7 @@ func (s ControlService) ListForFrameworkID(
 }
 
 func (s ControlService) CountForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	filter *coredata.ControlFilter,
 ) (int, error) {
@@ -273,7 +273,7 @@ func (s ControlService) CountForOrganizationID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			controls := &coredata.Controls{}
 
-			count, err = controls.CountByOrganizationID(ctx, conn, s.svc.scope, organizationID, filter)
+			count, err = controls.CountByOrganizationID(ctx, conn, scope, organizationID, filter)
 			if err != nil {
 				return fmt.Errorf("cannot count controls: %w", err)
 			}
@@ -289,7 +289,7 @@ func (s ControlService) CountForOrganizationID(
 }
 
 func (s ControlService) ListForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.ControlOrderField],
 	filter *coredata.ControlFilter,
@@ -301,14 +301,14 @@ func (s ControlService) ListForOrganizationID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := organization.LoadByID(ctx, conn, s.svc.scope, organizationID); err != nil {
+			if err := organization.LoadByID(ctx, conn, scope, organizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
 			return controls.LoadByOrganizationID(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				organization.ID,
 				cursor,
 				filter,
@@ -323,7 +323,7 @@ func (s ControlService) ListForOrganizationID(
 }
 
 func (s ControlService) CountForRiskID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	riskID gid.GID,
 	filter *coredata.ControlFilter,
 ) (int, error) {
@@ -334,7 +334,7 @@ func (s ControlService) CountForRiskID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			controls := &coredata.Controls{}
 
-			count, err = controls.CountByRiskID(ctx, conn, s.svc.scope, riskID, filter)
+			count, err = controls.CountByRiskID(ctx, conn, scope, riskID, filter)
 			if err != nil {
 				return fmt.Errorf("cannot count controls: %w", err)
 			}
@@ -350,7 +350,7 @@ func (s ControlService) CountForRiskID(
 }
 
 func (s ControlService) ListForRiskID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	riskID gid.GID,
 	cursor *page.Cursor[coredata.ControlOrderField],
 	filter *coredata.ControlFilter,
@@ -362,11 +362,11 @@ func (s ControlService) ListForRiskID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := risk.LoadByID(ctx, conn, s.svc.scope, riskID); err != nil {
+			if err := risk.LoadByID(ctx, conn, scope, riskID); err != nil {
 				return fmt.Errorf("cannot load risk: %w", err)
 			}
 
-			return controls.LoadByRiskID(ctx, conn, s.svc.scope, risk.ID, cursor, filter)
+			return controls.LoadByRiskID(ctx, conn, scope, risk.ID, cursor, filter)
 		},
 	)
 	if err != nil {
@@ -377,7 +377,7 @@ func (s ControlService) ListForRiskID(
 }
 
 func (s ControlService) CreateMeasureMapping(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	controlID gid.GID,
 	measureID gid.GID,
 ) (*coredata.Control, *coredata.Measure, error) {
@@ -387,11 +387,11 @@ func (s ControlService) CreateMeasureMapping(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := control.LoadByID(ctx, conn, s.svc.scope, controlID); err != nil {
+			if err := control.LoadByID(ctx, conn, scope, controlID); err != nil {
 				return fmt.Errorf("cannot load control: %w", err)
 			}
 
-			if err := measure.LoadByID(ctx, conn, s.svc.scope, measureID); err != nil {
+			if err := measure.LoadByID(ctx, conn, scope, measureID); err != nil {
 				return fmt.Errorf("cannot load measure: %w", err)
 			}
 
@@ -399,11 +399,11 @@ func (s ControlService) CreateMeasureMapping(
 				ControlID:      controlID,
 				MeasureID:      measureID,
 				OrganizationID: control.OrganizationID,
-				TenantID:       s.svc.scope.GetTenantID(),
+				TenantID:       scope.GetTenantID(),
 				CreatedAt:      time.Now(),
 			}
 
-			return controlMeasure.Upsert(ctx, conn, s.svc.scope)
+			return controlMeasure.Upsert(ctx, conn, scope)
 		},
 	)
 	if err != nil {
@@ -414,7 +414,7 @@ func (s ControlService) CreateMeasureMapping(
 }
 
 func (s ControlService) DeleteMeasureMapping(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	controlID gid.GID,
 	measureID gid.GID,
 ) (*coredata.Control, *coredata.Measure, error) {
@@ -424,16 +424,16 @@ func (s ControlService) DeleteMeasureMapping(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := control.LoadByID(ctx, tx, s.svc.scope, controlID); err != nil {
+			if err := control.LoadByID(ctx, tx, scope, controlID); err != nil {
 				return fmt.Errorf("cannot load control: %w", err)
 			}
 
-			if err := measure.LoadByID(ctx, tx, s.svc.scope, measureID); err != nil {
+			if err := measure.LoadByID(ctx, tx, scope, measureID); err != nil {
 				return fmt.Errorf("cannot load measure: %w", err)
 			}
 
 			controlMeasure := &coredata.ControlMeasure{}
-			if err := controlMeasure.Delete(ctx, tx, s.svc.scope, control.ID, measure.ID); err != nil {
+			if err := controlMeasure.Delete(ctx, tx, scope, control.ID, measure.ID); err != nil {
 				return fmt.Errorf("cannot delete control measure mapping: %w", err)
 			}
 
@@ -448,7 +448,7 @@ func (s ControlService) DeleteMeasureMapping(
 }
 
 func (s ControlService) CreateDocumentMapping(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	controlID gid.GID,
 	documentID gid.GID,
 ) (*coredata.Control, *coredata.Document, error) {
@@ -458,11 +458,11 @@ func (s ControlService) CreateDocumentMapping(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := control.LoadByID(ctx, tx, s.svc.scope, controlID); err != nil {
+			if err := control.LoadByID(ctx, tx, scope, controlID); err != nil {
 				return fmt.Errorf("cannot load control: %w", err)
 			}
 
-			if err := document.LoadByID(ctx, tx, s.svc.scope, documentID); err != nil {
+			if err := document.LoadByID(ctx, tx, scope, documentID); err != nil {
 				return fmt.Errorf("cannot load document: %w", err)
 			}
 
@@ -470,11 +470,11 @@ func (s ControlService) CreateDocumentMapping(
 				ControlID:      control.ID,
 				DocumentID:     document.ID,
 				OrganizationID: control.OrganizationID,
-				TenantID:       s.svc.scope.GetTenantID(),
+				TenantID:       scope.GetTenantID(),
 				CreatedAt:      time.Now(),
 			}
 
-			if err := controlDocument.Insert(ctx, tx, s.svc.scope); err != nil {
+			if err := controlDocument.Insert(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot insert control document: %w", err)
 			}
 
@@ -489,7 +489,7 @@ func (s ControlService) CreateDocumentMapping(
 }
 
 func (s ControlService) DeleteDocumentMapping(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	controlID gid.GID,
 	documentID gid.GID,
 ) (*coredata.Control, *coredata.Document, error) {
@@ -499,16 +499,16 @@ func (s ControlService) DeleteDocumentMapping(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := control.LoadByID(ctx, tx, s.svc.scope, controlID); err != nil {
+			if err := control.LoadByID(ctx, tx, scope, controlID); err != nil {
 				return fmt.Errorf("cannot load control: %w", err)
 			}
 
-			if err := document.LoadByID(ctx, tx, s.svc.scope, documentID); err != nil {
+			if err := document.LoadByID(ctx, tx, scope, documentID); err != nil {
 				return fmt.Errorf("cannot load document: %w", err)
 			}
 
 			controlDocument := &coredata.ControlDocument{}
-			if err := controlDocument.Delete(ctx, tx, s.svc.scope, control.ID, document.ID); err != nil {
+			if err := controlDocument.Delete(ctx, tx, scope, control.ID, document.ID); err != nil {
 				return fmt.Errorf("cannot delete control document mapping: %w", err)
 			}
 
@@ -523,7 +523,7 @@ func (s ControlService) DeleteDocumentMapping(
 }
 
 func (s ControlService) CreateAuditMapping(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	controlID gid.GID,
 	auditID gid.GID,
 ) (*coredata.Control, *coredata.Audit, error) {
@@ -533,11 +533,11 @@ func (s ControlService) CreateAuditMapping(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := control.LoadByID(ctx, conn, s.svc.scope, controlID); err != nil {
+			if err := control.LoadByID(ctx, conn, scope, controlID); err != nil {
 				return fmt.Errorf("cannot load control: %w", err)
 			}
 
-			if err := audit.LoadByID(ctx, conn, s.svc.scope, auditID); err != nil {
+			if err := audit.LoadByID(ctx, conn, scope, auditID); err != nil {
 				return fmt.Errorf("cannot load audit: %w", err)
 			}
 
@@ -548,7 +548,7 @@ func (s ControlService) CreateAuditMapping(
 				CreatedAt:      time.Now(),
 			}
 
-			if err := controlAudit.Upsert(ctx, conn, s.svc.scope); err != nil {
+			if err := controlAudit.Upsert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot create control audit mapping: %w", err)
 			}
 
@@ -563,7 +563,7 @@ func (s ControlService) CreateAuditMapping(
 }
 
 func (s ControlService) DeleteAuditMapping(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	controlID gid.GID,
 	auditID gid.GID,
 ) (*coredata.Control, *coredata.Audit, error) {
@@ -573,16 +573,16 @@ func (s ControlService) DeleteAuditMapping(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := control.LoadByID(ctx, tx, s.svc.scope, controlID); err != nil {
+			if err := control.LoadByID(ctx, tx, scope, controlID); err != nil {
 				return fmt.Errorf("cannot load control: %w", err)
 			}
 
-			if err := audit.LoadByID(ctx, tx, s.svc.scope, auditID); err != nil {
+			if err := audit.LoadByID(ctx, tx, scope, auditID); err != nil {
 				return fmt.Errorf("cannot load audit: %w", err)
 			}
 
 			controlAudit := &coredata.ControlAudit{}
-			if err := controlAudit.Delete(ctx, tx, s.svc.scope, control.ID, audit.ID); err != nil {
+			if err := controlAudit.Delete(ctx, tx, scope, control.ID, audit.ID); err != nil {
 				return fmt.Errorf("cannot delete control audit mapping: %w", err)
 			}
 
@@ -597,7 +597,7 @@ func (s ControlService) DeleteAuditMapping(
 }
 
 func (s ControlService) CreateObligationMapping(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	controlID gid.GID,
 	obligationID gid.GID,
 ) (*coredata.Control, *coredata.Obligation, error) {
@@ -607,11 +607,11 @@ func (s ControlService) CreateObligationMapping(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := control.LoadByID(ctx, conn, s.svc.scope, controlID); err != nil {
+			if err := control.LoadByID(ctx, conn, scope, controlID); err != nil {
 				return fmt.Errorf("cannot load control: %w", err)
 			}
 
-			if err := obligation.LoadByID(ctx, conn, s.svc.scope, obligationID); err != nil {
+			if err := obligation.LoadByID(ctx, conn, scope, obligationID); err != nil {
 				return fmt.Errorf("cannot load obligation: %w", err)
 			}
 
@@ -621,7 +621,7 @@ func (s ControlService) CreateObligationMapping(
 				CreatedAt:    time.Now(),
 			}
 
-			if err := controlObligation.Upsert(ctx, conn, s.svc.scope); err != nil {
+			if err := controlObligation.Upsert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot create control obligation mapping: %w", err)
 			}
 
@@ -636,7 +636,7 @@ func (s ControlService) CreateObligationMapping(
 }
 
 func (s ControlService) DeleteObligationMapping(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	controlID gid.GID,
 	obligationID gid.GID,
 ) (*coredata.Control, *coredata.Obligation, error) {
@@ -646,16 +646,16 @@ func (s ControlService) DeleteObligationMapping(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := control.LoadByID(ctx, tx, s.svc.scope, controlID); err != nil {
+			if err := control.LoadByID(ctx, tx, scope, controlID); err != nil {
 				return fmt.Errorf("cannot load control: %w", err)
 			}
 
-			if err := obligation.LoadByID(ctx, tx, s.svc.scope, obligationID); err != nil {
+			if err := obligation.LoadByID(ctx, tx, scope, obligationID); err != nil {
 				return fmt.Errorf("cannot load obligation: %w", err)
 			}
 
 			controlObligation := &coredata.ControlObligation{}
-			if err := controlObligation.Delete(ctx, tx, s.svc.scope, control.ID, obligation.ID); err != nil {
+			if err := controlObligation.Delete(ctx, tx, scope, control.ID, obligation.ID); err != nil {
 				return fmt.Errorf("cannot delete control obligation mapping: %w", err)
 			}
 
@@ -670,7 +670,7 @@ func (s ControlService) DeleteObligationMapping(
 }
 
 func (s ControlService) ListForAuditID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	auditID gid.GID,
 	cursor *page.Cursor[coredata.ControlOrderField],
 	filter *coredata.ControlFilter,
@@ -682,11 +682,11 @@ func (s ControlService) ListForAuditID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := audit.LoadByID(ctx, conn, s.svc.scope, auditID); err != nil {
+			if err := audit.LoadByID(ctx, conn, scope, auditID); err != nil {
 				return fmt.Errorf("cannot load audit: %w", err)
 			}
 
-			if err := controls.LoadByAuditID(ctx, conn, s.svc.scope, auditID, cursor, filter); err != nil {
+			if err := controls.LoadByAuditID(ctx, conn, scope, auditID, cursor, filter); err != nil {
 				return fmt.Errorf("cannot load controls: %w", err)
 			}
 
@@ -701,7 +701,7 @@ func (s ControlService) ListForAuditID(
 }
 
 func (s ControlService) CountForStatementOfApplicabilityID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	statementOfApplicabilityID gid.GID,
 	filter *coredata.ControlFilter,
 ) (int, error) {
@@ -712,7 +712,7 @@ func (s ControlService) CountForStatementOfApplicabilityID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			controls := &coredata.Controls{}
 
-			count, err = controls.CountByStatementOfApplicabilityID(ctx, conn, s.svc.scope, statementOfApplicabilityID, filter)
+			count, err = controls.CountByStatementOfApplicabilityID(ctx, conn, scope, statementOfApplicabilityID, filter)
 			if err != nil {
 				return fmt.Errorf("cannot count controls: %w", err)
 			}
@@ -728,7 +728,7 @@ func (s ControlService) CountForStatementOfApplicabilityID(
 }
 
 func (s ControlService) Create(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req CreateControlRequest,
 ) (*coredata.Control, error) {
 	if err := req.Validate(); err != nil {
@@ -744,7 +744,7 @@ func (s ControlService) Create(
 	}
 
 	control := &coredata.Control{
-		ID:                          gid.New(s.svc.scope.GetTenantID(), coredata.ControlEntityType),
+		ID:                          gid.New(scope.GetTenantID(), coredata.ControlEntityType),
 		FrameworkID:                 req.FrameworkID,
 		Name:                        req.Name,
 		Description:                 req.Description,
@@ -759,14 +759,14 @@ func (s ControlService) Create(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := framework.LoadByID(ctx, conn, s.svc.scope, req.FrameworkID); err != nil {
+			if err := framework.LoadByID(ctx, conn, scope, req.FrameworkID); err != nil {
 				return fmt.Errorf("cannot load framework: %w", err)
 			}
 
 			control.FrameworkID = framework.ID
 			control.OrganizationID = framework.OrganizationID
 
-			return control.Insert(ctx, conn, s.svc.scope)
+			return control.Insert(ctx, conn, scope)
 		},
 	)
 	if err != nil {
@@ -777,7 +777,7 @@ func (s ControlService) Create(
 }
 
 func (s ControlService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	controlID gid.GID,
 ) (*coredata.Control, error) {
 	control := &coredata.Control{}
@@ -785,7 +785,7 @@ func (s ControlService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return control.LoadByID(ctx, conn, s.svc.scope, controlID)
+			return control.LoadByID(ctx, conn, scope, controlID)
 		},
 	)
 	if err != nil {
@@ -796,7 +796,7 @@ func (s ControlService) Get(
 }
 
 func (s ControlService) GetByIDs(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	controlIDs ...gid.GID,
 ) (coredata.Controls, error) {
 	var controls coredata.Controls
@@ -807,7 +807,7 @@ func (s ControlService) GetByIDs(
 			if err := controls.LoadByIDs(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				controlIDs,
 			); err != nil {
 				return fmt.Errorf("cannot load controls by ids: %w", err)
@@ -824,7 +824,7 @@ func (s ControlService) GetByIDs(
 }
 
 func (s ControlService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req UpdateControlRequest,
 ) (*coredata.Control, error) {
 	if err := req.Validate(); err != nil {
@@ -836,7 +836,7 @@ func (s ControlService) Update(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := control.LoadByID(ctx, conn, s.svc.scope, req.ID); err != nil {
+			if err := control.LoadByID(ctx, conn, scope, req.ID); err != nil {
 				return fmt.Errorf("cannot load control: %w", err)
 			}
 
@@ -869,7 +869,7 @@ func (s ControlService) Update(
 
 			control.UpdatedAt = time.Now()
 
-			return control.Update(ctx, conn, s.svc.scope)
+			return control.Update(ctx, conn, scope)
 		},
 	)
 	if err != nil {
@@ -880,7 +880,7 @@ func (s ControlService) Update(
 }
 
 func (s ControlService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	controlID gid.GID,
 ) error {
 	control := &coredata.Control{ID: controlID}
@@ -888,13 +888,13 @@ func (s ControlService) Delete(
 	return s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			return control.Delete(ctx, tx, s.svc.scope)
+			return control.Delete(ctx, tx, scope)
 		},
 	)
 }
 
 func (s ControlService) HasRegulatoryObligation(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	controlID gid.GID,
 ) (bool, error) {
 	var hasRegulatory bool
@@ -907,7 +907,7 @@ func (s ControlService) HasRegulatoryObligation(
 		func(ctx context.Context, conn pg.Querier) error {
 			var controlObligations coredata.ControlObligations
 
-			count, err := controlObligations.CountByControlID(ctx, conn, s.svc.scope, controlID, filter)
+			count, err := controlObligations.CountByControlID(ctx, conn, scope, controlID, filter)
 			if err != nil {
 				return fmt.Errorf("cannot count regulatory obligations: %w", err)
 			}
@@ -922,7 +922,7 @@ func (s ControlService) HasRegulatoryObligation(
 }
 
 func (s ControlService) HasContractualObligation(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	controlID gid.GID,
 ) (bool, error) {
 	var hasContractual bool
@@ -935,7 +935,7 @@ func (s ControlService) HasContractualObligation(
 		func(ctx context.Context, conn pg.Querier) error {
 			var controlObligations coredata.ControlObligations
 
-			count, err := controlObligations.CountByControlID(ctx, conn, s.svc.scope, controlID, filter)
+			count, err := controlObligations.CountByControlID(ctx, conn, scope, controlID, filter)
 			if err != nil {
 				return fmt.Errorf("cannot count contractual obligations: %w", err)
 			}
@@ -950,7 +950,7 @@ func (s ControlService) HasContractualObligation(
 }
 
 func (s ControlService) HasRiskAssessment(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	controlID gid.GID,
 ) (bool, error) {
 	var hasRisk bool
@@ -959,7 +959,7 @@ func (s ControlService) HasRiskAssessment(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			var controlsWithRisk coredata.ControlsWithRisk
-			if err := controlsWithRisk.LoadByControlIDs(ctx, conn, s.svc.scope, []gid.GID{controlID}); err != nil {
+			if err := controlsWithRisk.LoadByControlIDs(ctx, conn, scope, []gid.GID{controlID}); err != nil {
 				return fmt.Errorf("cannot load controls with risk: %w", err)
 			}
 

--- a/pkg/probo/custom_domain_service.go
+++ b/pkg/probo/custom_domain_service.go
@@ -29,7 +29,7 @@ import (
 
 type (
 	CustomDomainService struct {
-		svc           *TenantService
+		svc           *Service
 		acmeService   *certmanager.ACMEService
 		encryptionKey cipher.EncryptionKey
 		logger        *log.Logger
@@ -51,7 +51,7 @@ func (ccdr *CreateCustomDomainRequest) Validate() error {
 }
 
 func (s *CustomDomainService) CreateCustomDomain(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req CreateCustomDomainRequest,
 ) (*coredata.CustomDomain, error) {
 	if err := req.Validate(); err != nil {
@@ -63,20 +63,20 @@ func (s *CustomDomainService) CreateCustomDomain(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			domain = coredata.NewCustomDomain(s.svc.scope.GetTenantID(), req.Domain)
+			domain = coredata.NewCustomDomain(scope.GetTenantID(), req.Domain)
 			domain.OrganizationID = req.OrganizationID
 
-			if err := domain.Insert(ctx, tx, s.svc.scope, s.encryptionKey); err != nil {
+			if err := domain.Insert(ctx, tx, scope, s.encryptionKey); err != nil {
 				return fmt.Errorf("cannot insert custom domain: %w", err)
 			}
 
 			var org coredata.Organization
-			if err := org.LoadByID(ctx, tx, s.svc.scope, req.OrganizationID); err != nil {
+			if err := org.LoadByID(ctx, tx, scope, req.OrganizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
 			org.CustomDomainID = &domain.ID
-			if err := org.Update(ctx, s.svc.scope, tx); err != nil {
+			if err := org.Update(ctx, scope, tx); err != nil {
 				return fmt.Errorf("cannot update organization: %w", err)
 			}
 
@@ -91,14 +91,14 @@ func (s *CustomDomainService) CreateCustomDomain(
 }
 
 func (s *CustomDomainService) DeleteCustomDomain(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) error {
 	return s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			var org coredata.Organization
-			if err := org.LoadByID(ctx, tx, s.svc.scope, organizationID); err != nil {
+			if err := org.LoadByID(ctx, tx, scope, organizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
@@ -107,16 +107,16 @@ func (s *CustomDomainService) DeleteCustomDomain(
 			}
 
 			domain := &coredata.CustomDomain{}
-			if err := domain.LoadByID(ctx, tx, s.svc.scope, *org.CustomDomainID); err != nil {
+			if err := domain.LoadByID(ctx, tx, scope, *org.CustomDomainID); err != nil {
 				return fmt.Errorf("cannot load domain: %w", err)
 			}
 
-			if err := domain.Delete(ctx, tx, s.svc.scope); err != nil {
+			if err := domain.Delete(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot delete domain: %w", err)
 			}
 
 			org.CustomDomainID = nil
-			if err := org.Update(ctx, s.svc.scope, tx); err != nil {
+			if err := org.Update(ctx, scope, tx); err != nil {
 				return fmt.Errorf("cannot update organization: %w", err)
 			}
 
@@ -126,7 +126,7 @@ func (s *CustomDomainService) DeleteCustomDomain(
 }
 
 func (s *CustomDomainService) GetOrganizationCustomDomain(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (*coredata.CustomDomain, error) {
 	var domain *coredata.CustomDomain
@@ -135,7 +135,7 @@ func (s *CustomDomainService) GetOrganizationCustomDomain(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			var org coredata.Organization
-			if err := org.LoadByID(ctx, conn, s.svc.scope, organizationID); err != nil {
+			if err := org.LoadByID(ctx, conn, scope, organizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
@@ -144,7 +144,7 @@ func (s *CustomDomainService) GetOrganizationCustomDomain(
 			}
 
 			domain = &coredata.CustomDomain{}
-			if err := domain.LoadByID(ctx, conn, s.svc.scope, *org.CustomDomainID); err != nil {
+			if err := domain.LoadByID(ctx, conn, scope, *org.CustomDomainID); err != nil {
 				return fmt.Errorf("cannot load custom domain: %w", err)
 			}
 

--- a/pkg/probo/data_protection_impact_assessment_service.go
+++ b/pkg/probo/data_protection_impact_assessment_service.go
@@ -27,7 +27,7 @@ import (
 )
 
 type DataProtectionImpactAssessmentService struct {
-	svc *TenantService
+	svc *Service
 }
 
 type (
@@ -77,7 +77,7 @@ func (req *UpdateDataProtectionImpactAssessmentRequest) Validate() error {
 }
 
 func (s DataProtectionImpactAssessmentService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	dpiaID gid.GID,
 ) (*coredata.DataProtectionImpactAssessment, error) {
 	dpia := &coredata.DataProtectionImpactAssessment{}
@@ -85,7 +85,7 @@ func (s DataProtectionImpactAssessmentService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := dpia.LoadByID(ctx, conn, s.svc.scope, dpiaID); err != nil {
+			if err := dpia.LoadByID(ctx, conn, scope, dpiaID); err != nil {
 				return fmt.Errorf("cannot load data protection impact assessment: %w", err)
 			}
 
@@ -100,7 +100,7 @@ func (s DataProtectionImpactAssessmentService) Get(
 }
 
 func (s DataProtectionImpactAssessmentService) GetByProcessingActivityID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	processingActivityID gid.GID,
 ) (*coredata.DataProtectionImpactAssessment, error) {
 	dpia := &coredata.DataProtectionImpactAssessment{}
@@ -108,7 +108,7 @@ func (s DataProtectionImpactAssessmentService) GetByProcessingActivityID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := dpia.LoadByProcessingActivityID(ctx, conn, s.svc.scope, processingActivityID); err != nil {
+			if err := dpia.LoadByProcessingActivityID(ctx, conn, scope, processingActivityID); err != nil {
 				return fmt.Errorf("cannot load data protection impact assessment: %w", err)
 			}
 
@@ -123,7 +123,7 @@ func (s DataProtectionImpactAssessmentService) GetByProcessingActivityID(
 }
 
 func (s DataProtectionImpactAssessmentService) ListForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.DataProtectionImpactAssessmentOrderField],
 ) (*page.Page[*coredata.DataProtectionImpactAssessment, coredata.DataProtectionImpactAssessmentOrderField], error) {
@@ -132,7 +132,7 @@ func (s DataProtectionImpactAssessmentService) ListForOrganizationID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			err := dpias.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID, cursor)
+			err := dpias.LoadByOrganizationID(ctx, conn, scope, organizationID, cursor)
 			if err != nil {
 				return fmt.Errorf("cannot load data protection impact assessments: %w", err)
 			}
@@ -148,7 +148,7 @@ func (s DataProtectionImpactAssessmentService) ListForOrganizationID(
 }
 
 func (s DataProtectionImpactAssessmentService) CountForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (int, error) {
 	var count int
@@ -157,7 +157,7 @@ func (s DataProtectionImpactAssessmentService) CountForOrganizationID(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			dpias := coredata.DataProtectionImpactAssessments{}
-			count, err = dpias.CountByOrganizationID(ctx, conn, s.svc.scope, organizationID)
+			count, err = dpias.CountByOrganizationID(ctx, conn, scope, organizationID)
 
 			return err
 		},
@@ -170,7 +170,7 @@ func (s DataProtectionImpactAssessmentService) CountForOrganizationID(
 }
 
 func (s *DataProtectionImpactAssessmentService) Create(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *CreateDataProtectionImpactAssessmentRequest,
 ) (*coredata.DataProtectionImpactAssessment, error) {
 	if err := req.Validate(); err != nil {
@@ -180,7 +180,7 @@ func (s *DataProtectionImpactAssessmentService) Create(
 	now := time.Now()
 
 	dpia := &coredata.DataProtectionImpactAssessment{
-		ID:                          gid.New(s.svc.scope.GetTenantID(), coredata.DataProtectionImpactAssessmentEntityType),
+		ID:                          gid.New(scope.GetTenantID(), coredata.DataProtectionImpactAssessmentEntityType),
 		ProcessingActivityID:        req.ProcessingActivityID,
 		Description:                 req.Description,
 		NecessityAndProportionality: req.NecessityAndProportionality,
@@ -195,13 +195,13 @@ func (s *DataProtectionImpactAssessmentService) Create(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			processingActivity := &coredata.ProcessingActivity{}
-			if err := processingActivity.LoadByID(ctx, conn, s.svc.scope, req.ProcessingActivityID); err != nil {
+			if err := processingActivity.LoadByID(ctx, conn, scope, req.ProcessingActivityID); err != nil {
 				return fmt.Errorf("cannot load processing activity: %w", err)
 			}
 
 			dpia.OrganizationID = processingActivity.OrganizationID
 
-			if err := dpia.Insert(ctx, conn, s.svc.scope); err != nil {
+			if err := dpia.Insert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot insert data protection impact assessment: %w", err)
 			}
 
@@ -216,7 +216,7 @@ func (s *DataProtectionImpactAssessmentService) Create(
 }
 
 func (s *DataProtectionImpactAssessmentService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *UpdateDataProtectionImpactAssessmentRequest,
 ) (*coredata.DataProtectionImpactAssessment, error) {
 	if err := req.Validate(); err != nil {
@@ -228,7 +228,7 @@ func (s *DataProtectionImpactAssessmentService) Update(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := dpia.LoadByID(ctx, conn, s.svc.scope, req.ID); err != nil {
+			if err := dpia.LoadByID(ctx, conn, scope, req.ID); err != nil {
 				return fmt.Errorf("cannot load data protection impact assessment: %w", err)
 			}
 
@@ -254,7 +254,7 @@ func (s *DataProtectionImpactAssessmentService) Update(
 
 			dpia.UpdatedAt = time.Now()
 
-			if err := dpia.Update(ctx, conn, s.svc.scope); err != nil {
+			if err := dpia.Update(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot update data protection impact assessment: %w", err)
 			}
 
@@ -269,18 +269,18 @@ func (s *DataProtectionImpactAssessmentService) Update(
 }
 
 func (s *DataProtectionImpactAssessmentService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	dpiaID gid.GID,
 ) error {
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			dpia := &coredata.DataProtectionImpactAssessment{}
-			if err := dpia.LoadByID(ctx, conn, s.svc.scope, dpiaID); err != nil {
+			if err := dpia.LoadByID(ctx, conn, scope, dpiaID); err != nil {
 				return fmt.Errorf("cannot load data protection impact assessment: %w", err)
 			}
 
-			if err := dpia.Delete(ctx, conn, s.svc.scope); err != nil {
+			if err := dpia.Delete(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot delete data protection impact assessment: %w", err)
 			}
 

--- a/pkg/probo/datum_service.go
+++ b/pkg/probo/datum_service.go
@@ -28,7 +28,7 @@ import (
 
 type (
 	DatumService struct {
-		svc *TenantService
+		svc *Service
 	}
 
 	CreateDatumRequest struct {
@@ -77,7 +77,7 @@ func (udr *UpdateDatumRequest) Validate() error {
 }
 
 func (s DatumService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	datumID gid.GID,
 ) (*coredata.Datum, error) {
 	datum := &coredata.Datum{}
@@ -85,7 +85,7 @@ func (s DatumService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return datum.LoadByID(ctx, conn, s.svc.scope, datumID)
+			return datum.LoadByID(ctx, conn, scope, datumID)
 		},
 	)
 	if err != nil {
@@ -96,7 +96,7 @@ func (s DatumService) Get(
 }
 
 func (s DatumService) GetByOwnerID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	ownerID gid.GID,
 ) (*coredata.Datum, error) {
 	datum := &coredata.Datum{OwnerID: ownerID}
@@ -104,7 +104,7 @@ func (s DatumService) GetByOwnerID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return datum.LoadByOwnerID(ctx, conn, s.svc.scope)
+			return datum.LoadByOwnerID(ctx, conn, scope)
 		},
 	)
 	if err != nil {
@@ -115,7 +115,7 @@ func (s DatumService) GetByOwnerID(
 }
 
 func (s DatumService) CountForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (int, error) {
 	var count int
@@ -125,7 +125,7 @@ func (s DatumService) CountForOrganizationID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			data := coredata.Data{}
 
-			count, err = data.CountByOrganizationID(ctx, conn, s.svc.scope, organizationID)
+			count, err = data.CountByOrganizationID(ctx, conn, scope, organizationID)
 			if err != nil {
 				return fmt.Errorf("cannot count data: %w", err)
 			}
@@ -141,7 +141,7 @@ func (s DatumService) CountForOrganizationID(
 }
 
 func (s DatumService) ListForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.DatumOrderField],
 ) (*page.Page[*coredata.Datum, coredata.DatumOrderField], error) {
@@ -153,7 +153,7 @@ func (s DatumService) ListForOrganizationID(
 			return data.LoadByOrganizationID(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				organizationID,
 				cursor,
 			)
@@ -167,7 +167,7 @@ func (s DatumService) ListForOrganizationID(
 }
 
 func (s DatumService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req UpdateDatumRequest,
 ) (*coredata.Datum, error) {
 	if err := req.Validate(); err != nil {
@@ -179,7 +179,7 @@ func (s DatumService) Update(
 	datumThirdParties := &coredata.DatumThirdParties{}
 
 	err := s.svc.pg.WithTx(ctx, func(ctx context.Context, conn pg.Tx) error {
-		if err := datum.LoadByID(ctx, conn, s.svc.scope, req.ID); err != nil {
+		if err := datum.LoadByID(ctx, conn, scope, req.ID); err != nil {
 			return fmt.Errorf("cannot load data: %w", err)
 		}
 
@@ -193,7 +193,7 @@ func (s DatumService) Update(
 
 		if req.OwnerID != nil {
 			owner := &coredata.MembershipProfile{}
-			if err := owner.LoadByID(ctx, conn, s.svc.scope, *req.OwnerID); err != nil {
+			if err := owner.LoadByID(ctx, conn, scope, *req.OwnerID); err != nil {
 				return fmt.Errorf("cannot load owner profile: %w", err)
 			}
 
@@ -202,12 +202,12 @@ func (s DatumService) Update(
 
 		datum.UpdatedAt = now
 
-		if err := datum.Update(ctx, conn, s.svc.scope); err != nil {
+		if err := datum.Update(ctx, conn, scope); err != nil {
 			return fmt.Errorf("cannot update data: %w", err)
 		}
 
 		if req.ThirdPartyIDs != nil {
-			if err := datumThirdParties.Merge(ctx, conn, s.svc.scope, datum.ID, datum.OrganizationID, req.ThirdPartyIDs); err != nil {
+			if err := datumThirdParties.Merge(ctx, conn, scope, datum.ID, datum.OrganizationID, req.ThirdPartyIDs); err != nil {
 				return fmt.Errorf("cannot update data thirdParties: %w", err)
 			}
 		}
@@ -222,7 +222,7 @@ func (s DatumService) Update(
 }
 
 func (s DatumService) Create(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req CreateDatumRequest,
 ) (*coredata.Datum, error) {
 	if err := req.Validate(); err != nil {
@@ -230,7 +230,7 @@ func (s DatumService) Create(
 	}
 
 	now := time.Now()
-	datumID := gid.New(s.svc.scope.GetTenantID(), coredata.DatumEntityType)
+	datumID := gid.New(scope.GetTenantID(), coredata.DatumEntityType)
 	datumThirdParties := &coredata.DatumThirdParties{}
 
 	datum := &coredata.Datum{
@@ -247,16 +247,16 @@ func (s DatumService) Create(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			owner := &coredata.MembershipProfile{}
-			if err := owner.LoadByID(ctx, conn, s.svc.scope, req.OwnerID); err != nil {
+			if err := owner.LoadByID(ctx, conn, scope, req.OwnerID); err != nil {
 				return fmt.Errorf("cannot load owner profile: %w", err)
 			}
 
-			if err := datum.Insert(ctx, conn, s.svc.scope); err != nil {
+			if err := datum.Insert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot insert datum: %w", err)
 			}
 
 			if len(req.ThirdPartyIDs) > 0 {
-				if err := datumThirdParties.Insert(ctx, conn, s.svc.scope, datum.ID, datum.OrganizationID, req.ThirdPartyIDs); err != nil {
+				if err := datumThirdParties.Insert(ctx, conn, scope, datum.ID, datum.OrganizationID, req.ThirdPartyIDs); err != nil {
 					return fmt.Errorf("cannot create data thirdParties: %w", err)
 				}
 			}
@@ -272,7 +272,7 @@ func (s DatumService) Create(
 }
 
 func (s DatumService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	datumID gid.GID,
 ) error {
 	datum := &coredata.Datum{ID: datumID}
@@ -280,13 +280,13 @@ func (s DatumService) Delete(
 	return s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			return datum.Delete(ctx, tx, s.svc.scope)
+			return datum.Delete(ctx, tx, scope)
 		},
 	)
 }
 
 func (s DatumService) ListThirdParties(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	datumID gid.GID,
 	cursor *page.Cursor[coredata.ThirdPartyOrderField],
 ) (*page.Page[*coredata.ThirdParty, coredata.ThirdPartyOrderField], error) {
@@ -295,7 +295,7 @@ func (s DatumService) ListThirdParties(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return thirdParties.LoadByDatumID(ctx, conn, s.svc.scope, datumID, cursor)
+			return thirdParties.LoadByDatumID(ctx, conn, scope, datumID, cursor)
 		},
 	)
 	if err != nil {

--- a/pkg/probo/document_approval_service.go
+++ b/pkg/probo/document_approval_service.go
@@ -38,7 +38,7 @@ import (
 
 type (
 	DocumentApprovalService struct {
-		svc                     *TenantService
+		svc                     *Service
 		html2pdfConverter       *html2pdf.Converter
 		invitationTokenValidity time.Duration
 		tokenSecret             string
@@ -73,7 +73,7 @@ func (e ErrApprovalDecisionAlreadyMade) Error() string {
 }
 
 func (s *DocumentApprovalService) RequestApprovalInTx(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	tx pg.Tx,
 	document *coredata.Document,
 	documentVersion *coredata.DocumentVersion,
@@ -81,12 +81,12 @@ func (s *DocumentApprovalService) RequestApprovalInTx(
 	changelog *string,
 ) (*coredata.DocumentVersionApprovalQuorum, error) {
 	organization := &coredata.Organization{}
-	if err := organization.LoadByID(ctx, tx, s.svc.scope, document.OrganizationID); err != nil {
+	if err := organization.LoadByID(ctx, tx, scope, document.OrganizationID); err != nil {
 		return nil, fmt.Errorf("cannot load organization: %w", err)
 	}
 
 	approverProfiles := &coredata.MembershipProfiles{}
-	if err := approverProfiles.LoadByIDs(ctx, tx, s.svc.scope, approverIDs); err != nil {
+	if err := approverProfiles.LoadByIDs(ctx, tx, scope, approverIDs); err != nil {
 		return nil, fmt.Errorf("cannot load approver profiles: %w", err)
 	}
 
@@ -106,12 +106,12 @@ func (s *DocumentApprovalService) RequestApprovalInTx(
 	documentVersion.Minor = 0
 
 	documentVersion.UpdatedAt = now
-	if err := documentVersion.Update(ctx, tx, s.svc.scope); err != nil {
+	if err := documentVersion.Update(ctx, tx, scope); err != nil {
 		return nil, fmt.Errorf("cannot update document version: %w", err)
 	}
 
 	quorum := &coredata.DocumentVersionApprovalQuorum{
-		ID:             gid.New(s.svc.scope.GetTenantID(), coredata.DocumentVersionApprovalQuorumEntityType),
+		ID:             gid.New(scope.GetTenantID(), coredata.DocumentVersionApprovalQuorumEntityType),
 		OrganizationID: document.OrganizationID,
 		VersionID:      documentVersion.ID,
 		Status:         coredata.DocumentVersionApprovalQuorumStatusPending,
@@ -119,15 +119,15 @@ func (s *DocumentApprovalService) RequestApprovalInTx(
 		UpdatedAt:      now,
 	}
 
-	if err := quorum.Insert(ctx, tx, s.svc.scope); err != nil {
+	if err := quorum.Insert(ctx, tx, scope); err != nil {
 		return nil, fmt.Errorf("cannot insert approval quorum: %w", err)
 	}
 
-	if err := s.createDecisions(ctx, tx, quorum, document.OrganizationID, approverIDs, now); err != nil {
+	if err := s.createDecisions(ctx, scope, tx, quorum, document.OrganizationID, approverIDs, now); err != nil {
 		return nil, fmt.Errorf("cannot create approval decisions: %w", err)
 	}
 
-	if err := s.sendApprovalEmails(ctx, tx, *approverProfiles, document, organization, documentVersion.ID); err != nil {
+	if err := s.sendApprovalEmails(ctx, scope, tx, *approverProfiles, document, organization, documentVersion.ID); err != nil {
 		return nil, fmt.Errorf("cannot send approval emails: %w", err)
 	}
 
@@ -141,7 +141,7 @@ func (s *DocumentApprovalService) RequestApprovalInTx(
 // an approval is requested for it; otherwise it is published as a major
 // bump. Documents with no draft (or already pending approval) are skipped.
 func (s *DocumentApprovalService) BulkPublishVersions(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req BulkPublishVersionsRequest,
 ) ([]*coredata.DocumentVersion, []*coredata.Document, error) {
 	var (
@@ -154,7 +154,7 @@ func (s *DocumentApprovalService) BulkPublishVersions(
 		func(ctx context.Context, tx pg.Tx) error {
 			for _, documentID := range req.DocumentIDs {
 				dv := &coredata.DocumentVersion{}
-				if err := dv.LoadLatestVersion(ctx, tx, s.svc.scope, documentID); err != nil {
+				if err := dv.LoadLatestVersion(ctx, tx, scope, documentID); err != nil {
 					return fmt.Errorf("cannot load latest version for %q: %w", documentID, err)
 				}
 
@@ -163,7 +163,7 @@ func (s *DocumentApprovalService) BulkPublishVersions(
 				}
 
 				document := &coredata.Document{}
-				if err := document.LoadByID(ctx, tx, s.svc.scope, documentID); err != nil {
+				if err := document.LoadByID(ctx, tx, scope, documentID); err != nil {
 					return fmt.Errorf("cannot load document %q: %w", documentID, err)
 				}
 
@@ -188,13 +188,13 @@ func (s *DocumentApprovalService) BulkPublishVersions(
 				if req.Minor {
 					var err error
 
-					document, dv, err = s.svc.Documents.publishMinorVersionInTx(ctx, tx, documentID, &req.Changelog, true)
+					document, dv, err = s.svc.Documents.publishMinorVersionInTx(ctx, scope, tx, documentID, &req.Changelog, true)
 					if err != nil {
 						return fmt.Errorf("cannot publish document %q: %w", documentID, err)
 					}
 				} else {
 					defaultApprovers := &coredata.DocumentDefaultApprovers{}
-					if err := defaultApprovers.LoadByDocumentID(ctx, tx, s.svc.scope, documentID); err != nil {
+					if err := defaultApprovers.LoadByDocumentID(ctx, tx, scope, documentID); err != nil {
 						return fmt.Errorf("cannot load default approvers for %q: %w", documentID, err)
 					}
 
@@ -204,13 +204,13 @@ func (s *DocumentApprovalService) BulkPublishVersions(
 							approverIDs[i] = a.ApproverProfileID
 						}
 
-						if _, err := s.RequestApprovalInTx(ctx, tx, document, dv, approverIDs, &req.Changelog); err != nil {
+						if _, err := s.RequestApprovalInTx(ctx, scope, tx, document, dv, approverIDs, &req.Changelog); err != nil {
 							return fmt.Errorf("cannot request approval for %q: %w", documentID, err)
 						}
 					} else {
 						var err error
 
-						document, dv, err = s.svc.Documents.publishMajorVersionInTx(ctx, tx, documentID, &req.Changelog, true)
+						document, dv, err = s.svc.Documents.publishMajorVersionInTx(ctx, scope, tx, documentID, &req.Changelog, true)
 						if err != nil {
 							return fmt.Errorf("cannot publish document %q: %w", documentID, err)
 						}
@@ -232,7 +232,7 @@ func (s *DocumentApprovalService) BulkPublishVersions(
 }
 
 func (s *DocumentApprovalService) Approve(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req ApproveDocumentVersionRequest,
 ) (*coredata.DocumentVersionApprovalDecision, error) {
 	var (
@@ -246,12 +246,12 @@ func (s *DocumentApprovalService) Approve(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			documentVersion = &coredata.DocumentVersion{}
-			if err := documentVersion.LoadByID(ctx, conn, s.svc.scope, req.DocumentVersionID); err != nil {
+			if err := documentVersion.LoadByID(ctx, conn, scope, req.DocumentVersionID); err != nil {
 				return fmt.Errorf("cannot load document version: %w", err)
 			}
 
 			document = &coredata.Document{}
-			if err := document.LoadByID(ctx, conn, s.svc.scope, documentVersion.DocumentID); err != nil {
+			if err := document.LoadByID(ctx, conn, scope, documentVersion.DocumentID); err != nil {
 				return fmt.Errorf("cannot load document: %w", err)
 			}
 
@@ -264,7 +264,7 @@ func (s *DocumentApprovalService) Approve(
 				err     error
 			)
 
-			quorum, profile, err = s.loadQuorumAndProfile(ctx, conn, req.DocumentVersionID, req.IdentityID, documentVersion.OrganizationID)
+			quorum, profile, err = s.loadQuorumAndProfile(ctx, scope, conn, req.DocumentVersionID, req.IdentityID, documentVersion.OrganizationID)
 			if err != nil {
 				return fmt.Errorf("cannot load quorum and profile: %w", err)
 			}
@@ -274,7 +274,7 @@ func (s *DocumentApprovalService) Approve(
 			}
 
 			decision = &coredata.DocumentVersionApprovalDecision{}
-			if err := decision.LoadByQuorumIDAndApproverID(ctx, conn, s.svc.scope, quorum.ID, profile.ID); err != nil {
+			if err := decision.LoadByQuorumIDAndApproverID(ctx, conn, scope, quorum.ID, profile.ID); err != nil {
 				return fmt.Errorf("cannot load approval decision: %w", err)
 			}
 
@@ -291,13 +291,13 @@ func (s *DocumentApprovalService) Approve(
 
 	now := time.Now()
 
-	pdfData, err := s.generateApprovalPDF(ctx, req.DocumentVersionID)
+	pdfData, err := s.generateApprovalPDF(ctx, scope, req.DocumentVersionID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot export document PDF: %w", err)
 	}
 
 	fileRecord := &coredata.File{
-		ID:             gid.New(s.svc.scope.GetTenantID(), coredata.FileEntityType),
+		ID:             gid.New(scope.GetTenantID(), coredata.FileEntityType),
 		OrganizationID: documentVersion.OrganizationID,
 		BucketName:     s.svc.bucket,
 		MimeType:       "application/pdf",
@@ -331,7 +331,7 @@ func (s *DocumentApprovalService) Approve(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			quorum = &coredata.DocumentVersionApprovalQuorum{}
-			if err := quorum.LoadByID(ctx, tx, s.svc.scope, quorumID); err != nil {
+			if err := quorum.LoadByID(ctx, tx, scope, quorumID); err != nil {
 				return fmt.Errorf("cannot load quorum: %w", err)
 			}
 
@@ -340,7 +340,7 @@ func (s *DocumentApprovalService) Approve(
 			}
 
 			decision = &coredata.DocumentVersionApprovalDecision{}
-			if err := decision.LoadByQuorumIDAndApproverID(ctx, tx, s.svc.scope, quorum.ID, approverID); err != nil {
+			if err := decision.LoadByQuorumIDAndApproverID(ctx, tx, scope, quorum.ID, approverID); err != nil {
 				return fmt.Errorf("cannot load approval decision: %w", err)
 			}
 
@@ -348,7 +348,7 @@ func (s *DocumentApprovalService) Approve(
 				return &ErrApprovalDecisionAlreadyMade{}
 			}
 
-			if err := fileRecord.Insert(ctx, tx, s.svc.scope); err != nil {
+			if err := fileRecord.Insert(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot insert approval file record: %w", err)
 			}
 
@@ -377,11 +377,11 @@ func (s *DocumentApprovalService) Approve(
 			decision.DecidedAt = &now
 			decision.UpdatedAt = now
 
-			if err := decision.Update(ctx, tx, s.svc.scope); err != nil {
+			if err := decision.Update(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot update approval decision: %w", err)
 			}
 
-			if err := s.maybeApproveQuorum(ctx, tx, quorum.ID); err != nil {
+			if err := s.maybeApproveQuorum(ctx, scope, tx, quorum.ID); err != nil {
 				return fmt.Errorf("cannot check quorum approval: %w", err)
 			}
 
@@ -396,7 +396,7 @@ func (s *DocumentApprovalService) Approve(
 }
 
 func (s *DocumentApprovalService) Reject(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req RejectDocumentVersionRequest,
 ) (*coredata.DocumentVersionApprovalDecision, error) {
 	var decision *coredata.DocumentVersionApprovalDecision
@@ -405,12 +405,12 @@ func (s *DocumentApprovalService) Reject(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			documentVersion := &coredata.DocumentVersion{}
-			if err := documentVersion.LoadByID(ctx, tx, s.svc.scope, req.DocumentVersionID); err != nil {
+			if err := documentVersion.LoadByID(ctx, tx, scope, req.DocumentVersionID); err != nil {
 				return fmt.Errorf("cannot load document version: %w", err)
 			}
 
 			document := &coredata.Document{}
-			if err := document.LoadByID(ctx, tx, s.svc.scope, documentVersion.DocumentID); err != nil {
+			if err := document.LoadByID(ctx, tx, scope, documentVersion.DocumentID); err != nil {
 				return fmt.Errorf("cannot load document: %w", err)
 			}
 
@@ -418,13 +418,13 @@ func (s *DocumentApprovalService) Reject(
 				return &ErrDocumentArchived{}
 			}
 
-			quorum, profile, err := s.loadQuorumAndProfile(ctx, tx, req.DocumentVersionID, req.IdentityID, documentVersion.OrganizationID)
+			quorum, profile, err := s.loadQuorumAndProfile(ctx, scope, tx, req.DocumentVersionID, req.IdentityID, documentVersion.OrganizationID)
 			if err != nil {
 				return fmt.Errorf("cannot load quorum and profile: %w", err)
 			}
 
 			decision = &coredata.DocumentVersionApprovalDecision{}
-			if err := decision.LoadByQuorumIDAndApproverID(ctx, tx, s.svc.scope, quorum.ID, profile.ID); err != nil {
+			if err := decision.LoadByQuorumIDAndApproverID(ctx, tx, scope, quorum.ID, profile.ID); err != nil {
 				return fmt.Errorf("cannot load approval decision: %w", err)
 			}
 
@@ -439,19 +439,19 @@ func (s *DocumentApprovalService) Reject(
 			decision.DecidedAt = &now
 			decision.UpdatedAt = now
 
-			if err := decision.Update(ctx, tx, s.svc.scope); err != nil {
+			if err := decision.Update(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot update approval decision: %w", err)
 			}
 
 			quorum.Status = coredata.DocumentVersionApprovalQuorumStatusRejected
 			quorum.UpdatedAt = now
 
-			if err := quorum.Update(ctx, tx, s.svc.scope); err != nil {
+			if err := quorum.Update(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot update approval quorum: %w", err)
 			}
 
 			decisions := &coredata.DocumentVersionApprovalDecisions{}
-			if err := decisions.VoidPendingByQuorumID(ctx, tx, s.svc.scope, quorum.ID, now); err != nil {
+			if err := decisions.VoidPendingByQuorumID(ctx, tx, scope, quorum.ID, now); err != nil {
 				return fmt.Errorf("cannot void pending decisions: %w", err)
 			}
 
@@ -466,7 +466,7 @@ func (s *DocumentApprovalService) Reject(
 
 			documentVersion.UpdatedAt = now
 
-			if err := documentVersion.Update(ctx, tx, s.svc.scope); err != nil {
+			if err := documentVersion.Update(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot update document version status: %w", err)
 			}
 
@@ -481,7 +481,7 @@ func (s *DocumentApprovalService) Reject(
 }
 
 func (s *DocumentApprovalService) VoidApproval(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentVersionID gid.GID,
 ) (*coredata.DocumentVersionApprovalQuorum, *coredata.DocumentVersion, error) {
 	var (
@@ -493,12 +493,12 @@ func (s *DocumentApprovalService) VoidApproval(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			documentVersion = &coredata.DocumentVersion{}
-			if err := documentVersion.LoadByID(ctx, tx, s.svc.scope, documentVersionID); err != nil {
+			if err := documentVersion.LoadByID(ctx, tx, scope, documentVersionID); err != nil {
 				return fmt.Errorf("cannot load document version: %w", err)
 			}
 
 			document := &coredata.Document{}
-			if err := document.LoadByID(ctx, tx, s.svc.scope, documentVersion.DocumentID); err != nil {
+			if err := document.LoadByID(ctx, tx, scope, documentVersion.DocumentID); err != nil {
 				return fmt.Errorf("cannot load document: %w", err)
 			}
 
@@ -511,7 +511,7 @@ func (s *DocumentApprovalService) VoidApproval(
 			}
 
 			quorum = &coredata.DocumentVersionApprovalQuorum{}
-			if err := quorum.LoadLastByDocumentVersionID(ctx, tx, s.svc.scope, documentVersionID); err != nil {
+			if err := quorum.LoadLastByDocumentVersionID(ctx, tx, scope, documentVersionID); err != nil {
 				return fmt.Errorf("cannot load approval quorum: %w", err)
 			}
 
@@ -524,12 +524,12 @@ func (s *DocumentApprovalService) VoidApproval(
 			quorum.Status = coredata.DocumentVersionApprovalQuorumStatusVoided
 			quorum.UpdatedAt = now
 
-			if err := quorum.Update(ctx, tx, s.svc.scope); err != nil {
+			if err := quorum.Update(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot update approval quorum: %w", err)
 			}
 
 			decisions := &coredata.DocumentVersionApprovalDecisions{}
-			if err := decisions.VoidPendingByQuorumID(ctx, tx, s.svc.scope, quorum.ID, now); err != nil {
+			if err := decisions.VoidPendingByQuorumID(ctx, tx, scope, quorum.ID, now); err != nil {
 				return fmt.Errorf("cannot void pending decisions: %w", err)
 			}
 
@@ -544,7 +544,7 @@ func (s *DocumentApprovalService) VoidApproval(
 
 			documentVersion.UpdatedAt = now
 
-			if err := documentVersion.Update(ctx, tx, s.svc.scope); err != nil {
+			if err := documentVersion.Update(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot update document version status: %w", err)
 			}
 
@@ -559,7 +559,7 @@ func (s *DocumentApprovalService) VoidApproval(
 }
 
 func (s *DocumentApprovalService) GetQuorum(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	quorumID gid.GID,
 ) (*coredata.DocumentVersionApprovalQuorum, error) {
 	quorum := &coredata.DocumentVersionApprovalQuorum{}
@@ -567,7 +567,7 @@ func (s *DocumentApprovalService) GetQuorum(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := quorum.LoadByID(ctx, conn, s.svc.scope, quorumID); err != nil {
+			if err := quorum.LoadByID(ctx, conn, scope, quorumID); err != nil {
 				return fmt.Errorf("cannot load approval quorum: %w", err)
 			}
 
@@ -582,7 +582,7 @@ func (s *DocumentApprovalService) GetQuorum(
 }
 
 func (s *DocumentApprovalService) ListQuorums(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentVersionID gid.GID,
 	cursor *page.Cursor[coredata.DocumentVersionApprovalQuorumOrderField],
 ) (*page.Page[*coredata.DocumentVersionApprovalQuorum, coredata.DocumentVersionApprovalQuorumOrderField], error) {
@@ -591,7 +591,7 @@ func (s *DocumentApprovalService) ListQuorums(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := quorums.LoadAllByDocumentVersionID(ctx, conn, s.svc.scope, documentVersionID, cursor); err != nil {
+			if err := quorums.LoadAllByDocumentVersionID(ctx, conn, scope, documentVersionID, cursor); err != nil {
 				return fmt.Errorf("cannot list approval quorums: %w", err)
 			}
 
@@ -606,7 +606,7 @@ func (s *DocumentApprovalService) ListQuorums(
 }
 
 func (s *DocumentApprovalService) CountQuorums(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentVersionID gid.GID,
 ) (int, error) {
 	var count int
@@ -616,7 +616,7 @@ func (s *DocumentApprovalService) CountQuorums(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			quorums := &coredata.DocumentVersionApprovalQuorums{}
 
-			count, err = quorums.CountByDocumentVersionID(ctx, conn, s.svc.scope, documentVersionID)
+			count, err = quorums.CountByDocumentVersionID(ctx, conn, scope, documentVersionID)
 			if err != nil {
 				return fmt.Errorf("cannot count approval quorums: %w", err)
 			}
@@ -632,7 +632,7 @@ func (s *DocumentApprovalService) CountQuorums(
 }
 
 func (s *DocumentApprovalService) ListDecisions(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	quorumID gid.GID,
 	cursor *page.Cursor[coredata.DocumentVersionApprovalDecisionOrderField],
 	filter *coredata.DocumentVersionApprovalDecisionFilter,
@@ -642,7 +642,7 @@ func (s *DocumentApprovalService) ListDecisions(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := decisions.LoadByQuorumID(ctx, conn, s.svc.scope, quorumID, cursor, filter); err != nil {
+			if err := decisions.LoadByQuorumID(ctx, conn, scope, quorumID, cursor, filter); err != nil {
 				return fmt.Errorf("cannot list approval decisions: %w", err)
 			}
 
@@ -657,7 +657,7 @@ func (s *DocumentApprovalService) ListDecisions(
 }
 
 func (s *DocumentApprovalService) CountDecisions(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	quorumID gid.GID,
 	filter *coredata.DocumentVersionApprovalDecisionFilter,
 ) (int, error) {
@@ -668,7 +668,7 @@ func (s *DocumentApprovalService) CountDecisions(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			decisions := &coredata.DocumentVersionApprovalDecisions{}
 
-			count, err = decisions.CountByQuorumID(ctx, conn, s.svc.scope, quorumID, filter)
+			count, err = decisions.CountByQuorumID(ctx, conn, scope, quorumID, filter)
 			if err != nil {
 				return fmt.Errorf("cannot count approval decisions: %w", err)
 			}
@@ -684,7 +684,7 @@ func (s *DocumentApprovalService) CountDecisions(
 }
 
 func (s *DocumentApprovalService) GetDecision(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	decisionID gid.GID,
 ) (*coredata.DocumentVersionApprovalDecision, error) {
 	decision := &coredata.DocumentVersionApprovalDecision{}
@@ -692,7 +692,7 @@ func (s *DocumentApprovalService) GetDecision(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := decision.LoadByID(ctx, conn, s.svc.scope, decisionID); err != nil {
+			if err := decision.LoadByID(ctx, conn, scope, decisionID); err != nil {
 				return fmt.Errorf("cannot load approval decision: %w", err)
 			}
 
@@ -707,7 +707,7 @@ func (s *DocumentApprovalService) GetDecision(
 }
 
 func (s *DocumentApprovalService) GetViewerDecision(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentVersionID gid.GID,
 	identityID gid.GID,
 ) (*coredata.DocumentVersionApprovalDecision, error) {
@@ -717,7 +717,7 @@ func (s *DocumentApprovalService) GetViewerDecision(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			documentVersion := &coredata.DocumentVersion{}
-			if err := documentVersion.LoadByID(ctx, conn, s.svc.scope, documentVersionID); err != nil {
+			if err := documentVersion.LoadByID(ctx, conn, scope, documentVersionID); err != nil {
 				return fmt.Errorf("cannot load document version: %w", err)
 			}
 
@@ -725,7 +725,7 @@ func (s *DocumentApprovalService) GetViewerDecision(
 			if err := profile.LoadByIdentityIDAndOrganizationID(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				identityID,
 				documentVersion.OrganizationID,
 			); err != nil {
@@ -733,12 +733,12 @@ func (s *DocumentApprovalService) GetViewerDecision(
 			}
 
 			quorum := &coredata.DocumentVersionApprovalQuorum{}
-			if err := quorum.LoadLastByDocumentVersionID(ctx, conn, s.svc.scope, documentVersionID); err != nil {
+			if err := quorum.LoadLastByDocumentVersionID(ctx, conn, scope, documentVersionID); err != nil {
 				return fmt.Errorf("cannot load last approval quorum: %w", err)
 			}
 
 			d := &coredata.DocumentVersionApprovalDecision{}
-			if err := d.LoadByQuorumIDAndApproverID(ctx, conn, s.svc.scope, quorum.ID, profile.ID); err != nil {
+			if err := d.LoadByQuorumIDAndApproverID(ctx, conn, scope, quorum.ID, profile.ID); err != nil {
 				return fmt.Errorf("cannot load viewer approval decision: %w", err)
 			}
 
@@ -755,14 +755,14 @@ func (s *DocumentApprovalService) GetViewerDecision(
 }
 
 func (s *DocumentApprovalService) loadQuorumAndProfile(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	conn pg.Querier,
 	documentVersionID gid.GID,
 	identityID gid.GID,
 	organizationID gid.GID,
 ) (*coredata.DocumentVersionApprovalQuorum, *coredata.MembershipProfile, error) {
 	quorum := &coredata.DocumentVersionApprovalQuorum{}
-	if err := quorum.LoadLastByDocumentVersionID(ctx, conn, s.svc.scope, documentVersionID); err != nil {
+	if err := quorum.LoadLastByDocumentVersionID(ctx, conn, scope, documentVersionID); err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil, &ErrDocumentVersionNotPendingApproval{}
 		}
@@ -771,7 +771,7 @@ func (s *DocumentApprovalService) loadQuorumAndProfile(
 	}
 
 	profile := &coredata.MembershipProfile{}
-	if err := profile.LoadByIdentityIDAndOrganizationID(ctx, conn, s.svc.scope, identityID, organizationID); err != nil {
+	if err := profile.LoadByIdentityIDAndOrganizationID(ctx, conn, scope, identityID, organizationID); err != nil {
 		return nil, nil, fmt.Errorf("cannot find profile for identity: %w", err)
 	}
 
@@ -779,7 +779,7 @@ func (s *DocumentApprovalService) loadQuorumAndProfile(
 }
 
 func (s *DocumentApprovalService) createDecisions(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	tx pg.Tx,
 	quorum *coredata.DocumentVersionApprovalQuorum,
 	organizationID gid.GID,
@@ -789,7 +789,7 @@ func (s *DocumentApprovalService) createDecisions(
 	decisions := make(coredata.DocumentVersionApprovalDecisions, 0, len(approverIDs))
 	for _, approverID := range approverIDs {
 		decisions = append(decisions, &coredata.DocumentVersionApprovalDecision{
-			ID:             gid.New(s.svc.scope.GetTenantID(), coredata.DocumentVersionApprovalDecisionEntityType),
+			ID:             gid.New(scope.GetTenantID(), coredata.DocumentVersionApprovalDecisionEntityType),
 			OrganizationID: organizationID,
 			QuorumID:       quorum.ID,
 			ApproverID:     approverID,
@@ -799,7 +799,7 @@ func (s *DocumentApprovalService) createDecisions(
 		})
 	}
 
-	if err := decisions.BulkInsert(ctx, tx, s.svc.scope); err != nil {
+	if err := decisions.BulkInsert(ctx, tx, scope); err != nil {
 		return fmt.Errorf("cannot insert approval decisions: %w", err)
 	}
 
@@ -807,7 +807,7 @@ func (s *DocumentApprovalService) createDecisions(
 }
 
 func (s *DocumentApprovalService) sendApprovalEmails(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	tx pg.Tx,
 	profiles coredata.MembershipProfiles,
 	document *coredata.Document,
@@ -889,7 +889,7 @@ func (s *DocumentApprovalService) sendApprovalEmails(
 }
 
 func (s *DocumentApprovalService) generateApprovalPDF(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentVersionID gid.GID,
 ) ([]byte, error) {
 	var pdfData []byte
@@ -904,7 +904,7 @@ func (s *DocumentApprovalService) generateApprovalPDF(
 				s.svc,
 				s.html2pdfConverter,
 				conn,
-				s.svc.scope,
+				scope,
 				documentVersionID,
 				ExportPDFOptions{},
 			)
@@ -917,7 +917,7 @@ func (s *DocumentApprovalService) generateApprovalPDF(
 }
 
 func (s *DocumentApprovalService) countDecisions(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	conn pg.Querier,
 	quorumID gid.GID,
 ) (int, error) {
@@ -926,7 +926,7 @@ func (s *DocumentApprovalService) countDecisions(
 	count, err := decisions.CountByQuorumID(
 		ctx,
 		conn,
-		s.svc.scope,
+		scope,
 		quorumID,
 		coredata.NewDocumentVersionApprovalDecisionFilter(nil),
 	)
@@ -938,11 +938,11 @@ func (s *DocumentApprovalService) countDecisions(
 }
 
 func (s *DocumentApprovalService) maybeApproveQuorum(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	tx pg.Tx,
 	quorumID gid.GID,
 ) error {
-	totalCount, err := s.countDecisions(ctx, tx, quorumID)
+	totalCount, err := s.countDecisions(ctx, scope, tx, quorumID)
 	if err != nil {
 		return fmt.Errorf("cannot count total decisions: %w", err)
 	}
@@ -953,7 +953,7 @@ func (s *DocumentApprovalService) maybeApproveQuorum(
 
 	decisions := &coredata.DocumentVersionApprovalDecisions{}
 
-	approvedCount, err := decisions.CountApprovedByQuorumID(ctx, tx, s.svc.scope, quorumID)
+	approvedCount, err := decisions.CountApprovedByQuorumID(ctx, tx, scope, quorumID)
 	if err != nil {
 		return fmt.Errorf("cannot count approved decisions: %w", err)
 	}
@@ -963,7 +963,7 @@ func (s *DocumentApprovalService) maybeApproveQuorum(
 	}
 
 	quorum := &coredata.DocumentVersionApprovalQuorum{}
-	if err := quorum.LoadByID(ctx, tx, s.svc.scope, quorumID); err != nil {
+	if err := quorum.LoadByID(ctx, tx, scope, quorumID); err != nil {
 		return fmt.Errorf("cannot load quorum: %w", err)
 	}
 
@@ -971,11 +971,11 @@ func (s *DocumentApprovalService) maybeApproveQuorum(
 	quorum.Status = coredata.DocumentVersionApprovalQuorumStatusApproved
 	quorum.UpdatedAt = now
 
-	if err := quorum.Update(ctx, tx, s.svc.scope); err != nil {
+	if err := quorum.Update(ctx, tx, scope); err != nil {
 		return fmt.Errorf("cannot update quorum: %w", err)
 	}
 
-	if err := s.publishVersion(ctx, tx, quorum.VersionID); err != nil {
+	if err := s.publishVersion(ctx, scope, tx, quorum.VersionID); err != nil {
 		return fmt.Errorf("cannot publish version: %w", err)
 	}
 
@@ -983,24 +983,24 @@ func (s *DocumentApprovalService) maybeApproveQuorum(
 }
 
 func (s *DocumentApprovalService) publishVersion(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	tx pg.Tx,
 	versionID gid.GID,
 ) error {
 	version := &coredata.DocumentVersion{}
-	if err := version.LoadByID(ctx, tx, s.svc.scope, versionID); err != nil {
+	if err := version.LoadByID(ctx, tx, scope, versionID); err != nil {
 		return fmt.Errorf("cannot load document version: %w", err)
 	}
 
 	document := &coredata.Document{}
-	if err := document.LoadByID(ctx, tx, s.svc.scope, version.DocumentID); err != nil {
+	if err := document.LoadByID(ctx, tx, scope, version.DocumentID); err != nil {
 		return fmt.Errorf("cannot load document: %w", err)
 	}
 
 	document.CurrentPublishedMajor = &version.Major
 	document.CurrentPublishedMinor = &version.Minor
 
-	if err := s.svc.Documents.finalizePublish(ctx, tx, document, version, nil); err != nil {
+	if err := s.svc.Documents.finalizePublish(ctx, scope, tx, document, version, nil); err != nil {
 		return fmt.Errorf("cannot finalize publish: %w", err)
 	}
 

--- a/pkg/probo/document_pdf_worker.go
+++ b/pkg/probo/document_pdf_worker.go
@@ -69,9 +69,9 @@ func (h *documentPDFHandler) Claim(ctx context.Context) (coredata.DocumentVersio
 }
 
 func (h *documentPDFHandler) Process(ctx context.Context, version coredata.DocumentVersion) error {
-	tenantService := h.service.WithTenant(version.ID.TenantID())
+	scope := coredata.NewScope(version.ID.TenantID())
 
-	if err := tenantService.Documents.generateAndUploadPublicationPDF(ctx, &version); err != nil {
+	if err := h.service.Documents.generateAndUploadPublicationPDF(ctx, scope, &version); err != nil {
 		h.logger.ErrorCtx(
 			ctx,
 			"document pdf worker failure",

--- a/pkg/probo/document_service.go
+++ b/pkg/probo/document_service.go
@@ -52,7 +52,7 @@ import (
 
 type (
 	DocumentService struct {
-		svc                     *TenantService
+		svc                     *Service
 		html2pdfConverter       *html2pdf.Converter
 		invitationTokenValidity time.Duration
 		tokenSecret             string
@@ -281,7 +281,7 @@ func (e ErrProfileContractEnded) Error() string {
 }
 
 func (s *DocumentService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentID gid.GID,
 ) (*coredata.Document, error) {
 	document := &coredata.Document{}
@@ -289,7 +289,7 @@ func (s *DocumentService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return document.LoadByID(ctx, conn, s.svc.scope, documentID)
+			return document.LoadByID(ctx, conn, scope, documentID)
 		},
 	)
 	if err != nil {
@@ -300,7 +300,7 @@ func (s *DocumentService) Get(
 }
 
 func (s *DocumentService) GetDefaultApprovers(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentID gid.GID,
 ) (coredata.MembershipProfiles, error) {
 	var approvers coredata.DocumentDefaultApprovers
@@ -308,7 +308,7 @@ func (s *DocumentService) GetDefaultApprovers(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return approvers.LoadByDocumentID(ctx, conn, s.svc.scope, documentID)
+			return approvers.LoadByDocumentID(ctx, conn, scope, documentID)
 		},
 	)
 	if err != nil {
@@ -329,7 +329,7 @@ func (s *DocumentService) GetDefaultApprovers(
 	err = s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return profiles.LoadByIDs(ctx, conn, s.svc.scope, profileIDs)
+			return profiles.LoadByIDs(ctx, conn, scope, profileIDs)
 		},
 	)
 	if err != nil {
@@ -340,7 +340,7 @@ func (s *DocumentService) GetDefaultApprovers(
 }
 
 func (s *DocumentService) GetByIDs(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentIDs ...gid.GID,
 ) (coredata.Documents, error) {
 	var documents coredata.Documents
@@ -351,7 +351,7 @@ func (s *DocumentService) GetByIDs(
 			if err := documents.LoadByIDs(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				documentIDs,
 			); err != nil {
 				return fmt.Errorf("cannot load documents by ids: %w", err)
@@ -368,7 +368,7 @@ func (s *DocumentService) GetByIDs(
 }
 
 func (s *DocumentService) ListVersionApprovers(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentVersionID gid.GID,
 	cursor *page.Cursor[coredata.MembershipProfileOrderField],
 ) (*page.Page[*coredata.MembershipProfile, coredata.MembershipProfileOrderField], error) {
@@ -377,7 +377,7 @@ func (s *DocumentService) ListVersionApprovers(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := profiles.LoadByDocumentVersionID(ctx, conn, s.svc.scope, documentVersionID, cursor); err != nil {
+			if err := profiles.LoadByDocumentVersionID(ctx, conn, scope, documentVersionID, cursor); err != nil {
 				return fmt.Errorf("cannot load document version approvers: %w", err)
 			}
 
@@ -392,7 +392,7 @@ func (s *DocumentService) ListVersionApprovers(
 }
 
 func (s *DocumentService) CountVersionApprovers(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentVersionID gid.GID,
 ) (int, error) {
 	var count int
@@ -402,7 +402,7 @@ func (s *DocumentService) CountVersionApprovers(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			profiles := coredata.MembershipProfiles{}
 
-			count, err = profiles.CountByDocumentVersionID(ctx, conn, s.svc.scope, documentVersionID)
+			count, err = profiles.CountByDocumentVersionID(ctx, conn, scope, documentVersionID)
 			if err != nil {
 				return fmt.Errorf("cannot count document version approvers: %w", err)
 			}
@@ -418,7 +418,7 @@ func (s *DocumentService) CountVersionApprovers(
 }
 
 func (s *DocumentService) GetWithFilter(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentID gid.GID,
 	filter *coredata.DocumentFilter,
 ) (*coredata.Document, error) {
@@ -427,7 +427,7 @@ func (s *DocumentService) GetWithFilter(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			err := document.LoadByIDWithFilter(ctx, conn, s.svc.scope, documentID, filter)
+			err := document.LoadByIDWithFilter(ctx, conn, scope, documentID, filter)
 			if err != nil {
 				return fmt.Errorf("cannot load document: %w", err)
 			}
@@ -443,7 +443,7 @@ func (s *DocumentService) GetWithFilter(
 }
 
 func (s DocumentService) GenerateChangelog(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentID gid.GID,
 ) (*string, error) {
 	var changelog *string
@@ -454,7 +454,7 @@ func (s DocumentService) GenerateChangelog(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := draftVersion.LoadLatestVersion(ctx, conn, s.svc.scope, documentID); err != nil {
+			if err := draftVersion.LoadLatestVersion(ctx, conn, scope, documentID); err != nil {
 				return fmt.Errorf("cannot load draft version: %w", err)
 			}
 
@@ -463,7 +463,7 @@ func (s DocumentService) GenerateChangelog(
 			}
 
 			document := &coredata.Document{}
-			if err := document.LoadByID(ctx, conn, s.svc.scope, documentID); err != nil {
+			if err := document.LoadByID(ctx, conn, scope, documentID); err != nil {
 				return fmt.Errorf("cannot load document: %w", err)
 			}
 
@@ -475,7 +475,7 @@ func (s DocumentService) GenerateChangelog(
 				initialVersionChangelog := "Initial version"
 				changelog = &initialVersionChangelog
 			} else {
-				if err := publishedVersion.LoadByDocumentIDAndVersion(ctx, conn, s.svc.scope, documentID, *document.CurrentPublishedMajor, *document.CurrentPublishedMinor); err != nil {
+				if err := publishedVersion.LoadByDocumentIDAndVersion(ctx, conn, scope, documentID, *document.CurrentPublishedMajor, *document.CurrentPublishedMinor); err != nil {
 					return fmt.Errorf("cannot load published version: %w", err)
 				}
 			}
@@ -493,7 +493,7 @@ func (s DocumentService) GenerateChangelog(
 	}
 
 	if changelog == nil {
-		changelog, err = s.generateChangelog(ctx, publishedVersion.Content, draftVersion.Content)
+		changelog, err = s.generateChangelog(ctx, scope, publishedVersion.Content, draftVersion.Content)
 		if err != nil {
 			return nil, fmt.Errorf("cannot generate changelog: %w", err)
 		}
@@ -506,7 +506,7 @@ func (s DocumentService) GenerateChangelog(
 var changelogGeneratorSystemPrompt string
 
 func (s DocumentService) generateChangelog(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	oldContent, newContent string,
 ) (*string, error) {
 	ag := agent.New(
@@ -550,7 +550,7 @@ func (s DocumentService) generateChangelog(
 //   - Minor=false without ApproverIDs: publish the draft immediately as a
 //     major bump (currentMajor+1.0).
 func (s *DocumentService) PublishVersion(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req PublishDocumentRequest,
 ) (*PublishDocumentResult, error) {
 	if err := req.Validate(); err != nil {
@@ -563,7 +563,7 @@ func (s *DocumentService) PublishVersion(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			dv := &coredata.DocumentVersion{}
-			if err := dv.LoadLatestVersion(ctx, tx, s.svc.scope, req.DocumentID); err != nil {
+			if err := dv.LoadLatestVersion(ctx, tx, scope, req.DocumentID); err != nil {
 				return fmt.Errorf("cannot load latest version: %w", err)
 			}
 
@@ -572,7 +572,7 @@ func (s *DocumentService) PublishVersion(
 			}
 
 			if req.Minor {
-				document, version, err := s.publishMinorVersionInTx(ctx, tx, req.DocumentID, &req.Changelog, false)
+				document, version, err := s.publishMinorVersionInTx(ctx, scope, tx, req.DocumentID, &req.Changelog, false)
 				if err != nil {
 					return fmt.Errorf("cannot publish minor version: %w", err)
 				}
@@ -584,7 +584,7 @@ func (s *DocumentService) PublishVersion(
 			}
 
 			if len(req.ApproverIDs) == 0 {
-				document, version, err := s.publishMajorVersionInTx(ctx, tx, req.DocumentID, &req.Changelog, false)
+				document, version, err := s.publishMajorVersionInTx(ctx, scope, tx, req.DocumentID, &req.Changelog, false)
 				if err != nil {
 					return fmt.Errorf("cannot publish major version: %w", err)
 				}
@@ -596,7 +596,7 @@ func (s *DocumentService) PublishVersion(
 			}
 
 			profiles := &coredata.MembershipProfiles{}
-			if err := profiles.LoadByIDs(ctx, tx, s.svc.scope, req.ApproverIDs); err != nil {
+			if err := profiles.LoadByIDs(ctx, tx, scope, req.ApproverIDs); err != nil {
 				return fmt.Errorf("cannot load approver profiles: %w", err)
 			}
 
@@ -608,7 +608,7 @@ func (s *DocumentService) PublishVersion(
 			}
 
 			document := &coredata.Document{}
-			if err := document.LoadByID(ctx, tx, s.svc.scope, req.DocumentID); err != nil {
+			if err := document.LoadByID(ctx, tx, scope, req.DocumentID); err != nil {
 				return fmt.Errorf("cannot load document: %w", err)
 			}
 
@@ -620,13 +620,13 @@ func (s *DocumentService) PublishVersion(
 				return &ErrDocumentVersionNotDraft{}
 			}
 
-			quorum, err := s.svc.DocumentApprovals.RequestApprovalInTx(ctx, tx, document, dv, req.ApproverIDs, &req.Changelog)
+			quorum, err := s.svc.DocumentApprovals.RequestApprovalInTx(ctx, scope, tx, document, dv, req.ApproverIDs, &req.Changelog)
 			if err != nil {
 				return fmt.Errorf("cannot request approval: %w", err)
 			}
 
 			defaultApprovers := &coredata.DocumentDefaultApprovers{}
-			if err := defaultApprovers.MergeByDocumentID(ctx, tx, s.svc.scope, req.DocumentID, document.OrganizationID, req.ApproverIDs); err != nil {
+			if err := defaultApprovers.MergeByDocumentID(ctx, tx, scope, req.DocumentID, document.OrganizationID, req.ApproverIDs); err != nil {
 				return fmt.Errorf("cannot update default approvers: %w", err)
 			}
 
@@ -645,7 +645,7 @@ func (s *DocumentService) PublishVersion(
 }
 
 func (s *DocumentService) Create(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req CreateDocumentRequest,
 ) (*coredata.Document, *coredata.DocumentVersion, error) {
 	if err := req.Validate(); err != nil {
@@ -653,8 +653,8 @@ func (s *DocumentService) Create(
 	}
 
 	now := time.Now()
-	documentID := gid.New(s.svc.scope.GetTenantID(), coredata.DocumentEntityType)
-	documentVersionID := gid.New(s.svc.scope.GetTenantID(), coredata.DocumentVersionEntityType)
+	documentID := gid.New(scope.GetTenantID(), coredata.DocumentEntityType)
+	documentVersionID := gid.New(scope.GetTenantID(), coredata.DocumentVersionEntityType)
 
 	organization := &coredata.Organization{}
 
@@ -699,25 +699,25 @@ func (s *DocumentService) Create(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := organization.LoadByID(ctx, conn, s.svc.scope, req.OrganizationID); err != nil {
+			if err := organization.LoadByID(ctx, conn, scope, req.OrganizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
 			document.OrganizationID = organization.ID
 
-			if err := document.Insert(ctx, conn, s.svc.scope); err != nil {
+			if err := document.Insert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot insert document: %w", err)
 			}
 
 			documentVersion.OrganizationID = organization.ID
 
-			if err := documentVersion.Insert(ctx, conn, s.svc.scope); err != nil {
+			if err := documentVersion.Insert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot create document version: %w", err)
 			}
 
 			if len(req.DefaultApproverIDs) > 0 {
 				approvers := &coredata.DocumentDefaultApprovers{}
-				if err := approvers.MergeByDocumentID(ctx, conn, s.svc.scope, documentID, organization.ID, req.DefaultApproverIDs); err != nil {
+				if err := approvers.MergeByDocumentID(ctx, conn, scope, documentID, organization.ID, req.DefaultApproverIDs); err != nil {
 					return fmt.Errorf("cannot set default approvers: %w", err)
 				}
 			}
@@ -733,7 +733,7 @@ func (s *DocumentService) Create(
 }
 
 func (s *DocumentService) SendSigningNotifications(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) error {
 	now := time.Now()
@@ -742,12 +742,12 @@ func (s *DocumentService) SendSigningNotifications(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			var signatories coredata.MembershipProfiles
-			if err := signatories.LoadAwaitingSigning(ctx, tx, s.svc.scope); err != nil {
+			if err := signatories.LoadAwaitingSigning(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot load signatories: %w", err)
 			}
 
 			organization := &coredata.Organization{}
-			if err := organization.LoadByID(ctx, tx, s.svc.scope, organizationID); err != nil {
+			if err := organization.LoadByID(ctx, tx, scope, organizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
@@ -829,7 +829,7 @@ func (s *DocumentService) SendSigningNotifications(
 }
 
 func (s *DocumentService) SignDocumentVersionByIdentity(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentVersionID gid.GID,
 	identityID gid.GID,
 ) (*coredata.DocumentVersionSignature, error) {
@@ -839,19 +839,19 @@ func (s *DocumentService) SignDocumentVersionByIdentity(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			documentVersion := &coredata.DocumentVersion{}
-			if err := documentVersion.LoadByID(ctx, conn, s.svc.scope, documentVersionID); err != nil {
+			if err := documentVersion.LoadByID(ctx, conn, scope, documentVersionID); err != nil {
 				return fmt.Errorf("cannot get document version: %w", err)
 			}
 
 			profile := &coredata.MembershipProfile{}
 			// FIXME: will be done differently
-			if err := profile.LoadByIdentityIDAndOrganizationID(ctx, conn, s.svc.scope, identityID, documentVersion.OrganizationID); err != nil {
+			if err := profile.LoadByIdentityIDAndOrganizationID(ctx, conn, scope, identityID, documentVersion.OrganizationID); err != nil {
 				return fmt.Errorf("cannot find profile record for user email in organization %q: %w", documentVersion.OrganizationID, err)
 			}
 
 			var signErr error
 
-			documentVersionSignature, signErr = s.signDocumentVersionInTx(ctx, conn, documentVersionID, profile.ID)
+			documentVersionSignature, signErr = s.signDocumentVersionInTx(ctx, scope, conn, documentVersionID, profile.ID)
 
 			return signErr
 		},
@@ -864,7 +864,7 @@ func (s *DocumentService) SignDocumentVersionByIdentity(
 }
 
 func (s *DocumentService) signDocumentVersionInTx(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	conn pg.Tx,
 	documentVersionID gid.GID,
 	signatory gid.GID,
@@ -873,7 +873,7 @@ func (s *DocumentService) signDocumentVersionInTx(
 	documentVersionSignature := &coredata.DocumentVersionSignature{}
 	now := time.Now()
 
-	if err := documentVersion.LoadByID(ctx, conn, s.svc.scope, documentVersionID); err != nil {
+	if err := documentVersion.LoadByID(ctx, conn, scope, documentVersionID); err != nil {
 		return nil, fmt.Errorf("cannot load document version %q: %w", documentVersionID, err)
 	}
 
@@ -881,7 +881,7 @@ func (s *DocumentService) signDocumentVersionInTx(
 		return nil, fmt.Errorf("cannot sign unpublished version")
 	}
 
-	if err := documentVersionSignature.LoadByDocumentVersionIDAndSignatory(ctx, conn, s.svc.scope, documentVersionID, signatory); err != nil {
+	if err := documentVersionSignature.LoadByDocumentVersionIDAndSignatory(ctx, conn, scope, documentVersionID, signatory); err != nil {
 		return nil, fmt.Errorf("cannot load document version signature: %w", err)
 	}
 
@@ -893,11 +893,11 @@ func (s *DocumentService) signDocumentVersionInTx(
 	documentVersionSignature.SignedAt = &now
 	documentVersionSignature.UpdatedAt = now
 
-	if err := documentVersion.Update(ctx, conn, s.svc.scope); err != nil {
+	if err := documentVersion.Update(ctx, conn, scope); err != nil {
 		return nil, fmt.Errorf("cannot update document version: %w", err)
 	}
 
-	if err := documentVersionSignature.Update(ctx, conn, s.svc.scope); err != nil {
+	if err := documentVersionSignature.Update(ctx, conn, scope); err != nil {
 		return nil, fmt.Errorf("cannot update document version signature: %w", err)
 	}
 
@@ -905,7 +905,7 @@ func (s *DocumentService) signDocumentVersionInTx(
 }
 
 func (s *DocumentService) updateVersionInTx(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	tx pg.Tx,
 	draftVersion *coredata.DocumentVersion,
 	content *string,
@@ -936,7 +936,7 @@ func (s *DocumentService) updateVersionInTx(
 
 	draftVersion.UpdatedAt = time.Now()
 
-	if err := draftVersion.Update(ctx, tx, s.svc.scope); err != nil {
+	if err := draftVersion.Update(ctx, tx, scope); err != nil {
 		return fmt.Errorf("cannot update document version: %w", err)
 	}
 
@@ -944,7 +944,7 @@ func (s *DocumentService) updateVersionInTx(
 }
 
 func (s *DocumentService) GetVersionSignature(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	signatureID gid.GID,
 ) (*coredata.DocumentVersionSignature, error) {
 	documentVersionSignature := &coredata.DocumentVersionSignature{}
@@ -952,7 +952,7 @@ func (s *DocumentService) GetVersionSignature(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return documentVersionSignature.LoadByID(ctx, conn, s.svc.scope, signatureID)
+			return documentVersionSignature.LoadByID(ctx, conn, scope, signatureID)
 		},
 	)
 	if err != nil {
@@ -963,7 +963,7 @@ func (s *DocumentService) GetVersionSignature(
 }
 
 func (s *DocumentService) BulkRequestSignatures(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req BulkRequestSignaturesRequest,
 ) ([]*coredata.DocumentVersionSignature, error) {
 	var signatures []*coredata.DocumentVersionSignature
@@ -972,7 +972,7 @@ func (s *DocumentService) BulkRequestSignatures(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			profiles := &coredata.MembershipProfiles{}
-			if err := profiles.LoadByIDs(ctx, tx, s.svc.scope, req.SignatoryIDs); err != nil {
+			if err := profiles.LoadByIDs(ctx, tx, scope, req.SignatoryIDs); err != nil {
 				return fmt.Errorf("cannot load signatory profiles: %w", err)
 			}
 
@@ -985,7 +985,7 @@ func (s *DocumentService) BulkRequestSignatures(
 
 			for _, documentID := range req.DocumentIDs {
 				documentVersion := &coredata.DocumentVersion{}
-				if err := documentVersion.LoadLatestVersion(ctx, tx, s.svc.scope, documentID); err != nil {
+				if err := documentVersion.LoadLatestVersion(ctx, tx, scope, documentID); err != nil {
 					return fmt.Errorf("cannot load latest version for document %q: %w", documentID, err)
 				}
 
@@ -994,7 +994,7 @@ func (s *DocumentService) BulkRequestSignatures(
 				}
 
 				for _, signatoryID := range req.SignatoryIDs {
-					signature, err := s.createSignatureRequestInTx(ctx, tx, documentVersion.ID, signatoryID, true)
+					signature, err := s.createSignatureRequestInTx(ctx, scope, tx, documentVersion.ID, signatoryID, true)
 					if err != nil {
 						return fmt.Errorf("cannot create signature request for document %q and signatory %q: %w", documentID, signatoryID, err)
 					}
@@ -1014,7 +1014,7 @@ func (s *DocumentService) BulkRequestSignatures(
 }
 
 func (s *DocumentService) createSignatureRequestInTx(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	tx pg.Tx,
 	documentVersionID gid.GID,
 	signatoryID gid.GID,
@@ -1023,22 +1023,22 @@ func (s *DocumentService) createSignatureRequestInTx(
 	signatory := &coredata.MembershipProfile{}
 	documentVersion := &coredata.DocumentVersion{}
 
-	if err := documentVersion.LoadByID(ctx, tx, s.svc.scope, documentVersionID); err != nil {
+	if err := documentVersion.LoadByID(ctx, tx, scope, documentVersionID); err != nil {
 		return nil, fmt.Errorf("cannot load document version: %w", err)
 	}
 
-	if err := signatory.LoadByID(ctx, tx, s.svc.scope, signatoryID); err != nil {
+	if err := signatory.LoadByID(ctx, tx, scope, signatoryID); err != nil {
 		return nil, fmt.Errorf("cannot load signatory: %w", err)
 	}
 
 	existingSignature := &coredata.DocumentVersionSignature{}
 
-	err := existingSignature.LoadByDocumentVersionIDAndSignatory(ctx, tx, s.svc.scope, documentVersionID, signatoryID)
+	err := existingSignature.LoadByDocumentVersionIDAndSignatory(ctx, tx, scope, documentVersionID, signatoryID)
 	if err == nil && ignoreExisting {
 		return existingSignature, nil
 	}
 
-	documentVersionSignatureID := gid.New(s.svc.scope.GetTenantID(), coredata.DocumentVersionSignatureEntityType)
+	documentVersionSignatureID := gid.New(scope.GetTenantID(), coredata.DocumentVersionSignatureEntityType)
 	now := time.Now()
 	documentVersionSignature := &coredata.DocumentVersionSignature{
 		ID:                documentVersionSignatureID,
@@ -1052,7 +1052,7 @@ func (s *DocumentService) createSignatureRequestInTx(
 		UpdatedAt:         now,
 	}
 
-	if err := documentVersionSignature.Insert(ctx, tx, s.svc.scope); err != nil {
+	if err := documentVersionSignature.Insert(ctx, tx, scope); err != nil {
 		return nil, fmt.Errorf("cannot insert document version signature: %w", err)
 	}
 
@@ -1060,7 +1060,7 @@ func (s *DocumentService) createSignatureRequestInTx(
 }
 
 func (s *DocumentService) RequestSignature(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req RequestSignatureRequest,
 ) (*coredata.DocumentVersionSignature, error) {
 	var signature *coredata.DocumentVersionSignature
@@ -1069,12 +1069,12 @@ func (s *DocumentService) RequestSignature(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			documentVersion := &coredata.DocumentVersion{}
-			if err := documentVersion.LoadByID(ctx, tx, s.svc.scope, req.DocumentVersionID); err != nil {
+			if err := documentVersion.LoadByID(ctx, tx, scope, req.DocumentVersionID); err != nil {
 				return fmt.Errorf("cannot load document version: %w", err)
 			}
 
 			document := &coredata.Document{}
-			if err := document.LoadByID(ctx, tx, s.svc.scope, documentVersion.DocumentID); err != nil {
+			if err := document.LoadByID(ctx, tx, scope, documentVersion.DocumentID); err != nil {
 				return fmt.Errorf("cannot load document: %w", err)
 			}
 
@@ -1087,7 +1087,7 @@ func (s *DocumentService) RequestSignature(
 			}
 
 			profile := &coredata.MembershipProfile{}
-			if err := profile.LoadByID(ctx, tx, s.svc.scope, req.Signatory); err != nil {
+			if err := profile.LoadByID(ctx, tx, scope, req.Signatory); err != nil {
 				return fmt.Errorf("cannot load signatory profile: %w", err)
 			}
 
@@ -1097,7 +1097,7 @@ func (s *DocumentService) RequestSignature(
 
 			var err error
 
-			signature, err = s.createSignatureRequestInTx(ctx, tx, req.DocumentVersionID, req.Signatory, false)
+			signature, err = s.createSignatureRequestInTx(ctx, scope, tx, req.DocumentVersionID, req.Signatory, false)
 			if err != nil {
 				return fmt.Errorf("cannot create signature request: %w", err)
 			}
@@ -1113,7 +1113,7 @@ func (s *DocumentService) RequestSignature(
 }
 
 func (s *DocumentService) ListSignatures(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentVersionID gid.GID,
 	cursor *page.Cursor[coredata.DocumentVersionSignatureOrderField],
 	filter *coredata.DocumentVersionSignatureFilter,
@@ -1123,7 +1123,7 @@ func (s *DocumentService) ListSignatures(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return documentVersionSignatures.LoadByDocumentVersionID(ctx, conn, s.svc.scope, documentVersionID, cursor, filter)
+			return documentVersionSignatures.LoadByDocumentVersionID(ctx, conn, scope, documentVersionID, cursor, filter)
 		},
 	)
 	if err != nil {
@@ -1134,7 +1134,7 @@ func (s *DocumentService) ListSignatures(
 }
 
 func (s *DocumentService) IsVersionSignedByUserEmail(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentVersionID gid.GID,
 	userEmail mail.Addr,
 ) (bool, error) {
@@ -1150,7 +1150,7 @@ func (s *DocumentService) IsVersionSignedByUserEmail(
 			signed, err = documentVersionSignature.IsSignedByUserEmail(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				documentVersionID,
 				userEmail,
 			)
@@ -1166,7 +1166,7 @@ func (s *DocumentService) IsVersionSignedByUserEmail(
 }
 
 func (s *DocumentService) createDraftInTx(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	tx pg.Tx,
 	document *coredata.Document,
 	latestVersion *coredata.DocumentVersion,
@@ -1174,7 +1174,7 @@ func (s *DocumentService) createDraftInTx(
 	now := time.Now()
 
 	draftVersion := &coredata.DocumentVersion{
-		ID:             gid.New(s.svc.scope.GetTenantID(), coredata.DocumentVersionEntityType),
+		ID:             gid.New(scope.GetTenantID(), coredata.DocumentVersionEntityType),
 		OrganizationID: document.OrganizationID,
 		DocumentID:     document.ID,
 		Title:          latestVersion.Title,
@@ -1189,7 +1189,7 @@ func (s *DocumentService) createDraftInTx(
 		UpdatedAt:      now,
 	}
 
-	if err := draftVersion.Insert(ctx, tx, s.svc.scope); err != nil {
+	if err := draftVersion.Insert(ctx, tx, scope); err != nil {
 		return nil, fmt.Errorf("cannot create draft: %w", err)
 	}
 
@@ -1197,11 +1197,11 @@ func (s *DocumentService) createDraftInTx(
 }
 
 func (s *DocumentService) deleteDraftInTx(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	tx pg.Tx,
 	draftVersion *coredata.DocumentVersion,
 ) error {
-	if err := draftVersion.Delete(ctx, tx, s.svc.scope); err != nil {
+	if err := draftVersion.Delete(ctx, tx, scope); err != nil {
 		return fmt.Errorf("cannot delete document version: %w", err)
 	}
 
@@ -1209,7 +1209,7 @@ func (s *DocumentService) deleteDraftInTx(
 }
 
 func (s *DocumentService) SoftDelete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentID gid.GID,
 ) error {
 	document := coredata.Document{ID: documentID}
@@ -1217,17 +1217,17 @@ func (s *DocumentService) SoftDelete(
 	return s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := s.clearDocumentReferences(ctx, tx, []gid.GID{documentID}); err != nil {
+			if err := s.clearDocumentReferences(ctx, scope, tx, []gid.GID{documentID}); err != nil {
 				return err
 			}
 
-			return document.SoftDelete(ctx, tx, s.svc.scope)
+			return document.SoftDelete(ctx, tx, scope)
 		},
 	)
 }
 
 func (s *DocumentService) BulkSoftDelete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentIDs []gid.GID,
 ) error {
 	documents := coredata.Documents{}
@@ -1239,17 +1239,17 @@ func (s *DocumentService) BulkSoftDelete(
 	return s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := s.clearDocumentReferences(ctx, tx, documentIDs); err != nil {
+			if err := s.clearDocumentReferences(ctx, scope, tx, documentIDs); err != nil {
 				return err
 			}
 
-			return documents.BulkSoftDelete(ctx, tx, s.svc.scope)
+			return documents.BulkSoftDelete(ctx, tx, scope)
 		},
 	)
 }
 
 func (s *DocumentService) BulkArchive(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentIDs []gid.GID,
 ) error {
 	documents := coredata.Documents{}
@@ -1262,31 +1262,31 @@ func (s *DocumentService) BulkArchive(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			controlDocument := coredata.ControlDocument{}
-			if err := controlDocument.DeleteByDocumentIDs(ctx, tx, s.svc.scope, documentIDs); err != nil {
+			if err := controlDocument.DeleteByDocumentIDs(ctx, tx, scope, documentIDs); err != nil {
 				return fmt.Errorf("cannot delete control mappings: %w", err)
 			}
 
 			riskDocument := coredata.RiskDocument{}
-			if err := riskDocument.DeleteByDocumentIDs(ctx, tx, s.svc.scope, documentIDs); err != nil {
+			if err := riskDocument.DeleteByDocumentIDs(ctx, tx, scope, documentIDs); err != nil {
 				return fmt.Errorf("cannot delete risk mappings: %w", err)
 			}
 
 			measureDocument := coredata.MeasureDocument{}
-			if err := measureDocument.DeleteByDocumentIDs(ctx, tx, s.svc.scope, documentIDs); err != nil {
+			if err := measureDocument.DeleteByDocumentIDs(ctx, tx, scope, documentIDs); err != nil {
 				return fmt.Errorf("cannot delete measure mappings: %w", err)
 			}
 
-			if err := s.clearDocumentReferences(ctx, tx, documentIDs); err != nil {
+			if err := s.clearDocumentReferences(ctx, scope, tx, documentIDs); err != nil {
 				return err
 			}
 
-			return documents.BulkArchive(ctx, tx, s.svc.scope)
+			return documents.BulkArchive(ctx, tx, scope)
 		},
 	)
 }
 
 func (s *DocumentService) BulkUnarchive(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentIDs []gid.GID,
 ) error {
 	documents := coredata.Documents{}
@@ -1298,7 +1298,7 @@ func (s *DocumentService) BulkUnarchive(
 	return s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return documents.BulkUnarchive(ctx, conn, s.svc.scope)
+			return documents.BulkUnarchive(ctx, conn, scope)
 		},
 	)
 }
@@ -1308,7 +1308,7 @@ func (s *DocumentService) BulkUnarchive(
 // inside a transaction before soft-deleting or archiving documents, because
 // those operations are UPDATEs and do not trigger ON DELETE SET NULL.
 func (s *DocumentService) clearDocumentReferences(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	tx pg.Tx,
 	documentIDs []gid.GID,
 ) error {
@@ -1341,7 +1341,7 @@ func (s *DocumentService) clearDocumentReferences(
 }
 
 func (s *DocumentService) RequestExport(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentIDs []gid.GID,
 	recipientEmail mail.Addr,
 	recipientName string,
@@ -1362,7 +1362,7 @@ func (s *DocumentService) RequestExport(
 
 		for _, documentID := range documentIDs {
 			document := &coredata.Document{}
-			if err := document.LoadByID(ctx, conn, s.svc.scope, documentID); err != nil {
+			if err := document.LoadByID(ctx, conn, scope, documentID); err != nil {
 				return fmt.Errorf("cannot load document %q: %w", documentID, err)
 			}
 
@@ -1370,7 +1370,7 @@ func (s *DocumentService) RequestExport(
 		}
 
 		now := time.Now()
-		exportJobID = gid.New(s.svc.scope.GetTenantID(), coredata.ExportJobEntityType)
+		exportJobID = gid.New(scope.GetTenantID(), coredata.ExportJobEntityType)
 
 		args := coredata.DocumentExportArguments{
 			DocumentIDs:    documentIDs,
@@ -1395,7 +1395,7 @@ func (s *DocumentService) RequestExport(
 			CreatedAt:      now,
 		}
 
-		if err := exportJob.Insert(ctx, conn, s.svc.scope); err != nil {
+		if err := exportJob.Insert(ctx, conn, scope); err != nil {
 			return fmt.Errorf("cannot insert export job: %w", err)
 		}
 
@@ -1409,7 +1409,7 @@ func (s *DocumentService) RequestExport(
 }
 
 func (s *DocumentService) CountVersionsForDocumentID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentID gid.GID,
 	filter *coredata.DocumentVersionFilter,
 ) (int, error) {
@@ -1419,7 +1419,7 @@ func (s *DocumentService) CountVersionsForDocumentID(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			documentVersions := &coredata.DocumentVersions{}
-			count, err = documentVersions.CountByDocumentID(ctx, conn, s.svc.scope, documentID, filter)
+			count, err = documentVersions.CountByDocumentID(ctx, conn, scope, documentID, filter)
 
 			return err
 		},
@@ -1432,7 +1432,7 @@ func (s *DocumentService) CountVersionsForDocumentID(
 }
 
 func (s *DocumentService) CountSignaturesForVersionID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentVersionID gid.GID,
 	filter *coredata.DocumentVersionSignatureFilter,
 ) (int, error) {
@@ -1442,7 +1442,7 @@ func (s *DocumentService) CountSignaturesForVersionID(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			documentVersionSignatures := &coredata.DocumentVersionSignatures{}
-			count, err = documentVersionSignatures.CountByDocumentVersionID(ctx, conn, s.svc.scope, documentVersionID, filter)
+			count, err = documentVersionSignatures.CountByDocumentVersionID(ctx, conn, scope, documentVersionID, filter)
 
 			return err
 		},
@@ -1455,7 +1455,7 @@ func (s *DocumentService) CountSignaturesForVersionID(
 }
 
 func (s *DocumentService) ListVersions(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentID gid.GID,
 	cursor *page.Cursor[coredata.DocumentVersionOrderField],
 	filter *coredata.DocumentVersionFilter,
@@ -1465,7 +1465,7 @@ func (s *DocumentService) ListVersions(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			err := documentVersions.LoadByDocumentID(ctx, conn, s.svc.scope, documentID, cursor, filter)
+			err := documentVersions.LoadByDocumentID(ctx, conn, scope, documentID, cursor, filter)
 			if err != nil {
 				return fmt.Errorf("cannot load document versions: %w", err)
 			}
@@ -1481,7 +1481,7 @@ func (s *DocumentService) ListVersions(
 }
 
 func (s *DocumentService) GetVersion(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentVersionID gid.GID,
 ) (*coredata.DocumentVersion, error) {
 	documentVersion := &coredata.DocumentVersion{}
@@ -1489,7 +1489,7 @@ func (s *DocumentService) GetVersion(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return documentVersion.LoadByID(ctx, conn, s.svc.scope, documentVersionID)
+			return documentVersion.LoadByID(ctx, conn, scope, documentVersionID)
 		},
 	)
 	if err != nil {
@@ -1500,7 +1500,7 @@ func (s *DocumentService) GetVersion(
 }
 
 func (s *DocumentService) IsSigned(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentID gid.GID,
 	userEmail mail.Addr,
 ) (bool, error) {
@@ -1516,7 +1516,7 @@ func (s *DocumentService) IsSigned(
 			signed, err = document.IsLastSignableVersionSignedByUserEmail(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				documentID,
 				userEmail,
 			)
@@ -1532,7 +1532,7 @@ func (s *DocumentService) IsSigned(
 }
 
 func (s *DocumentService) GetViewerApprovalState(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentID gid.GID,
 	identityID gid.GID,
 ) (coredata.DocumentVersionApprovalDecisionState, error) {
@@ -1548,7 +1548,7 @@ func (s *DocumentService) GetViewerApprovalState(
 			state, err = document.GetViewerApprovalStateForLastVersion(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				documentID,
 				identityID,
 			)
@@ -1564,7 +1564,7 @@ func (s *DocumentService) GetViewerApprovalState(
 }
 
 func (s *DocumentService) CountForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	filter *coredata.DocumentFilter,
 ) (int, error) {
@@ -1575,7 +1575,7 @@ func (s *DocumentService) CountForOrganizationID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			documents := &coredata.Documents{}
 
-			count, err = documents.CountByOrganizationID(ctx, conn, s.svc.scope, organizationID, filter)
+			count, err = documents.CountByOrganizationID(ctx, conn, scope, organizationID, filter)
 			if err != nil {
 				return fmt.Errorf("cannot count documents: %w", err)
 			}
@@ -1591,7 +1591,7 @@ func (s *DocumentService) CountForOrganizationID(
 }
 
 func (s *DocumentService) ListByOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.DocumentOrderField],
 	filter *coredata.DocumentFilter,
@@ -1604,7 +1604,7 @@ func (s *DocumentService) ListByOrganizationID(
 			return documents.LoadByOrganizationID(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				organizationID,
 				cursor,
 				filter,
@@ -1619,7 +1619,7 @@ func (s *DocumentService) ListByOrganizationID(
 }
 
 func (s *DocumentService) CountForControlID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	controlID gid.GID,
 	filter *coredata.DocumentFilter,
 ) (int, error) {
@@ -1630,7 +1630,7 @@ func (s *DocumentService) CountForControlID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			documents := &coredata.Documents{}
 
-			count, err = documents.CountByControlID(ctx, conn, s.svc.scope, controlID, filter)
+			count, err = documents.CountByControlID(ctx, conn, scope, controlID, filter)
 			if err != nil {
 				return fmt.Errorf("cannot count documents: %w", err)
 			}
@@ -1646,7 +1646,7 @@ func (s *DocumentService) CountForControlID(
 }
 
 func (s *DocumentService) ListForControlID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	controlID gid.GID,
 	cursor *page.Cursor[coredata.DocumentOrderField],
 	filter *coredata.DocumentFilter,
@@ -1656,7 +1656,7 @@ func (s *DocumentService) ListForControlID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return documents.LoadByControlID(ctx, conn, s.svc.scope, controlID, cursor, filter)
+			return documents.LoadByControlID(ctx, conn, scope, controlID, cursor, filter)
 		},
 	)
 	if err != nil {
@@ -1667,7 +1667,7 @@ func (s *DocumentService) ListForControlID(
 }
 
 func (s *DocumentService) CountForRiskID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	riskID gid.GID,
 	filter *coredata.DocumentFilter,
 ) (int, error) {
@@ -1678,7 +1678,7 @@ func (s *DocumentService) CountForRiskID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			documents := &coredata.Documents{}
 
-			count, err = documents.CountByRiskID(ctx, conn, s.svc.scope, riskID, filter)
+			count, err = documents.CountByRiskID(ctx, conn, scope, riskID, filter)
 			if err != nil {
 				return fmt.Errorf("cannot count documents: %w", err)
 			}
@@ -1694,7 +1694,7 @@ func (s *DocumentService) CountForRiskID(
 }
 
 func (s *DocumentService) ListForRiskID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	riskID gid.GID,
 	cursor *page.Cursor[coredata.DocumentOrderField],
 	filter *coredata.DocumentFilter,
@@ -1704,7 +1704,7 @@ func (s *DocumentService) ListForRiskID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return documents.LoadByRiskID(ctx, conn, s.svc.scope, riskID, cursor, filter)
+			return documents.LoadByRiskID(ctx, conn, scope, riskID, cursor, filter)
 		},
 	)
 	if err != nil {
@@ -1715,7 +1715,7 @@ func (s *DocumentService) ListForRiskID(
 }
 
 func (s *DocumentService) CountForMeasureID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	measureID gid.GID,
 	filter *coredata.DocumentFilter,
 ) (int, error) {
@@ -1726,7 +1726,7 @@ func (s *DocumentService) CountForMeasureID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			documents := &coredata.Documents{}
 
-			count, err = documents.CountByMeasureID(ctx, conn, s.svc.scope, measureID, filter)
+			count, err = documents.CountByMeasureID(ctx, conn, scope, measureID, filter)
 			if err != nil {
 				return fmt.Errorf("cannot count documents: %w", err)
 			}
@@ -1742,7 +1742,7 @@ func (s *DocumentService) CountForMeasureID(
 }
 
 func (s *DocumentService) ListForMeasureID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	measureID gid.GID,
 	cursor *page.Cursor[coredata.DocumentOrderField],
 	filter *coredata.DocumentFilter,
@@ -1752,7 +1752,7 @@ func (s *DocumentService) ListForMeasureID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := documents.LoadByMeasureID(ctx, conn, s.svc.scope, measureID, cursor, filter); err != nil {
+			if err := documents.LoadByMeasureID(ctx, conn, scope, measureID, cursor, filter); err != nil {
 				return fmt.Errorf("cannot list documents for measure: %w", err)
 			}
 
@@ -1767,7 +1767,7 @@ func (s *DocumentService) ListForMeasureID(
 }
 
 func (s *DocumentService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req UpdateDocumentRequest,
 ) (*coredata.Document, *coredata.DocumentVersion, bool, error) {
 	if err := req.Validate(); err != nil {
@@ -1786,7 +1786,7 @@ func (s *DocumentService) Update(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := document.LoadByID(ctx, tx, s.svc.scope, req.DocumentID); err != nil {
+			if err := document.LoadByID(ctx, tx, scope, req.DocumentID); err != nil {
 				return fmt.Errorf("cannot load document %q: %w", req.DocumentID, err)
 			}
 
@@ -1800,13 +1800,13 @@ func (s *DocumentService) Update(
 
 			document.UpdatedAt = now
 
-			if err := document.Update(ctx, tx, s.svc.scope); err != nil {
+			if err := document.Update(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot update document: %w", err)
 			}
 
 			// Handle draft version logic for title/content/classification/type changes.
 			latestVersion := &coredata.DocumentVersion{}
-			if err := latestVersion.LoadLatestVersion(ctx, tx, s.svc.scope, req.DocumentID); err != nil {
+			if err := latestVersion.LoadLatestVersion(ctx, tx, scope, req.DocumentID); err != nil {
 				return fmt.Errorf("cannot load latest version: %w", err)
 			}
 
@@ -1819,7 +1819,7 @@ func (s *DocumentService) Update(
 			if !hasVersionChanges {
 				if req.DefaultApproverIDs != nil {
 					defaultApprovers := &coredata.DocumentDefaultApprovers{}
-					if err := defaultApprovers.MergeByDocumentID(ctx, tx, s.svc.scope, req.DocumentID, document.OrganizationID, *req.DefaultApproverIDs); err != nil {
+					if err := defaultApprovers.MergeByDocumentID(ctx, tx, scope, req.DocumentID, document.OrganizationID, *req.DefaultApproverIDs); err != nil {
 						return fmt.Errorf("cannot update default approvers: %w", err)
 					}
 				}
@@ -1829,7 +1829,7 @@ func (s *DocumentService) Update(
 
 			if latestVersion.Status == coredata.DocumentVersionStatusDraft {
 				// Draft exists: update it with any new values.
-				if err := s.updateVersionInTx(ctx, tx, latestVersion, req.Content, req.Classification, req.DocumentType, req.Title); err != nil {
+				if err := s.updateVersionInTx(ctx, scope, tx, latestVersion, req.Content, req.Classification, req.DocumentType, req.Title); err != nil {
 					return err
 				}
 
@@ -1840,7 +1840,7 @@ func (s *DocumentService) Update(
 					if err := publishedVersion.LoadByDocumentIDAndVersion(
 						ctx,
 						tx,
-						s.svc.scope,
+						scope,
 						req.DocumentID,
 						*document.CurrentPublishedMajor,
 						*document.CurrentPublishedMinor,
@@ -1852,7 +1852,7 @@ func (s *DocumentService) Update(
 						latestVersion.Content == publishedVersion.Content &&
 						latestVersion.Classification == publishedVersion.Classification &&
 						latestVersion.DocumentType == publishedVersion.DocumentType {
-						if err := s.deleteDraftInTx(ctx, tx, latestVersion); err != nil {
+						if err := s.deleteDraftInTx(ctx, scope, tx, latestVersion); err != nil {
 							return err
 						}
 
@@ -1865,12 +1865,12 @@ func (s *DocumentService) Update(
 				resultVersion = latestVersion
 			} else {
 				// No draft exists: create one.
-				draftVersion, err := s.createDraftInTx(ctx, tx, document, latestVersion)
+				draftVersion, err := s.createDraftInTx(ctx, scope, tx, document, latestVersion)
 				if err != nil {
 					return err
 				}
 
-				if err := s.updateVersionInTx(ctx, tx, draftVersion, req.Content, req.Classification, req.DocumentType, req.Title); err != nil {
+				if err := s.updateVersionInTx(ctx, scope, tx, draftVersion, req.Content, req.Classification, req.DocumentType, req.Title); err != nil {
 					return err
 				}
 
@@ -1880,7 +1880,7 @@ func (s *DocumentService) Update(
 
 			if req.DefaultApproverIDs != nil {
 				defaultApprovers := &coredata.DocumentDefaultApprovers{}
-				if err := defaultApprovers.MergeByDocumentID(ctx, tx, s.svc.scope, req.DocumentID, document.OrganizationID, *req.DefaultApproverIDs); err != nil {
+				if err := defaultApprovers.MergeByDocumentID(ctx, tx, scope, req.DocumentID, document.OrganizationID, *req.DefaultApproverIDs); err != nil {
 					return fmt.Errorf("cannot update default approvers: %w", err)
 				}
 			}
@@ -1896,7 +1896,7 @@ func (s *DocumentService) Update(
 }
 
 func (s *DocumentService) DeleteDraft(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentID gid.GID,
 ) (*coredata.Document, error) {
 	document := &coredata.Document{}
@@ -1904,7 +1904,7 @@ func (s *DocumentService) DeleteDraft(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := document.LoadByID(ctx, tx, s.svc.scope, documentID); err != nil {
+			if err := document.LoadByID(ctx, tx, scope, documentID); err != nil {
 				return fmt.Errorf("cannot load document %q: %w", documentID, err)
 			}
 
@@ -1913,7 +1913,7 @@ func (s *DocumentService) DeleteDraft(
 			}
 
 			latestVersion := &coredata.DocumentVersion{}
-			if err := latestVersion.LoadLatestVersion(ctx, tx, s.svc.scope, documentID); err != nil {
+			if err := latestVersion.LoadLatestVersion(ctx, tx, scope, documentID); err != nil {
 				return fmt.Errorf("cannot load latest version: %w", err)
 			}
 
@@ -1925,7 +1925,7 @@ func (s *DocumentService) DeleteDraft(
 				return &ErrDocumentDraftNotDeletable{}
 			}
 
-			return s.deleteDraftInTx(ctx, tx, latestVersion)
+			return s.deleteDraftInTx(ctx, scope, tx, latestVersion)
 		},
 	)
 	if err != nil {
@@ -1936,7 +1936,7 @@ func (s *DocumentService) DeleteDraft(
 }
 
 func (s *DocumentService) Archive(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentID gid.GID,
 ) (*coredata.Document, error) {
 	document := &coredata.Document{}
@@ -1945,7 +1945,7 @@ func (s *DocumentService) Archive(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := document.LoadByID(ctx, tx, s.svc.scope, documentID); err != nil {
+			if err := document.LoadByID(ctx, tx, scope, documentID); err != nil {
 				return fmt.Errorf("cannot load document %q: %w", documentID, err)
 			}
 
@@ -1954,21 +1954,21 @@ func (s *DocumentService) Archive(
 			}
 
 			controlDocument := coredata.ControlDocument{}
-			if err := controlDocument.DeleteByDocumentIDs(ctx, tx, s.svc.scope, []gid.GID{documentID}); err != nil {
+			if err := controlDocument.DeleteByDocumentIDs(ctx, tx, scope, []gid.GID{documentID}); err != nil {
 				return fmt.Errorf("cannot delete control mappings: %w", err)
 			}
 
 			riskDocument := coredata.RiskDocument{}
-			if err := riskDocument.DeleteByDocumentIDs(ctx, tx, s.svc.scope, []gid.GID{documentID}); err != nil {
+			if err := riskDocument.DeleteByDocumentIDs(ctx, tx, scope, []gid.GID{documentID}); err != nil {
 				return fmt.Errorf("cannot delete risk mappings: %w", err)
 			}
 
 			measureDocument := coredata.MeasureDocument{}
-			if err := measureDocument.DeleteByDocumentIDs(ctx, tx, s.svc.scope, []gid.GID{documentID}); err != nil {
+			if err := measureDocument.DeleteByDocumentIDs(ctx, tx, scope, []gid.GID{documentID}); err != nil {
 				return fmt.Errorf("cannot delete measure mappings: %w", err)
 			}
 
-			if err := s.clearDocumentReferences(ctx, tx, []gid.GID{documentID}); err != nil {
+			if err := s.clearDocumentReferences(ctx, scope, tx, []gid.GID{documentID}); err != nil {
 				return err
 			}
 
@@ -1977,7 +1977,7 @@ func (s *DocumentService) Archive(
 			document.UpdatedAt = now
 			document.TrustCenterVisibility = coredata.TrustCenterVisibilityNone
 
-			if err := document.Update(ctx, tx, s.svc.scope); err != nil {
+			if err := document.Update(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot archive document: %w", err)
 			}
 
@@ -1992,7 +1992,7 @@ func (s *DocumentService) Archive(
 }
 
 func (s *DocumentService) Unarchive(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentID gid.GID,
 ) (*coredata.Document, error) {
 	document := &coredata.Document{}
@@ -2001,7 +2001,7 @@ func (s *DocumentService) Unarchive(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := document.LoadByID(ctx, tx, s.svc.scope, documentID); err != nil {
+			if err := document.LoadByID(ctx, tx, scope, documentID); err != nil {
 				return fmt.Errorf("cannot load document %q: %w", documentID, err)
 			}
 
@@ -2013,7 +2013,7 @@ func (s *DocumentService) Unarchive(
 			document.ArchivedAt = nil
 			document.UpdatedAt = now
 
-			if err := document.Update(ctx, tx, s.svc.scope); err != nil {
+			if err := document.Update(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot unarchive document: %w", err)
 			}
 
@@ -2028,7 +2028,7 @@ func (s *DocumentService) Unarchive(
 }
 
 func (s *DocumentService) CancelSignatureRequest(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentVersionSignatureID gid.GID,
 ) error {
 	documentVersionSignature := &coredata.DocumentVersionSignature{}
@@ -2036,17 +2036,17 @@ func (s *DocumentService) CancelSignatureRequest(
 	return s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := documentVersionSignature.LoadByID(ctx, tx, s.svc.scope, documentVersionSignatureID); err != nil {
+			if err := documentVersionSignature.LoadByID(ctx, tx, scope, documentVersionSignatureID); err != nil {
 				return fmt.Errorf("cannot load document version signature: %w", err)
 			}
 
 			documentVersion := &coredata.DocumentVersion{}
-			if err := documentVersion.LoadByID(ctx, tx, s.svc.scope, documentVersionSignature.DocumentVersionID); err != nil {
+			if err := documentVersion.LoadByID(ctx, tx, scope, documentVersionSignature.DocumentVersionID); err != nil {
 				return fmt.Errorf("cannot load document version: %w", err)
 			}
 
 			document := &coredata.Document{}
-			if err := document.LoadByID(ctx, tx, s.svc.scope, documentVersion.DocumentID); err != nil {
+			if err := document.LoadByID(ctx, tx, scope, documentVersion.DocumentID); err != nil {
 				return fmt.Errorf("cannot load document: %w", err)
 			}
 
@@ -2061,7 +2061,7 @@ func (s *DocumentService) CancelSignatureRequest(
 				}
 			}
 
-			if err := documentVersionSignature.Delete(ctx, tx, s.svc.scope, documentVersionSignatureID); err != nil {
+			if err := documentVersionSignature.Delete(ctx, tx, scope, documentVersionSignatureID); err != nil {
 				return fmt.Errorf("cannot delete document version signature: %w", err)
 			}
 
@@ -2077,7 +2077,7 @@ type ExportPDFOptions struct {
 }
 
 func (s *DocumentService) ExportPDF(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentVersionID gid.GID,
 	options ExportPDFOptions,
 ) ([]byte, error) {
@@ -2086,7 +2086,7 @@ func (s *DocumentService) ExportPDF(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) (err error) {
-			data, err = exportDocumentPDF(ctx, s.svc, s.html2pdfConverter, conn, s.svc.scope, documentVersionID, options)
+			data, err = exportDocumentPDF(ctx, s.svc, s.html2pdfConverter, conn, scope, documentVersionID, options)
 			if err != nil {
 				return fmt.Errorf("cannot export document PDF: %w", err)
 			}
@@ -2101,13 +2101,13 @@ func (s *DocumentService) ExportPDF(
 	return data, nil
 }
 
-func (s *DocumentService) BuildAndUploadExport(ctx context.Context, exportJobID gid.GID) (*coredata.ExportJob, error) {
+func (s *DocumentService) BuildAndUploadExport(ctx context.Context, scope coredata.Scoper, exportJobID gid.GID) (*coredata.ExportJob, error) {
 	exportJob := &coredata.ExportJob{}
 
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := exportJob.LoadByID(ctx, tx, s.svc.scope, exportJobID); err != nil {
+			if err := exportJob.LoadByID(ctx, tx, scope, exportJobID); err != nil {
 				return fmt.Errorf("cannot load export job: %w", err)
 			}
 
@@ -2123,7 +2123,7 @@ func (s *DocumentService) BuildAndUploadExport(ctx context.Context, exportJobID 
 			var organizationID gid.GID
 
 			firstDocument := &coredata.Document{}
-			if err := firstDocument.LoadByID(ctx, tx, s.svc.scope, documentIDs[0]); err != nil {
+			if err := firstDocument.LoadByID(ctx, tx, scope, documentIDs[0]); err != nil {
 				return fmt.Errorf("cannot load document for organization ID: %w", err)
 			}
 
@@ -2150,7 +2150,7 @@ func (s *DocumentService) BuildAndUploadExport(ctx context.Context, exportJobID 
 				WithSignatures: exportArgs.WithSignatures,
 			}
 
-			err = s.Export(ctx, documentIDs, tempFile, exportOptions)
+			err = s.Export(ctx, scope, documentIDs, tempFile, exportOptions)
 			if err != nil {
 				return fmt.Errorf("cannot export documents: %w", err)
 			}
@@ -2203,12 +2203,12 @@ func (s *DocumentService) BuildAndUploadExport(ctx context.Context, exportJobID 
 				UpdatedAt:  now,
 			}
 
-			if err := file.Insert(ctx, tx, s.svc.scope); err != nil {
+			if err := file.Insert(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot insert file: %w", err)
 			}
 
 			exportJob.FileID = &file.ID
-			if err := exportJob.Update(ctx, tx, s.svc.scope); err != nil {
+			if err := exportJob.Update(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot update export job: %w", err)
 			}
 
@@ -2224,7 +2224,7 @@ func (s *DocumentService) BuildAndUploadExport(ctx context.Context, exportJobID 
 
 func exportDocumentPDF(
 	ctx context.Context,
-	svc *TenantService,
+	svc *Service,
 	html2pdfConverter *html2pdf.Converter,
 	conn pg.Querier,
 	scope coredata.Scoper,
@@ -2283,7 +2283,7 @@ func exportDocumentPDF(
 
 func exportStoredPDF(
 	ctx context.Context,
-	svc *TenantService,
+	svc *Service,
 	html2pdfConverter *html2pdf.Converter,
 	conn pg.Querier,
 	scope coredata.Scoper,
@@ -2330,7 +2330,7 @@ func exportStoredPDF(
 
 func generateSignaturePagePDF(
 	ctx context.Context,
-	svc *TenantService,
+	svc *Service,
 	html2pdfConverter *html2pdf.Converter,
 	conn pg.Querier,
 	scope coredata.Scoper,
@@ -2396,7 +2396,7 @@ func generateSignaturePagePDF(
 
 func generateDocumentPDF(
 	ctx context.Context,
-	svc *TenantService,
+	svc *Service,
 	html2pdfConverter *html2pdf.Converter,
 	conn pg.Querier,
 	scope coredata.Scoper,
@@ -2553,7 +2553,7 @@ func generateDocumentPDF(
 }
 
 func (s *DocumentService) Export(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentIDs []gid.GID,
 	file io.Writer,
 	options ExportPDFOptions,
@@ -2571,12 +2571,12 @@ func (s *DocumentService) Export(
 		func(ctx context.Context, conn pg.Tx) error {
 			for i, documentID := range documentIDs {
 				document := &coredata.Document{}
-				if err := document.LoadByID(ctx, conn, s.svc.scope, documentID); err != nil {
+				if err := document.LoadByID(ctx, conn, scope, documentID); err != nil {
 					return fmt.Errorf("cannot load document %q: %w", documentID, err)
 				}
 
 				documentVersion := &coredata.DocumentVersion{}
-				if err := documentVersion.LoadLatestVersion(ctx, conn, s.svc.scope, documentID); err != nil {
+				if err := documentVersion.LoadLatestVersion(ctx, conn, scope, documentID); err != nil {
 					return fmt.Errorf("cannot load document version for %q: %w", documentID, err)
 				}
 
@@ -2585,7 +2585,7 @@ func (s *DocumentService) Export(
 					s.svc,
 					s.html2pdfConverter,
 					conn,
-					s.svc.scope,
+					scope,
 					documentVersion.ID,
 					options,
 				)
@@ -2612,7 +2612,7 @@ func (s *DocumentService) Export(
 }
 
 func (s *DocumentService) SendExportEmail(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	fileID gid.GID,
 	recipientName string,
 	recipientEmail mail.Addr,
@@ -2621,11 +2621,11 @@ func (s *DocumentService) SendExportEmail(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			file := &coredata.File{}
-			if err := file.LoadByID(ctx, tx, s.svc.scope, fileID); err != nil {
+			if err := file.LoadByID(ctx, tx, scope, fileID); err != nil {
 				return fmt.Errorf("cannot load file: %w", err)
 			}
 
-			downloadURL, err := s.GenerateDocumentExportDownloadURL(ctx, file)
+			downloadURL, err := s.GenerateDocumentExportDownloadURL(ctx, scope, file)
 			if err != nil {
 				return fmt.Errorf("cannot generate download URL: %w", err)
 			}
@@ -2659,7 +2659,7 @@ func (s *DocumentService) SendExportEmail(
 }
 
 func (s *DocumentService) GenerateDocumentExportDownloadURL(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	file *coredata.File,
 ) (string, error) {
 	presignClient := s3.NewPresignClient(s.svc.s3)
@@ -2712,7 +2712,7 @@ func sanitizeFilename(title string) string {
 }
 
 func (s *DocumentService) loadDraftForPublish(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	tx pg.Tx,
 	documentID gid.GID,
 	ignoreExisting bool,
@@ -2720,7 +2720,7 @@ func (s *DocumentService) loadDraftForPublish(
 	document := &coredata.Document{}
 	documentVersion := &coredata.DocumentVersion{}
 
-	if err := document.LoadByID(ctx, tx, s.svc.scope, documentID); err != nil {
+	if err := document.LoadByID(ctx, tx, scope, documentID); err != nil {
 		return nil, nil, fmt.Errorf("cannot load document %q: %w", documentID, err)
 	}
 
@@ -2728,7 +2728,7 @@ func (s *DocumentService) loadDraftForPublish(
 		return nil, nil, &ErrDocumentArchived{}
 	}
 
-	if err := documentVersion.LoadLatestVersion(ctx, tx, s.svc.scope, documentID); err != nil {
+	if err := documentVersion.LoadLatestVersion(ctx, tx, scope, documentID); err != nil {
 		return nil, nil, fmt.Errorf("cannot load current draft: %w", err)
 	}
 
@@ -2744,7 +2744,7 @@ func (s *DocumentService) loadDraftForPublish(
 }
 
 func (s *DocumentService) finalizePublish(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	tx pg.Tx,
 	document *coredata.Document,
 	documentVersion *coredata.DocumentVersion,
@@ -2761,11 +2761,11 @@ func (s *DocumentService) finalizePublish(
 	documentVersion.PublishedAt = &now
 	documentVersion.UpdatedAt = now
 
-	if err := document.Update(ctx, tx, s.svc.scope); err != nil {
+	if err := document.Update(ctx, tx, scope); err != nil {
 		return fmt.Errorf("cannot update document: %w", err)
 	}
 
-	if err := documentVersion.Update(ctx, tx, s.svc.scope); err != nil {
+	if err := documentVersion.Update(ctx, tx, scope); err != nil {
 		return fmt.Errorf("cannot update document version: %w", err)
 	}
 
@@ -2773,13 +2773,13 @@ func (s *DocumentService) finalizePublish(
 }
 
 func (s *DocumentService) publishMajorVersionInTx(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	tx pg.Tx,
 	documentID gid.GID,
 	changelog *string,
 	ignoreExisting bool,
 ) (*coredata.Document, *coredata.DocumentVersion, error) {
-	document, documentVersion, err := s.loadDraftForPublish(ctx, tx, documentID, ignoreExisting)
+	document, documentVersion, err := s.loadDraftForPublish(ctx, scope, tx, documentID, ignoreExisting)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2790,7 +2790,7 @@ func (s *DocumentService) publishMajorVersionInTx(
 
 	if document.CurrentPublishedMajor != nil {
 		publishedVersion := &coredata.DocumentVersion{}
-		if err := publishedVersion.LoadByDocumentIDAndVersion(ctx, tx, s.svc.scope, documentID, *document.CurrentPublishedMajor, *document.CurrentPublishedMinor); err != nil {
+		if err := publishedVersion.LoadByDocumentIDAndVersion(ctx, tx, scope, documentID, *document.CurrentPublishedMajor, *document.CurrentPublishedMinor); err != nil {
 			return nil, nil, fmt.Errorf("cannot load published version: %w", err)
 		}
 
@@ -2803,7 +2803,7 @@ func (s *DocumentService) publishMajorVersionInTx(
 	document.CurrentPublishedMajor = &documentVersion.Major
 	document.CurrentPublishedMinor = &documentVersion.Minor
 
-	if err := s.finalizePublish(ctx, tx, document, documentVersion, changelog); err != nil {
+	if err := s.finalizePublish(ctx, scope, tx, document, documentVersion, changelog); err != nil {
 		return nil, nil, err
 	}
 
@@ -2811,13 +2811,13 @@ func (s *DocumentService) publishMajorVersionInTx(
 }
 
 func (s *DocumentService) publishMinorVersionInTx(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	tx pg.Tx,
 	documentID gid.GID,
 	changelog *string,
 	ignoreExisting bool,
 ) (*coredata.Document, *coredata.DocumentVersion, error) {
-	document, documentVersion, err := s.loadDraftForPublish(ctx, tx, documentID, ignoreExisting)
+	document, documentVersion, err := s.loadDraftForPublish(ctx, scope, tx, documentID, ignoreExisting)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2833,7 +2833,7 @@ func (s *DocumentService) publishMinorVersionInTx(
 	document.CurrentPublishedMajor = &documentVersion.Major
 	document.CurrentPublishedMinor = &documentVersion.Minor
 
-	if err := s.finalizePublish(ctx, tx, document, documentVersion, changelog); err != nil {
+	if err := s.finalizePublish(ctx, scope, tx, document, documentVersion, changelog); err != nil {
 		return nil, nil, err
 	}
 
@@ -2841,7 +2841,7 @@ func (s *DocumentService) publishMinorVersionInTx(
 }
 
 func (s *DocumentService) generateAndUploadPublicationPDF(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	documentVersion *coredata.DocumentVersion,
 ) error {
 	var pdfData []byte
@@ -2856,7 +2856,7 @@ func (s *DocumentService) generateAndUploadPublicationPDF(
 				s.svc,
 				s.html2pdfConverter,
 				conn,
-				s.svc.scope,
+				scope,
 				documentVersion.ID,
 				ExportPDFOptions{},
 			)
@@ -2871,7 +2871,7 @@ func (s *DocumentService) generateAndUploadPublicationPDF(
 	now := time.Now()
 
 	fileRecord := &coredata.File{
-		ID:             gid.New(s.svc.scope.GetTenantID(), coredata.FileEntityType),
+		ID:             gid.New(scope.GetTenantID(), coredata.FileEntityType),
 		OrganizationID: documentVersion.OrganizationID,
 		BucketName:     s.svc.bucket,
 		MimeType:       "application/pdf",
@@ -2900,14 +2900,14 @@ func (s *DocumentService) generateAndUploadPublicationPDF(
 	err = s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := fileRecord.Insert(ctx, tx, s.svc.scope); err != nil {
+			if err := fileRecord.Insert(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot insert file record: %w", err)
 			}
 
 			documentVersion.FileID = &fileRecord.ID
 
 			documentVersion.UpdatedAt = now
-			if err := documentVersion.Update(ctx, tx, s.svc.scope); err != nil {
+			if err := documentVersion.Update(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot update document version with file ID: %w", err)
 			}
 

--- a/pkg/probo/evidence_service.go
+++ b/pkg/probo/evidence_service.go
@@ -30,7 +30,7 @@ import (
 
 type (
 	EvidenceService struct {
-		svc           *TenantService
+		svc           *Service
 		fileValidator *filevalidation.FileValidator
 	}
 
@@ -52,7 +52,7 @@ func (umer *UploadMeasureEvidenceRequest) Validate() error {
 }
 
 func (s EvidenceService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	evidenceID gid.GID,
 ) (*coredata.Evidence, error) {
 	evidence := &coredata.Evidence{}
@@ -60,7 +60,7 @@ func (s EvidenceService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := evidence.LoadByID(ctx, conn, s.svc.scope, evidenceID); err != nil {
+			if err := evidence.LoadByID(ctx, conn, scope, evidenceID); err != nil {
 				return fmt.Errorf("cannot load evidence %w", err)
 			}
 
@@ -75,7 +75,7 @@ func (s EvidenceService) Get(
 }
 
 func (s EvidenceService) UploadMeasureEvidence(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req UploadMeasureEvidenceRequest,
 ) (*coredata.Evidence, error) {
 	if err := req.Validate(); err != nil {
@@ -83,7 +83,7 @@ func (s EvidenceService) UploadMeasureEvidence(
 	}
 
 	now := time.Now()
-	evidenceID := gid.New(s.svc.scope.GetTenantID(), coredata.EvidenceEntityType)
+	evidenceID := gid.New(scope.GetTenantID(), coredata.EvidenceEntityType)
 
 	referenceID, err := uuid.NewV4()
 	if err != nil {
@@ -111,12 +111,13 @@ func (s EvidenceService) UploadMeasureEvidence(
 				err  error
 			)
 
-			if err := measure.LoadByID(ctx, conn, s.svc.scope, req.MeasureID); err != nil {
+			if err := measure.LoadByID(ctx, conn, scope, req.MeasureID); err != nil {
 				return fmt.Errorf("cannot load measure %q: %w", req.MeasureID, err)
 			}
 
 			file, err = s.svc.Files.UploadAndSaveFile(
 				ctx,
+				scope,
 				s.fileValidator,
 				map[string]string{
 					"type":            "evidence",
@@ -132,7 +133,7 @@ func (s EvidenceService) UploadMeasureEvidence(
 			evidence.EvidenceFileId = &file.ID
 			evidence.MeasureID = req.MeasureID
 
-			if err := evidence.Insert(ctx, conn, s.svc.scope); err != nil {
+			if err := evidence.Insert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot insert evidence: %w", err)
 			}
 
@@ -148,7 +149,7 @@ func (s EvidenceService) UploadMeasureEvidence(
 }
 
 func (s EvidenceService) CountForMeasureID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	measureID gid.GID,
 ) (int, error) {
 	var count int
@@ -158,7 +159,7 @@ func (s EvidenceService) CountForMeasureID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			evidences := coredata.Evidences{}
 
-			count, err = evidences.CountByMeasureID(ctx, conn, s.svc.scope, measureID)
+			count, err = evidences.CountByMeasureID(ctx, conn, scope, measureID)
 			if err != nil {
 				return fmt.Errorf("cannot count evidences: %w", err)
 			}
@@ -174,7 +175,7 @@ func (s EvidenceService) CountForMeasureID(
 }
 
 func (s EvidenceService) ListForMeasureID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	measureID gid.GID,
 	cursor *page.Cursor[coredata.EvidenceOrderField],
 ) (*page.Page[*coredata.Evidence, coredata.EvidenceOrderField], error) {
@@ -186,7 +187,7 @@ func (s EvidenceService) ListForMeasureID(
 			return evidences.LoadByMeasureID(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				measureID,
 				cursor,
 			)
@@ -200,7 +201,7 @@ func (s EvidenceService) ListForMeasureID(
 }
 
 func (s EvidenceService) CountForTaskID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	taskID gid.GID,
 ) (int, error) {
 	var count int
@@ -210,7 +211,7 @@ func (s EvidenceService) CountForTaskID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			evidences := coredata.Evidences{}
 
-			count, err = evidences.CountByTaskID(ctx, conn, s.svc.scope, taskID)
+			count, err = evidences.CountByTaskID(ctx, conn, scope, taskID)
 			if err != nil {
 				return fmt.Errorf("cannot count evidences: %w", err)
 			}
@@ -226,7 +227,7 @@ func (s EvidenceService) CountForTaskID(
 }
 
 func (s EvidenceService) ListForTaskID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	taskID gid.GID,
 	cursor *page.Cursor[coredata.EvidenceOrderField],
 ) (*page.Page[*coredata.Evidence, coredata.EvidenceOrderField], error) {
@@ -238,7 +239,7 @@ func (s EvidenceService) ListForTaskID(
 			return evidences.LoadByTaskID(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				taskID,
 				cursor,
 			)
@@ -252,7 +253,7 @@ func (s EvidenceService) ListForTaskID(
 }
 
 func (s *EvidenceService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	evidenceID gid.GID,
 ) error {
 	evidence := &coredata.Evidence{ID: evidenceID}
@@ -260,7 +261,7 @@ func (s *EvidenceService) Delete(
 	return s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			err := evidence.Delete(ctx, tx, s.svc.scope)
+			err := evidence.Delete(ctx, tx, scope)
 			if err != nil {
 				return fmt.Errorf("cannot delete evidence: %w", err)
 			}

--- a/pkg/probo/file_service.go
+++ b/pkg/probo/file_service.go
@@ -31,7 +31,7 @@ import (
 
 type (
 	FileService struct {
-		svc *TenantService
+		svc *Service
 	}
 
 	File struct {
@@ -50,7 +50,7 @@ type (
 )
 
 func (s FileService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	fileID gid.GID,
 ) (*coredata.File, error) {
 	file := &coredata.File{}
@@ -58,7 +58,7 @@ func (s FileService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := file.LoadByID(ctx, conn, s.svc.scope, fileID); err != nil {
+			if err := file.LoadByID(ctx, conn, scope, fileID); err != nil {
 				return fmt.Errorf("cannot load file %w", err)
 			}
 
@@ -73,7 +73,7 @@ func (s FileService) Get(
 }
 
 func (s FileService) GetByIDs(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	fileIDs ...gid.GID,
 ) (coredata.Files, error) {
 	var files coredata.Files
@@ -84,7 +84,7 @@ func (s FileService) GetByIDs(
 			if err := files.LoadByIDs(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				fileIDs,
 			); err != nil {
 				return fmt.Errorf("cannot load files by ids: %w", err)
@@ -101,7 +101,7 @@ func (s FileService) GetByIDs(
 }
 
 func (s FileService) UploadAndSaveFile(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	fileValidator *filevalidation.FileValidator,
 	s3Metadata map[string]string,
 	req *FileUpload,
@@ -145,7 +145,7 @@ func (s FileService) UploadAndSaveFile(
 
 	now := time.Now()
 
-	fileID := gid.New(s.svc.scope.GetTenantID(), coredata.FileEntityType)
+	fileID := gid.New(scope.GetTenantID(), coredata.FileEntityType)
 
 	var file *coredata.File
 
@@ -179,7 +179,7 @@ func (s FileService) UploadAndSaveFile(
 				UpdatedAt:      now,
 			}
 
-			if err := file.Insert(ctx, conn, s.svc.scope); err != nil {
+			if err := file.Insert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot insert file: %w", err)
 			}
 
@@ -194,11 +194,11 @@ func (s FileService) UploadAndSaveFile(
 }
 
 func (s FileService) GenerateFileTempURL(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	fileID gid.GID,
 	expiresIn time.Duration,
 ) (string, error) {
-	file, err := s.Get(ctx, fileID)
+	file, err := s.Get(ctx, scope, fileID)
 	if err != nil {
 		return "", fmt.Errorf("cannot get file: %w", err)
 	}

--- a/pkg/probo/finding_service.go
+++ b/pkg/probo/finding_service.go
@@ -27,7 +27,7 @@ import (
 )
 
 type FindingService struct {
-	svc *TenantService
+	svc *Service
 }
 
 type (
@@ -103,7 +103,7 @@ func (r *UpdateFindingRequest) Validate() error {
 }
 
 func (s FindingService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	findingID gid.GID,
 ) (*coredata.Finding, error) {
 	finding := &coredata.Finding{}
@@ -111,7 +111,7 @@ func (s FindingService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return finding.LoadByID(ctx, conn, s.svc.scope, findingID)
+			return finding.LoadByID(ctx, conn, scope, findingID)
 		},
 	)
 	if err != nil {
@@ -122,7 +122,7 @@ func (s FindingService) Get(
 }
 
 func (s *FindingService) Create(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *CreateFindingRequest,
 ) (*coredata.Finding, error) {
 	if err := req.Validate(); err != nil {
@@ -132,7 +132,7 @@ func (s *FindingService) Create(
 	now := time.Now()
 
 	finding := &coredata.Finding{
-		ID:                 gid.New(s.svc.scope.GetTenantID(), coredata.FindingEntityType),
+		ID:                 gid.New(scope.GetTenantID(), coredata.FindingEntityType),
 		OrganizationID:     req.OrganizationID,
 		Kind:               req.Kind,
 		Description:        req.Description,
@@ -162,18 +162,18 @@ func (s *FindingService) Create(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			organization := &coredata.Organization{}
-			if err := organization.LoadByID(ctx, conn, s.svc.scope, req.OrganizationID); err != nil {
+			if err := organization.LoadByID(ctx, conn, scope, req.OrganizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
 			if req.OwnerID != nil {
 				owner := &coredata.MembershipProfile{}
-				if err := owner.LoadByID(ctx, conn, s.svc.scope, *req.OwnerID); err != nil {
+				if err := owner.LoadByID(ctx, conn, scope, *req.OwnerID); err != nil {
 					return fmt.Errorf("cannot load owner profile: %w", err)
 				}
 			}
 
-			if err := finding.Insert(ctx, conn, s.svc.scope); err != nil {
+			if err := finding.Insert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot insert finding: %w", err)
 			}
 
@@ -188,7 +188,7 @@ func (s *FindingService) Create(
 }
 
 func (s *FindingService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *UpdateFindingRequest,
 ) (*coredata.Finding, error) {
 	if err := req.Validate(); err != nil {
@@ -200,7 +200,7 @@ func (s *FindingService) Update(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := finding.LoadByID(ctx, conn, s.svc.scope, req.ID); err != nil {
+			if err := finding.LoadByID(ctx, conn, scope, req.ID); err != nil {
 				return fmt.Errorf("cannot load finding: %w", err)
 			}
 
@@ -226,7 +226,7 @@ func (s *FindingService) Update(
 
 			if req.OwnerID != nil {
 				owner := &coredata.MembershipProfile{}
-				if err := owner.LoadByID(ctx, conn, s.svc.scope, *req.OwnerID); err != nil {
+				if err := owner.LoadByID(ctx, conn, scope, *req.OwnerID); err != nil {
 					return fmt.Errorf("cannot load owner profile: %w", err)
 				}
 
@@ -259,7 +259,7 @@ func (s *FindingService) Update(
 
 			finding.UpdatedAt = time.Now()
 
-			if err := finding.Update(ctx, conn, s.svc.scope); err != nil {
+			if err := finding.Update(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot update finding: %w", err)
 			}
 
@@ -274,7 +274,7 @@ func (s *FindingService) Update(
 }
 
 func (s FindingService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	findingID gid.GID,
 ) error {
 	finding := coredata.Finding{ID: findingID}
@@ -282,7 +282,7 @@ func (s FindingService) Delete(
 	return s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			err := finding.Delete(ctx, tx, s.svc.scope)
+			err := finding.Delete(ctx, tx, scope)
 			if err != nil {
 				return fmt.Errorf("cannot delete finding: %w", err)
 			}
@@ -293,7 +293,7 @@ func (s FindingService) Delete(
 }
 
 func (s FindingService) ListForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.FindingOrderField],
 	filter *coredata.FindingFilter,
@@ -303,7 +303,7 @@ func (s FindingService) ListForOrganizationID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			err := findings.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID, cursor, filter)
+			err := findings.LoadByOrganizationID(ctx, conn, scope, organizationID, cursor, filter)
 			if err != nil {
 				return fmt.Errorf("cannot load findings: %w", err)
 			}
@@ -319,7 +319,7 @@ func (s FindingService) ListForOrganizationID(
 }
 
 func (s FindingService) CountForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	filter *coredata.FindingFilter,
 ) (int, error) {
@@ -330,7 +330,7 @@ func (s FindingService) CountForOrganizationID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			findings := coredata.Findings{}
 
-			count, err = findings.CountByOrganizationID(ctx, conn, s.svc.scope, organizationID, filter)
+			count, err = findings.CountByOrganizationID(ctx, conn, scope, organizationID, filter)
 			if err != nil {
 				return fmt.Errorf("cannot count findings: %w", err)
 			}
@@ -346,7 +346,7 @@ func (s FindingService) CountForOrganizationID(
 }
 
 func (s FindingService) CreateAuditMapping(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	findingID gid.GID,
 	auditID gid.GID,
 	referenceID string,
@@ -357,11 +357,11 @@ func (s FindingService) CreateAuditMapping(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := finding.LoadByID(ctx, conn, s.svc.scope, findingID); err != nil {
+			if err := finding.LoadByID(ctx, conn, scope, findingID); err != nil {
 				return fmt.Errorf("cannot load finding: %w", err)
 			}
 
-			if err := audit.LoadByID(ctx, conn, s.svc.scope, auditID); err != nil {
+			if err := audit.LoadByID(ctx, conn, scope, auditID); err != nil {
 				return fmt.Errorf("cannot load audit: %w", err)
 			}
 
@@ -377,7 +377,7 @@ func (s FindingService) CreateAuditMapping(
 				CreatedAt:      time.Now(),
 			}
 
-			if err := findingAudit.Upsert(ctx, conn, s.svc.scope); err != nil {
+			if err := findingAudit.Upsert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot create finding audit mapping: %w", err)
 			}
 
@@ -392,7 +392,7 @@ func (s FindingService) CreateAuditMapping(
 }
 
 func (s FindingService) DeleteAuditMapping(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	findingID gid.GID,
 	auditID gid.GID,
 ) (*coredata.Finding, *coredata.Audit, error) {
@@ -402,16 +402,16 @@ func (s FindingService) DeleteAuditMapping(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := finding.LoadByID(ctx, tx, s.svc.scope, findingID); err != nil {
+			if err := finding.LoadByID(ctx, tx, scope, findingID); err != nil {
 				return fmt.Errorf("cannot load finding: %w", err)
 			}
 
-			if err := audit.LoadByID(ctx, tx, s.svc.scope, auditID); err != nil {
+			if err := audit.LoadByID(ctx, tx, scope, auditID); err != nil {
 				return fmt.Errorf("cannot load audit: %w", err)
 			}
 
 			findingAudit := &coredata.FindingAudit{}
-			if err := findingAudit.Delete(ctx, tx, s.svc.scope, finding.ID, audit.ID); err != nil {
+			if err := findingAudit.Delete(ctx, tx, scope, finding.ID, audit.ID); err != nil {
 				return fmt.Errorf("cannot delete finding audit mapping: %w", err)
 			}
 
@@ -426,7 +426,7 @@ func (s FindingService) DeleteAuditMapping(
 }
 
 func (s FindingService) ListForAuditID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	auditID gid.GID,
 	cursor *page.Cursor[coredata.FindingOrderField],
 	filter *coredata.FindingFilter,
@@ -438,11 +438,11 @@ func (s FindingService) ListForAuditID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := audit.LoadByID(ctx, conn, s.svc.scope, auditID); err != nil {
+			if err := audit.LoadByID(ctx, conn, scope, auditID); err != nil {
 				return fmt.Errorf("cannot load audit: %w", err)
 			}
 
-			if err := findings.LoadByAuditID(ctx, conn, s.svc.scope, auditID, cursor, filter); err != nil {
+			if err := findings.LoadByAuditID(ctx, conn, scope, auditID, cursor, filter); err != nil {
 				return fmt.Errorf("cannot load findings: %w", err)
 			}
 
@@ -457,7 +457,7 @@ func (s FindingService) ListForAuditID(
 }
 
 func (s FindingService) CountForAuditID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	auditID gid.GID,
 	filter *coredata.FindingFilter,
 ) (int, error) {
@@ -468,7 +468,7 @@ func (s FindingService) CountForAuditID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			findings := coredata.Findings{}
 
-			count, err = findings.CountByAuditID(ctx, conn, s.svc.scope, auditID, filter)
+			count, err = findings.CountByAuditID(ctx, conn, scope, auditID, filter)
 			if err != nil {
 				return fmt.Errorf("cannot count findings: %w", err)
 			}

--- a/pkg/probo/framework_service.go
+++ b/pkg/probo/framework_service.go
@@ -43,7 +43,7 @@ const (
 
 type (
 	FrameworkService struct {
-		svc               *TenantService
+		svc               *Service
 		html2pdfConverter *html2pdf.Converter
 	}
 
@@ -100,7 +100,7 @@ func (ufr *UpdateFrameworkRequest) Validate() error {
 }
 
 func (s FrameworkService) RequestExport(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	frameworkID gid.GID,
 	recipientEmail mail.Addr,
 	recipientName string,
@@ -111,12 +111,12 @@ func (s FrameworkService) RequestExport(
 
 	err := s.svc.pg.WithTx(ctx, func(ctx context.Context, conn pg.Tx) error {
 		framework := &coredata.Framework{}
-		if err := framework.LoadByID(ctx, conn, s.svc.scope, frameworkID); err != nil {
+		if err := framework.LoadByID(ctx, conn, scope, frameworkID); err != nil {
 			return fmt.Errorf("cannot load framework: %w", err)
 		}
 
 		now := time.Now()
-		exportJobID = gid.New(s.svc.scope.GetTenantID(), coredata.ExportJobEntityType)
+		exportJobID = gid.New(scope.GetTenantID(), coredata.ExportJobEntityType)
 
 		args := coredata.FrameworkExportArguments{
 			FrameworkID: frameworkID,
@@ -138,7 +138,7 @@ func (s FrameworkService) RequestExport(
 			CreatedAt:      now,
 		}
 
-		if err := exportJob.Insert(ctx, conn, s.svc.scope); err != nil {
+		if err := exportJob.Insert(ctx, conn, scope); err != nil {
 			return fmt.Errorf("cannot insert export job: %w", err)
 		}
 
@@ -152,7 +152,7 @@ func (s FrameworkService) RequestExport(
 }
 
 func (s FrameworkService) Export(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	frameworkID gid.GID,
 	file io.Writer,
 ) error {
@@ -164,7 +164,7 @@ func (s FrameworkService) Export(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			framework := &coredata.Framework{}
-			if err := framework.LoadByID(ctx, conn, s.svc.scope, frameworkID); err != nil {
+			if err := framework.LoadByID(ctx, conn, scope, frameworkID); err != nil {
 				return fmt.Errorf("cannot load framework: %w", err)
 			}
 
@@ -173,7 +173,7 @@ func (s FrameworkService) Export(
 			err := controls.LoadByFrameworkID(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				frameworkID,
 				page.NewCursor(
 					10_000,
@@ -201,7 +201,7 @@ func (s FrameworkService) Export(
 				err = measures.LoadByControlID(
 					ctx,
 					conn,
-					s.svc.scope,
+					scope,
 					control.ID,
 					page.NewCursor(
 						10_000,
@@ -229,7 +229,7 @@ func (s FrameworkService) Export(
 					err = evidences.LoadByMeasureID(
 						ctx,
 						conn,
-						s.svc.scope,
+						scope,
 						measure.ID,
 						page.NewCursor(
 							10_000,
@@ -253,7 +253,7 @@ func (s FrameworkService) Export(
 						}
 
 						evidence_file := &coredata.File{}
-						if err := evidence_file.LoadByID(ctx, conn, s.svc.scope, *evidence.EvidenceFileId); err != nil {
+						if err := evidence_file.LoadByID(ctx, conn, scope, *evidence.EvidenceFileId); err != nil {
 							return fmt.Errorf("cannot load evidence file: %w", err)
 						}
 
@@ -287,7 +287,7 @@ func (s FrameworkService) Export(
 				err = documents.LoadByControlID(
 					ctx,
 					conn,
-					s.svc.scope,
+					scope,
 					control.ID,
 					page.NewCursor(
 						10_000,
@@ -306,7 +306,7 @@ func (s FrameworkService) Export(
 
 				for _, document := range documents {
 					documentVersion := &coredata.DocumentVersion{}
-					if err := documentVersion.LoadLatestPublishedVersion(ctx, conn, s.svc.scope, document.ID); err != nil {
+					if err := documentVersion.LoadLatestPublishedVersion(ctx, conn, scope, document.ID); err != nil {
 						return fmt.Errorf("cannot load document version: %w", err)
 					}
 
@@ -315,7 +315,7 @@ func (s FrameworkService) Export(
 						s.svc,
 						s.html2pdfConverter,
 						conn,
-						s.svc.scope,
+						scope,
 						documentVersion.ID,
 						ExportPDFOptions{WithSignatures: true},
 					)
@@ -341,7 +341,7 @@ func (s FrameworkService) Export(
 }
 
 func (s FrameworkService) Create(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req CreateFrameworkRequest,
 ) (*coredata.Framework, error) {
 	if err := req.Validate(); err != nil {
@@ -352,7 +352,7 @@ func (s FrameworkService) Create(
 	organization := &coredata.Organization{}
 
 	framework := &coredata.Framework{
-		ID:          gid.New(s.svc.scope.GetTenantID(), coredata.FrameworkEntityType),
+		ID:          gid.New(scope.GetTenantID(), coredata.FrameworkEntityType),
 		Name:        req.Name,
 		Description: req.Description,
 		ReferenceID: slug.Make(req.Name),
@@ -361,13 +361,13 @@ func (s FrameworkService) Create(
 	}
 
 	err := s.svc.pg.WithTx(ctx, func(ctx context.Context, conn pg.Tx) error {
-		if err := organization.LoadByID(ctx, conn, s.svc.scope, req.OrganizationID); err != nil {
+		if err := organization.LoadByID(ctx, conn, scope, req.OrganizationID); err != nil {
 			return fmt.Errorf("cannot load organization: %w", err)
 		}
 
 		framework.OrganizationID = organization.ID
 
-		if err := framework.Insert(ctx, conn, s.svc.scope); err != nil {
+		if err := framework.Insert(ctx, conn, scope); err != nil {
 			return fmt.Errorf("cannot insert framework: %w", err)
 		}
 
@@ -381,7 +381,7 @@ func (s FrameworkService) Create(
 }
 
 func (s FrameworkService) CountForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (int, error) {
 	var count int
@@ -389,7 +389,7 @@ func (s FrameworkService) CountForOrganizationID(
 	err := s.svc.pg.WithConn(ctx, func(ctx context.Context, conn pg.Querier) (err error) {
 		frameworks := &coredata.Frameworks{}
 
-		count, err = frameworks.CountByOrganizationID(ctx, conn, s.svc.scope, organizationID)
+		count, err = frameworks.CountByOrganizationID(ctx, conn, scope, organizationID)
 		if err != nil {
 			return fmt.Errorf("cannot count frameworks: %w", err)
 		}
@@ -404,7 +404,7 @@ func (s FrameworkService) CountForOrganizationID(
 }
 
 func (s FrameworkService) ListForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.FrameworkOrderField],
 ) (*page.Page[*coredata.Framework, coredata.FrameworkOrderField], error) {
@@ -413,14 +413,14 @@ func (s FrameworkService) ListForOrganizationID(
 	organization := &coredata.Organization{}
 
 	err := s.svc.pg.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
-		if err := organization.LoadByID(ctx, conn, s.svc.scope, organizationID); err != nil {
+		if err := organization.LoadByID(ctx, conn, scope, organizationID); err != nil {
 			return fmt.Errorf("cannot load organization: %w", err)
 		}
 
 		err := frameworks.LoadByOrganizationID(
 			ctx,
 			conn,
-			s.svc.scope,
+			scope,
 			organization.ID,
 			cursor,
 		)
@@ -438,13 +438,13 @@ func (s FrameworkService) ListForOrganizationID(
 }
 
 func (s FrameworkService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	frameworkID gid.GID,
 ) (*coredata.Framework, error) {
 	framework := &coredata.Framework{}
 
 	err := s.svc.pg.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
-		return framework.LoadByID(ctx, conn, s.svc.scope, frameworkID)
+		return framework.LoadByID(ctx, conn, scope, frameworkID)
 	})
 	if err != nil {
 		return nil, err
@@ -454,7 +454,7 @@ func (s FrameworkService) Get(
 }
 
 func (s FrameworkService) GetByIDs(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	frameworkIDs ...gid.GID,
 ) (coredata.Frameworks, error) {
 	var frameworks coredata.Frameworks
@@ -465,7 +465,7 @@ func (s FrameworkService) GetByIDs(
 			if err := frameworks.LoadByIDs(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				frameworkIDs,
 			); err != nil {
 				return fmt.Errorf("cannot load frameworks by ids: %w", err)
@@ -482,7 +482,7 @@ func (s FrameworkService) GetByIDs(
 }
 
 func (s FrameworkService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req UpdateFrameworkRequest,
 ) (*coredata.Framework, error) {
 	if err := req.Validate(); err != nil {
@@ -492,7 +492,7 @@ func (s FrameworkService) Update(
 	framework := &coredata.Framework{ID: req.ID}
 
 	err := s.svc.pg.WithTx(ctx, func(ctx context.Context, conn pg.Tx) error {
-		if err := framework.LoadByID(ctx, conn, s.svc.scope, req.ID); err != nil {
+		if err := framework.LoadByID(ctx, conn, scope, req.ID); err != nil {
 			return fmt.Errorf("cannot load framework: %w", err)
 		}
 
@@ -504,7 +504,7 @@ func (s FrameworkService) Update(
 			framework.Description = *req.Description
 		}
 
-		return framework.Update(ctx, conn, s.svc.scope)
+		return framework.Update(ctx, conn, scope)
 	})
 	if err != nil {
 		return nil, err
@@ -514,18 +514,18 @@ func (s FrameworkService) Update(
 }
 
 func (s FrameworkService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	frameworkID gid.GID,
 ) error {
 	framework := &coredata.Framework{}
 
 	return s.svc.pg.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
-		return framework.Delete(ctx, tx, s.svc.scope, frameworkID)
+		return framework.Delete(ctx, tx, scope, frameworkID)
 	})
 }
 
 func (s FrameworkService) Import(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	req ImportFrameworkRequest,
 ) (*coredata.Framework, error) {
@@ -536,7 +536,7 @@ func (s FrameworkService) Import(
 
 	err := s.svc.pg.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
 		organization := &coredata.Organization{}
-		if err := organization.LoadByID(ctx, tx, s.svc.scope, organizationID); err != nil {
+		if err := organization.LoadByID(ctx, tx, scope, organizationID); err != nil {
 			return fmt.Errorf("cannot load organization: %w", err)
 		}
 
@@ -554,7 +554,7 @@ func (s FrameworkService) Import(
 				"light": req.Framework.Logo.Light,
 				"dark":  req.Framework.Logo.Dark,
 			} {
-				fileID := gid.New(s.svc.scope.GetTenantID(), coredata.FileEntityType)
+				fileID := gid.New(scope.GetTenantID(), coredata.FileEntityType)
 
 				objectKey, err := uuid.NewV7()
 				if err != nil {
@@ -587,7 +587,7 @@ func (s FrameworkService) Import(
 
 				fileRecord.FileSize = fileSize
 
-				if err := fileRecord.Insert(ctx, tx, s.svc.scope); err != nil {
+				if err := fileRecord.Insert(ctx, tx, scope); err != nil {
 					return fmt.Errorf("cannot insert file: %w", err)
 				}
 
@@ -599,7 +599,7 @@ func (s FrameworkService) Import(
 			}
 		}
 
-		if err := framework.Insert(ctx, tx, s.svc.scope); err != nil {
+		if err := framework.Insert(ctx, tx, scope); err != nil {
 			return fmt.Errorf("cannot insert framework: %w", err)
 		}
 
@@ -642,7 +642,7 @@ func (s FrameworkService) Import(
 				UpdatedAt:                   now,
 			}
 
-			if err := control.Insert(ctx, tx, s.svc.scope); err != nil {
+			if err := control.Insert(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot insert control: %w", err)
 			}
 		}
@@ -657,7 +657,7 @@ func (s FrameworkService) Import(
 }
 
 func (s FrameworkService) SendExportEmail(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	fileID gid.GID,
 	recipientName string,
 	recipientEmail mail.Addr,
@@ -666,11 +666,11 @@ func (s FrameworkService) SendExportEmail(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			file := &coredata.File{}
-			if err := file.LoadByID(ctx, tx, s.svc.scope, fileID); err != nil {
+			if err := file.LoadByID(ctx, tx, scope, fileID); err != nil {
 				return fmt.Errorf("cannot load file: %w", err)
 			}
 
-			downloadURL, err := s.GenerateFrameworkExportDownloadURL(ctx, file)
+			downloadURL, err := s.GenerateFrameworkExportDownloadURL(ctx, scope, file)
 			if err != nil {
 				return fmt.Errorf("cannot generate download URL: %w", err)
 			}
@@ -704,7 +704,7 @@ func (s FrameworkService) SendExportEmail(
 }
 
 func (s FrameworkService) GenerateFrameworkExportDownloadURL(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	file *coredata.File,
 ) (string, error) {
 	presignClient := s3.NewPresignClient(s.svc.s3)
@@ -729,13 +729,13 @@ func (s FrameworkService) GenerateFrameworkExportDownloadURL(
 	return presignedReq.URL, nil
 }
 
-func (s *FrameworkService) BuildAndUploadExport(ctx context.Context, exportJobID gid.GID) (*coredata.ExportJob, error) {
+func (s *FrameworkService) BuildAndUploadExport(ctx context.Context, scope coredata.Scoper, exportJobID gid.GID) (*coredata.ExportJob, error) {
 	exportJob := &coredata.ExportJob{}
 
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := exportJob.LoadByID(ctx, tx, s.svc.scope, exportJobID); err != nil {
+			if err := exportJob.LoadByID(ctx, tx, scope, exportJobID); err != nil {
 				return fmt.Errorf("cannot load export job: %w", err)
 			}
 
@@ -745,7 +745,7 @@ func (s *FrameworkService) BuildAndUploadExport(ctx context.Context, exportJobID
 			}
 
 			framework := &coredata.Framework{}
-			if err := framework.LoadByID(ctx, tx, s.svc.scope, frameworkID); err != nil {
+			if err := framework.LoadByID(ctx, tx, scope, frameworkID); err != nil {
 				return fmt.Errorf("cannot load framework: %w", err)
 			}
 
@@ -759,7 +759,7 @@ func (s *FrameworkService) BuildAndUploadExport(ctx context.Context, exportJobID
 			defer func() { _ = tempFile.Close() }()
 			defer func() { _ = os.Remove(tempFile.Name()) }()
 
-			err = s.Export(ctx, frameworkID, tempFile)
+			err = s.Export(ctx, scope, frameworkID, tempFile)
 			if err != nil {
 				return fmt.Errorf("cannot export framework: %w", err)
 			}
@@ -812,12 +812,12 @@ func (s *FrameworkService) BuildAndUploadExport(ctx context.Context, exportJobID
 				UpdatedAt:  now,
 			}
 
-			if err := file.Insert(ctx, tx, s.svc.scope); err != nil {
+			if err := file.Insert(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot insert file: %w", err)
 			}
 
 			exportJob.FileID = &file.ID
-			if err := exportJob.Update(ctx, tx, s.svc.scope); err != nil {
+			if err := exportJob.Update(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot update export job: %w", err)
 			}
 
@@ -832,7 +832,7 @@ func (s *FrameworkService) BuildAndUploadExport(ctx context.Context, exportJobID
 }
 
 func (s FrameworkService) GenerateLightLogoURL(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	frameworkID gid.GID,
 	expiresIn time.Duration,
 ) (*string, error) {
@@ -842,7 +842,7 @@ func (s FrameworkService) GenerateLightLogoURL(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			framework := &coredata.Framework{}
-			if err := framework.LoadByID(ctx, conn, s.svc.scope, frameworkID); err != nil {
+			if err := framework.LoadByID(ctx, conn, scope, frameworkID); err != nil {
 				return fmt.Errorf("cannot load framework: %w", err)
 			}
 
@@ -850,7 +850,7 @@ func (s FrameworkService) GenerateLightLogoURL(
 				return nil
 			}
 
-			if err := file.LoadByID(ctx, conn, s.svc.scope, *framework.LightLogoFileID); err != nil {
+			if err := file.LoadByID(ctx, conn, scope, *framework.LightLogoFileID); err != nil {
 				return fmt.Errorf("cannot load file: %w", err)
 			}
 
@@ -874,7 +874,7 @@ func (s FrameworkService) GenerateLightLogoURL(
 }
 
 func (s FrameworkService) GenerateDarkLogoURL(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	frameworkID gid.GID,
 	expiresIn time.Duration,
 ) (*string, error) {
@@ -884,7 +884,7 @@ func (s FrameworkService) GenerateDarkLogoURL(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			framework := &coredata.Framework{}
-			if err := framework.LoadByID(ctx, conn, s.svc.scope, frameworkID); err != nil {
+			if err := framework.LoadByID(ctx, conn, scope, frameworkID); err != nil {
 				return fmt.Errorf("cannot load framework: %w", err)
 			}
 
@@ -892,7 +892,7 @@ func (s FrameworkService) GenerateDarkLogoURL(
 				return nil
 			}
 
-			if err := file.LoadByID(ctx, conn, s.svc.scope, *framework.DarkLogoFileID); err != nil {
+			if err := file.LoadByID(ctx, conn, scope, *framework.DarkLogoFileID); err != nil {
 				return fmt.Errorf("cannot load file: %w", err)
 			}
 

--- a/pkg/probo/generated_document_service.go
+++ b/pkg/probo/generated_document_service.go
@@ -31,11 +31,11 @@ import (
 )
 
 type GeneratedDocumentService struct {
-	svc *TenantService
+	svc *Service
 }
 
 func (s *GeneratedDocumentService) PublishStatementOfApplicability(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	statementOfApplicabilityID gid.GID,
 	approverIDs []gid.GID,
 	minor bool,
@@ -49,11 +49,11 @@ func (s *GeneratedDocumentService) PublishStatementOfApplicability(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			soa := &coredata.StatementOfApplicability{}
-			if err := soa.LoadByID(ctx, tx, s.svc.scope, statementOfApplicabilityID); err != nil {
+			if err := soa.LoadByID(ctx, tx, scope, statementOfApplicabilityID); err != nil {
 				return fmt.Errorf("cannot load statement of applicability: %w", err)
 			}
 
-			documentData, err := s.buildStatementOfApplicabilityDocumentData(ctx, tx, soa)
+			documentData, err := s.buildStatementOfApplicabilityDocumentData(ctx, scope, tx, soa)
 			if err != nil {
 				return fmt.Errorf("cannot build document data: %w", err)
 			}
@@ -70,7 +70,7 @@ func (s *GeneratedDocumentService) PublishStatementOfApplicability(
 			if soa.DocumentID != nil {
 				doc := &coredata.Document{}
 
-				err = doc.LoadByID(ctx, tx, s.svc.scope, *soa.DocumentID)
+				err = doc.LoadByID(ctx, tx, scope, *soa.DocumentID)
 				if err != nil && !errors.Is(err, coredata.ErrResourceNotFound) {
 					return fmt.Errorf("cannot load statement of applicability document: %w", err)
 				}
@@ -81,14 +81,14 @@ func (s *GeneratedDocumentService) PublishStatementOfApplicability(
 					soa.DocumentID = nil
 
 					soa.UpdatedAt = now
-					if err := soa.Update(ctx, tx, s.svc.scope); err != nil {
+					if err := soa.Update(ctx, tx, scope); err != nil {
 						return fmt.Errorf("cannot clear document reference: %w", err)
 					}
 				}
 			}
 
 			if existingDoc == nil {
-				documentID := gid.New(s.svc.scope.GetTenantID(), coredata.DocumentEntityType)
+				documentID := gid.New(scope.GetTenantID(), coredata.DocumentEntityType)
 
 				document = &coredata.Document{
 					ID:                    documentID,
@@ -100,21 +100,21 @@ func (s *GeneratedDocumentService) PublishStatementOfApplicability(
 					UpdatedAt:             now,
 				}
 
-				if err := document.Insert(ctx, tx, s.svc.scope); err != nil {
+				if err := document.Insert(ctx, tx, scope); err != nil {
 					return fmt.Errorf("cannot insert document: %w", err)
 				}
 
 				soa.DocumentID = &documentID
 
 				soa.UpdatedAt = now
-				if err := soa.Update(ctx, tx, s.svc.scope); err != nil {
+				if err := soa.Update(ctx, tx, scope); err != nil {
 					return fmt.Errorf("cannot update document reference: %w", err)
 				}
 			} else {
 				document = existingDoc
 			}
 
-			documentVersionID := gid.New(s.svc.scope.GetTenantID(), coredata.DocumentVersionEntityType)
+			documentVersionID := gid.New(scope.GetTenantID(), coredata.DocumentVersionEntityType)
 			documentVersion = &coredata.DocumentVersion{
 				ID:             documentVersionID,
 				OrganizationID: soa.OrganizationID,
@@ -128,7 +128,7 @@ func (s *GeneratedDocumentService) PublishStatementOfApplicability(
 				UpdatedAt:      now,
 			}
 
-			return s.publishOrRequestApproval(ctx, tx, document, documentVersion, soa.OrganizationID, approverIDs, minor, now)
+			return s.publishOrRequestApproval(ctx, scope, tx, document, documentVersion, soa.OrganizationID, approverIDs, minor, now)
 		},
 	)
 	if err != nil {
@@ -139,17 +139,17 @@ func (s *GeneratedDocumentService) PublishStatementOfApplicability(
 }
 
 func (s *GeneratedDocumentService) buildStatementOfApplicabilityDocumentData(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	conn pg.Querier,
 	statementOfApplicability *coredata.StatementOfApplicability,
 ) (docgen.StatementOfApplicabilityData, error) {
 	organization := &coredata.Organization{}
-	if err := organization.LoadByID(ctx, conn, s.svc.scope, statementOfApplicability.OrganizationID); err != nil {
+	if err := organization.LoadByID(ctx, conn, scope, statementOfApplicability.OrganizationID); err != nil {
 		return docgen.StatementOfApplicabilityData{}, fmt.Errorf("cannot load organization: %w", err)
 	}
 
 	var applicabilityStatements coredata.ApplicabilityStatements
-	if err := applicabilityStatements.LoadAllByStatementOfApplicabilityID(ctx, conn, s.svc.scope, statementOfApplicability.ID); err != nil {
+	if err := applicabilityStatements.LoadAllByStatementOfApplicabilityID(ctx, conn, scope, statementOfApplicability.ID); err != nil {
 		return docgen.StatementOfApplicabilityData{}, fmt.Errorf("cannot load applicability statements: %w", err)
 	}
 
@@ -168,7 +168,7 @@ func (s *GeneratedDocumentService) buildStatementOfApplicabilityDocumentData(
 	}
 
 	var controls coredata.Controls
-	if err := controls.LoadByIDs(ctx, conn, s.svc.scope, controlIDs); err != nil {
+	if err := controls.LoadByIDs(ctx, conn, scope, controlIDs); err != nil {
 		return docgen.StatementOfApplicabilityData{}, fmt.Errorf("cannot load controls: %w", err)
 	}
 
@@ -186,7 +186,7 @@ func (s *GeneratedDocumentService) buildStatementOfApplicabilityDocumentData(
 	}
 
 	var frameworks coredata.Frameworks
-	if err := frameworks.LoadByIDs(ctx, conn, s.svc.scope, frameworkIDs); err != nil {
+	if err := frameworks.LoadByIDs(ctx, conn, scope, frameworkIDs); err != nil {
 		return docgen.StatementOfApplicabilityData{}, fmt.Errorf("cannot load frameworks: %w", err)
 	}
 
@@ -195,7 +195,7 @@ func (s *GeneratedDocumentService) buildStatementOfApplicabilityDocumentData(
 		frameworkMap[f.ID] = f
 	}
 
-	controlOblTypes, err := coredata.LoadObligationTypesByControlIDs(ctx, conn, s.svc.scope, controlIDs)
+	controlOblTypes, err := coredata.LoadObligationTypesByControlIDs(ctx, conn, scope, controlIDs)
 	if err != nil {
 		return docgen.StatementOfApplicabilityData{}, fmt.Errorf("cannot load obligation types: %w", err)
 	}
@@ -211,7 +211,7 @@ func (s *GeneratedDocumentService) buildStatementOfApplicabilityDocumentData(
 	}
 
 	var controlsWithRisk coredata.ControlsWithRisk
-	if err := controlsWithRisk.LoadByControlIDs(ctx, conn, s.svc.scope, controlIDs); err != nil {
+	if err := controlsWithRisk.LoadByControlIDs(ctx, conn, scope, controlIDs); err != nil {
 		return docgen.StatementOfApplicabilityData{}, fmt.Errorf("cannot load controls with risks: %w", err)
 	}
 
@@ -290,7 +290,7 @@ func (s *GeneratedDocumentService) buildStatementOfApplicabilityDocumentData(
 }
 
 func (s *GeneratedDocumentService) PublishDataList(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	approverIDs []gid.GID,
 	minor bool,
@@ -304,11 +304,11 @@ func (s *GeneratedDocumentService) PublishDataList(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			organization := &coredata.Organization{}
-			if err := organization.LoadByID(ctx, tx, s.svc.scope, organizationID); err != nil {
+			if err := organization.LoadByID(ctx, tx, scope, organizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
-			documentData, err := s.buildDataListDocumentData(ctx, tx, organization)
+			documentData, err := s.buildDataListDocumentData(ctx, scope, tx, organization)
 			if err != nil {
 				return fmt.Errorf("cannot build document data: %w", err)
 			}
@@ -332,7 +332,7 @@ func (s *GeneratedDocumentService) PublishDataList(
 			if dataDocumentID != nil {
 				doc := &coredata.Document{}
 
-				err = doc.LoadByID(ctx, tx, s.svc.scope, *dataDocumentID)
+				err = doc.LoadByID(ctx, tx, scope, *dataDocumentID)
 				if err != nil && !errors.Is(err, coredata.ErrResourceNotFound) {
 					return fmt.Errorf("cannot load data list document: %w", err)
 				}
@@ -347,7 +347,7 @@ func (s *GeneratedDocumentService) PublishDataList(
 			}
 
 			if existingDoc == nil {
-				documentID := gid.New(s.svc.scope.GetTenantID(), coredata.DocumentEntityType)
+				documentID := gid.New(scope.GetTenantID(), coredata.DocumentEntityType)
 
 				document = &coredata.Document{
 					ID:                    documentID,
@@ -359,18 +359,18 @@ func (s *GeneratedDocumentService) PublishDataList(
 					UpdatedAt:             now,
 				}
 
-				if err := document.Insert(ctx, tx, s.svc.scope); err != nil {
+				if err := document.Insert(ctx, tx, scope); err != nil {
 					return fmt.Errorf("cannot insert document: %w", err)
 				}
 
-				if err := datum.UpsertGeneratedDocumentID(ctx, tx, organizationID, s.svc.scope.GetTenantID(), documentID); err != nil {
+				if err := datum.UpsertGeneratedDocumentID(ctx, tx, organizationID, scope.GetTenantID(), documentID); err != nil {
 					return fmt.Errorf("cannot upsert generated documents: %w", err)
 				}
 			} else {
 				document = existingDoc
 			}
 
-			documentVersionID := gid.New(s.svc.scope.GetTenantID(), coredata.DocumentVersionEntityType)
+			documentVersionID := gid.New(scope.GetTenantID(), coredata.DocumentVersionEntityType)
 			documentVersion = &coredata.DocumentVersion{
 				ID:             documentVersionID,
 				OrganizationID: organizationID,
@@ -384,7 +384,7 @@ func (s *GeneratedDocumentService) PublishDataList(
 				UpdatedAt:      now,
 			}
 
-			return s.publishOrRequestApproval(ctx, tx, document, documentVersion, organizationID, approverIDs, minor, now)
+			return s.publishOrRequestApproval(ctx, scope, tx, document, documentVersion, organizationID, approverIDs, minor, now)
 		},
 	)
 	if err != nil {
@@ -395,7 +395,7 @@ func (s *GeneratedDocumentService) PublishDataList(
 }
 
 func (s *GeneratedDocumentService) GetDataListDocumentID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (*gid.GID, error) {
 	var dataDocumentID *gid.GID
@@ -417,12 +417,12 @@ func (s *GeneratedDocumentService) GetDataListDocumentID(
 }
 
 func (s *GeneratedDocumentService) buildDataListDocumentData(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	conn pg.Querier,
 	organization *coredata.Organization,
 ) (docgen.DataListData, error) {
 	var data coredata.Data
-	if err := data.LoadAllByOrganizationID(ctx, conn, s.svc.scope, organization.ID); err != nil {
+	if err := data.LoadAllByOrganizationID(ctx, conn, scope, organization.ID); err != nil {
 		return docgen.DataListData{}, fmt.Errorf("cannot load data: %w", err)
 	}
 
@@ -446,7 +446,7 @@ func (s *GeneratedDocumentService) buildDataListDocumentData(
 	}
 
 	var profiles coredata.MembershipProfiles
-	if err := profiles.LoadByIDs(ctx, conn, s.svc.scope, ownerIDs); err != nil {
+	if err := profiles.LoadByIDs(ctx, conn, scope, ownerIDs); err != nil {
 		return docgen.DataListData{}, fmt.Errorf("cannot load profiles: %w", err)
 	}
 
@@ -463,7 +463,7 @@ func (s *GeneratedDocumentService) buildDataListDocumentData(
 		}
 
 		var thirdParties coredata.ThirdParties
-		if err := thirdParties.LoadAllByDatumID(ctx, conn, s.svc.scope, d.ID); err != nil {
+		if err := thirdParties.LoadAllByDatumID(ctx, conn, scope, d.ID); err != nil {
 			return docgen.DataListData{}, fmt.Errorf("cannot load thirdParties for datum %s: %w", d.ID, err)
 		}
 
@@ -534,7 +534,7 @@ func BuildDataListDocument(data docgen.DataListData) (string, error) {
 }
 
 func (s *GeneratedDocumentService) PublishAssetList(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	approverIDs []gid.GID,
 	minor bool,
@@ -548,11 +548,11 @@ func (s *GeneratedDocumentService) PublishAssetList(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			organization := &coredata.Organization{}
-			if err := organization.LoadByID(ctx, tx, s.svc.scope, organizationID); err != nil {
+			if err := organization.LoadByID(ctx, tx, scope, organizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
-			documentData, err := s.buildAssetListDocumentData(ctx, tx, organization)
+			documentData, err := s.buildAssetListDocumentData(ctx, scope, tx, organization)
 			if err != nil {
 				return fmt.Errorf("cannot build document data: %w", err)
 			}
@@ -576,7 +576,7 @@ func (s *GeneratedDocumentService) PublishAssetList(
 			if assetDocumentID != nil {
 				doc := &coredata.Document{}
 
-				err = doc.LoadByID(ctx, tx, s.svc.scope, *assetDocumentID)
+				err = doc.LoadByID(ctx, tx, scope, *assetDocumentID)
 				if err != nil && !errors.Is(err, coredata.ErrResourceNotFound) {
 					return fmt.Errorf("cannot load asset list document: %w", err)
 				}
@@ -591,7 +591,7 @@ func (s *GeneratedDocumentService) PublishAssetList(
 			}
 
 			if existingDoc == nil {
-				documentID := gid.New(s.svc.scope.GetTenantID(), coredata.DocumentEntityType)
+				documentID := gid.New(scope.GetTenantID(), coredata.DocumentEntityType)
 
 				document = &coredata.Document{
 					ID:                    documentID,
@@ -603,18 +603,18 @@ func (s *GeneratedDocumentService) PublishAssetList(
 					UpdatedAt:             now,
 				}
 
-				if err := document.Insert(ctx, tx, s.svc.scope); err != nil {
+				if err := document.Insert(ctx, tx, scope); err != nil {
 					return fmt.Errorf("cannot insert document: %w", err)
 				}
 
-				if err := asset.UpsertGeneratedDocumentID(ctx, tx, organizationID, s.svc.scope.GetTenantID(), documentID); err != nil {
+				if err := asset.UpsertGeneratedDocumentID(ctx, tx, organizationID, scope.GetTenantID(), documentID); err != nil {
 					return fmt.Errorf("cannot upsert generated documents: %w", err)
 				}
 			} else {
 				document = existingDoc
 			}
 
-			documentVersionID := gid.New(s.svc.scope.GetTenantID(), coredata.DocumentVersionEntityType)
+			documentVersionID := gid.New(scope.GetTenantID(), coredata.DocumentVersionEntityType)
 			documentVersion = &coredata.DocumentVersion{
 				ID:             documentVersionID,
 				OrganizationID: organizationID,
@@ -628,7 +628,7 @@ func (s *GeneratedDocumentService) PublishAssetList(
 				UpdatedAt:      now,
 			}
 
-			return s.publishOrRequestApproval(ctx, tx, document, documentVersion, organizationID, approverIDs, minor, now)
+			return s.publishOrRequestApproval(ctx, scope, tx, document, documentVersion, organizationID, approverIDs, minor, now)
 		},
 	)
 	if err != nil {
@@ -639,7 +639,7 @@ func (s *GeneratedDocumentService) PublishAssetList(
 }
 
 func (s *GeneratedDocumentService) GetAssetListDocumentID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (*gid.GID, error) {
 	var assetDocumentID *gid.GID
@@ -661,12 +661,12 @@ func (s *GeneratedDocumentService) GetAssetListDocumentID(
 }
 
 func (s *GeneratedDocumentService) buildAssetListDocumentData(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	conn pg.Querier,
 	organization *coredata.Organization,
 ) (docgen.AssetListData, error) {
 	var assets coredata.Assets
-	if err := assets.LoadAllByOrganizationID(ctx, conn, s.svc.scope, organization.ID); err != nil {
+	if err := assets.LoadAllByOrganizationID(ctx, conn, scope, organization.ID); err != nil {
 		return docgen.AssetListData{}, fmt.Errorf("cannot load assets: %w", err)
 	}
 
@@ -690,7 +690,7 @@ func (s *GeneratedDocumentService) buildAssetListDocumentData(
 	}
 
 	var profiles coredata.MembershipProfiles
-	if err := profiles.LoadByIDs(ctx, conn, s.svc.scope, ownerIDs); err != nil {
+	if err := profiles.LoadByIDs(ctx, conn, scope, ownerIDs); err != nil {
 		return docgen.AssetListData{}, fmt.Errorf("cannot load profiles: %w", err)
 	}
 
@@ -707,7 +707,7 @@ func (s *GeneratedDocumentService) buildAssetListDocumentData(
 		}
 
 		var thirdParties coredata.ThirdParties
-		if err := thirdParties.LoadAllByAssetID(ctx, conn, s.svc.scope, a.ID); err != nil {
+		if err := thirdParties.LoadAllByAssetID(ctx, conn, scope, a.ID); err != nil {
 			return docgen.AssetListData{}, fmt.Errorf("cannot load thirdParties for asset %s: %w", a.ID, err)
 		}
 
@@ -801,7 +801,7 @@ func BuildStatementOfApplicabilityDocument(data docgen.StatementOfApplicabilityD
 }
 
 func (s *GeneratedDocumentService) PublishFindingList(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	approverIDs []gid.GID,
 	minor bool,
@@ -815,11 +815,11 @@ func (s *GeneratedDocumentService) PublishFindingList(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			organization := &coredata.Organization{}
-			if err := organization.LoadByID(ctx, tx, s.svc.scope, organizationID); err != nil {
+			if err := organization.LoadByID(ctx, tx, scope, organizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
-			documentData, err := s.buildFindingListDocumentData(ctx, tx, organization)
+			documentData, err := s.buildFindingListDocumentData(ctx, scope, tx, organization)
 			if err != nil {
 				return fmt.Errorf("cannot build document data: %w", err)
 			}
@@ -843,7 +843,7 @@ func (s *GeneratedDocumentService) PublishFindingList(
 			if findingDocumentID != nil {
 				doc := &coredata.Document{}
 
-				err = doc.LoadByID(ctx, tx, s.svc.scope, *findingDocumentID)
+				err = doc.LoadByID(ctx, tx, scope, *findingDocumentID)
 				if err != nil && !errors.Is(err, coredata.ErrResourceNotFound) {
 					return fmt.Errorf("cannot load finding list document: %w", err)
 				}
@@ -858,7 +858,7 @@ func (s *GeneratedDocumentService) PublishFindingList(
 			}
 
 			if existingDoc == nil {
-				documentID := gid.New(s.svc.scope.GetTenantID(), coredata.DocumentEntityType)
+				documentID := gid.New(scope.GetTenantID(), coredata.DocumentEntityType)
 
 				document = &coredata.Document{
 					ID:                    documentID,
@@ -870,18 +870,18 @@ func (s *GeneratedDocumentService) PublishFindingList(
 					UpdatedAt:             now,
 				}
 
-				if err := document.Insert(ctx, tx, s.svc.scope); err != nil {
+				if err := document.Insert(ctx, tx, scope); err != nil {
 					return fmt.Errorf("cannot insert document: %w", err)
 				}
 
-				if err := finding.UpsertGeneratedDocumentID(ctx, tx, organizationID, s.svc.scope.GetTenantID(), documentID); err != nil {
+				if err := finding.UpsertGeneratedDocumentID(ctx, tx, organizationID, scope.GetTenantID(), documentID); err != nil {
 					return fmt.Errorf("cannot upsert generated documents: %w", err)
 				}
 			} else {
 				document = existingDoc
 			}
 
-			documentVersionID := gid.New(s.svc.scope.GetTenantID(), coredata.DocumentVersionEntityType)
+			documentVersionID := gid.New(scope.GetTenantID(), coredata.DocumentVersionEntityType)
 			documentVersion = &coredata.DocumentVersion{
 				ID:             documentVersionID,
 				OrganizationID: organizationID,
@@ -895,7 +895,7 @@ func (s *GeneratedDocumentService) PublishFindingList(
 				UpdatedAt:      now,
 			}
 
-			return s.publishOrRequestApproval(ctx, tx, document, documentVersion, organizationID, approverIDs, minor, now)
+			return s.publishOrRequestApproval(ctx, scope, tx, document, documentVersion, organizationID, approverIDs, minor, now)
 		},
 	)
 	if err != nil {
@@ -906,7 +906,7 @@ func (s *GeneratedDocumentService) PublishFindingList(
 }
 
 func (s *GeneratedDocumentService) GetFindingsDocumentID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (*gid.GID, error) {
 	var findingDocumentID *gid.GID
@@ -928,12 +928,12 @@ func (s *GeneratedDocumentService) GetFindingsDocumentID(
 }
 
 func (s *GeneratedDocumentService) buildFindingListDocumentData(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	conn pg.Querier,
 	organization *coredata.Organization,
 ) (docgen.FindingListData, error) {
 	var findings coredata.Findings
-	if err := findings.LoadAllByOrganizationID(ctx, conn, s.svc.scope, organization.ID); err != nil {
+	if err := findings.LoadAllByOrganizationID(ctx, conn, scope, organization.ID); err != nil {
 		return docgen.FindingListData{}, fmt.Errorf("cannot load findings: %w", err)
 	}
 
@@ -962,7 +962,7 @@ func (s *GeneratedDocumentService) buildFindingListDocumentData(
 
 	if len(ownerIDs) > 0 {
 		var profiles coredata.MembershipProfiles
-		if err := profiles.LoadByIDs(ctx, conn, s.svc.scope, ownerIDs); err != nil {
+		if err := profiles.LoadByIDs(ctx, conn, scope, ownerIDs); err != nil {
 			return docgen.FindingListData{}, fmt.Errorf("cannot load profiles: %w", err)
 		}
 
@@ -1113,7 +1113,7 @@ func BuildFindingListDocument(data docgen.FindingListData) (string, error) {
 }
 
 func (s *GeneratedDocumentService) PublishObligationList(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	approverIDs []gid.GID,
 	minor bool,
@@ -1127,11 +1127,11 @@ func (s *GeneratedDocumentService) PublishObligationList(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			organization := &coredata.Organization{}
-			if err := organization.LoadByID(ctx, tx, s.svc.scope, organizationID); err != nil {
+			if err := organization.LoadByID(ctx, tx, scope, organizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
-			documentData, err := s.buildObligationListDocumentData(ctx, tx, organization)
+			documentData, err := s.buildObligationListDocumentData(ctx, scope, tx, organization)
 			if err != nil {
 				return fmt.Errorf("cannot build document data: %w", err)
 			}
@@ -1155,7 +1155,7 @@ func (s *GeneratedDocumentService) PublishObligationList(
 			if obligationDocumentID != nil {
 				doc := &coredata.Document{}
 
-				err = doc.LoadByID(ctx, tx, s.svc.scope, *obligationDocumentID)
+				err = doc.LoadByID(ctx, tx, scope, *obligationDocumentID)
 				if err != nil && !errors.Is(err, coredata.ErrResourceNotFound) {
 					return fmt.Errorf("cannot load obligation list document: %w", err)
 				}
@@ -1170,7 +1170,7 @@ func (s *GeneratedDocumentService) PublishObligationList(
 			}
 
 			if existingDoc == nil {
-				documentID := gid.New(s.svc.scope.GetTenantID(), coredata.DocumentEntityType)
+				documentID := gid.New(scope.GetTenantID(), coredata.DocumentEntityType)
 
 				document = &coredata.Document{
 					ID:                    documentID,
@@ -1182,18 +1182,18 @@ func (s *GeneratedDocumentService) PublishObligationList(
 					UpdatedAt:             now,
 				}
 
-				if err := document.Insert(ctx, tx, s.svc.scope); err != nil {
+				if err := document.Insert(ctx, tx, scope); err != nil {
 					return fmt.Errorf("cannot insert document: %w", err)
 				}
 
-				if err := obligation.UpsertGeneratedDocumentID(ctx, tx, organizationID, s.svc.scope.GetTenantID(), documentID); err != nil {
+				if err := obligation.UpsertGeneratedDocumentID(ctx, tx, organizationID, scope.GetTenantID(), documentID); err != nil {
 					return fmt.Errorf("cannot upsert generated documents: %w", err)
 				}
 			} else {
 				document = existingDoc
 			}
 
-			documentVersionID := gid.New(s.svc.scope.GetTenantID(), coredata.DocumentVersionEntityType)
+			documentVersionID := gid.New(scope.GetTenantID(), coredata.DocumentVersionEntityType)
 			documentVersion = &coredata.DocumentVersion{
 				ID:             documentVersionID,
 				OrganizationID: organizationID,
@@ -1207,7 +1207,7 @@ func (s *GeneratedDocumentService) PublishObligationList(
 				UpdatedAt:      now,
 			}
 
-			return s.publishOrRequestApproval(ctx, tx, document, documentVersion, organizationID, approverIDs, minor, now)
+			return s.publishOrRequestApproval(ctx, scope, tx, document, documentVersion, organizationID, approverIDs, minor, now)
 		},
 	)
 	if err != nil {
@@ -1218,7 +1218,7 @@ func (s *GeneratedDocumentService) PublishObligationList(
 }
 
 func (s *GeneratedDocumentService) GetObligationsDocumentID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (*gid.GID, error) {
 	var obligationDocumentID *gid.GID
@@ -1240,12 +1240,12 @@ func (s *GeneratedDocumentService) GetObligationsDocumentID(
 }
 
 func (s *GeneratedDocumentService) buildObligationListDocumentData(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	conn pg.Querier,
 	organization *coredata.Organization,
 ) (docgen.ObligationListData, error) {
 	var obligations coredata.Obligations
-	if err := obligations.LoadAllByOrganizationID(ctx, conn, s.svc.scope, organization.ID); err != nil {
+	if err := obligations.LoadAllByOrganizationID(ctx, conn, scope, organization.ID); err != nil {
 		return docgen.ObligationListData{}, fmt.Errorf("cannot load obligations: %w", err)
 	}
 
@@ -1276,7 +1276,7 @@ func (s *GeneratedDocumentService) buildObligationListDocumentData(
 
 	if len(ownerIDs) > 0 {
 		var profiles coredata.MembershipProfiles
-		if err := profiles.LoadByIDs(ctx, conn, s.svc.scope, ownerIDs); err != nil {
+		if err := profiles.LoadByIDs(ctx, conn, scope, ownerIDs); err != nil {
 			return docgen.ObligationListData{}, fmt.Errorf("cannot load profiles: %w", err)
 		}
 
@@ -1393,7 +1393,7 @@ func BuildObligationListDocument(data docgen.ObligationListData) (string, error)
 }
 
 func (s *GeneratedDocumentService) PublishProcessingActivityList(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	approverIDs []gid.GID,
 	minor bool,
@@ -1407,11 +1407,11 @@ func (s *GeneratedDocumentService) PublishProcessingActivityList(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			organization := &coredata.Organization{}
-			if err := organization.LoadByID(ctx, tx, s.svc.scope, organizationID); err != nil {
+			if err := organization.LoadByID(ctx, tx, scope, organizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
-			documentData, err := s.buildProcessingActivityListDocumentData(ctx, tx, organization)
+			documentData, err := s.buildProcessingActivityListDocumentData(ctx, scope, tx, organization)
 			if err != nil {
 				return fmt.Errorf("cannot build document data: %w", err)
 			}
@@ -1435,7 +1435,7 @@ func (s *GeneratedDocumentService) PublishProcessingActivityList(
 			if processingActivityDocumentID != nil {
 				doc := &coredata.Document{}
 
-				err = doc.LoadByID(ctx, tx, s.svc.scope, *processingActivityDocumentID)
+				err = doc.LoadByID(ctx, tx, scope, *processingActivityDocumentID)
 				if err != nil && !errors.Is(err, coredata.ErrResourceNotFound) {
 					return fmt.Errorf("cannot load processing activity list document: %w", err)
 				}
@@ -1450,7 +1450,7 @@ func (s *GeneratedDocumentService) PublishProcessingActivityList(
 			}
 
 			if existingDoc == nil {
-				documentID := gid.New(s.svc.scope.GetTenantID(), coredata.DocumentEntityType)
+				documentID := gid.New(scope.GetTenantID(), coredata.DocumentEntityType)
 
 				document = &coredata.Document{
 					ID:                    documentID,
@@ -1462,18 +1462,18 @@ func (s *GeneratedDocumentService) PublishProcessingActivityList(
 					UpdatedAt:             now,
 				}
 
-				if err := document.Insert(ctx, tx, s.svc.scope); err != nil {
+				if err := document.Insert(ctx, tx, scope); err != nil {
 					return fmt.Errorf("cannot insert document: %w", err)
 				}
 
-				if err := processingActivity.UpsertGeneratedDocumentID(ctx, tx, organizationID, s.svc.scope.GetTenantID(), documentID); err != nil {
+				if err := processingActivity.UpsertGeneratedDocumentID(ctx, tx, organizationID, scope.GetTenantID(), documentID); err != nil {
 					return fmt.Errorf("cannot upsert generated documents: %w", err)
 				}
 			} else {
 				document = existingDoc
 			}
 
-			documentVersionID := gid.New(s.svc.scope.GetTenantID(), coredata.DocumentVersionEntityType)
+			documentVersionID := gid.New(scope.GetTenantID(), coredata.DocumentVersionEntityType)
 			documentVersion = &coredata.DocumentVersion{
 				ID:             documentVersionID,
 				OrganizationID: organizationID,
@@ -1487,7 +1487,7 @@ func (s *GeneratedDocumentService) PublishProcessingActivityList(
 				UpdatedAt:      now,
 			}
 
-			return s.publishOrRequestApproval(ctx, tx, document, documentVersion, organizationID, approverIDs, minor, now)
+			return s.publishOrRequestApproval(ctx, scope, tx, document, documentVersion, organizationID, approverIDs, minor, now)
 		},
 	)
 	if err != nil {
@@ -1498,7 +1498,7 @@ func (s *GeneratedDocumentService) PublishProcessingActivityList(
 }
 
 func (s *GeneratedDocumentService) GetProcessingActivitiesDocumentID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (*gid.GID, error) {
 	var documentID *gid.GID
@@ -1520,12 +1520,12 @@ func (s *GeneratedDocumentService) GetProcessingActivitiesDocumentID(
 }
 
 func (s *GeneratedDocumentService) buildProcessingActivityListDocumentData(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	conn pg.Querier,
 	organization *coredata.Organization,
 ) (docgen.ProcessingActivityListData, error) {
 	var processingActivities coredata.ProcessingActivities
-	if err := processingActivities.LoadAllByOrganizationID(ctx, conn, s.svc.scope, organization.ID); err != nil {
+	if err := processingActivities.LoadAllByOrganizationID(ctx, conn, scope, organization.ID); err != nil {
 		return docgen.ProcessingActivityListData{}, fmt.Errorf("cannot load processing activities: %w", err)
 	}
 
@@ -1540,7 +1540,7 @@ func (s *GeneratedDocumentService) buildProcessingActivityListDocumentData(
 
 	var thirdParties coredata.ThirdParties
 
-	thirdPartyMap, err := thirdParties.LoadAllByProcessingActivities(ctx, conn, s.svc.scope, organization.ID)
+	thirdPartyMap, err := thirdParties.LoadAllByProcessingActivities(ctx, conn, scope, organization.ID)
 	if err != nil {
 		return docgen.ProcessingActivityListData{}, fmt.Errorf("cannot load thirdParties: %w", err)
 	}
@@ -1561,7 +1561,7 @@ func (s *GeneratedDocumentService) buildProcessingActivityListDocumentData(
 
 	if len(dpoIDs) > 0 {
 		var profiles coredata.MembershipProfiles
-		if err := profiles.LoadByIDs(ctx, conn, s.svc.scope, dpoIDs); err != nil {
+		if err := profiles.LoadByIDs(ctx, conn, scope, dpoIDs); err != nil {
 			return docgen.ProcessingActivityListData{}, fmt.Errorf("cannot load DPO profiles: %w", err)
 		}
 
@@ -1774,7 +1774,7 @@ func BuildProcessingActivityListDocument(data docgen.ProcessingActivityListData)
 }
 
 func (s *GeneratedDocumentService) PublishDataProtectionImpactAssessmentList(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	approverIDs []gid.GID,
 	minor bool,
@@ -1788,11 +1788,11 @@ func (s *GeneratedDocumentService) PublishDataProtectionImpactAssessmentList(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			organization := &coredata.Organization{}
-			if err := organization.LoadByID(ctx, tx, s.svc.scope, organizationID); err != nil {
+			if err := organization.LoadByID(ctx, tx, scope, organizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
-			documentData, err := s.buildDataProtectionImpactAssessmentListDocumentData(ctx, tx, organization)
+			documentData, err := s.buildDataProtectionImpactAssessmentListDocumentData(ctx, scope, tx, organization)
 			if err != nil {
 				return fmt.Errorf("cannot build document data: %w", err)
 			}
@@ -1816,7 +1816,7 @@ func (s *GeneratedDocumentService) PublishDataProtectionImpactAssessmentList(
 			if dpiaDocumentID != nil {
 				doc := &coredata.Document{}
 
-				err = doc.LoadByID(ctx, tx, s.svc.scope, *dpiaDocumentID)
+				err = doc.LoadByID(ctx, tx, scope, *dpiaDocumentID)
 				if err != nil && !errors.Is(err, coredata.ErrResourceNotFound) {
 					return fmt.Errorf("cannot load DPIA list document: %w", err)
 				}
@@ -1831,7 +1831,7 @@ func (s *GeneratedDocumentService) PublishDataProtectionImpactAssessmentList(
 			}
 
 			if existingDoc == nil {
-				documentID := gid.New(s.svc.scope.GetTenantID(), coredata.DocumentEntityType)
+				documentID := gid.New(scope.GetTenantID(), coredata.DocumentEntityType)
 
 				document = &coredata.Document{
 					ID:                    documentID,
@@ -1843,18 +1843,18 @@ func (s *GeneratedDocumentService) PublishDataProtectionImpactAssessmentList(
 					UpdatedAt:             now,
 				}
 
-				if err := document.Insert(ctx, tx, s.svc.scope); err != nil {
+				if err := document.Insert(ctx, tx, scope); err != nil {
 					return fmt.Errorf("cannot insert document: %w", err)
 				}
 
-				if err := dpia.UpsertGeneratedDocumentID(ctx, tx, organizationID, s.svc.scope.GetTenantID(), documentID); err != nil {
+				if err := dpia.UpsertGeneratedDocumentID(ctx, tx, organizationID, scope.GetTenantID(), documentID); err != nil {
 					return fmt.Errorf("cannot upsert generated documents: %w", err)
 				}
 			} else {
 				document = existingDoc
 			}
 
-			documentVersionID := gid.New(s.svc.scope.GetTenantID(), coredata.DocumentVersionEntityType)
+			documentVersionID := gid.New(scope.GetTenantID(), coredata.DocumentVersionEntityType)
 			documentVersion = &coredata.DocumentVersion{
 				ID:             documentVersionID,
 				OrganizationID: organizationID,
@@ -1868,7 +1868,7 @@ func (s *GeneratedDocumentService) PublishDataProtectionImpactAssessmentList(
 				UpdatedAt:      now,
 			}
 
-			return s.publishOrRequestApproval(ctx, tx, document, documentVersion, organizationID, approverIDs, minor, now)
+			return s.publishOrRequestApproval(ctx, scope, tx, document, documentVersion, organizationID, approverIDs, minor, now)
 		},
 	)
 	if err != nil {
@@ -1879,7 +1879,7 @@ func (s *GeneratedDocumentService) PublishDataProtectionImpactAssessmentList(
 }
 
 func (s *GeneratedDocumentService) GetDataProtectionImpactAssessmentsDocumentID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (*gid.GID, error) {
 	var documentID *gid.GID
@@ -1901,12 +1901,12 @@ func (s *GeneratedDocumentService) GetDataProtectionImpactAssessmentsDocumentID(
 }
 
 func (s *GeneratedDocumentService) buildDataProtectionImpactAssessmentListDocumentData(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	conn pg.Querier,
 	organization *coredata.Organization,
 ) (docgen.DataProtectionImpactAssessmentListData, error) {
 	var assessments coredata.DataProtectionImpactAssessments
-	if err := assessments.LoadAllByOrganizationID(ctx, conn, s.svc.scope, organization.ID); err != nil {
+	if err := assessments.LoadAllByOrganizationID(ctx, conn, scope, organization.ID); err != nil {
 		return docgen.DataProtectionImpactAssessmentListData{}, fmt.Errorf("cannot load DPIAs: %w", err)
 	}
 
@@ -1930,7 +1930,7 @@ func (s *GeneratedDocumentService) buildDataProtectionImpactAssessmentListDocume
 	}
 
 	var processingActivities coredata.ProcessingActivities
-	if err := processingActivities.LoadByIDs(ctx, conn, s.svc.scope, processingActivityIDs); err != nil {
+	if err := processingActivities.LoadByIDs(ctx, conn, scope, processingActivityIDs); err != nil {
 		return docgen.DataProtectionImpactAssessmentListData{}, fmt.Errorf("cannot load processing activities: %w", err)
 	}
 
@@ -1992,7 +1992,7 @@ func BuildDataProtectionImpactAssessmentListDocument(data docgen.DataProtectionI
 }
 
 func (s *GeneratedDocumentService) PublishTransferImpactAssessmentList(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	approverIDs []gid.GID,
 	minor bool,
@@ -2006,11 +2006,11 @@ func (s *GeneratedDocumentService) PublishTransferImpactAssessmentList(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			organization := &coredata.Organization{}
-			if err := organization.LoadByID(ctx, tx, s.svc.scope, organizationID); err != nil {
+			if err := organization.LoadByID(ctx, tx, scope, organizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
-			documentData, err := s.buildTransferImpactAssessmentListDocumentData(ctx, tx, organization)
+			documentData, err := s.buildTransferImpactAssessmentListDocumentData(ctx, scope, tx, organization)
 			if err != nil {
 				return fmt.Errorf("cannot build document data: %w", err)
 			}
@@ -2034,7 +2034,7 @@ func (s *GeneratedDocumentService) PublishTransferImpactAssessmentList(
 			if tiaDocumentID != nil {
 				doc := &coredata.Document{}
 
-				err = doc.LoadByID(ctx, tx, s.svc.scope, *tiaDocumentID)
+				err = doc.LoadByID(ctx, tx, scope, *tiaDocumentID)
 				if err != nil && !errors.Is(err, coredata.ErrResourceNotFound) {
 					return fmt.Errorf("cannot load TIA list document: %w", err)
 				}
@@ -2049,7 +2049,7 @@ func (s *GeneratedDocumentService) PublishTransferImpactAssessmentList(
 			}
 
 			if existingDoc == nil {
-				documentID := gid.New(s.svc.scope.GetTenantID(), coredata.DocumentEntityType)
+				documentID := gid.New(scope.GetTenantID(), coredata.DocumentEntityType)
 
 				document = &coredata.Document{
 					ID:                    documentID,
@@ -2061,18 +2061,18 @@ func (s *GeneratedDocumentService) PublishTransferImpactAssessmentList(
 					UpdatedAt:             now,
 				}
 
-				if err := document.Insert(ctx, tx, s.svc.scope); err != nil {
+				if err := document.Insert(ctx, tx, scope); err != nil {
 					return fmt.Errorf("cannot insert document: %w", err)
 				}
 
-				if err := tia.UpsertGeneratedDocumentID(ctx, tx, organizationID, s.svc.scope.GetTenantID(), documentID); err != nil {
+				if err := tia.UpsertGeneratedDocumentID(ctx, tx, organizationID, scope.GetTenantID(), documentID); err != nil {
 					return fmt.Errorf("cannot upsert generated documents: %w", err)
 				}
 			} else {
 				document = existingDoc
 			}
 
-			documentVersionID := gid.New(s.svc.scope.GetTenantID(), coredata.DocumentVersionEntityType)
+			documentVersionID := gid.New(scope.GetTenantID(), coredata.DocumentVersionEntityType)
 			documentVersion = &coredata.DocumentVersion{
 				ID:             documentVersionID,
 				OrganizationID: organizationID,
@@ -2086,7 +2086,7 @@ func (s *GeneratedDocumentService) PublishTransferImpactAssessmentList(
 				UpdatedAt:      now,
 			}
 
-			return s.publishOrRequestApproval(ctx, tx, document, documentVersion, organizationID, approverIDs, minor, now)
+			return s.publishOrRequestApproval(ctx, scope, tx, document, documentVersion, organizationID, approverIDs, minor, now)
 		},
 	)
 	if err != nil {
@@ -2097,7 +2097,7 @@ func (s *GeneratedDocumentService) PublishTransferImpactAssessmentList(
 }
 
 func (s *GeneratedDocumentService) GetTransferImpactAssessmentsDocumentID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (*gid.GID, error) {
 	var documentID *gid.GID
@@ -2119,12 +2119,12 @@ func (s *GeneratedDocumentService) GetTransferImpactAssessmentsDocumentID(
 }
 
 func (s *GeneratedDocumentService) buildTransferImpactAssessmentListDocumentData(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	conn pg.Querier,
 	organization *coredata.Organization,
 ) (docgen.TransferImpactAssessmentListData, error) {
 	var assessments coredata.TransferImpactAssessments
-	if err := assessments.LoadAllByOrganizationID(ctx, conn, s.svc.scope, organization.ID); err != nil {
+	if err := assessments.LoadAllByOrganizationID(ctx, conn, scope, organization.ID); err != nil {
 		return docgen.TransferImpactAssessmentListData{}, fmt.Errorf("cannot load TIAs: %w", err)
 	}
 
@@ -2148,7 +2148,7 @@ func (s *GeneratedDocumentService) buildTransferImpactAssessmentListDocumentData
 	}
 
 	var processingActivities coredata.ProcessingActivities
-	if err := processingActivities.LoadByIDs(ctx, conn, s.svc.scope, processingActivityIDs); err != nil {
+	if err := processingActivities.LoadByIDs(ctx, conn, scope, processingActivityIDs); err != nil {
 		return docgen.TransferImpactAssessmentListData{}, fmt.Errorf("cannot load processing activities: %w", err)
 	}
 
@@ -2210,7 +2210,7 @@ func BuildTransferImpactAssessmentListDocument(data docgen.TransferImpactAssessm
 }
 
 func (s *GeneratedDocumentService) PublishThirdPartyList(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	approverIDs []gid.GID,
 	minor bool,
@@ -2223,13 +2223,13 @@ func (s *GeneratedDocumentService) PublishThirdPartyList(
 
 	err := s.svc.pg.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
 		organization := &coredata.Organization{}
-		if err := organization.LoadByID(ctx, conn, s.svc.scope, organizationID); err != nil {
+		if err := organization.LoadByID(ctx, conn, scope, organizationID); err != nil {
 			return fmt.Errorf("cannot load organization: %w", err)
 		}
 
 		var err error
 
-		documentData, err = s.buildThirdPartyListDocumentData(ctx, conn, organization)
+		documentData, err = s.buildThirdPartyListDocumentData(ctx, scope, conn, organization)
 		if err != nil {
 			return fmt.Errorf("cannot build document data: %w", err)
 		}
@@ -2268,7 +2268,7 @@ func (s *GeneratedDocumentService) PublishThirdPartyList(
 			if thirdPartyDocumentID != nil {
 				doc := &coredata.Document{}
 
-				err = doc.LoadByID(ctx, tx, s.svc.scope, *thirdPartyDocumentID)
+				err = doc.LoadByID(ctx, tx, scope, *thirdPartyDocumentID)
 				if err != nil && !errors.Is(err, coredata.ErrResourceNotFound) {
 					return fmt.Errorf("cannot load thirdParty list document: %w", err)
 				}
@@ -2283,7 +2283,7 @@ func (s *GeneratedDocumentService) PublishThirdPartyList(
 			}
 
 			if existingDoc == nil {
-				documentID := gid.New(s.svc.scope.GetTenantID(), coredata.DocumentEntityType)
+				documentID := gid.New(scope.GetTenantID(), coredata.DocumentEntityType)
 
 				document = &coredata.Document{
 					ID:                    documentID,
@@ -2295,18 +2295,18 @@ func (s *GeneratedDocumentService) PublishThirdPartyList(
 					UpdatedAt:             now,
 				}
 
-				if err := document.Insert(ctx, tx, s.svc.scope); err != nil {
+				if err := document.Insert(ctx, tx, scope); err != nil {
 					return fmt.Errorf("cannot insert document: %w", err)
 				}
 
-				if err := thirdParty.UpsertGeneratedDocumentID(ctx, tx, organizationID, s.svc.scope.GetTenantID(), documentID); err != nil {
+				if err := thirdParty.UpsertGeneratedDocumentID(ctx, tx, organizationID, scope.GetTenantID(), documentID); err != nil {
 					return fmt.Errorf("cannot upsert generated documents: %w", err)
 				}
 			} else {
 				document = existingDoc
 			}
 
-			documentVersionID := gid.New(s.svc.scope.GetTenantID(), coredata.DocumentVersionEntityType)
+			documentVersionID := gid.New(scope.GetTenantID(), coredata.DocumentVersionEntityType)
 			documentVersion = &coredata.DocumentVersion{
 				ID:             documentVersionID,
 				OrganizationID: organizationID,
@@ -2320,7 +2320,7 @@ func (s *GeneratedDocumentService) PublishThirdPartyList(
 				UpdatedAt:      now,
 			}
 
-			return s.publishOrRequestApproval(ctx, tx, document, documentVersion, organizationID, approverIDs, minor, now)
+			return s.publishOrRequestApproval(ctx, scope, tx, document, documentVersion, organizationID, approverIDs, minor, now)
 		},
 	)
 	if err != nil {
@@ -2331,7 +2331,7 @@ func (s *GeneratedDocumentService) PublishThirdPartyList(
 }
 
 func (s *GeneratedDocumentService) GetThirdPartiesDocumentID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (*gid.GID, error) {
 	var documentID *gid.GID
@@ -2353,12 +2353,12 @@ func (s *GeneratedDocumentService) GetThirdPartiesDocumentID(
 }
 
 func (s *GeneratedDocumentService) buildThirdPartyListDocumentData(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	conn pg.Querier,
 	organization *coredata.Organization,
 ) (docgen.ThirdPartyListData, error) {
 	var thirdParties coredata.ThirdParties
-	if err := thirdParties.LoadAllByOrganizationID(ctx, conn, s.svc.scope, organization.ID); err != nil {
+	if err := thirdParties.LoadAllByOrganizationID(ctx, conn, scope, organization.ID); err != nil {
 		return docgen.ThirdPartyListData{}, fmt.Errorf("cannot load thirdParties: %w", err)
 	}
 
@@ -2394,7 +2394,7 @@ func (s *GeneratedDocumentService) buildThirdPartyListDocumentData(
 
 	if len(ownerIDs) > 0 {
 		var profiles coredata.MembershipProfiles
-		if err := profiles.LoadByIDs(ctx, conn, s.svc.scope, ownerIDs); err != nil {
+		if err := profiles.LoadByIDs(ctx, conn, scope, ownerIDs); err != nil {
 			return docgen.ThirdPartyListData{}, fmt.Errorf("cannot load owner profiles: %w", err)
 		}
 
@@ -2409,7 +2409,7 @@ func (s *GeneratedDocumentService) buildThirdPartyListDocumentData(
 	}
 
 	var allServices coredata.ThirdPartyServices
-	if err := allServices.LoadByThirdPartyIDs(ctx, conn, s.svc.scope, thirdPartyIDs); err != nil {
+	if err := allServices.LoadByThirdPartyIDs(ctx, conn, scope, thirdPartyIDs); err != nil {
 		return docgen.ThirdPartyListData{}, fmt.Errorf("cannot load thirdParty services: %w", err)
 	}
 
@@ -2419,7 +2419,7 @@ func (s *GeneratedDocumentService) buildThirdPartyListDocumentData(
 	}
 
 	var allContacts coredata.ThirdPartyContacts
-	if err := allContacts.LoadByThirdPartyIDs(ctx, conn, s.svc.scope, thirdPartyIDs); err != nil {
+	if err := allContacts.LoadByThirdPartyIDs(ctx, conn, scope, thirdPartyIDs); err != nil {
 		return docgen.ThirdPartyListData{}, fmt.Errorf("cannot load thirdParty contacts: %w", err)
 	}
 
@@ -2429,7 +2429,7 @@ func (s *GeneratedDocumentService) buildThirdPartyListDocumentData(
 	}
 
 	var allAssessments coredata.ThirdPartyRiskAssessments
-	if err := allAssessments.LoadByThirdPartyIDs(ctx, conn, s.svc.scope, thirdPartyIDs); err != nil {
+	if err := allAssessments.LoadByThirdPartyIDs(ctx, conn, scope, thirdPartyIDs); err != nil {
 		return docgen.ThirdPartyListData{}, fmt.Errorf("cannot load thirdParty risk assessments: %w", err)
 	}
 
@@ -2439,7 +2439,7 @@ func (s *GeneratedDocumentService) buildThirdPartyListDocumentData(
 	}
 
 	var allReports coredata.ThirdPartyComplianceReports
-	if err := allReports.LoadByThirdPartyIDs(ctx, conn, s.svc.scope, thirdPartyIDs); err != nil {
+	if err := allReports.LoadByThirdPartyIDs(ctx, conn, scope, thirdPartyIDs); err != nil {
 		return docgen.ThirdPartyListData{}, fmt.Errorf("cannot load thirdParty compliance reports: %w", err)
 	}
 
@@ -2449,7 +2449,7 @@ func (s *GeneratedDocumentService) buildThirdPartyListDocumentData(
 	}
 
 	var allBAAs coredata.ThirdPartyBusinessAssociateAgreements
-	if err := allBAAs.LoadByThirdPartyIDs(ctx, conn, s.svc.scope, thirdPartyIDs); err != nil {
+	if err := allBAAs.LoadByThirdPartyIDs(ctx, conn, scope, thirdPartyIDs); err != nil {
 		return docgen.ThirdPartyListData{}, fmt.Errorf("cannot load thirdParty business associate agreements: %w", err)
 	}
 
@@ -2459,7 +2459,7 @@ func (s *GeneratedDocumentService) buildThirdPartyListDocumentData(
 	}
 
 	var allDPAs coredata.ThirdPartyDataPrivacyAgreements
-	if err := allDPAs.LoadByThirdPartyIDs(ctx, conn, s.svc.scope, thirdPartyIDs); err != nil {
+	if err := allDPAs.LoadByThirdPartyIDs(ctx, conn, scope, thirdPartyIDs); err != nil {
 		return docgen.ThirdPartyListData{}, fmt.Errorf("cannot load thirdParty data privacy agreements: %w", err)
 	}
 
@@ -2742,7 +2742,7 @@ func BuildRiskListDocument(data docgen.RiskListData) (string, error) {
 }
 
 func (s *GeneratedDocumentService) PublishRiskList(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	approverIDs []gid.GID,
 	minor bool,
@@ -2756,11 +2756,11 @@ func (s *GeneratedDocumentService) PublishRiskList(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			organization := &coredata.Organization{}
-			if err := organization.LoadByID(ctx, tx, s.svc.scope, organizationID); err != nil {
+			if err := organization.LoadByID(ctx, tx, scope, organizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
-			documentData, err := s.buildRiskListDocumentData(ctx, tx, organization)
+			documentData, err := s.buildRiskListDocumentData(ctx, scope, tx, organization)
 			if err != nil {
 				return fmt.Errorf("cannot build document data: %w", err)
 			}
@@ -2784,7 +2784,7 @@ func (s *GeneratedDocumentService) PublishRiskList(
 			if riskDocumentID != nil {
 				doc := &coredata.Document{}
 
-				err = doc.LoadByID(ctx, tx, s.svc.scope, *riskDocumentID)
+				err = doc.LoadByID(ctx, tx, scope, *riskDocumentID)
 				if err != nil && !errors.Is(err, coredata.ErrResourceNotFound) {
 					return fmt.Errorf("cannot load risk list document: %w", err)
 				}
@@ -2799,7 +2799,7 @@ func (s *GeneratedDocumentService) PublishRiskList(
 			}
 
 			if existingDoc == nil {
-				documentID := gid.New(s.svc.scope.GetTenantID(), coredata.DocumentEntityType)
+				documentID := gid.New(scope.GetTenantID(), coredata.DocumentEntityType)
 
 				document = &coredata.Document{
 					ID:                    documentID,
@@ -2811,18 +2811,18 @@ func (s *GeneratedDocumentService) PublishRiskList(
 					UpdatedAt:             now,
 				}
 
-				if err := document.Insert(ctx, tx, s.svc.scope); err != nil {
+				if err := document.Insert(ctx, tx, scope); err != nil {
 					return fmt.Errorf("cannot insert document: %w", err)
 				}
 
-				if err := risk.UpsertGeneratedDocumentID(ctx, tx, organizationID, s.svc.scope.GetTenantID(), documentID); err != nil {
+				if err := risk.UpsertGeneratedDocumentID(ctx, tx, organizationID, scope.GetTenantID(), documentID); err != nil {
 					return fmt.Errorf("cannot upsert generated documents: %w", err)
 				}
 			} else {
 				document = existingDoc
 			}
 
-			documentVersionID := gid.New(s.svc.scope.GetTenantID(), coredata.DocumentVersionEntityType)
+			documentVersionID := gid.New(scope.GetTenantID(), coredata.DocumentVersionEntityType)
 			documentVersion = &coredata.DocumentVersion{
 				ID:             documentVersionID,
 				OrganizationID: organizationID,
@@ -2836,7 +2836,7 @@ func (s *GeneratedDocumentService) PublishRiskList(
 				UpdatedAt:      now,
 			}
 
-			return s.publishOrRequestApproval(ctx, tx, document, documentVersion, organizationID, approverIDs, minor, now)
+			return s.publishOrRequestApproval(ctx, scope, tx, document, documentVersion, organizationID, approverIDs, minor, now)
 		},
 	)
 	if err != nil {
@@ -2847,7 +2847,7 @@ func (s *GeneratedDocumentService) PublishRiskList(
 }
 
 func (s *GeneratedDocumentService) GetRisksDocumentID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (*gid.GID, error) {
 	var riskDocumentID *gid.GID
@@ -2869,12 +2869,12 @@ func (s *GeneratedDocumentService) GetRisksDocumentID(
 }
 
 func (s *GeneratedDocumentService) buildRiskListDocumentData(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	conn pg.Querier,
 	organization *coredata.Organization,
 ) (docgen.RiskListData, error) {
 	var risks coredata.Risks
-	if err := risks.LoadAllByOrganizationID(ctx, conn, s.svc.scope, organization.ID); err != nil {
+	if err := risks.LoadAllByOrganizationID(ctx, conn, scope, organization.ID); err != nil {
 		return docgen.RiskListData{}, fmt.Errorf("cannot load risks: %w", err)
 	}
 
@@ -2903,7 +2903,7 @@ func (s *GeneratedDocumentService) buildRiskListDocumentData(
 
 	if len(ownerIDs) > 0 {
 		var profiles coredata.MembershipProfiles
-		if err := profiles.LoadByIDs(ctx, conn, s.svc.scope, ownerIDs); err != nil {
+		if err := profiles.LoadByIDs(ctx, conn, scope, ownerIDs); err != nil {
 			return docgen.RiskListData{}, fmt.Errorf("cannot load profiles: %w", err)
 		}
 
@@ -3014,7 +3014,7 @@ func formatRiskTreatment(t coredata.RiskTreatment) string {
 // request at (currentMajor+1).0; otherwise the version is published at
 // (currentMajor+1).0.
 func (s *GeneratedDocumentService) publishOrRequestApproval(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	tx pg.Tx,
 	document *coredata.Document,
 	version *coredata.DocumentVersion,
@@ -3025,7 +3025,7 @@ func (s *GeneratedDocumentService) publishOrRequestApproval(
 ) error {
 	previousVersion := &coredata.DocumentVersion{}
 
-	err := previousVersion.LoadLatestVersion(ctx, tx, s.svc.scope, document.ID)
+	err := previousVersion.LoadLatestVersion(ctx, tx, scope, document.ID)
 	switch {
 	case err == nil:
 		version.Title = previousVersion.Title
@@ -3064,7 +3064,7 @@ func (s *GeneratedDocumentService) publishOrRequestApproval(
 		}
 	}
 
-	if err := version.Insert(ctx, tx, s.svc.scope); err != nil {
+	if err := version.Insert(ctx, tx, scope); err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			switch previousVersion.Status {
 			case coredata.DocumentVersionStatusDraft:
@@ -3081,11 +3081,11 @@ func (s *GeneratedDocumentService) publishOrRequestApproval(
 
 	if len(approverIDs) > 0 {
 		defaultApprovers := &coredata.DocumentDefaultApprovers{}
-		if err := defaultApprovers.MergeByDocumentID(ctx, tx, s.svc.scope, document.ID, organizationID, approverIDs); err != nil {
+		if err := defaultApprovers.MergeByDocumentID(ctx, tx, scope, document.ID, organizationID, approverIDs); err != nil {
 			return fmt.Errorf("cannot save default approvers: %w", err)
 		}
 
-		if _, err := s.svc.DocumentApprovals.RequestApprovalInTx(ctx, tx, document, version, approverIDs, nil); err != nil {
+		if _, err := s.svc.DocumentApprovals.RequestApprovalInTx(ctx, scope, tx, document, version, approverIDs, nil); err != nil {
 			return fmt.Errorf("cannot request approval: %w", err)
 		}
 
@@ -3096,7 +3096,7 @@ func (s *GeneratedDocumentService) publishOrRequestApproval(
 	document.CurrentPublishedMinor = &version.Minor
 	document.UpdatedAt = now
 
-	if err := document.Update(ctx, tx, s.svc.scope); err != nil {
+	if err := document.Update(ctx, tx, scope); err != nil {
 		return fmt.Errorf("cannot update document: %w", err)
 	}
 

--- a/pkg/probo/measure_service.go
+++ b/pkg/probo/measure_service.go
@@ -29,7 +29,7 @@ import (
 
 type (
 	MeasureService struct {
-		svc *TenantService
+		svc *Service
 	}
 
 	CreateMeasureRequest struct {
@@ -94,7 +94,7 @@ func (umr *UpdateMeasureRequest) Validate() error {
 }
 
 func (s MeasureService) CountForRiskID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	riskID gid.GID,
 	filter *coredata.MeasureFilter,
 ) (int, error) {
@@ -105,7 +105,7 @@ func (s MeasureService) CountForRiskID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			measures := &coredata.Measures{}
 
-			count, err = measures.CountByRiskID(ctx, conn, s.svc.scope, riskID, filter)
+			count, err = measures.CountByRiskID(ctx, conn, scope, riskID, filter)
 			if err != nil {
 				return fmt.Errorf("cannot count measures: %w", err)
 			}
@@ -120,7 +120,7 @@ func (s MeasureService) CountForRiskID(
 	return count, nil
 }
 func (s MeasureService) ListForRiskID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	riskID gid.GID,
 	cursor *page.Cursor[coredata.MeasureOrderField],
 	filter *coredata.MeasureFilter,
@@ -132,11 +132,11 @@ func (s MeasureService) ListForRiskID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := risk.LoadByID(ctx, conn, s.svc.scope, riskID); err != nil {
+			if err := risk.LoadByID(ctx, conn, scope, riskID); err != nil {
 				return fmt.Errorf("cannot load risk: %w", err)
 			}
 
-			err := measures.LoadByRiskID(ctx, conn, s.svc.scope, risk.ID, cursor, filter)
+			err := measures.LoadByRiskID(ctx, conn, scope, risk.ID, cursor, filter)
 			if err != nil {
 				return fmt.Errorf("cannot load measures: %w", err)
 			}
@@ -152,7 +152,7 @@ func (s MeasureService) ListForRiskID(
 }
 
 func (s MeasureService) CountForControlID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	controlID gid.GID,
 	filter *coredata.MeasureFilter,
 ) (int, error) {
@@ -163,7 +163,7 @@ func (s MeasureService) CountForControlID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			measures := &coredata.Measures{}
 
-			count, err = measures.CountByControlID(ctx, conn, s.svc.scope, controlID, filter)
+			count, err = measures.CountByControlID(ctx, conn, scope, controlID, filter)
 			if err != nil {
 				return fmt.Errorf("cannot count measures: %w", err)
 			}
@@ -179,7 +179,7 @@ func (s MeasureService) CountForControlID(
 }
 
 func (s MeasureService) ListForControlID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	controlID gid.GID,
 	cursor *page.Cursor[coredata.MeasureOrderField],
 	filter *coredata.MeasureFilter,
@@ -191,11 +191,11 @@ func (s MeasureService) ListForControlID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := control.LoadByID(ctx, conn, s.svc.scope, controlID); err != nil {
+			if err := control.LoadByID(ctx, conn, scope, controlID); err != nil {
 				return fmt.Errorf("cannot load control: %w", err)
 			}
 
-			err := measures.LoadByControlID(ctx, conn, s.svc.scope, control.ID, cursor, filter)
+			err := measures.LoadByControlID(ctx, conn, scope, control.ID, cursor, filter)
 			if err != nil {
 				return fmt.Errorf("cannot load measures: %w", err)
 			}
@@ -211,7 +211,7 @@ func (s MeasureService) ListForControlID(
 }
 
 func (s MeasureService) CountForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	filter *coredata.MeasureFilter,
 ) (int, error) {
@@ -222,7 +222,7 @@ func (s MeasureService) CountForOrganizationID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			measures := &coredata.Measures{}
 
-			count, err = measures.CountByOrganizationID(ctx, conn, s.svc.scope, organizationID, filter)
+			count, err = measures.CountByOrganizationID(ctx, conn, scope, organizationID, filter)
 			if err != nil {
 				return fmt.Errorf("cannot count measures: %w", err)
 			}
@@ -238,7 +238,7 @@ func (s MeasureService) CountForOrganizationID(
 }
 
 func (s MeasureService) ListDistinctCategoriesForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) ([]string, error) {
 	var categories []string
@@ -247,7 +247,7 @@ func (s MeasureService) ListDistinctCategoriesForOrganizationID(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			organization := &coredata.Organization{}
-			if err := organization.LoadByID(ctx, conn, s.svc.scope, organizationID); err != nil {
+			if err := organization.LoadByID(ctx, conn, scope, organizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
@@ -259,7 +259,7 @@ func (s MeasureService) ListDistinctCategoriesForOrganizationID(
 			categories, err = measures.LoadDistinctCategoriesByOrganizationID(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				organization.ID,
 			)
 			if err != nil {
@@ -277,7 +277,7 @@ func (s MeasureService) ListDistinctCategoriesForOrganizationID(
 }
 
 func (s MeasureService) ListForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.MeasureOrderField],
 	filter *coredata.MeasureFilter,
@@ -289,14 +289,14 @@ func (s MeasureService) ListForOrganizationID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := organization.LoadByID(ctx, conn, s.svc.scope, organizationID); err != nil {
+			if err := organization.LoadByID(ctx, conn, scope, organizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
 			err := measures.LoadByOrganizationID(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				organization.ID,
 				cursor,
 				filter,
@@ -316,7 +316,7 @@ func (s MeasureService) ListForOrganizationID(
 }
 
 func (s MeasureService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	measureID gid.GID,
 ) (*coredata.Measure, error) {
 	measure := &coredata.Measure{}
@@ -324,7 +324,7 @@ func (s MeasureService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return measure.LoadByID(ctx, conn, s.svc.scope, measureID)
+			return measure.LoadByID(ctx, conn, scope, measureID)
 		},
 	)
 	if err != nil {
@@ -335,7 +335,7 @@ func (s MeasureService) Get(
 }
 
 func (s MeasureService) GetByIDs(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	measureIDs ...gid.GID,
 ) (coredata.Measures, error) {
 	var measures coredata.Measures
@@ -346,7 +346,7 @@ func (s MeasureService) GetByIDs(
 			if err := measures.LoadByIDs(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				measureIDs,
 			); err != nil {
 				return fmt.Errorf("cannot load measures by ids: %w", err)
@@ -363,7 +363,7 @@ func (s MeasureService) GetByIDs(
 }
 
 func (s MeasureService) Import(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	req ImportMeasureRequest,
 ) (*page.Page[*coredata.Measure, coredata.MeasureOrderField], error) {
@@ -373,7 +373,7 @@ func (s MeasureService) Import(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := organization.LoadByID(ctx, tx, s.svc.scope, organizationID); err != nil {
+			if err := organization.LoadByID(ctx, tx, scope, organizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
@@ -396,7 +396,7 @@ func (s MeasureService) Import(
 
 				importedMeasures = append(importedMeasures, measure)
 
-				if err := measure.Upsert(ctx, tx, s.svc.scope); err != nil {
+				if err := measure.Upsert(ctx, tx, scope); err != nil {
 					return fmt.Errorf("cannot upsert measure: %w", err)
 				}
 
@@ -417,7 +417,7 @@ func (s MeasureService) Import(
 						UpdatedAt:      now,
 					}
 
-					if err := task.Upsert(ctx, tx, s.svc.scope); err != nil {
+					if err := task.Upsert(ctx, tx, scope); err != nil {
 						return fmt.Errorf("cannot upsert task: %w", err)
 					}
 
@@ -437,7 +437,7 @@ func (s MeasureService) Import(
 							UpdatedAt:         now,
 						}
 
-						if err := evidence.Upsert(ctx, tx, s.svc.scope); err != nil {
+						if err := evidence.Upsert(ctx, tx, scope); err != nil {
 							return fmt.Errorf("cannot upsert evidence: %w", err)
 						}
 					}
@@ -445,12 +445,12 @@ func (s MeasureService) Import(
 
 				for _, standard := range req.Measures[i].Standards {
 					framework := &coredata.Framework{}
-					if err := framework.LoadByReferenceID(ctx, tx, s.svc.scope, standard.Framework); err != nil {
+					if err := framework.LoadByReferenceID(ctx, tx, scope, standard.Framework); err != nil {
 						continue
 					}
 
 					control := &coredata.Control{}
-					if err := control.LoadByFrameworkIDAndSectionTitle(ctx, tx, s.svc.scope, framework.ID, standard.Control); err != nil {
+					if err := control.LoadByFrameworkIDAndSectionTitle(ctx, tx, scope, framework.ID, standard.Control); err != nil {
 						continue
 					}
 
@@ -461,7 +461,7 @@ func (s MeasureService) Import(
 						CreatedAt:      now,
 					}
 
-					if err := controlMeasure.Upsert(ctx, tx, s.svc.scope); err != nil {
+					if err := controlMeasure.Upsert(ctx, tx, scope); err != nil {
 						return fmt.Errorf("cannot insert control measure: %w", err)
 					}
 				}
@@ -488,7 +488,7 @@ func (s MeasureService) Import(
 }
 
 func (s MeasureService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req UpdateMeasureRequest,
 ) (*coredata.Measure, error) {
 	if err := req.Validate(); err != nil {
@@ -500,7 +500,7 @@ func (s MeasureService) Update(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := measure.LoadByID(ctx, conn, s.svc.scope, req.ID); err != nil {
+			if err := measure.LoadByID(ctx, conn, scope, req.ID); err != nil {
 				return fmt.Errorf("cannot load measure: %w", err)
 			}
 
@@ -522,7 +522,7 @@ func (s MeasureService) Update(
 
 			measure.UpdatedAt = time.Now()
 
-			if err := measure.Update(ctx, conn, s.svc.scope); err != nil {
+			if err := measure.Update(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot update measure: %w", err)
 			}
 
@@ -537,7 +537,7 @@ func (s MeasureService) Update(
 }
 
 func (s MeasureService) Create(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req CreateMeasureRequest,
 ) (*coredata.Measure, error) {
 	if err := req.Validate(); err != nil {
@@ -558,7 +558,7 @@ func (s MeasureService) Create(
 	err = s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := organization.LoadByID(ctx, conn, s.svc.scope, req.OrganizationID); err != nil {
+			if err := organization.LoadByID(ctx, conn, scope, req.OrganizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
@@ -574,7 +574,7 @@ func (s MeasureService) Create(
 				UpdatedAt:      now,
 			}
 
-			if err := measure.Insert(ctx, conn, s.svc.scope); err != nil {
+			if err := measure.Insert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot insert measure: %w", err)
 			}
 
@@ -589,13 +589,13 @@ func (s MeasureService) Create(
 }
 
 func (s MeasureService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	measureID gid.GID,
 ) error {
 	return s.svc.pg.WithTx(ctx, func(ctx context.Context, conn pg.Tx) error {
 		measure := &coredata.Measure{}
 
-		if err := measure.Delete(ctx, conn, s.svc.scope, measureID); err != nil {
+		if err := measure.Delete(ctx, conn, scope, measureID); err != nil {
 			return fmt.Errorf("cannot delete measure: %w", err)
 		}
 
@@ -604,7 +604,7 @@ func (s MeasureService) Delete(
 }
 
 func (s MeasureService) CreateDocumentMapping(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	measureID gid.GID,
 	documentID gid.GID,
 ) (*coredata.Measure, *coredata.Document, error) {
@@ -614,11 +614,11 @@ func (s MeasureService) CreateDocumentMapping(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := measure.LoadByID(ctx, tx, s.svc.scope, measureID); err != nil {
+			if err := measure.LoadByID(ctx, tx, scope, measureID); err != nil {
 				return fmt.Errorf("cannot load measure: %w", err)
 			}
 
-			if err := document.LoadByID(ctx, tx, s.svc.scope, documentID); err != nil {
+			if err := document.LoadByID(ctx, tx, scope, documentID); err != nil {
 				return fmt.Errorf("cannot load document: %w", err)
 			}
 
@@ -626,11 +626,11 @@ func (s MeasureService) CreateDocumentMapping(
 				MeasureID:      measure.ID,
 				DocumentID:     document.ID,
 				OrganizationID: measure.OrganizationID,
-				TenantID:       s.svc.scope.GetTenantID(),
+				TenantID:       scope.GetTenantID(),
 				CreatedAt:      time.Now(),
 			}
 
-			if err := measureDocument.Insert(ctx, tx, s.svc.scope); err != nil {
+			if err := measureDocument.Insert(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot insert measure document: %w", err)
 			}
 
@@ -645,7 +645,7 @@ func (s MeasureService) CreateDocumentMapping(
 }
 
 func (s MeasureService) DeleteDocumentMapping(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	measureID gid.GID,
 	documentID gid.GID,
 ) (*coredata.Measure, *coredata.Document, error) {
@@ -655,16 +655,16 @@ func (s MeasureService) DeleteDocumentMapping(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := measure.LoadByID(ctx, tx, s.svc.scope, measureID); err != nil {
+			if err := measure.LoadByID(ctx, tx, scope, measureID); err != nil {
 				return fmt.Errorf("cannot load measure: %w", err)
 			}
 
-			if err := document.LoadByID(ctx, tx, s.svc.scope, documentID); err != nil {
+			if err := document.LoadByID(ctx, tx, scope, documentID); err != nil {
 				return fmt.Errorf("cannot load document: %w", err)
 			}
 
 			measureDocument := &coredata.MeasureDocument{}
-			if err := measureDocument.Delete(ctx, tx, s.svc.scope, measure.ID, document.ID); err != nil {
+			if err := measureDocument.Delete(ctx, tx, scope, measure.ID, document.ID); err != nil {
 				return fmt.Errorf("cannot delete measure document mapping: %w", err)
 			}
 

--- a/pkg/probo/obligation_service.go
+++ b/pkg/probo/obligation_service.go
@@ -29,7 +29,7 @@ import (
 )
 
 type ObligationService struct {
-	svc *TenantService
+	svc *Service
 }
 
 type (
@@ -95,7 +95,7 @@ func (uor *UpdateObligationRequest) Validate() error {
 }
 
 func (s ObligationService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	obligationID gid.GID,
 ) (*coredata.Obligation, error) {
 	obligation := &coredata.Obligation{}
@@ -103,7 +103,7 @@ func (s ObligationService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := obligation.LoadByID(ctx, conn, s.svc.scope, obligationID); err != nil {
+			if err := obligation.LoadByID(ctx, conn, scope, obligationID); err != nil {
 				return fmt.Errorf("cannot load obligation: %w", err)
 			}
 
@@ -118,7 +118,7 @@ func (s ObligationService) Get(
 }
 
 func (s *ObligationService) Create(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *CreateObligationRequest,
 ) (*coredata.Obligation, error) {
 	if err := req.Validate(); err != nil {
@@ -128,7 +128,7 @@ func (s *ObligationService) Create(
 	now := time.Now()
 
 	obligation := &coredata.Obligation{
-		ID:                     gid.New(s.svc.scope.GetTenantID(), coredata.ObligationEntityType),
+		ID:                     gid.New(scope.GetTenantID(), coredata.ObligationEntityType),
 		OrganizationID:         req.OrganizationID,
 		Area:                   req.Area,
 		Source:                 req.Source,
@@ -148,20 +148,20 @@ func (s *ObligationService) Create(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			organization := &coredata.Organization{}
-			if err := organization.LoadByID(ctx, conn, s.svc.scope, req.OrganizationID); err != nil {
+			if err := organization.LoadByID(ctx, conn, scope, req.OrganizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
 			owner := &coredata.MembershipProfile{}
-			if err := owner.LoadByID(ctx, conn, s.svc.scope, req.OwnerID); err != nil {
+			if err := owner.LoadByID(ctx, conn, scope, req.OwnerID); err != nil {
 				return fmt.Errorf("cannot load owner profile: %w", err)
 			}
 
-			if err := obligation.Insert(ctx, conn, s.svc.scope); err != nil {
+			if err := obligation.Insert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot insert obligation: %w", err)
 			}
 
-			if err := webhook.InsertData(ctx, conn, s.svc.scope, req.OrganizationID, coredata.WebhookEventTypeObligationCreated, webhooktypes.NewObligation(obligation)); err != nil {
+			if err := webhook.InsertData(ctx, conn, scope, req.OrganizationID, coredata.WebhookEventTypeObligationCreated, webhooktypes.NewObligation(obligation)); err != nil {
 				return fmt.Errorf("cannot insert webhook event: %w", err)
 			}
 
@@ -176,7 +176,7 @@ func (s *ObligationService) Create(
 }
 
 func (s *ObligationService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *UpdateObligationRequest,
 ) (*coredata.Obligation, error) {
 	if err := req.Validate(); err != nil {
@@ -188,7 +188,7 @@ func (s *ObligationService) Update(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := obligation.LoadByID(ctx, conn, s.svc.scope, req.ID); err != nil {
+			if err := obligation.LoadByID(ctx, conn, scope, req.ID); err != nil {
 				return fmt.Errorf("cannot load obligation: %w", err)
 			}
 
@@ -214,7 +214,7 @@ func (s *ObligationService) Update(
 
 			if req.OwnerID != nil {
 				owner := &coredata.MembershipProfile{}
-				if err := owner.LoadByID(ctx, conn, s.svc.scope, *req.OwnerID); err != nil {
+				if err := owner.LoadByID(ctx, conn, scope, *req.OwnerID); err != nil {
 					return fmt.Errorf("cannot load owner profile: %w", err)
 				}
 
@@ -239,11 +239,11 @@ func (s *ObligationService) Update(
 
 			obligation.UpdatedAt = time.Now()
 
-			if err := obligation.Update(ctx, conn, s.svc.scope); err != nil {
+			if err := obligation.Update(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot update obligation: %w", err)
 			}
 
-			if err := webhook.InsertData(ctx, conn, s.svc.scope, obligation.OrganizationID, coredata.WebhookEventTypeObligationUpdated, webhooktypes.NewObligation(obligation)); err != nil {
+			if err := webhook.InsertData(ctx, conn, scope, obligation.OrganizationID, coredata.WebhookEventTypeObligationUpdated, webhooktypes.NewObligation(obligation)); err != nil {
 				return fmt.Errorf("cannot insert webhook event: %w", err)
 			}
 
@@ -258,22 +258,22 @@ func (s *ObligationService) Update(
 }
 
 func (s *ObligationService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	obligationID gid.GID,
 ) error {
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			obligation := &coredata.Obligation{}
-			if err := obligation.LoadByID(ctx, conn, s.svc.scope, obligationID); err != nil {
+			if err := obligation.LoadByID(ctx, conn, scope, obligationID); err != nil {
 				return fmt.Errorf("cannot load obligation: %w", err)
 			}
 
-			if err := webhook.InsertData(ctx, conn, s.svc.scope, obligation.OrganizationID, coredata.WebhookEventTypeObligationDeleted, webhooktypes.NewObligation(obligation)); err != nil {
+			if err := webhook.InsertData(ctx, conn, scope, obligation.OrganizationID, coredata.WebhookEventTypeObligationDeleted, webhooktypes.NewObligation(obligation)); err != nil {
 				return fmt.Errorf("cannot insert webhook event: %w", err)
 			}
 
-			if err := obligation.Delete(ctx, conn, s.svc.scope); err != nil {
+			if err := obligation.Delete(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot delete obligation: %w", err)
 			}
 
@@ -285,7 +285,7 @@ func (s *ObligationService) Delete(
 }
 
 func (s ObligationService) CountForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (int, error) {
 	var count int
@@ -295,7 +295,7 @@ func (s ObligationService) CountForOrganizationID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			obligations := coredata.Obligations{}
 
-			count, err = obligations.CountByOrganizationID(ctx, conn, s.svc.scope, organizationID)
+			count, err = obligations.CountByOrganizationID(ctx, conn, scope, organizationID)
 			if err != nil {
 				return fmt.Errorf("cannot count obligations: %w", err)
 			}
@@ -311,7 +311,7 @@ func (s ObligationService) CountForOrganizationID(
 }
 
 func (s ObligationService) ListForControlID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	controlID gid.GID,
 	cursor *page.Cursor[coredata.ObligationOrderField],
 ) (*page.Page[*coredata.Obligation, coredata.ObligationOrderField], error) {
@@ -322,11 +322,11 @@ func (s ObligationService) ListForControlID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := control.LoadByID(ctx, conn, s.svc.scope, controlID); err != nil {
+			if err := control.LoadByID(ctx, conn, scope, controlID); err != nil {
 				return fmt.Errorf("cannot load control: %w", err)
 			}
 
-			err := obligations.LoadByControlID(ctx, conn, s.svc.scope, control.ID, cursor)
+			err := obligations.LoadByControlID(ctx, conn, scope, control.ID, cursor)
 			if err != nil {
 				return fmt.Errorf("cannot load obligations: %w", err)
 			}
@@ -342,7 +342,7 @@ func (s ObligationService) ListForControlID(
 }
 
 func (s ObligationService) ListForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.ObligationOrderField],
 ) (*page.Page[*coredata.Obligation, coredata.ObligationOrderField], error) {
@@ -351,7 +351,7 @@ func (s ObligationService) ListForOrganizationID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			err := obligations.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID, cursor)
+			err := obligations.LoadByOrganizationID(ctx, conn, scope, organizationID, cursor)
 			if err != nil {
 				return fmt.Errorf("cannot load obligations: %w", err)
 			}
@@ -367,7 +367,7 @@ func (s ObligationService) ListForOrganizationID(
 }
 
 func (s ObligationService) CountForRiskID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	riskID gid.GID,
 ) (int, error) {
 	var count int
@@ -377,7 +377,7 @@ func (s ObligationService) CountForRiskID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			obligations := &coredata.Obligations{}
 
-			count, err = obligations.CountByRiskID(ctx, conn, s.svc.scope, riskID)
+			count, err = obligations.CountByRiskID(ctx, conn, scope, riskID)
 			if err != nil {
 				return fmt.Errorf("cannot count obligations: %w", err)
 			}
@@ -393,7 +393,7 @@ func (s ObligationService) CountForRiskID(
 }
 
 func (s ObligationService) ListForRiskID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	riskID gid.GID,
 	cursor *page.Cursor[coredata.ObligationOrderField],
 ) (*page.Page[*coredata.Obligation, coredata.ObligationOrderField], error) {
@@ -402,7 +402,7 @@ func (s ObligationService) ListForRiskID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			err := obligations.LoadByRiskID(ctx, conn, s.svc.scope, riskID, cursor)
+			err := obligations.LoadByRiskID(ctx, conn, scope, riskID, cursor)
 			if err != nil {
 				return fmt.Errorf("cannot load obligations: %w", err)
 			}

--- a/pkg/probo/organization_service.go
+++ b/pkg/probo/organization_service.go
@@ -32,7 +32,7 @@ import (
 
 type (
 	OrganizationService struct {
-		svc           *TenantService
+		svc           *Service
 		fileValidator *filevalidation.FileValidator
 	}
 
@@ -86,7 +86,7 @@ func (uocr *UpdateOrganizationContextRequest) Validate() error {
 }
 
 func (s OrganizationService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (*coredata.Organization, error) {
 	organization := &coredata.Organization{}
@@ -97,7 +97,7 @@ func (s OrganizationService) Get(
 			return organization.LoadByID(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				organizationID,
 			)
 		},
@@ -110,7 +110,7 @@ func (s OrganizationService) Get(
 }
 
 func (s OrganizationService) GetByIDs(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationIDs ...gid.GID,
 ) (coredata.Organizations, error) {
 	var organizations coredata.Organizations
@@ -121,7 +121,7 @@ func (s OrganizationService) GetByIDs(
 			if err := organizations.LoadByIDs(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				organizationIDs,
 			); err != nil {
 				return fmt.Errorf("cannot load organizations by ids: %w", err)
@@ -138,7 +138,7 @@ func (s OrganizationService) GetByIDs(
 }
 
 func (s OrganizationService) GetContext(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (*coredata.OrganizationContext, error) {
 	organizationContext := &coredata.OrganizationContext{}
@@ -149,7 +149,7 @@ func (s OrganizationService) GetContext(
 			err := organizationContext.LoadByOrganizationID(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				organizationID,
 			)
 			if err != nil {
@@ -167,7 +167,7 @@ func (s OrganizationService) GetContext(
 }
 
 func (s OrganizationService) UpdateContext(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req UpdateOrganizationContextRequest,
 ) (*coredata.OrganizationContext, error) {
 	if err := req.Validate(); err != nil {
@@ -180,11 +180,11 @@ func (s OrganizationService) UpdateContext(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := organization.LoadByID(ctx, tx, s.svc.scope, req.OrganizationID); err != nil {
+			if err := organization.LoadByID(ctx, tx, scope, req.OrganizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
-			if err := organizationContext.LoadByOrganizationID(ctx, tx, s.svc.scope, req.OrganizationID); err != nil {
+			if err := organizationContext.LoadByOrganizationID(ctx, tx, scope, req.OrganizationID); err != nil {
 				return fmt.Errorf("cannot load organization context: %w", err)
 			}
 
@@ -210,7 +210,7 @@ func (s OrganizationService) UpdateContext(
 
 			organizationContext.UpdatedAt = time.Now()
 
-			if err := organizationContext.Update(ctx, tx, s.svc.scope); err != nil {
+			if err := organizationContext.Update(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot update organization context: %w", err)
 			}
 
@@ -225,7 +225,7 @@ func (s OrganizationService) UpdateContext(
 }
 
 func (s OrganizationService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req UpdateOrganizationRequest,
 ) (*coredata.Organization, error) {
 	if err := req.Validate(); err != nil {
@@ -237,7 +237,7 @@ func (s OrganizationService) Update(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := organization.LoadByID(ctx, tx, s.svc.scope, req.ID); err != nil {
+			if err := organization.LoadByID(ctx, tx, scope, req.ID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
@@ -270,12 +270,12 @@ func (s OrganizationService) Update(
 				organization.HeadquarterAddress = *req.HeadquarterAddress
 			}
 
-			if err := organization.Update(ctx, s.svc.scope, tx); err != nil {
+			if err := organization.Update(ctx, scope, tx); err != nil {
 				return fmt.Errorf("cannot update organization: %w", err)
 			}
 
 			if req.File != nil {
-				fileID := gid.New(s.svc.scope.GetTenantID(), coredata.FileEntityType)
+				fileID := gid.New(scope.GetTenantID(), coredata.FileEntityType)
 
 				objectKey, err := uuid.NewV7()
 				if err != nil {
@@ -330,7 +330,7 @@ func (s OrganizationService) Update(
 
 				fileRecord.FileSize = fileSize
 
-				if err := fileRecord.Insert(ctx, tx, s.svc.scope); err != nil {
+				if err := fileRecord.Insert(ctx, tx, scope); err != nil {
 					return fmt.Errorf("cannot insert file: %w", err)
 				}
 
@@ -338,7 +338,7 @@ func (s OrganizationService) Update(
 			}
 
 			if req.HorizontalLogoFile != nil {
-				fileID := gid.New(s.svc.scope.GetTenantID(), coredata.FileEntityType)
+				fileID := gid.New(scope.GetTenantID(), coredata.FileEntityType)
 
 				objectKey, err := uuid.NewV7()
 				if err != nil {
@@ -393,14 +393,14 @@ func (s OrganizationService) Update(
 
 				fileRecord.FileSize = fileSize
 
-				if err := fileRecord.Insert(ctx, tx, s.svc.scope); err != nil {
+				if err := fileRecord.Insert(ctx, tx, scope); err != nil {
 					return fmt.Errorf("cannot insert file: %w", err)
 				}
 
 				organization.HorizontalLogoFileID = &fileID
 			}
 
-			if err := organization.Update(ctx, s.svc.scope, tx); err != nil {
+			if err := organization.Update(ctx, scope, tx); err != nil {
 				return fmt.Errorf("cannot update organization: %w", err)
 			}
 
@@ -415,7 +415,7 @@ func (s OrganizationService) Update(
 }
 
 func (s OrganizationService) GenerateLogoURL(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	expiresIn time.Duration,
 ) (*string, error) {
@@ -425,7 +425,7 @@ func (s OrganizationService) GenerateLogoURL(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			organization := &coredata.Organization{}
-			if err := organization.LoadByID(ctx, conn, s.svc.scope, organizationID); err != nil {
+			if err := organization.LoadByID(ctx, conn, scope, organizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
@@ -433,7 +433,7 @@ func (s OrganizationService) GenerateLogoURL(
 				return nil
 			}
 
-			if err := file.LoadByID(ctx, conn, s.svc.scope, *organization.LogoFileID); err != nil {
+			if err := file.LoadByID(ctx, conn, scope, *organization.LogoFileID); err != nil {
 				return fmt.Errorf("cannot load file: %w", err)
 			}
 
@@ -457,7 +457,7 @@ func (s OrganizationService) GenerateLogoURL(
 }
 
 func (s OrganizationService) GenerateHorizontalLogoURL(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	expiresIn time.Duration,
 ) (*string, error) {
@@ -467,7 +467,7 @@ func (s OrganizationService) GenerateHorizontalLogoURL(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			organization := &coredata.Organization{}
-			if err := organization.LoadByID(ctx, conn, s.svc.scope, organizationID); err != nil {
+			if err := organization.LoadByID(ctx, conn, scope, organizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
@@ -475,7 +475,7 @@ func (s OrganizationService) GenerateHorizontalLogoURL(
 				return nil
 			}
 
-			if err := file.LoadByID(ctx, conn, s.svc.scope, *organization.HorizontalLogoFileID); err != nil {
+			if err := file.LoadByID(ctx, conn, scope, *organization.HorizontalLogoFileID); err != nil {
 				return fmt.Errorf("cannot load file: %w", err)
 			}
 
@@ -499,7 +499,7 @@ func (s OrganizationService) GenerateHorizontalLogoURL(
 }
 
 func (s OrganizationService) DeleteHorizontalLogo(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (*coredata.Organization, error) {
 	organization := &coredata.Organization{}
@@ -507,14 +507,14 @@ func (s OrganizationService) DeleteHorizontalLogo(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := organization.LoadByID(ctx, tx, s.svc.scope, organizationID); err != nil {
+			if err := organization.LoadByID(ctx, tx, scope, organizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
 			organization.HorizontalLogoFileID = nil
 			organization.UpdatedAt = time.Now()
 
-			if err := organization.Update(ctx, s.svc.scope, tx); err != nil {
+			if err := organization.Update(ctx, scope, tx); err != nil {
 				return fmt.Errorf("cannot update organization: %w", err)
 			}
 

--- a/pkg/probo/processing_activity_service.go
+++ b/pkg/probo/processing_activity_service.go
@@ -27,7 +27,7 @@ import (
 )
 
 type ProcessingActivityService struct {
-	svc *TenantService
+	svc *Service
 }
 
 type (
@@ -136,7 +136,7 @@ func (upar *UpdateProcessingActivityRequest) Validate() error {
 }
 
 func (s ProcessingActivityService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	processingActivityID gid.GID,
 ) (*coredata.ProcessingActivity, error) {
 	processingActivity := &coredata.ProcessingActivity{}
@@ -144,7 +144,7 @@ func (s ProcessingActivityService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return processingActivity.LoadByID(ctx, conn, s.svc.scope, processingActivityID)
+			return processingActivity.LoadByID(ctx, conn, scope, processingActivityID)
 		},
 	)
 	if err != nil {
@@ -155,14 +155,14 @@ func (s ProcessingActivityService) Get(
 }
 
 func (s *ProcessingActivityService) Create(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *CreateProcessingActivityRequest,
 ) (*coredata.ProcessingActivity, error) {
 	now := time.Now()
 	processingActivityThirdParties := &coredata.ProcessingActivityThirdParties{}
 
 	processingActivity := &coredata.ProcessingActivity{
-		ID:                                   gid.New(s.svc.scope.GetTenantID(), coredata.ProcessingActivityEntityType),
+		ID:                                   gid.New(scope.GetTenantID(), coredata.ProcessingActivityEntityType),
 		OrganizationID:                       req.OrganizationID,
 		Name:                                 req.Name,
 		Purpose:                              req.Purpose,
@@ -191,16 +191,16 @@ func (s *ProcessingActivityService) Create(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			organization := &coredata.Organization{}
-			if err := organization.LoadByID(ctx, conn, s.svc.scope, req.OrganizationID); err != nil {
+			if err := organization.LoadByID(ctx, conn, scope, req.OrganizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
-			if err := processingActivity.Insert(ctx, conn, s.svc.scope); err != nil {
+			if err := processingActivity.Insert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot insert processing activity: %w", err)
 			}
 
 			if len(req.ThirdPartyIDs) > 0 {
-				if err := processingActivityThirdParties.Insert(ctx, conn, s.svc.scope, processingActivity.ID, req.OrganizationID, req.ThirdPartyIDs); err != nil {
+				if err := processingActivityThirdParties.Insert(ctx, conn, scope, processingActivity.ID, req.OrganizationID, req.ThirdPartyIDs); err != nil {
 					return fmt.Errorf("cannot create processing activity thirdParties: %w", err)
 				}
 			}
@@ -216,7 +216,7 @@ func (s *ProcessingActivityService) Create(
 }
 
 func (s *ProcessingActivityService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *UpdateProcessingActivityRequest,
 ) (*coredata.ProcessingActivity, error) {
 	processingActivity := &coredata.ProcessingActivity{}
@@ -225,7 +225,7 @@ func (s *ProcessingActivityService) Update(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := processingActivity.LoadByID(ctx, conn, s.svc.scope, req.ID); err != nil {
+			if err := processingActivity.LoadByID(ctx, conn, scope, req.ID); err != nil {
 				return fmt.Errorf("cannot load processing activity: %w", err)
 			}
 
@@ -307,12 +307,12 @@ func (s *ProcessingActivityService) Update(
 
 			processingActivity.UpdatedAt = time.Now()
 
-			if err := processingActivity.Update(ctx, conn, s.svc.scope); err != nil {
+			if err := processingActivity.Update(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot update processing activity: %w", err)
 			}
 
 			if req.ThirdPartyIDs != nil {
-				if err := processingActivityThirdParties.Merge(ctx, conn, s.svc.scope, processingActivity.ID, processingActivity.OrganizationID, *req.ThirdPartyIDs); err != nil {
+				if err := processingActivityThirdParties.Merge(ctx, conn, scope, processingActivity.ID, processingActivity.OrganizationID, *req.ThirdPartyIDs); err != nil {
 					return fmt.Errorf("cannot update processing activity thirdParties: %w", err)
 				}
 			}
@@ -328,7 +328,7 @@ func (s *ProcessingActivityService) Update(
 }
 
 func (s ProcessingActivityService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	processingActivityID gid.GID,
 ) error {
 	processingActivity := coredata.ProcessingActivity{ID: processingActivityID}
@@ -336,7 +336,7 @@ func (s ProcessingActivityService) Delete(
 	return s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			err := processingActivity.Delete(ctx, tx, s.svc.scope)
+			err := processingActivity.Delete(ctx, tx, scope)
 			if err != nil {
 				return fmt.Errorf("cannot delete processing activity: %w", err)
 			}
@@ -347,7 +347,7 @@ func (s ProcessingActivityService) Delete(
 }
 
 func (s ProcessingActivityService) ListForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.ProcessingActivityOrderField],
 ) (*page.Page[*coredata.ProcessingActivity, coredata.ProcessingActivityOrderField], error) {
@@ -356,7 +356,7 @@ func (s ProcessingActivityService) ListForOrganizationID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			err := processingActivities.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID, cursor)
+			err := processingActivities.LoadByOrganizationID(ctx, conn, scope, organizationID, cursor)
 			if err != nil {
 				return fmt.Errorf("cannot load processing activities: %w", err)
 			}
@@ -372,7 +372,7 @@ func (s ProcessingActivityService) ListForOrganizationID(
 }
 
 func (s ProcessingActivityService) CountForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (int, error) {
 	var count int
@@ -382,7 +382,7 @@ func (s ProcessingActivityService) CountForOrganizationID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			processingActivities := coredata.ProcessingActivities{}
 
-			count, err = processingActivities.CountByOrganizationID(ctx, conn, s.svc.scope, organizationID)
+			count, err = processingActivities.CountByOrganizationID(ctx, conn, scope, organizationID)
 			if err != nil {
 				return fmt.Errorf("cannot count processing activities: %w", err)
 			}

--- a/pkg/probo/report_service.go
+++ b/pkg/probo/report_service.go
@@ -26,11 +26,11 @@ import (
 )
 
 type ReportService struct {
-	svc *TenantService
+	svc *Service
 }
 
 func (s ReportService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	reportID gid.GID,
 ) (*coredata.Report, error) {
 	report := &coredata.Report{}
@@ -38,7 +38,7 @@ func (s ReportService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			err := report.LoadByID(ctx, conn, s.svc.scope, reportID)
+			err := report.LoadByID(ctx, conn, scope, reportID)
 			if err != nil {
 				return fmt.Errorf("cannot load report: %w", err)
 			}
@@ -54,7 +54,7 @@ func (s ReportService) Get(
 }
 
 func (s ReportService) GetByIDs(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	reportIDs ...gid.GID,
 ) (coredata.Reports, error) {
 	var reports coredata.Reports
@@ -65,7 +65,7 @@ func (s ReportService) GetByIDs(
 			if err := reports.LoadByIDs(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				reportIDs,
 			); err != nil {
 				return fmt.Errorf("cannot load reports by ids: %w", err)
@@ -82,18 +82,18 @@ func (s ReportService) GetByIDs(
 }
 
 func (s ReportService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	reportID gid.GID,
 ) error {
 	return s.svc.pg.WithTx(ctx, func(ctx context.Context, conn pg.Tx) error {
 		report := &coredata.Report{}
 
-		err := report.LoadByID(ctx, conn, s.svc.scope, reportID)
+		err := report.LoadByID(ctx, conn, scope, reportID)
 		if err != nil {
 			return fmt.Errorf("cannot get report: %w", err)
 		}
 
-		err = report.Delete(ctx, conn, s.svc.scope)
+		err = report.Delete(ctx, conn, scope)
 		if err != nil {
 			return fmt.Errorf("cannot delete report: %w", err)
 		}
@@ -103,11 +103,11 @@ func (s ReportService) Delete(
 }
 
 func (s ReportService) GenerateDownloadURL(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	reportID gid.GID,
 	expiresIn time.Duration,
 ) (*string, error) {
-	report, err := s.Get(ctx, reportID)
+	report, err := s.Get(ctx, scope, reportID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get report: %w", err)
 	}

--- a/pkg/probo/rights_request_service.go
+++ b/pkg/probo/rights_request_service.go
@@ -27,7 +27,7 @@ import (
 )
 
 type RightsRequestService struct {
-	svc *TenantService
+	svc *Service
 }
 
 type (
@@ -83,7 +83,7 @@ func (urrr *UpdateRightsRequestRequest) Validate() error {
 }
 
 func (s RightsRequestService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	rightsRequestID gid.GID,
 ) (*coredata.RightsRequest, error) {
 	request := &coredata.RightsRequest{}
@@ -91,7 +91,7 @@ func (s RightsRequestService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := request.LoadByID(ctx, conn, s.svc.scope, rightsRequestID); err != nil {
+			if err := request.LoadByID(ctx, conn, scope, rightsRequestID); err != nil {
 				return fmt.Errorf("cannot load rights request: %w", err)
 			}
 
@@ -106,7 +106,7 @@ func (s RightsRequestService) Get(
 }
 
 func (s *RightsRequestService) Create(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *CreateRightsRequestRequest,
 ) (*coredata.RightsRequest, error) {
 	if err := req.Validate(); err != nil {
@@ -116,7 +116,7 @@ func (s *RightsRequestService) Create(
 	now := time.Now()
 
 	request := &coredata.RightsRequest{
-		ID:             gid.New(s.svc.scope.GetTenantID(), coredata.RightsRequestEntityType),
+		ID:             gid.New(scope.GetTenantID(), coredata.RightsRequestEntityType),
 		OrganizationID: req.OrganizationID,
 		RequestType:    *req.RequestType,
 		RequestState:   *req.RequestState,
@@ -133,11 +133,11 @@ func (s *RightsRequestService) Create(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			organization := &coredata.Organization{}
-			if err := organization.LoadByID(ctx, conn, s.svc.scope, req.OrganizationID); err != nil {
+			if err := organization.LoadByID(ctx, conn, scope, req.OrganizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
-			if err := request.Insert(ctx, conn, s.svc.scope); err != nil {
+			if err := request.Insert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot insert rights request: %w", err)
 			}
 
@@ -152,7 +152,7 @@ func (s *RightsRequestService) Create(
 }
 
 func (s *RightsRequestService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *UpdateRightsRequestRequest,
 ) (*coredata.RightsRequest, error) {
 	if err := req.Validate(); err != nil {
@@ -164,7 +164,7 @@ func (s *RightsRequestService) Update(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := request.LoadByID(ctx, conn, s.svc.scope, req.ID); err != nil {
+			if err := request.LoadByID(ctx, conn, scope, req.ID); err != nil {
 				return fmt.Errorf("cannot load rights request: %w", err)
 			}
 
@@ -198,7 +198,7 @@ func (s *RightsRequestService) Update(
 
 			request.UpdatedAt = time.Now()
 
-			if err := request.Update(ctx, conn, s.svc.scope); err != nil {
+			if err := request.Update(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot update rights request: %w", err)
 			}
 
@@ -213,18 +213,18 @@ func (s *RightsRequestService) Update(
 }
 
 func (s *RightsRequestService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	rightsRequestID gid.GID,
 ) error {
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			request := &coredata.RightsRequest{}
-			if err := request.LoadByID(ctx, conn, s.svc.scope, rightsRequestID); err != nil {
+			if err := request.LoadByID(ctx, conn, scope, rightsRequestID); err != nil {
 				return fmt.Errorf("cannot load rights request: %w", err)
 			}
 
-			if err := request.Delete(ctx, conn, s.svc.scope); err != nil {
+			if err := request.Delete(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot delete rights request: %w", err)
 			}
 
@@ -236,7 +236,7 @@ func (s *RightsRequestService) Delete(
 }
 
 func (s RightsRequestService) CountByOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (int, error) {
 	var count int
@@ -246,7 +246,7 @@ func (s RightsRequestService) CountByOrganizationID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			requests := coredata.RightsRequests{}
 
-			count, err = requests.CountByOrganizationID(ctx, conn, s.svc.scope, organizationID)
+			count, err = requests.CountByOrganizationID(ctx, conn, scope, organizationID)
 			if err != nil {
 				return fmt.Errorf("cannot count rights requests: %w", err)
 			}
@@ -262,7 +262,7 @@ func (s RightsRequestService) CountByOrganizationID(
 }
 
 func (s RightsRequestService) ListForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.RightsRequestOrderField],
 ) (*page.Page[*coredata.RightsRequest, coredata.RightsRequestOrderField], error) {
@@ -271,7 +271,7 @@ func (s RightsRequestService) ListForOrganizationID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			err := requests.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID, cursor)
+			err := requests.LoadByOrganizationID(ctx, conn, scope, organizationID, cursor)
 			if err != nil {
 				return fmt.Errorf("cannot load rights requests: %w", err)
 			}

--- a/pkg/probo/risk_service.go
+++ b/pkg/probo/risk_service.go
@@ -28,7 +28,7 @@ import (
 
 type (
 	RiskService struct {
-		svc *TenantService
+		svc *Service
 	}
 
 	CreateRiskRequest struct {
@@ -97,7 +97,7 @@ func (urr *UpdateRiskRequest) Validate() error {
 }
 
 func (s RiskService) CountForMeasureID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	measureID gid.GID,
 	filter *coredata.RiskFilter,
 ) (int, error) {
@@ -108,7 +108,7 @@ func (s RiskService) CountForMeasureID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			risks := &coredata.Risks{}
 
-			count, err = risks.CountByMeasureID(ctx, conn, s.svc.scope, measureID, filter)
+			count, err = risks.CountByMeasureID(ctx, conn, scope, measureID, filter)
 			if err != nil {
 				return fmt.Errorf("cannot count risks: %w", err)
 			}
@@ -124,7 +124,7 @@ func (s RiskService) CountForMeasureID(
 }
 
 func (s RiskService) ListForMeasureID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	measureID gid.GID,
 	cursor *page.Cursor[coredata.RiskOrderField],
 	filter *coredata.RiskFilter,
@@ -134,7 +134,7 @@ func (s RiskService) ListForMeasureID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return risks.LoadByMeasureID(ctx, conn, s.svc.scope, measureID, cursor, filter)
+			return risks.LoadByMeasureID(ctx, conn, scope, measureID, cursor, filter)
 		},
 	)
 	if err != nil {
@@ -145,7 +145,7 @@ func (s RiskService) ListForMeasureID(
 }
 
 func (s RiskService) CountForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	filter *coredata.RiskFilter,
 ) (int, error) {
@@ -156,7 +156,7 @@ func (s RiskService) CountForOrganizationID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			risks := &coredata.Risks{}
 
-			count, err = risks.CountByOrganizationID(ctx, conn, s.svc.scope, organizationID, filter)
+			count, err = risks.CountByOrganizationID(ctx, conn, scope, organizationID, filter)
 			if err != nil {
 				return fmt.Errorf("cannot count risks: %w", err)
 			}
@@ -172,7 +172,7 @@ func (s RiskService) CountForOrganizationID(
 }
 
 func (s RiskService) ListForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.RiskOrderField],
 	filter *coredata.RiskFilter,
@@ -185,7 +185,7 @@ func (s RiskService) ListForOrganizationID(
 			return risks.LoadByOrganizationID(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				organizationID,
 				cursor,
 				filter,
@@ -200,7 +200,7 @@ func (s RiskService) ListForOrganizationID(
 }
 
 func (s RiskService) CreateDocumentMapping(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	riskID gid.GID,
 	documentID gid.GID,
 ) (*coredata.Risk, *coredata.Document, error) {
@@ -210,11 +210,11 @@ func (s RiskService) CreateDocumentMapping(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := risk.LoadByID(ctx, tx, s.svc.scope, riskID); err != nil {
+			if err := risk.LoadByID(ctx, tx, scope, riskID); err != nil {
 				return fmt.Errorf("cannot load risk: %w", err)
 			}
 
-			if err := document.LoadByID(ctx, tx, s.svc.scope, documentID); err != nil {
+			if err := document.LoadByID(ctx, tx, scope, documentID); err != nil {
 				return fmt.Errorf("cannot load document: %w", err)
 			}
 
@@ -225,7 +225,7 @@ func (s RiskService) CreateDocumentMapping(
 				CreatedAt:      time.Now(),
 			}
 
-			return riskDocument.Insert(ctx, tx, s.svc.scope)
+			return riskDocument.Insert(ctx, tx, scope)
 		},
 	)
 	if err != nil {
@@ -236,7 +236,7 @@ func (s RiskService) CreateDocumentMapping(
 }
 
 func (s RiskService) DeleteDocumentMapping(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	riskID gid.GID,
 	documentID gid.GID,
 ) (*coredata.Risk, *coredata.Document, error) {
@@ -247,15 +247,15 @@ func (s RiskService) DeleteDocumentMapping(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := risk.LoadByID(ctx, tx, s.svc.scope, riskID); err != nil {
+			if err := risk.LoadByID(ctx, tx, scope, riskID); err != nil {
 				return fmt.Errorf("cannot load risk: %w", err)
 			}
 
-			if err := document.LoadByID(ctx, tx, s.svc.scope, documentID); err != nil {
+			if err := document.LoadByID(ctx, tx, scope, documentID); err != nil {
 				return fmt.Errorf("cannot load document: %w", err)
 			}
 
-			return riskDocument.Delete(ctx, tx, s.svc.scope, risk.ID, document.ID)
+			return riskDocument.Delete(ctx, tx, scope, risk.ID, document.ID)
 		},
 	)
 	if err != nil {
@@ -266,7 +266,7 @@ func (s RiskService) DeleteDocumentMapping(
 }
 
 func (s RiskService) CreateMeasureMapping(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	riskID gid.GID,
 	measureID gid.GID,
 ) (*coredata.Risk, *coredata.Measure, error) {
@@ -276,11 +276,11 @@ func (s RiskService) CreateMeasureMapping(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := risk.LoadByID(ctx, tx, s.svc.scope, riskID); err != nil {
+			if err := risk.LoadByID(ctx, tx, scope, riskID); err != nil {
 				return fmt.Errorf("cannot load risk: %w", err)
 			}
 
-			if err := measure.LoadByID(ctx, tx, s.svc.scope, measureID); err != nil {
+			if err := measure.LoadByID(ctx, tx, scope, measureID); err != nil {
 				return fmt.Errorf("cannot load measure: %w", err)
 			}
 
@@ -291,7 +291,7 @@ func (s RiskService) CreateMeasureMapping(
 				CreatedAt:      time.Now(),
 			}
 
-			return riskMeasure.Insert(ctx, tx, s.svc.scope)
+			return riskMeasure.Insert(ctx, tx, scope)
 		},
 	)
 	if err != nil {
@@ -302,7 +302,7 @@ func (s RiskService) CreateMeasureMapping(
 }
 
 func (s RiskService) DeleteMeasureMapping(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	riskID gid.GID,
 	measureID gid.GID,
 ) (*coredata.Risk, *coredata.Measure, error) {
@@ -312,11 +312,11 @@ func (s RiskService) DeleteMeasureMapping(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := risk.LoadByID(ctx, tx, s.svc.scope, riskID); err != nil {
+			if err := risk.LoadByID(ctx, tx, scope, riskID); err != nil {
 				return fmt.Errorf("cannot load risk: %w", err)
 			}
 
-			if err := measure.LoadByID(ctx, tx, s.svc.scope, measureID); err != nil {
+			if err := measure.LoadByID(ctx, tx, scope, measureID); err != nil {
 				return fmt.Errorf("cannot load measure: %w", err)
 			}
 
@@ -327,7 +327,7 @@ func (s RiskService) DeleteMeasureMapping(
 				CreatedAt:      time.Now(),
 			}
 
-			return riskMeasure.Delete(ctx, tx, s.svc.scope, risk.ID, measure.ID)
+			return riskMeasure.Delete(ctx, tx, scope, risk.ID, measure.ID)
 		},
 	)
 	if err != nil {
@@ -338,7 +338,7 @@ func (s RiskService) DeleteMeasureMapping(
 }
 
 func (s RiskService) CreateObligationMapping(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	riskID gid.GID,
 	obligationID gid.GID,
 ) (*coredata.Risk, *coredata.Obligation, error) {
@@ -348,11 +348,11 @@ func (s RiskService) CreateObligationMapping(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := risk.LoadByID(ctx, tx, s.svc.scope, riskID); err != nil {
+			if err := risk.LoadByID(ctx, tx, scope, riskID); err != nil {
 				return fmt.Errorf("cannot load risk: %w", err)
 			}
 
-			if err := obligation.LoadByID(ctx, tx, s.svc.scope, obligationID); err != nil {
+			if err := obligation.LoadByID(ctx, tx, scope, obligationID); err != nil {
 				return fmt.Errorf("cannot load obligation: %w", err)
 			}
 
@@ -363,7 +363,7 @@ func (s RiskService) CreateObligationMapping(
 				CreatedAt:      time.Now(),
 			}
 
-			return riskObligation.Insert(ctx, tx, s.svc.scope)
+			return riskObligation.Insert(ctx, tx, scope)
 		},
 	)
 	if err != nil {
@@ -374,7 +374,7 @@ func (s RiskService) CreateObligationMapping(
 }
 
 func (s RiskService) DeleteObligationMapping(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	riskID gid.GID,
 	obligationID gid.GID,
 ) (*coredata.Risk, *coredata.Obligation, error) {
@@ -385,18 +385,18 @@ func (s RiskService) DeleteObligationMapping(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := risk.LoadByID(ctx, tx, s.svc.scope, riskID); err != nil {
+			if err := risk.LoadByID(ctx, tx, scope, riskID); err != nil {
 				return fmt.Errorf("cannot load risk: %w", err)
 			}
 
-			if err := obligation.LoadByID(ctx, tx, s.svc.scope, obligationID); err != nil {
+			if err := obligation.LoadByID(ctx, tx, scope, obligationID); err != nil {
 				return fmt.Errorf("cannot load obligation: %w", err)
 			}
 
 			riskObligation.RiskID = risk.ID
 			riskObligation.ObligationID = obligation.ID
 
-			return riskObligation.Delete(ctx, tx, s.svc.scope)
+			return riskObligation.Delete(ctx, tx, scope)
 		},
 	)
 	if err != nil {
@@ -407,7 +407,7 @@ func (s RiskService) DeleteObligationMapping(
 }
 
 func (s RiskService) Create(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req CreateRiskRequest,
 ) (*coredata.Risk, error) {
 	if err := req.Validate(); err != nil {
@@ -419,7 +419,7 @@ func (s RiskService) Create(
 	organization := coredata.Organization{}
 
 	risk := &coredata.Risk{
-		ID:                 gid.New(s.svc.scope.GetTenantID(), coredata.RiskEntityType),
+		ID:                 gid.New(scope.GetTenantID(), coredata.RiskEntityType),
 		OrganizationID:     req.OrganizationID,
 		Name:               req.Name,
 		Description:        req.Description,
@@ -449,17 +449,17 @@ func (s RiskService) Create(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := organization.LoadByID(ctx, tx, s.svc.scope, req.OrganizationID); err != nil {
+			if err := organization.LoadByID(ctx, tx, scope, req.OrganizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
 			if req.OwnerID != nil {
-				if err := owner.LoadByID(ctx, tx, s.svc.scope, *req.OwnerID); err != nil {
+				if err := owner.LoadByID(ctx, tx, scope, *req.OwnerID); err != nil {
 					return fmt.Errorf("cannot load owner profile: %w", err)
 				}
 			}
 
-			return risk.Insert(ctx, tx, s.svc.scope)
+			return risk.Insert(ctx, tx, scope)
 		},
 	)
 	if err != nil {
@@ -470,7 +470,7 @@ func (s RiskService) Create(
 }
 
 func (s RiskService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	riskID gid.GID,
 ) (*coredata.Risk, error) {
 	risk := &coredata.Risk{}
@@ -478,7 +478,7 @@ func (s RiskService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return risk.LoadByID(ctx, conn, s.svc.scope, riskID)
+			return risk.LoadByID(ctx, conn, scope, riskID)
 		},
 	)
 	if err != nil {
@@ -489,7 +489,7 @@ func (s RiskService) Get(
 }
 
 func (s RiskService) GetByIDs(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	riskIDs ...gid.GID,
 ) (coredata.Risks, error) {
 	var risks coredata.Risks
@@ -500,7 +500,7 @@ func (s RiskService) GetByIDs(
 			if err := risks.LoadByIDs(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				riskIDs,
 			); err != nil {
 				return fmt.Errorf("cannot load risks by ids: %w", err)
@@ -517,7 +517,7 @@ func (s RiskService) GetByIDs(
 }
 
 func (s RiskService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req UpdateRiskRequest,
 ) (*coredata.Risk, error) {
 	if err := req.Validate(); err != nil {
@@ -529,7 +529,7 @@ func (s RiskService) Update(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := risk.LoadByID(ctx, conn, s.svc.scope, req.ID); err != nil {
+			if err := risk.LoadByID(ctx, conn, scope, req.ID); err != nil {
 				return fmt.Errorf("cannot load risk: %w", err)
 			}
 
@@ -564,7 +564,7 @@ func (s RiskService) Update(
 			if req.OwnerID != nil {
 				if *req.OwnerID != nil {
 					owner := coredata.MembershipProfile{}
-					if err := owner.LoadByID(ctx, conn, s.svc.scope, **req.OwnerID); err != nil {
+					if err := owner.LoadByID(ctx, conn, scope, **req.OwnerID); err != nil {
 						return fmt.Errorf("cannot load owner profile: %w", err)
 					}
 
@@ -584,7 +584,7 @@ func (s RiskService) Update(
 
 			risk.UpdatedAt = time.Now()
 
-			if err := risk.Update(ctx, conn, s.svc.scope); err != nil {
+			if err := risk.Update(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot update risk: %w", err)
 			}
 
@@ -599,7 +599,7 @@ func (s RiskService) Update(
 }
 
 func (s RiskService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	riskID gid.GID,
 ) error {
 	risk := &coredata.Risk{}
@@ -607,7 +607,7 @@ func (s RiskService) Delete(
 	return s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			return risk.Delete(ctx, tx, s.svc.scope, riskID)
+			return risk.Delete(ctx, tx, scope, riskID)
 		},
 	)
 }

--- a/pkg/probo/service.go
+++ b/pkg/probo/service.go
@@ -44,48 +44,41 @@ const (
 )
 
 type ExportService interface {
-	BuildAndUploadExport(ctx context.Context, exportJobID gid.GID) (*coredata.ExportJob, error)
-	SendExportEmail(ctx context.Context, fileID gid.GID, recipientName string, recipientEmail mail.Addr) error
+	BuildAndUploadExport(
+		ctx context.Context,
+		scope coredata.Scoper,
+		exportJobID gid.GID,
+	) (*coredata.ExportJob, error)
+	SendExportEmail(
+		ctx context.Context,
+		scope coredata.Scoper,
+		fileID gid.GID,
+		recipientName string,
+		recipientEmail mail.Addr,
+	) error
 }
 
 type (
 	Service struct {
-		pg                      *pg.Client
-		s3                      *s3.Client
-		bucket                  string
-		encryptionKey           cipher.EncryptionKey
-		baseURL                 string
-		tokenSecret             string
-		llmClient               *llm.Client
-		llmModel                string
-		llmTemperature          float64
-		llmMaxTokens            int
-		html2pdfConverter       *html2pdf.Converter
-		acmeService             *certmanager.ACMEService
-		fileManager             *filemanager.Service
-		logger                  *log.Logger
-		slack                   *slack.Service
-		esign                   *esign.Service
-		connectorRegistry       *connector.ConnectorRegistry
-		invitationTokenValidity time.Duration
-		thirdPartyAssessor      ThirdPartyAssessor
-	}
-
-	TenantService struct {
 		pg                                    *pg.Client
 		s3                                    *s3.Client
 		bucket                                string
 		encryptionKey                         cipher.EncryptionKey
-		scope                                 coredata.Scoper
 		baseURL                               string
 		tokenSecret                           string
 		llmClient                             *llm.Client
 		llmModel                              string
 		llmTemperature                        float64
 		llmMaxTokens                          int
-		thirdPartyAssessor                    ThirdPartyAssessor
+		html2pdfConverter                     *html2pdf.Converter
+		acmeService                           *certmanager.ACMEService
 		fileManager                           *filemanager.Service
+		logger                                *log.Logger
+		slack                                 *slack.Service
 		esign                                 *esign.Service
+		connectorRegistry                     *connector.ConnectorRegistry
+		invitationTokenValidity               time.Duration
+		thirdPartyAssessor                    ThirdPartyAssessor
 		Frameworks                            *FrameworkService
 		Measures                              *MeasureService
 		Tasks                                 *TaskService
@@ -123,7 +116,7 @@ type (
 		GeneratedDocuments                    *GeneratedDocumentService
 		Files                                 *FileService
 		CustomDomains                         *CustomDomainService
-		SlackMessages                         *slack.SlackMessageService
+		SlackMessages                         *slack.Service
 	}
 )
 
@@ -178,35 +171,14 @@ func NewService(
 		thirdPartyAssessor:      thirdPartyAssessor,
 	}
 
-	return svc, nil
-}
-
-func (s *Service) WithTenant(tenantID gid.TenantID) *TenantService {
-	tenantService := &TenantService{
-		pg:                 s.pg,
-		s3:                 s.s3,
-		bucket:             s.bucket,
-		encryptionKey:      s.encryptionKey,
-		baseURL:            s.baseURL,
-		scope:              coredata.NewScope(tenantID),
-		tokenSecret:        s.tokenSecret,
-		llmClient:          s.llmClient,
-		llmModel:           s.llmModel,
-		llmTemperature:     s.llmTemperature,
-		llmMaxTokens:       s.llmMaxTokens,
-		thirdPartyAssessor: s.thirdPartyAssessor,
-		fileManager:        s.fileManager,
-		esign:              s.esign,
+	svc.Frameworks = &FrameworkService{
+		svc:               svc,
+		html2pdfConverter: html2pdfConverter,
 	}
-
-	tenantService.Frameworks = &FrameworkService{
-		svc:               tenantService,
-		html2pdfConverter: s.html2pdfConverter,
-	}
-	tenantService.Measures = &MeasureService{svc: tenantService}
-	tenantService.Tasks = &TaskService{svc: tenantService}
-	tenantService.Evidences = &EvidenceService{
-		svc: tenantService,
+	svc.Measures = &MeasureService{svc: svc}
+	svc.Tasks = &TaskService{svc: svc}
+	svc.Evidences = &EvidenceService{
+		svc: svc,
 		fileValidator: filevalidation.NewValidator(
 			filevalidation.WithCategories(
 				filevalidation.CategoryDocument,
@@ -219,50 +191,50 @@ func (s *Service) WithTenant(tenantID gid.TenantID) *TenantService {
 			),
 		),
 	}
-	tenantService.ThirdParties = &ThirdPartyService{svc: tenantService}
-	tenantService.Documents = &DocumentService{
-		svc:                     tenantService,
-		html2pdfConverter:       s.html2pdfConverter,
-		invitationTokenValidity: s.invitationTokenValidity,
-		tokenSecret:             s.tokenSecret,
+	svc.ThirdParties = &ThirdPartyService{svc: svc}
+	svc.Documents = &DocumentService{
+		svc:                     svc,
+		html2pdfConverter:       html2pdfConverter,
+		invitationTokenValidity: invitationTokenValidity,
+		tokenSecret:             tokenSecret,
 	}
-	tenantService.DocumentApprovals = &DocumentApprovalService{
-		svc:                     tenantService,
-		html2pdfConverter:       s.html2pdfConverter,
-		invitationTokenValidity: s.invitationTokenValidity,
-		tokenSecret:             s.tokenSecret,
+	svc.DocumentApprovals = &DocumentApprovalService{
+		svc:                     svc,
+		html2pdfConverter:       html2pdfConverter,
+		invitationTokenValidity: invitationTokenValidity,
+		tokenSecret:             tokenSecret,
 	}
-	tenantService.Organizations = &OrganizationService{
-		svc: tenantService,
+	svc.Organizations = &OrganizationService{
+		svc: svc,
 		fileValidator: filevalidation.NewValidator(
 			filevalidation.WithCategories(filevalidation.CategoryImage),
 		),
 	}
-	tenantService.Controls = &ControlService{svc: tenantService}
-	tenantService.Risks = &RiskService{svc: tenantService}
-	tenantService.ThirdPartyComplianceReports = &ThirdPartyComplianceReportService{
-		svc: tenantService,
+	svc.Controls = &ControlService{svc: svc}
+	svc.Risks = &RiskService{svc: svc}
+	svc.ThirdPartyComplianceReports = &ThirdPartyComplianceReportService{
+		svc: svc,
 		fileValidator: filevalidation.NewValidator(
 			filevalidation.WithCategories(filevalidation.CategoryDocument),
 		),
 	}
-	tenantService.ThirdPartyBusinessAssociateAgreements = &ThirdPartyBusinessAssociateAgreementService{svc: tenantService}
-	tenantService.ThirdPartyContacts = &ThirdPartyContactService{svc: tenantService}
-	tenantService.ThirdPartyDataPrivacyAgreements = &ThirdPartyDataPrivacyAgreementService{svc: tenantService}
-	tenantService.ThirdPartyServices = &ThirdPartyServiceService{svc: tenantService}
-	tenantService.Connectors = &ConnectorService{svc: tenantService}
-	tenantService.Assets = &AssetService{svc: tenantService}
-	tenantService.Data = &DatumService{svc: tenantService}
-	tenantService.Audits = &AuditService{svc: tenantService}
-	tenantService.WebhookSubscriptions = &WebhookSubscriptionService{svc: tenantService}
-	tenantService.Reports = &ReportService{svc: tenantService}
-	tenantService.TrustCenters = &TrustCenterService{svc: tenantService}
-	tenantService.TrustCenterAccesses = &TrustCenterAccessService{svc: tenantService}
-	tenantService.TrustCenterReferences = &TrustCenterReferenceService{svc: tenantService}
-	tenantService.ComplianceFrameworks = &ComplianceFrameworkService{svc: tenantService}
-	tenantService.ComplianceExternalURLs = &ComplianceExternalURLService{svc: tenantService}
-	tenantService.TrustCenterFiles = &TrustCenterFileService{
-		svc: tenantService,
+	svc.ThirdPartyBusinessAssociateAgreements = &ThirdPartyBusinessAssociateAgreementService{svc: svc}
+	svc.ThirdPartyContacts = &ThirdPartyContactService{svc: svc}
+	svc.ThirdPartyDataPrivacyAgreements = &ThirdPartyDataPrivacyAgreementService{svc: svc}
+	svc.ThirdPartyServices = &ThirdPartyServiceService{svc: svc}
+	svc.Connectors = &ConnectorService{svc: svc}
+	svc.Assets = &AssetService{svc: svc}
+	svc.Data = &DatumService{svc: svc}
+	svc.Audits = &AuditService{svc: svc}
+	svc.WebhookSubscriptions = &WebhookSubscriptionService{svc: svc}
+	svc.Reports = &ReportService{svc: svc}
+	svc.TrustCenters = &TrustCenterService{svc: svc}
+	svc.TrustCenterAccesses = &TrustCenterAccessService{svc: svc}
+	svc.TrustCenterReferences = &TrustCenterReferenceService{svc: svc}
+	svc.ComplianceFrameworks = &ComplianceFrameworkService{svc: svc}
+	svc.ComplianceExternalURLs = &ComplianceExternalURLService{svc: svc}
+	svc.TrustCenterFiles = &TrustCenterFileService{
+		svc: svc,
 		fileValidator: filevalidation.NewValidator(
 			filevalidation.WithCategories(
 				filevalidation.CategoryData,
@@ -275,34 +247,24 @@ func (s *Service) WithTenant(tenantID gid.TenantID) *TenantService {
 			filevalidation.WithMaxFileSize(10*1024*1024), // 10MB
 		),
 	}
-	tenantService.Findings = &FindingService{svc: tenantService}
-	tenantService.Obligations = &ObligationService{svc: tenantService}
-	tenantService.RightsRequests = &RightsRequestService{svc: tenantService}
-	tenantService.ProcessingActivities = &ProcessingActivityService{
-		svc: tenantService,
+	svc.Findings = &FindingService{svc: svc}
+	svc.Obligations = &ObligationService{svc: svc}
+	svc.RightsRequests = &RightsRequestService{svc: svc}
+	svc.ProcessingActivities = &ProcessingActivityService{svc: svc}
+	svc.DataProtectionImpactAssessments = &DataProtectionImpactAssessmentService{svc: svc}
+	svc.TransferImpactAssessments = &TransferImpactAssessmentService{svc: svc}
+	svc.StatementsOfApplicability = &StatementOfApplicabilityService{svc: svc}
+	svc.GeneratedDocuments = &GeneratedDocumentService{svc: svc}
+	svc.Files = &FileService{svc: svc}
+	svc.CustomDomains = &CustomDomainService{
+		svc:           svc,
+		encryptionKey: encryptionKey,
+		acmeService:   acmeService,
+		logger:        logger.Named("custom_domains"),
 	}
-	tenantService.DataProtectionImpactAssessments = &DataProtectionImpactAssessmentService{
-		svc: tenantService,
-	}
-	tenantService.TransferImpactAssessments = &TransferImpactAssessmentService{
-		svc: tenantService,
-	}
-	tenantService.StatementsOfApplicability = &StatementOfApplicabilityService{
-		svc: tenantService,
-	}
-	tenantService.GeneratedDocuments = &GeneratedDocumentService{
-		svc: tenantService,
-	}
-	tenantService.Files = &FileService{svc: tenantService}
-	tenantService.CustomDomains = &CustomDomainService{
-		svc:           tenantService,
-		encryptionKey: s.encryptionKey,
-		acmeService:   s.acmeService,
-		logger:        s.logger.Named("custom_domains"),
-	}
-	tenantService.SlackMessages = s.slack.WithTenant(tenantID).SlackMessages
+	svc.SlackMessages = slackService
 
-	return tenantService
+	return svc, nil
 }
 
 func (s *Service) ExportJob(ctx context.Context) error {
@@ -311,15 +273,15 @@ func (s *Service) ExportJob(ctx context.Context) error {
 		return fmt.Errorf("cannot lock export job: %w", err)
 	}
 
-	tenantService := s.WithTenant(exportJob.ID.TenantID())
+	scope := coredata.NewScope(exportJob.ID.TenantID())
 
 	var exportService ExportService
 
 	switch exportJob.Type {
 	case coredata.ExportJobTypeFramework:
-		exportService = tenantService.Frameworks
+		exportService = s.Frameworks
 	case coredata.ExportJobTypeDocument:
-		exportService = tenantService.Documents
+		exportService = s.Documents
 	default:
 		unknownTypeErr := fmt.Errorf("unknown export job type: %q", exportJob.Type)
 		if err := s.commitFailedExport(ctx, exportJob, unknownTypeErr); err != nil {
@@ -329,7 +291,7 @@ func (s *Service) ExportJob(ctx context.Context) error {
 		return unknownTypeErr
 	}
 
-	updatedExportJob, buildErr := exportService.BuildAndUploadExport(ctx, exportJob.ID)
+	updatedExportJob, buildErr := exportService.BuildAndUploadExport(ctx, scope, exportJob.ID)
 	if buildErr != nil {
 		if err := s.commitFailedExport(ctx, exportJob, buildErr); err != nil {
 			return fmt.Errorf(
@@ -345,7 +307,13 @@ func (s *Service) ExportJob(ctx context.Context) error {
 
 	exportJob = updatedExportJob
 
-	if emailErr := exportService.SendExportEmail(ctx, *exportJob.FileID, exportJob.RecipientName, exportJob.RecipientEmail); emailErr != nil {
+	if emailErr := exportService.SendExportEmail(
+		ctx,
+		scope,
+		*exportJob.FileID,
+		exportJob.RecipientName,
+		exportJob.RecipientEmail,
+	); emailErr != nil {
 		if err := s.commitFailedExport(ctx, exportJob, emailErr); err != nil {
 			return fmt.Errorf(
 				"cannot send completion email: %w, and cannot commit failed export: %w",

--- a/pkg/probo/statement_of_applicability_service.go
+++ b/pkg/probo/statement_of_applicability_service.go
@@ -27,7 +27,7 @@ import (
 )
 
 type StatementOfApplicabilityService struct {
-	svc *TenantService
+	svc *Service
 }
 
 type (
@@ -61,7 +61,7 @@ func (usr *UpdateStatementOfApplicabilityRequest) Validate() error {
 }
 
 func (s StatementOfApplicabilityService) ListForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.StatementOfApplicabilityOrderField],
 ) (*page.Page[*coredata.StatementOfApplicability, coredata.StatementOfApplicabilityOrderField], error) {
@@ -72,14 +72,14 @@ func (s StatementOfApplicabilityService) ListForOrganizationID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := organization.LoadByID(ctx, conn, s.svc.scope, organizationID); err != nil {
+			if err := organization.LoadByID(ctx, conn, scope, organizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
 			err := statementsOfApplicability.LoadByOrganizationID(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				organization.ID,
 				cursor,
 			)
@@ -98,7 +98,7 @@ func (s StatementOfApplicabilityService) ListForOrganizationID(
 }
 
 func (s StatementOfApplicabilityService) CountForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (int, error) {
 	var count int
@@ -108,7 +108,7 @@ func (s StatementOfApplicabilityService) CountForOrganizationID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			statementsOfApplicability := &coredata.StatementsOfApplicability{}
 
-			count, err = statementsOfApplicability.CountByOrganizationID(ctx, conn, s.svc.scope, organizationID)
+			count, err = statementsOfApplicability.CountByOrganizationID(ctx, conn, scope, organizationID)
 			if err != nil {
 				return fmt.Errorf("cannot count statements_of_applicability: %w", err)
 			}
@@ -124,7 +124,7 @@ func (s StatementOfApplicabilityService) CountForOrganizationID(
 }
 
 func (s StatementOfApplicabilityService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	statementOfApplicabilityID gid.GID,
 ) (*coredata.StatementOfApplicability, error) {
 	statementOfApplicability := &coredata.StatementOfApplicability{}
@@ -132,7 +132,7 @@ func (s StatementOfApplicabilityService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return statementOfApplicability.LoadByID(ctx, conn, s.svc.scope, statementOfApplicabilityID)
+			return statementOfApplicability.LoadByID(ctx, conn, scope, statementOfApplicabilityID)
 		},
 	)
 	if err != nil {
@@ -143,7 +143,7 @@ func (s StatementOfApplicabilityService) Get(
 }
 
 func (s StatementOfApplicabilityService) Create(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req CreateStatementOfApplicabilityRequest,
 ) (*coredata.StatementOfApplicability, error) {
 	if err := req.Validate(); err != nil {
@@ -156,7 +156,7 @@ func (s StatementOfApplicabilityService) Create(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return organization.LoadByID(ctx, conn, s.svc.scope, req.OrganizationID)
+			return organization.LoadByID(ctx, conn, scope, req.OrganizationID)
 		},
 	)
 	if err != nil {
@@ -175,7 +175,7 @@ func (s StatementOfApplicabilityService) Create(
 	err = s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := statementOfApplicability.Insert(ctx, conn, s.svc.scope); err != nil {
+			if err := statementOfApplicability.Insert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot insert statement_of_applicability: %w", err)
 			}
 
@@ -190,7 +190,7 @@ func (s StatementOfApplicabilityService) Create(
 }
 
 func (s StatementOfApplicabilityService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req UpdateStatementOfApplicabilityRequest,
 ) (*coredata.StatementOfApplicability, error) {
 	if err := req.Validate(); err != nil {
@@ -202,7 +202,7 @@ func (s StatementOfApplicabilityService) Update(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := statementOfApplicability.LoadByID(ctx, conn, s.svc.scope, req.StatementOfApplicabilityID); err != nil {
+			if err := statementOfApplicability.LoadByID(ctx, conn, scope, req.StatementOfApplicabilityID); err != nil {
 				return fmt.Errorf("cannot load statement_of_applicability: %w", err)
 			}
 
@@ -212,7 +212,7 @@ func (s StatementOfApplicabilityService) Update(
 
 			statementOfApplicability.UpdatedAt = time.Now()
 
-			if err := statementOfApplicability.Update(ctx, conn, s.svc.scope); err != nil {
+			if err := statementOfApplicability.Update(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot update statement_of_applicability: %w", err)
 			}
 
@@ -227,7 +227,7 @@ func (s StatementOfApplicabilityService) Update(
 }
 
 func (s StatementOfApplicabilityService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	statementOfApplicabilityID gid.GID,
 ) error {
 	statementOfApplicability := &coredata.StatementOfApplicability{ID: statementOfApplicabilityID}
@@ -235,11 +235,11 @@ func (s StatementOfApplicabilityService) Delete(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := statementOfApplicability.LoadByID(ctx, conn, s.svc.scope, statementOfApplicabilityID); err != nil {
+			if err := statementOfApplicability.LoadByID(ctx, conn, scope, statementOfApplicabilityID); err != nil {
 				return fmt.Errorf("cannot load statement_of_applicability: %w", err)
 			}
 
-			if err := statementOfApplicability.Delete(ctx, conn, s.svc.scope); err != nil {
+			if err := statementOfApplicability.Delete(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot delete statement_of_applicability: %w", err)
 			}
 
@@ -254,7 +254,7 @@ func (s StatementOfApplicabilityService) Delete(
 }
 
 func (s StatementOfApplicabilityService) GetApplicabilityStatement(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	applicabilityStatementID gid.GID,
 ) (*coredata.ApplicabilityStatement, error) {
 	applicabilityStatement := &coredata.ApplicabilityStatement{}
@@ -262,7 +262,7 @@ func (s StatementOfApplicabilityService) GetApplicabilityStatement(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return applicabilityStatement.LoadByID(ctx, conn, s.svc.scope, applicabilityStatementID)
+			return applicabilityStatement.LoadByID(ctx, conn, scope, applicabilityStatementID)
 		},
 	)
 	if err != nil {
@@ -273,7 +273,7 @@ func (s StatementOfApplicabilityService) GetApplicabilityStatement(
 }
 
 func (s StatementOfApplicabilityService) ListApplicabilityStatements(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	statementOfApplicabilityID gid.GID,
 	cursor *page.Cursor[coredata.ApplicabilityStatementOrderField],
 ) (*page.Page[*coredata.ApplicabilityStatement, coredata.ApplicabilityStatementOrderField], error) {
@@ -282,7 +282,7 @@ func (s StatementOfApplicabilityService) ListApplicabilityStatements(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := statements.LoadByStatementOfApplicabilityID(ctx, conn, s.svc.scope, statementOfApplicabilityID, cursor); err != nil {
+			if err := statements.LoadByStatementOfApplicabilityID(ctx, conn, scope, statementOfApplicabilityID, cursor); err != nil {
 				return fmt.Errorf("cannot load applicability statements: %w", err)
 			}
 
@@ -297,7 +297,7 @@ func (s StatementOfApplicabilityService) ListApplicabilityStatements(
 }
 
 func (s StatementOfApplicabilityService) CountApplicabilityStatements(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	statementOfApplicabilityID gid.GID,
 ) (int, error) {
 	var count int
@@ -307,7 +307,7 @@ func (s StatementOfApplicabilityService) CountApplicabilityStatements(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			statements := &coredata.ApplicabilityStatements{}
 
-			count, err = statements.CountByStatementOfApplicabilityID(ctx, conn, s.svc.scope, statementOfApplicabilityID)
+			count, err = statements.CountByStatementOfApplicabilityID(ctx, conn, scope, statementOfApplicabilityID)
 			if err != nil {
 				return fmt.Errorf("cannot count applicability statements: %w", err)
 			}
@@ -323,7 +323,7 @@ func (s StatementOfApplicabilityService) CountApplicabilityStatements(
 }
 
 func (s StatementOfApplicabilityService) CreateApplicabilityStatement(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	statementOfApplicabilityID gid.GID,
 	controlID gid.GID,
 	applicability bool,
@@ -338,12 +338,12 @@ func (s StatementOfApplicabilityService) CreateApplicabilityStatement(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := statementOfApplicability.LoadByID(ctx, conn, s.svc.scope, statementOfApplicabilityID); err != nil {
+			if err := statementOfApplicability.LoadByID(ctx, conn, scope, statementOfApplicabilityID); err != nil {
 				return fmt.Errorf("cannot load statement of applicability: %w", err)
 			}
 
 			applicabilityStatement = &coredata.ApplicabilityStatement{
-				ID:                         gid.New(s.svc.scope.GetTenantID(), coredata.ApplicabilityStatementEntityType),
+				ID:                         gid.New(scope.GetTenantID(), coredata.ApplicabilityStatementEntityType),
 				StatementOfApplicabilityID: statementOfApplicabilityID,
 				ControlID:                  controlID,
 				OrganizationID:             statementOfApplicability.OrganizationID,
@@ -353,7 +353,7 @@ func (s StatementOfApplicabilityService) CreateApplicabilityStatement(
 				UpdatedAt:                  now,
 			}
 
-			if err := applicabilityStatement.Insert(ctx, conn, s.svc.scope); err != nil {
+			if err := applicabilityStatement.Insert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot insert applicability statement: %w", err)
 			}
 
@@ -368,7 +368,7 @@ func (s StatementOfApplicabilityService) CreateApplicabilityStatement(
 }
 
 func (s StatementOfApplicabilityService) UpdateApplicabilityStatement(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	applicabilityStatementID gid.GID,
 	applicability bool,
 	justification *string,
@@ -378,7 +378,7 @@ func (s StatementOfApplicabilityService) UpdateApplicabilityStatement(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := applicabilityStatement.LoadByID(ctx, conn, s.svc.scope, applicabilityStatementID); err != nil {
+			if err := applicabilityStatement.LoadByID(ctx, conn, scope, applicabilityStatementID); err != nil {
 				return err
 			}
 
@@ -386,7 +386,7 @@ func (s StatementOfApplicabilityService) UpdateApplicabilityStatement(
 			applicabilityStatement.Justification = justification
 			applicabilityStatement.UpdatedAt = time.Now()
 
-			return applicabilityStatement.UpdateByID(ctx, conn, s.svc.scope)
+			return applicabilityStatement.UpdateByID(ctx, conn, scope)
 		},
 	)
 	if err != nil {
@@ -397,7 +397,7 @@ func (s StatementOfApplicabilityService) UpdateApplicabilityStatement(
 }
 
 func (s StatementOfApplicabilityService) DeleteApplicabilityStatement(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	applicabilityStatementID gid.GID,
 ) error {
 	applicabilityStatement := &coredata.ApplicabilityStatement{}
@@ -405,20 +405,20 @@ func (s StatementOfApplicabilityService) DeleteApplicabilityStatement(
 	return s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			return applicabilityStatement.DeleteByID(ctx, conn, s.svc.scope, applicabilityStatementID)
+			return applicabilityStatement.DeleteByID(ctx, conn, scope, applicabilityStatementID)
 		},
 	)
 }
 
 func (s StatementOfApplicabilityService) ListControlLinks(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	controlID gid.GID,
 	cursor *page.Cursor[coredata.ApplicabilityStatementOrderField],
 ) (*page.Page[*coredata.ApplicabilityStatement, coredata.ApplicabilityStatementOrderField], error) {
 	var controls coredata.ApplicabilityStatements
 
 	err := s.svc.pg.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
-		return controls.LoadByControlID(ctx, conn, s.svc.scope, controlID, cursor)
+		return controls.LoadByControlID(ctx, conn, scope, controlID, cursor)
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/probo/task_service.go
+++ b/pkg/probo/task_service.go
@@ -29,7 +29,7 @@ import (
 
 type (
 	TaskService struct {
-		svc *TenantService
+		svc *Service
 	}
 
 	CreateTaskRequest struct {
@@ -88,7 +88,7 @@ func (utr *UpdateTaskRequest) Validate() error {
 }
 
 func (s TaskService) Create(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req CreateTaskRequest,
 ) (*coredata.Task, error) {
 	if err := req.Validate(); err != nil {
@@ -96,7 +96,7 @@ func (s TaskService) Create(
 	}
 
 	now := time.Now()
-	taskID := gid.New(s.svc.scope.GetTenantID(), coredata.TaskEntityType)
+	taskID := gid.New(scope.GetTenantID(), coredata.TaskEntityType)
 
 	referenceID, err := uuid.NewV4()
 	if err != nil {
@@ -124,19 +124,19 @@ func (s TaskService) Create(
 		func(ctx context.Context, conn pg.Tx) error {
 			if req.MeasureID != nil {
 				measure := &coredata.Measure{}
-				if err := measure.LoadByID(ctx, conn, s.svc.scope, *req.MeasureID); err != nil {
+				if err := measure.LoadByID(ctx, conn, scope, *req.MeasureID); err != nil {
 					return fmt.Errorf("cannot load measure: %w", err)
 				}
 			}
 
 			if req.AssignedToID != nil {
 				assignee := &coredata.MembershipProfile{}
-				if err := assignee.LoadByID(ctx, conn, s.svc.scope, *req.AssignedToID); err != nil {
+				if err := assignee.LoadByID(ctx, conn, scope, *req.AssignedToID); err != nil {
 					return fmt.Errorf("cannot load assignee profile: %w", err)
 				}
 			}
 
-			if err := task.Insert(ctx, conn, s.svc.scope); err != nil {
+			if err := task.Insert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot insert task: %w", err)
 			}
 
@@ -151,7 +151,7 @@ func (s TaskService) Create(
 }
 
 func (s TaskService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	taskID gid.GID,
 ) (*coredata.Task, error) {
 	task := &coredata.Task{}
@@ -159,7 +159,7 @@ func (s TaskService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return task.LoadByID(ctx, conn, s.svc.scope, taskID)
+			return task.LoadByID(ctx, conn, scope, taskID)
 		},
 	)
 	if err != nil {
@@ -170,7 +170,7 @@ func (s TaskService) Get(
 }
 
 func (s TaskService) GetByIDs(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	taskIDs ...gid.GID,
 ) (coredata.Tasks, error) {
 	var tasks coredata.Tasks
@@ -181,7 +181,7 @@ func (s TaskService) GetByIDs(
 			if err := tasks.LoadByIDs(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				taskIDs,
 			); err != nil {
 				return fmt.Errorf("cannot load tasks by ids: %w", err)
@@ -198,7 +198,7 @@ func (s TaskService) GetByIDs(
 }
 
 func (s TaskService) Assign(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	taskID gid.GID,
 	assignedToID gid.GID,
 ) (*coredata.Task, error) {
@@ -207,19 +207,19 @@ func (s TaskService) Assign(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := task.LoadByID(ctx, conn, s.svc.scope, taskID); err != nil {
+			if err := task.LoadByID(ctx, conn, scope, taskID); err != nil {
 				return fmt.Errorf("cannot load task %q: %w", taskID, err)
 			}
 
 			assignee := &coredata.MembershipProfile{}
-			if err := assignee.LoadByID(ctx, conn, s.svc.scope, assignedToID); err != nil {
+			if err := assignee.LoadByID(ctx, conn, scope, assignedToID); err != nil {
 				return fmt.Errorf("cannot load assignee profile: %w", err)
 			}
 
 			task.AssignedToID = &assignedToID
 			task.UpdatedAt = time.Now()
 
-			if err := task.Update(ctx, conn, s.svc.scope); err != nil {
+			if err := task.Update(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot assign task %q to %q: %w", taskID, assignedToID, err)
 			}
 
@@ -234,7 +234,7 @@ func (s TaskService) Assign(
 }
 
 func (s TaskService) Unassign(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	taskID gid.GID,
 ) (*coredata.Task, error) {
 	task := &coredata.Task{}
@@ -242,14 +242,14 @@ func (s TaskService) Unassign(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := task.LoadByID(ctx, conn, s.svc.scope, taskID); err != nil {
+			if err := task.LoadByID(ctx, conn, scope, taskID); err != nil {
 				return fmt.Errorf("cannot load task %q: %w", taskID, err)
 			}
 
 			task.AssignedToID = nil
 			task.UpdatedAt = time.Now()
 
-			if err := task.Update(ctx, conn, s.svc.scope); err != nil {
+			if err := task.Update(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot unassign task %q: %w", taskID, err)
 			}
 
@@ -264,7 +264,7 @@ func (s TaskService) Unassign(
 }
 
 func (s TaskService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req UpdateTaskRequest,
 ) (*coredata.Task, error) {
 	if err := req.Validate(); err != nil {
@@ -276,7 +276,7 @@ func (s TaskService) Update(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := task.LoadByID(ctx, conn, s.svc.scope, req.TaskID); err != nil {
+			if err := task.LoadByID(ctx, conn, scope, req.TaskID); err != nil {
 				return fmt.Errorf("cannot load task %q: %w", req.TaskID, err)
 			}
 
@@ -308,7 +308,7 @@ func (s TaskService) Update(
 					task.AssignedToID = nil
 				} else {
 					assignee := &coredata.MembershipProfile{}
-					if err := assignee.LoadByID(ctx, conn, s.svc.scope, **req.AssignedToID); err != nil {
+					if err := assignee.LoadByID(ctx, conn, scope, **req.AssignedToID); err != nil {
 						return fmt.Errorf("cannot load assignee profile: %w", err)
 					}
 
@@ -321,7 +321,7 @@ func (s TaskService) Update(
 					task.MeasureID = nil
 				} else {
 					measure := &coredata.Measure{}
-					if err := measure.LoadByID(ctx, conn, s.svc.scope, **req.MeasureID); err != nil {
+					if err := measure.LoadByID(ctx, conn, scope, **req.MeasureID); err != nil {
 						return fmt.Errorf("cannot load measure: %w", err)
 					}
 
@@ -340,18 +340,18 @@ func (s TaskService) Update(
 			stateChanged := task.State != oldState
 
 			if priorityChanged || stateChanged {
-				if err := task.NextRankForStatePriority(ctx, conn, s.svc.scope); err != nil {
+				if err := task.NextRankForStatePriority(ctx, conn, scope); err != nil {
 					return fmt.Errorf("cannot get next rank: %w", err)
 				}
 			}
 
-			if err := task.Update(ctx, conn, s.svc.scope); err != nil {
+			if err := task.Update(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot update task: %w", err)
 			}
 
 			if targetRank != nil {
 				task.Rank = *targetRank
-				if err := task.UpdateRank(ctx, conn, s.svc.scope); err != nil {
+				if err := task.UpdateRank(ctx, conn, scope); err != nil {
 					return fmt.Errorf("cannot update task rank: %w", err)
 				}
 			}
@@ -367,7 +367,7 @@ func (s TaskService) Update(
 }
 
 func (s TaskService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	taskID gid.GID,
 ) error {
 	task := &coredata.Task{ID: taskID}
@@ -375,7 +375,7 @@ func (s TaskService) Delete(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			return task.Delete(ctx, conn, s.svc.scope)
+			return task.Delete(ctx, conn, scope)
 		},
 	)
 	if err != nil {
@@ -386,7 +386,7 @@ func (s TaskService) Delete(
 }
 
 func (s TaskService) CountForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (int, error) {
 	var count int
@@ -396,7 +396,7 @@ func (s TaskService) CountForOrganizationID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			tasks := coredata.Tasks{}
 
-			count, err = tasks.CountByOrganizationID(ctx, conn, s.svc.scope, organizationID)
+			count, err = tasks.CountByOrganizationID(ctx, conn, scope, organizationID)
 			if err != nil {
 				return fmt.Errorf("cannot count tasks: %w", err)
 			}
@@ -412,7 +412,7 @@ func (s TaskService) CountForOrganizationID(
 }
 
 func (s TaskService) ListForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.TaskOrderField],
 ) (*page.Page[*coredata.Task, coredata.TaskOrderField], error) {
@@ -421,7 +421,7 @@ func (s TaskService) ListForOrganizationID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return tasks.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID, cursor)
+			return tasks.LoadByOrganizationID(ctx, conn, scope, organizationID, cursor)
 		},
 	)
 	if err != nil {
@@ -432,7 +432,7 @@ func (s TaskService) ListForOrganizationID(
 }
 
 func (s TaskService) CountForMeasureID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	measureID gid.GID,
 ) (int, error) {
 	var count int
@@ -442,7 +442,7 @@ func (s TaskService) CountForMeasureID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			tasks := coredata.Tasks{}
 
-			count, err = tasks.CountByMeasureID(ctx, conn, s.svc.scope, measureID)
+			count, err = tasks.CountByMeasureID(ctx, conn, scope, measureID)
 			if err != nil {
 				return fmt.Errorf("cannot count tasks: %w", err)
 			}
@@ -458,7 +458,7 @@ func (s TaskService) CountForMeasureID(
 }
 
 func (s TaskService) ListForMeasureID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	measureID gid.GID,
 	cursor *page.Cursor[coredata.TaskOrderField],
 ) (*page.Page[*coredata.Task, coredata.TaskOrderField], error) {
@@ -470,7 +470,7 @@ func (s TaskService) ListForMeasureID(
 			return tasks.LoadByMeasureID(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				measureID,
 				cursor,
 			)

--- a/pkg/probo/third_party_business_associate_agreement_service.go
+++ b/pkg/probo/third_party_business_associate_agreement_service.go
@@ -33,7 +33,7 @@ import (
 
 type (
 	ThirdPartyBusinessAssociateAgreementService struct {
-		svc *TenantService
+		svc *Service
 	}
 
 	ThirdPartyBusinessAssociateAgreementCreateRequest struct {
@@ -67,7 +67,7 @@ func (vbaaur *ThirdPartyBusinessAssociateAgreementUpdateRequest) Validate() erro
 }
 
 func (s ThirdPartyBusinessAssociateAgreementService) GetByThirdPartyID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyID gid.GID,
 ) (*coredata.ThirdPartyBusinessAssociateAgreement, *coredata.File, error) {
 	var (
@@ -79,12 +79,12 @@ func (s ThirdPartyBusinessAssociateAgreementService) GetByThirdPartyID(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			thirdPartyBusinessAssociateAgreement = &coredata.ThirdPartyBusinessAssociateAgreement{}
-			if err := thirdPartyBusinessAssociateAgreement.LoadByThirdPartyID(ctx, conn, s.svc.scope, thirdPartyID); err != nil {
+			if err := thirdPartyBusinessAssociateAgreement.LoadByThirdPartyID(ctx, conn, scope, thirdPartyID); err != nil {
 				return fmt.Errorf("cannot load thirdParty business associate agreement: %w", err)
 			}
 
 			file = &coredata.File{}
-			if err := file.LoadByID(ctx, conn, s.svc.scope, thirdPartyBusinessAssociateAgreement.FileID); err != nil {
+			if err := file.LoadByID(ctx, conn, scope, thirdPartyBusinessAssociateAgreement.FileID); err != nil {
 				return fmt.Errorf("cannot load file: %w", err)
 			}
 
@@ -99,7 +99,7 @@ func (s ThirdPartyBusinessAssociateAgreementService) GetByThirdPartyID(
 }
 
 func (s ThirdPartyBusinessAssociateAgreementService) Upload(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyID gid.GID,
 	req *ThirdPartyBusinessAssociateAgreementCreateRequest,
 ) (*coredata.ThirdPartyBusinessAssociateAgreement, *coredata.File, error) {
@@ -121,7 +121,7 @@ func (s ThirdPartyBusinessAssociateAgreementService) Upload(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			thirdParty := &coredata.ThirdParty{}
-			if err := thirdParty.LoadByID(ctx, conn, s.svc.scope, thirdPartyID); err != nil {
+			if err := thirdParty.LoadByID(ctx, conn, scope, thirdPartyID); err != nil {
 				return fmt.Errorf("cannot load thirdParty: %w", err)
 			}
 
@@ -152,8 +152,8 @@ func (s ThirdPartyBusinessAssociateAgreementService) Upload(
 			}
 
 			now := time.Now()
-			fileID := gid.New(s.svc.scope.GetTenantID(), coredata.FileEntityType)
-			thirdPartyBusinessAssociateAgreementID := gid.New(s.svc.scope.GetTenantID(), coredata.ThirdPartyBusinessAssociateAgreementEntityType)
+			fileID := gid.New(scope.GetTenantID(), coredata.FileEntityType)
+			thirdPartyBusinessAssociateAgreementID := gid.New(scope.GetTenantID(), coredata.ThirdPartyBusinessAssociateAgreementEntityType)
 
 			file = &coredata.File{
 				ID:         fileID,
@@ -178,11 +178,11 @@ func (s ThirdPartyBusinessAssociateAgreementService) Upload(
 				UpdatedAt:      now,
 			}
 
-			if err := file.Insert(ctx, conn, s.svc.scope); err != nil {
+			if err := file.Insert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot insert file: %w", err)
 			}
 
-			if err := thirdPartyBusinessAssociateAgreement.Upsert(ctx, conn, s.svc.scope); err != nil {
+			if err := thirdPartyBusinessAssociateAgreement.Upsert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot insert thirdParty business associate agreement: %w", err)
 			}
 
@@ -197,7 +197,7 @@ func (s ThirdPartyBusinessAssociateAgreementService) Upload(
 }
 
 func (s ThirdPartyBusinessAssociateAgreementService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyBusinessAssociateAgreementID gid.GID,
 ) (*coredata.ThirdPartyBusinessAssociateAgreement, *coredata.File, error) {
 	var (
@@ -209,12 +209,12 @@ func (s ThirdPartyBusinessAssociateAgreementService) Get(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			thirdPartyBusinessAssociateAgreement = &coredata.ThirdPartyBusinessAssociateAgreement{}
-			if err := thirdPartyBusinessAssociateAgreement.LoadByID(ctx, conn, s.svc.scope, thirdPartyBusinessAssociateAgreementID); err != nil {
+			if err := thirdPartyBusinessAssociateAgreement.LoadByID(ctx, conn, scope, thirdPartyBusinessAssociateAgreementID); err != nil {
 				return fmt.Errorf("cannot load thirdParty business associate agreement: %w", err)
 			}
 
 			file = &coredata.File{}
-			if err := file.LoadByID(ctx, conn, s.svc.scope, thirdPartyBusinessAssociateAgreement.FileID); err != nil {
+			if err := file.LoadByID(ctx, conn, scope, thirdPartyBusinessAssociateAgreement.FileID); err != nil {
 				return fmt.Errorf("cannot load file: %w", err)
 			}
 
@@ -229,7 +229,7 @@ func (s ThirdPartyBusinessAssociateAgreementService) Get(
 }
 
 func (s ThirdPartyBusinessAssociateAgreementService) GenerateFileURL(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyBusinessAssociateAgreementID gid.GID,
 	expiresIn time.Duration,
 ) (string, error) {
@@ -239,12 +239,12 @@ func (s ThirdPartyBusinessAssociateAgreementService) GenerateFileURL(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			thirdPartyBusinessAssociateAgreement := &coredata.ThirdPartyBusinessAssociateAgreement{}
-			if err := thirdPartyBusinessAssociateAgreement.LoadByID(ctx, conn, s.svc.scope, thirdPartyBusinessAssociateAgreementID); err != nil {
+			if err := thirdPartyBusinessAssociateAgreement.LoadByID(ctx, conn, scope, thirdPartyBusinessAssociateAgreementID); err != nil {
 				return fmt.Errorf("cannot load thirdParty business associate agreement: %w", err)
 			}
 
 			file = &coredata.File{}
-			if err := file.LoadByID(ctx, conn, s.svc.scope, thirdPartyBusinessAssociateAgreement.FileID); err != nil {
+			if err := file.LoadByID(ctx, conn, scope, thirdPartyBusinessAssociateAgreement.FileID); err != nil {
 				return fmt.Errorf("cannot load file: %w", err)
 			}
 
@@ -277,7 +277,7 @@ func (s ThirdPartyBusinessAssociateAgreementService) GenerateFileURL(
 }
 
 func (s ThirdPartyBusinessAssociateAgreementService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyID gid.GID,
 	req *ThirdPartyBusinessAssociateAgreementUpdateRequest,
 ) (*coredata.ThirdPartyBusinessAssociateAgreement, *coredata.File, error) {
@@ -291,7 +291,7 @@ func (s ThirdPartyBusinessAssociateAgreementService) Update(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := existingAgreement.LoadByThirdPartyID(ctx, conn, s.svc.scope, thirdPartyID); err != nil {
+			if err := existingAgreement.LoadByThirdPartyID(ctx, conn, scope, thirdPartyID); err != nil {
 				return fmt.Errorf("cannot load existing thirdParty business associate agreement: %w", err)
 			}
 
@@ -307,11 +307,11 @@ func (s ThirdPartyBusinessAssociateAgreementService) Update(
 
 			existingAgreement.UpdatedAt = now
 
-			if err := existingAgreement.Update(ctx, conn, s.svc.scope); err != nil {
+			if err := existingAgreement.Update(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot update thirdParty business associate agreement: %w", err)
 			}
 
-			if err := file.LoadByID(ctx, conn, s.svc.scope, existingAgreement.FileID); err != nil {
+			if err := file.LoadByID(ctx, conn, scope, existingAgreement.FileID); err != nil {
 				return fmt.Errorf("cannot load file: %w", err)
 			}
 
@@ -326,18 +326,18 @@ func (s ThirdPartyBusinessAssociateAgreementService) Update(
 }
 
 func (s ThirdPartyBusinessAssociateAgreementService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyBusinessAssociateAgreementID gid.GID,
 ) error {
 	return s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			thirdPartyBusinessAssociateAgreement := &coredata.ThirdPartyBusinessAssociateAgreement{}
-			if err := thirdPartyBusinessAssociateAgreement.LoadByID(ctx, conn, s.svc.scope, thirdPartyBusinessAssociateAgreementID); err != nil {
+			if err := thirdPartyBusinessAssociateAgreement.LoadByID(ctx, conn, scope, thirdPartyBusinessAssociateAgreementID); err != nil {
 				return fmt.Errorf("cannot load thirdParty business associate agreement: %w", err)
 			}
 
-			if err := thirdPartyBusinessAssociateAgreement.Delete(ctx, conn, s.svc.scope); err != nil {
+			if err := thirdPartyBusinessAssociateAgreement.Delete(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot delete thirdParty business associate agreement: %w", err)
 			}
 
@@ -347,18 +347,18 @@ func (s ThirdPartyBusinessAssociateAgreementService) Delete(
 }
 
 func (s ThirdPartyBusinessAssociateAgreementService) DeleteByThirdPartyID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyID gid.GID,
 ) error {
 	return s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			thirdPartyBusinessAssociateAgreement := &coredata.ThirdPartyBusinessAssociateAgreement{}
-			if err := thirdPartyBusinessAssociateAgreement.LoadByThirdPartyID(ctx, conn, s.svc.scope, thirdPartyID); err != nil {
+			if err := thirdPartyBusinessAssociateAgreement.LoadByThirdPartyID(ctx, conn, scope, thirdPartyID); err != nil {
 				return fmt.Errorf("cannot load thirdParty business associate agreement: %w", err)
 			}
 
-			if err := thirdPartyBusinessAssociateAgreement.DeleteByThirdPartyID(ctx, conn, s.svc.scope, thirdPartyID); err != nil {
+			if err := thirdPartyBusinessAssociateAgreement.DeleteByThirdPartyID(ctx, conn, scope, thirdPartyID); err != nil {
 				return fmt.Errorf("cannot delete thirdParty business associate agreement: %w", err)
 			}
 

--- a/pkg/probo/third_party_compliance_report_service.go
+++ b/pkg/probo/third_party_compliance_report_service.go
@@ -29,7 +29,7 @@ import (
 
 type (
 	ThirdPartyComplianceReportService struct {
-		svc           *TenantService
+		svc           *Service
 		fileValidator *filevalidation.FileValidator
 	}
 
@@ -50,7 +50,7 @@ func (vcrcr *ThirdPartyComplianceReportCreateRequest) Validate() error {
 }
 
 func (s ThirdPartyComplianceReportService) ListForThirdPartyID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyID gid.GID,
 	cursor *page.Cursor[coredata.ThirdPartyComplianceReportOrderField],
 ) (*page.Page[*coredata.ThirdPartyComplianceReport, coredata.ThirdPartyComplianceReportOrderField], error) {
@@ -59,7 +59,7 @@ func (s ThirdPartyComplianceReportService) ListForThirdPartyID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return thirdPartyComplianceReports.LoadForThirdPartyID(ctx, conn, s.svc.scope, thirdPartyID, cursor)
+			return thirdPartyComplianceReports.LoadForThirdPartyID(ctx, conn, scope, thirdPartyID, cursor)
 		},
 	)
 	if err != nil {
@@ -70,7 +70,7 @@ func (s ThirdPartyComplianceReportService) ListForThirdPartyID(
 }
 
 func (s ThirdPartyComplianceReportService) Upload(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyID gid.GID,
 	req *ThirdPartyComplianceReportCreateRequest,
 ) (*coredata.ThirdPartyComplianceReport, error) {
@@ -78,13 +78,14 @@ func (s ThirdPartyComplianceReportService) Upload(
 		return nil, err
 	}
 
-	thirdParty, err := s.svc.ThirdParties.Get(ctx, thirdPartyID)
+	thirdParty, err := s.svc.ThirdParties.Get(ctx, scope, thirdPartyID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get thirdParty: %w", err)
 	}
 
 	f, err := s.svc.Files.UploadAndSaveFile(
 		ctx,
+		scope,
 		s.fileValidator,
 		map[string]string{
 			"type":            "thirdParty-compliance-report",
@@ -98,7 +99,7 @@ func (s ThirdPartyComplianceReportService) Upload(
 
 	now := time.Now()
 
-	thirdPartyComplianceReportID := gid.New(s.svc.scope.GetTenantID(), coredata.ThirdPartyComplianceReportEntityType)
+	thirdPartyComplianceReportID := gid.New(scope.GetTenantID(), coredata.ThirdPartyComplianceReportEntityType)
 
 	thirdPartyComplianceReport := &coredata.ThirdPartyComplianceReport{
 		ID:             thirdPartyComplianceReportID,
@@ -115,7 +116,7 @@ func (s ThirdPartyComplianceReportService) Upload(
 	err = s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			return thirdPartyComplianceReport.Insert(ctx, tx, s.svc.scope)
+			return thirdPartyComplianceReport.Insert(ctx, tx, scope)
 		},
 	)
 	if err != nil {
@@ -126,7 +127,7 @@ func (s ThirdPartyComplianceReportService) Upload(
 }
 
 func (s ThirdPartyComplianceReportService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyComplianceReportID gid.GID,
 ) (*coredata.ThirdPartyComplianceReport, error) {
 	thirdPartyComplianceReport := &coredata.ThirdPartyComplianceReport{}
@@ -134,7 +135,7 @@ func (s ThirdPartyComplianceReportService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return thirdPartyComplianceReport.LoadByID(ctx, conn, s.svc.scope, thirdPartyComplianceReportID)
+			return thirdPartyComplianceReport.LoadByID(ctx, conn, scope, thirdPartyComplianceReportID)
 		},
 	)
 	if err != nil {
@@ -145,7 +146,7 @@ func (s ThirdPartyComplianceReportService) Get(
 }
 
 func (s ThirdPartyComplianceReportService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyComplianceReportID gid.GID,
 ) error {
 	thirdPartyComplianceReport := &coredata.ThirdPartyComplianceReport{ID: thirdPartyComplianceReportID}
@@ -153,7 +154,7 @@ func (s ThirdPartyComplianceReportService) Delete(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			if err := thirdPartyComplianceReport.Delete(ctx, tx, s.svc.scope); err != nil {
+			if err := thirdPartyComplianceReport.Delete(ctx, tx, scope); err != nil {
 				return err
 			}
 

--- a/pkg/probo/third_party_contact_service.go
+++ b/pkg/probo/third_party_contact_service.go
@@ -29,7 +29,7 @@ import (
 
 type (
 	ThirdPartyContactService struct {
-		svc *TenantService
+		svc *Service
 	}
 
 	CreateThirdPartyContactRequest struct {
@@ -72,7 +72,7 @@ func (uvcr *UpdateThirdPartyContactRequest) Validate() error {
 }
 
 func (s ThirdPartyContactService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyContactID gid.GID,
 ) (*coredata.ThirdPartyContact, error) {
 	thirdPartyContact := &coredata.ThirdPartyContact{}
@@ -80,7 +80,7 @@ func (s ThirdPartyContactService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			err := thirdPartyContact.LoadByID(ctx, conn, s.svc.scope, thirdPartyContactID)
+			err := thirdPartyContact.LoadByID(ctx, conn, scope, thirdPartyContactID)
 			if err != nil {
 				return fmt.Errorf("cannot load thirdParty contact: %w", err)
 			}
@@ -96,7 +96,7 @@ func (s ThirdPartyContactService) Get(
 }
 
 func (s ThirdPartyContactService) List(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyID gid.GID,
 	cursor *page.Cursor[coredata.ThirdPartyContactOrderField],
 ) (*page.Page[*coredata.ThirdPartyContact, coredata.ThirdPartyContactOrderField], error) {
@@ -105,7 +105,7 @@ func (s ThirdPartyContactService) List(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			err := thirdPartyContacts.LoadByThirdPartyID(ctx, conn, s.svc.scope, thirdPartyID, cursor)
+			err := thirdPartyContacts.LoadByThirdPartyID(ctx, conn, scope, thirdPartyID, cursor)
 			if err != nil {
 				return fmt.Errorf("cannot load thirdParty contacts: %w", err)
 			}
@@ -121,7 +121,7 @@ func (s ThirdPartyContactService) List(
 }
 
 func (s ThirdPartyContactService) Create(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req CreateThirdPartyContactRequest,
 ) (*coredata.ThirdPartyContact, error) {
 	if err := req.Validate(); err != nil {
@@ -130,7 +130,7 @@ func (s ThirdPartyContactService) Create(
 
 	now := time.Now()
 	thirdPartyContact := &coredata.ThirdPartyContact{
-		ID:           gid.New(s.svc.scope.GetTenantID(), coredata.ThirdPartyContactEntityType),
+		ID:           gid.New(scope.GetTenantID(), coredata.ThirdPartyContactEntityType),
 		ThirdPartyID: req.ThirdPartyID,
 		FullName:     req.FullName,
 		Email:        req.Email,
@@ -144,13 +144,13 @@ func (s ThirdPartyContactService) Create(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			thirdParty := &coredata.ThirdParty{}
-			if err := thirdParty.LoadByID(ctx, conn, s.svc.scope, req.ThirdPartyID); err != nil {
+			if err := thirdParty.LoadByID(ctx, conn, scope, req.ThirdPartyID); err != nil {
 				return fmt.Errorf("cannot load thirdParty: %w", err)
 			}
 
 			thirdPartyContact.OrganizationID = thirdParty.OrganizationID
 
-			if err := thirdPartyContact.Insert(ctx, conn, s.svc.scope); err != nil {
+			if err := thirdPartyContact.Insert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot insert thirdParty contact: %w", err)
 			}
 
@@ -165,7 +165,7 @@ func (s ThirdPartyContactService) Create(
 }
 
 func (s ThirdPartyContactService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req UpdateThirdPartyContactRequest,
 ) (*coredata.ThirdPartyContact, error) {
 	if err := req.Validate(); err != nil {
@@ -177,7 +177,7 @@ func (s ThirdPartyContactService) Update(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			err := thirdPartyContact.LoadByID(ctx, conn, s.svc.scope, req.ID)
+			err := thirdPartyContact.LoadByID(ctx, conn, scope, req.ID)
 			if err != nil {
 				return fmt.Errorf("cannot load thirdParty contact: %w", err)
 			}
@@ -200,7 +200,7 @@ func (s ThirdPartyContactService) Update(
 
 			thirdPartyContact.UpdatedAt = time.Now()
 
-			return thirdPartyContact.Update(ctx, conn, s.svc.scope)
+			return thirdPartyContact.Update(ctx, conn, scope)
 		},
 	)
 	if err != nil {
@@ -211,7 +211,7 @@ func (s ThirdPartyContactService) Update(
 }
 
 func (s ThirdPartyContactService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyContactID gid.GID,
 ) error {
 	thirdPartyContact := coredata.ThirdPartyContact{ID: thirdPartyContactID}
@@ -219,11 +219,11 @@ func (s ThirdPartyContactService) Delete(
 	return s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := thirdPartyContact.LoadByID(ctx, conn, s.svc.scope, thirdPartyContactID); err != nil {
+			if err := thirdPartyContact.LoadByID(ctx, conn, scope, thirdPartyContactID); err != nil {
 				return fmt.Errorf("cannot load thirdParty contact: %w", err)
 			}
 
-			if err := thirdPartyContact.Delete(ctx, conn, s.svc.scope); err != nil {
+			if err := thirdPartyContact.Delete(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot delete thirdParty contact: %w", err)
 			}
 

--- a/pkg/probo/third_party_data_privacy_agreement_service.go
+++ b/pkg/probo/third_party_data_privacy_agreement_service.go
@@ -33,7 +33,7 @@ import (
 
 type (
 	ThirdPartyDataPrivacyAgreementService struct {
-		svc *TenantService
+		svc *Service
 	}
 
 	ThirdPartyDataPrivacyAgreementCreateRequest struct {
@@ -67,7 +67,7 @@ func (vdpaur *ThirdPartyDataPrivacyAgreementUpdateRequest) Validate() error {
 }
 
 func (s ThirdPartyDataPrivacyAgreementService) GetByThirdPartyID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyID gid.GID,
 ) (*coredata.ThirdPartyDataPrivacyAgreement, *coredata.File, error) {
 	var (
@@ -79,12 +79,12 @@ func (s ThirdPartyDataPrivacyAgreementService) GetByThirdPartyID(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			thirdPartyDataPrivacyAgreement = &coredata.ThirdPartyDataPrivacyAgreement{}
-			if err := thirdPartyDataPrivacyAgreement.LoadByThirdPartyID(ctx, conn, s.svc.scope, thirdPartyID); err != nil {
+			if err := thirdPartyDataPrivacyAgreement.LoadByThirdPartyID(ctx, conn, scope, thirdPartyID); err != nil {
 				return fmt.Errorf("cannot load thirdParty data privacy agreement: %w", err)
 			}
 
 			file = &coredata.File{}
-			if err := file.LoadByID(ctx, conn, s.svc.scope, thirdPartyDataPrivacyAgreement.FileID); err != nil {
+			if err := file.LoadByID(ctx, conn, scope, thirdPartyDataPrivacyAgreement.FileID); err != nil {
 				return fmt.Errorf("cannot load file: %w", err)
 			}
 
@@ -99,7 +99,7 @@ func (s ThirdPartyDataPrivacyAgreementService) GetByThirdPartyID(
 }
 
 func (s ThirdPartyDataPrivacyAgreementService) Upload(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyID gid.GID,
 	req *ThirdPartyDataPrivacyAgreementCreateRequest,
 ) (*coredata.ThirdPartyDataPrivacyAgreement, *coredata.File, error) {
@@ -122,7 +122,7 @@ func (s ThirdPartyDataPrivacyAgreementService) Upload(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			thirdParty = &coredata.ThirdParty{}
-			if err := thirdParty.LoadByID(ctx, conn, s.svc.scope, thirdPartyID); err != nil {
+			if err := thirdParty.LoadByID(ctx, conn, scope, thirdPartyID); err != nil {
 				return fmt.Errorf("cannot load thirdParty: %w", err)
 			}
 
@@ -153,8 +153,8 @@ func (s ThirdPartyDataPrivacyAgreementService) Upload(
 			}
 
 			now := time.Now()
-			fileID := gid.New(s.svc.scope.GetTenantID(), coredata.FileEntityType)
-			thirdPartyDataPrivacyAgreementID := gid.New(s.svc.scope.GetTenantID(), coredata.ThirdPartyDataPrivacyAgreementEntityType)
+			fileID := gid.New(scope.GetTenantID(), coredata.FileEntityType)
+			thirdPartyDataPrivacyAgreementID := gid.New(scope.GetTenantID(), coredata.ThirdPartyDataPrivacyAgreementEntityType)
 			file = &coredata.File{
 				ID:         fileID,
 				BucketName: s.svc.bucket,
@@ -178,11 +178,11 @@ func (s ThirdPartyDataPrivacyAgreementService) Upload(
 				UpdatedAt:      now,
 			}
 
-			if err := file.Insert(ctx, conn, s.svc.scope); err != nil {
+			if err := file.Insert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot insert file: %w", err)
 			}
 
-			if err := thirdPartyDataPrivacyAgreement.Upsert(ctx, conn, s.svc.scope); err != nil {
+			if err := thirdPartyDataPrivacyAgreement.Upsert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot insert thirdParty data privacy agreement: %w", err)
 			}
 
@@ -197,7 +197,7 @@ func (s ThirdPartyDataPrivacyAgreementService) Upload(
 }
 
 func (s ThirdPartyDataPrivacyAgreementService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyDataPrivacyAgreementID gid.GID,
 ) (*coredata.ThirdPartyDataPrivacyAgreement, *coredata.File, error) {
 	var (
@@ -209,12 +209,12 @@ func (s ThirdPartyDataPrivacyAgreementService) Get(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			thirdPartyDataPrivacyAgreement = &coredata.ThirdPartyDataPrivacyAgreement{}
-			if err := thirdPartyDataPrivacyAgreement.LoadByID(ctx, conn, s.svc.scope, thirdPartyDataPrivacyAgreementID); err != nil {
+			if err := thirdPartyDataPrivacyAgreement.LoadByID(ctx, conn, scope, thirdPartyDataPrivacyAgreementID); err != nil {
 				return fmt.Errorf("cannot load thirdParty data privacy agreement: %w", err)
 			}
 
 			file = &coredata.File{}
-			if err := file.LoadByID(ctx, conn, s.svc.scope, thirdPartyDataPrivacyAgreement.FileID); err != nil {
+			if err := file.LoadByID(ctx, conn, scope, thirdPartyDataPrivacyAgreement.FileID); err != nil {
 				return fmt.Errorf("cannot load file: %w", err)
 			}
 
@@ -229,7 +229,7 @@ func (s ThirdPartyDataPrivacyAgreementService) Get(
 }
 
 func (s ThirdPartyDataPrivacyAgreementService) GenerateFileURL(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyDataPrivacyAgreementID gid.GID,
 	expiresIn time.Duration,
 ) (string, error) {
@@ -239,12 +239,12 @@ func (s ThirdPartyDataPrivacyAgreementService) GenerateFileURL(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			thirdPartyDataPrivacyAgreement := &coredata.ThirdPartyDataPrivacyAgreement{}
-			if err := thirdPartyDataPrivacyAgreement.LoadByID(ctx, conn, s.svc.scope, thirdPartyDataPrivacyAgreementID); err != nil {
+			if err := thirdPartyDataPrivacyAgreement.LoadByID(ctx, conn, scope, thirdPartyDataPrivacyAgreementID); err != nil {
 				return fmt.Errorf("cannot load thirdParty data privacy agreement: %w", err)
 			}
 
 			file = &coredata.File{}
-			if err := file.LoadByID(ctx, conn, s.svc.scope, thirdPartyDataPrivacyAgreement.FileID); err != nil {
+			if err := file.LoadByID(ctx, conn, scope, thirdPartyDataPrivacyAgreement.FileID); err != nil {
 				return fmt.Errorf("cannot load file: %w", err)
 			}
 
@@ -277,7 +277,7 @@ func (s ThirdPartyDataPrivacyAgreementService) GenerateFileURL(
 }
 
 func (s ThirdPartyDataPrivacyAgreementService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyID gid.GID,
 	req *ThirdPartyDataPrivacyAgreementUpdateRequest,
 ) (*coredata.ThirdPartyDataPrivacyAgreement, *coredata.File, error) {
@@ -291,7 +291,7 @@ func (s ThirdPartyDataPrivacyAgreementService) Update(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := existingAgreement.LoadByThirdPartyID(ctx, conn, s.svc.scope, thirdPartyID); err != nil {
+			if err := existingAgreement.LoadByThirdPartyID(ctx, conn, scope, thirdPartyID); err != nil {
 				return fmt.Errorf("cannot load existing thirdParty data privacy agreement: %w", err)
 			}
 
@@ -307,11 +307,11 @@ func (s ThirdPartyDataPrivacyAgreementService) Update(
 
 			existingAgreement.UpdatedAt = now
 
-			if err := existingAgreement.Update(ctx, conn, s.svc.scope); err != nil {
+			if err := existingAgreement.Update(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot update thirdParty data privacy agreement: %w", err)
 			}
 
-			if err := file.LoadByID(ctx, conn, s.svc.scope, existingAgreement.FileID); err != nil {
+			if err := file.LoadByID(ctx, conn, scope, existingAgreement.FileID); err != nil {
 				return fmt.Errorf("cannot load file: %w", err)
 			}
 
@@ -326,18 +326,18 @@ func (s ThirdPartyDataPrivacyAgreementService) Update(
 }
 
 func (s ThirdPartyDataPrivacyAgreementService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyDataPrivacyAgreementID gid.GID,
 ) error {
 	return s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			thirdPartyDataPrivacyAgreement := &coredata.ThirdPartyDataPrivacyAgreement{}
-			if err := thirdPartyDataPrivacyAgreement.LoadByID(ctx, conn, s.svc.scope, thirdPartyDataPrivacyAgreementID); err != nil {
+			if err := thirdPartyDataPrivacyAgreement.LoadByID(ctx, conn, scope, thirdPartyDataPrivacyAgreementID); err != nil {
 				return fmt.Errorf("cannot load thirdParty data privacy agreement: %w", err)
 			}
 
-			if err := thirdPartyDataPrivacyAgreement.Delete(ctx, conn, s.svc.scope); err != nil {
+			if err := thirdPartyDataPrivacyAgreement.Delete(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot delete thirdParty data privacy agreement: %w", err)
 			}
 
@@ -347,18 +347,18 @@ func (s ThirdPartyDataPrivacyAgreementService) Delete(
 }
 
 func (s ThirdPartyDataPrivacyAgreementService) DeleteByThirdPartyID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyID gid.GID,
 ) error {
 	return s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			thirdPartyDataPrivacyAgreement := &coredata.ThirdPartyDataPrivacyAgreement{}
-			if err := thirdPartyDataPrivacyAgreement.LoadByThirdPartyID(ctx, conn, s.svc.scope, thirdPartyID); err != nil {
+			if err := thirdPartyDataPrivacyAgreement.LoadByThirdPartyID(ctx, conn, scope, thirdPartyID); err != nil {
 				return fmt.Errorf("cannot load thirdParty data privacy agreement: %w", err)
 			}
 
-			if err := thirdPartyDataPrivacyAgreement.DeleteByThirdPartyID(ctx, conn, s.svc.scope, thirdPartyID); err != nil {
+			if err := thirdPartyDataPrivacyAgreement.DeleteByThirdPartyID(ctx, conn, scope, thirdPartyID); err != nil {
 				return fmt.Errorf("cannot delete thirdParty data privacy agreement: %w", err)
 			}
 

--- a/pkg/probo/third_party_service.go
+++ b/pkg/probo/third_party_service.go
@@ -68,7 +68,7 @@ func (DisabledThirdPartyAssessor) Assess(
 
 type (
 	ThirdPartyService struct {
-		svc *TenantService
+		svc *Service
 	}
 
 	CreateThirdPartyRequest struct {
@@ -207,7 +207,7 @@ func (cvrar *CreateThirdPartyRiskAssessmentRequest) Validate() error {
 }
 
 func (s ThirdPartyService) CountForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (int, error) {
 	var count int
@@ -218,7 +218,7 @@ func (s ThirdPartyService) CountForOrganizationID(
 			thirdParties := coredata.ThirdParties{}
 			filter := &coredata.ThirdPartyFilter{}
 
-			count, err = thirdParties.CountByOrganizationID(ctx, conn, s.svc.scope, organizationID, filter)
+			count, err = thirdParties.CountByOrganizationID(ctx, conn, scope, organizationID, filter)
 			if err != nil {
 				return fmt.Errorf("cannot count thirdParties: %w", err)
 			}
@@ -234,7 +234,7 @@ func (s ThirdPartyService) CountForOrganizationID(
 }
 
 func (s ThirdPartyService) ListForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.ThirdPartyOrderField],
 	filter *coredata.ThirdPartyFilter,
@@ -246,14 +246,14 @@ func (s ThirdPartyService) ListForOrganizationID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := organization.LoadByID(ctx, conn, s.svc.scope, organizationID); err != nil {
+			if err := organization.LoadByID(ctx, conn, scope, organizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
 			return thirdParties.LoadByOrganizationID(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				organization.ID,
 				cursor,
 				filter,
@@ -268,7 +268,7 @@ func (s ThirdPartyService) ListForOrganizationID(
 }
 
 func (s ThirdPartyService) CountForDatumID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	datumID gid.GID,
 ) (int, error) {
 	var count int
@@ -278,7 +278,7 @@ func (s ThirdPartyService) CountForDatumID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			thirdParties := coredata.ThirdParties{}
 
-			count, err = thirdParties.CountByDatumID(ctx, conn, s.svc.scope, datumID)
+			count, err = thirdParties.CountByDatumID(ctx, conn, scope, datumID)
 			if err != nil {
 				return fmt.Errorf("cannot count thirdParties: %w", err)
 			}
@@ -294,7 +294,7 @@ func (s ThirdPartyService) CountForDatumID(
 }
 
 func (s ThirdPartyService) ListForDatumID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	datumID gid.GID,
 	cursor *page.Cursor[coredata.ThirdPartyOrderField],
 ) (*page.Page[*coredata.ThirdParty, coredata.ThirdPartyOrderField], error) {
@@ -306,7 +306,7 @@ func (s ThirdPartyService) ListForDatumID(
 			return thirdParties.LoadByDatumID(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				datumID,
 				cursor,
 			)
@@ -320,7 +320,7 @@ func (s ThirdPartyService) ListForDatumID(
 }
 
 func (s ThirdPartyService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req UpdateThirdPartyRequest,
 ) (*coredata.ThirdParty, error) {
 	if err := req.Validate(); err != nil {
@@ -332,7 +332,7 @@ func (s ThirdPartyService) Update(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := thirdParty.LoadByID(ctx, conn, s.svc.scope, req.ID); err != nil {
+			if err := thirdParty.LoadByID(ctx, conn, scope, req.ID); err != nil {
 				return fmt.Errorf("cannot load thirdParty %q: %w", req.ID, err)
 			}
 
@@ -417,7 +417,7 @@ func (s ThirdPartyService) Update(
 			if req.BusinessOwnerID != nil {
 				if *req.BusinessOwnerID != nil {
 					businessOwner := &coredata.MembershipProfile{}
-					if err := businessOwner.LoadByID(ctx, conn, s.svc.scope, **req.BusinessOwnerID); err != nil {
+					if err := businessOwner.LoadByID(ctx, conn, scope, **req.BusinessOwnerID); err != nil {
 						return fmt.Errorf("cannot load business owner profile: %w", err)
 					}
 
@@ -430,7 +430,7 @@ func (s ThirdPartyService) Update(
 			if req.SecurityOwnerID != nil {
 				if *req.SecurityOwnerID != nil {
 					securityOwner := &coredata.MembershipProfile{}
-					if err := securityOwner.LoadByID(ctx, conn, s.svc.scope, **req.SecurityOwnerID); err != nil {
+					if err := securityOwner.LoadByID(ctx, conn, scope, **req.SecurityOwnerID); err != nil {
 						return fmt.Errorf("cannot load security owner profile: %w", err)
 					}
 
@@ -442,14 +442,14 @@ func (s ThirdPartyService) Update(
 
 			thirdParty.UpdatedAt = time.Now()
 
-			if err := thirdParty.Update(ctx, conn, s.svc.scope); err != nil {
+			if err := thirdParty.Update(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot update thirdParty: %w", err)
 			}
 
 			if err := webhook.InsertData(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				thirdParty.OrganizationID,
 				coredata.WebhookEventTypeThirdPartyUpdated,
 				webhooktypes.NewThirdParty(thirdParty),
@@ -468,7 +468,7 @@ func (s ThirdPartyService) Update(
 }
 
 func (s ThirdPartyService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyID gid.GID,
 ) (*coredata.ThirdParty, error) {
 	thirdParty := &coredata.ThirdParty{}
@@ -476,7 +476,7 @@ func (s ThirdPartyService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return thirdParty.LoadByID(ctx, conn, s.svc.scope, thirdPartyID)
+			return thirdParty.LoadByID(ctx, conn, scope, thirdPartyID)
 		},
 	)
 	if err != nil {
@@ -487,7 +487,7 @@ func (s ThirdPartyService) Get(
 }
 
 func (s ThirdPartyService) GetByIDs(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyIDs ...gid.GID,
 ) (coredata.ThirdParties, error) {
 	var thirdParties coredata.ThirdParties
@@ -498,7 +498,7 @@ func (s ThirdPartyService) GetByIDs(
 			if err := thirdParties.LoadByIDs(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				thirdPartyIDs,
 			); err != nil {
 				return fmt.Errorf("cannot load thirdParties by ids: %w", err)
@@ -515,7 +515,7 @@ func (s ThirdPartyService) GetByIDs(
 }
 
 func (s ThirdPartyService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyID gid.GID,
 ) error {
 	thirdParty := &coredata.ThirdParty{}
@@ -523,14 +523,14 @@ func (s ThirdPartyService) Delete(
 	return s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := thirdParty.LoadByID(ctx, conn, s.svc.scope, thirdPartyID); err != nil {
+			if err := thirdParty.LoadByID(ctx, conn, scope, thirdPartyID); err != nil {
 				return fmt.Errorf("cannot load thirdParty: %w", err)
 			}
 
 			if err := webhook.InsertData(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				thirdParty.OrganizationID,
 				coredata.WebhookEventTypeThirdPartyDeleted,
 				webhooktypes.NewThirdParty(thirdParty),
@@ -538,13 +538,13 @@ func (s ThirdPartyService) Delete(
 				return fmt.Errorf("cannot insert webhook event: %w", err)
 			}
 
-			return thirdParty.Delete(ctx, conn, s.svc.scope)
+			return thirdParty.Delete(ctx, conn, scope)
 		},
 	)
 }
 
 func (s ThirdPartyService) Create(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req CreateThirdPartyRequest,
 ) (*coredata.ThirdParty, error) {
 	if err := req.Validate(); err != nil {
@@ -553,7 +553,7 @@ func (s ThirdPartyService) Create(
 
 	now := time.Now()
 	thirdParty := &coredata.ThirdParty{
-		ID:                            gid.New(s.svc.scope.GetTenantID(), coredata.ThirdPartyEntityType),
+		ID:                            gid.New(scope.GetTenantID(), coredata.ThirdPartyEntityType),
 		Name:                          req.Name,
 		CreatedAt:                     now,
 		UpdatedAt:                     now,
@@ -579,7 +579,7 @@ func (s ThirdPartyService) Create(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			organization := &coredata.Organization{}
-			if err := organization.LoadByID(ctx, conn, s.svc.scope, req.OrganizationID); err != nil {
+			if err := organization.LoadByID(ctx, conn, scope, req.OrganizationID); err != nil {
 				return fmt.Errorf("cannot load organization %q: %w", req.OrganizationID, err)
 			}
 
@@ -587,7 +587,7 @@ func (s ThirdPartyService) Create(
 
 			if req.BusinessOwnerID != nil {
 				businessOwner := &coredata.MembershipProfile{}
-				if err := businessOwner.LoadByID(ctx, conn, s.svc.scope, *req.BusinessOwnerID); err != nil {
+				if err := businessOwner.LoadByID(ctx, conn, scope, *req.BusinessOwnerID); err != nil {
 					return fmt.Errorf("cannot load business owner profile: %w", err)
 				}
 
@@ -596,7 +596,7 @@ func (s ThirdPartyService) Create(
 
 			if req.SecurityOwnerID != nil {
 				securityOwner := &coredata.MembershipProfile{}
-				if err := securityOwner.LoadByID(ctx, conn, s.svc.scope, *req.SecurityOwnerID); err != nil {
+				if err := securityOwner.LoadByID(ctx, conn, scope, *req.SecurityOwnerID); err != nil {
 					return fmt.Errorf("cannot load security owner profile: %w", err)
 				}
 
@@ -609,14 +609,14 @@ func (s ThirdPartyService) Create(
 				thirdParty.Category = coredata.ThirdPartyCategoryOther
 			}
 
-			if err := thirdParty.Insert(ctx, conn, s.svc.scope); err != nil {
+			if err := thirdParty.Insert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot insert thirdParty: %w", err)
 			}
 
 			if err := webhook.InsertData(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				organization.ID,
 				coredata.WebhookEventTypeThirdPartyCreated,
 				webhooktypes.NewThirdParty(thirdParty),
@@ -635,7 +635,7 @@ func (s ThirdPartyService) Create(
 }
 
 func (s ThirdPartyService) CountForAssetID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	assetID gid.GID,
 ) (int, error) {
 	var count int
@@ -645,7 +645,7 @@ func (s ThirdPartyService) CountForAssetID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			thirdParties := coredata.ThirdParties{}
 
-			count, err = thirdParties.CountByAssetID(ctx, conn, s.svc.scope, assetID)
+			count, err = thirdParties.CountByAssetID(ctx, conn, scope, assetID)
 			if err != nil {
 				return fmt.Errorf("cannot count thirdParties: %w", err)
 			}
@@ -661,7 +661,7 @@ func (s ThirdPartyService) CountForAssetID(
 }
 
 func (s ThirdPartyService) ListForAssetID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	assetID gid.GID,
 	cursor *page.Cursor[coredata.ThirdPartyOrderField],
 ) (*page.Page[*coredata.ThirdParty, coredata.ThirdPartyOrderField], error) {
@@ -670,7 +670,7 @@ func (s ThirdPartyService) ListForAssetID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return thirdParties.LoadByAssetID(ctx, conn, s.svc.scope, assetID, cursor)
+			return thirdParties.LoadByAssetID(ctx, conn, scope, assetID, cursor)
 		},
 	)
 	if err != nil {
@@ -681,7 +681,7 @@ func (s ThirdPartyService) ListForAssetID(
 }
 
 func (s ThirdPartyService) ListForProcessingActivityID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	processingActivityID gid.GID,
 	cursor *page.Cursor[coredata.ThirdPartyOrderField],
 ) (*page.Page[*coredata.ThirdParty, coredata.ThirdPartyOrderField], error) {
@@ -690,7 +690,7 @@ func (s ThirdPartyService) ListForProcessingActivityID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			err := thirdParties.LoadByProcessingActivityID(ctx, conn, s.svc.scope, processingActivityID, cursor)
+			err := thirdParties.LoadByProcessingActivityID(ctx, conn, scope, processingActivityID, cursor)
 			if err != nil {
 				return fmt.Errorf("cannot load thirdParties by processing activity: %w", err)
 			}
@@ -706,7 +706,7 @@ func (s ThirdPartyService) ListForProcessingActivityID(
 }
 
 func (s ThirdPartyService) ListRiskAssessments(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyID gid.GID,
 	cursor *page.Cursor[coredata.ThirdPartyRiskAssessmentOrderField],
 ) (*page.Page[*coredata.ThirdPartyRiskAssessment, coredata.ThirdPartyRiskAssessmentOrderField], error) {
@@ -715,7 +715,7 @@ func (s ThirdPartyService) ListRiskAssessments(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return thirdPartyRiskAssessments.LoadByThirdPartyID(ctx, conn, s.svc.scope, thirdPartyID, cursor)
+			return thirdPartyRiskAssessments.LoadByThirdPartyID(ctx, conn, scope, thirdPartyID, cursor)
 		},
 	)
 	if err != nil {
@@ -726,14 +726,14 @@ func (s ThirdPartyService) ListRiskAssessments(
 }
 
 func (s ThirdPartyService) CreateRiskAssessment(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req CreateThirdPartyRiskAssessmentRequest,
 ) (*coredata.ThirdPartyRiskAssessment, error) {
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
 
-	thirdPartyRiskAssessmentID := gid.New(s.svc.scope.GetTenantID(), coredata.ThirdPartyRiskAssessmentEntityType)
+	thirdPartyRiskAssessmentID := gid.New(scope.GetTenantID(), coredata.ThirdPartyRiskAssessmentEntityType)
 
 	now := time.Now()
 
@@ -756,17 +756,17 @@ func (s ThirdPartyService) CreateRiskAssessment(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			thirdParty := coredata.ThirdParty{}
-			if err := thirdParty.LoadByID(ctx, tx, s.svc.scope, req.ThirdPartyID); err != nil {
+			if err := thirdParty.LoadByID(ctx, tx, scope, req.ThirdPartyID); err != nil {
 				return fmt.Errorf("cannot load thirdParty: %w", err)
 			}
 
 			thirdPartyRiskAssessment.OrganizationID = thirdParty.OrganizationID
 
-			if err := thirdParty.ExpireNonExpiredRiskAssessments(ctx, tx, s.svc.scope); err != nil {
+			if err := thirdParty.ExpireNonExpiredRiskAssessments(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot expire thirdParty risk assessments: %w", err)
 			}
 
-			if err := thirdPartyRiskAssessment.Insert(ctx, tx, s.svc.scope); err != nil {
+			if err := thirdPartyRiskAssessment.Insert(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot insert thirdParty risk assessment: %w", err)
 			}
 
@@ -781,7 +781,7 @@ func (s ThirdPartyService) CreateRiskAssessment(
 }
 
 func (s ThirdPartyService) GetRiskAssessment(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyRiskAssessmentID gid.GID,
 ) (*coredata.ThirdPartyRiskAssessment, error) {
 	thirdPartyRiskAssessment := &coredata.ThirdPartyRiskAssessment{}
@@ -789,7 +789,7 @@ func (s ThirdPartyService) GetRiskAssessment(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return thirdPartyRiskAssessment.LoadByID(ctx, conn, s.svc.scope, thirdPartyRiskAssessmentID)
+			return thirdPartyRiskAssessment.LoadByID(ctx, conn, scope, thirdPartyRiskAssessmentID)
 		},
 	)
 	if err != nil {
@@ -800,7 +800,7 @@ func (s ThirdPartyService) GetRiskAssessment(
 }
 
 func (s ThirdPartyService) GetByRiskAssessmentID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyRiskAssessmentID gid.GID,
 ) (*coredata.ThirdParty, error) {
 	thirdParty := &coredata.ThirdParty{}
@@ -809,11 +809,11 @@ func (s ThirdPartyService) GetByRiskAssessmentID(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			thirdPartyRiskAssessment := &coredata.ThirdPartyRiskAssessment{}
-			if err := thirdPartyRiskAssessment.LoadByID(ctx, conn, s.svc.scope, thirdPartyRiskAssessmentID); err != nil {
+			if err := thirdPartyRiskAssessment.LoadByID(ctx, conn, scope, thirdPartyRiskAssessmentID); err != nil {
 				return fmt.Errorf("cannot load thirdParty risk assessment: %w", err)
 			}
 
-			if err := thirdParty.LoadByID(ctx, conn, s.svc.scope, thirdPartyRiskAssessment.ThirdPartyID); err != nil {
+			if err := thirdParty.LoadByID(ctx, conn, scope, thirdPartyRiskAssessment.ThirdPartyID); err != nil {
 				return fmt.Errorf("cannot load thirdParty: %w", err)
 			}
 
@@ -828,7 +828,7 @@ func (s ThirdPartyService) GetByRiskAssessmentID(
 }
 
 func (s ThirdPartyService) Assess(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req AssessThirdPartyRequest,
 ) (*AssessThirdPartyResult, error) {
 	result, err := s.svc.thirdPartyAssessor.Assess(ctx, req.WebsiteURL, ref.UnrefOrZero(req.Procedure), nil)
@@ -841,7 +841,7 @@ func (s ThirdPartyService) Assess(
 	err = s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := thirdParty.LoadByID(ctx, conn, s.svc.scope, req.ID); err != nil {
+			if err := thirdParty.LoadByID(ctx, conn, scope, req.ID); err != nil {
 				return fmt.Errorf("cannot load thirdParty %q: %w", req.ID, err)
 			}
 
@@ -910,14 +910,14 @@ func (s ThirdPartyService) Assess(
 				thirdParty.Certifications = info.Certifications
 			}
 
-			if err := thirdParty.Update(ctx, conn, s.svc.scope); err != nil {
+			if err := thirdParty.Update(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot update thirdParty: %w", err)
 			}
 
 			if err := webhook.InsertData(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				thirdParty.OrganizationID,
 				coredata.WebhookEventTypeThirdPartyUpdated,
 				webhooktypes.NewThirdParty(thirdParty),

--- a/pkg/probo/third_party_service_service.go
+++ b/pkg/probo/third_party_service_service.go
@@ -28,7 +28,7 @@ import (
 
 type (
 	ThirdPartyServiceService struct {
-		svc *TenantService
+		svc *Service
 	}
 
 	CreateThirdPartyServiceRequest struct {
@@ -65,7 +65,7 @@ func (uvsr *UpdateThirdPartyServiceRequest) Validate() error {
 }
 
 func (s ThirdPartyServiceService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyServiceID gid.GID,
 ) (*coredata.ThirdPartyService, error) {
 	thirdPartyService := &coredata.ThirdPartyService{}
@@ -73,7 +73,7 @@ func (s ThirdPartyServiceService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			err := thirdPartyService.LoadByID(ctx, conn, s.svc.scope, thirdPartyServiceID)
+			err := thirdPartyService.LoadByID(ctx, conn, scope, thirdPartyServiceID)
 			if err != nil {
 				return fmt.Errorf("cannot load thirdParty service: %w", err)
 			}
@@ -89,7 +89,7 @@ func (s ThirdPartyServiceService) Get(
 }
 
 func (s ThirdPartyServiceService) List(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyID gid.GID,
 	cursor *page.Cursor[coredata.ThirdPartyServiceOrderField],
 ) (*page.Page[*coredata.ThirdPartyService, coredata.ThirdPartyServiceOrderField], error) {
@@ -98,7 +98,7 @@ func (s ThirdPartyServiceService) List(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			err := thirdPartyServices.LoadByThirdPartyID(ctx, conn, s.svc.scope, thirdPartyID, cursor)
+			err := thirdPartyServices.LoadByThirdPartyID(ctx, conn, scope, thirdPartyID, cursor)
 			if err != nil {
 				return fmt.Errorf("cannot load thirdParty services: %w", err)
 			}
@@ -114,7 +114,7 @@ func (s ThirdPartyServiceService) List(
 }
 
 func (s ThirdPartyServiceService) Create(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req CreateThirdPartyServiceRequest,
 ) (*coredata.ThirdPartyService, error) {
 	if err := req.Validate(); err != nil {
@@ -123,7 +123,7 @@ func (s ThirdPartyServiceService) Create(
 
 	now := time.Now()
 	thirdPartyService := &coredata.ThirdPartyService{
-		ID:           gid.New(s.svc.scope.GetTenantID(), coredata.ThirdPartyServiceEntityType),
+		ID:           gid.New(scope.GetTenantID(), coredata.ThirdPartyServiceEntityType),
 		ThirdPartyID: req.ThirdPartyID,
 		Name:         req.Name,
 		Description:  req.Description,
@@ -135,13 +135,13 @@ func (s ThirdPartyServiceService) Create(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			thirdParty := &coredata.ThirdParty{}
-			if err := thirdParty.LoadByID(ctx, conn, s.svc.scope, req.ThirdPartyID); err != nil {
+			if err := thirdParty.LoadByID(ctx, conn, scope, req.ThirdPartyID); err != nil {
 				return fmt.Errorf("cannot load thirdParty: %w", err)
 			}
 
 			thirdPartyService.OrganizationID = thirdParty.OrganizationID
 
-			if err := thirdPartyService.Insert(ctx, conn, s.svc.scope); err != nil {
+			if err := thirdPartyService.Insert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot insert thirdParty service: %w", err)
 			}
 
@@ -156,7 +156,7 @@ func (s ThirdPartyServiceService) Create(
 }
 
 func (s ThirdPartyServiceService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req UpdateThirdPartyServiceRequest,
 ) (*coredata.ThirdPartyService, error) {
 	if err := req.Validate(); err != nil {
@@ -168,7 +168,7 @@ func (s ThirdPartyServiceService) Update(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			err := thirdPartyService.LoadByID(ctx, conn, s.svc.scope, req.ID)
+			err := thirdPartyService.LoadByID(ctx, conn, scope, req.ID)
 			if err != nil {
 				return fmt.Errorf("cannot load thirdParty service: %w", err)
 			}
@@ -183,7 +183,7 @@ func (s ThirdPartyServiceService) Update(
 
 			thirdPartyService.UpdatedAt = time.Now()
 
-			if err := thirdPartyService.Update(ctx, conn, s.svc.scope); err != nil {
+			if err := thirdPartyService.Update(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot update thirdParty service: %w", err)
 			}
 
@@ -198,7 +198,7 @@ func (s ThirdPartyServiceService) Update(
 }
 
 func (s ThirdPartyServiceService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	thirdPartyServiceID gid.GID,
 ) error {
 	thirdPartyService := coredata.ThirdPartyService{ID: thirdPartyServiceID}
@@ -206,11 +206,11 @@ func (s ThirdPartyServiceService) Delete(
 	return s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := thirdPartyService.LoadByID(ctx, conn, s.svc.scope, thirdPartyServiceID); err != nil {
+			if err := thirdPartyService.LoadByID(ctx, conn, scope, thirdPartyServiceID); err != nil {
 				return fmt.Errorf("cannot load thirdParty service: %w", err)
 			}
 
-			if err := thirdPartyService.Delete(ctx, conn, s.svc.scope); err != nil {
+			if err := thirdPartyService.Delete(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot delete thirdParty service: %w", err)
 			}
 

--- a/pkg/probo/transfer_impact_assessment_service.go
+++ b/pkg/probo/transfer_impact_assessment_service.go
@@ -27,7 +27,7 @@ import (
 )
 
 type TransferImpactAssessmentService struct {
-	svc *TenantService
+	svc *Service
 }
 
 type (
@@ -77,7 +77,7 @@ func (req *UpdateTransferImpactAssessmentRequest) Validate() error {
 }
 
 func (s TransferImpactAssessmentService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	tiaID gid.GID,
 ) (*coredata.TransferImpactAssessment, error) {
 	tia := &coredata.TransferImpactAssessment{}
@@ -85,7 +85,7 @@ func (s TransferImpactAssessmentService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := tia.LoadByID(ctx, conn, s.svc.scope, tiaID); err != nil {
+			if err := tia.LoadByID(ctx, conn, scope, tiaID); err != nil {
 				return fmt.Errorf("cannot load transfer impact assessment: %w", err)
 			}
 
@@ -100,7 +100,7 @@ func (s TransferImpactAssessmentService) Get(
 }
 
 func (s TransferImpactAssessmentService) GetByProcessingActivityID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	processingActivityID gid.GID,
 ) (*coredata.TransferImpactAssessment, error) {
 	tia := &coredata.TransferImpactAssessment{}
@@ -108,7 +108,7 @@ func (s TransferImpactAssessmentService) GetByProcessingActivityID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := tia.LoadByProcessingActivityID(ctx, conn, s.svc.scope, processingActivityID); err != nil {
+			if err := tia.LoadByProcessingActivityID(ctx, conn, scope, processingActivityID); err != nil {
 				return fmt.Errorf("cannot load transfer impact assessment: %w", err)
 			}
 
@@ -123,7 +123,7 @@ func (s TransferImpactAssessmentService) GetByProcessingActivityID(
 }
 
 func (s TransferImpactAssessmentService) ListForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.TransferImpactAssessmentOrderField],
 ) (*page.Page[*coredata.TransferImpactAssessment, coredata.TransferImpactAssessmentOrderField], error) {
@@ -132,7 +132,7 @@ func (s TransferImpactAssessmentService) ListForOrganizationID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			err := tias.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID, cursor)
+			err := tias.LoadByOrganizationID(ctx, conn, scope, organizationID, cursor)
 			if err != nil {
 				return fmt.Errorf("cannot load transfer impact assessments: %w", err)
 			}
@@ -148,7 +148,7 @@ func (s TransferImpactAssessmentService) ListForOrganizationID(
 }
 
 func (s TransferImpactAssessmentService) CountForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (int, error) {
 	var count int
@@ -157,7 +157,7 @@ func (s TransferImpactAssessmentService) CountForOrganizationID(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			tias := coredata.TransferImpactAssessments{}
-			count, err = tias.CountByOrganizationID(ctx, conn, s.svc.scope, organizationID)
+			count, err = tias.CountByOrganizationID(ctx, conn, scope, organizationID)
 
 			return err
 		},
@@ -170,7 +170,7 @@ func (s TransferImpactAssessmentService) CountForOrganizationID(
 }
 
 func (s *TransferImpactAssessmentService) Create(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *CreateTransferImpactAssessmentRequest,
 ) (*coredata.TransferImpactAssessment, error) {
 	if err := req.Validate(); err != nil {
@@ -180,7 +180,7 @@ func (s *TransferImpactAssessmentService) Create(
 	now := time.Now()
 
 	tia := &coredata.TransferImpactAssessment{
-		ID:                    gid.New(s.svc.scope.GetTenantID(), coredata.TransferImpactAssessmentEntityType),
+		ID:                    gid.New(scope.GetTenantID(), coredata.TransferImpactAssessmentEntityType),
 		ProcessingActivityID:  req.ProcessingActivityID,
 		DataSubjects:          req.DataSubjects,
 		LegalMechanism:        req.LegalMechanism,
@@ -195,13 +195,13 @@ func (s *TransferImpactAssessmentService) Create(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			processingActivity := &coredata.ProcessingActivity{}
-			if err := processingActivity.LoadByID(ctx, conn, s.svc.scope, req.ProcessingActivityID); err != nil {
+			if err := processingActivity.LoadByID(ctx, conn, scope, req.ProcessingActivityID); err != nil {
 				return fmt.Errorf("cannot load processing activity: %w", err)
 			}
 
 			tia.OrganizationID = processingActivity.OrganizationID
 
-			if err := tia.Insert(ctx, conn, s.svc.scope); err != nil {
+			if err := tia.Insert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot insert transfer impact assessment: %w", err)
 			}
 
@@ -216,7 +216,7 @@ func (s *TransferImpactAssessmentService) Create(
 }
 
 func (s *TransferImpactAssessmentService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *UpdateTransferImpactAssessmentRequest,
 ) (*coredata.TransferImpactAssessment, error) {
 	if err := req.Validate(); err != nil {
@@ -228,7 +228,7 @@ func (s *TransferImpactAssessmentService) Update(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := tia.LoadByID(ctx, conn, s.svc.scope, req.ID); err != nil {
+			if err := tia.LoadByID(ctx, conn, scope, req.ID); err != nil {
 				return fmt.Errorf("cannot load transfer impact assessment: %w", err)
 			}
 
@@ -254,7 +254,7 @@ func (s *TransferImpactAssessmentService) Update(
 
 			tia.UpdatedAt = time.Now()
 
-			if err := tia.Update(ctx, conn, s.svc.scope); err != nil {
+			if err := tia.Update(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot update transfer impact assessment: %w", err)
 			}
 
@@ -269,18 +269,18 @@ func (s *TransferImpactAssessmentService) Update(
 }
 
 func (s *TransferImpactAssessmentService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	tiaID gid.GID,
 ) error {
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			tia := &coredata.TransferImpactAssessment{}
-			if err := tia.LoadByID(ctx, conn, s.svc.scope, tiaID); err != nil {
+			if err := tia.LoadByID(ctx, conn, scope, tiaID); err != nil {
 				return fmt.Errorf("cannot load transfer impact assessment: %w", err)
 			}
 
-			if err := tia.Delete(ctx, conn, s.svc.scope); err != nil {
+			if err := tia.Delete(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot delete transfer impact assessment: %w", err)
 			}
 

--- a/pkg/probo/trust_center_access_service.go
+++ b/pkg/probo/trust_center_access_service.go
@@ -32,7 +32,7 @@ import (
 
 type (
 	TrustCenterAccessService struct {
-		svc *TenantService
+		svc *Service
 	}
 
 	CreateTrustCenterAccessRequest struct {
@@ -79,7 +79,7 @@ func (utcar *UpdateTrustCenterAccessRequest) Validate() error {
 }
 
 func (s TrustCenterAccessService) ListForTrustCenterID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	trustCenterID gid.GID,
 	cursor *page.Cursor[coredata.TrustCenterAccessOrderField],
 ) (*page.Page[*coredata.TrustCenterAccess, coredata.TrustCenterAccessOrderField], error) {
@@ -88,7 +88,7 @@ func (s TrustCenterAccessService) ListForTrustCenterID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return accesses.LoadByTrustCenterID(ctx, conn, s.svc.scope, trustCenterID, cursor)
+			return accesses.LoadByTrustCenterID(ctx, conn, scope, trustCenterID, cursor)
 		},
 	)
 	if err != nil {
@@ -99,7 +99,7 @@ func (s TrustCenterAccessService) ListForTrustCenterID(
 }
 
 func (s TrustCenterAccessService) ListAvailableDocumentAccesses(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	trustCenterAccessID gid.GID,
 	cursor *page.Cursor[coredata.TrustCenterDocumentAccessOrderField],
 ) (*page.Page[*coredata.TrustCenterDocumentAccess, coredata.TrustCenterDocumentAccessOrderField], error) {
@@ -108,7 +108,7 @@ func (s TrustCenterAccessService) ListAvailableDocumentAccesses(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return documentAccesses.LoadAvailableByTrustCenterAccessID(ctx, conn, s.svc.scope, trustCenterAccessID, cursor)
+			return documentAccesses.LoadAvailableByTrustCenterAccessID(ctx, conn, scope, trustCenterAccessID, cursor)
 		},
 	)
 	if err != nil {
@@ -119,7 +119,7 @@ func (s TrustCenterAccessService) ListAvailableDocumentAccesses(
 }
 
 func (s TrustCenterAccessService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	accessID gid.GID,
 ) (*coredata.TrustCenterAccess, error) {
 	var access coredata.TrustCenterAccess
@@ -127,7 +127,7 @@ func (s TrustCenterAccessService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return access.LoadByID(ctx, conn, s.svc.scope, accessID)
+			return access.LoadByID(ctx, conn, scope, accessID)
 		},
 	)
 	if err != nil {
@@ -138,7 +138,7 @@ func (s TrustCenterAccessService) Get(
 }
 
 func (s TrustCenterAccessService) CountDocumentAccesses(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	trustCenterAccessID gid.GID,
 ) (int, error) {
 	var count int
@@ -151,7 +151,7 @@ func (s TrustCenterAccessService) CountDocumentAccesses(
 				err              error
 			)
 
-			count, err = documentAccesses.CountByTrustCenterAccessID(ctx, conn, s.svc.scope, trustCenterAccessID)
+			count, err = documentAccesses.CountByTrustCenterAccessID(ctx, conn, scope, trustCenterAccessID)
 
 			return err
 		},
@@ -164,7 +164,7 @@ func (s TrustCenterAccessService) CountDocumentAccesses(
 }
 
 func (s TrustCenterAccessService) CountPendingRequestDocumentAccesses(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	trustCenterAccessID gid.GID,
 ) (int, error) {
 	var count int
@@ -177,7 +177,7 @@ func (s TrustCenterAccessService) CountPendingRequestDocumentAccesses(
 				err              error
 			)
 
-			count, err = documentAccesses.CountPendingRequestByTrustCenterAccessID(ctx, conn, s.svc.scope, trustCenterAccessID)
+			count, err = documentAccesses.CountPendingRequestByTrustCenterAccessID(ctx, conn, scope, trustCenterAccessID)
 
 			return err
 		},
@@ -190,7 +190,7 @@ func (s TrustCenterAccessService) CountPendingRequestDocumentAccesses(
 }
 
 func (s TrustCenterAccessService) CountActiveDocumentAccesses(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	trustCenterAccessID gid.GID,
 ) (int, error) {
 	var count int
@@ -203,7 +203,7 @@ func (s TrustCenterAccessService) CountActiveDocumentAccesses(
 				err              error
 			)
 
-			count, err = documentAccesses.CountActiveByTrustCenterAccessID(ctx, conn, s.svc.scope, trustCenterAccessID)
+			count, err = documentAccesses.CountActiveByTrustCenterAccessID(ctx, conn, scope, trustCenterAccessID)
 
 			return err
 		},
@@ -216,7 +216,7 @@ func (s TrustCenterAccessService) CountActiveDocumentAccesses(
 }
 
 func (s TrustCenterAccessService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *UpdateTrustCenterAccessRequest,
 ) (*coredata.TrustCenterAccess, error) {
 	if err := req.Validate(); err != nil {
@@ -234,7 +234,7 @@ func (s TrustCenterAccessService) Update(
 		func(ctx context.Context, tx pg.Tx) error {
 			access = &coredata.TrustCenterAccess{}
 
-			if err := access.LoadByID(ctx, tx, s.svc.scope, req.ID); err != nil {
+			if err := access.LoadByID(ctx, tx, scope, req.ID); err != nil {
 				return fmt.Errorf("cannot load trust center access: %w", err)
 			}
 
@@ -249,7 +249,7 @@ func (s TrustCenterAccessService) Update(
 					})
 				}
 
-				if err := tcdas.MergeDocumentAccesses(ctx, tx, s.svc.scope, access.OrganizationID, access.ID, documentData); err != nil {
+				if err := tcdas.MergeDocumentAccesses(ctx, tx, scope, access.OrganizationID, access.ID, documentData); err != nil {
 					return fmt.Errorf("cannot merge document accesses: %w", err)
 				}
 			}
@@ -263,7 +263,7 @@ func (s TrustCenterAccessService) Update(
 					})
 				}
 
-				if err := tcdas.MergeReportAccesses(ctx, tx, s.svc.scope, access.OrganizationID, access.ID, reportData); err != nil {
+				if err := tcdas.MergeReportAccesses(ctx, tx, scope, access.OrganizationID, access.ID, reportData); err != nil {
 					return fmt.Errorf("cannot merge report accesses: %w", err)
 				}
 			}
@@ -277,13 +277,13 @@ func (s TrustCenterAccessService) Update(
 					})
 				}
 
-				if err := tcdas.MergeTrustCenterFileAccesses(ctx, tx, s.svc.scope, access.OrganizationID, access.ID, fileData); err != nil {
+				if err := tcdas.MergeTrustCenterFileAccesses(ctx, tx, scope, access.OrganizationID, access.ID, fileData); err != nil {
 					return fmt.Errorf("cannot merge trust center file accesses: %w", err)
 				}
 			}
 
 			if trustCenterAcessActivated {
-				if err := s.sendAccessEmail(ctx, tx, access); err != nil {
+				if err := s.sendAccessEmail(ctx, scope, tx, access); err != nil {
 					return fmt.Errorf("cannot send access email: %w", err)
 				}
 			}
@@ -301,7 +301,7 @@ func (s TrustCenterAccessService) Update(
 	}
 
 	if shouldUpdateSlackMessage {
-		if err := s.svc.SlackMessages.QueueSlackNotification(ctx, access.IdentityID, access.TrustCenterID); err != nil {
+		if err := s.svc.SlackMessages.QueueSlackNotification(ctx, scope, access.IdentityID, access.TrustCenterID); err != nil {
 			if !errors.Is(err, slack.ErrNoSlackConnector) {
 				return nil, fmt.Errorf("cannot queue slack notification: %w", err)
 			}
@@ -312,7 +312,7 @@ func (s TrustCenterAccessService) Update(
 }
 
 func (s TrustCenterAccessService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	trustCenterAccessID gid.GID,
 ) error {
 	err := s.svc.pg.WithTx(
@@ -320,11 +320,11 @@ func (s TrustCenterAccessService) Delete(
 		func(ctx context.Context, tx pg.Tx) error {
 			access := &coredata.TrustCenterAccess{}
 
-			if err := access.LoadByID(ctx, tx, s.svc.scope, trustCenterAccessID); err != nil {
+			if err := access.LoadByID(ctx, tx, scope, trustCenterAccessID); err != nil {
 				return fmt.Errorf("cannot load trust center access: %w", err)
 			}
 
-			if err := access.Delete(ctx, tx, s.svc.scope); err != nil {
+			if err := access.Delete(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot delete trust center access: %w", err)
 			}
 
@@ -335,16 +335,16 @@ func (s TrustCenterAccessService) Delete(
 	return err
 }
 
-func (s TrustCenterAccessService) sendAccessEmail(ctx context.Context, tx pg.Tx, access *coredata.TrustCenterAccess) error {
+func (s TrustCenterAccessService) sendAccessEmail(ctx context.Context, scope coredata.Scoper, tx pg.Tx, access *coredata.TrustCenterAccess) error {
 	organization := &coredata.Organization{}
-	if err := organization.LoadByID(ctx, tx, s.svc.scope, access.OrganizationID); err != nil {
+	if err := organization.LoadByID(ctx, tx, scope, access.OrganizationID); err != nil {
 		return fmt.Errorf("cannot load organization: %w", err)
 	}
 
 	now := time.Now()
 	access.UpdatedAt = now
 
-	if err := access.Update(ctx, tx, s.svc.scope); err != nil {
+	if err := access.Update(ctx, tx, scope); err != nil {
 		return fmt.Errorf("cannot update trust center access with expiration: %w", err)
 	}
 
@@ -352,14 +352,14 @@ func (s TrustCenterAccessService) sendAccessEmail(ctx context.Context, tx pg.Tx,
 	if err := profile.LoadByIdentityIDAndOrganizationID(
 		ctx,
 		tx,
-		s.svc.scope,
+		scope,
 		access.IdentityID,
 		access.OrganizationID,
 	); err != nil {
 		return fmt.Errorf("cannot load profile: %w", err)
 	}
 
-	emailPresenterCfg, err := s.svc.TrustCenters.EmailPresenterConfig(ctx, access.TrustCenterID)
+	emailPresenterCfg, err := s.svc.TrustCenters.EmailPresenterConfig(ctx, scope, access.TrustCenterID)
 	if err != nil {
 		return fmt.Errorf("cannot get compliance page email presenter config: %w", err)
 	}

--- a/pkg/probo/trust_center_file_service.go
+++ b/pkg/probo/trust_center_file_service.go
@@ -35,7 +35,7 @@ import (
 
 type (
 	TrustCenterFileService struct {
-		svc           *TenantService
+		svc           *Service
 		fileValidator *filevalidation.FileValidator
 	}
 
@@ -79,7 +79,7 @@ func (utcfr *UpdateTrustCenterFileRequest) Validate() error {
 }
 
 func (s TrustCenterFileService) ListForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.TrustCenterFileOrderField],
 	filter *coredata.TrustCenterFileFilter,
@@ -89,7 +89,7 @@ func (s TrustCenterFileService) ListForOrganizationID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := files.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID, cursor, filter); err != nil {
+			if err := files.LoadByOrganizationID(ctx, conn, scope, organizationID, cursor, filter); err != nil {
 				return fmt.Errorf("cannot load trust center files: %w", err)
 			}
 
@@ -103,7 +103,7 @@ func (s TrustCenterFileService) ListForOrganizationID(
 }
 
 func (s TrustCenterFileService) CountForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (int, error) {
 	var count int
@@ -113,7 +113,7 @@ func (s TrustCenterFileService) CountForOrganizationID(
 		func(ctx context.Context, conn pg.Querier) error {
 			var err error
 
-			count, err = (&coredata.TrustCenterFiles{}).CountByOrganizationID(ctx, conn, s.svc.scope, organizationID)
+			count, err = (&coredata.TrustCenterFiles{}).CountByOrganizationID(ctx, conn, scope, organizationID)
 			if err != nil {
 				return fmt.Errorf("cannot count trust center files: %w", err)
 			}
@@ -128,14 +128,14 @@ func (s TrustCenterFileService) CountForOrganizationID(
 }
 
 func (s TrustCenterFileService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	id gid.GID,
 ) (*coredata.TrustCenterFile, error) {
 	var file *coredata.TrustCenterFile
 
 	err := s.svc.pg.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
 		file = &coredata.TrustCenterFile{}
-		if err := file.LoadByID(ctx, conn, s.svc.scope, id); err != nil {
+		if err := file.LoadByID(ctx, conn, scope, id); err != nil {
 			return fmt.Errorf("cannot load trust center file: %w", err)
 		}
 
@@ -149,7 +149,7 @@ func (s TrustCenterFileService) Get(
 }
 
 func (s TrustCenterFileService) Create(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *CreateTrustCenterFileRequest,
 ) (*coredata.TrustCenterFile, error) {
 	if err := req.Validate(); err != nil {
@@ -171,7 +171,7 @@ func (s TrustCenterFileService) Create(
 
 	now := time.Now()
 
-	trustCenterFileID := gid.New(s.svc.scope.GetTenantID(), coredata.TrustCenterFileEntityType)
+	trustCenterFileID := gid.New(scope.GetTenantID(), coredata.TrustCenterFileEntityType)
 
 	var (
 		file  *coredata.TrustCenterFile
@@ -181,7 +181,7 @@ func (s TrustCenterFileService) Create(
 	err = s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
-			fileID, objectKey, err := s.uploadFile(ctx, tx, req.File, trustCenterFileID, req.OrganizationID, now)
+			fileID, objectKey, err := s.uploadFile(ctx, scope, tx, req.File, trustCenterFileID, req.OrganizationID, now)
 			if err != nil {
 				return fmt.Errorf("cannot upload file: %w", err)
 			}
@@ -199,7 +199,7 @@ func (s TrustCenterFileService) Create(
 				UpdatedAt:             now,
 			}
 
-			if err := file.Insert(ctx, tx, s.svc.scope); err != nil {
+			if err := file.Insert(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot insert trust center file: %w", err)
 			}
 
@@ -207,7 +207,7 @@ func (s TrustCenterFileService) Create(
 		},
 	)
 	if err != nil {
-		s.cleanupS3Object(ctx, s3Key)
+		s.cleanupS3Object(ctx, scope, s3Key)
 		return nil, err
 	}
 
@@ -215,7 +215,7 @@ func (s TrustCenterFileService) Create(
 }
 
 func (s TrustCenterFileService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *UpdateTrustCenterFileRequest,
 ) (*coredata.TrustCenterFile, error) {
 	if err := req.Validate(); err != nil {
@@ -231,7 +231,7 @@ func (s TrustCenterFileService) Update(
 		func(ctx context.Context, tx pg.Tx) error {
 			file = &coredata.TrustCenterFile{}
 
-			if err := file.LoadByID(ctx, tx, s.svc.scope, req.ID); err != nil {
+			if err := file.LoadByID(ctx, tx, scope, req.ID); err != nil {
 				return fmt.Errorf("cannot load trust center file: %w", err)
 			}
 
@@ -249,7 +249,7 @@ func (s TrustCenterFileService) Update(
 
 			file.UpdatedAt = now
 
-			if err := file.Update(ctx, tx, s.svc.scope); err != nil {
+			if err := file.Update(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot update trust center file: %w", err)
 			}
 
@@ -264,7 +264,7 @@ func (s TrustCenterFileService) Update(
 }
 
 func (s TrustCenterFileService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	trustCenterFileID gid.GID,
 ) error {
 	err := s.svc.pg.WithTx(
@@ -272,11 +272,11 @@ func (s TrustCenterFileService) Delete(
 		func(ctx context.Context, tx pg.Tx) error {
 			file := &coredata.TrustCenterFile{}
 
-			if err := file.LoadByID(ctx, tx, s.svc.scope, trustCenterFileID); err != nil {
+			if err := file.LoadByID(ctx, tx, scope, trustCenterFileID); err != nil {
 				return fmt.Errorf("cannot load trust center file: %w", err)
 			}
 
-			if err := file.Delete(ctx, tx, s.svc.scope); err != nil {
+			if err := file.Delete(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot delete trust center file: %w", err)
 			}
 
@@ -287,7 +287,7 @@ func (s TrustCenterFileService) Delete(
 }
 
 func (s TrustCenterFileService) GenerateFileURL(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	trustCenterFileID gid.GID,
 	duration time.Duration,
 ) (string, error) {
@@ -297,12 +297,12 @@ func (s TrustCenterFileService) GenerateFileURL(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			file := &coredata.TrustCenterFile{}
-			if err := file.LoadByID(ctx, conn, s.svc.scope, trustCenterFileID); err != nil {
+			if err := file.LoadByID(ctx, conn, scope, trustCenterFileID); err != nil {
 				return fmt.Errorf("cannot load trust center file: %w", err)
 			}
 
 			storedFile = &coredata.File{}
-			if err := storedFile.LoadByID(ctx, conn, s.svc.scope, file.FileID); err != nil {
+			if err := storedFile.LoadByID(ctx, conn, scope, file.FileID); err != nil {
 				return fmt.Errorf("cannot load file: %w", err)
 			}
 
@@ -322,14 +322,14 @@ func (s TrustCenterFileService) GenerateFileURL(
 }
 
 func (s TrustCenterFileService) uploadFile(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	tx pg.Tx,
 	file File,
 	trustCenterFileID gid.GID,
 	organizationID gid.GID,
 	now time.Time,
 ) (gid.GID, string, error) {
-	fileID := gid.New(s.svc.scope.GetTenantID(), coredata.FileEntityType)
+	fileID := gid.New(scope.GetTenantID(), coredata.FileEntityType)
 
 	objectKey, err := uuid.NewV7()
 	if err != nil {
@@ -410,14 +410,14 @@ func (s TrustCenterFileService) uploadFile(
 		UpdatedAt:  now,
 	}
 
-	if err := fileRecord.Insert(ctx, tx, s.svc.scope); err != nil {
+	if err := fileRecord.Insert(ctx, tx, scope); err != nil {
 		return gid.GID{}, "", fmt.Errorf("cannot insert file: %w", err)
 	}
 
 	return fileID, objectKey.String(), nil
 }
 
-func (s TrustCenterFileService) cleanupS3Object(ctx context.Context, s3Key string) {
+func (s TrustCenterFileService) cleanupS3Object(ctx context.Context, scope coredata.Scoper, s3Key string) {
 	if s3Key == "" {
 		return
 	}

--- a/pkg/probo/trust_center_reference_service.go
+++ b/pkg/probo/trust_center_reference_service.go
@@ -35,7 +35,7 @@ import (
 
 type (
 	TrustCenterReferenceService struct {
-		svc *TenantService
+		svc *Service
 	}
 
 	CreateTrustCenterReferenceRequest struct {
@@ -79,14 +79,14 @@ func (utcrr *UpdateTrustCenterReferenceRequest) Validate() error {
 }
 
 func (s TrustCenterReferenceService) ListForTrustCenterID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	trustCenterID gid.GID,
 	cursor *page.Cursor[coredata.TrustCenterReferenceOrderField],
 ) (*page.Page[*coredata.TrustCenterReference, coredata.TrustCenterReferenceOrderField], error) {
 	var references coredata.TrustCenterReferences
 
 	err := s.svc.pg.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
-		err := references.LoadByTrustCenterID(ctx, conn, s.svc.scope, trustCenterID, cursor)
+		err := references.LoadByTrustCenterID(ctx, conn, scope, trustCenterID, cursor)
 		if err != nil {
 			return fmt.Errorf("cannot load trust center references: %w", err)
 		}
@@ -101,7 +101,7 @@ func (s TrustCenterReferenceService) ListForTrustCenterID(
 }
 
 func (s TrustCenterReferenceService) CountForTrustCenterID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	trustCenterID gid.GID,
 ) (int, error) {
 	var count int
@@ -109,7 +109,7 @@ func (s TrustCenterReferenceService) CountForTrustCenterID(
 	err := s.svc.pg.WithConn(ctx, func(ctx context.Context, conn pg.Querier) (err error) {
 		references := coredata.TrustCenterReferences{}
 
-		count, err = references.CountByTrustCenterID(ctx, conn, s.svc.scope, trustCenterID)
+		count, err = references.CountByTrustCenterID(ctx, conn, scope, trustCenterID)
 		if err != nil {
 			return fmt.Errorf("cannot count trust center references: %w", err)
 		}
@@ -124,13 +124,13 @@ func (s TrustCenterReferenceService) CountForTrustCenterID(
 }
 
 func (s TrustCenterReferenceService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	referenceID gid.GID,
 ) (*coredata.TrustCenterReference, error) {
 	var reference coredata.TrustCenterReference
 
 	err := s.svc.pg.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
-		err := reference.LoadByID(ctx, conn, s.svc.scope, referenceID)
+		err := reference.LoadByID(ctx, conn, scope, referenceID)
 		if err != nil {
 			return fmt.Errorf("cannot load trust center reference: %w", err)
 		}
@@ -145,7 +145,7 @@ func (s TrustCenterReferenceService) Get(
 }
 
 func (s TrustCenterReferenceService) Create(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *CreateTrustCenterReferenceRequest,
 ) (*coredata.TrustCenterReference, error) {
 	if err := req.Validate(); err != nil {
@@ -154,7 +154,7 @@ func (s TrustCenterReferenceService) Create(
 
 	now := time.Now()
 
-	referenceID := gid.New(s.svc.scope.GetTenantID(), coredata.TrustCenterReferenceEntityType)
+	referenceID := gid.New(scope.GetTenantID(), coredata.TrustCenterReferenceEntityType)
 
 	var reference *coredata.TrustCenterReference
 
@@ -162,11 +162,11 @@ func (s TrustCenterReferenceService) Create(
 
 	err := s.svc.pg.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
 		trustCenter := &coredata.TrustCenter{}
-		if err := trustCenter.LoadByID(ctx, tx, s.svc.scope, req.TrustCenterID); err != nil {
+		if err := trustCenter.LoadByID(ctx, tx, scope, req.TrustCenterID); err != nil {
 			return fmt.Errorf("cannot load trust center: %w", err)
 		}
 
-		fileID, s3Key, err := s.uploadLogoFile(ctx, tx, req.LogoFile, referenceID, req.TrustCenterID, now)
+		fileID, s3Key, err := s.uploadLogoFile(ctx, scope, tx, req.LogoFile, referenceID, req.TrustCenterID, now)
 		if err != nil {
 			return fmt.Errorf("cannot upload logo file: %w", err)
 		}
@@ -185,14 +185,14 @@ func (s TrustCenterReferenceService) Create(
 			UpdatedAt:      now,
 		}
 
-		if err := reference.Insert(ctx, tx, s.svc.scope); err != nil {
+		if err := reference.Insert(ctx, tx, scope); err != nil {
 			return fmt.Errorf("cannot insert trust center reference: %w", err)
 		}
 
 		return nil
 	})
 	if err != nil {
-		s.cleanupS3Object(ctx, logoKey)
+		s.cleanupS3Object(ctx, scope, logoKey)
 		return nil, err
 	}
 
@@ -200,7 +200,7 @@ func (s TrustCenterReferenceService) Create(
 }
 
 func (s TrustCenterReferenceService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *UpdateTrustCenterReferenceRequest,
 ) (*coredata.TrustCenterReference, error) {
 	if err := req.Validate(); err != nil {
@@ -218,12 +218,12 @@ func (s TrustCenterReferenceService) Update(
 	err := s.svc.pg.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
 		reference = &coredata.TrustCenterReference{}
 
-		if err := reference.LoadByID(ctx, tx, s.svc.scope, req.ID); err != nil {
+		if err := reference.LoadByID(ctx, tx, scope, req.ID); err != nil {
 			return fmt.Errorf("cannot load trust center reference: %w", err)
 		}
 
 		if req.LogoFile != nil {
-			fileID, s3Key, err := s.uploadLogoFile(ctx, tx, *req.LogoFile, req.ID, reference.TrustCenterID, now)
+			fileID, s3Key, err := s.uploadLogoFile(ctx, scope, tx, *req.LogoFile, req.ID, reference.TrustCenterID, now)
 			if err != nil {
 				return fmt.Errorf("cannot upload logo file: %w", err)
 			}
@@ -252,19 +252,19 @@ func (s TrustCenterReferenceService) Update(
 
 		if req.Rank != nil {
 			reference.Rank = *req.Rank
-			if err := reference.UpdateRank(ctx, tx, s.svc.scope); err != nil {
+			if err := reference.UpdateRank(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot update rank: %w", err)
 			}
 		}
 
-		if err := reference.Update(ctx, tx, s.svc.scope); err != nil {
+		if err := reference.Update(ctx, tx, scope); err != nil {
 			return fmt.Errorf("cannot update trust center reference: %w", err)
 		}
 
 		return nil
 	})
 	if err != nil {
-		s.cleanupS3Object(ctx, logoKey)
+		s.cleanupS3Object(ctx, scope, logoKey)
 		return nil, err
 	}
 
@@ -272,17 +272,17 @@ func (s TrustCenterReferenceService) Update(
 }
 
 func (s TrustCenterReferenceService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	trustCenterReferenceID gid.GID,
 ) error {
 	err := s.svc.pg.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
 		reference := &coredata.TrustCenterReference{}
 
-		if err := reference.LoadByID(ctx, tx, s.svc.scope, trustCenterReferenceID); err != nil {
+		if err := reference.LoadByID(ctx, tx, scope, trustCenterReferenceID); err != nil {
 			return fmt.Errorf("cannot load trust center reference: %w", err)
 		}
 
-		if err := reference.Delete(ctx, tx, s.svc.scope); err != nil {
+		if err := reference.Delete(ctx, tx, scope); err != nil {
 			return fmt.Errorf("cannot delete trust center reference: %w", err)
 		}
 
@@ -293,7 +293,7 @@ func (s TrustCenterReferenceService) Delete(
 }
 
 func (s TrustCenterReferenceService) GenerateLogoURL(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	referenceID gid.GID,
 	duration time.Duration,
 ) (string, error) {
@@ -301,12 +301,12 @@ func (s TrustCenterReferenceService) GenerateLogoURL(
 	file := &coredata.File{}
 
 	err := s.svc.pg.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
-		err := reference.LoadByID(ctx, tx, s.svc.scope, referenceID)
+		err := reference.LoadByID(ctx, tx, scope, referenceID)
 		if err != nil {
 			return fmt.Errorf("cannot load trust center reference: %w", err)
 		}
 
-		err = file.LoadByID(ctx, tx, s.svc.scope, reference.LogoFileID)
+		err = file.LoadByID(ctx, tx, scope, reference.LogoFileID)
 		if err != nil {
 			return fmt.Errorf("cannot load logo file: %w", err)
 		}
@@ -339,14 +339,14 @@ func (s TrustCenterReferenceService) GenerateLogoURL(
 }
 
 func (s TrustCenterReferenceService) uploadLogoFile(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	tx pg.Tx,
 	file File,
 	referenceID gid.GID,
 	trustCenterID gid.GID,
 	now time.Time,
 ) (gid.GID, string, error) {
-	fileID := gid.New(s.svc.scope.GetTenantID(), coredata.FileEntityType)
+	fileID := gid.New(scope.GetTenantID(), coredata.FileEntityType)
 
 	objectKey, err := uuid.NewV7()
 	if err != nil {
@@ -354,7 +354,7 @@ func (s TrustCenterReferenceService) uploadLogoFile(
 	}
 
 	trustCenter := &coredata.TrustCenter{}
-	if err := trustCenter.LoadByID(ctx, tx, s.svc.scope, trustCenterID); err != nil {
+	if err := trustCenter.LoadByID(ctx, tx, scope, trustCenterID); err != nil {
 		return gid.GID{}, "", fmt.Errorf("cannot load trust center: %w", err)
 	}
 
@@ -432,14 +432,14 @@ func (s TrustCenterReferenceService) uploadLogoFile(
 		UpdatedAt:  now,
 	}
 
-	if err := fileRecord.Insert(ctx, tx, s.svc.scope); err != nil {
+	if err := fileRecord.Insert(ctx, tx, scope); err != nil {
 		return gid.GID{}, "", fmt.Errorf("cannot insert file: %w", err)
 	}
 
 	return fileID, objectKey.String(), nil
 }
 
-func (s TrustCenterReferenceService) cleanupS3Object(ctx context.Context, s3Key string) {
+func (s TrustCenterReferenceService) cleanupS3Object(ctx context.Context, scope coredata.Scoper, s3Key string) {
 	if s3Key == "" {
 		return
 	}

--- a/pkg/probo/trust_center_service.go
+++ b/pkg/probo/trust_center_service.go
@@ -36,7 +36,7 @@ import (
 
 type (
 	TrustCenterService struct {
-		svc *TenantService
+		svc *Service
 	}
 
 	UpdateTrustCenterRequest struct {
@@ -105,7 +105,7 @@ func (req *UpdateTrustCenterBrandRequest) Validate() error {
 }
 
 func (s TrustCenterService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	trustCenterID gid.GID,
 ) (*coredata.TrustCenter, error) {
 	var trustCenter *coredata.TrustCenter
@@ -114,7 +114,7 @@ func (s TrustCenterService) Get(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			trustCenter = &coredata.TrustCenter{}
-			if err := trustCenter.LoadByID(ctx, conn, s.svc.scope, trustCenterID); err != nil {
+			if err := trustCenter.LoadByID(ctx, conn, scope, trustCenterID); err != nil {
 				return fmt.Errorf("cannot load trust center: %w", err)
 			}
 
@@ -129,7 +129,7 @@ func (s TrustCenterService) Get(
 }
 
 func (s TrustCenterService) GetByOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (*coredata.TrustCenter, error) {
 	var trustCenter *coredata.TrustCenter
@@ -138,7 +138,7 @@ func (s TrustCenterService) GetByOrganizationID(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			trustCenter = &coredata.TrustCenter{}
-			if err := trustCenter.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID); err != nil {
+			if err := trustCenter.LoadByOrganizationID(ctx, conn, scope, organizationID); err != nil {
 				return fmt.Errorf("cannot load trust center: %w", err)
 			}
 
@@ -153,7 +153,7 @@ func (s TrustCenterService) GetByOrganizationID(
 }
 
 func (s TrustCenterService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *UpdateTrustCenterRequest,
 ) (*coredata.TrustCenter, *coredata.File, error) {
 	if err := req.Validate(); err != nil {
@@ -169,7 +169,7 @@ func (s TrustCenterService) Update(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			trustCenter = &coredata.TrustCenter{}
-			if err := trustCenter.LoadByID(ctx, conn, s.svc.scope, req.ID); err != nil {
+			if err := trustCenter.LoadByID(ctx, conn, scope, req.ID); err != nil {
 				return fmt.Errorf("cannot load trust center: %w", err)
 			}
 
@@ -187,13 +187,13 @@ func (s TrustCenterService) Update(
 
 			trustCenter.UpdatedAt = time.Now()
 
-			if err := trustCenter.Update(ctx, conn, s.svc.scope); err != nil {
+			if err := trustCenter.Update(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot update trust center: %w", err)
 			}
 
 			if trustCenter.NonDisclosureAgreementFileID != nil {
 				file = &coredata.File{}
-				if err := file.LoadByID(ctx, conn, s.svc.scope, *trustCenter.NonDisclosureAgreementFileID); err != nil {
+				if err := file.LoadByID(ctx, conn, scope, *trustCenter.NonDisclosureAgreementFileID); err != nil {
 					return fmt.Errorf("cannot load file: %w", err)
 				}
 			}
@@ -209,7 +209,7 @@ func (s TrustCenterService) Update(
 }
 
 func (s TrustCenterService) UploadNDA(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *UploadTrustCenterNDARequest,
 ) (*coredata.TrustCenter, *coredata.File, error) {
 	if err := req.Validate(); err != nil {
@@ -230,7 +230,7 @@ func (s TrustCenterService) UploadNDA(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			trustCenter = &coredata.TrustCenter{}
-			if err := trustCenter.LoadByID(ctx, conn, s.svc.scope, req.TrustCenterID); err != nil {
+			if err := trustCenter.LoadByID(ctx, conn, scope, req.TrustCenterID); err != nil {
 				return fmt.Errorf("cannot load trust center: %w", err)
 			}
 
@@ -261,7 +261,7 @@ func (s TrustCenterService) UploadNDA(
 			}
 
 			now := time.Now()
-			fileID := gid.New(s.svc.scope.GetTenantID(), coredata.FileEntityType)
+			fileID := gid.New(scope.GetTenantID(), coredata.FileEntityType)
 
 			file = &coredata.File{
 				ID:         fileID,
@@ -275,14 +275,14 @@ func (s TrustCenterService) UploadNDA(
 				UpdatedAt:  now,
 			}
 
-			if err := file.Insert(ctx, conn, s.svc.scope); err != nil {
+			if err := file.Insert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot insert file: %w", err)
 			}
 
 			trustCenter.NonDisclosureAgreementFileID = &fileID
 			trustCenter.UpdatedAt = now
 
-			if err := trustCenter.Update(ctx, conn, s.svc.scope); err != nil {
+			if err := trustCenter.Update(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot update trust center: %w", err)
 			}
 
@@ -297,7 +297,7 @@ func (s TrustCenterService) UploadNDA(
 }
 
 func (s TrustCenterService) DeleteNDA(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	trustCenterID gid.GID,
 ) (*coredata.TrustCenter, *coredata.File, error) {
 	var trustCenter *coredata.TrustCenter
@@ -306,14 +306,14 @@ func (s TrustCenterService) DeleteNDA(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			trustCenter = &coredata.TrustCenter{}
-			if err := trustCenter.LoadByID(ctx, conn, s.svc.scope, trustCenterID); err != nil {
+			if err := trustCenter.LoadByID(ctx, conn, scope, trustCenterID); err != nil {
 				return fmt.Errorf("cannot load trust center: %w", err)
 			}
 
 			trustCenter.NonDisclosureAgreementFileID = nil
 			trustCenter.UpdatedAt = time.Now()
 
-			if err := trustCenter.Update(ctx, conn, s.svc.scope); err != nil {
+			if err := trustCenter.Update(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot update trust center: %w", err)
 			}
 
@@ -328,7 +328,7 @@ func (s TrustCenterService) DeleteNDA(
 }
 
 func (s TrustCenterService) UpdateTrustCenterBrand(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req *UpdateTrustCenterBrandRequest,
 ) (*coredata.TrustCenter, *coredata.File, error) {
 	if err := req.Validate(); err != nil {
@@ -344,7 +344,7 @@ func (s TrustCenterService) UpdateTrustCenterBrand(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			trustCenter = &coredata.TrustCenter{}
-			if err := trustCenter.LoadByID(ctx, conn, s.svc.scope, req.TrustCenterID); err != nil {
+			if err := trustCenter.LoadByID(ctx, conn, scope, req.TrustCenterID); err != nil {
 				return fmt.Errorf("cannot load trust center: %w", err)
 			}
 
@@ -354,7 +354,7 @@ func (s TrustCenterService) UpdateTrustCenterBrand(
 				if *req.LogoFile == nil {
 					trustCenter.LogoFileID = nil
 				} else {
-					file, err := s.uploadFile(ctx, conn, *req.LogoFile, "trust-center-logo", trustCenter)
+					file, err := s.uploadFile(ctx, scope, conn, *req.LogoFile, "trust-center-logo", trustCenter)
 					if err != nil {
 						return fmt.Errorf("cannot upload logo file: %w", err)
 					}
@@ -367,7 +367,7 @@ func (s TrustCenterService) UpdateTrustCenterBrand(
 				if *req.DarkLogoFile == nil {
 					trustCenter.DarkLogoFileID = nil
 				} else {
-					file, err := s.uploadFile(ctx, conn, *req.DarkLogoFile, "trust-center-dark-logo", trustCenter)
+					file, err := s.uploadFile(ctx, scope, conn, *req.DarkLogoFile, "trust-center-dark-logo", trustCenter)
 					if err != nil {
 						return fmt.Errorf("cannot upload dark logo file: %w", err)
 					}
@@ -378,13 +378,13 @@ func (s TrustCenterService) UpdateTrustCenterBrand(
 
 			trustCenter.UpdatedAt = now
 
-			if err := trustCenter.Update(ctx, conn, s.svc.scope); err != nil {
+			if err := trustCenter.Update(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot update trust center: %w", err)
 			}
 
 			if trustCenter.NonDisclosureAgreementFileID != nil {
 				ndaFile = &coredata.File{}
-				if err := ndaFile.LoadByID(ctx, conn, s.svc.scope, *trustCenter.NonDisclosureAgreementFileID); err != nil {
+				if err := ndaFile.LoadByID(ctx, conn, scope, *trustCenter.NonDisclosureAgreementFileID); err != nil {
 					return fmt.Errorf("cannot load nda file: %w", err)
 				}
 			}
@@ -400,7 +400,7 @@ func (s TrustCenterService) UpdateTrustCenterBrand(
 }
 
 func (s TrustCenterService) uploadFile(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	conn pg.Tx,
 	fileUpload *FileUpload,
 	fileType string,
@@ -441,7 +441,7 @@ func (s TrustCenterService) uploadFile(
 	}
 
 	now := time.Now()
-	fileID := gid.New(s.svc.scope.GetTenantID(), coredata.FileEntityType)
+	fileID := gid.New(scope.GetTenantID(), coredata.FileEntityType)
 
 	file := &coredata.File{
 		ID:             fileID,
@@ -456,7 +456,7 @@ func (s TrustCenterService) uploadFile(
 		UpdatedAt:      now,
 	}
 
-	if err := file.Insert(ctx, conn, s.svc.scope); err != nil {
+	if err := file.Insert(ctx, conn, scope); err != nil {
 		return nil, fmt.Errorf("cannot insert file: %w", err)
 	}
 
@@ -464,7 +464,7 @@ func (s TrustCenterService) uploadFile(
 }
 
 func (s TrustCenterService) GenerateNDAFileURL(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	trustCenterID gid.GID,
 	expiresIn time.Duration,
 ) (*string, error) {
@@ -475,7 +475,7 @@ func (s TrustCenterService) GenerateNDAFileURL(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := trustCenter.LoadByID(ctx, conn, s.svc.scope, trustCenterID); err != nil {
+			if err := trustCenter.LoadByID(ctx, conn, scope, trustCenterID); err != nil {
 				return fmt.Errorf("cannot load trust center: %w", err)
 			}
 
@@ -484,7 +484,7 @@ func (s TrustCenterService) GenerateNDAFileURL(
 			}
 
 			file = &coredata.File{}
-			if err := file.LoadByID(ctx, conn, s.svc.scope, *trustCenter.NonDisclosureAgreementFileID); err != nil {
+			if err := file.LoadByID(ctx, conn, scope, *trustCenter.NonDisclosureAgreementFileID); err != nil {
 				return fmt.Errorf("cannot load file: %w", err)
 			}
 
@@ -508,7 +508,7 @@ func (s TrustCenterService) GenerateNDAFileURL(
 }
 
 func (s TrustCenterService) GenerateLogoURL(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	compliancePageID gid.GID,
 	expiresIn time.Duration,
 ) (*string, error) {
@@ -518,7 +518,7 @@ func (s TrustCenterService) GenerateLogoURL(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := compliancePage.LoadByID(ctx, conn, s.svc.scope, compliancePageID); err != nil {
+			if err := compliancePage.LoadByID(ctx, conn, scope, compliancePageID); err != nil {
 				return fmt.Errorf("cannot load compliance page: %w", err)
 			}
 
@@ -526,7 +526,7 @@ func (s TrustCenterService) GenerateLogoURL(
 				return nil
 			}
 
-			if err := file.LoadByID(ctx, conn, s.svc.scope, *compliancePage.LogoFileID); err != nil {
+			if err := file.LoadByID(ctx, conn, scope, *compliancePage.LogoFileID); err != nil {
 				return fmt.Errorf("cannot load file: %w", err)
 			}
 
@@ -554,7 +554,7 @@ func (s TrustCenterService) GenerateLogoURL(
 }
 
 func (s TrustCenterService) GenerateDarkLogoURL(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	compliancePageID gid.GID,
 	expiresIn time.Duration,
 ) (*string, error) {
@@ -564,7 +564,7 @@ func (s TrustCenterService) GenerateDarkLogoURL(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := compliancePage.LoadByID(ctx, conn, s.svc.scope, compliancePageID); err != nil {
+			if err := compliancePage.LoadByID(ctx, conn, scope, compliancePageID); err != nil {
 				return fmt.Errorf("cannot load compliance page: %w", err)
 			}
 
@@ -572,7 +572,7 @@ func (s TrustCenterService) GenerateDarkLogoURL(
 				return nil
 			}
 
-			if err := file.LoadByID(ctx, conn, s.svc.scope, *compliancePage.DarkLogoFileID); err != nil {
+			if err := file.LoadByID(ctx, conn, scope, *compliancePage.DarkLogoFileID); err != nil {
 				return fmt.Errorf("cannot load file: %w", err)
 			}
 
@@ -599,7 +599,7 @@ func (s TrustCenterService) GenerateDarkLogoURL(
 	return &presignedURL, nil
 }
 
-func (s *TrustCenterService) EmailPresenterConfig(ctx context.Context, compliancePageID gid.GID) (emails.PresenterConfig, error) {
+func (s *TrustCenterService) EmailPresenterConfig(ctx context.Context, scope coredata.Scoper, compliancePageID gid.GID) (emails.PresenterConfig, error) {
 	var (
 		compliancePage    = &coredata.TrustCenter{}
 		organization      = &coredata.Organization{}
@@ -607,8 +607,6 @@ func (s *TrustCenterService) EmailPresenterConfig(ctx context.Context, complianc
 		logoFile          = &coredata.File{}
 		emailPresenterCfg = emails.DefaultPresenterConfig(s.svc.bucket, s.svc.baseURL)
 	)
-
-	scope := coredata.NewScopeFromObjectID(compliancePageID)
 
 	err := s.svc.pg.WithConn(
 		ctx,
@@ -687,7 +685,7 @@ func (s *TrustCenterService) EmailPresenterConfig(ctx context.Context, complianc
 }
 
 func (s *TrustCenterService) GetMailingList(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	trustCenterID gid.GID,
 ) (*coredata.MailingList, error) {
 	var mailingList *coredata.MailingList
@@ -696,7 +694,7 @@ func (s *TrustCenterService) GetMailingList(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			trustCenter := &coredata.TrustCenter{}
-			if err := trustCenter.LoadByID(ctx, conn, s.svc.scope, trustCenterID); err != nil {
+			if err := trustCenter.LoadByID(ctx, conn, scope, trustCenterID); err != nil {
 				return fmt.Errorf("cannot load trust center: %w", err)
 			}
 
@@ -705,7 +703,7 @@ func (s *TrustCenterService) GetMailingList(
 			}
 
 			mailingList = &coredata.MailingList{}
-			if err := mailingList.LoadByID(ctx, conn, s.svc.scope, *trustCenter.MailingListID); err != nil {
+			if err := mailingList.LoadByID(ctx, conn, scope, *trustCenter.MailingListID); err != nil {
 				return fmt.Errorf("cannot load mailing list: %w", err)
 			}
 

--- a/pkg/probo/webhook_subscription_service.go
+++ b/pkg/probo/webhook_subscription_service.go
@@ -27,7 +27,7 @@ import (
 )
 
 type WebhookSubscriptionService struct {
-	svc *TenantService
+	svc *Service
 }
 
 type (
@@ -63,7 +63,7 @@ func (r *UpdateWebhookSubscriptionRequest) Validate() error {
 }
 
 func (s WebhookSubscriptionService) ListForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.WebhookSubscriptionOrderField],
 ) (*page.Page[*coredata.WebhookSubscription, coredata.WebhookSubscriptionOrderField], error) {
@@ -74,14 +74,14 @@ func (s WebhookSubscriptionService) ListForOrganizationID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := organization.LoadByID(ctx, conn, s.svc.scope, organizationID); err != nil {
+			if err := organization.LoadByID(ctx, conn, scope, organizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
 			err := subscriptions.LoadByOrganizationID(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				organization.ID,
 				cursor,
 			)
@@ -100,7 +100,7 @@ func (s WebhookSubscriptionService) ListForOrganizationID(
 }
 
 func (s WebhookSubscriptionService) CountForOrganizationID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	organizationID gid.GID,
 ) (int, error) {
 	var count int
@@ -110,7 +110,7 @@ func (s WebhookSubscriptionService) CountForOrganizationID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			subscriptions := &coredata.WebhookSubscriptions{}
 
-			count, err = subscriptions.CountByOrganizationID(ctx, conn, s.svc.scope, organizationID)
+			count, err = subscriptions.CountByOrganizationID(ctx, conn, scope, organizationID)
 			if err != nil {
 				return fmt.Errorf("cannot count webhook subscriptions: %w", err)
 			}
@@ -126,7 +126,7 @@ func (s WebhookSubscriptionService) CountForOrganizationID(
 }
 
 func (s WebhookSubscriptionService) Get(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	webhookSubscriptionID gid.GID,
 ) (*coredata.WebhookSubscription, error) {
 	wc := &coredata.WebhookSubscription{}
@@ -134,7 +134,7 @@ func (s WebhookSubscriptionService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := wc.LoadByID(ctx, conn, s.svc.scope, webhookSubscriptionID); err != nil {
+			if err := wc.LoadByID(ctx, conn, scope, webhookSubscriptionID); err != nil {
 				return fmt.Errorf("cannot load webhook subscription: %w", err)
 			}
 
@@ -149,7 +149,7 @@ func (s WebhookSubscriptionService) Get(
 }
 
 func (s WebhookSubscriptionService) Create(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req CreateWebhookSubscriptionRequest,
 ) (*coredata.WebhookSubscription, error) {
 	if err := req.Validate(); err != nil {
@@ -165,7 +165,7 @@ func (s WebhookSubscriptionService) Create(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := organization.LoadByID(ctx, conn, s.svc.scope, req.OrganizationID); err != nil {
+			if err := organization.LoadByID(ctx, conn, scope, req.OrganizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
@@ -182,7 +182,7 @@ func (s WebhookSubscriptionService) Create(
 				return fmt.Errorf("cannot generate signing secret: %w", err)
 			}
 
-			if err := wc.Insert(ctx, conn, s.svc.scope); err != nil {
+			if err := wc.Insert(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot insert webhook subscription: %w", err)
 			}
 
@@ -197,7 +197,7 @@ func (s WebhookSubscriptionService) Create(
 }
 
 func (s WebhookSubscriptionService) Update(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	req UpdateWebhookSubscriptionRequest,
 ) (*coredata.WebhookSubscription, error) {
 	if err := req.Validate(); err != nil {
@@ -209,7 +209,7 @@ func (s WebhookSubscriptionService) Update(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := wc.LoadByID(ctx, conn, s.svc.scope, req.WebhookSubscriptionID); err != nil {
+			if err := wc.LoadByID(ctx, conn, scope, req.WebhookSubscriptionID); err != nil {
 				return fmt.Errorf("cannot load webhook subscription: %w", err)
 			}
 
@@ -223,7 +223,7 @@ func (s WebhookSubscriptionService) Update(
 
 			wc.UpdatedAt = time.Now()
 
-			if err := wc.Update(ctx, conn, s.svc.scope); err != nil {
+			if err := wc.Update(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot update webhook subscription: %w", err)
 			}
 
@@ -238,7 +238,7 @@ func (s WebhookSubscriptionService) Update(
 }
 
 func (s WebhookSubscriptionService) GetSigningSecret(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	webhookSubscriptionID gid.GID,
 ) (string, error) {
 	wc := &coredata.WebhookSubscription{}
@@ -246,7 +246,7 @@ func (s WebhookSubscriptionService) GetSigningSecret(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := wc.LoadByID(ctx, conn, s.svc.scope, webhookSubscriptionID); err != nil {
+			if err := wc.LoadByID(ctx, conn, scope, webhookSubscriptionID); err != nil {
 				return fmt.Errorf("cannot load webhook subscription: %w", err)
 			}
 
@@ -261,7 +261,7 @@ func (s WebhookSubscriptionService) GetSigningSecret(
 }
 
 func (s WebhookSubscriptionService) ListEventsForSubscriptionID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	webhookSubscriptionID gid.GID,
 	cursor *page.Cursor[coredata.WebhookEventOrderField],
 ) (*page.Page[*coredata.WebhookEvent, coredata.WebhookEventOrderField], error) {
@@ -270,7 +270,7 @@ func (s WebhookSubscriptionService) ListEventsForSubscriptionID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := events.LoadBySubscriptionID(ctx, conn, s.svc.scope, webhookSubscriptionID, cursor); err != nil {
+			if err := events.LoadBySubscriptionID(ctx, conn, scope, webhookSubscriptionID, cursor); err != nil {
 				return fmt.Errorf("cannot load webhook events: %w", err)
 			}
 
@@ -285,7 +285,7 @@ func (s WebhookSubscriptionService) ListEventsForSubscriptionID(
 }
 
 func (s WebhookSubscriptionService) CountEventsForSubscriptionID(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	webhookSubscriptionID gid.GID,
 ) (int, error) {
 	var count int
@@ -295,7 +295,7 @@ func (s WebhookSubscriptionService) CountEventsForSubscriptionID(
 		func(ctx context.Context, conn pg.Querier) (err error) {
 			events := &coredata.WebhookEvents{}
 
-			count, err = events.CountBySubscriptionID(ctx, conn, s.svc.scope, webhookSubscriptionID)
+			count, err = events.CountBySubscriptionID(ctx, conn, scope, webhookSubscriptionID)
 			if err != nil {
 				return fmt.Errorf("cannot count webhook events: %w", err)
 			}
@@ -311,7 +311,7 @@ func (s WebhookSubscriptionService) CountEventsForSubscriptionID(
 }
 
 func (s WebhookSubscriptionService) Delete(
-	ctx context.Context,
+	ctx context.Context, scope coredata.Scoper,
 	webhookSubscriptionID gid.GID,
 ) error {
 	wc := &coredata.WebhookSubscription{ID: webhookSubscriptionID}
@@ -319,11 +319,11 @@ func (s WebhookSubscriptionService) Delete(
 	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
-			if err := wc.LoadByID(ctx, conn, s.svc.scope, webhookSubscriptionID); err != nil {
+			if err := wc.LoadByID(ctx, conn, scope, webhookSubscriptionID); err != nil {
 				return fmt.Errorf("cannot load webhook subscription: %w", err)
 			}
 
-			if err := wc.Delete(ctx, conn, s.svc.scope); err != nil {
+			if err := wc.Delete(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot delete webhook subscription: %w", err)
 			}
 

--- a/pkg/server/api/compliancepage/markdown_handler.go
+++ b/pkg/server/api/compliancepage/markdown_handler.go
@@ -17,6 +17,7 @@ package compliancepage
 import (
 	"net/http"
 
+	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/trust"
 )
 
@@ -37,7 +38,9 @@ func (h *Handler) HandleLLMsTxt(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 
-	if err := h.trustService.RenderCompliancePageMarkdown(r.Context(), w, tc.ID, tc.TenantID); err != nil {
+	scope := coredata.NewScopeFromObjectID(tc.ID)
+
+	if err := h.trustService.RenderCompliancePageMarkdown(r.Context(), w, tc.ID, scope); err != nil {
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 	}
 }
@@ -77,7 +80,9 @@ func (h *Handler) HandleSitemap(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/xml; charset=utf-8")
 
-	if err := h.trustService.RenderSitemap(r.Context(), w, tc.ID, tc.TenantID, *baseURL); err != nil {
+	scope := coredata.NewScopeFromObjectID(tc.ID)
+
+	if err := h.trustService.RenderSitemap(r.Context(), w, tc.ID, scope, *baseURL); err != nil {
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 	}
 }

--- a/pkg/server/api/console/v1/access_review_campaign_resolvers.go
+++ b/pkg/server/api/console/v1/access_review_campaign_resolvers.go
@@ -373,9 +373,10 @@ func (r *accessSourceResolver) Connector(ctx context.Context, obj *types.AccessS
 		return nil, nil
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	connector, err := prb.Connectors.Get(ctx, *obj.ConnectorID)
+	connector, err := prb.Connectors.Get(ctx, scope, *obj.ConnectorID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil
@@ -441,9 +442,10 @@ func (r *accessSourceResolver) NeedsConfiguration(ctx context.Context, obj *type
 		return false, nil
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	dbConnector, err := prb.Connectors.Get(ctx, *obj.ConnectorID)
+	dbConnector, err := prb.Connectors.Get(ctx, scope, *obj.ConnectorID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return false, nil
@@ -502,9 +504,10 @@ func (r *accessSourceResolver) SelectedOrganization(ctx context.Context, obj *ty
 		return nil, nil
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	dbConnector, err := prb.Connectors.Get(ctx, *obj.ConnectorID)
+	dbConnector, err := prb.Connectors.Get(ctx, scope, *obj.ConnectorID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil

--- a/pkg/server/api/console/v1/asset_resolvers.go
+++ b/pkg/server/api/console/v1/asset_resolvers.go
@@ -51,7 +51,8 @@ func (r *assetResolver) ThirdParties(ctx context.Context, obj *types.Asset, firs
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyOrderField]{
 		Field:     coredata.ThirdPartyOrderFieldCreatedAt,
@@ -66,7 +67,7 @@ func (r *assetResolver) ThirdParties(ctx context.Context, obj *types.Asset, firs
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.ThirdParties.ListForAssetID(ctx, obj.ID, cursor)
+	page, err := prb.ThirdParties.ListForAssetID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list asset thirdParties", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -81,15 +82,16 @@ func (r *assetResolver) Organization(ctx context.Context, obj *types.Asset) (*ty
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	asset, err := prb.Assets.Get(ctx, obj.ID)
+	asset, err := prb.Assets.Get(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot load audit", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	org, err := prb.Organizations.Get(ctx, asset.OrganizationID)
+	org, err := prb.Organizations.Get(ctx, scope, asset.OrganizationID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -114,11 +116,12 @@ func (r *assetConnectionResolver) TotalCount(ctx context.Context, obj *types.Ass
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	prb := r.probo
 
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.Assets.CountForOrganizationID(ctx, obj.ParentID)
+		count, err := prb.Assets.CountForOrganizationID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count assets", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -158,7 +161,8 @@ func (r *datumResolver) ThirdParties(ctx context.Context, obj *types.Datum, firs
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyOrderField]{
 		Field:     coredata.ThirdPartyOrderFieldCreatedAt,
@@ -173,7 +177,7 @@ func (r *datumResolver) ThirdParties(ctx context.Context, obj *types.Datum, firs
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Data.ListThirdParties(ctx, obj.ID, cursor)
+	page, err := prb.Data.ListThirdParties(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list data thirdParties", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -215,11 +219,12 @@ func (r *datumConnectionResolver) TotalCount(ctx context.Context, obj *types.Dat
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	prb := r.probo
 
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.Data.CountForOrganizationID(ctx, obj.ParentID)
+		count, err := prb.Data.CountForOrganizationID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count data", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -239,10 +244,11 @@ func (r *mutationResolver) CreateAsset(ctx context.Context, input types.CreateAs
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
 	asset, err := prb.Assets.Create(
-		ctx,
+		ctx, scope,
 		probo.CreateAssetRequest{
 			OrganizationID:  input.OrganizationID,
 			Name:            input.Name,
@@ -274,10 +280,11 @@ func (r *mutationResolver) UpdateAsset(ctx context.Context, input types.UpdateAs
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
 	asset, err := prb.Assets.Update(
-		ctx,
+		ctx, scope,
 		probo.UpdateAssetRequest{
 			ID:              input.ID,
 			Name:            input.Name,
@@ -309,9 +316,10 @@ func (r *mutationResolver) DeleteAsset(ctx context.Context, input types.DeleteAs
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.AssetID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.AssetID)
+	prb := r.probo
 
-	err := prb.Assets.Delete(ctx, input.AssetID)
+	err := prb.Assets.Delete(ctx, scope, input.AssetID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete asset", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -328,10 +336,11 @@ func (r *mutationResolver) CreateDatum(ctx context.Context, input types.CreateDa
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
 	data, err := prb.Data.Create(
-		ctx,
+		ctx, scope,
 		probo.CreateDatumRequest{
 			OrganizationID:     input.OrganizationID,
 			Name:               input.Name,
@@ -361,10 +370,11 @@ func (r *mutationResolver) UpdateDatum(ctx context.Context, input types.UpdateDa
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
 	datum, err := prb.Data.Update(
-		ctx,
+		ctx, scope,
 		probo.UpdateDatumRequest{
 			ID:                 input.ID,
 			Name:               input.Name,
@@ -394,9 +404,10 @@ func (r *mutationResolver) DeleteDatum(ctx context.Context, input types.DeleteDa
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.DatumID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.DatumID)
+	prb := r.probo
 
-	if err := prb.Data.Delete(ctx, input.DatumID); err != nil {
+	if err := prb.Data.Delete(ctx, scope, input.DatumID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete datum", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -412,9 +423,10 @@ func (r *mutationResolver) PublishDataList(ctx context.Context, input types.Publ
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
-	document, documentVersion, err := prb.GeneratedDocuments.PublishDataList(ctx, input.OrganizationID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := prb.GeneratedDocuments.PublishDataList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -441,9 +453,10 @@ func (r *mutationResolver) PublishAssetList(ctx context.Context, input types.Pub
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
-	document, documentVersion, err := prb.GeneratedDocuments.PublishAssetList(ctx, input.OrganizationID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := prb.GeneratedDocuments.PublishAssetList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)

--- a/pkg/server/api/console/v1/audit_resolvers.go
+++ b/pkg/server/api/console/v1/audit_resolvers.go
@@ -104,9 +104,10 @@ func (r *auditResolver) ReportURL(ctx context.Context, obj *types.Audit) (*strin
 		return nil, nil
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	url, err := prb.Audits.GenerateReportURL(ctx, obj.ID, 15*time.Minute)
+	url, err := prb.Audits.GenerateReportURL(ctx, scope, obj.ID, 15*time.Minute)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate report URL", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -121,7 +122,8 @@ func (r *auditResolver) Controls(ctx context.Context, obj *types.Audit, first *i
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ControlOrderField]{
 		Field:     coredata.ControlOrderFieldCreatedAt,
@@ -141,7 +143,7 @@ func (r *auditResolver) Controls(ctx context.Context, obj *types.Audit, first *i
 		controlFilter = coredata.NewControlFilter(filter.Query)
 	}
 
-	page, err := prb.Controls.ListForAuditID(ctx, obj.ID, cursor, controlFilter)
+	page, err := prb.Controls.ListForAuditID(ctx, scope, obj.ID, cursor, controlFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list audit controls", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -156,7 +158,8 @@ func (r *auditResolver) Findings(ctx context.Context, obj *types.Audit, first *i
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.FindingOrderField]{
 		Field:     coredata.FindingOrderFieldCreatedAt,
@@ -186,7 +189,7 @@ func (r *auditResolver) Findings(ctx context.Context, obj *types.Audit, first *i
 
 	findingFilter := coredata.NewFindingFilter(kind, status, priority, ownerID)
 
-	p, err := prb.Findings.ListForAuditID(ctx, obj.ID, cursor, findingFilter)
+	p, err := prb.Findings.ListForAuditID(ctx, scope, obj.ID, cursor, findingFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list audit findings", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -206,11 +209,12 @@ func (r *auditConnectionResolver) TotalCount(ctx context.Context, obj *types.Aud
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	prb := r.probo
 
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.Audits.CountForOrganizationID(ctx, obj.ParentID)
+		count, err := prb.Audits.CountForOrganizationID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count audits", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -218,7 +222,7 @@ func (r *auditConnectionResolver) TotalCount(ctx context.Context, obj *types.Aud
 
 		return count, nil
 	case *findingResolver:
-		count, err := prb.Audits.CountForFindingID(ctx, obj.ParentID)
+		count, err := prb.Audits.CountForFindingID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count audits", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -226,7 +230,7 @@ func (r *auditConnectionResolver) TotalCount(ctx context.Context, obj *types.Aud
 
 		return count, nil
 	case *controlResolver:
-		count, err := prb.Audits.CountForControlID(ctx, obj.ParentID)
+		count, err := prb.Audits.CountForControlID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count audits", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -267,7 +271,8 @@ func (r *findingResolver) Audits(ctx context.Context, obj *types.Finding, first 
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.AuditOrderField]{
 		Field:     coredata.AuditOrderFieldCreatedAt,
@@ -282,7 +287,7 @@ func (r *findingResolver) Audits(ctx context.Context, obj *types.Finding, first 
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	p, err := prb.Audits.ListForFindingID(ctx, obj.ID, cursor)
+	p, err := prb.Audits.ListForFindingID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list finding audits", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -354,7 +359,8 @@ func (r *findingConnectionResolver) TotalCount(ctx context.Context, obj *types.F
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	prb := r.probo
 
 	var (
 		kind     *coredata.FindingKind
@@ -373,7 +379,7 @@ func (r *findingConnectionResolver) TotalCount(ctx context.Context, obj *types.F
 
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.Findings.CountForOrganizationID(ctx, obj.ParentID, findingFilter)
+		count, err := prb.Findings.CountForOrganizationID(ctx, scope, obj.ParentID, findingFilter)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count findings", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -381,7 +387,7 @@ func (r *findingConnectionResolver) TotalCount(ctx context.Context, obj *types.F
 
 		return count, nil
 	case *auditResolver:
-		count, err := prb.Findings.CountForAuditID(ctx, obj.ParentID, findingFilter)
+		count, err := prb.Findings.CountForAuditID(ctx, scope, obj.ParentID, findingFilter)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count findings", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -401,7 +407,8 @@ func (r *mutationResolver) CreateAudit(ctx context.Context, input types.CreateAu
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
 	req := probo.CreateAuditRequest{
 		OrganizationID:        input.OrganizationID,
@@ -413,7 +420,7 @@ func (r *mutationResolver) CreateAudit(ctx context.Context, input types.CreateAu
 		TrustCenterVisibility: input.TrustCenterVisibility,
 	}
 
-	audit, err := prb.Audits.Create(ctx, &req)
+	audit, err := prb.Audits.Create(ctx, scope, &req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -435,7 +442,7 @@ func (r *mutationResolver) CreateAudit(ctx context.Context, input types.CreateAu
 			},
 		}
 
-		audit, err = prb.Audits.UploadReport(ctx, uploadReq)
+		audit, err = prb.Audits.UploadReport(ctx, scope, uploadReq)
 		if err != nil {
 			if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 				return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -458,7 +465,8 @@ func (r *mutationResolver) UpdateAudit(ctx context.Context, input types.UpdateAu
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
 	req := probo.UpdateAuditRequest{
 		ID:                    input.ID,
@@ -469,7 +477,7 @@ func (r *mutationResolver) UpdateAudit(ctx context.Context, input types.UpdateAu
 		TrustCenterVisibility: input.TrustCenterVisibility,
 	}
 
-	audit, err := prb.Audits.Update(ctx, &req)
+	audit, err := prb.Audits.Update(ctx, scope, &req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -491,9 +499,10 @@ func (r *mutationResolver) DeleteAudit(ctx context.Context, input types.DeleteAu
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.AuditID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.AuditID)
+	prb := r.probo
 
-	err := prb.Audits.Delete(ctx, input.AuditID)
+	err := prb.Audits.Delete(ctx, scope, input.AuditID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete audit", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -510,7 +519,8 @@ func (r *mutationResolver) UploadAuditReport(ctx context.Context, input types.Up
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.AuditID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.AuditID)
+	prb := r.probo
 
 	req := probo.UploadAuditReportRequest{
 		AuditID: input.AuditID,
@@ -522,7 +532,7 @@ func (r *mutationResolver) UploadAuditReport(ctx context.Context, input types.Up
 		},
 	}
 
-	audit, err := prb.Audits.UploadReport(ctx, req)
+	audit, err := prb.Audits.UploadReport(ctx, scope, req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -544,9 +554,10 @@ func (r *mutationResolver) DeleteAuditReport(ctx context.Context, input types.De
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.AuditID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.AuditID)
+	prb := r.probo
 
-	audit, err := prb.Audits.DeleteReport(ctx, input.AuditID)
+	audit, err := prb.Audits.DeleteReport(ctx, scope, input.AuditID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete audit report", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -563,7 +574,8 @@ func (r *mutationResolver) CreateFinding(ctx context.Context, input types.Create
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
 	req := probo.CreateFindingRequest{
 		OrganizationID:     input.OrganizationID,
@@ -581,7 +593,7 @@ func (r *mutationResolver) CreateFinding(ctx context.Context, input types.Create
 		EffectivenessCheck: input.EffectivenessCheck,
 	}
 
-	finding, err := prb.Findings.Create(ctx, &req)
+	finding, err := prb.Findings.Create(ctx, scope, &req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -603,7 +615,8 @@ func (r *mutationResolver) UpdateFinding(ctx context.Context, input types.Update
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
 	req := probo.UpdateFindingRequest{
 		ID:                 input.ID,
@@ -620,7 +633,7 @@ func (r *mutationResolver) UpdateFinding(ctx context.Context, input types.Update
 		EffectivenessCheck: gqlutils.UnwrapOmittable(input.EffectivenessCheck),
 	}
 
-	finding, err := prb.Findings.Update(ctx, &req)
+	finding, err := prb.Findings.Update(ctx, scope, &req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -642,9 +655,10 @@ func (r *mutationResolver) DeleteFinding(ctx context.Context, input types.Delete
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.FindingID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.FindingID)
+	prb := r.probo
 
-	err := prb.Findings.Delete(ctx, input.FindingID)
+	err := prb.Findings.Delete(ctx, scope, input.FindingID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete finding", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -661,9 +675,10 @@ func (r *mutationResolver) CreateFindingAuditMapping(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.FindingID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.FindingID)
+	prb := r.probo
 
-	finding, audit, err := prb.Findings.CreateAuditMapping(ctx, input.FindingID, input.AuditID, input.ReferenceID)
+	finding, audit, err := prb.Findings.CreateAuditMapping(ctx, scope, input.FindingID, input.AuditID, input.ReferenceID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot create finding audit mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -681,9 +696,10 @@ func (r *mutationResolver) DeleteFindingAuditMapping(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.FindingID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.FindingID)
+	prb := r.probo
 
-	finding, audit, err := prb.Findings.DeleteAuditMapping(ctx, input.FindingID, input.AuditID)
+	finding, audit, err := prb.Findings.DeleteAuditMapping(ctx, scope, input.FindingID, input.AuditID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete finding audit mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -701,9 +717,10 @@ func (r *mutationResolver) PublishFindingList(ctx context.Context, input types.P
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
-	document, documentVersion, err := prb.GeneratedDocuments.PublishFindingList(ctx, input.OrganizationID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := prb.GeneratedDocuments.PublishFindingList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -730,9 +747,10 @@ func (r *reportResolver) DownloadURL(ctx context.Context, obj *types.Report) (*s
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	url, err := prb.Reports.GenerateDownloadURL(ctx, obj.ID, 15*time.Minute)
+	url, err := prb.Reports.GenerateDownloadURL(ctx, scope, obj.ID, 15*time.Minute)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate download URL", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -747,9 +765,10 @@ func (r *reportResolver) Audit(ctx context.Context, obj *types.Report) (*types.A
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	audit, err := prb.Audits.GetByReportID(ctx, obj.ID)
+	audit, err := prb.Audits.GetByReportID(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot load audit for report", log.Error(err))
 		return nil, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/base_resolvers.go
+++ b/pkg/server/api/console/v1/base_resolvers.go
@@ -26,14 +26,15 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	var (
 		loadNode func(ctx context.Context, id gid.GID) (types.Node, error)
 		action   string
-		prb      = r.ProboService(ctx, id.TenantID())
+		scope    = coredata.NewScopeFromObjectID(id)
+		prb      = r.probo
 	)
 
 	switch id.EntityType() {
 	case coredata.OrganizationEntityType:
 		action = iam.ActionOrganizationGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			organization, err := prb.Organizations.Get(ctx, id)
+			organization, err := prb.Organizations.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -43,7 +44,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.ThirdPartyEntityType:
 		action = probo.ActionThirdPartyGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			thirdParty, err := prb.ThirdParties.Get(ctx, id)
+			thirdParty, err := prb.ThirdParties.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -53,7 +54,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.FrameworkEntityType:
 		action = probo.ActionFrameworkGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			framework, err := prb.Frameworks.Get(ctx, id)
+			framework, err := prb.Frameworks.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -63,7 +64,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.MeasureEntityType:
 		action = probo.ActionMeasureGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			measure, err := prb.Measures.Get(ctx, id)
+			measure, err := prb.Measures.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -73,7 +74,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.TaskEntityType:
 		action = probo.ActionTaskGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			task, err := prb.Tasks.Get(ctx, id)
+			task, err := prb.Tasks.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -83,7 +84,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.EvidenceEntityType:
 		action = probo.ActionEvidenceList
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			evidence, err := prb.Evidences.Get(ctx, id)
+			evidence, err := prb.Evidences.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -93,7 +94,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.DocumentEntityType:
 		action = probo.ActionDocumentGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			document, err := prb.Documents.Get(ctx, id)
+			document, err := prb.Documents.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -103,7 +104,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.ControlEntityType:
 		action = probo.ActionControlList
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			control, err := prb.Controls.Get(ctx, id)
+			control, err := prb.Controls.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -113,7 +114,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.RiskEntityType:
 		action = probo.ActionRiskGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			risk, err := prb.Risks.Get(ctx, id)
+			risk, err := prb.Risks.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -195,7 +196,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.ThirdPartyComplianceReportEntityType:
 		action = probo.ActionThirdPartyComplianceReportGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			thirdPartyComplianceReport, err := prb.ThirdPartyComplianceReports.Get(ctx, id)
+			thirdPartyComplianceReport, err := prb.ThirdPartyComplianceReports.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -205,7 +206,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.ThirdPartyContactEntityType:
 		action = probo.ActionThirdPartyContactGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			thirdPartyContact, err := prb.ThirdPartyContacts.Get(ctx, id)
+			thirdPartyContact, err := prb.ThirdPartyContacts.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -215,7 +216,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.ThirdPartyServiceEntityType:
 		action = probo.ActionThirdPartyServiceGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			thirdPartyService, err := prb.ThirdPartyServices.Get(ctx, id)
+			thirdPartyService, err := prb.ThirdPartyServices.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -225,7 +226,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.DocumentVersionEntityType:
 		action = probo.ActionDocumentVersionList
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			documentVersion, err := prb.Documents.GetVersion(ctx, id)
+			documentVersion, err := prb.Documents.GetVersion(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -235,7 +236,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.DocumentVersionSignatureEntityType:
 		action = probo.ActionDocumentVersionSignatureList
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			documentVersionSignature, err := prb.Documents.GetVersionSignature(ctx, id)
+			documentVersionSignature, err := prb.Documents.GetVersionSignature(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -245,7 +246,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.AssetEntityType:
 		action = probo.ActionAssetList
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			asset, err := prb.Assets.Get(ctx, id)
+			asset, err := prb.Assets.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -255,7 +256,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.DatumEntityType:
 		action = probo.ActionDatumList
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			datum, err := prb.Data.Get(ctx, id)
+			datum, err := prb.Data.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -265,7 +266,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.AuditEntityType:
 		action = probo.ActionAuditList
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			audit, err := prb.Audits.Get(ctx, id)
+			audit, err := prb.Audits.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -275,7 +276,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.FindingEntityType:
 		action = probo.ActionFindingList
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			finding, err := prb.Findings.Get(ctx, id)
+			finding, err := prb.Findings.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -285,7 +286,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.ObligationEntityType:
 		action = probo.ActionObligationList
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			obligation, err := prb.Obligations.Get(ctx, id)
+			obligation, err := prb.Obligations.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -295,7 +296,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.ReportEntityType:
 		action = probo.ActionReportGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			report, err := prb.Reports.Get(ctx, id)
+			report, err := prb.Reports.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -305,7 +306,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.ProcessingActivityEntityType:
 		action = probo.ActionProcessingActivityList
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			processingActivity, err := prb.ProcessingActivities.Get(ctx, id)
+			processingActivity, err := prb.ProcessingActivities.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -316,7 +317,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		// TODO: add action
 		// action = probo.ActionDataProtectionImpactAssessmentGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			dpia, err := prb.DataProtectionImpactAssessments.Get(ctx, id)
+			dpia, err := prb.DataProtectionImpactAssessments.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -327,7 +328,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		// TODO: add action
 		//action = probo.ActionTransferImpactAssessmentGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			tia, err := prb.TransferImpactAssessments.Get(ctx, id)
+			tia, err := prb.TransferImpactAssessments.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -337,14 +338,14 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.TrustCenterEntityType:
 		action = probo.ActionTrustCenterGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			trustCenter, err := prb.TrustCenters.Get(ctx, id)
+			trustCenter, err := prb.TrustCenters.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
 
 			var file *coredata.File
 			if trustCenter.NonDisclosureAgreementFileID != nil {
-				file, err = prb.Files.Get(ctx, *trustCenter.NonDisclosureAgreementFileID)
+				file, err = prb.Files.Get(ctx, scope, *trustCenter.NonDisclosureAgreementFileID)
 				if err != nil {
 					return nil, fmt.Errorf("cannot get NDA file: %w", err)
 				}
@@ -355,7 +356,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.TrustCenterAccessEntityType:
 		action = probo.ActionTrustCenterAccessGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			trustCenterAccess, err := prb.TrustCenterAccesses.Get(ctx, id)
+			trustCenterAccess, err := prb.TrustCenterAccesses.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -365,7 +366,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.RightsRequestEntityType:
 		action = probo.ActionRightsRequestGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			rightsRequest, err := prb.RightsRequests.Get(ctx, id)
+			rightsRequest, err := prb.RightsRequests.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -375,7 +376,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.StatementOfApplicabilityEntityType:
 		action = probo.ActionStatementOfApplicabilityGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			statementOfApplicability, err := prb.StatementsOfApplicability.Get(ctx, id)
+			statementOfApplicability, err := prb.StatementsOfApplicability.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -385,7 +386,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.WebhookSubscriptionEntityType:
 		action = probo.ActionWebhookSubscriptionGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			wc, err := prb.WebhookSubscriptions.Get(ctx, id)
+			wc, err := prb.WebhookSubscriptions.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/server/api/console/v1/connector_initiate.go
+++ b/pkg/server/api/console/v1/connector_initiate.go
@@ -83,13 +83,14 @@ func handleConnectorInitiate(
 		}
 
 		requestedScopes := r.URL.Query()["scope"]
-		prb := proboSvc.WithTenant(organizationID.TenantID())
+		scope := coredata.NewScopeFromObjectID(organizationID)
+		prb := proboSvc
 
 		// Look up any existing connector so we can union its stored scopes
 		// into the new auth request. Cross-org/provider/protocol mismatches
 		// are caught inside Reconnect at callback time; this handler only
 		// needs the scope set.
-		existing, err := loadExistingConnector(r, prb, organizationID, provider)
+		existing, err := loadExistingConnector(r, prb, scope, organizationID, provider)
 		if err != nil {
 			if errors.Is(err, coredata.ErrResourceNotFound) {
 				httpserver.RenderError(w, http.StatusBadRequest, fmt.Errorf("cannot reconnect: connector not found"))
@@ -138,7 +139,8 @@ func handleConnectorInitiate(
 // from nil (no existing row — fresh install path).
 func loadExistingConnector(
 	r *http.Request,
-	prb *probo.TenantService,
+	prb *probo.Service,
+	scope coredata.Scoper,
 	organizationID gid.GID,
 	provider string,
 ) (*coredata.Connector, error) {
@@ -148,7 +150,7 @@ func loadExistingConnector(
 			return nil, fmt.Errorf("%w: cannot parse connector id: %w", errInvalidReconnectConnector, err)
 		}
 
-		found, err := prb.Connectors.GetWithConnection(r.Context(), parsedID)
+		found, err := prb.Connectors.GetWithConnection(r.Context(), scope, parsedID)
 		if err != nil {
 			return nil, err
 		}
@@ -158,6 +160,7 @@ func loadExistingConnector(
 
 	found, err := prb.Connectors.GetByOrganizationIDAndProvider(
 		r.Context(),
+		scope,
 		organizationID,
 		coredata.ConnectorProvider(provider),
 	)

--- a/pkg/server/api/console/v1/connector_resolvers.go
+++ b/pkg/server/api/console/v1/connector_resolvers.go
@@ -36,7 +36,8 @@ func (r *mutationResolver) CreateAPIKeyConnector(ctx context.Context, input type
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
 	req := probo.CreateConnectorRequest{
 		OrganizationID: input.OrganizationID,
@@ -75,7 +76,7 @@ func (r *mutationResolver) CreateAPIKeyConnector(ctx context.Context, input type
 		}
 	}
 
-	cnnctr, err := prb.Connectors.Create(ctx, req)
+	cnnctr, err := prb.Connectors.Create(ctx, scope, req)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -95,7 +96,8 @@ func (r *mutationResolver) CreateClientCredentialsConnector(ctx context.Context,
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
 	oauth2Conn := &connector.OAuth2Connection{
 		GrantType:    connector.OAuth2GrantTypeClientCredentials,
@@ -121,7 +123,7 @@ func (r *mutationResolver) CreateClientCredentialsConnector(ctx context.Context,
 		}
 	}
 
-	cnnctr, err := prb.Connectors.Create(ctx, req)
+	cnnctr, err := prb.Connectors.Create(ctx, scope, req)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -141,9 +143,10 @@ func (r *mutationResolver) DeleteConnector(ctx context.Context, input types.Dele
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ConnectorID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ConnectorID)
+	prb := r.probo
 
-	if err := prb.Connectors.Delete(ctx, input.ConnectorID); err != nil {
+	if err := prb.Connectors.Delete(ctx, scope, input.ConnectorID); err != nil {
 		panic(fmt.Errorf("cannot delete connector: %w", err))
 	}
 
@@ -158,9 +161,10 @@ func (r *mutationResolver) DeleteSlackConnection(ctx context.Context, input type
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.SlackConnectionID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.SlackConnectionID)
+	prb := r.probo
 
-	err := prb.Connectors.Delete(ctx, input.SlackConnectionID)
+	err := prb.Connectors.Delete(ctx, scope, input.SlackConnectionID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete slack connection", log.Error(err))
 		return nil, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/control_resolvers.go
+++ b/pkg/server/api/console/v1/control_resolvers.go
@@ -28,9 +28,10 @@ func (r *applicabilityStatementResolver) StatementOfApplicability(ctx context.Co
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.StatementOfApplicability.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.StatementOfApplicability.ID)
+	prb := r.probo
 
-	soa, err := prb.StatementsOfApplicability.Get(ctx, obj.StatementOfApplicability.ID)
+	soa, err := prb.StatementsOfApplicability.Get(ctx, scope, obj.StatementOfApplicability.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get statement of applicability", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -72,11 +73,12 @@ func (r *applicabilityStatementConnectionResolver) TotalCount(ctx context.Contex
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	prb := r.probo
 
 	switch obj.Resolver.(type) {
 	case *statementOfApplicabilityResolver:
-		count, err := prb.StatementsOfApplicability.CountApplicabilityStatements(ctx, obj.ParentID)
+		count, err := prb.StatementsOfApplicability.CountApplicabilityStatements(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count applicability statements", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -114,9 +116,10 @@ func (r *controlResolver) Organization(ctx context.Context, obj *types.Control) 
 
 // Regulatory is the resolver for the regulatory field.
 func (r *controlResolver) Regulatory(ctx context.Context, obj *types.Control) (bool, error) {
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	hasRegulatory, err := prb.Controls.HasRegulatoryObligation(ctx, obj.ID)
+	hasRegulatory, err := prb.Controls.HasRegulatoryObligation(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot check regulatory obligation", log.Error(err))
 		return false, gqlutils.Internal(ctx)
@@ -127,9 +130,10 @@ func (r *controlResolver) Regulatory(ctx context.Context, obj *types.Control) (b
 
 // Contractual is the resolver for the contractual field.
 func (r *controlResolver) Contractual(ctx context.Context, obj *types.Control) (bool, error) {
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	hasContractual, err := prb.Controls.HasContractualObligation(ctx, obj.ID)
+	hasContractual, err := prb.Controls.HasContractualObligation(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot check contractual obligation", log.Error(err))
 		return false, gqlutils.Internal(ctx)
@@ -140,9 +144,10 @@ func (r *controlResolver) Contractual(ctx context.Context, obj *types.Control) (
 
 // RiskAssessment is the resolver for the riskAssessment field.
 func (r *controlResolver) RiskAssessment(ctx context.Context, obj *types.Control) (bool, error) {
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	hasRisk, err := prb.Controls.HasRiskAssessment(ctx, obj.ID)
+	hasRisk, err := prb.Controls.HasRiskAssessment(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot check risk assessment", log.Error(err))
 		return false, gqlutils.Internal(ctx)
@@ -179,7 +184,8 @@ func (r *controlResolver) Measures(ctx context.Context, obj *types.Control, firs
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.MeasureOrderField]{
 		Field:     coredata.MeasureOrderFieldCreatedAt,
@@ -199,7 +205,7 @@ func (r *controlResolver) Measures(ctx context.Context, obj *types.Control, firs
 		measureFilter = coredata.NewMeasureFilter(filter.Query, filter.State, filter.Category)
 	}
 
-	page, err := prb.Measures.ListForControlID(ctx, obj.ID, cursor, measureFilter)
+	page, err := prb.Measures.ListForControlID(ctx, scope, obj.ID, cursor, measureFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list measures", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -214,7 +220,8 @@ func (r *controlResolver) Documents(ctx context.Context, obj *types.Control, fir
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
 		Field:     coredata.DocumentOrderFieldCreatedAt,
@@ -237,7 +244,7 @@ func (r *controlResolver) Documents(ctx context.Context, obj *types.Control, fir
 			WithClassifications(filter.Classifications)
 	}
 
-	page, err := prb.Documents.ListForControlID(ctx, obj.ID, cursor, documentFilter)
+	page, err := prb.Documents.ListForControlID(ctx, scope, obj.ID, cursor, documentFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list documents", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -252,7 +259,8 @@ func (r *controlResolver) Audits(ctx context.Context, obj *types.Control, first 
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.AuditOrderField]{
 		Field:     coredata.AuditOrderFieldCreatedAt,
@@ -267,7 +275,7 @@ func (r *controlResolver) Audits(ctx context.Context, obj *types.Control, first 
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Audits.ListForControlID(ctx, obj.ID, cursor)
+	page, err := prb.Audits.ListForControlID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list control audits", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -282,7 +290,8 @@ func (r *controlResolver) Obligations(ctx context.Context, obj *types.Control, f
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ObligationOrderField]{
 		Field:     coredata.ObligationOrderFieldCreatedAt,
@@ -297,7 +306,7 @@ func (r *controlResolver) Obligations(ctx context.Context, obj *types.Control, f
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Obligations.ListForControlID(ctx, obj.ID, cursor)
+	page, err := prb.Obligations.ListForControlID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list control obligations", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -317,11 +326,12 @@ func (r *controlConnectionResolver) TotalCount(ctx context.Context, obj *types.C
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	prb := r.probo
 
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.Controls.CountForOrganizationID(ctx, obj.ParentID, obj.Filters)
+		count, err := prb.Controls.CountForOrganizationID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count controls", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -329,7 +339,7 @@ func (r *controlConnectionResolver) TotalCount(ctx context.Context, obj *types.C
 
 		return count, nil
 	case *frameworkResolver:
-		count, err := prb.Controls.CountForFrameworkID(ctx, obj.ParentID, obj.Filters)
+		count, err := prb.Controls.CountForFrameworkID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count controls", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -337,7 +347,7 @@ func (r *controlConnectionResolver) TotalCount(ctx context.Context, obj *types.C
 
 		return count, nil
 	case *documentResolver:
-		count, err := prb.Controls.CountForDocumentID(ctx, obj.ParentID, obj.Filters)
+		count, err := prb.Controls.CountForDocumentID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count controls", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -345,7 +355,7 @@ func (r *controlConnectionResolver) TotalCount(ctx context.Context, obj *types.C
 
 		return count, nil
 	case *measureResolver:
-		count, err := prb.Controls.CountForMeasureID(ctx, obj.ParentID, obj.Filters)
+		count, err := prb.Controls.CountForMeasureID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count controls", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -353,7 +363,7 @@ func (r *controlConnectionResolver) TotalCount(ctx context.Context, obj *types.C
 
 		return count, nil
 	case *riskResolver:
-		count, err := prb.Controls.CountForRiskID(ctx, obj.ParentID, obj.Filters)
+		count, err := prb.Controls.CountForRiskID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count controls", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -361,7 +371,7 @@ func (r *controlConnectionResolver) TotalCount(ctx context.Context, obj *types.C
 
 		return count, nil
 	case *statementOfApplicabilityResolver:
-		count, err := prb.Controls.CountForStatementOfApplicabilityID(ctx, obj.ParentID, obj.Filters)
+		count, err := prb.Controls.CountForStatementOfApplicabilityID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count controls", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -381,10 +391,11 @@ func (r *mutationResolver) CreateControl(ctx context.Context, input types.Create
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.FrameworkID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.FrameworkID)
+	prb := r.probo
 
 	control, err := prb.Controls.Create(
-		ctx,
+		ctx, scope,
 		probo.CreateControlRequest{
 			FrameworkID:                 input.FrameworkID,
 			Name:                        input.Name,
@@ -420,10 +431,11 @@ func (r *mutationResolver) UpdateControl(ctx context.Context, input types.Update
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
 	control, err := prb.Controls.Update(
-		ctx,
+		ctx, scope,
 		probo.UpdateControlRequest{
 			ID:                          input.ID,
 			Name:                        input.Name,
@@ -459,9 +471,10 @@ func (r *mutationResolver) DeleteControl(ctx context.Context, input types.Delete
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ControlID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ControlID)
+	prb := r.probo
 
-	err := prb.Controls.Delete(ctx, input.ControlID)
+	err := prb.Controls.Delete(ctx, scope, input.ControlID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete control", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -478,9 +491,10 @@ func (r *mutationResolver) CreateControlMeasureMapping(ctx context.Context, inpu
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.MeasureID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.MeasureID)
+	prb := r.probo
 
-	control, measure, err := prb.Controls.CreateMeasureMapping(ctx, input.ControlID, input.MeasureID)
+	control, measure, err := prb.Controls.CreateMeasureMapping(ctx, scope, input.ControlID, input.MeasureID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot create control measure mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -498,9 +512,10 @@ func (r *mutationResolver) CreateControlDocumentMapping(ctx context.Context, inp
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.DocumentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.DocumentID)
+	prb := r.probo
 
-	control, document, err := prb.Controls.CreateDocumentMapping(ctx, input.ControlID, input.DocumentID)
+	control, document, err := prb.Controls.CreateDocumentMapping(ctx, scope, input.ControlID, input.DocumentID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -523,9 +538,10 @@ func (r *mutationResolver) DeleteControlMeasureMapping(ctx context.Context, inpu
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.MeasureID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.MeasureID)
+	prb := r.probo
 
-	control, measure, err := prb.Controls.DeleteMeasureMapping(ctx, input.ControlID, input.MeasureID)
+	control, measure, err := prb.Controls.DeleteMeasureMapping(ctx, scope, input.ControlID, input.MeasureID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete control measure mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -543,9 +559,10 @@ func (r *mutationResolver) DeleteControlDocumentMapping(ctx context.Context, inp
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.DocumentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.DocumentID)
+	prb := r.probo
 
-	control, document, err := prb.Controls.DeleteDocumentMapping(ctx, input.ControlID, input.DocumentID)
+	control, document, err := prb.Controls.DeleteDocumentMapping(ctx, scope, input.ControlID, input.DocumentID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete control document mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -563,9 +580,10 @@ func (r *mutationResolver) CreateApplicabilityStatement(ctx context.Context, inp
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.StatementOfApplicabilityID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.StatementOfApplicabilityID)
+	prb := r.probo
 
-	applicabilityStatement, err := prb.StatementsOfApplicability.CreateApplicabilityStatement(ctx, input.StatementOfApplicabilityID, input.ControlID, input.Applicability, input.Justification)
+	applicabilityStatement, err := prb.StatementsOfApplicability.CreateApplicabilityStatement(ctx, scope, input.StatementOfApplicabilityID, input.ControlID, input.Applicability, input.Justification)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot create applicability statement", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -582,9 +600,10 @@ func (r *mutationResolver) UpdateApplicabilityStatement(ctx context.Context, inp
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ApplicabilityStatementID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ApplicabilityStatementID)
+	prb := r.probo
 
-	applicabilityStatement, err := prb.StatementsOfApplicability.UpdateApplicabilityStatement(ctx, input.ApplicabilityStatementID, input.Applicability, input.Justification)
+	applicabilityStatement, err := prb.StatementsOfApplicability.UpdateApplicabilityStatement(ctx, scope, input.ApplicabilityStatementID, input.Applicability, input.Justification)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot update applicability statement", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -601,9 +620,10 @@ func (r *mutationResolver) DeleteApplicabilityStatement(ctx context.Context, inp
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ApplicabilityStatementID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ApplicabilityStatementID)
+	prb := r.probo
 
-	err := prb.StatementsOfApplicability.DeleteApplicabilityStatement(ctx, input.ApplicabilityStatementID)
+	err := prb.StatementsOfApplicability.DeleteApplicabilityStatement(ctx, scope, input.ApplicabilityStatementID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete applicability statement", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -620,9 +640,10 @@ func (r *mutationResolver) CreateControlAuditMapping(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.AuditID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.AuditID)
+	prb := r.probo
 
-	control, audit, err := prb.Controls.CreateAuditMapping(ctx, input.ControlID, input.AuditID)
+	control, audit, err := prb.Controls.CreateAuditMapping(ctx, scope, input.ControlID, input.AuditID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot create control audit mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -640,9 +661,10 @@ func (r *mutationResolver) DeleteControlAuditMapping(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.AuditID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.AuditID)
+	prb := r.probo
 
-	control, audit, err := prb.Controls.DeleteAuditMapping(ctx, input.ControlID, input.AuditID)
+	control, audit, err := prb.Controls.DeleteAuditMapping(ctx, scope, input.ControlID, input.AuditID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete control audit mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -660,9 +682,10 @@ func (r *mutationResolver) CreateControlObligationMapping(ctx context.Context, i
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ObligationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ObligationID)
+	prb := r.probo
 
-	control, obligation, err := prb.Controls.CreateObligationMapping(ctx, input.ControlID, input.ObligationID)
+	control, obligation, err := prb.Controls.CreateObligationMapping(ctx, scope, input.ControlID, input.ObligationID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot create control obligation mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -680,9 +703,10 @@ func (r *mutationResolver) DeleteControlObligationMapping(ctx context.Context, i
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ObligationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ObligationID)
+	prb := r.probo
 
-	control, obligation, err := prb.Controls.DeleteObligationMapping(ctx, input.ControlID, input.ObligationID)
+	control, obligation, err := prb.Controls.DeleteObligationMapping(ctx, scope, input.ControlID, input.ObligationID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete control obligation mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -700,10 +724,11 @@ func (r *mutationResolver) CreateStatementOfApplicability(ctx context.Context, i
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
 	statementOfApplicability, err := prb.StatementsOfApplicability.Create(
-		ctx,
+		ctx, scope,
 		probo.CreateStatementOfApplicabilityRequest{
 			OrganizationID: input.OrganizationID,
 			Name:           input.Name,
@@ -734,7 +759,8 @@ func (r *mutationResolver) UpdateStatementOfApplicability(ctx context.Context, i
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
 	var name *string
 	if input.Name != nil {
@@ -742,7 +768,7 @@ func (r *mutationResolver) UpdateStatementOfApplicability(ctx context.Context, i
 	}
 
 	statementOfApplicability, err := prb.StatementsOfApplicability.Update(
-		ctx,
+		ctx, scope,
 		probo.UpdateStatementOfApplicabilityRequest{
 			StatementOfApplicabilityID: input.ID,
 			Name:                       name,
@@ -773,9 +799,10 @@ func (r *mutationResolver) DeleteStatementOfApplicability(ctx context.Context, i
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.StatementOfApplicabilityID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.StatementOfApplicabilityID)
+	prb := r.probo
 
-	err := prb.StatementsOfApplicability.Delete(ctx, input.StatementOfApplicabilityID)
+	err := prb.StatementsOfApplicability.Delete(ctx, scope, input.StatementOfApplicabilityID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete statement_of_applicability", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -792,9 +819,10 @@ func (r *mutationResolver) PublishStatementOfApplicability(ctx context.Context, 
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.StatementOfApplicabilityID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.StatementOfApplicabilityID)
+	prb := r.probo
 
-	document, documentVersion, err := prb.GeneratedDocuments.PublishStatementOfApplicability(ctx, input.StatementOfApplicabilityID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := prb.GeneratedDocuments.PublishStatementOfApplicability(ctx, scope, input.StatementOfApplicabilityID, input.ApproverIds, input.Minor)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -825,9 +853,10 @@ func (r *statementOfApplicabilityResolver) Document(ctx context.Context, obj *ty
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.Document.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.Document.ID)
+	prb := r.probo
 
-	document, err := prb.Documents.Get(ctx, obj.Document.ID)
+	document, err := prb.Documents.Get(ctx, scope, obj.Document.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil
@@ -869,7 +898,8 @@ func (r *statementOfApplicabilityResolver) ApplicabilityStatements(ctx context.C
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ApplicabilityStatementOrderField]{
 		Field:     coredata.ApplicabilityStatementOrderFieldCreatedAt,
@@ -884,7 +914,7 @@ func (r *statementOfApplicabilityResolver) ApplicabilityStatements(ctx context.C
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	p, err := prb.StatementsOfApplicability.ListApplicabilityStatements(ctx, obj.ID, cursor)
+	p, err := prb.StatementsOfApplicability.ListApplicabilityStatements(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list applicability statements", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -900,11 +930,12 @@ func (r *statementOfApplicabilityResolver) Permission(ctx context.Context, obj *
 
 // TotalCount is the resolver for the totalCount field.
 func (r *statementOfApplicabilityConnectionResolver) TotalCount(ctx context.Context, obj *types.StatementOfApplicabilityConnection) (int, error) {
-	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	prb := r.probo
 
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.StatementsOfApplicability.CountForOrganizationID(ctx, obj.ParentID)
+		count, err := prb.StatementsOfApplicability.CountForOrganizationID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count statements_of_applicability", log.Error(err))
 			return 0, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/data_protection_impact_assessment_resolvers.go
+++ b/pkg/server/api/console/v1/data_protection_impact_assessment_resolvers.go
@@ -26,15 +26,16 @@ func (r *dataProtectionImpactAssessmentResolver) ProcessingActivity(ctx context.
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	dpia, err := prb.DataProtectionImpactAssessments.Get(ctx, obj.ID)
+	dpia, err := prb.DataProtectionImpactAssessments.Get(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get processing activity dpia", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	processingActivity, err := prb.ProcessingActivities.Get(ctx, dpia.ProcessingActivityID)
+	processingActivity, err := prb.ProcessingActivities.Get(ctx, scope, dpia.ProcessingActivityID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get processing activity", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -49,15 +50,16 @@ func (r *dataProtectionImpactAssessmentResolver) Organization(ctx context.Contex
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	dpia, err := prb.DataProtectionImpactAssessments.Get(ctx, obj.ID)
+	dpia, err := prb.DataProtectionImpactAssessments.Get(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get processing activity dpia", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	organization, err := prb.Organizations.Get(ctx, dpia.OrganizationID)
+	organization, err := prb.Organizations.Get(ctx, scope, dpia.OrganizationID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -82,11 +84,12 @@ func (r *dataProtectionImpactAssessmentConnectionResolver) TotalCount(ctx contex
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	prb := r.probo
 
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.DataProtectionImpactAssessments.CountForOrganizationID(ctx, obj.ParentID)
+		count, err := prb.DataProtectionImpactAssessments.CountForOrganizationID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count organization data protection impact assessments", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -106,7 +109,8 @@ func (r *mutationResolver) CreateDataProtectionImpactAssessment(ctx context.Cont
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ProcessingActivityID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ProcessingActivityID)
+	prb := r.probo
 
 	req := probo.CreateDataProtectionImpactAssessmentRequest{
 		ProcessingActivityID:        input.ProcessingActivityID,
@@ -117,7 +121,7 @@ func (r *mutationResolver) CreateDataProtectionImpactAssessment(ctx context.Cont
 		ResidualRisk:                input.ResidualRisk,
 	}
 
-	dpia, err := prb.DataProtectionImpactAssessments.Create(ctx, &req)
+	dpia, err := prb.DataProtectionImpactAssessments.Create(ctx, scope, &req)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -143,7 +147,8 @@ func (r *mutationResolver) UpdateDataProtectionImpactAssessment(ctx context.Cont
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
 	req := probo.UpdateDataProtectionImpactAssessmentRequest{
 		ID:                          input.ID,
@@ -154,7 +159,7 @@ func (r *mutationResolver) UpdateDataProtectionImpactAssessment(ctx context.Cont
 		ResidualRisk:                input.ResidualRisk,
 	}
 
-	dpia, err := prb.DataProtectionImpactAssessments.Update(ctx, &req)
+	dpia, err := prb.DataProtectionImpactAssessments.Update(ctx, scope, &req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -176,9 +181,10 @@ func (r *mutationResolver) DeleteDataProtectionImpactAssessment(ctx context.Cont
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.DataProtectionImpactAssessmentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.DataProtectionImpactAssessmentID)
+	prb := r.probo
 
-	err := prb.DataProtectionImpactAssessments.Delete(ctx, input.DataProtectionImpactAssessmentID)
+	err := prb.DataProtectionImpactAssessments.Delete(ctx, scope, input.DataProtectionImpactAssessmentID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete data protection impact assessment", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -195,7 +201,8 @@ func (r *mutationResolver) CreateTransferImpactAssessment(ctx context.Context, i
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ProcessingActivityID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ProcessingActivityID)
+	prb := r.probo
 
 	req := probo.CreateTransferImpactAssessmentRequest{
 		ProcessingActivityID:  input.ProcessingActivityID,
@@ -206,7 +213,7 @@ func (r *mutationResolver) CreateTransferImpactAssessment(ctx context.Context, i
 		SupplementaryMeasures: input.SupplementaryMeasures,
 	}
 
-	tia, err := prb.TransferImpactAssessments.Create(ctx, &req)
+	tia, err := prb.TransferImpactAssessments.Create(ctx, scope, &req)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -232,7 +239,8 @@ func (r *mutationResolver) UpdateTransferImpactAssessment(ctx context.Context, i
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
 	req := probo.UpdateTransferImpactAssessmentRequest{
 		ID:                    input.ID,
@@ -243,7 +251,7 @@ func (r *mutationResolver) UpdateTransferImpactAssessment(ctx context.Context, i
 		SupplementaryMeasures: gqlutils.UnwrapOmittable(input.SupplementaryMeasures),
 	}
 
-	tia, err := prb.TransferImpactAssessments.Update(ctx, &req)
+	tia, err := prb.TransferImpactAssessments.Update(ctx, scope, &req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -265,9 +273,10 @@ func (r *mutationResolver) DeleteTransferImpactAssessment(ctx context.Context, i
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.TransferImpactAssessmentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.TransferImpactAssessmentID)
+	prb := r.probo
 
-	err := prb.TransferImpactAssessments.Delete(ctx, input.TransferImpactAssessmentID)
+	err := prb.TransferImpactAssessments.Delete(ctx, scope, input.TransferImpactAssessmentID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete transfer impact assessment", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -284,9 +293,10 @@ func (r *mutationResolver) PublishDataProtectionImpactAssessmentList(ctx context
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
-	document, documentVersion, err := prb.GeneratedDocuments.PublishDataProtectionImpactAssessmentList(ctx, input.OrganizationID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := prb.GeneratedDocuments.PublishDataProtectionImpactAssessmentList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -313,9 +323,10 @@ func (r *mutationResolver) PublishTransferImpactAssessmentList(ctx context.Conte
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
-	document, documentVersion, err := prb.GeneratedDocuments.PublishTransferImpactAssessmentList(ctx, input.OrganizationID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := prb.GeneratedDocuments.PublishTransferImpactAssessmentList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -342,9 +353,10 @@ func (r *transferImpactAssessmentResolver) ProcessingActivity(ctx context.Contex
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	processingActivity, err := prb.ProcessingActivities.Get(ctx, obj.ProcessingActivity.ID)
+	processingActivity, err := prb.ProcessingActivities.Get(ctx, scope, obj.ProcessingActivity.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get processing activity", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -386,11 +398,12 @@ func (r *transferImpactAssessmentConnectionResolver) TotalCount(ctx context.Cont
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	prb := r.probo
 
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.TransferImpactAssessments.CountForOrganizationID(ctx, obj.ParentID)
+		count, err := prb.TransferImpactAssessments.CountForOrganizationID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count organization transfer impact assessments", log.Error(err))
 			return 0, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/dataloader/dataloader.go
+++ b/pkg/server/api/console/v1/dataloader/dataloader.go
@@ -91,9 +91,9 @@ func (f *batchFetcher) newLoaders() *Loaders {
 }
 
 func (f *batchFetcher) fetchOrganizations(ctx context.Context, keys []gid.GID) (map[gid.GID]*coredata.Organization, error) {
-	tenantSvc := f.probo.WithTenant(keys[0].TenantID())
+	scope := coredata.NewScopeFromObjectID(keys[0])
 
-	orgs, err := tenantSvc.Organizations.GetByIDs(ctx, keys...)
+	orgs, err := f.probo.Organizations.GetByIDs(ctx, scope, keys...)
 	if err != nil {
 		return nil, fmt.Errorf("cannot batch load organizations: %w", err)
 	}
@@ -107,9 +107,9 @@ func (f *batchFetcher) fetchOrganizations(ctx context.Context, keys []gid.GID) (
 }
 
 func (f *batchFetcher) fetchFrameworks(ctx context.Context, keys []gid.GID) (map[gid.GID]*coredata.Framework, error) {
-	tenantSvc := f.probo.WithTenant(keys[0].TenantID())
+	scope := coredata.NewScopeFromObjectID(keys[0])
 
-	frameworks, err := tenantSvc.Frameworks.GetByIDs(ctx, keys...)
+	frameworks, err := f.probo.Frameworks.GetByIDs(ctx, scope, keys...)
 	if err != nil {
 		return nil, fmt.Errorf("cannot batch load frameworks: %w", err)
 	}
@@ -123,9 +123,9 @@ func (f *batchFetcher) fetchFrameworks(ctx context.Context, keys []gid.GID) (map
 }
 
 func (f *batchFetcher) fetchControls(ctx context.Context, keys []gid.GID) (map[gid.GID]*coredata.Control, error) {
-	tenantSvc := f.probo.WithTenant(keys[0].TenantID())
+	scope := coredata.NewScopeFromObjectID(keys[0])
 
-	controls, err := tenantSvc.Controls.GetByIDs(ctx, keys...)
+	controls, err := f.probo.Controls.GetByIDs(ctx, scope, keys...)
 	if err != nil {
 		return nil, fmt.Errorf("cannot batch load controls: %w", err)
 	}
@@ -139,9 +139,9 @@ func (f *batchFetcher) fetchControls(ctx context.Context, keys []gid.GID) (map[g
 }
 
 func (f *batchFetcher) fetchThirdParties(ctx context.Context, keys []gid.GID) (map[gid.GID]*coredata.ThirdParty, error) {
-	tenantSvc := f.probo.WithTenant(keys[0].TenantID())
+	scope := coredata.NewScopeFromObjectID(keys[0])
 
-	thirdParties, err := tenantSvc.ThirdParties.GetByIDs(ctx, keys...)
+	thirdParties, err := f.probo.ThirdParties.GetByIDs(ctx, scope, keys...)
 	if err != nil {
 		return nil, fmt.Errorf("cannot batch load thirdParties: %w", err)
 	}
@@ -155,9 +155,9 @@ func (f *batchFetcher) fetchThirdParties(ctx context.Context, keys []gid.GID) (m
 }
 
 func (f *batchFetcher) fetchDocuments(ctx context.Context, keys []gid.GID) (map[gid.GID]*coredata.Document, error) {
-	tenantSvc := f.probo.WithTenant(keys[0].TenantID())
+	scope := coredata.NewScopeFromObjectID(keys[0])
 
-	documents, err := tenantSvc.Documents.GetByIDs(ctx, keys...)
+	documents, err := f.probo.Documents.GetByIDs(ctx, scope, keys...)
 	if err != nil {
 		return nil, fmt.Errorf("cannot batch load documents: %w", err)
 	}
@@ -187,9 +187,9 @@ func (f *batchFetcher) fetchProfiles(ctx context.Context, keys []gid.GID) (map[g
 }
 
 func (f *batchFetcher) fetchRisks(ctx context.Context, keys []gid.GID) (map[gid.GID]*coredata.Risk, error) {
-	tenantSvc := f.probo.WithTenant(keys[0].TenantID())
+	scope := coredata.NewScopeFromObjectID(keys[0])
 
-	risks, err := tenantSvc.Risks.GetByIDs(ctx, keys...)
+	risks, err := f.probo.Risks.GetByIDs(ctx, scope, keys...)
 	if err != nil {
 		return nil, fmt.Errorf("cannot batch load risks: %w", err)
 	}
@@ -203,9 +203,9 @@ func (f *batchFetcher) fetchRisks(ctx context.Context, keys []gid.GID) (map[gid.
 }
 
 func (f *batchFetcher) fetchMeasures(ctx context.Context, keys []gid.GID) (map[gid.GID]*coredata.Measure, error) {
-	tenantSvc := f.probo.WithTenant(keys[0].TenantID())
+	scope := coredata.NewScopeFromObjectID(keys[0])
 
-	measures, err := tenantSvc.Measures.GetByIDs(ctx, keys...)
+	measures, err := f.probo.Measures.GetByIDs(ctx, scope, keys...)
 	if err != nil {
 		return nil, fmt.Errorf("cannot batch load measures: %w", err)
 	}
@@ -219,9 +219,9 @@ func (f *batchFetcher) fetchMeasures(ctx context.Context, keys []gid.GID) (map[g
 }
 
 func (f *batchFetcher) fetchTasks(ctx context.Context, keys []gid.GID) (map[gid.GID]*coredata.Task, error) {
-	tenantSvc := f.probo.WithTenant(keys[0].TenantID())
+	scope := coredata.NewScopeFromObjectID(keys[0])
 
-	tasks, err := tenantSvc.Tasks.GetByIDs(ctx, keys...)
+	tasks, err := f.probo.Tasks.GetByIDs(ctx, scope, keys...)
 	if err != nil {
 		return nil, fmt.Errorf("cannot batch load tasks: %w", err)
 	}
@@ -235,9 +235,9 @@ func (f *batchFetcher) fetchTasks(ctx context.Context, keys []gid.GID) (map[gid.
 }
 
 func (f *batchFetcher) fetchFiles(ctx context.Context, keys []gid.GID) (map[gid.GID]*coredata.File, error) {
-	tenantSvc := f.probo.WithTenant(keys[0].TenantID())
+	scope := coredata.NewScopeFromObjectID(keys[0])
 
-	files, err := tenantSvc.Files.GetByIDs(ctx, keys...)
+	files, err := f.probo.Files.GetByIDs(ctx, scope, keys...)
 	if err != nil {
 		return nil, fmt.Errorf("cannot batch load files: %w", err)
 	}
@@ -251,9 +251,9 @@ func (f *batchFetcher) fetchFiles(ctx context.Context, keys []gid.GID) (map[gid.
 }
 
 func (f *batchFetcher) fetchReports(ctx context.Context, keys []gid.GID) (map[gid.GID]*coredata.Report, error) {
-	tenantSvc := f.probo.WithTenant(keys[0].TenantID())
+	scope := coredata.NewScopeFromObjectID(keys[0])
 
-	reports, err := tenantSvc.Reports.GetByIDs(ctx, keys...)
+	reports, err := f.probo.Reports.GetByIDs(ctx, scope, keys...)
 	if err != nil {
 		return nil, fmt.Errorf("cannot batch load reports: %w", err)
 	}

--- a/pkg/server/api/console/v1/document_resolvers.go
+++ b/pkg/server/api/console/v1/document_resolvers.go
@@ -55,7 +55,8 @@ func (r *documentResolver) Versions(ctx context.Context, obj *types.Document, fi
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentVersionOrderField]{
 		Field:     coredata.DocumentVersionOrderFieldCreatedAt,
@@ -75,7 +76,7 @@ func (r *documentResolver) Versions(ctx context.Context, obj *types.Document, fi
 		versionFilter = versionFilter.WithStatuses(filter.Statuses...)
 	}
 
-	page, err := prb.Documents.ListVersions(ctx, obj.ID, cursor, versionFilter)
+	page, err := prb.Documents.ListVersions(ctx, scope, obj.ID, cursor, versionFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list document versions", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -90,7 +91,8 @@ func (r *documentResolver) Controls(ctx context.Context, obj *types.Document, fi
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ControlOrderField]{
 		Field:     coredata.ControlOrderFieldCreatedAt,
@@ -110,7 +112,7 @@ func (r *documentResolver) Controls(ctx context.Context, obj *types.Document, fi
 		controlFilter = coredata.NewControlFilter(filter.Query)
 	}
 
-	page, err := prb.Controls.ListForDocumentID(ctx, obj.ID, cursor, controlFilter)
+	page, err := prb.Controls.ListForDocumentID(ctx, scope, obj.ID, cursor, controlFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list document controls", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -125,9 +127,10 @@ func (r *documentResolver) DefaultApprovers(ctx context.Context, obj *types.Docu
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	profiles, err := prb.Documents.GetDefaultApprovers(ctx, obj.ID)
+	profiles, err := prb.Documents.GetDefaultApprovers(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get default approvers", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -152,11 +155,12 @@ func (r *documentConnectionResolver) TotalCount(ctx context.Context, obj *types.
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	prb := r.probo
 
 	switch obj.Resolver.(type) {
 	case *controlResolver:
-		count, err := prb.Documents.CountForControlID(ctx, obj.ParentID, obj.Filters)
+		count, err := prb.Documents.CountForControlID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count controls", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -164,7 +168,7 @@ func (r *documentConnectionResolver) TotalCount(ctx context.Context, obj *types.
 
 		return count, nil
 	case *organizationResolver:
-		count, err := prb.Documents.CountForOrganizationID(ctx, obj.ParentID, obj.Filters)
+		count, err := prb.Documents.CountForOrganizationID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count documents", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -172,7 +176,7 @@ func (r *documentConnectionResolver) TotalCount(ctx context.Context, obj *types.
 
 		return count, nil
 	case *riskResolver:
-		count, err := prb.Documents.CountForRiskID(ctx, obj.ParentID, obj.Filters)
+		count, err := prb.Documents.CountForRiskID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count risks", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -180,7 +184,7 @@ func (r *documentConnectionResolver) TotalCount(ctx context.Context, obj *types.
 
 		return count, nil
 	case *measureResolver:
-		count, err := prb.Documents.CountForMeasureID(ctx, obj.ParentID, obj.Filters)
+		count, err := prb.Documents.CountForMeasureID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count documents", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -229,7 +233,8 @@ func (r *documentVersionResolver) Approvers(ctx context.Context, obj *types.Docu
 		}, nil
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.MembershipProfileOrderField]{
 		Field:     coredata.MembershipProfileOrderFieldCreatedAt,
@@ -242,7 +247,7 @@ func (r *documentVersionResolver) Approvers(ctx context.Context, obj *types.Docu
 
 	c := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	p, err := prb.Documents.ListVersionApprovers(ctx, obj.ID, c)
+	p, err := prb.Documents.ListVersionApprovers(ctx, scope, obj.ID, c)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list document version approvers", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -257,7 +262,8 @@ func (r *documentVersionResolver) Signatures(ctx context.Context, obj *types.Doc
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentVersionSignatureOrderField]{
 		Field:     coredata.DocumentVersionSignatureOrderFieldCreatedAt,
@@ -289,7 +295,7 @@ func (r *documentVersionResolver) Signatures(ctx context.Context, obj *types.Doc
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Documents.ListSignatures(ctx, obj.ID, cursor, signatureFilter)
+	page, err := prb.Documents.ListSignatures(ctx, scope, obj.ID, cursor, signatureFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list document version signatures", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -304,7 +310,8 @@ func (r *documentVersionResolver) ApprovalQuorums(ctx context.Context, obj *type
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentVersionApprovalQuorumOrderField]{
 		Field:     coredata.DocumentVersionApprovalQuorumOrderFieldCreatedAt,
@@ -319,7 +326,7 @@ func (r *documentVersionResolver) ApprovalQuorums(ctx context.Context, obj *type
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	p, err := prb.DocumentApprovals.ListQuorums(ctx, obj.ID, cursor)
+	p, err := prb.DocumentApprovals.ListQuorums(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list approval quorums", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -336,9 +343,10 @@ func (r *documentVersionResolver) Signed(ctx context.Context, obj *types.Documen
 
 	identity := authn.IdentityFromContext(ctx)
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	signed, err := prb.Documents.IsVersionSignedByUserEmail(ctx, obj.ID, identity.EmailAddress)
+	signed, err := prb.Documents.IsVersionSignedByUserEmail(ctx, scope, obj.ID, identity.EmailAddress)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot check if document version is signed", log.Error(err))
 		return false, gqlutils.Internal(ctx)
@@ -358,9 +366,10 @@ func (r *documentVersionApprovalDecisionResolver) Quorum(ctx context.Context, ob
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	quorum, err := prb.DocumentApprovals.GetQuorum(ctx, obj.Quorum.ID)
+	quorum, err := prb.DocumentApprovals.GetQuorum(ctx, scope, obj.Quorum.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -380,9 +389,10 @@ func (r *documentVersionApprovalDecisionResolver) DocumentVersion(ctx context.Co
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	quorum, err := prb.DocumentApprovals.GetQuorum(ctx, obj.Quorum.ID)
+	quorum, err := prb.DocumentApprovals.GetQuorum(ctx, scope, obj.Quorum.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -393,7 +403,7 @@ func (r *documentVersionApprovalDecisionResolver) DocumentVersion(ctx context.Co
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	documentVersion, err := prb.Documents.GetVersion(ctx, quorum.VersionID)
+	documentVersion, err := prb.Documents.GetVersion(ctx, scope, quorum.VersionID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -460,14 +470,15 @@ func (r *documentVersionApprovalDecisionConnectionResolver) TotalCount(ctx conte
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	prb := r.probo
 
 	filter := coredata.NewDocumentVersionApprovalDecisionFilter(nil)
 	if obj.Filters != nil {
 		filter = obj.Filters
 	}
 
-	count, err := prb.DocumentApprovals.CountDecisions(ctx, obj.ParentID, filter)
+	count, err := prb.DocumentApprovals.CountDecisions(ctx, scope, obj.ParentID, filter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot count approval decisions", log.Error(err))
 		return 0, gqlutils.Internal(ctx)
@@ -482,9 +493,10 @@ func (r *documentVersionApprovalQuorumResolver) DocumentVersion(ctx context.Cont
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	documentVersion, err := prb.Documents.GetVersion(ctx, obj.DocumentVersion.ID)
+	documentVersion, err := prb.Documents.GetVersion(ctx, scope, obj.DocumentVersion.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -504,7 +516,8 @@ func (r *documentVersionApprovalQuorumResolver) Decisions(ctx context.Context, o
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentVersionApprovalDecisionOrderField]{
 		Field:     coredata.DocumentVersionApprovalDecisionOrderFieldCreatedAt,
@@ -526,7 +539,7 @@ func (r *documentVersionApprovalQuorumResolver) Decisions(ctx context.Context, o
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	p, err := prb.DocumentApprovals.ListDecisions(ctx, obj.ID, cursor, approvalFilter)
+	p, err := prb.DocumentApprovals.ListDecisions(ctx, scope, obj.ID, cursor, approvalFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list approval decisions", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -546,9 +559,10 @@ func (r *documentVersionApprovalQuorumConnectionResolver) TotalCount(ctx context
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	prb := r.probo
 
-	count, err := prb.DocumentApprovals.CountQuorums(ctx, obj.ParentID)
+	count, err := prb.DocumentApprovals.CountQuorums(ctx, scope, obj.ParentID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot count approval quorums", log.Error(err))
 		return 0, gqlutils.Internal(ctx)
@@ -563,7 +577,8 @@ func (r *documentVersionConnectionResolver) TotalCount(ctx context.Context, obj 
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	prb := r.probo
 
 	switch obj.Resolver.(type) {
 	case *documentResolver:
@@ -572,7 +587,7 @@ func (r *documentVersionConnectionResolver) TotalCount(ctx context.Context, obj 
 			filter = obj.Filters
 		}
 
-		count, err := prb.Documents.CountVersionsForDocumentID(ctx, obj.ParentID, filter)
+		count, err := prb.Documents.CountVersionsForDocumentID(ctx, scope, obj.ParentID, filter)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count document versions", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -592,9 +607,10 @@ func (r *documentVersionSignatureResolver) DocumentVersion(ctx context.Context, 
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	documentVersion, err := prb.Documents.GetVersion(ctx, obj.DocumentVersion.ID)
+	documentVersion, err := prb.Documents.GetVersion(ctx, scope, obj.DocumentVersion.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -641,7 +657,8 @@ func (r *documentVersionSignatureConnectionResolver) TotalCount(ctx context.Cont
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	prb := r.probo
 
 	switch obj.Resolver.(type) {
 	case *documentVersionResolver:
@@ -650,7 +667,7 @@ func (r *documentVersionSignatureConnectionResolver) TotalCount(ctx context.Cont
 			filter = obj.Filters
 		}
 
-		count, err := prb.Documents.CountSignaturesForVersionID(ctx, obj.ParentID, filter)
+		count, err := prb.Documents.CountSignaturesForVersionID(ctx, scope, obj.ParentID, filter)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count signatures", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -672,9 +689,10 @@ func (r *employeeDocumentResolver) Signed(ctx context.Context, obj *types.Employ
 
 	identity := authn.IdentityFromContext(ctx)
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	signed, err := prb.Documents.IsSigned(ctx, obj.ID, identity.EmailAddress)
+	signed, err := prb.Documents.IsSigned(ctx, scope, obj.ID, identity.EmailAddress)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil
@@ -696,9 +714,10 @@ func (r *employeeDocumentResolver) ApprovalState(ctx context.Context, obj *types
 
 	identity := authn.IdentityFromContext(ctx)
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	state, err := prb.Documents.GetViewerApprovalState(ctx, obj.ID, identity.ID)
+	state, err := prb.Documents.GetViewerApprovalState(ctx, scope, obj.ID, identity.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil
@@ -718,7 +737,8 @@ func (r *employeeDocumentResolver) Versions(ctx context.Context, obj *types.Empl
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentVersionOrderField]{
 		Field:     coredata.DocumentVersionOrderFieldCreatedAt,
@@ -750,7 +770,7 @@ func (r *employeeDocumentResolver) Versions(ctx context.Context, obj *types.Empl
 	versionFilter := coredata.NewDocumentVersionFilter().
 		WithEmployeeIdentityID(&identity.ID, filterMode)
 
-	versionsPage, err := prb.Documents.ListVersions(ctx, obj.ID, cursor, versionFilter)
+	versionsPage, err := prb.Documents.ListVersions(ctx, scope, obj.ID, cursor, versionFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list employee document versions", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -786,9 +806,10 @@ func (r *employeeDocumentVersionResolver) Signed(ctx context.Context, obj *types
 
 	identity := authn.IdentityFromContext(ctx)
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	signed, err := prb.Documents.IsVersionSignedByUserEmail(ctx, obj.ID, identity.EmailAddress)
+	signed, err := prb.Documents.IsVersionSignedByUserEmail(ctx, scope, obj.ID, identity.EmailAddress)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot check if version is signed", log.Error(err))
 		return false, gqlutils.Internal(ctx)
@@ -804,9 +825,10 @@ func (r *employeeDocumentVersionResolver) ApprovalDecision(ctx context.Context, 
 	}
 
 	identity := authn.IdentityFromContext(ctx)
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	decision, err := prb.DocumentApprovals.GetViewerDecision(ctx, obj.ID, identity.ID)
+	decision, err := prb.DocumentApprovals.GetViewerDecision(ctx, scope, obj.ID, identity.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil
@@ -826,7 +848,8 @@ func (r *mutationResolver) CreateDocument(ctx context.Context, input types.Creat
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
 	var content string
 	if input.Content != nil {
@@ -834,7 +857,7 @@ func (r *mutationResolver) CreateDocument(ctx context.Context, input types.Creat
 	}
 
 	document, documentVersion, err := prb.Documents.Create(
-		ctx,
+		ctx, scope,
 		probo.CreateDocumentRequest{
 			OrganizationID:        input.OrganizationID,
 			Title:                 input.Title,
@@ -871,7 +894,8 @@ func (r *mutationResolver) UpdateDocument(ctx context.Context, input types.Updat
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
 	var defaultApproverIDs *[]gid.GID
 	if input.DefaultApproverIds != nil {
@@ -879,7 +903,7 @@ func (r *mutationResolver) UpdateDocument(ctx context.Context, input types.Updat
 	}
 
 	document, documentVersion, draftCreated, err := prb.Documents.Update(
-		ctx,
+		ctx, scope,
 		probo.UpdateDocumentRequest{
 			DocumentID:            input.ID,
 			Title:                 input.Title,
@@ -936,9 +960,10 @@ func (r *mutationResolver) DeleteDocumentDraft(ctx context.Context, input types.
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.DocumentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.DocumentID)
+	prb := r.probo
 
-	document, err := prb.Documents.DeleteDraft(ctx, input.DocumentID)
+	document, err := prb.Documents.DeleteDraft(ctx, scope, input.DocumentID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -968,9 +993,10 @@ func (r *mutationResolver) ArchiveDocument(ctx context.Context, input types.Arch
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.DocumentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.DocumentID)
+	prb := r.probo
 
-	document, err := prb.Documents.Archive(ctx, input.DocumentID)
+	document, err := prb.Documents.Archive(ctx, scope, input.DocumentID)
 	if err != nil {
 		if errArchived, ok := errors.AsType[*probo.ErrDocumentArchived](err); ok {
 			return nil, gqlutils.Conflict(ctx, errArchived)
@@ -992,9 +1018,10 @@ func (r *mutationResolver) UnarchiveDocument(ctx context.Context, input types.Un
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.DocumentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.DocumentID)
+	prb := r.probo
 
-	document, err := prb.Documents.Unarchive(ctx, input.DocumentID)
+	document, err := prb.Documents.Unarchive(ctx, scope, input.DocumentID)
 	if err != nil {
 		if errNotArchived, ok := errors.AsType[*probo.ErrDocumentNotArchived](err); ok {
 			return nil, gqlutils.Conflict(ctx, errNotArchived)
@@ -1016,9 +1043,10 @@ func (r *mutationResolver) DeleteDocument(ctx context.Context, input types.Delet
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.DocumentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.DocumentID)
+	prb := r.probo
 
-	err := prb.Documents.SoftDelete(ctx, input.DocumentID)
+	err := prb.Documents.SoftDelete(ctx, scope, input.DocumentID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot soft delete document", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1040,9 +1068,10 @@ func (r *mutationResolver) PublishDocument(ctx context.Context, input types.Publ
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.DocumentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.DocumentID)
+	prb := r.probo
 
-	result, err := prb.Documents.PublishVersion(ctx, probo.PublishDocumentRequest{
+	result, err := prb.Documents.PublishVersion(ctx, scope, probo.PublishDocumentRequest{
 		DocumentID:  input.DocumentID,
 		Minor:       input.Minor,
 		ApproverIDs: input.ApproverIds,
@@ -1104,9 +1133,10 @@ func (r *mutationResolver) BulkPublishDocuments(ctx context.Context, input types
 		}
 	}
 
-	prb := r.ProboService(ctx, input.DocumentIds[0].TenantID())
+	scope := coredata.NewScopeFromObjectID(input.DocumentIds[0])
+	prb := r.probo
 
-	versions, documents, err := prb.DocumentApprovals.BulkPublishVersions(ctx, probo.BulkPublishVersionsRequest{
+	versions, documents, err := prb.DocumentApprovals.BulkPublishVersions(ctx, scope, probo.BulkPublishVersionsRequest{
 		DocumentIDs: input.DocumentIds,
 		Minor:       input.Minor,
 		Changelog:   input.Changelog,
@@ -1151,9 +1181,10 @@ func (r *mutationResolver) VoidDocumentVersionApproval(ctx context.Context, inpu
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.DocumentVersionID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.DocumentVersionID)
+	prb := r.probo
 
-	quorum, documentVersion, err := prb.DocumentApprovals.VoidApproval(ctx, input.DocumentVersionID)
+	quorum, documentVersion, err := prb.DocumentApprovals.VoidApproval(ctx, scope, input.DocumentVersionID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -1192,9 +1223,10 @@ func (r *mutationResolver) BulkDeleteDocuments(ctx context.Context, input types.
 		}
 	}
 
-	prb := r.ProboService(ctx, input.DocumentIds[0].TenantID())
+	scope := coredata.NewScopeFromObjectID(input.DocumentIds[0])
+	prb := r.probo
 
-	err := prb.Documents.BulkSoftDelete(ctx, input.DocumentIds)
+	err := prb.Documents.BulkSoftDelete(ctx, scope, input.DocumentIds)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot bulk delete documents", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1219,9 +1251,10 @@ func (r *mutationResolver) BulkArchiveDocuments(ctx context.Context, input types
 		}
 	}
 
-	prb := r.ProboService(ctx, input.DocumentIds[0].TenantID())
+	scope := coredata.NewScopeFromObjectID(input.DocumentIds[0])
+	prb := r.probo
 
-	if err := prb.Documents.BulkArchive(ctx, input.DocumentIds); err != nil {
+	if err := prb.Documents.BulkArchive(ctx, scope, input.DocumentIds); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot bulk archive documents", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -1245,9 +1278,10 @@ func (r *mutationResolver) BulkUnarchiveDocuments(ctx context.Context, input typ
 		}
 	}
 
-	prb := r.ProboService(ctx, input.DocumentIds[0].TenantID())
+	scope := coredata.NewScopeFromObjectID(input.DocumentIds[0])
+	prb := r.probo
 
-	if err := prb.Documents.BulkUnarchive(ctx, input.DocumentIds); err != nil {
+	if err := prb.Documents.BulkUnarchive(ctx, scope, input.DocumentIds); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot bulk unarchive documents", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -1271,7 +1305,8 @@ func (r *mutationResolver) BulkExportDocuments(ctx context.Context, input types.
 		}
 	}
 
-	prb := r.ProboService(ctx, input.DocumentIds[0].TenantID())
+	scope := coredata.NewScopeFromObjectID(input.DocumentIds[0])
+	prb := r.probo
 
 	identity := authn.IdentityFromContext(ctx)
 
@@ -1281,7 +1316,7 @@ func (r *mutationResolver) BulkExportDocuments(ctx context.Context, input types.
 		WatermarkEmail: input.WatermarkEmail,
 	}
 
-	documentExport, exportErr := prb.Documents.RequestExport(ctx, input.DocumentIds, identity.EmailAddress, identity.FullName, options)
+	documentExport, exportErr := prb.Documents.RequestExport(ctx, scope, input.DocumentIds, identity.EmailAddress, identity.FullName, options)
 	if exportErr != nil {
 		r.logger.ErrorCtx(ctx, "cannot request document export", log.Error(exportErr))
 		return nil, gqlutils.Internal(ctx)
@@ -1298,9 +1333,10 @@ func (r *mutationResolver) GenerateDocumentChangelog(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.DocumentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.DocumentID)
+	prb := r.probo
 
-	changelog, err := prb.Documents.GenerateChangelog(ctx, input.DocumentID)
+	changelog, err := prb.Documents.GenerateChangelog(ctx, scope, input.DocumentID)
 	if err != nil {
 		if errArchived, ok := errors.AsType[*probo.ErrDocumentArchived](err); ok {
 			return nil, gqlutils.Conflict(ctx, errArchived)
@@ -1322,10 +1358,11 @@ func (r *mutationResolver) RequestSignature(ctx context.Context, input types.Req
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.DocumentVersionID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.DocumentVersionID)
+	prb := r.probo
 
 	documentVersionSignature, err := prb.Documents.RequestSignature(
-		ctx,
+		ctx, scope,
 		probo.RequestSignatureRequest{
 			DocumentVersionID: input.DocumentVersionID,
 			Signatory:         input.SignatoryID,
@@ -1372,10 +1409,11 @@ func (r *mutationResolver) BulkRequestSignatures(ctx context.Context, input type
 		}
 	}
 
-	prb := r.ProboService(ctx, input.DocumentIds[0].TenantID())
+	scope := coredata.NewScopeFromObjectID(input.DocumentIds[0])
+	prb := r.probo
 
 	documentVersionSignatures, err := prb.Documents.BulkRequestSignatures(
-		ctx,
+		ctx, scope,
 		probo.BulkRequestSignaturesRequest{
 			DocumentIDs:  input.DocumentIds,
 			SignatoryIDs: input.SignatoryIds,
@@ -1410,9 +1448,10 @@ func (r *mutationResolver) SendSigningNotifications(ctx context.Context, input t
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
-	err := prb.Documents.SendSigningNotifications(ctx, input.OrganizationID)
+	err := prb.Documents.SendSigningNotifications(ctx, scope, input.OrganizationID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot send signing notifications", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1429,9 +1468,10 @@ func (r *mutationResolver) CancelSignatureRequest(ctx context.Context, input typ
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.DocumentVersionSignatureID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.DocumentVersionSignatureID)
+	prb := r.probo
 
-	err := prb.Documents.CancelSignatureRequest(ctx, input.DocumentVersionSignatureID)
+	err := prb.Documents.CancelSignatureRequest(ctx, scope, input.DocumentVersionSignatureID)
 	if err != nil {
 		if errArchived, ok := errors.AsType[*probo.ErrDocumentArchived](err); ok {
 			return nil, gqlutils.Conflict(ctx, errArchived)
@@ -1454,9 +1494,10 @@ func (r *mutationResolver) SignDocument(ctx context.Context, input types.SignDoc
 	}
 
 	identity := authn.IdentityFromContext(ctx)
-	prb := r.ProboService(ctx, input.DocumentVersionID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.DocumentVersionID)
+	prb := r.probo
 
-	documentVersionSignature, err := prb.Documents.SignDocumentVersionByIdentity(ctx, input.DocumentVersionID, identity.ID)
+	documentVersionSignature, err := prb.Documents.SignDocumentVersionByIdentity(ctx, scope, input.DocumentVersionID, identity.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -1486,9 +1527,10 @@ func (r *mutationResolver) ApproveDocumentVersion(ctx context.Context, input typ
 		signerIP = httpReq.RemoteAddr
 	}
 
-	prb := r.ProboService(ctx, input.DocumentVersionID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.DocumentVersionID)
+	prb := r.probo
 
-	decision, err := prb.DocumentApprovals.Approve(ctx, probo.ApproveDocumentVersionRequest{
+	decision, err := prb.DocumentApprovals.Approve(ctx, scope, probo.ApproveDocumentVersionRequest{
 		DocumentVersionID: input.DocumentVersionID,
 		IdentityID:        identity.ID,
 		Comment:           input.Comment,
@@ -1532,9 +1574,10 @@ func (r *mutationResolver) RejectDocumentVersion(ctx context.Context, input type
 
 	identity := authn.IdentityFromContext(ctx)
 
-	prb := r.ProboService(ctx, input.DocumentVersionID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.DocumentVersionID)
+	prb := r.probo
 
-	decision, err := prb.DocumentApprovals.Reject(ctx, probo.RejectDocumentVersionRequest{
+	decision, err := prb.DocumentApprovals.Reject(ctx, scope, probo.RejectDocumentVersionRequest{
 		DocumentVersionID: input.DocumentVersionID,
 		IdentityID:        identity.ID,
 		Comment:           input.Comment,
@@ -1572,7 +1615,8 @@ func (r *mutationResolver) ExportDocumentVersionPDF(ctx context.Context, input t
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.DocumentVersionID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.DocumentVersionID)
+	prb := r.probo
 
 	watermarkEmail := input.WatermarkEmail
 	if input.WithWatermark && watermarkEmail == nil {
@@ -1586,7 +1630,7 @@ func (r *mutationResolver) ExportDocumentVersionPDF(ctx context.Context, input t
 		WatermarkEmail: watermarkEmail,
 	}
 
-	pdf, err := prb.Documents.ExportPDF(ctx, input.DocumentVersionID, options)
+	pdf, err := prb.Documents.ExportPDF(ctx, scope, input.DocumentVersionID, options)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot export document version PDF", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1603,9 +1647,10 @@ func (r *mutationResolver) ExportEmployeeDocumentVersionPDF(ctx context.Context,
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.DocumentVersionID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.DocumentVersionID)
+	prb := r.probo
 
-	documentVersion, err := prb.Documents.GetVersion(ctx, input.DocumentVersionID)
+	documentVersion, err := prb.Documents.GetVersion(ctx, scope, input.DocumentVersionID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get document version", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1618,7 +1663,7 @@ func (r *mutationResolver) ExportEmployeeDocumentVersionPDF(ctx context.Context,
 		coredata.EmployeeFilterModeApproval,
 	)
 
-	_, err = prb.Documents.GetWithFilter(ctx, documentVersion.DocumentID, documentFilter)
+	_, err = prb.Documents.GetWithFilter(ctx, scope, documentVersion.DocumentID, documentFilter)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -1635,7 +1680,7 @@ func (r *mutationResolver) ExportEmployeeDocumentVersionPDF(ctx context.Context,
 		WatermarkEmail: &identity.EmailAddress,
 	}
 
-	pdf, err := prb.Documents.ExportPDF(ctx, input.DocumentVersionID, options)
+	pdf, err := prb.Documents.ExportPDF(ctx, scope, input.DocumentVersionID, options)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot export employee document PDF", log.Error(err))
 		return nil, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/evidence_resolvers.go
+++ b/pkg/server/api/console/v1/evidence_resolvers.go
@@ -106,11 +106,12 @@ func (r *evidenceConnectionResolver) TotalCount(ctx context.Context, obj *types.
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	prb := r.probo
 
 	switch obj.Resolver.(type) {
 	case *measureResolver:
-		count, err := prb.Evidences.CountForMeasureID(ctx, obj.ParentID)
+		count, err := prb.Evidences.CountForMeasureID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count measure evidence", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -118,7 +119,7 @@ func (r *evidenceConnectionResolver) TotalCount(ctx context.Context, obj *types.
 
 		return count, nil
 	case *taskResolver:
-		count, err := prb.Evidences.CountForTaskID(ctx, obj.ParentID)
+		count, err := prb.Evidences.CountForTaskID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count task evidence", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -138,9 +139,10 @@ func (r *mutationResolver) DeleteEvidence(ctx context.Context, input types.Delet
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.EvidenceID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.EvidenceID)
+	prb := r.probo
 
-	err := prb.Evidences.Delete(ctx, input.EvidenceID)
+	err := prb.Evidences.Delete(ctx, scope, input.EvidenceID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete evidence", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -157,10 +159,11 @@ func (r *mutationResolver) UploadMeasureEvidence(ctx context.Context, input type
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.MeasureID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.MeasureID)
+	prb := r.probo
 
 	evidence, err := prb.Evidences.UploadMeasureEvidence(
-		ctx,
+		ctx, scope,
 		probo.UploadMeasureEvidenceRequest{
 			MeasureID: input.MeasureID,
 			File: probo.FileUpload{

--- a/pkg/server/api/console/v1/file_resolvers.go
+++ b/pkg/server/api/console/v1/file_resolvers.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/probo"
 	"go.probo.inc/probo/pkg/server/api/console/v1/schema"
 	"go.probo.inc/probo/pkg/server/api/console/v1/types"
@@ -22,9 +23,10 @@ func (r *fileResolver) DownloadURL(ctx context.Context, obj *types.File) (string
 		return "", err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	downloadUrl, err := prb.Files.GenerateFileTempURL(ctx, obj.ID, 60*time.Second)
+	downloadUrl, err := prb.Files.GenerateFileTempURL(ctx, scope, obj.ID, 60*time.Second)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate download URL", log.Error(err))
 		return "", gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/framework_resolvers.go
+++ b/pkg/server/api/console/v1/framework_resolvers.go
@@ -52,7 +52,8 @@ func (r *frameworkResolver) Controls(ctx context.Context, obj *types.Framework, 
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ControlOrderField]{
 		Field:     coredata.ControlOrderFieldCreatedAt,
@@ -72,7 +73,7 @@ func (r *frameworkResolver) Controls(ctx context.Context, obj *types.Framework, 
 		controlFilter = coredata.NewControlFilter(filter.Query)
 	}
 
-	page, err := prb.Controls.ListForFrameworkID(ctx, obj.ID, cursor, controlFilter)
+	page, err := prb.Controls.ListForFrameworkID(ctx, scope, obj.ID, cursor, controlFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list controls", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -87,9 +88,10 @@ func (r *frameworkResolver) LightLogoURL(ctx context.Context, obj *types.Framewo
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	return prb.Frameworks.GenerateLightLogoURL(ctx, obj.ID, 1*time.Hour)
+	return prb.Frameworks.GenerateLightLogoURL(ctx, scope, obj.ID, 1*time.Hour)
 }
 
 // DarkLogoURL is the resolver for the darkLogoURL field.
@@ -98,9 +100,10 @@ func (r *frameworkResolver) DarkLogoURL(ctx context.Context, obj *types.Framewor
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	return prb.Frameworks.GenerateDarkLogoURL(ctx, obj.ID, 1*time.Hour)
+	return prb.Frameworks.GenerateDarkLogoURL(ctx, scope, obj.ID, 1*time.Hour)
 }
 
 // Permission is the resolver for the permission field.
@@ -116,9 +119,10 @@ func (r *frameworkConnectionResolver) TotalCount(ctx context.Context, obj *types
 
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		prb := r.ProboService(ctx, obj.ParentID.TenantID())
+		scope := coredata.NewScopeFromObjectID(obj.ParentID)
+		prb := r.probo
 
-		count, err := prb.Frameworks.CountForOrganizationID(ctx, obj.ParentID)
+		count, err := prb.Frameworks.CountForOrganizationID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count frameworks", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -138,10 +142,11 @@ func (r *mutationResolver) CreateFramework(ctx context.Context, input types.Crea
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
 	framework, err := prb.Frameworks.Create(
-		ctx,
+		ctx, scope,
 		probo.CreateFrameworkRequest{
 			OrganizationID: input.OrganizationID,
 			Name:           input.Name,
@@ -168,10 +173,11 @@ func (r *mutationResolver) UpdateFramework(ctx context.Context, input types.Upda
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
 	framework, err := prb.Frameworks.Update(
-		ctx,
+		ctx, scope,
 		probo.UpdateFrameworkRequest{
 			ID:          input.ID,
 			Name:        input.Name,
@@ -199,7 +205,8 @@ func (r *mutationResolver) ImportFramework(ctx context.Context, input types.Impo
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
 	req := probo.ImportFrameworkRequest{}
 	if err := json.NewDecoder(input.File.File).Decode(&req.Framework); err != nil {
@@ -207,7 +214,7 @@ func (r *mutationResolver) ImportFramework(ctx context.Context, input types.Impo
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	framework, err := prb.Frameworks.Import(ctx, input.OrganizationID, req)
+	framework, err := prb.Frameworks.Import(ctx, scope, input.OrganizationID, req)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -229,9 +236,10 @@ func (r *mutationResolver) DeleteFramework(ctx context.Context, input types.Dele
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.FrameworkID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.FrameworkID)
+	prb := r.probo
 
-	err := prb.Frameworks.Delete(ctx, input.FrameworkID)
+	err := prb.Frameworks.Delete(ctx, scope, input.FrameworkID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete framework", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -248,11 +256,13 @@ func (r *mutationResolver) ExportFramework(ctx context.Context, input types.Expo
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.FrameworkID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.FrameworkID)
+	prb := r.probo
+
 	identity := authn.IdentityFromContext(ctx)
 
 	exportJob, exportErr := prb.Frameworks.RequestExport(
-		ctx,
+		ctx, scope,
 		input.FrameworkID,
 		identity.EmailAddress,
 		identity.FullName,

--- a/pkg/server/api/console/v1/measure_resolvers.go
+++ b/pkg/server/api/console/v1/measure_resolvers.go
@@ -26,7 +26,8 @@ func (r *measureResolver) Evidences(ctx context.Context, obj *types.Measure, fir
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.EvidenceOrderField]{
 		Field:     coredata.EvidenceOrderFieldCreatedAt,
@@ -41,7 +42,7 @@ func (r *measureResolver) Evidences(ctx context.Context, obj *types.Measure, fir
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Evidences.ListForMeasureID(ctx, obj.ID, cursor)
+	page, err := prb.Evidences.ListForMeasureID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list measure evidences", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -56,7 +57,8 @@ func (r *measureResolver) Tasks(ctx context.Context, obj *types.Measure, first *
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.TaskOrderField]{
 		Field:     coredata.TaskOrderFieldCreatedAt,
@@ -71,7 +73,7 @@ func (r *measureResolver) Tasks(ctx context.Context, obj *types.Measure, first *
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Tasks.ListForMeasureID(ctx, obj.ID, cursor)
+	page, err := prb.Tasks.ListForMeasureID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list measure tasks", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -86,7 +88,8 @@ func (r *measureResolver) Risks(ctx context.Context, obj *types.Measure, first *
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.RiskOrderField]{
 		Field:     coredata.RiskOrderFieldCreatedAt,
@@ -106,7 +109,7 @@ func (r *measureResolver) Risks(ctx context.Context, obj *types.Measure, first *
 		riskFilter = coredata.NewRiskFilter(filter.Query)
 	}
 
-	page, err := prb.Risks.ListForMeasureID(ctx, obj.ID, cursor, riskFilter)
+	page, err := prb.Risks.ListForMeasureID(ctx, scope, obj.ID, cursor, riskFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list measure risks", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -121,7 +124,8 @@ func (r *measureResolver) Controls(ctx context.Context, obj *types.Measure, firs
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ControlOrderField]{
 		Field:     coredata.ControlOrderFieldCreatedAt,
@@ -141,7 +145,7 @@ func (r *measureResolver) Controls(ctx context.Context, obj *types.Measure, firs
 		controlFilter = coredata.NewControlFilter(filter.Query)
 	}
 
-	page, err := prb.Controls.ListForMeasureID(ctx, obj.ID, cursor, controlFilter)
+	page, err := prb.Controls.ListForMeasureID(ctx, scope, obj.ID, cursor, controlFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list measure controls", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -156,7 +160,8 @@ func (r *measureResolver) Documents(ctx context.Context, obj *types.Measure, fir
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
 		Field:     coredata.DocumentOrderFieldCreatedAt,
@@ -179,7 +184,7 @@ func (r *measureResolver) Documents(ctx context.Context, obj *types.Measure, fir
 			WithClassifications(filter.Classifications)
 	}
 
-	pg, err := prb.Documents.ListForMeasureID(ctx, obj.ID, cursor, documentFilter)
+	pg, err := prb.Documents.ListForMeasureID(ctx, scope, obj.ID, cursor, documentFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list documents", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -199,11 +204,12 @@ func (r *measureConnectionResolver) TotalCount(ctx context.Context, obj *types.M
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	prb := r.probo
 
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.Measures.CountForOrganizationID(ctx, obj.ParentID, obj.Filters)
+		count, err := prb.Measures.CountForOrganizationID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count measures", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -211,7 +217,7 @@ func (r *measureConnectionResolver) TotalCount(ctx context.Context, obj *types.M
 
 		return count, nil
 	case *controlResolver:
-		count, err := prb.Measures.CountForControlID(ctx, obj.ParentID, obj.Filters)
+		count, err := prb.Measures.CountForControlID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count measures", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -219,7 +225,7 @@ func (r *measureConnectionResolver) TotalCount(ctx context.Context, obj *types.M
 
 		return count, nil
 	case *riskResolver:
-		count, err := prb.Measures.CountForRiskID(ctx, obj.ParentID, obj.Filters)
+		count, err := prb.Measures.CountForRiskID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count measures", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -239,10 +245,11 @@ func (r *mutationResolver) CreateMeasure(ctx context.Context, input types.Create
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
 	measure, err := prb.Measures.Create(
-		ctx,
+		ctx, scope,
 		probo.CreateMeasureRequest{
 			OrganizationID: input.OrganizationID,
 			Name:           input.Name,
@@ -275,10 +282,11 @@ func (r *mutationResolver) UpdateMeasure(ctx context.Context, input types.Update
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
 	measure, err := prb.Measures.Update(
-		ctx,
+		ctx, scope,
 		probo.UpdateMeasureRequest{
 			ID:          input.ID,
 			Name:        input.Name,
@@ -308,7 +316,8 @@ func (r *mutationResolver) ImportMeasure(ctx context.Context, input types.Import
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
 	var req probo.ImportMeasureRequest
 	if err := json.NewDecoder(input.File.File).Decode(&req.Measures); err != nil {
@@ -316,7 +325,7 @@ func (r *mutationResolver) ImportMeasure(ctx context.Context, input types.Import
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	measures, err := prb.Measures.Import(ctx, input.OrganizationID, req)
+	measures, err := prb.Measures.Import(ctx, scope, input.OrganizationID, req)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot import measure", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -338,9 +347,10 @@ func (r *mutationResolver) DeleteMeasure(ctx context.Context, input types.Delete
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.MeasureID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.MeasureID)
+	prb := r.probo
 
-	err := prb.Measures.Delete(ctx, input.MeasureID)
+	err := prb.Measures.Delete(ctx, scope, input.MeasureID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete measure", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -357,9 +367,10 @@ func (r *mutationResolver) CreateMeasureDocumentMapping(ctx context.Context, inp
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.MeasureID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.MeasureID)
+	prb := r.probo
 
-	measure, document, err := prb.Measures.CreateDocumentMapping(ctx, input.MeasureID, input.DocumentID)
+	measure, document, err := prb.Measures.CreateDocumentMapping(ctx, scope, input.MeasureID, input.DocumentID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -382,9 +393,10 @@ func (r *mutationResolver) DeleteMeasureDocumentMapping(ctx context.Context, inp
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.MeasureID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.MeasureID)
+	prb := r.probo
 
-	measure, document, err := prb.Measures.DeleteDocumentMapping(ctx, input.MeasureID, input.DocumentID)
+	measure, document, err := prb.Measures.DeleteDocumentMapping(ctx, scope, input.MeasureID, input.DocumentID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete measure document mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/obligation_resolvers.go
+++ b/pkg/server/api/console/v1/obligation_resolvers.go
@@ -27,7 +27,8 @@ func (r *mutationResolver) CreateObligation(ctx context.Context, input types.Cre
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
 	req := probo.CreateObligationRequest{
 		OrganizationID:         input.OrganizationID,
@@ -43,7 +44,7 @@ func (r *mutationResolver) CreateObligation(ctx context.Context, input types.Cre
 		Type:                   input.Type,
 	}
 
-	obligation, err := prb.Obligations.Create(ctx, &req)
+	obligation, err := prb.Obligations.Create(ctx, scope, &req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -65,7 +66,8 @@ func (r *mutationResolver) UpdateObligation(ctx context.Context, input types.Upd
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
 	req := probo.UpdateObligationRequest{
 		ID:                     input.ID,
@@ -81,7 +83,7 @@ func (r *mutationResolver) UpdateObligation(ctx context.Context, input types.Upd
 		Type:                   input.Type,
 	}
 
-	obligation, err := prb.Obligations.Update(ctx, &req)
+	obligation, err := prb.Obligations.Update(ctx, scope, &req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -103,9 +105,10 @@ func (r *mutationResolver) DeleteObligation(ctx context.Context, input types.Del
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ObligationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ObligationID)
+	prb := r.probo
 
-	err := prb.Obligations.Delete(ctx, input.ObligationID)
+	err := prb.Obligations.Delete(ctx, scope, input.ObligationID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete obligation", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -122,9 +125,10 @@ func (r *mutationResolver) PublishObligationList(ctx context.Context, input type
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
-	document, documentVersion, err := prb.GeneratedDocuments.PublishObligationList(ctx, input.OrganizationID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := prb.GeneratedDocuments.PublishObligationList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -200,11 +204,12 @@ func (r *obligationConnectionResolver) TotalCount(ctx context.Context, obj *type
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	prb := r.probo
 
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.Obligations.CountForOrganizationID(ctx, obj.ParentID)
+		count, err := prb.Obligations.CountForOrganizationID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count obligations", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -212,7 +217,7 @@ func (r *obligationConnectionResolver) TotalCount(ctx context.Context, obj *type
 
 		return count, nil
 	case *riskResolver:
-		count, err := prb.Obligations.CountForRiskID(ctx, obj.ParentID)
+		count, err := prb.Obligations.CountForRiskID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count risk obligations", log.Error(err))
 			return 0, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/organization_resolvers.go
+++ b/pkg/server/api/console/v1/organization_resolvers.go
@@ -32,7 +32,8 @@ func (r *mutationResolver) UpdateOrganizationContext(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
 	req := probo.UpdateOrganizationContextRequest{
 		OrganizationID: input.OrganizationID,
@@ -43,7 +44,7 @@ func (r *mutationResolver) UpdateOrganizationContext(ctx context.Context, input 
 		Customers:      gqlutils.UnwrapOmittable(input.Customers),
 	}
 
-	organizationContext, err := prb.Organizations.UpdateContext(ctx, req)
+	organizationContext, err := prb.Organizations.UpdateContext(ctx, scope, req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -65,9 +66,10 @@ func (r *organizationResolver) LogoURL(ctx context.Context, obj *types.Organizat
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	logoURL, err := prb.Organizations.GenerateLogoURL(ctx, obj.ID, 1*time.Hour)
+	logoURL, err := prb.Organizations.GenerateLogoURL(ctx, scope, obj.ID, 1*time.Hour)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate logo url", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -82,9 +84,10 @@ func (r *organizationResolver) HorizontalLogoURL(ctx context.Context, obj *types
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	horizontalLogoURL, err := prb.Organizations.GenerateHorizontalLogoURL(ctx, obj.ID, 1*time.Hour)
+	horizontalLogoURL, err := prb.Organizations.GenerateHorizontalLogoURL(ctx, scope, obj.ID, 1*time.Hour)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate horizontal logo url", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -99,9 +102,10 @@ func (r *organizationResolver) Context(ctx context.Context, obj *types.Organizat
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	orgContext, err := prb.Organizations.GetContext(ctx, obj.ID)
+	orgContext, err := prb.Organizations.GetContext(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot load organization context", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -157,9 +161,10 @@ func (r *organizationResolver) MeasureCategories(ctx context.Context, obj *types
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	categories, err := prb.Measures.ListDistinctCategoriesForOrganizationID(ctx, obj.ID)
+	categories, err := prb.Measures.ListDistinctCategoriesForOrganizationID(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list measure categories", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -232,9 +237,10 @@ func (r *organizationResolver) AssetListDocument(ctx context.Context, obj *types
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	assetDocumentID, err := prb.GeneratedDocuments.GetAssetListDocumentID(ctx, obj.ID)
+	assetDocumentID, err := prb.GeneratedDocuments.GetAssetListDocumentID(ctx, scope, obj.ID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get asset list document ID: %w", err)
 	}
@@ -243,7 +249,7 @@ func (r *organizationResolver) AssetListDocument(ctx context.Context, obj *types
 		return nil, nil
 	}
 
-	doc, err := prb.Documents.Get(ctx, *assetDocumentID)
+	doc, err := prb.Documents.Get(ctx, scope, *assetDocumentID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get asset list document: %w", err)
 	}
@@ -257,7 +263,8 @@ func (r *organizationResolver) Assets(ctx context.Context, obj *types.Organizati
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.AssetOrderField]{
 		Field:     coredata.AssetOrderFieldCreatedAt,
@@ -272,7 +279,7 @@ func (r *organizationResolver) Assets(ctx context.Context, obj *types.Organizati
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Assets.ListForOrganizationID(ctx, obj.ID, cursor)
+	page, err := prb.Assets.ListForOrganizationID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization assets", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -287,9 +294,10 @@ func (r *organizationResolver) DataListDocument(ctx context.Context, obj *types.
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	dataDocumentID, err := prb.GeneratedDocuments.GetDataListDocumentID(ctx, obj.ID)
+	dataDocumentID, err := prb.GeneratedDocuments.GetDataListDocumentID(ctx, scope, obj.ID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get data export document ID: %w", err)
 	}
@@ -298,7 +306,7 @@ func (r *organizationResolver) DataListDocument(ctx context.Context, obj *types.
 		return nil, nil
 	}
 
-	doc, err := prb.Documents.Get(ctx, *dataDocumentID)
+	doc, err := prb.Documents.Get(ctx, scope, *dataDocumentID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get data export document: %w", err)
 	}
@@ -312,7 +320,8 @@ func (r *organizationResolver) Data(ctx context.Context, obj *types.Organization
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DatumOrderField]{
 		Field:     coredata.DatumOrderFieldCreatedAt,
@@ -327,7 +336,7 @@ func (r *organizationResolver) Data(ctx context.Context, obj *types.Organization
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Data.ListForOrganizationID(ctx, obj.ID, cursor)
+	page, err := prb.Data.ListForOrganizationID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization data", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -342,7 +351,8 @@ func (r *organizationResolver) Audits(ctx context.Context, obj *types.Organizati
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.AuditOrderField]{
 		Field:     coredata.AuditOrderFieldCreatedAt,
@@ -357,7 +367,7 @@ func (r *organizationResolver) Audits(ctx context.Context, obj *types.Organizati
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Audits.ListForOrganizationID(ctx, obj.ID, cursor)
+	page, err := prb.Audits.ListForOrganizationID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization audits", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -372,9 +382,10 @@ func (r *organizationResolver) FindingsDocument(ctx context.Context, obj *types.
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	findingDocumentID, err := prb.GeneratedDocuments.GetFindingsDocumentID(ctx, obj.ID)
+	findingDocumentID, err := prb.GeneratedDocuments.GetFindingsDocumentID(ctx, scope, obj.ID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get finding list document ID: %w", err)
 	}
@@ -383,7 +394,7 @@ func (r *organizationResolver) FindingsDocument(ctx context.Context, obj *types.
 		return nil, nil
 	}
 
-	doc, err := prb.Documents.Get(ctx, *findingDocumentID)
+	doc, err := prb.Documents.Get(ctx, scope, *findingDocumentID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get finding list document: %w", err)
 	}
@@ -397,7 +408,8 @@ func (r *organizationResolver) Findings(ctx context.Context, obj *types.Organiza
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.FindingOrderField]{
 		Field:     coredata.FindingOrderFieldCreatedAt,
@@ -428,7 +440,7 @@ func (r *organizationResolver) Findings(ctx context.Context, obj *types.Organiza
 
 	findingFilter := coredata.NewFindingFilter(kind, status, priority, ownerID)
 
-	page, err := prb.Findings.ListForOrganizationID(ctx, obj.ID, cursor, findingFilter)
+	page, err := prb.Findings.ListForOrganizationID(ctx, scope, obj.ID, cursor, findingFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization findings", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -491,7 +503,8 @@ func (r *organizationResolver) SlackConnections(ctx context.Context, obj *types.
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	slackProvider := coredata.ConnectorProviderSlack
 	filter := coredata.NewConnectorProviderFilter(&slackProvider)
@@ -503,7 +516,7 @@ func (r *organizationResolver) SlackConnections(ctx context.Context, obj *types.
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Connectors.ListForOrganizationID(ctx, obj.ID, cursor, filter)
+	page, err := prb.Connectors.ListForOrganizationID(ctx, scope, obj.ID, cursor, filter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization slack connections", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -523,9 +536,10 @@ func (r *organizationResolver) Connectors(ctx context.Context, obj *types.Organi
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	connectors, err := prb.Connectors.ListAllForOrganizationID(ctx, obj.ID)
+	connectors, err := prb.Connectors.ListAllForOrganizationID(ctx, scope, obj.ID)
 	if err != nil {
 		panic(fmt.Errorf("cannot list organization connectors: %w", err))
 	}
@@ -586,7 +600,8 @@ func (r *organizationResolver) Controls(ctx context.Context, obj *types.Organiza
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ControlOrderField]{
 		Field:     coredata.ControlOrderFieldCreatedAt,
@@ -606,7 +621,7 @@ func (r *organizationResolver) Controls(ctx context.Context, obj *types.Organiza
 		controlFilter = coredata.NewControlFilter(filter.Query)
 	}
 
-	page, err := prb.Controls.ListForOrganizationID(ctx, obj.ID, cursor, controlFilter)
+	page, err := prb.Controls.ListForOrganizationID(ctx, scope, obj.ID, cursor, controlFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list controls", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -621,7 +636,8 @@ func (r *organizationResolver) StatementsOfApplicability(ctx context.Context, ob
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.StatementOfApplicabilityOrderField]{
 		Field:     coredata.StatementOfApplicabilityOrderFieldCreatedAt,
@@ -636,7 +652,7 @@ func (r *organizationResolver) StatementsOfApplicability(ctx context.Context, ob
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.StatementsOfApplicability.ListForOrganizationID(ctx, obj.ID, cursor)
+	page, err := prb.StatementsOfApplicability.ListForOrganizationID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization statements_of_applicability", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -651,7 +667,8 @@ func (r *organizationResolver) DataProtectionImpactAssessments(ctx context.Conte
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DataProtectionImpactAssessmentOrderField]{
 		Field:     coredata.DataProtectionImpactAssessmentOrderFieldCreatedAt,
@@ -667,7 +684,7 @@ func (r *organizationResolver) DataProtectionImpactAssessments(ctx context.Conte
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.DataProtectionImpactAssessments.ListForOrganizationID(ctx, obj.ID, cursor)
+	page, err := prb.DataProtectionImpactAssessments.ListForOrganizationID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization data protection impact assessments", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -682,9 +699,10 @@ func (r *organizationResolver) DataProtectionImpactAssessmentsDocument(ctx conte
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	documentID, err := prb.GeneratedDocuments.GetDataProtectionImpactAssessmentsDocumentID(ctx, obj.ID)
+	documentID, err := prb.GeneratedDocuments.GetDataProtectionImpactAssessmentsDocumentID(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get DPIA list document ID", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -694,7 +712,7 @@ func (r *organizationResolver) DataProtectionImpactAssessmentsDocument(ctx conte
 		return nil, nil
 	}
 
-	document, err := prb.Documents.Get(ctx, *documentID)
+	document, err := prb.Documents.Get(ctx, scope, *documentID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil
@@ -714,7 +732,8 @@ func (r *organizationResolver) TransferImpactAssessments(ctx context.Context, ob
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.TransferImpactAssessmentOrderField]{
 		Field:     coredata.TransferImpactAssessmentOrderFieldCreatedAt,
@@ -730,7 +749,7 @@ func (r *organizationResolver) TransferImpactAssessments(ctx context.Context, ob
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.TransferImpactAssessments.ListForOrganizationID(ctx, obj.ID, cursor)
+	page, err := prb.TransferImpactAssessments.ListForOrganizationID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization transfer impact assessments", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -745,9 +764,10 @@ func (r *organizationResolver) TransferImpactAssessmentsDocument(ctx context.Con
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	documentID, err := prb.GeneratedDocuments.GetTransferImpactAssessmentsDocumentID(ctx, obj.ID)
+	documentID, err := prb.GeneratedDocuments.GetTransferImpactAssessmentsDocumentID(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get TIA list document ID", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -757,7 +777,7 @@ func (r *organizationResolver) TransferImpactAssessmentsDocument(ctx context.Con
 		return nil, nil
 	}
 
-	document, err := prb.Documents.Get(ctx, *documentID)
+	document, err := prb.Documents.Get(ctx, scope, *documentID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil
@@ -777,7 +797,8 @@ func (r *organizationResolver) Documents(ctx context.Context, obj *types.Organiz
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
 		Field:     coredata.DocumentOrderFieldTitle,
@@ -801,7 +822,7 @@ func (r *organizationResolver) Documents(ctx context.Context, obj *types.Organiz
 			WithStatus(filter.Status)
 	}
 
-	page, err := prb.Documents.ListByOrganizationID(ctx, obj.ID, cursor, documentFilter)
+	page, err := prb.Documents.ListByOrganizationID(ctx, scope, obj.ID, cursor, documentFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization documents", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -821,7 +842,8 @@ func (r *organizationResolver) Frameworks(ctx context.Context, obj *types.Organi
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.FrameworkOrderField]{
 		Field:     coredata.FrameworkOrderFieldCreatedAt,
@@ -836,7 +858,7 @@ func (r *organizationResolver) Frameworks(ctx context.Context, obj *types.Organi
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Frameworks.ListForOrganizationID(ctx, obj.ID, cursor)
+	page, err := prb.Frameworks.ListForOrganizationID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization frameworks", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -851,7 +873,8 @@ func (r *organizationResolver) Measures(ctx context.Context, obj *types.Organiza
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.MeasureOrderField]{
 		Field:     coredata.MeasureOrderFieldCreatedAt,
@@ -871,7 +894,7 @@ func (r *organizationResolver) Measures(ctx context.Context, obj *types.Organiza
 		measureFilter = coredata.NewMeasureFilter(filter.Query, filter.State, filter.Category)
 	}
 
-	page, err := prb.Measures.ListForOrganizationID(ctx, obj.ID, cursor, measureFilter)
+	page, err := prb.Measures.ListForOrganizationID(ctx, scope, obj.ID, cursor, measureFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization measures", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -886,9 +909,10 @@ func (r *organizationResolver) ObligationsDocument(ctx context.Context, obj *typ
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	obligationDocumentID, err := prb.GeneratedDocuments.GetObligationsDocumentID(ctx, obj.ID)
+	obligationDocumentID, err := prb.GeneratedDocuments.GetObligationsDocumentID(ctx, scope, obj.ID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get obligation list document ID: %w", err)
 	}
@@ -897,7 +921,7 @@ func (r *organizationResolver) ObligationsDocument(ctx context.Context, obj *typ
 		return nil, nil
 	}
 
-	doc, err := prb.Documents.Get(ctx, *obligationDocumentID)
+	doc, err := prb.Documents.Get(ctx, scope, *obligationDocumentID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get obligation list document: %w", err)
 	}
@@ -911,7 +935,8 @@ func (r *organizationResolver) Obligations(ctx context.Context, obj *types.Organ
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ObligationOrderField]{
 		Field:     coredata.ObligationOrderFieldCreatedAt,
@@ -927,7 +952,7 @@ func (r *organizationResolver) Obligations(ctx context.Context, obj *types.Organ
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Obligations.ListForOrganizationID(ctx, obj.ID, cursor)
+	page, err := prb.Obligations.ListForOrganizationID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization obligations", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -942,7 +967,8 @@ func (r *organizationResolver) ProcessingActivities(ctx context.Context, obj *ty
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ProcessingActivityOrderField]{
 		Field:     coredata.ProcessingActivityOrderFieldCreatedAt,
@@ -958,7 +984,7 @@ func (r *organizationResolver) ProcessingActivities(ctx context.Context, obj *ty
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.ProcessingActivities.ListForOrganizationID(ctx, obj.ID, cursor)
+	page, err := prb.ProcessingActivities.ListForOrganizationID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization processing activities", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -973,9 +999,10 @@ func (r *organizationResolver) ProcessingActivitiesDocument(ctx context.Context,
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	documentID, err := prb.GeneratedDocuments.GetProcessingActivitiesDocumentID(ctx, obj.ID)
+	documentID, err := prb.GeneratedDocuments.GetProcessingActivitiesDocumentID(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get processing activities document ID", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -985,7 +1012,7 @@ func (r *organizationResolver) ProcessingActivitiesDocument(ctx context.Context,
 		return nil, nil
 	}
 
-	document, err := prb.Documents.Get(ctx, *documentID)
+	document, err := prb.Documents.Get(ctx, scope, *documentID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil
@@ -1005,7 +1032,8 @@ func (r *organizationResolver) RightsRequests(ctx context.Context, obj *types.Or
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.RightsRequestOrderField]{
 		Field:     coredata.RightsRequestOrderFieldCreatedAt,
@@ -1021,7 +1049,7 @@ func (r *organizationResolver) RightsRequests(ctx context.Context, obj *types.Or
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.RightsRequests.ListForOrganizationID(ctx, obj.ID, cursor)
+	page, err := prb.RightsRequests.ListForOrganizationID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization rights requests", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1036,7 +1064,8 @@ func (r *organizationResolver) Risks(ctx context.Context, obj *types.Organizatio
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.RiskOrderField]{
 		Field:     coredata.RiskOrderFieldCreatedAt,
@@ -1056,7 +1085,7 @@ func (r *organizationResolver) Risks(ctx context.Context, obj *types.Organizatio
 		riskFilter = coredata.NewRiskFilter(filter.Query)
 	}
 
-	page, err := prb.Risks.ListForOrganizationID(ctx, obj.ID, cursor, riskFilter)
+	page, err := prb.Risks.ListForOrganizationID(ctx, scope, obj.ID, cursor, riskFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization risks", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1071,9 +1100,10 @@ func (r *organizationResolver) RisksDocument(ctx context.Context, obj *types.Org
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	documentID, err := prb.GeneratedDocuments.GetRisksDocumentID(ctx, obj.ID)
+	documentID, err := prb.GeneratedDocuments.GetRisksDocumentID(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get risks document ID", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1083,7 +1113,7 @@ func (r *organizationResolver) RisksDocument(ctx context.Context, obj *types.Org
 		return nil, nil
 	}
 
-	document, err := prb.Documents.Get(ctx, *documentID)
+	document, err := prb.Documents.Get(ctx, scope, *documentID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil
@@ -1163,7 +1193,8 @@ func (r *organizationResolver) Tasks(ctx context.Context, obj *types.Organizatio
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.TaskOrderField]{
 		Field:     coredata.TaskOrderFieldCreatedAt,
@@ -1178,7 +1209,7 @@ func (r *organizationResolver) Tasks(ctx context.Context, obj *types.Organizatio
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Tasks.ListForOrganizationID(ctx, obj.ID, cursor)
+	page, err := prb.Tasks.ListForOrganizationID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization tasks", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1193,9 +1224,10 @@ func (r *organizationResolver) TrustCenter(ctx context.Context, obj *types.Organ
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	trustCenter, err := prb.TrustCenters.GetByOrganizationID(ctx, obj.ID)
+	trustCenter, err := prb.TrustCenters.GetByOrganizationID(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get trust center", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1203,7 +1235,7 @@ func (r *organizationResolver) TrustCenter(ctx context.Context, obj *types.Organ
 
 	var file *coredata.File
 	if trustCenter.NonDisclosureAgreementFileID != nil {
-		file, err = prb.Files.Get(ctx, *trustCenter.NonDisclosureAgreementFileID)
+		file, err = prb.Files.Get(ctx, scope, *trustCenter.NonDisclosureAgreementFileID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot get NDA file", log.Error(err))
 			return nil, gqlutils.Internal(ctx)
@@ -1219,9 +1251,10 @@ func (r *organizationResolver) CustomDomain(ctx context.Context, obj *types.Orga
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	domain, err := prb.CustomDomains.GetOrganizationCustomDomain(ctx, obj.ID)
+	domain, err := prb.CustomDomains.GetOrganizationCustomDomain(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get custom domain", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1240,7 +1273,8 @@ func (r *organizationResolver) TrustCenterFiles(ctx context.Context, obj *types.
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.TrustCenterFileOrderField]{
 		Field:     coredata.TrustCenterFileOrderFieldCreatedAt,
@@ -1255,7 +1289,7 @@ func (r *organizationResolver) TrustCenterFiles(ctx context.Context, obj *types.
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	pageResult, err := prb.TrustCenterFiles.ListForOrganizationID(ctx, obj.ID, cursor, &coredata.TrustCenterFileFilter{})
+	pageResult, err := prb.TrustCenterFiles.ListForOrganizationID(ctx, scope, obj.ID, cursor, &coredata.TrustCenterFileFilter{})
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization trust center files", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1301,7 +1335,8 @@ func (r *organizationResolver) ThirdParties(ctx context.Context, obj *types.Orga
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyOrderField]{
 		Field:     coredata.ThirdPartyOrderFieldCreatedAt,
@@ -1318,7 +1353,7 @@ func (r *organizationResolver) ThirdParties(ctx context.Context, obj *types.Orga
 
 	thirdPartyFilter := coredata.NewThirdPartyFilter(nil)
 
-	page, err := prb.ThirdParties.ListForOrganizationID(ctx, obj.ID, cursor, thirdPartyFilter)
+	page, err := prb.ThirdParties.ListForOrganizationID(ctx, scope, obj.ID, cursor, thirdPartyFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization thirdParties", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1333,9 +1368,10 @@ func (r *organizationResolver) ThirdPartiesDocument(ctx context.Context, obj *ty
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	documentID, err := prb.GeneratedDocuments.GetThirdPartiesDocumentID(ctx, obj.ID)
+	documentID, err := prb.GeneratedDocuments.GetThirdPartiesDocumentID(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get thirdParties document ID", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1345,7 +1381,7 @@ func (r *organizationResolver) ThirdPartiesDocument(ctx context.Context, obj *ty
 		return nil, nil
 	}
 
-	document, err := prb.Documents.Get(ctx, *documentID)
+	document, err := prb.Documents.Get(ctx, scope, *documentID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil
@@ -1365,7 +1401,8 @@ func (r *organizationResolver) WebhookSubscriptions(ctx context.Context, obj *ty
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.WebhookSubscriptionOrderField]{
 		Field:     coredata.WebhookSubscriptionOrderFieldCreatedAt,
@@ -1380,7 +1417,7 @@ func (r *organizationResolver) WebhookSubscriptions(ctx context.Context, obj *ty
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.WebhookSubscriptions.ListForOrganizationID(ctx, obj.ID, cursor)
+	page, err := prb.WebhookSubscriptions.ListForOrganizationID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization webhook subscriptions", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1415,9 +1452,10 @@ func (r *profileConnectionResolver) TotalCount(ctx context.Context, obj *types.P
 
 		return count, nil
 	case *documentVersionResolver:
-		prb := r.ProboService(ctx, obj.ParentID.TenantID())
+		scope := coredata.NewScopeFromObjectID(obj.ParentID)
+		prb := r.probo
 
-		count, err := prb.Documents.CountVersionApprovers(ctx, obj.ParentID)
+		count, err := prb.Documents.CountVersionApprovers(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count document version approvers", log.Error(err))
 			return 0, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/processing_activity_resolvers.go
+++ b/pkg/server/api/console/v1/processing_activity_resolvers.go
@@ -27,7 +27,8 @@ func (r *mutationResolver) CreateProcessingActivity(ctx context.Context, input t
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
 	req := probo.CreateProcessingActivityRequest{
 		OrganizationID:                       input.OrganizationID,
@@ -52,7 +53,7 @@ func (r *mutationResolver) CreateProcessingActivity(ctx context.Context, input t
 		ThirdPartyIDs:                        input.ThirdPartyIds,
 	}
 
-	activity, err := prb.ProcessingActivities.Create(ctx, &req)
+	activity, err := prb.ProcessingActivities.Create(ctx, scope, &req)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot create processing activity", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -69,7 +70,8 @@ func (r *mutationResolver) UpdateProcessingActivity(ctx context.Context, input t
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
 	req := probo.UpdateProcessingActivityRequest{
 		ID:                                   input.ID,
@@ -94,7 +96,7 @@ func (r *mutationResolver) UpdateProcessingActivity(ctx context.Context, input t
 		ThirdPartyIDs:                        &input.ThirdPartyIds,
 	}
 
-	activity, err := prb.ProcessingActivities.Update(ctx, &req)
+	activity, err := prb.ProcessingActivities.Update(ctx, scope, &req)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot update processing activity", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -111,9 +113,10 @@ func (r *mutationResolver) DeleteProcessingActivity(ctx context.Context, input t
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ProcessingActivityID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ProcessingActivityID)
+	prb := r.probo
 
-	err := prb.ProcessingActivities.Delete(ctx, input.ProcessingActivityID)
+	err := prb.ProcessingActivities.Delete(ctx, scope, input.ProcessingActivityID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete processing activity", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -130,9 +133,10 @@ func (r *mutationResolver) PublishProcessingActivityList(ctx context.Context, in
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
-	document, documentVersion, err := prb.GeneratedDocuments.PublishProcessingActivityList(ctx, input.OrganizationID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := prb.GeneratedDocuments.PublishProcessingActivityList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -207,7 +211,8 @@ func (r *processingActivityResolver) ThirdParties(ctx context.Context, obj *type
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyOrderField]{
 		Field:     coredata.ThirdPartyOrderFieldCreatedAt,
@@ -222,7 +227,7 @@ func (r *processingActivityResolver) ThirdParties(ctx context.Context, obj *type
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.ThirdParties.ListForProcessingActivityID(ctx, obj.ID, cursor)
+	page, err := prb.ThirdParties.ListForProcessingActivityID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list processing activity thirdParties", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -237,9 +242,10 @@ func (r *processingActivityResolver) DataProtectionImpactAssessment(ctx context.
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	dpia, err := prb.DataProtectionImpactAssessments.GetByProcessingActivityID(ctx, obj.ID)
+	dpia, err := prb.DataProtectionImpactAssessments.GetByProcessingActivityID(ctx, scope, obj.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil
@@ -259,9 +265,10 @@ func (r *processingActivityResolver) TransferImpactAssessment(ctx context.Contex
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	tia, err := prb.TransferImpactAssessments.GetByProcessingActivityID(ctx, obj.ID)
+	tia, err := prb.TransferImpactAssessments.GetByProcessingActivityID(ctx, scope, obj.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil
@@ -286,11 +293,12 @@ func (r *processingActivityConnectionResolver) TotalCount(ctx context.Context, o
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	prb := r.probo
 
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.ProcessingActivities.CountForOrganizationID(ctx, obj.ParentID)
+		count, err := prb.ProcessingActivities.CountForOrganizationID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count organization processing activities", log.Error(err))
 			return 0, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/resolver.go
+++ b/pkg/server/api/console/v1/resolver.go
@@ -172,7 +172,8 @@ func handleConnectorComplete(
 			return
 		}
 
-		svc := proboSvc.WithTenant(organizationID.TenantID())
+		scope := coredata.NewScopeFromObjectID(organizationID)
+		svc := proboSvc
 
 		var cnnctr *coredata.Connector
 
@@ -187,6 +188,7 @@ func handleConnectorComplete(
 
 			cnnctr, err = svc.Connectors.Reconnect(
 				r.Context(),
+				scope,
 				probo.ReconnectConnectorRequest{
 					ConnectorID:    connectorID,
 					OrganizationID: organizationID,
@@ -263,7 +265,7 @@ func handleConnectorComplete(
 				}
 			}
 
-			cnnctr, err = svc.Connectors.Create(r.Context(), createReq)
+			cnnctr, err = svc.Connectors.Create(r.Context(), scope, createReq)
 			if err != nil {
 				logger.ErrorCtx(r.Context(), "cannot create connector", log.Error(err))
 				httpserver.RenderError(w, http.StatusInternalServerError, fmt.Errorf("internal error"))
@@ -355,10 +357,6 @@ func isValidPagerDutySubdomain(s string) bool {
 	}
 
 	return true
-}
-
-func (r *Resolver) ProboService(ctx context.Context, tenantID gid.TenantID) *probo.TenantService {
-	return r.probo.WithTenant(tenantID)
 }
 
 func (r *Resolver) Permission(ctx context.Context, obj types.Node, action string) (bool, error) {

--- a/pkg/server/api/console/v1/rights_request_resolvers.go
+++ b/pkg/server/api/console/v1/rights_request_resolvers.go
@@ -25,7 +25,8 @@ func (r *mutationResolver) CreateRightsRequest(ctx context.Context, input types.
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
 	req := probo.CreateRightsRequestRequest{
 		OrganizationID: input.OrganizationID,
@@ -38,7 +39,7 @@ func (r *mutationResolver) CreateRightsRequest(ctx context.Context, input types.
 		ActionTaken:    input.ActionTaken,
 	}
 
-	rightsRequest, err := prb.RightsRequests.Create(ctx, &req)
+	rightsRequest, err := prb.RightsRequests.Create(ctx, scope, &req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -60,7 +61,8 @@ func (r *mutationResolver) UpdateRightsRequest(ctx context.Context, input types.
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
 	req := probo.UpdateRightsRequestRequest{
 		ID:           input.ID,
@@ -73,7 +75,7 @@ func (r *mutationResolver) UpdateRightsRequest(ctx context.Context, input types.
 		ActionTaken:  gqlutils.UnwrapOmittable(input.ActionTaken),
 	}
 
-	rightsRequest, err := prb.RightsRequests.Update(ctx, &req)
+	rightsRequest, err := prb.RightsRequests.Update(ctx, scope, &req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -95,9 +97,10 @@ func (r *mutationResolver) DeleteRightsRequest(ctx context.Context, input types.
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.RightsRequestID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.RightsRequestID)
+	prb := r.probo
 
-	err := prb.RightsRequests.Delete(ctx, input.RightsRequestID)
+	err := prb.RightsRequests.Delete(ctx, scope, input.RightsRequestID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete rights request", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -114,15 +117,16 @@ func (r *rightsRequestResolver) Organization(ctx context.Context, obj *types.Rig
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	rightsRequest, err := prb.RightsRequests.Get(ctx, obj.ID)
+	rightsRequest, err := prb.RightsRequests.Get(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get rights request", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	organization, err := prb.Organizations.Get(ctx, rightsRequest.OrganizationID)
+	organization, err := prb.Organizations.Get(ctx, scope, rightsRequest.OrganizationID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -147,11 +151,12 @@ func (r *rightsRequestConnectionResolver) TotalCount(ctx context.Context, obj *t
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	prb := r.probo
 
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.RightsRequests.CountByOrganizationID(ctx, obj.ParentID)
+		count, err := prb.RightsRequests.CountByOrganizationID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count rights requests", log.Error(err))
 			return 0, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/risk_resolvers.go
+++ b/pkg/server/api/console/v1/risk_resolvers.go
@@ -28,10 +28,11 @@ func (r *mutationResolver) CreateRisk(ctx context.Context, input types.CreateRis
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
 	risk, err := prb.Risks.Create(
-		ctx,
+		ctx, scope,
 		probo.CreateRiskRequest{
 			OrganizationID:     input.OrganizationID,
 			Name:               input.Name,
@@ -71,10 +72,11 @@ func (r *mutationResolver) UpdateRisk(ctx context.Context, input types.UpdateRis
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
 	risk, err := prb.Risks.Update(
-		ctx,
+		ctx, scope,
 		probo.UpdateRiskRequest{
 			ID:                 input.ID,
 			Name:               input.Name,
@@ -110,9 +112,10 @@ func (r *mutationResolver) DeleteRisk(ctx context.Context, input types.DeleteRis
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.RiskID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.RiskID)
+	prb := r.probo
 
-	err := prb.Risks.Delete(ctx, input.RiskID)
+	err := prb.Risks.Delete(ctx, scope, input.RiskID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete risk", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -129,9 +132,10 @@ func (r *mutationResolver) CreateRiskMeasureMapping(ctx context.Context, input t
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.RiskID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.RiskID)
+	prb := r.probo
 
-	risk, measure, err := prb.Risks.CreateMeasureMapping(ctx, input.RiskID, input.MeasureID)
+	risk, measure, err := prb.Risks.CreateMeasureMapping(ctx, scope, input.RiskID, input.MeasureID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot create risk measure mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -149,9 +153,10 @@ func (r *mutationResolver) DeleteRiskMeasureMapping(ctx context.Context, input t
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.RiskID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.RiskID)
+	prb := r.probo
 
-	risk, measure, err := prb.Risks.DeleteMeasureMapping(ctx, input.RiskID, input.MeasureID)
+	risk, measure, err := prb.Risks.DeleteMeasureMapping(ctx, scope, input.RiskID, input.MeasureID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete risk measure mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -169,9 +174,10 @@ func (r *mutationResolver) CreateRiskDocumentMapping(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.RiskID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.RiskID)
+	prb := r.probo
 
-	risk, document, err := prb.Risks.CreateDocumentMapping(ctx, input.RiskID, input.DocumentID)
+	risk, document, err := prb.Risks.CreateDocumentMapping(ctx, scope, input.RiskID, input.DocumentID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot create risk document mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -189,9 +195,10 @@ func (r *mutationResolver) DeleteRiskDocumentMapping(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.RiskID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.RiskID)
+	prb := r.probo
 
-	risk, document, err := prb.Risks.DeleteDocumentMapping(ctx, input.RiskID, input.DocumentID)
+	risk, document, err := prb.Risks.DeleteDocumentMapping(ctx, scope, input.RiskID, input.DocumentID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete risk document mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -209,9 +216,10 @@ func (r *mutationResolver) CreateRiskObligationMapping(ctx context.Context, inpu
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.RiskID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.RiskID)
+	prb := r.probo
 
-	risk, obligation, err := prb.Risks.CreateObligationMapping(ctx, input.RiskID, input.ObligationID)
+	risk, obligation, err := prb.Risks.CreateObligationMapping(ctx, scope, input.RiskID, input.ObligationID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot create risk obligation mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -229,9 +237,10 @@ func (r *mutationResolver) DeleteRiskObligationMapping(ctx context.Context, inpu
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.RiskID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.RiskID)
+	prb := r.probo
 
-	risk, obligation, err := prb.Risks.DeleteObligationMapping(ctx, input.RiskID, input.ObligationID)
+	risk, obligation, err := prb.Risks.DeleteObligationMapping(ctx, scope, input.RiskID, input.ObligationID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete risk obligation mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -249,9 +258,10 @@ func (r *mutationResolver) PublishRiskList(ctx context.Context, input types.Publ
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
-	document, documentVersion, err := prb.GeneratedDocuments.PublishRiskList(ctx, input.OrganizationID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := prb.GeneratedDocuments.PublishRiskList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -326,7 +336,8 @@ func (r *riskResolver) Measures(ctx context.Context, obj *types.Risk, first *int
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.MeasureOrderField]{
 		Field:     coredata.MeasureOrderFieldCreatedAt,
@@ -346,7 +357,7 @@ func (r *riskResolver) Measures(ctx context.Context, obj *types.Risk, first *int
 		measureFilter = coredata.NewMeasureFilter(filter.Query, filter.State, filter.Category)
 	}
 
-	page, err := prb.Measures.ListForRiskID(ctx, obj.ID, cursor, measureFilter)
+	page, err := prb.Measures.ListForRiskID(ctx, scope, obj.ID, cursor, measureFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list risk measures", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -361,7 +372,8 @@ func (r *riskResolver) Documents(ctx context.Context, obj *types.Risk, first *in
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
 		Field:     coredata.DocumentOrderFieldCreatedAt,
@@ -384,7 +396,7 @@ func (r *riskResolver) Documents(ctx context.Context, obj *types.Risk, first *in
 			WithClassifications(filter.Classifications)
 	}
 
-	page, err := prb.Documents.ListForRiskID(ctx, obj.ID, cursor, documentFilter)
+	page, err := prb.Documents.ListForRiskID(ctx, scope, obj.ID, cursor, documentFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list risk documents", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -399,7 +411,8 @@ func (r *riskResolver) Controls(ctx context.Context, obj *types.Risk, first *int
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ControlOrderField]{
 		Field:     coredata.ControlOrderFieldCreatedAt,
@@ -419,7 +432,7 @@ func (r *riskResolver) Controls(ctx context.Context, obj *types.Risk, first *int
 		filters = coredata.NewControlFilter(filter.Query)
 	}
 
-	page, err := prb.Controls.ListForRiskID(ctx, obj.ID, cursor, filters)
+	page, err := prb.Controls.ListForRiskID(ctx, scope, obj.ID, cursor, filters)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list risk controls", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -434,7 +447,8 @@ func (r *riskResolver) Obligations(ctx context.Context, obj *types.Risk, first *
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ObligationOrderField]{
 		Field:     coredata.ObligationOrderFieldCreatedAt,
@@ -449,7 +463,7 @@ func (r *riskResolver) Obligations(ctx context.Context, obj *types.Risk, first *
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Obligations.ListForRiskID(ctx, obj.ID, cursor)
+	page, err := prb.Obligations.ListForRiskID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list risk obligations", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -496,11 +510,12 @@ func (r *riskConnectionResolver) TotalCount(ctx context.Context, obj *types.Risk
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	prb := r.probo
 
 	switch obj.Resolver.(type) {
 	case *measureResolver:
-		count, err := prb.Risks.CountForMeasureID(ctx, obj.ParentID, obj.Filters)
+		count, err := prb.Risks.CountForMeasureID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count risks", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -508,7 +523,7 @@ func (r *riskConnectionResolver) TotalCount(ctx context.Context, obj *types.Risk
 
 		return count, nil
 	case *organizationResolver:
-		count, err := prb.Risks.CountForOrganizationID(ctx, obj.ParentID, obj.Filters)
+		count, err := prb.Risks.CountForOrganizationID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count risks", log.Error(err))
 			return 0, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/task_resolvers.go
+++ b/pkg/server/api/console/v1/task_resolvers.go
@@ -28,10 +28,11 @@ func (r *mutationResolver) CreateTask(ctx context.Context, input types.CreateTas
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
 	task, err := prb.Tasks.Create(
-		ctx,
+		ctx, scope,
 		probo.CreateTaskRequest{
 			MeasureID:      input.MeasureID,
 			OrganizationID: input.OrganizationID,
@@ -68,10 +69,11 @@ func (r *mutationResolver) UpdateTask(ctx context.Context, input types.UpdateTas
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.TaskID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.TaskID)
+	prb := r.probo
 
 	task, err := prb.Tasks.Update(
-		ctx,
+		ctx, scope,
 		probo.UpdateTaskRequest{
 			TaskID:       input.TaskID,
 			Name:         input.Name,
@@ -106,9 +108,10 @@ func (r *mutationResolver) DeleteTask(ctx context.Context, input types.DeleteTas
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.TaskID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.TaskID)
+	prb := r.probo
 
-	err := prb.Tasks.Delete(ctx, input.TaskID)
+	err := prb.Tasks.Delete(ctx, scope, input.TaskID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete task", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -199,7 +202,8 @@ func (r *taskResolver) Evidences(ctx context.Context, obj *types.Task, first *in
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.EvidenceOrderField]{
 		Field:     coredata.EvidenceOrderFieldCreatedAt,
@@ -214,7 +218,7 @@ func (r *taskResolver) Evidences(ctx context.Context, obj *types.Task, first *in
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Evidences.ListForTaskID(ctx, obj.ID, cursor)
+	page, err := prb.Evidences.ListForTaskID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list task evidences", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -234,11 +238,12 @@ func (r *taskConnectionResolver) TotalCount(ctx context.Context, obj *types.Task
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	prb := r.probo
 
 	switch obj.Resolver.(type) {
 	case *measureResolver:
-		count, err := prb.Tasks.CountForMeasureID(ctx, obj.ParentID)
+		count, err := prb.Tasks.CountForMeasureID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count tasks", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -246,7 +251,7 @@ func (r *taskConnectionResolver) TotalCount(ctx context.Context, obj *types.Task
 
 		return count, nil
 	case *organizationResolver:
-		count, err := prb.Tasks.CountForOrganizationID(ctx, obj.ParentID)
+		count, err := prb.Tasks.CountForOrganizationID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count tasks", log.Error(err))
 			return 0, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/third_party_resolvers.go
+++ b/pkg/server/api/console/v1/third_party_resolvers.go
@@ -31,10 +31,11 @@ func (r *mutationResolver) CreateThirdParty(ctx context.Context, input types.Cre
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
 	thirdParty, err := prb.ThirdParties.Create(
-		ctx,
+		ctx, scope,
 		probo.CreateThirdPartyRequest{
 			OrganizationID:                input.OrganizationID,
 			Name:                          input.Name,
@@ -83,10 +84,11 @@ func (r *mutationResolver) UpdateThirdParty(ctx context.Context, input types.Upd
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
 	thirdParty, err := prb.ThirdParties.Update(
-		ctx,
+		ctx, scope,
 		probo.UpdateThirdPartyRequest{
 			ID:                            input.ID,
 			Name:                          input.Name,
@@ -132,9 +134,10 @@ func (r *mutationResolver) DeleteThirdParty(ctx context.Context, input types.Del
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ThirdPartyID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
+	prb := r.probo
 
-	err := prb.ThirdParties.Delete(ctx, input.ThirdPartyID)
+	err := prb.ThirdParties.Delete(ctx, scope, input.ThirdPartyID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete thirdParty", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -151,7 +154,8 @@ func (r *mutationResolver) CreateThirdPartyContact(ctx context.Context, input ty
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ThirdPartyID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
+	prb := r.probo
 
 	req := probo.CreateThirdPartyContactRequest{
 		ThirdPartyID: input.ThirdPartyID,
@@ -161,7 +165,7 @@ func (r *mutationResolver) CreateThirdPartyContact(ctx context.Context, input ty
 		Role:         input.Role,
 	}
 
-	thirdPartyContact, err := prb.ThirdPartyContacts.Create(ctx, req)
+	thirdPartyContact, err := prb.ThirdPartyContacts.Create(ctx, scope, req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -183,7 +187,8 @@ func (r *mutationResolver) UpdateThirdPartyContact(ctx context.Context, input ty
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
 	req := probo.UpdateThirdPartyContactRequest{
 		ID:       input.ID,
@@ -193,7 +198,7 @@ func (r *mutationResolver) UpdateThirdPartyContact(ctx context.Context, input ty
 		Role:     gqlutils.UnwrapOmittable(input.Role),
 	}
 
-	thirdPartyContact, err := prb.ThirdPartyContacts.Update(ctx, req)
+	thirdPartyContact, err := prb.ThirdPartyContacts.Update(ctx, scope, req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -215,9 +220,10 @@ func (r *mutationResolver) DeleteThirdPartyContact(ctx context.Context, input ty
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ThirdPartyContactID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ThirdPartyContactID)
+	prb := r.probo
 
-	err := prb.ThirdPartyContacts.Delete(ctx, input.ThirdPartyContactID)
+	err := prb.ThirdPartyContacts.Delete(ctx, scope, input.ThirdPartyContactID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete thirdParty contact", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -234,7 +240,8 @@ func (r *mutationResolver) CreateThirdPartyService(ctx context.Context, input ty
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ThirdPartyID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
+	prb := r.probo
 
 	req := probo.CreateThirdPartyServiceRequest{
 		ThirdPartyID: input.ThirdPartyID,
@@ -242,7 +249,7 @@ func (r *mutationResolver) CreateThirdPartyService(ctx context.Context, input ty
 		Description:  input.Description,
 	}
 
-	thirdPartyService, err := prb.ThirdPartyServices.Create(ctx, req)
+	thirdPartyService, err := prb.ThirdPartyServices.Create(ctx, scope, req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -264,7 +271,8 @@ func (r *mutationResolver) UpdateThirdPartyService(ctx context.Context, input ty
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
 	req := probo.UpdateThirdPartyServiceRequest{
 		ID:          input.ID,
@@ -272,7 +280,7 @@ func (r *mutationResolver) UpdateThirdPartyService(ctx context.Context, input ty
 		Description: gqlutils.UnwrapOmittable(input.Description),
 	}
 
-	thirdPartyService, err := prb.ThirdPartyServices.Update(ctx, req)
+	thirdPartyService, err := prb.ThirdPartyServices.Update(ctx, scope, req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -294,9 +302,10 @@ func (r *mutationResolver) DeleteThirdPartyService(ctx context.Context, input ty
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ThirdPartyServiceID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ThirdPartyServiceID)
+	prb := r.probo
 
-	err := prb.ThirdPartyServices.Delete(ctx, input.ThirdPartyServiceID)
+	err := prb.ThirdPartyServices.Delete(ctx, scope, input.ThirdPartyServiceID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete thirdParty service", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -313,10 +322,11 @@ func (r *mutationResolver) UploadThirdPartyComplianceReport(ctx context.Context,
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ThirdPartyID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
+	prb := r.probo
 
 	thirdPartyComplianceReport, err := prb.ThirdPartyComplianceReports.Upload(
-		ctx,
+		ctx, scope,
 		input.ThirdPartyID,
 		&probo.ThirdPartyComplianceReportCreateRequest{
 			File:       probo.FileUpload{Filename: input.File.Filename, Size: input.File.Size, Content: input.File.File, ContentType: input.File.ContentType},
@@ -346,9 +356,10 @@ func (r *mutationResolver) DeleteThirdPartyComplianceReport(ctx context.Context,
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ReportID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ReportID)
+	prb := r.probo
 
-	err := prb.ThirdPartyComplianceReports.Delete(ctx, input.ReportID)
+	err := prb.ThirdPartyComplianceReports.Delete(ctx, scope, input.ReportID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete thirdParty compliance report", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -365,10 +376,11 @@ func (r *mutationResolver) UploadThirdPartyBusinessAssociateAgreement(ctx contex
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ThirdPartyID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
+	prb := r.probo
 
 	thirdPartyBusinessAssociateAgreement, file, err := prb.ThirdPartyBusinessAssociateAgreements.Upload(
-		ctx,
+		ctx, scope,
 		input.ThirdPartyID,
 		&probo.ThirdPartyBusinessAssociateAgreementCreateRequest{
 			File:       input.File.File,
@@ -398,10 +410,11 @@ func (r *mutationResolver) UpdateThirdPartyBusinessAssociateAgreement(ctx contex
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ThirdPartyID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
+	prb := r.probo
 
 	thirdPartyBusinessAssociateAgreement, file, err := prb.ThirdPartyBusinessAssociateAgreements.Update(
-		ctx,
+		ctx, scope,
 		input.ThirdPartyID,
 		&probo.ThirdPartyBusinessAssociateAgreementUpdateRequest{
 			ValidFrom:  gqlutils.UnwrapOmittable(input.ValidFrom),
@@ -429,9 +442,10 @@ func (r *mutationResolver) DeleteThirdPartyBusinessAssociateAgreement(ctx contex
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ThirdPartyID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
+	prb := r.probo
 
-	err := prb.ThirdPartyBusinessAssociateAgreements.DeleteByThirdPartyID(ctx, input.ThirdPartyID)
+	err := prb.ThirdPartyBusinessAssociateAgreements.DeleteByThirdPartyID(ctx, scope, input.ThirdPartyID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete thirdParty business associate agreement", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -448,10 +462,11 @@ func (r *mutationResolver) UploadThirdPartyDataPrivacyAgreement(ctx context.Cont
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ThirdPartyID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
+	prb := r.probo
 
 	thirdPartyDataPrivacyAgreement, file, err := prb.ThirdPartyDataPrivacyAgreements.Upload(
-		ctx,
+		ctx, scope,
 		input.ThirdPartyID,
 		&probo.ThirdPartyDataPrivacyAgreementCreateRequest{
 			File:       input.File.File,
@@ -481,10 +496,11 @@ func (r *mutationResolver) UpdateThirdPartyDataPrivacyAgreement(ctx context.Cont
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ThirdPartyID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
+	prb := r.probo
 
 	thirdPartyDataPrivacyAgreement, file, err := prb.ThirdPartyDataPrivacyAgreements.Update(
-		ctx,
+		ctx, scope,
 		input.ThirdPartyID,
 		&probo.ThirdPartyDataPrivacyAgreementUpdateRequest{
 			ValidFrom:  gqlutils.UnwrapOmittable(input.ValidFrom),
@@ -512,9 +528,10 @@ func (r *mutationResolver) DeleteThirdPartyDataPrivacyAgreement(ctx context.Cont
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ThirdPartyID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
+	prb := r.probo
 
-	err := prb.ThirdPartyDataPrivacyAgreements.DeleteByThirdPartyID(ctx, input.ThirdPartyID)
+	err := prb.ThirdPartyDataPrivacyAgreements.DeleteByThirdPartyID(ctx, scope, input.ThirdPartyID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete thirdParty data privacy agreement", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -531,10 +548,11 @@ func (r *mutationResolver) CreateThirdPartyRiskAssessment(ctx context.Context, i
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ThirdPartyID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
+	prb := r.probo
 
 	thirdPartyRiskAssessment, err := prb.ThirdParties.CreateRiskAssessment(
-		ctx,
+		ctx, scope,
 		probo.CreateThirdPartyRiskAssessmentRequest{
 			ThirdPartyID:    input.ThirdPartyID,
 			ExpiresAt:       input.ExpiresAt,
@@ -564,10 +582,11 @@ func (r *mutationResolver) AssessThirdParty(ctx context.Context, input types.Ass
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
 	result, err := prb.ThirdParties.Assess(
-		ctx,
+		ctx, scope,
 		probo.AssessThirdPartyRequest{
 			ID:         input.ID,
 			WebsiteURL: input.WebsiteURL,
@@ -597,9 +616,10 @@ func (r *mutationResolver) PublishThirdPartyList(ctx context.Context, input type
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
-	document, documentVersion, err := prb.GeneratedDocuments.PublishThirdPartyList(ctx, input.OrganizationID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := prb.GeneratedDocuments.PublishThirdPartyList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -648,7 +668,8 @@ func (r *thirdPartyResolver) ComplianceReports(ctx context.Context, obj *types.T
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyComplianceReportOrderField]{
 		Field:     coredata.ThirdPartyComplianceReportOrderFieldReportDate,
@@ -663,7 +684,7 @@ func (r *thirdPartyResolver) ComplianceReports(ctx context.Context, obj *types.T
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.ThirdPartyComplianceReports.ListForThirdPartyID(ctx, obj.ID, cursor)
+	page, err := prb.ThirdPartyComplianceReports.ListForThirdPartyID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list thirdParty compliance reports", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -678,9 +699,10 @@ func (r *thirdPartyResolver) BusinessAssociateAgreement(ctx context.Context, obj
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	thirdPartyBusinessAssociateAgreement, file, err := prb.ThirdPartyBusinessAssociateAgreements.GetByThirdPartyID(ctx, obj.ID)
+	thirdPartyBusinessAssociateAgreement, file, err := prb.ThirdPartyBusinessAssociateAgreements.GetByThirdPartyID(ctx, scope, obj.ID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
@@ -700,9 +722,10 @@ func (r *thirdPartyResolver) DataPrivacyAgreement(ctx context.Context, obj *type
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	thirdPartyDataPrivacyAgreement, file, err := prb.ThirdPartyDataPrivacyAgreements.GetByThirdPartyID(ctx, obj.ID)
+	thirdPartyDataPrivacyAgreement, file, err := prb.ThirdPartyDataPrivacyAgreements.GetByThirdPartyID(ctx, scope, obj.ID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
@@ -722,7 +745,8 @@ func (r *thirdPartyResolver) Contacts(ctx context.Context, obj *types.ThirdParty
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyContactOrderField]{
 		Field:     coredata.ThirdPartyContactOrderFieldCreatedAt,
@@ -737,7 +761,7 @@ func (r *thirdPartyResolver) Contacts(ctx context.Context, obj *types.ThirdParty
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.ThirdPartyContacts.List(ctx, obj.ID, cursor)
+	page, err := prb.ThirdPartyContacts.List(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list thirdParty contacts", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -752,7 +776,8 @@ func (r *thirdPartyResolver) Services(ctx context.Context, obj *types.ThirdParty
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyServiceOrderField]{
 		Field:     coredata.ThirdPartyServiceOrderFieldCreatedAt,
@@ -767,7 +792,7 @@ func (r *thirdPartyResolver) Services(ctx context.Context, obj *types.ThirdParty
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.ThirdPartyServices.List(ctx, obj.ID, cursor)
+	page, err := prb.ThirdPartyServices.List(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list thirdParty services", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -782,7 +807,8 @@ func (r *thirdPartyResolver) RiskAssessments(ctx context.Context, obj *types.Thi
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyRiskAssessmentOrderField]{
 		Field:     coredata.ThirdPartyRiskAssessmentOrderFieldCreatedAt,
@@ -797,7 +823,7 @@ func (r *thirdPartyResolver) RiskAssessments(ctx context.Context, obj *types.Thi
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.ThirdParties.ListRiskAssessments(ctx, obj.ID, cursor)
+	page, err := prb.ThirdParties.ListRiskAssessments(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list thirdParty risk assessments", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -869,9 +895,10 @@ func (r *thirdPartyBusinessAssociateAgreementResolver) ThirdParty(ctx context.Co
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	thirdParty, err := prb.ThirdParties.Get(ctx, obj.ID)
+	thirdParty, err := prb.ThirdParties.Get(ctx, scope, obj.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -889,9 +916,10 @@ func (r *thirdPartyBusinessAssociateAgreementResolver) FileURL(ctx context.Conte
 		return "", err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	fileURL, err := prb.ThirdPartyBusinessAssociateAgreements.GenerateFileURL(ctx, obj.ID, 1*time.Hour)
+	fileURL, err := prb.ThirdPartyBusinessAssociateAgreements.GenerateFileURL(ctx, scope, obj.ID, 1*time.Hour)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate file URL", log.Error(err))
 		return "", gqlutils.Internal(ctx)
@@ -911,9 +939,10 @@ func (r *thirdPartyComplianceReportResolver) ThirdParty(ctx context.Context, obj
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	thirdParty, err := prb.ThirdParties.Get(ctx, obj.ID)
+	thirdParty, err := prb.ThirdParties.Get(ctx, scope, obj.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -933,9 +962,10 @@ func (r *thirdPartyComplianceReportResolver) File(ctx context.Context, obj *type
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	evidence, err := prb.ThirdPartyComplianceReports.Get(ctx, obj.ID)
+	evidence, err := prb.ThirdPartyComplianceReports.Get(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot load evidence", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -945,7 +975,7 @@ func (r *thirdPartyComplianceReportResolver) File(ctx context.Context, obj *type
 		return nil, nil
 	}
 
-	file, err := prb.Files.Get(ctx, *evidence.ReportFileId)
+	file, err := prb.Files.Get(ctx, scope, *evidence.ReportFileId)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -970,11 +1000,12 @@ func (r *thirdPartyConnectionResolver) TotalCount(ctx context.Context, obj *type
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	prb := r.probo
 
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.ThirdParties.CountForOrganizationID(ctx, obj.ParentID)
+		count, err := prb.ThirdParties.CountForOrganizationID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count thirdParties", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -982,7 +1013,7 @@ func (r *thirdPartyConnectionResolver) TotalCount(ctx context.Context, obj *type
 
 		return count, nil
 	case *assetResolver:
-		count, err := prb.ThirdParties.CountForAssetID(ctx, obj.ParentID)
+		count, err := prb.ThirdParties.CountForAssetID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count thirdParties", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -990,7 +1021,7 @@ func (r *thirdPartyConnectionResolver) TotalCount(ctx context.Context, obj *type
 
 		return count, nil
 	case *datumResolver:
-		count, err := prb.ThirdParties.CountForDatumID(ctx, obj.ParentID)
+		count, err := prb.ThirdParties.CountForDatumID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count thirdParties", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -1010,16 +1041,17 @@ func (r *thirdPartyContactResolver) ThirdParty(ctx context.Context, obj *types.T
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	// Get the thirdParty contact to access the ThirdPartyID
-	thirdPartyContact, err := prb.ThirdPartyContacts.Get(ctx, obj.ID)
+	thirdPartyContact, err := prb.ThirdPartyContacts.Get(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get thirdParty contact", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	thirdParty, err := prb.ThirdParties.Get(ctx, thirdPartyContact.ThirdPartyID)
+	thirdParty, err := prb.ThirdParties.Get(ctx, scope, thirdPartyContact.ThirdPartyID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -1044,9 +1076,10 @@ func (r *thirdPartyDataPrivacyAgreementResolver) ThirdParty(ctx context.Context,
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	thirdParty, err := prb.ThirdParties.Get(ctx, obj.ID)
+	thirdParty, err := prb.ThirdParties.Get(ctx, scope, obj.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -1066,9 +1099,10 @@ func (r *thirdPartyDataPrivacyAgreementResolver) FileURL(ctx context.Context, ob
 		return "", err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	fileURL, err := prb.ThirdPartyDataPrivacyAgreements.GenerateFileURL(ctx, obj.ID, 1*time.Hour)
+	fileURL, err := prb.ThirdPartyDataPrivacyAgreements.GenerateFileURL(ctx, scope, obj.ID, 1*time.Hour)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate file URL", log.Error(err))
 		return "", gqlutils.Internal(ctx)
@@ -1088,9 +1122,10 @@ func (r *thirdPartyRiskAssessmentResolver) ThirdParty(ctx context.Context, obj *
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	thirdParty, err := prb.ThirdParties.GetByRiskAssessmentID(ctx, obj.ID)
+	thirdParty, err := prb.ThirdParties.GetByRiskAssessmentID(ctx, scope, obj.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)

--- a/pkg/server/api/console/v1/trust_center_resolvers.go
+++ b/pkg/server/api/console/v1/trust_center_resolvers.go
@@ -62,10 +62,11 @@ func (r *mutationResolver) UpdateTrustCenter(ctx context.Context, input types.Up
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.TrustCenterID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
+	prb := r.probo
 
 	trustCenter, file, err := prb.TrustCenters.Update(
-		ctx,
+		ctx, scope,
 		&probo.UpdateTrustCenterRequest{
 			ID:                   input.TrustCenterID,
 			Active:               input.Active,
@@ -93,10 +94,11 @@ func (r *mutationResolver) UploadTrustCenterNda(ctx context.Context, input types
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.TrustCenterID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
+	prb := r.probo
 
 	trustCenter, file, err := prb.TrustCenters.UploadNDA(
-		ctx,
+		ctx, scope,
 		&probo.UploadTrustCenterNDARequest{
 			TrustCenterID: input.TrustCenterID,
 			File:          input.File.File,
@@ -124,9 +126,10 @@ func (r *mutationResolver) DeleteTrustCenterNda(ctx context.Context, input types
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.TrustCenterID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
+	prb := r.probo
 
-	trustCenter, file, err := prb.TrustCenters.DeleteNDA(ctx, input.TrustCenterID)
+	trustCenter, file, err := prb.TrustCenters.DeleteNDA(ctx, scope, input.TrustCenterID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete trust center NDA", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -143,7 +146,8 @@ func (r *mutationResolver) UpdateTrustCenterBrand(ctx context.Context, input typ
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.TrustCenterID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
+	prb := r.probo
 
 	req := &probo.UpdateTrustCenterBrandRequest{
 		TrustCenterID: input.TrustCenterID,
@@ -183,7 +187,7 @@ func (r *mutationResolver) UpdateTrustCenterBrand(ctx context.Context, input typ
 		}
 	}
 
-	trustCenter, file, err := prb.TrustCenters.UpdateTrustCenterBrand(ctx, req)
+	trustCenter, file, err := prb.TrustCenters.UpdateTrustCenterBrand(ctx, scope, req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -205,7 +209,8 @@ func (r *mutationResolver) UpdateTrustCenterAccess(ctx context.Context, input ty
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
 	var (
 		documentAccesses []probo.UpdateTrustCenterDocumentAccessRequest
@@ -235,7 +240,7 @@ func (r *mutationResolver) UpdateTrustCenterAccess(ctx context.Context, input ty
 	}
 
 	access, err := prb.TrustCenterAccesses.Update(
-		ctx,
+		ctx, scope,
 		&probo.UpdateTrustCenterAccessRequest{
 			ID:                      input.ID,
 			DocumentAccesses:        documentAccesses,
@@ -264,9 +269,10 @@ func (r *mutationResolver) DeleteTrustCenterAccess(ctx context.Context, input ty
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
-	err := prb.TrustCenterAccesses.Delete(ctx, input.ID)
+	err := prb.TrustCenterAccesses.Delete(ctx, scope, input.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete trust center access", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -283,10 +289,11 @@ func (r *mutationResolver) CreateTrustCenterReference(ctx context.Context, input
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.TrustCenterID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
+	prb := r.probo
 
 	reference, err := prb.TrustCenterReferences.Create(
-		ctx,
+		ctx, scope,
 		&probo.CreateTrustCenterReferenceRequest{
 			TrustCenterID: input.TrustCenterID,
 			Name:          input.Name,
@@ -321,7 +328,8 @@ func (r *mutationResolver) UpdateTrustCenterReference(ctx context.Context, input
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
 	req := &probo.UpdateTrustCenterReferenceRequest{
 		ID:          input.ID,
@@ -340,7 +348,7 @@ func (r *mutationResolver) UpdateTrustCenterReference(ctx context.Context, input
 		}
 	}
 
-	reference, err := prb.TrustCenterReferences.Update(ctx, req)
+	reference, err := prb.TrustCenterReferences.Update(ctx, scope, req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -362,9 +370,10 @@ func (r *mutationResolver) DeleteTrustCenterReference(ctx context.Context, input
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
-	err := prb.TrustCenterReferences.Delete(ctx, input.ID)
+	err := prb.TrustCenterReferences.Delete(ctx, scope, input.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete trust center reference", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -381,10 +390,11 @@ func (r *mutationResolver) CreateComplianceFramework(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.TrustCenterID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
+	prb := r.probo
 
 	cf, err := prb.ComplianceFrameworks.Create(
-		ctx,
+		ctx, scope,
 		&probo.CreateComplianceFrameworkRequest{
 			TrustCenterID: input.TrustCenterID,
 			FrameworkID:   input.FrameworkID,
@@ -411,9 +421,10 @@ func (r *mutationResolver) UpdateComplianceFramework(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
-	cf, err := prb.ComplianceFrameworks.Update(ctx, &probo.UpdateComplianceFrameworkRequest{
+	cf, err := prb.ComplianceFrameworks.Update(ctx, scope, &probo.UpdateComplianceFrameworkRequest{
 		ID:   input.ID,
 		Rank: input.Rank,
 	})
@@ -438,10 +449,11 @@ func (r *mutationResolver) DeleteComplianceFramework(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
 	err := prb.ComplianceFrameworks.Delete(
-		ctx,
+		ctx, scope,
 		&probo.DeleteComplianceFrameworkRequest{
 			ID: input.ID,
 		},
@@ -467,10 +479,11 @@ func (r *mutationResolver) CreateComplianceExternalURL(ctx context.Context, inpu
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.TrustCenterID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
+	prb := r.probo
 
 	item, err := prb.ComplianceExternalURLs.Create(
-		ctx,
+		ctx, scope,
 		&probo.CreateComplianceExternalURLRequest{
 			TrustCenterID: input.TrustCenterID,
 			Name:          input.Name,
@@ -498,9 +511,10 @@ func (r *mutationResolver) UpdateComplianceExternalURL(ctx context.Context, inpu
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
-	item, err := prb.ComplianceExternalURLs.Update(ctx, &probo.UpdateComplianceExternalURLRequest{
+	item, err := prb.ComplianceExternalURLs.Update(ctx, scope, &probo.UpdateComplianceExternalURLRequest{
 		ID:   input.ID,
 		Name: input.Name,
 		URL:  input.URL,
@@ -527,9 +541,10 @@ func (r *mutationResolver) DeleteComplianceExternalURL(ctx context.Context, inpu
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
-	if err := prb.ComplianceExternalURLs.Delete(ctx, &probo.DeleteComplianceExternalURLRequest{ID: input.ID}); err != nil {
+	if err := prb.ComplianceExternalURLs.Delete(ctx, scope, &probo.DeleteComplianceExternalURLRequest{ID: input.ID}); err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
 		}
@@ -550,10 +565,11 @@ func (r *mutationResolver) CreateTrustCenterFile(ctx context.Context, input type
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
 	file, err := prb.TrustCenterFiles.Create(
-		ctx,
+		ctx, scope,
 		&probo.CreateTrustCenterFileRequest{
 			OrganizationID: input.OrganizationID,
 			Name:           input.Name,
@@ -588,10 +604,11 @@ func (r *mutationResolver) UpdateTrustCenterFile(ctx context.Context, input type
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
 	file, err := prb.TrustCenterFiles.Update(
-		ctx,
+		ctx, scope,
 		&probo.UpdateTrustCenterFileRequest{
 			ID:                    input.ID,
 			Name:                  input.Name,
@@ -620,9 +637,10 @@ func (r *mutationResolver) GetTrustCenterFile(ctx context.Context, input types.G
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
-	file, err := prb.TrustCenterFiles.Get(ctx, input.ID)
+	file, err := prb.TrustCenterFiles.Get(ctx, scope, input.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get trust center file", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -639,9 +657,10 @@ func (r *mutationResolver) DeleteTrustCenterFile(ctx context.Context, input type
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
-	err := prb.TrustCenterFiles.Delete(ctx, input.ID)
+	err := prb.TrustCenterFiles.Delete(ctx, scope, input.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete trust center file", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -658,10 +677,11 @@ func (r *mutationResolver) CreateCustomDomain(ctx context.Context, input types.C
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
 	domain, err := prb.CustomDomains.CreateCustomDomain(
-		ctx,
+		ctx, scope,
 		probo.CreateCustomDomainRequest{
 			OrganizationID: input.OrganizationID,
 			Domain:         input.Domain,
@@ -688,11 +708,12 @@ func (r *mutationResolver) DeleteCustomDomain(ctx context.Context, input types.D
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
 	// TODO Drop this wierd logic
 	// Get the current custom domain ID before deleting
-	domain, err := prb.CustomDomains.GetOrganizationCustomDomain(ctx, input.OrganizationID)
+	domain, err := prb.CustomDomains.GetOrganizationCustomDomain(ctx, scope, input.OrganizationID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get custom domain", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -704,7 +725,7 @@ func (r *mutationResolver) DeleteCustomDomain(ctx context.Context, input types.D
 
 	deletedDomainID := domain.ID
 
-	if err := prb.CustomDomains.DeleteCustomDomain(ctx, input.OrganizationID); err != nil {
+	if err := prb.CustomDomains.DeleteCustomDomain(ctx, scope, input.OrganizationID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete custom domain", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -720,9 +741,10 @@ func (r *trustCenterResolver) LogoFileURL(ctx context.Context, obj *types.TrustC
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	logoURL, err := prb.TrustCenters.GenerateLogoURL(ctx, obj.ID, 1*time.Hour)
+	logoURL, err := prb.TrustCenters.GenerateLogoURL(ctx, scope, obj.ID, 1*time.Hour)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate logo url", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -737,9 +759,10 @@ func (r *trustCenterResolver) DarkLogoFileURL(ctx context.Context, obj *types.Tr
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	logoURL, err := prb.TrustCenters.GenerateDarkLogoURL(ctx, obj.ID, 1*time.Hour)
+	logoURL, err := prb.TrustCenters.GenerateDarkLogoURL(ctx, scope, obj.ID, 1*time.Hour)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate logo url", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -760,9 +783,10 @@ func (r *trustCenterResolver) NdaFileURL(ctx context.Context, obj *types.TrustCe
 		return nil, nil
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	fileURL, err := prb.TrustCenters.GenerateNDAFileURL(ctx, obj.ID, 15*time.Minute)
+	fileURL, err := prb.TrustCenters.GenerateNDAFileURL(ctx, scope, obj.ID, 15*time.Minute)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate NDA file URL", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -777,15 +801,16 @@ func (r *trustCenterResolver) Organization(ctx context.Context, obj *types.Trust
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	trustCenter, err := prb.TrustCenters.Get(ctx, obj.ID)
+	trustCenter, err := prb.TrustCenters.Get(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get trust center", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	organization, err := prb.Organizations.Get(ctx, trustCenter.OrganizationID)
+	organization, err := prb.Organizations.Get(ctx, scope, trustCenter.OrganizationID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -805,7 +830,8 @@ func (r *trustCenterResolver) Accesses(ctx context.Context, obj *types.TrustCent
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.TrustCenterAccessOrderField]{
 		Field:     coredata.TrustCenterAccessOrderFieldCreatedAt,
@@ -820,7 +846,7 @@ func (r *trustCenterResolver) Accesses(ctx context.Context, obj *types.TrustCent
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	result, err := prb.TrustCenterAccesses.ListForTrustCenterID(ctx, obj.ID, cursor)
+	result, err := prb.TrustCenterAccesses.ListForTrustCenterID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list trust center accesses", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -835,7 +861,8 @@ func (r *trustCenterResolver) References(ctx context.Context, obj *types.TrustCe
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.TrustCenterReferenceOrderField]{
 		Field:     coredata.TrustCenterReferenceOrderFieldRank,
@@ -850,7 +877,7 @@ func (r *trustCenterResolver) References(ctx context.Context, obj *types.TrustCe
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	result, err := prb.TrustCenterReferences.ListForTrustCenterID(ctx, obj.ID, cursor)
+	result, err := prb.TrustCenterReferences.ListForTrustCenterID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list trust center references", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -865,7 +892,8 @@ func (r *trustCenterResolver) ComplianceFrameworks(ctx context.Context, obj *typ
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ComplianceFrameworkOrderField]{
 		Field:     coredata.ComplianceFrameworkOrderFieldRank,
@@ -880,7 +908,7 @@ func (r *trustCenterResolver) ComplianceFrameworks(ctx context.Context, obj *typ
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	result, err := prb.ComplianceFrameworks.ListWithHiddenForTrustCenterID(ctx, obj.ID, cursor)
+	result, err := prb.ComplianceFrameworks.ListWithHiddenForTrustCenterID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list compliance frameworks", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -895,7 +923,8 @@ func (r *trustCenterResolver) ExternalUrls(ctx context.Context, obj *types.Trust
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ComplianceExternalURLOrderField]{
 		Field:     coredata.ComplianceExternalURLOrderFieldRank,
@@ -910,7 +939,7 @@ func (r *trustCenterResolver) ExternalUrls(ctx context.Context, obj *types.Trust
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	result, err := prb.ComplianceExternalURLs.List(ctx, obj.ID, cursor)
+	result, err := prb.ComplianceExternalURLs.List(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list compliance external URLs", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -929,9 +958,10 @@ func (r *trustCenterResolver) MailingList(ctx context.Context, obj *types.TrustC
 		return obj.MailingList, nil
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	ml, err := prb.TrustCenters.GetMailingList(ctx, obj.ID)
+	ml, err := prb.TrustCenters.GetMailingList(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get mailing list for trust center", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -955,9 +985,10 @@ func (r *trustCenterAccessResolver) NdaSignature(ctx context.Context, obj *types
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	access, err := prb.TrustCenterAccesses.Get(ctx, obj.ID)
+	access, err := prb.TrustCenterAccesses.Get(ctx, scope, obj.ID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot load trust center access: %w", err)
 	}
@@ -980,9 +1011,10 @@ func (r *trustCenterAccessResolver) PendingRequestCount(ctx context.Context, obj
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	count, err := prb.TrustCenterAccesses.CountPendingRequestDocumentAccesses(ctx, obj.ID)
+	count, err := prb.TrustCenterAccesses.CountPendingRequestDocumentAccesses(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot count pending request document accesses", log.Error(err))
 		return 0, gqlutils.Internal(ctx)
@@ -997,9 +1029,10 @@ func (r *trustCenterAccessResolver) ActiveCount(ctx context.Context, obj *types.
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	count, err := prb.TrustCenterAccesses.CountActiveDocumentAccesses(ctx, obj.ID)
+	count, err := prb.TrustCenterAccesses.CountActiveDocumentAccesses(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot count active document accesses", log.Error(err))
 		return 0, gqlutils.Internal(ctx)
@@ -1034,7 +1067,8 @@ func (r *trustCenterAccessResolver) AvailableDocumentAccesses(ctx context.Contex
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.TrustCenterDocumentAccessOrderField]{
 		Field:     coredata.TrustCenterDocumentAccessOrderFieldCreatedAt,
@@ -1049,7 +1083,7 @@ func (r *trustCenterAccessResolver) AvailableDocumentAccesses(ctx context.Contex
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	result, err := prb.TrustCenterAccesses.ListAvailableDocumentAccesses(ctx, obj.ID, cursor)
+	result, err := prb.TrustCenterAccesses.ListAvailableDocumentAccesses(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list trust center document accesses", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1073,9 +1107,10 @@ func (r *trustCenterDocumentAccessResolver) Document(ctx context.Context, obj *t
 		return nil, nil
 	}
 
-	prb := r.ProboService(ctx, obj.TrustCenterAccessID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.TrustCenterAccessID)
+	prb := r.probo
 
-	document, err := prb.Documents.Get(ctx, *obj.DocumentID)
+	document, err := prb.Documents.Get(ctx, scope, *obj.DocumentID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -1099,9 +1134,10 @@ func (r *trustCenterDocumentAccessResolver) Report(ctx context.Context, obj *typ
 		return nil, nil
 	}
 
-	prb := r.ProboService(ctx, obj.TrustCenterAccessID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.TrustCenterAccessID)
+	prb := r.probo
 
-	report, err := prb.Reports.Get(ctx, *obj.ReportID)
+	report, err := prb.Reports.Get(ctx, scope, *obj.ReportID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot load report", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1120,9 +1156,10 @@ func (r *trustCenterDocumentAccessResolver) TrustCenterFile(ctx context.Context,
 		return nil, nil
 	}
 
-	prb := r.ProboService(ctx, obj.TrustCenterAccessID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.TrustCenterAccessID)
+	prb := r.probo
 
-	trustCenterFile, err := prb.TrustCenterFiles.Get(ctx, *obj.TrustCenterFileID)
+	trustCenterFile, err := prb.TrustCenterFiles.Get(ctx, scope, *obj.TrustCenterFileID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot load trust center file", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1137,9 +1174,10 @@ func (r *trustCenterDocumentAccessConnectionResolver) TotalCount(ctx context.Con
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	prb := r.probo
 
-	count, err := prb.TrustCenterAccesses.CountDocumentAccesses(ctx, obj.ParentID)
+	count, err := prb.TrustCenterAccesses.CountDocumentAccesses(ctx, scope, obj.ParentID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot count trust center document accesses", log.Error(err))
 		return 0, gqlutils.Internal(ctx)
@@ -1154,9 +1192,10 @@ func (r *trustCenterFileResolver) FileURL(ctx context.Context, obj *types.TrustC
 		return "", err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	fileURL, err := prb.TrustCenterFiles.GenerateFileURL(ctx, obj.ID, 1*time.Hour)
+	fileURL, err := prb.TrustCenterFiles.GenerateFileURL(ctx, scope, obj.ID, 1*time.Hour)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate file URL", log.Error(err))
 		return "", gqlutils.Internal(ctx)
@@ -1171,15 +1210,16 @@ func (r *trustCenterFileResolver) Organization(ctx context.Context, obj *types.T
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	trustCenterFile, err := prb.TrustCenterFiles.Get(ctx, obj.ID)
+	trustCenterFile, err := prb.TrustCenterFiles.Get(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get trust center file", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	organization, err := prb.Organizations.Get(ctx, trustCenterFile.OrganizationID)
+	organization, err := prb.Organizations.Get(ctx, scope, trustCenterFile.OrganizationID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -1204,9 +1244,10 @@ func (r *trustCenterFileConnectionResolver) TotalCount(ctx context.Context, obj 
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	prb := r.probo
 
-	count, err := prb.TrustCenterFiles.CountForOrganizationID(ctx, obj.ParentID)
+	count, err := prb.TrustCenterFiles.CountForOrganizationID(ctx, scope, obj.ParentID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot count trust center files", log.Error(err))
 		return 0, gqlutils.Internal(ctx)
@@ -1221,9 +1262,10 @@ func (r *trustCenterReferenceResolver) LogoURL(ctx context.Context, obj *types.T
 		return "", err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	fileURL, err := prb.TrustCenterReferences.GenerateLogoURL(ctx, obj.ID, 1*time.Hour)
+	fileURL, err := prb.TrustCenterReferences.GenerateLogoURL(ctx, scope, obj.ID, 1*time.Hour)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate logo URL", log.Error(err))
 		return "", gqlutils.Internal(ctx)
@@ -1243,9 +1285,10 @@ func (r *trustCenterReferenceConnectionResolver) TotalCount(ctx context.Context,
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	prb := r.probo
 
-	count, err := prb.TrustCenterReferences.CountForTrustCenterID(ctx, obj.ParentID)
+	count, err := prb.TrustCenterReferences.CountForTrustCenterID(ctx, scope, obj.ParentID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot count trust center references", log.Error(err))
 		return 0, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/viewer_resolvers.go
+++ b/pkg/server/api/console/v1/viewer_resolvers.go
@@ -26,7 +26,8 @@ func (r *viewerResolver) SignableDocuments(ctx context.Context, obj *types.Viewe
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, organizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(organizationID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
 		Field:     coredata.DocumentOrderFieldCreatedAt,
@@ -45,7 +46,7 @@ func (r *viewerResolver) SignableDocuments(ctx context.Context, obj *types.Viewe
 
 	documentFilter := coredata.NewDocumentFilter(nil).WithEmployeeIdentityID(&identity.ID, coredata.EmployeeFilterModeSignature)
 
-	documentsPage, err := prb.Documents.ListByOrganizationID(ctx, organizationID, cursor, documentFilter)
+	documentsPage, err := prb.Documents.ListByOrganizationID(ctx, scope, organizationID, cursor, documentFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization signable documents", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -74,13 +75,14 @@ func (r *viewerResolver) SignableDocument(ctx context.Context, obj *types.Viewer
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, id.TenantID())
+	scope := coredata.NewScopeFromObjectID(id)
+	prb := r.probo
 
 	identity := authn.IdentityFromContext(ctx)
 
 	documentFilter := coredata.NewDocumentFilter(nil).WithEmployeeIdentityID(&identity.ID, coredata.EmployeeFilterModeSignature)
 
-	document, err := prb.Documents.GetWithFilter(ctx, id, documentFilter)
+	document, err := prb.Documents.GetWithFilter(ctx, scope, id, documentFilter)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -107,7 +109,8 @@ func (r *viewerResolver) ApprovableDocuments(ctx context.Context, obj *types.Vie
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, organizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(organizationID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
 		Field:     coredata.DocumentOrderFieldCreatedAt,
@@ -126,7 +129,7 @@ func (r *viewerResolver) ApprovableDocuments(ctx context.Context, obj *types.Vie
 
 	documentFilter := coredata.NewDocumentFilter(nil).WithEmployeeIdentityID(&identity.ID, coredata.EmployeeFilterModeApproval)
 
-	documentsPage, err := prb.Documents.ListByOrganizationID(ctx, organizationID, cursor, documentFilter)
+	documentsPage, err := prb.Documents.ListByOrganizationID(ctx, scope, organizationID, cursor, documentFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization approvable documents", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -155,13 +158,14 @@ func (r *viewerResolver) ApprovableDocument(ctx context.Context, obj *types.View
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, id.TenantID())
+	scope := coredata.NewScopeFromObjectID(id)
+	prb := r.probo
 
 	identity := authn.IdentityFromContext(ctx)
 
 	documentFilter := coredata.NewDocumentFilter(nil).WithEmployeeIdentityID(&identity.ID, coredata.EmployeeFilterModeApproval)
 
-	document, err := prb.Documents.GetWithFilter(ctx, id, documentFilter)
+	document, err := prb.Documents.GetWithFilter(ctx, scope, id, documentFilter)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)

--- a/pkg/server/api/console/v1/webhook_resolvers.go
+++ b/pkg/server/api/console/v1/webhook_resolvers.go
@@ -28,10 +28,11 @@ func (r *mutationResolver) CreateWebhookSubscription(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.OrganizationID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.probo
 
 	wc, err := prb.WebhookSubscriptions.Create(
-		ctx,
+		ctx, scope,
 		probo.CreateWebhookSubscriptionRequest{
 			OrganizationID: input.OrganizationID,
 			EndpointURL:    input.EndpointURL,
@@ -59,10 +60,11 @@ func (r *mutationResolver) UpdateWebhookSubscription(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.probo
 
 	wc, err := prb.WebhookSubscriptions.Update(
-		ctx,
+		ctx, scope,
 		probo.UpdateWebhookSubscriptionRequest{
 			WebhookSubscriptionID: input.ID,
 			EndpointURL:           input.EndpointURL,
@@ -90,9 +92,10 @@ func (r *mutationResolver) DeleteWebhookSubscription(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, input.WebhookSubscriptionID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.WebhookSubscriptionID)
+	prb := r.probo
 
-	err := prb.WebhookSubscriptions.Delete(ctx, input.WebhookSubscriptionID)
+	err := prb.WebhookSubscriptions.Delete(ctx, scope, input.WebhookSubscriptionID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete webhook subscription", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -109,9 +112,10 @@ func (r *webhookEventConnectionResolver) TotalCount(ctx context.Context, obj *ty
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	prb := r.probo
 
-	count, err := prb.WebhookSubscriptions.CountEventsForSubscriptionID(ctx, obj.ParentID)
+	count, err := prb.WebhookSubscriptions.CountEventsForSubscriptionID(ctx, scope, obj.ParentID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot count webhook events", log.Error(err))
 		return 0, gqlutils.Internal(ctx)
@@ -148,9 +152,10 @@ func (r *webhookSubscriptionResolver) SigningSecret(ctx context.Context, obj *ty
 		return "", err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
-	signingSecret, err := prb.WebhookSubscriptions.GetSigningSecret(ctx, obj.ID)
+	signingSecret, err := prb.WebhookSubscriptions.GetSigningSecret(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get signing secret", log.Error(err))
 		return "", gqlutils.Internal(ctx)
@@ -165,7 +170,8 @@ func (r *webhookSubscriptionResolver) Events(ctx context.Context, obj *types.Web
 		return nil, err
 	}
 
-	prb := r.ProboService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.WebhookEventOrderField]{
 		Field:     coredata.WebhookEventOrderFieldCreatedAt,
@@ -180,7 +186,7 @@ func (r *webhookSubscriptionResolver) Events(ctx context.Context, obj *types.Web
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.WebhookSubscriptions.ListEventsForSubscriptionID(ctx, obj.ID, cursor)
+	page, err := prb.WebhookSubscriptions.ListEventsForSubscriptionID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list webhook events", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -200,11 +206,12 @@ func (r *webhookSubscriptionConnectionResolver) TotalCount(ctx context.Context, 
 		return 0, err
 	}
 
-	prb := r.ProboService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	prb := r.probo
 
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.WebhookSubscriptions.CountForOrganizationID(ctx, obj.ParentID)
+		count, err := prb.WebhookSubscriptions.CountForOrganizationID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count webhook subscriptions", log.Error(err))
 			return 0, gqlutils.Internal(ctx)

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -50,7 +50,8 @@ func (r *Resolver) ListOrganizationsTool(ctx context.Context, req *mcp.CallToolR
 func (r *Resolver) ListThirdPartiesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListThirdPartiesInput) (*mcp.CallToolResult, types.ListThirdPartiesOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionThirdPartyList)
 
-	prb := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyOrderField]{
 		Field:     coredata.ThirdPartyOrderFieldCreatedAt,
@@ -67,7 +68,7 @@ func (r *Resolver) ListThirdPartiesTool(ctx context.Context, req *mcp.CallToolRe
 
 	thirdPartyFilter := coredata.NewThirdPartyFilter(nil)
 
-	page, err := prb.ThirdParties.ListForOrganizationID(ctx, input.OrganizationID, cursor, thirdPartyFilter)
+	page, err := prb.ThirdParties.ListForOrganizationID(ctx, scope, input.OrganizationID, cursor, thirdPartyFilter)
 	if err != nil {
 		panic(fmt.Errorf("cannot list organization thirdParties: %w", err))
 	}
@@ -80,7 +81,8 @@ func (r *Resolver) ListThirdPartiesTool(ctx context.Context, req *mcp.CallToolRe
 func (r *Resolver) AddThirdPartyTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddThirdPartyInput) (*mcp.CallToolResult, types.AddThirdPartyOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionThirdPartyCreate)
 
-	svc := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	svc := r.proboSvc
 
 	var category *coredata.ThirdPartyCategory
 
@@ -98,7 +100,7 @@ func (r *Resolver) AddThirdPartyTool(ctx context.Context, req *mcp.CallToolReque
 	}
 
 	thirdParty, err := svc.ThirdParties.Create(
-		ctx,
+		ctx, scope,
 		probo.CreateThirdPartyRequest{
 			OrganizationID:                input.OrganizationID,
 			Name:                          input.Name,
@@ -134,7 +136,8 @@ func (r *Resolver) AddThirdPartyTool(ctx context.Context, req *mcp.CallToolReque
 func (r *Resolver) UpdateThirdPartyTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateThirdPartyInput) (*mcp.CallToolResult, types.UpdateThirdPartyOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionThirdPartyUpdate)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
 	var description **string
 	if input.Description != nil {
@@ -227,7 +230,7 @@ func (r *Resolver) UpdateThirdPartyTool(ctx context.Context, req *mcp.CallToolRe
 	}
 
 	thirdParty, err := svc.ThirdParties.Update(
-		ctx,
+		ctx, scope,
 		probo.UpdateThirdPartyRequest{
 			ID:                            input.ID,
 			Name:                          input.Name,
@@ -261,7 +264,8 @@ func (r *Resolver) UpdateThirdPartyTool(ctx context.Context, req *mcp.CallToolRe
 func (r *Resolver) ListRisksTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListRisksInput) (*mcp.CallToolResult, types.ListRisksOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionRiskList)
 
-	prb := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.RiskOrderField]{
 		Field:     coredata.RiskOrderFieldCreatedAt,
@@ -281,7 +285,7 @@ func (r *Resolver) ListRisksTool(ctx context.Context, req *mcp.CallToolRequest, 
 		riskFilter = coredata.NewRiskFilter(input.Filter.Query)
 	}
 
-	page, err := prb.Risks.ListForOrganizationID(ctx, input.OrganizationID, cursor, riskFilter)
+	page, err := prb.Risks.ListForOrganizationID(ctx, scope, input.OrganizationID, cursor, riskFilter)
 	if err != nil {
 		panic(fmt.Errorf("cannot list organization risks: %w", err))
 	}
@@ -292,9 +296,10 @@ func (r *Resolver) ListRisksTool(ctx context.Context, req *mcp.CallToolRequest, 
 func (r *Resolver) GetRiskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetRiskInput) (*mcp.CallToolResult, types.GetRiskOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionRiskGet)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
-	risk, err := prb.Risks.Get(ctx, input.ID)
+	risk, err := prb.Risks.Get(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.GetRiskOutput{}, fmt.Errorf("failed to get risk: %w", err)
 	}
@@ -307,10 +312,11 @@ func (r *Resolver) GetRiskTool(ctx context.Context, req *mcp.CallToolRequest, in
 func (r *Resolver) AddRiskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddRiskInput) (*mcp.CallToolResult, types.AddRiskOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionRiskCreate)
 
-	svc := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	svc := r.proboSvc
 
 	risk, err := svc.Risks.Create(
-		ctx,
+		ctx, scope,
 		probo.CreateRiskRequest{
 			OrganizationID:     input.OrganizationID,
 			Name:               input.Name,
@@ -335,10 +341,11 @@ func (r *Resolver) AddRiskTool(ctx context.Context, req *mcp.CallToolRequest, in
 func (r *Resolver) UpdateRiskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateRiskInput) (*mcp.CallToolResult, types.UpdateRiskOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionRiskUpdate)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
 	risk, err := svc.Risks.Update(
-		ctx,
+		ctx, scope,
 		probo.UpdateRiskRequest{
 			ID:                 input.ID,
 			Name:               input.Name,
@@ -365,7 +372,8 @@ func (r *Resolver) UpdateRiskTool(ctx context.Context, req *mcp.CallToolRequest,
 func (r *Resolver) ListMeasuresTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListMeasuresInput) (*mcp.CallToolResult, types.ListMeasuresOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionMeasureList)
 
-	prb := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.MeasureOrderField]{
 		Field:     coredata.MeasureOrderFieldCreatedAt,
@@ -385,7 +393,7 @@ func (r *Resolver) ListMeasuresTool(ctx context.Context, req *mcp.CallToolReques
 		measureFilter = coredata.NewMeasureFilter(input.Filter.Query, input.Filter.State, input.Filter.Category)
 	}
 
-	page, err := prb.Measures.ListForOrganizationID(ctx, input.OrganizationID, cursor, measureFilter)
+	page, err := prb.Measures.ListForOrganizationID(ctx, scope, input.OrganizationID, cursor, measureFilter)
 	if err != nil {
 		panic(fmt.Errorf("cannot list organization measures: %w", err))
 	}
@@ -396,9 +404,10 @@ func (r *Resolver) ListMeasuresTool(ctx context.Context, req *mcp.CallToolReques
 func (r *Resolver) GetMeasureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetMeasureInput) (*mcp.CallToolResult, types.GetMeasureOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionMeasureGet)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
-	measure, err := prb.Measures.Get(ctx, input.ID)
+	measure, err := prb.Measures.Get(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.GetMeasureOutput{}, fmt.Errorf("failed to get measure: %w", err)
 	}
@@ -411,10 +420,11 @@ func (r *Resolver) GetMeasureTool(ctx context.Context, req *mcp.CallToolRequest,
 func (r *Resolver) AddMeasureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddMeasureInput) (*mcp.CallToolResult, types.AddMeasureOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionMeasureCreate)
 
-	svc := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	svc := r.proboSvc
 
 	measure, err := svc.Measures.Create(
-		ctx,
+		ctx, scope,
 		probo.CreateMeasureRequest{
 			OrganizationID: input.OrganizationID,
 			Name:           input.Name,
@@ -434,10 +444,11 @@ func (r *Resolver) AddMeasureTool(ctx context.Context, req *mcp.CallToolRequest,
 func (r *Resolver) UpdateMeasureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateMeasureInput) (*mcp.CallToolResult, types.UpdateMeasureOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionMeasureUpdate)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
 	measure, err := svc.Measures.Update(
-		ctx,
+		ctx, scope,
 		probo.UpdateMeasureRequest{
 			ID:          input.ID,
 			Name:        input.Name,
@@ -458,7 +469,8 @@ func (r *Resolver) UpdateMeasureTool(ctx context.Context, req *mcp.CallToolReque
 func (r *Resolver) ListFrameworksTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListFrameworksInput) (*mcp.CallToolResult, types.ListFrameworksOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionFrameworkList)
 
-	prb := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.FrameworkOrderField]{
 		Field:     coredata.FrameworkOrderFieldCreatedAt,
@@ -473,7 +485,7 @@ func (r *Resolver) ListFrameworksTool(ctx context.Context, req *mcp.CallToolRequ
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	page, err := prb.Frameworks.ListForOrganizationID(ctx, input.OrganizationID, cursor)
+	page, err := prb.Frameworks.ListForOrganizationID(ctx, scope, input.OrganizationID, cursor)
 	if err != nil {
 		panic(fmt.Errorf("cannot list organization frameworks: %w", err))
 	}
@@ -484,9 +496,10 @@ func (r *Resolver) ListFrameworksTool(ctx context.Context, req *mcp.CallToolRequ
 func (r *Resolver) GetFrameworkTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetFrameworkInput) (*mcp.CallToolResult, types.GetFrameworkOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionFrameworkGet)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
-	framework, err := prb.Frameworks.Get(ctx, input.ID)
+	framework, err := prb.Frameworks.Get(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.GetFrameworkOutput{}, fmt.Errorf("failed to get framework: %w", err)
 	}
@@ -499,10 +512,11 @@ func (r *Resolver) GetFrameworkTool(ctx context.Context, req *mcp.CallToolReques
 func (r *Resolver) AddFrameworkTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddFrameworkInput) (*mcp.CallToolResult, types.AddFrameworkOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionFrameworkCreate)
 
-	svc := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	svc := r.proboSvc
 
 	framework, err := svc.Frameworks.Create(
-		ctx,
+		ctx, scope,
 		probo.CreateFrameworkRequest{
 			OrganizationID: input.OrganizationID,
 			Name:           input.Name,
@@ -521,10 +535,11 @@ func (r *Resolver) AddFrameworkTool(ctx context.Context, req *mcp.CallToolReques
 func (r *Resolver) UpdateFrameworkTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateFrameworkInput) (*mcp.CallToolResult, types.UpdateFrameworkOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionFrameworkUpdate)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
 	framework, err := svc.Frameworks.Update(
-		ctx,
+		ctx, scope,
 		probo.UpdateFrameworkRequest{
 			ID:          input.ID,
 			Name:        input.Name,
@@ -543,7 +558,8 @@ func (r *Resolver) UpdateFrameworkTool(ctx context.Context, req *mcp.CallToolReq
 func (r *Resolver) ListAssetsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListAssetsInput) (*mcp.CallToolResult, types.ListAssetsOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionAssetList)
 
-	prb := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.AssetOrderField]{
 		Field:     coredata.AssetOrderFieldCreatedAt,
@@ -558,7 +574,7 @@ func (r *Resolver) ListAssetsTool(ctx context.Context, req *mcp.CallToolRequest,
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	page, err := prb.Assets.ListForOrganizationID(ctx, input.OrganizationID, cursor)
+	page, err := prb.Assets.ListForOrganizationID(ctx, scope, input.OrganizationID, cursor)
 	if err != nil {
 		panic(fmt.Errorf("cannot list organization assets: %w", err))
 	}
@@ -569,9 +585,10 @@ func (r *Resolver) ListAssetsTool(ctx context.Context, req *mcp.CallToolRequest,
 func (r *Resolver) GetAssetTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetAssetInput) (*mcp.CallToolResult, types.GetAssetOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionAssetGet)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
-	asset, err := prb.Assets.Get(ctx, input.ID)
+	asset, err := prb.Assets.Get(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.GetAssetOutput{}, fmt.Errorf("failed to get asset: %w", err)
 	}
@@ -584,10 +601,11 @@ func (r *Resolver) GetAssetTool(ctx context.Context, req *mcp.CallToolRequest, i
 func (r *Resolver) AddAssetTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddAssetInput) (*mcp.CallToolResult, types.AddAssetOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionAssetCreate)
 
-	svc := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	svc := r.proboSvc
 
 	asset, err := svc.Assets.Create(
-		ctx,
+		ctx, scope,
 		probo.CreateAssetRequest{
 			OrganizationID:  input.OrganizationID,
 			Name:            input.Name,
@@ -610,10 +628,11 @@ func (r *Resolver) AddAssetTool(ctx context.Context, req *mcp.CallToolRequest, i
 func (r *Resolver) UpdateAssetTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateAssetInput) (*mcp.CallToolResult, types.UpdateAssetOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionAssetUpdate)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
 	asset, err := svc.Assets.Update(
-		ctx,
+		ctx, scope,
 		probo.UpdateAssetRequest{
 			ID:              input.ID,
 			Name:            input.Name,
@@ -636,7 +655,8 @@ func (r *Resolver) UpdateAssetTool(ctx context.Context, req *mcp.CallToolRequest
 func (r *Resolver) ListDataTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListDataInput) (*mcp.CallToolResult, types.ListDataOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionDatumList)
 
-	prb := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.DatumOrderField]{
 		Field:     coredata.DatumOrderFieldCreatedAt,
@@ -651,7 +671,7 @@ func (r *Resolver) ListDataTool(ctx context.Context, req *mcp.CallToolRequest, i
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	page, err := prb.Data.ListForOrganizationID(ctx, input.OrganizationID, cursor)
+	page, err := prb.Data.ListForOrganizationID(ctx, scope, input.OrganizationID, cursor)
 	if err != nil {
 		panic(fmt.Errorf("cannot list organization data: %w", err))
 	}
@@ -662,9 +682,10 @@ func (r *Resolver) ListDataTool(ctx context.Context, req *mcp.CallToolRequest, i
 func (r *Resolver) GetDatumTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetDatumInput) (*mcp.CallToolResult, types.GetDatumOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionDatumGet)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
-	datum, err := prb.Data.Get(ctx, input.ID)
+	datum, err := prb.Data.Get(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.GetDatumOutput{}, fmt.Errorf("failed to get datum: %w", err)
 	}
@@ -677,10 +698,11 @@ func (r *Resolver) GetDatumTool(ctx context.Context, req *mcp.CallToolRequest, i
 func (r *Resolver) AddDatumTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddDatumInput) (*mcp.CallToolResult, types.AddDatumOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionDatumCreate)
 
-	svc := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	svc := r.proboSvc
 
 	datum, err := svc.Data.Create(
-		ctx,
+		ctx, scope,
 		probo.CreateDatumRequest{
 			OrganizationID:     input.OrganizationID,
 			Name:               input.Name,
@@ -701,10 +723,11 @@ func (r *Resolver) AddDatumTool(ctx context.Context, req *mcp.CallToolRequest, i
 func (r *Resolver) UpdateDatumTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateDatumInput) (*mcp.CallToolResult, types.UpdateDatumOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionDatumUpdate)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
 	datum, err := svc.Data.Update(
-		ctx,
+		ctx, scope,
 		probo.UpdateDatumRequest{
 			ID:                 input.ID,
 			Name:               input.Name,
@@ -725,7 +748,8 @@ func (r *Resolver) UpdateDatumTool(ctx context.Context, req *mcp.CallToolRequest
 func (r *Resolver) ListFindingsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListFindingsInput) (*mcp.CallToolResult, types.ListFindingsOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionFindingList)
 
-	prb := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.FindingOrderField]{
 		Field:     coredata.FindingOrderFieldCreatedAt,
@@ -750,7 +774,7 @@ func (r *Resolver) ListFindingsTool(ctx context.Context, req *mcp.CallToolReques
 		)
 	}
 
-	page, err := prb.Findings.ListForOrganizationID(ctx, input.OrganizationID, cursor, findingFilter)
+	page, err := prb.Findings.ListForOrganizationID(ctx, scope, input.OrganizationID, cursor, findingFilter)
 	if err != nil {
 		panic(fmt.Errorf("cannot list organization findings: %w", err))
 	}
@@ -761,9 +785,10 @@ func (r *Resolver) ListFindingsTool(ctx context.Context, req *mcp.CallToolReques
 func (r *Resolver) GetFindingTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetFindingInput) (*mcp.CallToolResult, types.GetFindingOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionFindingGet)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
-	finding, err := prb.Findings.Get(ctx, input.ID)
+	finding, err := prb.Findings.Get(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.GetFindingOutput{}, fmt.Errorf("cannot get finding: %w", err)
 	}
@@ -776,10 +801,11 @@ func (r *Resolver) GetFindingTool(ctx context.Context, req *mcp.CallToolRequest,
 func (r *Resolver) AddFindingTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddFindingInput) (*mcp.CallToolResult, types.AddFindingOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionFindingCreate)
 
-	svc := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	svc := r.proboSvc
 
 	finding, err := svc.Findings.Create(
-		ctx,
+		ctx, scope,
 		&probo.CreateFindingRequest{
 			OrganizationID:     input.OrganizationID,
 			Kind:               input.Kind,
@@ -808,10 +834,11 @@ func (r *Resolver) AddFindingTool(ctx context.Context, req *mcp.CallToolRequest,
 func (r *Resolver) UpdateFindingTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateFindingInput) (*mcp.CallToolResult, types.UpdateFindingOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionFindingUpdate)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
 	finding, err := svc.Findings.Update(
-		ctx,
+		ctx, scope,
 		&probo.UpdateFindingRequest{
 			ID:                 input.ID,
 			Description:        UnwrapOmittable(input.Description),
@@ -839,7 +866,8 @@ func (r *Resolver) UpdateFindingTool(ctx context.Context, req *mcp.CallToolReque
 func (r *Resolver) ListObligationsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListObligationsInput) (*mcp.CallToolResult, types.ListObligationsOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionObligationList)
 
-	prb := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ObligationOrderField]{
 		Field:     coredata.ObligationOrderFieldCreatedAt,
@@ -854,7 +882,7 @@ func (r *Resolver) ListObligationsTool(ctx context.Context, req *mcp.CallToolReq
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	page, err := prb.Obligations.ListForOrganizationID(ctx, input.OrganizationID, cursor)
+	page, err := prb.Obligations.ListForOrganizationID(ctx, scope, input.OrganizationID, cursor)
 	if err != nil {
 		panic(fmt.Errorf("cannot list organization obligations: %w", err))
 	}
@@ -865,9 +893,10 @@ func (r *Resolver) ListObligationsTool(ctx context.Context, req *mcp.CallToolReq
 func (r *Resolver) GetObligationTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetObligationInput) (*mcp.CallToolResult, types.GetObligationOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionObligationGet)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
-	obligation, err := prb.Obligations.Get(ctx, input.ID)
+	obligation, err := prb.Obligations.Get(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.GetObligationOutput{}, fmt.Errorf("failed to get obligation: %w", err)
 	}
@@ -880,10 +909,11 @@ func (r *Resolver) GetObligationTool(ctx context.Context, req *mcp.CallToolReque
 func (r *Resolver) AddObligationTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddObligationInput) (*mcp.CallToolResult, types.AddObligationOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionObligationCreate)
 
-	svc := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	svc := r.proboSvc
 
 	obligation, err := svc.Obligations.Create(
-		ctx,
+		ctx, scope,
 		&probo.CreateObligationRequest{
 			OrganizationID:         input.OrganizationID,
 			Area:                   input.Area,
@@ -910,10 +940,11 @@ func (r *Resolver) AddObligationTool(ctx context.Context, req *mcp.CallToolReque
 func (r *Resolver) UpdateObligationTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateObligationInput) (*mcp.CallToolResult, types.UpdateObligationOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionObligationUpdate)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
 	obligation, err := svc.Obligations.Update(
-		ctx,
+		ctx, scope,
 		&probo.UpdateObligationRequest{
 			ID:                     input.ID,
 			Area:                   UnwrapOmittable(input.Area),
@@ -940,7 +971,8 @@ func (r *Resolver) UpdateObligationTool(ctx context.Context, req *mcp.CallToolRe
 func (r *Resolver) ListProcessingActivitiesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListProcessingActivitiesInput) (*mcp.CallToolResult, types.ListProcessingActivitiesOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionProcessingActivityList)
 
-	prb := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ProcessingActivityOrderField]{
 		Field:     coredata.ProcessingActivityOrderFieldCreatedAt,
@@ -955,7 +987,7 @@ func (r *Resolver) ListProcessingActivitiesTool(ctx context.Context, req *mcp.Ca
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	page, err := prb.ProcessingActivities.ListForOrganizationID(ctx, input.OrganizationID, cursor)
+	page, err := prb.ProcessingActivities.ListForOrganizationID(ctx, scope, input.OrganizationID, cursor)
 	if err != nil {
 		panic(fmt.Errorf("cannot list organization processing activities: %w", err))
 	}
@@ -966,9 +998,10 @@ func (r *Resolver) ListProcessingActivitiesTool(ctx context.Context, req *mcp.Ca
 func (r *Resolver) GetProcessingActivityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetProcessingActivityInput) (*mcp.CallToolResult, types.GetProcessingActivityOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionProcessingActivityGet)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
-	processingActivity, err := prb.ProcessingActivities.Get(ctx, input.ID)
+	processingActivity, err := prb.ProcessingActivities.Get(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.GetProcessingActivityOutput{}, fmt.Errorf("failed to get processing activity: %w", err)
 	}
@@ -981,10 +1014,11 @@ func (r *Resolver) GetProcessingActivityTool(ctx context.Context, req *mcp.CallT
 func (r *Resolver) AddProcessingActivityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddProcessingActivityInput) (*mcp.CallToolResult, types.AddProcessingActivityOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionProcessingActivityCreate)
 
-	svc := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	svc := r.proboSvc
 
 	processingActivity, err := svc.ProcessingActivities.Create(
-		ctx,
+		ctx, scope,
 		&probo.CreateProcessingActivityRequest{
 			OrganizationID:                       input.OrganizationID,
 			Name:                                 input.Name,
@@ -1021,7 +1055,8 @@ func (r *Resolver) AddProcessingActivityTool(ctx context.Context, req *mcp.CallT
 func (r *Resolver) UpdateProcessingActivityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateProcessingActivityInput) (*mcp.CallToolResult, types.UpdateProcessingActivityOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionProcessingActivityUpdate)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
 	var thirdPartyIDs *[]gid.GID
 	if input.ThirdPartyIds != nil {
@@ -1029,7 +1064,7 @@ func (r *Resolver) UpdateProcessingActivityTool(ctx context.Context, req *mcp.Ca
 	}
 
 	processingActivity, err := svc.ProcessingActivities.Update(
-		ctx,
+		ctx, scope,
 		&probo.UpdateProcessingActivityRequest{
 			ID:                                   input.ID,
 			Name:                                 input.Name,
@@ -1066,9 +1101,10 @@ func (r *Resolver) UpdateProcessingActivityTool(ctx context.Context, req *mcp.Ca
 func (r *Resolver) DeleteProcessingActivityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteProcessingActivityInput) (*mcp.CallToolResult, types.DeleteProcessingActivityOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionProcessingActivityDelete)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
-	err := svc.ProcessingActivities.Delete(ctx, input.ID)
+	err := svc.ProcessingActivities.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteProcessingActivityOutput{}, fmt.Errorf("failed to delete processing activity: %w", err)
 	}
@@ -1081,7 +1117,8 @@ func (r *Resolver) DeleteProcessingActivityTool(ctx context.Context, req *mcp.Ca
 func (r *Resolver) ListDataProtectionImpactAssessmentsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListDataProtectionImpactAssessmentsInput) (*mcp.CallToolResult, types.ListDataProtectionImpactAssessmentsOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionDataProtectionImpactAssessmentList)
 
-	prb := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.DataProtectionImpactAssessmentOrderField]{
 		Field:     coredata.DataProtectionImpactAssessmentOrderFieldCreatedAt,
@@ -1096,7 +1133,7 @@ func (r *Resolver) ListDataProtectionImpactAssessmentsTool(ctx context.Context, 
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	page, err := prb.DataProtectionImpactAssessments.ListForOrganizationID(ctx, input.OrganizationID, cursor)
+	page, err := prb.DataProtectionImpactAssessments.ListForOrganizationID(ctx, scope, input.OrganizationID, cursor)
 	if err != nil {
 		panic(fmt.Errorf("cannot list organization data protection impact assessments: %w", err))
 	}
@@ -1107,9 +1144,10 @@ func (r *Resolver) ListDataProtectionImpactAssessmentsTool(ctx context.Context, 
 func (r *Resolver) GetDataProtectionImpactAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetDataProtectionImpactAssessmentInput) (*mcp.CallToolResult, types.GetDataProtectionImpactAssessmentOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionDataProtectionImpactAssessmentGet)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
-	dpia, err := prb.DataProtectionImpactAssessments.Get(ctx, input.ID)
+	dpia, err := prb.DataProtectionImpactAssessments.Get(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.GetDataProtectionImpactAssessmentOutput{}, fmt.Errorf("failed to get data protection impact assessment: %w", err)
 	}
@@ -1122,10 +1160,11 @@ func (r *Resolver) GetDataProtectionImpactAssessmentTool(ctx context.Context, re
 func (r *Resolver) AddDataProtectionImpactAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddDataProtectionImpactAssessmentInput) (*mcp.CallToolResult, types.AddDataProtectionImpactAssessmentOutput, error) {
 	r.MustAuthorize(ctx, input.ProcessingActivityID, probo.ActionDataProtectionImpactAssessmentCreate)
 
-	svc := r.ProboService(ctx, input.ProcessingActivityID)
+	scope := coredata.NewScopeFromObjectID(input.ProcessingActivityID)
+	svc := r.proboSvc
 
 	dpia, err := svc.DataProtectionImpactAssessments.Create(
-		ctx,
+		ctx, scope,
 		&probo.CreateDataProtectionImpactAssessmentRequest{
 			ProcessingActivityID:        input.ProcessingActivityID,
 			Description:                 input.Description,
@@ -1147,10 +1186,11 @@ func (r *Resolver) AddDataProtectionImpactAssessmentTool(ctx context.Context, re
 func (r *Resolver) UpdateDataProtectionImpactAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateDataProtectionImpactAssessmentInput) (*mcp.CallToolResult, types.UpdateDataProtectionImpactAssessmentOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionDataProtectionImpactAssessmentUpdate)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
 	dpia, err := svc.DataProtectionImpactAssessments.Update(
-		ctx,
+		ctx, scope,
 		&probo.UpdateDataProtectionImpactAssessmentRequest{
 			ID:                          input.ID,
 			Description:                 UnwrapOmittable(input.Description),
@@ -1172,7 +1212,8 @@ func (r *Resolver) UpdateDataProtectionImpactAssessmentTool(ctx context.Context,
 func (r *Resolver) ListTransferImpactAssessmentsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListTransferImpactAssessmentsInput) (*mcp.CallToolResult, types.ListTransferImpactAssessmentsOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionTransferImpactAssessmentList)
 
-	prb := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.TransferImpactAssessmentOrderField]{
 		Field:     coredata.TransferImpactAssessmentOrderFieldCreatedAt,
@@ -1187,7 +1228,7 @@ func (r *Resolver) ListTransferImpactAssessmentsTool(ctx context.Context, req *m
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	page, err := prb.TransferImpactAssessments.ListForOrganizationID(ctx, input.OrganizationID, cursor)
+	page, err := prb.TransferImpactAssessments.ListForOrganizationID(ctx, scope, input.OrganizationID, cursor)
 	if err != nil {
 		panic(fmt.Errorf("cannot list organization transfer impact assessments: %w", err))
 	}
@@ -1198,9 +1239,10 @@ func (r *Resolver) ListTransferImpactAssessmentsTool(ctx context.Context, req *m
 func (r *Resolver) GetTransferImpactAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetTransferImpactAssessmentInput) (*mcp.CallToolResult, types.GetTransferImpactAssessmentOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionTransferImpactAssessmentGet)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
-	tia, err := prb.TransferImpactAssessments.Get(ctx, input.ID)
+	tia, err := prb.TransferImpactAssessments.Get(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.GetTransferImpactAssessmentOutput{}, fmt.Errorf("failed to get transfer impact assessment: %w", err)
 	}
@@ -1213,10 +1255,11 @@ func (r *Resolver) GetTransferImpactAssessmentTool(ctx context.Context, req *mcp
 func (r *Resolver) AddTransferImpactAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddTransferImpactAssessmentInput) (*mcp.CallToolResult, types.AddTransferImpactAssessmentOutput, error) {
 	r.MustAuthorize(ctx, input.ProcessingActivityID, probo.ActionTransferImpactAssessmentCreate)
 
-	svc := r.ProboService(ctx, input.ProcessingActivityID)
+	scope := coredata.NewScopeFromObjectID(input.ProcessingActivityID)
+	svc := r.proboSvc
 
 	tia, err := svc.TransferImpactAssessments.Create(
-		ctx,
+		ctx, scope,
 		&probo.CreateTransferImpactAssessmentRequest{
 			ProcessingActivityID:  input.ProcessingActivityID,
 			DataSubjects:          input.DataSubjects,
@@ -1238,10 +1281,11 @@ func (r *Resolver) AddTransferImpactAssessmentTool(ctx context.Context, req *mcp
 func (r *Resolver) UpdateTransferImpactAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateTransferImpactAssessmentInput) (*mcp.CallToolResult, types.UpdateTransferImpactAssessmentOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionTransferImpactAssessmentUpdate)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
 	tia, err := svc.TransferImpactAssessments.Update(
-		ctx,
+		ctx, scope,
 		&probo.UpdateTransferImpactAssessmentRequest{
 			ID:                    input.ID,
 			DataSubjects:          UnwrapOmittable(input.DataSubjects),
@@ -1263,9 +1307,10 @@ func (r *Resolver) UpdateTransferImpactAssessmentTool(ctx context.Context, req *
 func (r *Resolver) DeleteTransferImpactAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteTransferImpactAssessmentInput) (*mcp.CallToolResult, types.DeleteTransferImpactAssessmentOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionTransferImpactAssessmentDelete)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
-	err := svc.TransferImpactAssessments.Delete(ctx, input.ID)
+	err := svc.TransferImpactAssessments.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteTransferImpactAssessmentOutput{}, fmt.Errorf("failed to delete transfer impact assessment: %w", err)
 	}
@@ -1278,7 +1323,8 @@ func (r *Resolver) DeleteTransferImpactAssessmentTool(ctx context.Context, req *
 func (r *Resolver) ListAuditsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListAuditsInput) (*mcp.CallToolResult, types.ListAuditsOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionAuditList)
 
-	prb := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.AuditOrderField]{
 		Field:     coredata.AuditOrderFieldCreatedAt,
@@ -1293,7 +1339,7 @@ func (r *Resolver) ListAuditsTool(ctx context.Context, req *mcp.CallToolRequest,
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	page, err := prb.Audits.ListForOrganizationID(ctx, input.OrganizationID, cursor)
+	page, err := prb.Audits.ListForOrganizationID(ctx, scope, input.OrganizationID, cursor)
 	if err != nil {
 		panic(fmt.Errorf("cannot list organization audits: %w", err))
 	}
@@ -1304,16 +1350,17 @@ func (r *Resolver) ListAuditsTool(ctx context.Context, req *mcp.CallToolRequest,
 func (r *Resolver) GetAuditTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetAuditInput) (*mcp.CallToolResult, types.GetAuditOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionAuditGet)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
-	audit, err := prb.Audits.Get(ctx, input.ID)
+	audit, err := prb.Audits.Get(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.GetAuditOutput{}, fmt.Errorf("cannot get audit: %w", err)
 	}
 
 	var report *coredata.Report
 	if audit.ReportID != nil {
-		report, err = prb.Reports.Get(ctx, *audit.ReportID)
+		report, err = prb.Reports.Get(ctx, scope, *audit.ReportID)
 		if err != nil {
 			return nil, types.GetAuditOutput{}, fmt.Errorf("cannot get audit report: %w", err)
 		}
@@ -1327,10 +1374,11 @@ func (r *Resolver) GetAuditTool(ctx context.Context, req *mcp.CallToolRequest, i
 func (r *Resolver) AddAuditTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddAuditInput) (*mcp.CallToolResult, types.AddAuditOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionAuditCreate)
 
-	svc := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	svc := r.proboSvc
 
 	audit, err := svc.Audits.Create(
-		ctx,
+		ctx, scope,
 		&probo.CreateAuditRequest{
 			OrganizationID: input.OrganizationID,
 			Name:           input.Name,
@@ -1352,10 +1400,11 @@ func (r *Resolver) AddAuditTool(ctx context.Context, req *mcp.CallToolRequest, i
 func (r *Resolver) UpdateAuditTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateAuditInput) (*mcp.CallToolResult, types.UpdateAuditOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionAuditUpdate)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
 	audit, err := svc.Audits.Update(
-		ctx,
+		ctx, scope,
 		&probo.UpdateAuditRequest{
 			ID:                    input.ID,
 			Name:                  UnwrapOmittable(input.Name),
@@ -1371,7 +1420,7 @@ func (r *Resolver) UpdateAuditTool(ctx context.Context, req *mcp.CallToolRequest
 
 	var report *coredata.Report
 	if audit.ReportID != nil {
-		report, err = svc.Reports.Get(ctx, *audit.ReportID)
+		report, err = svc.Reports.Get(ctx, scope, *audit.ReportID)
 		if err != nil {
 			return nil, types.UpdateAuditOutput{}, fmt.Errorf("cannot get audit report: %w", err)
 		}
@@ -1385,7 +1434,8 @@ func (r *Resolver) UpdateAuditTool(ctx context.Context, req *mcp.CallToolRequest
 func (r *Resolver) ListControlsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListControlsInput) (*mcp.CallToolResult, types.ListControlsOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionControlList)
 
-	prb := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ControlOrderField]{
 		Field:     coredata.ControlOrderFieldCreatedAt,
@@ -1411,9 +1461,9 @@ func (r *Resolver) ListControlsTool(ctx context.Context, req *mcp.CallToolReques
 	)
 
 	if input.Filter != nil && input.Filter.FrameworkID != nil {
-		controlPage, err = prb.Controls.ListForFrameworkID(ctx, *input.Filter.FrameworkID, cursor, controlFilter)
+		controlPage, err = prb.Controls.ListForFrameworkID(ctx, scope, *input.Filter.FrameworkID, cursor, controlFilter)
 	} else {
-		controlPage, err = prb.Controls.ListForOrganizationID(ctx, input.OrganizationID, cursor, controlFilter)
+		controlPage, err = prb.Controls.ListForOrganizationID(ctx, scope, input.OrganizationID, cursor, controlFilter)
 	}
 
 	if err != nil {
@@ -1426,9 +1476,10 @@ func (r *Resolver) ListControlsTool(ctx context.Context, req *mcp.CallToolReques
 func (r *Resolver) GetControlTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetControlInput) (*mcp.CallToolResult, types.GetControlOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionControlGet)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
-	control, err := prb.Controls.Get(ctx, input.ID)
+	control, err := prb.Controls.Get(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.GetControlOutput{}, fmt.Errorf("failed to get control: %w", err)
 	}
@@ -1441,10 +1492,11 @@ func (r *Resolver) GetControlTool(ctx context.Context, req *mcp.CallToolRequest,
 func (r *Resolver) AddControlTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddControlInput) (*mcp.CallToolResult, types.AddControlOutput, error) {
 	r.MustAuthorize(ctx, input.FrameworkID, probo.ActionControlCreate)
 
-	svc := r.ProboService(ctx, input.FrameworkID)
+	scope := coredata.NewScopeFromObjectID(input.FrameworkID)
+	svc := r.proboSvc
 
 	control, err := svc.Controls.Create(
-		ctx,
+		ctx, scope,
 		probo.CreateControlRequest{
 			FrameworkID:                 input.FrameworkID,
 			Name:                        input.Name,
@@ -1467,7 +1519,8 @@ func (r *Resolver) AddControlTool(ctx context.Context, req *mcp.CallToolRequest,
 func (r *Resolver) UpdateControlTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateControlInput) (*mcp.CallToolResult, types.UpdateControlOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionControlUpdate)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
 	var maturityLevel *coredata.ControlMaturityLevel
 
@@ -1477,7 +1530,7 @@ func (r *Resolver) UpdateControlTool(ctx context.Context, req *mcp.CallToolReque
 	}
 
 	control, err := svc.Controls.Update(
-		ctx,
+		ctx, scope,
 		probo.UpdateControlRequest{
 			ID:                          input.ID,
 			Name:                        input.Name,
@@ -1498,31 +1551,32 @@ func (r *Resolver) UpdateControlTool(ctx context.Context, req *mcp.CallToolReque
 }
 
 func (r *Resolver) LinkControlTool(ctx context.Context, req *mcp.CallToolRequest, input *types.LinkControlInput) (*mcp.CallToolResult, types.LinkControlOutput, error) {
-	svc := r.ProboService(ctx, input.ControlID)
+	scope := coredata.NewScopeFromObjectID(input.ControlID)
+	svc := r.proboSvc
 
 	switch input.ResourceID.EntityType() {
 	case coredata.MeasureEntityType:
 		r.MustAuthorize(ctx, input.ControlID, probo.ActionControlMeasureMappingCreate)
 
-		if _, _, err := svc.Controls.CreateMeasureMapping(ctx, input.ControlID, input.ResourceID); err != nil {
+		if _, _, err := svc.Controls.CreateMeasureMapping(ctx, scope, input.ControlID, input.ResourceID); err != nil {
 			return nil, types.LinkControlOutput{}, fmt.Errorf("failed to link control to measure: %w", err)
 		}
 	case coredata.DocumentEntityType:
 		r.MustAuthorize(ctx, input.ControlID, probo.ActionControlDocumentMappingCreate)
 
-		if _, _, err := svc.Controls.CreateDocumentMapping(ctx, input.ControlID, input.ResourceID); err != nil {
+		if _, _, err := svc.Controls.CreateDocumentMapping(ctx, scope, input.ControlID, input.ResourceID); err != nil {
 			return nil, types.LinkControlOutput{}, fmt.Errorf("failed to link control to document: %w", err)
 		}
 	case coredata.AuditEntityType:
 		r.MustAuthorize(ctx, input.ControlID, probo.ActionControlAuditMappingCreate)
 
-		if _, _, err := svc.Controls.CreateAuditMapping(ctx, input.ControlID, input.ResourceID); err != nil {
+		if _, _, err := svc.Controls.CreateAuditMapping(ctx, scope, input.ControlID, input.ResourceID); err != nil {
 			return nil, types.LinkControlOutput{}, fmt.Errorf("failed to link control to audit: %w", err)
 		}
 	case coredata.ObligationEntityType:
 		r.MustAuthorize(ctx, input.ControlID, probo.ActionControlObligationMappingCreate)
 
-		if _, _, err := svc.Controls.CreateObligationMapping(ctx, input.ControlID, input.ResourceID); err != nil {
+		if _, _, err := svc.Controls.CreateObligationMapping(ctx, scope, input.ControlID, input.ResourceID); err != nil {
 			return nil, types.LinkControlOutput{}, fmt.Errorf("failed to link control to obligation: %w", err)
 		}
 	default:
@@ -1533,31 +1587,32 @@ func (r *Resolver) LinkControlTool(ctx context.Context, req *mcp.CallToolRequest
 }
 
 func (r *Resolver) UnlinkControlTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UnlinkControlInput) (*mcp.CallToolResult, types.UnlinkControlOutput, error) {
-	svc := r.ProboService(ctx, input.ControlID)
+	scope := coredata.NewScopeFromObjectID(input.ControlID)
+	svc := r.proboSvc
 
 	switch input.ResourceID.EntityType() {
 	case coredata.MeasureEntityType:
 		r.MustAuthorize(ctx, input.ControlID, probo.ActionControlMeasureMappingDelete)
 
-		if _, _, err := svc.Controls.DeleteMeasureMapping(ctx, input.ControlID, input.ResourceID); err != nil {
+		if _, _, err := svc.Controls.DeleteMeasureMapping(ctx, scope, input.ControlID, input.ResourceID); err != nil {
 			return nil, types.UnlinkControlOutput{}, fmt.Errorf("failed to unlink control from measure: %w", err)
 		}
 	case coredata.DocumentEntityType:
 		r.MustAuthorize(ctx, input.ControlID, probo.ActionControlDocumentMappingDelete)
 
-		if _, _, err := svc.Controls.DeleteDocumentMapping(ctx, input.ControlID, input.ResourceID); err != nil {
+		if _, _, err := svc.Controls.DeleteDocumentMapping(ctx, scope, input.ControlID, input.ResourceID); err != nil {
 			return nil, types.UnlinkControlOutput{}, fmt.Errorf("failed to unlink control from document: %w", err)
 		}
 	case coredata.AuditEntityType:
 		r.MustAuthorize(ctx, input.ControlID, probo.ActionControlAuditMappingDelete)
 
-		if _, _, err := svc.Controls.DeleteAuditMapping(ctx, input.ControlID, input.ResourceID); err != nil {
+		if _, _, err := svc.Controls.DeleteAuditMapping(ctx, scope, input.ControlID, input.ResourceID); err != nil {
 			return nil, types.UnlinkControlOutput{}, fmt.Errorf("failed to unlink control from audit: %w", err)
 		}
 	case coredata.ObligationEntityType:
 		r.MustAuthorize(ctx, input.ControlID, probo.ActionControlObligationMappingDelete)
 
-		if _, _, err := svc.Controls.DeleteObligationMapping(ctx, input.ControlID, input.ResourceID); err != nil {
+		if _, _, err := svc.Controls.DeleteObligationMapping(ctx, scope, input.ControlID, input.ResourceID); err != nil {
 			return nil, types.UnlinkControlOutput{}, fmt.Errorf("failed to unlink control from obligation: %w", err)
 		}
 	default:
@@ -1570,7 +1625,8 @@ func (r *Resolver) UnlinkControlTool(ctx context.Context, req *mcp.CallToolReque
 func (r *Resolver) ListControlObligationsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListControlObligationsInput) (*mcp.CallToolResult, types.ListControlObligationsOutput, error) {
 	r.MustAuthorize(ctx, input.ControlID, probo.ActionControlGet)
 
-	prb := r.ProboService(ctx, input.ControlID)
+	scope := coredata.NewScopeFromObjectID(input.ControlID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ObligationOrderField]{
 		Field:     coredata.ObligationOrderFieldCreatedAt,
@@ -1585,7 +1641,7 @@ func (r *Resolver) ListControlObligationsTool(ctx context.Context, req *mcp.Call
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	obligationPage, err := prb.Obligations.ListForControlID(ctx, input.ControlID, cursor)
+	obligationPage, err := prb.Obligations.ListForControlID(ctx, scope, input.ControlID, cursor)
 	if err != nil {
 		return nil, types.ListControlObligationsOutput{}, fmt.Errorf("failed to list control obligations: %w", err)
 	}
@@ -1596,7 +1652,8 @@ func (r *Resolver) ListControlObligationsTool(ctx context.Context, req *mcp.Call
 func (r *Resolver) ListControlMeasuresTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListControlMeasuresInput) (*mcp.CallToolResult, types.ListControlMeasuresOutput, error) {
 	r.MustAuthorize(ctx, input.ControlID, probo.ActionControlGet)
 
-	prb := r.ProboService(ctx, input.ControlID)
+	scope := coredata.NewScopeFromObjectID(input.ControlID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.MeasureOrderField]{
 		Field:     coredata.MeasureOrderFieldCreatedAt,
@@ -1611,7 +1668,7 @@ func (r *Resolver) ListControlMeasuresTool(ctx context.Context, req *mcp.CallToo
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	measurePage, err := prb.Measures.ListForControlID(ctx, input.ControlID, cursor, coredata.NewMeasureFilter(nil, nil, nil))
+	measurePage, err := prb.Measures.ListForControlID(ctx, scope, input.ControlID, cursor, coredata.NewMeasureFilter(nil, nil, nil))
 	if err != nil {
 		return nil, types.ListControlMeasuresOutput{}, fmt.Errorf("failed to list control measures: %w", err)
 	}
@@ -1622,7 +1679,8 @@ func (r *Resolver) ListControlMeasuresTool(ctx context.Context, req *mcp.CallToo
 func (r *Resolver) ListControlDocumentsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListControlDocumentsInput) (*mcp.CallToolResult, types.ListControlDocumentsOutput, error) {
 	r.MustAuthorize(ctx, input.ControlID, probo.ActionControlGet)
 
-	prb := r.ProboService(ctx, input.ControlID)
+	scope := coredata.NewScopeFromObjectID(input.ControlID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
 		Field:     coredata.DocumentOrderFieldCreatedAt,
@@ -1637,7 +1695,7 @@ func (r *Resolver) ListControlDocumentsTool(ctx context.Context, req *mcp.CallTo
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	docPage, err := prb.Documents.ListForControlID(ctx, input.ControlID, cursor, coredata.NewDocumentFilter(nil))
+	docPage, err := prb.Documents.ListForControlID(ctx, scope, input.ControlID, cursor, coredata.NewDocumentFilter(nil))
 	if err != nil {
 		return nil, types.ListControlDocumentsOutput{}, fmt.Errorf("failed to list control documents: %w", err)
 	}
@@ -1648,7 +1706,8 @@ func (r *Resolver) ListControlDocumentsTool(ctx context.Context, req *mcp.CallTo
 func (r *Resolver) ListControlAuditsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListControlAuditsInput) (*mcp.CallToolResult, types.ListControlAuditsOutput, error) {
 	r.MustAuthorize(ctx, input.ControlID, probo.ActionControlGet)
 
-	prb := r.ProboService(ctx, input.ControlID)
+	scope := coredata.NewScopeFromObjectID(input.ControlID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.AuditOrderField]{
 		Field:     coredata.AuditOrderFieldCreatedAt,
@@ -1663,7 +1722,7 @@ func (r *Resolver) ListControlAuditsTool(ctx context.Context, req *mcp.CallToolR
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	auditPage, err := prb.Audits.ListForControlID(ctx, input.ControlID, cursor)
+	auditPage, err := prb.Audits.ListForControlID(ctx, scope, input.ControlID, cursor)
 	if err != nil {
 		return nil, types.ListControlAuditsOutput{}, fmt.Errorf("failed to list control audits: %w", err)
 	}
@@ -1674,7 +1733,8 @@ func (r *Resolver) ListControlAuditsTool(ctx context.Context, req *mcp.CallToolR
 func (r *Resolver) ListRiskObligationsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListRiskObligationsInput) (*mcp.CallToolResult, types.ListRiskObligationsOutput, error) {
 	r.MustAuthorize(ctx, input.RiskID, probo.ActionRiskGet)
 
-	prb := r.ProboService(ctx, input.RiskID)
+	scope := coredata.NewScopeFromObjectID(input.RiskID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ObligationOrderField]{
 		Field:     coredata.ObligationOrderFieldCreatedAt,
@@ -1689,7 +1749,7 @@ func (r *Resolver) ListRiskObligationsTool(ctx context.Context, req *mcp.CallToo
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	obligationPage, err := prb.Obligations.ListForRiskID(ctx, input.RiskID, cursor)
+	obligationPage, err := prb.Obligations.ListForRiskID(ctx, scope, input.RiskID, cursor)
 	if err != nil {
 		return nil, types.ListRiskObligationsOutput{}, fmt.Errorf("failed to list risk obligations: %w", err)
 	}
@@ -1698,25 +1758,26 @@ func (r *Resolver) ListRiskObligationsTool(ctx context.Context, req *mcp.CallToo
 }
 
 func (r *Resolver) LinkRiskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.LinkRiskInput) (*mcp.CallToolResult, types.LinkRiskOutput, error) {
-	svc := r.ProboService(ctx, input.RiskID)
+	scope := coredata.NewScopeFromObjectID(input.RiskID)
+	svc := r.proboSvc
 
 	switch input.ResourceID.EntityType() {
 	case coredata.DocumentEntityType:
 		r.MustAuthorize(ctx, input.RiskID, probo.ActionRiskDocumentMappingCreate)
 
-		if _, _, err := svc.Risks.CreateDocumentMapping(ctx, input.RiskID, input.ResourceID); err != nil {
+		if _, _, err := svc.Risks.CreateDocumentMapping(ctx, scope, input.RiskID, input.ResourceID); err != nil {
 			return nil, types.LinkRiskOutput{}, fmt.Errorf("failed to link risk to document: %w", err)
 		}
 	case coredata.MeasureEntityType:
 		r.MustAuthorize(ctx, input.RiskID, probo.ActionRiskMeasureMappingCreate)
 
-		if _, _, err := svc.Risks.CreateMeasureMapping(ctx, input.RiskID, input.ResourceID); err != nil {
+		if _, _, err := svc.Risks.CreateMeasureMapping(ctx, scope, input.RiskID, input.ResourceID); err != nil {
 			return nil, types.LinkRiskOutput{}, fmt.Errorf("failed to link risk to measure: %w", err)
 		}
 	case coredata.ObligationEntityType:
 		r.MustAuthorize(ctx, input.RiskID, probo.ActionRiskObligationMappingCreate)
 
-		if _, _, err := svc.Risks.CreateObligationMapping(ctx, input.RiskID, input.ResourceID); err != nil {
+		if _, _, err := svc.Risks.CreateObligationMapping(ctx, scope, input.RiskID, input.ResourceID); err != nil {
 			return nil, types.LinkRiskOutput{}, fmt.Errorf("failed to link risk to obligation: %w", err)
 		}
 	default:
@@ -1727,25 +1788,26 @@ func (r *Resolver) LinkRiskTool(ctx context.Context, req *mcp.CallToolRequest, i
 }
 
 func (r *Resolver) UnlinkRiskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UnlinkRiskInput) (*mcp.CallToolResult, types.UnlinkRiskOutput, error) {
-	svc := r.ProboService(ctx, input.RiskID)
+	scope := coredata.NewScopeFromObjectID(input.RiskID)
+	svc := r.proboSvc
 
 	switch input.ResourceID.EntityType() {
 	case coredata.DocumentEntityType:
 		r.MustAuthorize(ctx, input.RiskID, probo.ActionRiskDocumentMappingDelete)
 
-		if _, _, err := svc.Risks.DeleteDocumentMapping(ctx, input.RiskID, input.ResourceID); err != nil {
+		if _, _, err := svc.Risks.DeleteDocumentMapping(ctx, scope, input.RiskID, input.ResourceID); err != nil {
 			return nil, types.UnlinkRiskOutput{}, fmt.Errorf("failed to unlink risk from document: %w", err)
 		}
 	case coredata.MeasureEntityType:
 		r.MustAuthorize(ctx, input.RiskID, probo.ActionRiskMeasureMappingDelete)
 
-		if _, _, err := svc.Risks.DeleteMeasureMapping(ctx, input.RiskID, input.ResourceID); err != nil {
+		if _, _, err := svc.Risks.DeleteMeasureMapping(ctx, scope, input.RiskID, input.ResourceID); err != nil {
 			return nil, types.UnlinkRiskOutput{}, fmt.Errorf("failed to unlink risk from measure: %w", err)
 		}
 	case coredata.ObligationEntityType:
 		r.MustAuthorize(ctx, input.RiskID, probo.ActionRiskObligationMappingDelete)
 
-		if _, _, err := svc.Risks.DeleteObligationMapping(ctx, input.RiskID, input.ResourceID); err != nil {
+		if _, _, err := svc.Risks.DeleteObligationMapping(ctx, scope, input.RiskID, input.ResourceID); err != nil {
 			return nil, types.UnlinkRiskOutput{}, fmt.Errorf("failed to unlink risk from obligation: %w", err)
 		}
 	default:
@@ -1758,7 +1820,8 @@ func (r *Resolver) UnlinkRiskTool(ctx context.Context, req *mcp.CallToolRequest,
 func (r *Resolver) ListTasksTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListTasksInput) (*mcp.CallToolResult, types.ListTasksOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionTaskList)
 
-	prb := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.TaskOrderField]{
 		Field:     coredata.TaskOrderFieldCreatedAt,
@@ -1773,7 +1836,7 @@ func (r *Resolver) ListTasksTool(ctx context.Context, req *mcp.CallToolRequest, 
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	page, err := prb.Tasks.ListForOrganizationID(ctx, input.OrganizationID, cursor)
+	page, err := prb.Tasks.ListForOrganizationID(ctx, scope, input.OrganizationID, cursor)
 	if err != nil {
 		panic(fmt.Errorf("cannot list organization tasks: %w", err))
 	}
@@ -1784,9 +1847,10 @@ func (r *Resolver) ListTasksTool(ctx context.Context, req *mcp.CallToolRequest, 
 func (r *Resolver) GetTaskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetTaskInput) (*mcp.CallToolResult, types.GetTaskOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionTaskGet)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
-	task, err := prb.Tasks.Get(ctx, input.ID)
+	task, err := prb.Tasks.Get(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.GetTaskOutput{}, fmt.Errorf("failed to get task: %w", err)
 	}
@@ -1799,7 +1863,8 @@ func (r *Resolver) GetTaskTool(ctx context.Context, req *mcp.CallToolRequest, in
 func (r *Resolver) AddTaskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddTaskInput) (*mcp.CallToolResult, types.AddTaskOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionTaskCreate)
 
-	svc := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	svc := r.proboSvc
 
 	priority := coredata.TaskPriorityMedium
 	if input.Priority != nil {
@@ -1807,7 +1872,7 @@ func (r *Resolver) AddTaskTool(ctx context.Context, req *mcp.CallToolRequest, in
 	}
 
 	task, err := svc.Tasks.Create(
-		ctx,
+		ctx, scope,
 		probo.CreateTaskRequest{
 			OrganizationID: input.OrganizationID,
 			MeasureID:      input.MeasureID,
@@ -1831,10 +1896,11 @@ func (r *Resolver) AddTaskTool(ctx context.Context, req *mcp.CallToolRequest, in
 func (r *Resolver) UpdateTaskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateTaskInput) (*mcp.CallToolResult, types.UpdateTaskOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionTaskUpdate)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
 	task, err := svc.Tasks.Update(
-		ctx,
+		ctx, scope,
 		probo.UpdateTaskRequest{
 			TaskID:       input.ID,
 			Name:         input.Name,
@@ -1860,9 +1926,10 @@ func (r *Resolver) UpdateTaskTool(ctx context.Context, req *mcp.CallToolRequest,
 func (r *Resolver) AssignTaskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AssignTaskInput) (*mcp.CallToolResult, types.AssignTaskOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionTaskAssign)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
-	task, err := svc.Tasks.Assign(ctx, input.ID, input.AssignedToID)
+	task, err := svc.Tasks.Assign(ctx, scope, input.ID, input.AssignedToID)
 	if err != nil {
 		return nil, types.AssignTaskOutput{}, fmt.Errorf("failed to assign task: %w", err)
 	}
@@ -1875,9 +1942,10 @@ func (r *Resolver) AssignTaskTool(ctx context.Context, req *mcp.CallToolRequest,
 func (r *Resolver) UnassignTaskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UnassignTaskInput) (*mcp.CallToolResult, types.UnassignTaskOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionTaskUnassign)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
-	task, err := svc.Tasks.Unassign(ctx, input.ID)
+	task, err := svc.Tasks.Unassign(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.UnassignTaskOutput{}, fmt.Errorf("failed to unassign task: %w", err)
 	}
@@ -1890,9 +1958,10 @@ func (r *Resolver) UnassignTaskTool(ctx context.Context, req *mcp.CallToolReques
 func (r *Resolver) DeleteTaskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteTaskInput) (*mcp.CallToolResult, types.DeleteTaskOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionTaskDelete)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
-	err := svc.Tasks.Delete(ctx, input.ID)
+	err := svc.Tasks.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteTaskOutput{}, fmt.Errorf("failed to delete task: %w", err)
 	}
@@ -1905,7 +1974,8 @@ func (r *Resolver) DeleteTaskTool(ctx context.Context, req *mcp.CallToolRequest,
 func (r *Resolver) ListDocumentsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListDocumentsInput) (*mcp.CallToolResult, types.ListDocumentsOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionDocumentList)
 
-	prb := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
 		Field:     coredata.DocumentOrderFieldCreatedAt,
@@ -1940,7 +2010,7 @@ func (r *Resolver) ListDocumentsTool(ctx context.Context, req *mcp.CallToolReque
 		}
 	}
 
-	docPage, err := prb.Documents.ListByOrganizationID(ctx, input.OrganizationID, cursor, documentFilter)
+	docPage, err := prb.Documents.ListByOrganizationID(ctx, scope, input.OrganizationID, cursor, documentFilter)
 	if err != nil {
 		panic(fmt.Errorf("cannot list organization documents: %w", err))
 	}
@@ -1951,9 +2021,10 @@ func (r *Resolver) ListDocumentsTool(ctx context.Context, req *mcp.CallToolReque
 func (r *Resolver) GetDocumentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetDocumentInput) (*mcp.CallToolResult, types.GetDocumentOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionDocumentGet)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
-	document, err := prb.Documents.Get(ctx, input.ID)
+	document, err := prb.Documents.Get(ctx, scope, input.ID)
 	if err != nil {
 		panic(fmt.Errorf("cannot get document: %w", err))
 	}
@@ -1966,7 +2037,8 @@ func (r *Resolver) GetDocumentTool(ctx context.Context, req *mcp.CallToolRequest
 func (r *Resolver) AddDocumentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddDocumentInput) (*mcp.CallToolResult, types.AddDocumentOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionDocumentCreate)
 
-	svc := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	svc := r.proboSvc
 
 	var trustCenterVisibility *coredata.TrustCenterVisibility
 	if input.TrustCenterVisibility != nil {
@@ -1979,7 +2051,7 @@ func (r *Resolver) AddDocumentTool(ctx context.Context, req *mcp.CallToolRequest
 	}
 
 	document, documentVersion, err := svc.Documents.Create(
-		ctx,
+		ctx, scope,
 		probo.CreateDocumentRequest{
 			OrganizationID:        input.OrganizationID,
 			Title:                 input.Title,
@@ -2000,7 +2072,8 @@ func (r *Resolver) AddDocumentTool(ctx context.Context, req *mcp.CallToolRequest
 func (r *Resolver) UpdateDocumentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateDocumentInput) (*mcp.CallToolResult, types.UpdateDocumentOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionDocumentUpdate)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
 	var defaultApproverIDs *[]gid.GID
 	if input.DefaultApproverIds != nil {
@@ -2019,7 +2092,7 @@ func (r *Resolver) UpdateDocumentTool(ctx context.Context, req *mcp.CallToolRequ
 	}
 
 	document, documentVersion, _, err := svc.Documents.Update(
-		ctx,
+		ctx, scope,
 		probo.UpdateDocumentRequest{
 			DocumentID:            input.ID,
 			Title:                 input.Title,
@@ -2060,14 +2133,15 @@ func (r *Resolver) ListDocumentVersionsTool(ctx context.Context, req *mcp.CallTo
 	}
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
-	svc := r.ProboService(ctx, input.DocumentID)
+	scope := coredata.NewScopeFromObjectID(input.DocumentID)
+	svc := r.proboSvc
 
 	versionFilter := coredata.NewDocumentVersionFilter()
 	if input.Filter != nil && len(input.Filter.Statuses) > 0 {
 		versionFilter = versionFilter.WithStatuses(input.Filter.Statuses...)
 	}
 
-	versionPage, err := svc.Documents.ListVersions(ctx, input.DocumentID, cursor, versionFilter)
+	versionPage, err := svc.Documents.ListVersions(ctx, scope, input.DocumentID, cursor, versionFilter)
 	if err != nil {
 		panic(fmt.Errorf("cannot list document versions: %w", err))
 	}
@@ -2078,9 +2152,10 @@ func (r *Resolver) ListDocumentVersionsTool(ctx context.Context, req *mcp.CallTo
 func (r *Resolver) GetDocumentVersionTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetDocumentVersionInput) (*mcp.CallToolResult, types.GetDocumentVersionOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionDocumentVersionGet)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
-	version, err := svc.Documents.GetVersion(ctx, input.ID)
+	version, err := svc.Documents.GetVersion(ctx, scope, input.ID)
 	if err != nil {
 		panic(fmt.Errorf("cannot get document version: %w", err))
 	}
@@ -2093,7 +2168,8 @@ func (r *Resolver) GetDocumentVersionTool(ctx context.Context, req *mcp.CallTool
 func (r *Resolver) ListDocumentVersionSignaturesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListDocumentVersionSignaturesInput) (*mcp.CallToolResult, types.ListDocumentVersionSignaturesOutput, error) {
 	r.MustAuthorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionSignatureList)
 
-	prb := r.ProboService(ctx, input.DocumentVersionID)
+	scope := coredata.NewScopeFromObjectID(input.DocumentVersionID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.DocumentVersionSignatureOrderField]{
 		Field:     coredata.DocumentVersionSignatureOrderFieldCreatedAt,
@@ -2125,7 +2201,7 @@ func (r *Resolver) ListDocumentVersionSignaturesTool(ctx context.Context, req *m
 
 	signatureFilter := coredata.NewDocumentVersionSignatureFilter(signatureStates, activeContract)
 
-	page, err := prb.Documents.ListSignatures(ctx, input.DocumentVersionID, cursor, signatureFilter)
+	page, err := prb.Documents.ListSignatures(ctx, scope, input.DocumentVersionID, cursor, signatureFilter)
 	if err != nil {
 		panic(fmt.Errorf("cannot list document version signatures: %w", err))
 	}
@@ -2136,9 +2212,10 @@ func (r *Resolver) ListDocumentVersionSignaturesTool(ctx context.Context, req *m
 func (r *Resolver) GetDocumentVersionSignatureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetDocumentVersionSignatureInput) (*mcp.CallToolResult, types.GetDocumentVersionSignatureOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionDocumentVersionSignatureGet)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
-	signature, err := prb.Documents.GetVersionSignature(ctx, input.ID)
+	signature, err := prb.Documents.GetVersionSignature(ctx, scope, input.ID)
 	if err != nil {
 		panic(fmt.Errorf("cannot get document version signature: %w", err))
 	}
@@ -2151,10 +2228,11 @@ func (r *Resolver) GetDocumentVersionSignatureTool(ctx context.Context, req *mcp
 func (r *Resolver) RequestDocumentVersionSignatureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.RequestDocumentVersionSignatureInput) (*mcp.CallToolResult, types.RequestDocumentVersionSignatureOutput, error) {
 	r.MustAuthorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionSignatureRequest)
 
-	svc := r.ProboService(ctx, input.DocumentVersionID)
+	scope := coredata.NewScopeFromObjectID(input.DocumentVersionID)
+	svc := r.proboSvc
 
 	documentVersionSignature, err := svc.Documents.RequestSignature(
-		ctx,
+		ctx, scope,
 		probo.RequestSignatureRequest{
 			DocumentVersionID: input.DocumentVersionID,
 			Signatory:         input.SignatoryID,
@@ -2172,9 +2250,10 @@ func (r *Resolver) RequestDocumentVersionSignatureTool(ctx context.Context, req 
 func (r *Resolver) DeleteDocumentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteDocumentInput) (*mcp.CallToolResult, types.DeleteDocumentOutput, error) {
 	r.MustAuthorize(ctx, input.DocumentID, probo.ActionDocumentDelete)
 
-	svc := r.ProboService(ctx, input.DocumentID)
+	scope := coredata.NewScopeFromObjectID(input.DocumentID)
+	svc := r.proboSvc
 
-	err := svc.Documents.SoftDelete(ctx, input.DocumentID)
+	err := svc.Documents.SoftDelete(ctx, scope, input.DocumentID)
 	if err != nil {
 		panic(fmt.Errorf("cannot soft delete document: %w", err))
 	}
@@ -2187,9 +2266,10 @@ func (r *Resolver) DeleteDocumentTool(ctx context.Context, req *mcp.CallToolRequ
 func (r *Resolver) CancelSignatureRequestTool(ctx context.Context, req *mcp.CallToolRequest, input *types.CancelSignatureRequestInput) (*mcp.CallToolResult, types.CancelSignatureRequestOutput, error) {
 	r.MustAuthorize(ctx, input.DocumentVersionSignatureID, probo.ActionDocumentVersionCancelSignature)
 
-	svc := r.ProboService(ctx, input.DocumentVersionSignatureID)
+	scope := coredata.NewScopeFromObjectID(input.DocumentVersionSignatureID)
+	svc := r.proboSvc
 
-	err := svc.Documents.CancelSignatureRequest(ctx, input.DocumentVersionSignatureID)
+	err := svc.Documents.CancelSignatureRequest(ctx, scope, input.DocumentVersionSignatureID)
 	if err != nil {
 		panic(fmt.Errorf("cannot cancel signature request: %w", err))
 	}
@@ -2202,9 +2282,10 @@ func (r *Resolver) CancelSignatureRequestTool(ctx context.Context, req *mcp.Call
 func (r *Resolver) DeleteRiskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteRiskInput) (*mcp.CallToolResult, types.DeleteRiskOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionRiskDelete)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
-	err := svc.Risks.Delete(ctx, input.ID)
+	err := svc.Risks.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteRiskOutput{}, fmt.Errorf("failed to delete risk: %w", err)
 	}
@@ -2217,9 +2298,10 @@ func (r *Resolver) DeleteRiskTool(ctx context.Context, req *mcp.CallToolRequest,
 func (r *Resolver) DeleteMeasureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteMeasureInput) (*mcp.CallToolResult, types.DeleteMeasureOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionMeasureDelete)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
-	err := svc.Measures.Delete(ctx, input.ID)
+	err := svc.Measures.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteMeasureOutput{}, fmt.Errorf("failed to delete measure: %w", err)
 	}
@@ -2232,7 +2314,8 @@ func (r *Resolver) DeleteMeasureTool(ctx context.Context, req *mcp.CallToolReque
 func (r *Resolver) ListMeasureRisksTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListMeasureRisksInput) (*mcp.CallToolResult, types.ListMeasureRisksOutput, error) {
 	r.MustAuthorize(ctx, input.MeasureID, probo.ActionMeasureGet)
 
-	prb := r.ProboService(ctx, input.MeasureID)
+	scope := coredata.NewScopeFromObjectID(input.MeasureID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.RiskOrderField]{
 		Field:     coredata.RiskOrderFieldCreatedAt,
@@ -2247,7 +2330,7 @@ func (r *Resolver) ListMeasureRisksTool(ctx context.Context, req *mcp.CallToolRe
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	riskPage, err := prb.Risks.ListForMeasureID(ctx, input.MeasureID, cursor, coredata.NewRiskFilter(nil))
+	riskPage, err := prb.Risks.ListForMeasureID(ctx, scope, input.MeasureID, cursor, coredata.NewRiskFilter(nil))
 	if err != nil {
 		return nil, types.ListMeasureRisksOutput{}, fmt.Errorf("failed to list measure risks: %w", err)
 	}
@@ -2258,7 +2341,8 @@ func (r *Resolver) ListMeasureRisksTool(ctx context.Context, req *mcp.CallToolRe
 func (r *Resolver) ListMeasureControlsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListMeasureControlsInput) (*mcp.CallToolResult, types.ListMeasureControlsOutput, error) {
 	r.MustAuthorize(ctx, input.MeasureID, probo.ActionMeasureGet)
 
-	prb := r.ProboService(ctx, input.MeasureID)
+	scope := coredata.NewScopeFromObjectID(input.MeasureID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ControlOrderField]{
 		Field:     coredata.ControlOrderFieldCreatedAt,
@@ -2273,7 +2357,7 @@ func (r *Resolver) ListMeasureControlsTool(ctx context.Context, req *mcp.CallToo
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	controlPage, err := prb.Controls.ListForMeasureID(ctx, input.MeasureID, cursor, coredata.NewControlFilter(nil))
+	controlPage, err := prb.Controls.ListForMeasureID(ctx, scope, input.MeasureID, cursor, coredata.NewControlFilter(nil))
 	if err != nil {
 		return nil, types.ListMeasureControlsOutput{}, fmt.Errorf("failed to list measure controls: %w", err)
 	}
@@ -2284,7 +2368,8 @@ func (r *Resolver) ListMeasureControlsTool(ctx context.Context, req *mcp.CallToo
 func (r *Resolver) ListMeasureTasksTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListMeasureTasksInput) (*mcp.CallToolResult, types.ListMeasureTasksOutput, error) {
 	r.MustAuthorize(ctx, input.MeasureID, probo.ActionMeasureGet)
 
-	prb := r.ProboService(ctx, input.MeasureID)
+	scope := coredata.NewScopeFromObjectID(input.MeasureID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.TaskOrderField]{
 		Field:     coredata.TaskOrderFieldCreatedAt,
@@ -2299,7 +2384,7 @@ func (r *Resolver) ListMeasureTasksTool(ctx context.Context, req *mcp.CallToolRe
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	taskPage, err := prb.Tasks.ListForMeasureID(ctx, input.MeasureID, cursor)
+	taskPage, err := prb.Tasks.ListForMeasureID(ctx, scope, input.MeasureID, cursor)
 	if err != nil {
 		return nil, types.ListMeasureTasksOutput{}, fmt.Errorf("failed to list measure tasks: %w", err)
 	}
@@ -2310,7 +2395,8 @@ func (r *Resolver) ListMeasureTasksTool(ctx context.Context, req *mcp.CallToolRe
 func (r *Resolver) ListMeasureEvidencesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListMeasureEvidencesInput) (*mcp.CallToolResult, types.ListMeasureEvidencesOutput, error) {
 	r.MustAuthorize(ctx, input.MeasureID, probo.ActionMeasureGet)
 
-	prb := r.ProboService(ctx, input.MeasureID)
+	scope := coredata.NewScopeFromObjectID(input.MeasureID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.EvidenceOrderField]{
 		Field:     coredata.EvidenceOrderFieldCreatedAt,
@@ -2319,7 +2405,7 @@ func (r *Resolver) ListMeasureEvidencesTool(ctx context.Context, req *mcp.CallTo
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	evidencePage, err := prb.Evidences.ListForMeasureID(ctx, input.MeasureID, cursor)
+	evidencePage, err := prb.Evidences.ListForMeasureID(ctx, scope, input.MeasureID, cursor)
 	if err != nil {
 		return nil, types.ListMeasureEvidencesOutput{}, fmt.Errorf("failed to list measure evidences: %w", err)
 	}
@@ -2328,25 +2414,26 @@ func (r *Resolver) ListMeasureEvidencesTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) LinkMeasureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.LinkMeasureInput) (*mcp.CallToolResult, types.LinkMeasureOutput, error) {
-	svc := r.ProboService(ctx, input.MeasureID)
+	scope := coredata.NewScopeFromObjectID(input.MeasureID)
+	svc := r.proboSvc
 
 	switch input.ResourceID.EntityType() {
 	case coredata.ControlEntityType:
 		r.MustAuthorize(ctx, input.MeasureID, probo.ActionControlMeasureMappingCreate)
 
-		if _, _, err := svc.Controls.CreateMeasureMapping(ctx, input.ResourceID, input.MeasureID); err != nil {
+		if _, _, err := svc.Controls.CreateMeasureMapping(ctx, scope, input.ResourceID, input.MeasureID); err != nil {
 			return nil, types.LinkMeasureOutput{}, fmt.Errorf("failed to link measure to control: %w", err)
 		}
 	case coredata.RiskEntityType:
 		r.MustAuthorize(ctx, input.MeasureID, probo.ActionRiskMeasureMappingCreate)
 
-		if _, _, err := svc.Risks.CreateMeasureMapping(ctx, input.ResourceID, input.MeasureID); err != nil {
+		if _, _, err := svc.Risks.CreateMeasureMapping(ctx, scope, input.ResourceID, input.MeasureID); err != nil {
 			return nil, types.LinkMeasureOutput{}, fmt.Errorf("failed to link measure to risk: %w", err)
 		}
 	case coredata.DocumentEntityType:
 		r.MustAuthorize(ctx, input.MeasureID, probo.ActionMeasureDocumentMappingCreate)
 
-		if _, _, err := svc.Measures.CreateDocumentMapping(ctx, input.MeasureID, input.ResourceID); err != nil {
+		if _, _, err := svc.Measures.CreateDocumentMapping(ctx, scope, input.MeasureID, input.ResourceID); err != nil {
 			return nil, types.LinkMeasureOutput{}, fmt.Errorf("failed to link measure to document: %w", err)
 		}
 	default:
@@ -2357,25 +2444,26 @@ func (r *Resolver) LinkMeasureTool(ctx context.Context, req *mcp.CallToolRequest
 }
 
 func (r *Resolver) UnlinkMeasureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UnlinkMeasureInput) (*mcp.CallToolResult, types.UnlinkMeasureOutput, error) {
-	svc := r.ProboService(ctx, input.MeasureID)
+	scope := coredata.NewScopeFromObjectID(input.MeasureID)
+	svc := r.proboSvc
 
 	switch input.ResourceID.EntityType() {
 	case coredata.ControlEntityType:
 		r.MustAuthorize(ctx, input.MeasureID, probo.ActionControlMeasureMappingDelete)
 
-		if _, _, err := svc.Controls.DeleteMeasureMapping(ctx, input.ResourceID, input.MeasureID); err != nil {
+		if _, _, err := svc.Controls.DeleteMeasureMapping(ctx, scope, input.ResourceID, input.MeasureID); err != nil {
 			return nil, types.UnlinkMeasureOutput{}, fmt.Errorf("failed to unlink measure from control: %w", err)
 		}
 	case coredata.RiskEntityType:
 		r.MustAuthorize(ctx, input.MeasureID, probo.ActionRiskMeasureMappingDelete)
 
-		if _, _, err := svc.Risks.DeleteMeasureMapping(ctx, input.ResourceID, input.MeasureID); err != nil {
+		if _, _, err := svc.Risks.DeleteMeasureMapping(ctx, scope, input.ResourceID, input.MeasureID); err != nil {
 			return nil, types.UnlinkMeasureOutput{}, fmt.Errorf("failed to unlink measure from risk: %w", err)
 		}
 	case coredata.DocumentEntityType:
 		r.MustAuthorize(ctx, input.MeasureID, probo.ActionMeasureDocumentMappingDelete)
 
-		if _, _, err := svc.Measures.DeleteDocumentMapping(ctx, input.MeasureID, input.ResourceID); err != nil {
+		if _, _, err := svc.Measures.DeleteDocumentMapping(ctx, scope, input.MeasureID, input.ResourceID); err != nil {
 			return nil, types.UnlinkMeasureOutput{}, fmt.Errorf("failed to unlink measure from document: %w", err)
 		}
 	default:
@@ -2588,9 +2676,10 @@ func (r *Resolver) RemoveUserTool(ctx context.Context, req *mcp.CallToolRequest,
 func (r *Resolver) DeleteDataProtectionImpactAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteDataProtectionImpactAssessmentInput) (*mcp.CallToolResult, types.DeleteDataProtectionImpactAssessmentOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionDataProtectionImpactAssessmentDelete)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
-	err := svc.DataProtectionImpactAssessments.Delete(ctx, input.ID)
+	err := svc.DataProtectionImpactAssessments.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteDataProtectionImpactAssessmentOutput{}, fmt.Errorf("failed to delete data protection impact assessment: %w", err)
 	}
@@ -2603,7 +2692,8 @@ func (r *Resolver) DeleteDataProtectionImpactAssessmentTool(ctx context.Context,
 func (r *Resolver) ListStatementsOfApplicabilityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListStatementsOfApplicabilityInput) (*mcp.CallToolResult, types.ListStatementsOfApplicabilityOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionStatementOfApplicabilityList)
 
-	prb := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.StatementOfApplicabilityOrderField]{
 		Field:     coredata.StatementOfApplicabilityOrderFieldCreatedAt,
@@ -2618,7 +2708,7 @@ func (r *Resolver) ListStatementsOfApplicabilityTool(ctx context.Context, req *m
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	pg, err := prb.StatementsOfApplicability.ListForOrganizationID(ctx, input.OrganizationID, cursor)
+	pg, err := prb.StatementsOfApplicability.ListForOrganizationID(ctx, scope, input.OrganizationID, cursor)
 	if err != nil {
 		return nil, types.ListStatementsOfApplicabilityOutput{}, fmt.Errorf("failed to list statements of applicability: %w", err)
 	}
@@ -2629,9 +2719,10 @@ func (r *Resolver) ListStatementsOfApplicabilityTool(ctx context.Context, req *m
 func (r *Resolver) GetStatementOfApplicabilityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetStatementOfApplicabilityInput) (*mcp.CallToolResult, types.GetStatementOfApplicabilityOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionStatementOfApplicabilityGet)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
-	soa, err := prb.StatementsOfApplicability.Get(ctx, input.ID)
+	soa, err := prb.StatementsOfApplicability.Get(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.GetStatementOfApplicabilityOutput{}, fmt.Errorf("failed to get statement of applicability: %w", err)
 	}
@@ -2644,9 +2735,10 @@ func (r *Resolver) GetStatementOfApplicabilityTool(ctx context.Context, req *mcp
 func (r *Resolver) AddStatementOfApplicabilityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddStatementOfApplicabilityInput) (*mcp.CallToolResult, types.AddStatementOfApplicabilityOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionStatementOfApplicabilityCreate)
 
-	svc := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	svc := r.proboSvc
 
-	soa, err := svc.StatementsOfApplicability.Create(ctx, probo.CreateStatementOfApplicabilityRequest{
+	soa, err := svc.StatementsOfApplicability.Create(ctx, scope, probo.CreateStatementOfApplicabilityRequest{
 		OrganizationID: input.OrganizationID,
 		Name:           input.Name,
 	})
@@ -2662,9 +2754,10 @@ func (r *Resolver) AddStatementOfApplicabilityTool(ctx context.Context, req *mcp
 func (r *Resolver) UpdateStatementOfApplicabilityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateStatementOfApplicabilityInput) (*mcp.CallToolResult, types.UpdateStatementOfApplicabilityOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionStatementOfApplicabilityUpdate)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
-	soa, err := svc.StatementsOfApplicability.Update(ctx, probo.UpdateStatementOfApplicabilityRequest{
+	soa, err := svc.StatementsOfApplicability.Update(ctx, scope, probo.UpdateStatementOfApplicabilityRequest{
 		StatementOfApplicabilityID: input.ID,
 		Name:                       input.Name,
 	})
@@ -2680,9 +2773,10 @@ func (r *Resolver) UpdateStatementOfApplicabilityTool(ctx context.Context, req *
 func (r *Resolver) DeleteStatementOfApplicabilityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteStatementOfApplicabilityInput) (*mcp.CallToolResult, types.DeleteStatementOfApplicabilityOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionStatementOfApplicabilityDelete)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
-	err := svc.StatementsOfApplicability.Delete(ctx, input.ID)
+	err := svc.StatementsOfApplicability.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteStatementOfApplicabilityOutput{}, fmt.Errorf("failed to delete statement of applicability: %w", err)
 	}
@@ -2695,7 +2789,8 @@ func (r *Resolver) DeleteStatementOfApplicabilityTool(ctx context.Context, req *
 func (r *Resolver) ListApplicabilityStatementsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListApplicabilityStatementsInput) (*mcp.CallToolResult, types.ListApplicabilityStatementsOutput, error) {
 	r.MustAuthorize(ctx, input.StatementOfApplicabilityID, probo.ActionApplicabilityStatementList)
 
-	prb := r.ProboService(ctx, input.StatementOfApplicabilityID)
+	scope := coredata.NewScopeFromObjectID(input.StatementOfApplicabilityID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ApplicabilityStatementOrderField]{
 		Field:     coredata.ApplicabilityStatementOrderFieldControlSectionTitle,
@@ -2710,7 +2805,7 @@ func (r *Resolver) ListApplicabilityStatementsTool(ctx context.Context, req *mcp
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	pg, err := prb.StatementsOfApplicability.ListApplicabilityStatements(ctx, input.StatementOfApplicabilityID, cursor)
+	pg, err := prb.StatementsOfApplicability.ListApplicabilityStatements(ctx, scope, input.StatementOfApplicabilityID, cursor)
 	if err != nil {
 		return nil, types.ListApplicabilityStatementsOutput{}, fmt.Errorf("failed to list applicability statements: %w", err)
 	}
@@ -2721,9 +2816,10 @@ func (r *Resolver) ListApplicabilityStatementsTool(ctx context.Context, req *mcp
 func (r *Resolver) GetApplicabilityStatementTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetApplicabilityStatementInput) (*mcp.CallToolResult, types.GetApplicabilityStatementOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionApplicabilityStatementGet)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
-	stmt, err := prb.StatementsOfApplicability.GetApplicabilityStatement(ctx, input.ID)
+	stmt, err := prb.StatementsOfApplicability.GetApplicabilityStatement(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.GetApplicabilityStatementOutput{}, fmt.Errorf("failed to get applicability statement: %w", err)
 	}
@@ -2736,10 +2832,11 @@ func (r *Resolver) GetApplicabilityStatementTool(ctx context.Context, req *mcp.C
 func (r *Resolver) AddApplicabilityStatementTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddApplicabilityStatementInput) (*mcp.CallToolResult, types.AddApplicabilityStatementOutput, error) {
 	r.MustAuthorize(ctx, input.StatementOfApplicabilityID, probo.ActionApplicabilityStatementCreate)
 
-	svc := r.ProboService(ctx, input.StatementOfApplicabilityID)
+	scope := coredata.NewScopeFromObjectID(input.StatementOfApplicabilityID)
+	svc := r.proboSvc
 
 	stmt, err := svc.StatementsOfApplicability.CreateApplicabilityStatement(
-		ctx,
+		ctx, scope,
 		input.StatementOfApplicabilityID,
 		input.ControlID,
 		input.Applicability,
@@ -2757,10 +2854,11 @@ func (r *Resolver) AddApplicabilityStatementTool(ctx context.Context, req *mcp.C
 func (r *Resolver) UpdateApplicabilityStatementTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateApplicabilityStatementInput) (*mcp.CallToolResult, types.UpdateApplicabilityStatementOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionApplicabilityStatementUpdate)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
 	stmt, err := svc.StatementsOfApplicability.UpdateApplicabilityStatement(
-		ctx,
+		ctx, scope,
 		input.ID,
 		input.Applicability,
 		input.Justification,
@@ -2777,9 +2875,10 @@ func (r *Resolver) UpdateApplicabilityStatementTool(ctx context.Context, req *mc
 func (r *Resolver) DeleteApplicabilityStatementTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteApplicabilityStatementInput) (*mcp.CallToolResult, types.DeleteApplicabilityStatementOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionApplicabilityStatementDelete)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
-	err := svc.StatementsOfApplicability.DeleteApplicabilityStatement(ctx, input.ID)
+	err := svc.StatementsOfApplicability.DeleteApplicabilityStatement(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteApplicabilityStatementOutput{}, fmt.Errorf("failed to delete applicability statement: %w", err)
 	}
@@ -2794,7 +2893,8 @@ func (r *Resolver) DeleteApplicabilityStatementTool(ctx context.Context, req *mc
 func (r *Resolver) ListThirdPartyRiskAssessmentsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListThirdPartyRiskAssessmentsInput) (*mcp.CallToolResult, types.ListThirdPartyRiskAssessmentsOutput, error) {
 	r.MustAuthorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyRiskAssessmentList)
 
-	prb := r.ProboService(ctx, input.ThirdPartyID)
+	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyRiskAssessmentOrderField]{
 		Field:     coredata.ThirdPartyRiskAssessmentOrderFieldCreatedAt,
@@ -2809,7 +2909,7 @@ func (r *Resolver) ListThirdPartyRiskAssessmentsTool(ctx context.Context, req *m
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	p, err := prb.ThirdParties.ListRiskAssessments(ctx, input.ThirdPartyID, cursor)
+	p, err := prb.ThirdParties.ListRiskAssessments(ctx, scope, input.ThirdPartyID, cursor)
 	if err != nil {
 		return nil, types.ListThirdPartyRiskAssessmentsOutput{}, fmt.Errorf("cannot list thirdParty risk assessments: %w", err)
 	}
@@ -2822,10 +2922,11 @@ func (r *Resolver) ListThirdPartyRiskAssessmentsTool(ctx context.Context, req *m
 func (r *Resolver) AddThirdPartyRiskAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddThirdPartyRiskAssessmentInput) (*mcp.CallToolResult, types.AddThirdPartyRiskAssessmentOutput, error) {
 	r.MustAuthorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyRiskAssessmentCreate)
 
-	prb := r.ProboService(ctx, input.ThirdPartyID)
+	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
+	prb := r.proboSvc
 
 	assessment, err := prb.ThirdParties.CreateRiskAssessment(
-		ctx,
+		ctx, scope,
 		probo.CreateThirdPartyRiskAssessmentRequest{
 			ThirdPartyID:    input.ThirdPartyID,
 			ExpiresAt:       input.ExpiresAt,
@@ -2844,9 +2945,10 @@ func (r *Resolver) AddThirdPartyRiskAssessmentTool(ctx context.Context, req *mcp
 func (r *Resolver) DeleteThirdPartyTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteThirdPartyInput) (*mcp.CallToolResult, types.DeleteThirdPartyOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionThirdPartyDelete)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
-	err := svc.ThirdParties.Delete(ctx, input.ID)
+	err := svc.ThirdParties.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteThirdPartyOutput{}, fmt.Errorf("failed to delete thirdParty: %w", err)
 	}
@@ -2859,9 +2961,10 @@ func (r *Resolver) DeleteThirdPartyTool(ctx context.Context, req *mcp.CallToolRe
 func (r *Resolver) DeleteFindingTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteFindingInput) (*mcp.CallToolResult, types.DeleteFindingOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionFindingDelete)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
-	err := svc.Findings.Delete(ctx, input.ID)
+	err := svc.Findings.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteFindingOutput{}, fmt.Errorf("cannot delete finding: %w", err)
 	}
@@ -2874,9 +2977,10 @@ func (r *Resolver) DeleteFindingTool(ctx context.Context, req *mcp.CallToolReque
 func (r *Resolver) LinkFindingAuditTool(ctx context.Context, req *mcp.CallToolRequest, input *types.LinkFindingAuditInput) (*mcp.CallToolResult, types.LinkFindingAuditOutput, error) {
 	r.MustAuthorize(ctx, input.FindingID, probo.ActionFindingAuditMappingCreate)
 
-	svc := r.ProboService(ctx, input.FindingID)
+	scope := coredata.NewScopeFromObjectID(input.FindingID)
+	svc := r.proboSvc
 
-	finding, audit, err := svc.Findings.CreateAuditMapping(ctx, input.FindingID, input.AuditID, input.ReferenceID)
+	finding, audit, err := svc.Findings.CreateAuditMapping(ctx, scope, input.FindingID, input.AuditID, input.ReferenceID)
 	if err != nil {
 		return nil, types.LinkFindingAuditOutput{}, fmt.Errorf("cannot link finding to audit: %w", err)
 	}
@@ -2890,9 +2994,10 @@ func (r *Resolver) LinkFindingAuditTool(ctx context.Context, req *mcp.CallToolRe
 func (r *Resolver) UnlinkFindingAuditTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UnlinkFindingAuditInput) (*mcp.CallToolResult, types.UnlinkFindingAuditOutput, error) {
 	r.MustAuthorize(ctx, input.FindingID, probo.ActionFindingAuditMappingDelete)
 
-	svc := r.ProboService(ctx, input.FindingID)
+	scope := coredata.NewScopeFromObjectID(input.FindingID)
+	svc := r.proboSvc
 
-	finding, audit, err := svc.Findings.DeleteAuditMapping(ctx, input.FindingID, input.AuditID)
+	finding, audit, err := svc.Findings.DeleteAuditMapping(ctx, scope, input.FindingID, input.AuditID)
 	if err != nil {
 		return nil, types.UnlinkFindingAuditOutput{}, fmt.Errorf("cannot unlink finding from audit: %w", err)
 	}
@@ -2906,7 +3011,8 @@ func (r *Resolver) UnlinkFindingAuditTool(ctx context.Context, req *mcp.CallTool
 func (r *Resolver) ListFindingAuditsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListFindingAuditsInput) (*mcp.CallToolResult, types.ListFindingAuditsOutput, error) {
 	r.MustAuthorize(ctx, input.FindingID, probo.ActionFindingGet)
 
-	prb := r.ProboService(ctx, input.FindingID)
+	scope := coredata.NewScopeFromObjectID(input.FindingID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.AuditOrderField]{
 		Field:     coredata.AuditOrderFieldCreatedAt,
@@ -2921,7 +3027,7 @@ func (r *Resolver) ListFindingAuditsTool(ctx context.Context, req *mcp.CallToolR
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	auditPage, err := prb.Audits.ListForFindingID(ctx, input.FindingID, cursor)
+	auditPage, err := prb.Audits.ListForFindingID(ctx, scope, input.FindingID, cursor)
 	if err != nil {
 		return nil, types.ListFindingAuditsOutput{}, fmt.Errorf("cannot list finding audits: %w", err)
 	}
@@ -3446,9 +3552,10 @@ func (r *Resolver) FlagAccessEntryTool(ctx context.Context, req *mcp.CallToolReq
 func (r *Resolver) GetAuditReportUrlTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetAuditReportUrlInput) (*mcp.CallToolResult, types.GetAuditReportUrlOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionReportGetReportUrl)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
-	url, err := prb.Audits.GenerateReportURL(ctx, input.ID, 15*time.Minute)
+	url, err := prb.Audits.GenerateReportURL(ctx, scope, input.ID, 15*time.Minute)
 	if err != nil {
 		return nil, types.GetAuditReportUrlOutput{}, fmt.Errorf("cannot generate audit report URL: %w", err)
 	}
@@ -3461,9 +3568,10 @@ func (r *Resolver) GetAuditReportUrlTool(ctx context.Context, req *mcp.CallToolR
 func (r *Resolver) ArchiveDocumentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ArchiveDocumentInput) (*mcp.CallToolResult, types.ArchiveDocumentOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionDocumentArchive)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
-	document, err := svc.Documents.Archive(ctx, input.ID)
+	document, err := svc.Documents.Archive(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.ArchiveDocumentOutput{}, fmt.Errorf("cannot archive document: %w", err)
 	}
@@ -3476,9 +3584,10 @@ func (r *Resolver) ArchiveDocumentTool(ctx context.Context, req *mcp.CallToolReq
 func (r *Resolver) UnarchiveDocumentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UnarchiveDocumentInput) (*mcp.CallToolResult, types.UnarchiveDocumentOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionDocumentUnarchive)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
-	document, err := svc.Documents.Unarchive(ctx, input.ID)
+	document, err := svc.Documents.Unarchive(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.UnarchiveDocumentOutput{}, fmt.Errorf("cannot unarchive document: %w", err)
 	}
@@ -3491,9 +3600,10 @@ func (r *Resolver) UnarchiveDocumentTool(ctx context.Context, req *mcp.CallToolR
 func (r *Resolver) GetOrganizationContextTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetOrganizationContextInput) (*mcp.CallToolResult, types.GetOrganizationContextOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionOrganizationContextGet)
 
-	prb := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.proboSvc
 
-	orgContext, err := prb.Organizations.GetContext(ctx, input.OrganizationID)
+	orgContext, err := prb.Organizations.GetContext(ctx, scope, input.OrganizationID)
 	if err != nil {
 		return nil, types.GetOrganizationContextOutput{}, fmt.Errorf("cannot get organization context: %w", err)
 	}
@@ -3506,10 +3616,11 @@ func (r *Resolver) GetOrganizationContextTool(ctx context.Context, req *mcp.Call
 func (r *Resolver) UpdateOrganizationContextTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateOrganizationContextInput) (*mcp.CallToolResult, types.UpdateOrganizationContextOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionOrganizationContextUpdate)
 
-	prb := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.proboSvc
 
 	orgContext, err := prb.Organizations.UpdateContext(
-		ctx,
+		ctx, scope,
 		probo.UpdateOrganizationContextRequest{
 			OrganizationID: input.OrganizationID,
 			Product:        &input.Product,
@@ -3582,7 +3693,8 @@ func (r *Resolver) ListAuditLogEntriesTool(ctx context.Context, req *mcp.CallToo
 func (r *Resolver) ListMeasureDocumentsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListMeasureDocumentsInput) (*mcp.CallToolResult, types.ListMeasureDocumentsOutput, error) {
 	r.MustAuthorize(ctx, input.MeasureID, probo.ActionMeasureGet)
 
-	prb := r.ProboService(ctx, input.MeasureID)
+	scope := coredata.NewScopeFromObjectID(input.MeasureID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
 		Field:     coredata.DocumentOrderFieldCreatedAt,
@@ -3597,7 +3709,7 @@ func (r *Resolver) ListMeasureDocumentsTool(ctx context.Context, req *mcp.CallTo
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	docPage, err := prb.Documents.ListForMeasureID(ctx, input.MeasureID, cursor, coredata.NewDocumentFilter(nil))
+	docPage, err := prb.Documents.ListForMeasureID(ctx, scope, input.MeasureID, cursor, coredata.NewDocumentFilter(nil))
 	if err != nil {
 		return nil, types.ListMeasureDocumentsOutput{}, fmt.Errorf("failed to list measure documents: %w", err)
 	}
@@ -3608,9 +3720,10 @@ func (r *Resolver) ListMeasureDocumentsTool(ctx context.Context, req *mcp.CallTo
 func (r *Resolver) VoidDocumentVersionApprovalTool(ctx context.Context, req *mcp.CallToolRequest, input *types.VoidDocumentVersionApprovalInput) (*mcp.CallToolResult, types.VoidDocumentVersionApprovalOutput, error) {
 	r.MustAuthorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionVoidApproval)
 
-	svc := r.ProboService(ctx, input.DocumentVersionID)
+	scope := coredata.NewScopeFromObjectID(input.DocumentVersionID)
+	svc := r.proboSvc
 
-	_, documentVersion, err := svc.DocumentApprovals.VoidApproval(ctx, input.DocumentVersionID)
+	_, documentVersion, err := svc.DocumentApprovals.VoidApproval(ctx, scope, input.DocumentVersionID)
 	if err != nil {
 		panic(fmt.Errorf("cannot void document version approval: %w", err))
 	}
@@ -3623,9 +3736,10 @@ func (r *Resolver) VoidDocumentVersionApprovalTool(ctx context.Context, req *mcp
 func (r *Resolver) SendSigningNotificationsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.SendSigningNotificationsInput) (*mcp.CallToolResult, types.SendSigningNotificationsOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionDocumentSendSigningNotifications)
 
-	svc := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	svc := r.proboSvc
 
-	err := svc.Documents.SendSigningNotifications(ctx, input.OrganizationID)
+	err := svc.Documents.SendSigningNotifications(ctx, scope, input.OrganizationID)
 	if err != nil {
 		panic(fmt.Errorf("cannot send signing notifications: %w", err))
 	}
@@ -3638,9 +3752,10 @@ func (r *Resolver) SendSigningNotificationsTool(ctx context.Context, req *mcp.Ca
 func (r *Resolver) DeleteDocumentDraftTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteDocumentDraftInput) (*mcp.CallToolResult, types.DeleteDocumentDraftOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionDocumentDeleteDraft)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
-	document, err := svc.Documents.DeleteDraft(ctx, input.ID)
+	document, err := svc.Documents.DeleteDraft(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteDocumentDraftOutput{}, fmt.Errorf("cannot delete document draft: %w", err)
 	}
@@ -3653,9 +3768,10 @@ func (r *Resolver) DeleteDocumentDraftTool(ctx context.Context, req *mcp.CallToo
 func (r *Resolver) PublishStatementOfApplicabilityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishStatementOfApplicabilityInput) (*mcp.CallToolResult, types.PublishStatementOfApplicabilityOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionStatementOfApplicabilityPublish)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
-	document, documentVersion, err := svc.GeneratedDocuments.PublishStatementOfApplicability(ctx, input.ID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := svc.GeneratedDocuments.PublishStatementOfApplicability(ctx, scope, input.ID, input.ApproverIds, input.Minor)
 	if err != nil {
 		return nil, types.PublishStatementOfApplicabilityOutput{}, fmt.Errorf("cannot publish statement of applicability: %w", err)
 	}
@@ -3669,7 +3785,8 @@ func (r *Resolver) PublishStatementOfApplicabilityTool(ctx context.Context, req 
 func (r *Resolver) ListWebhookSubscriptionsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListWebhookSubscriptionsInput) (*mcp.CallToolResult, types.ListWebhookSubscriptionsOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionWebhookSubscriptionList)
 
-	prb := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.WebhookSubscriptionOrderField]{
 		Field:     coredata.WebhookSubscriptionOrderFieldCreatedAt,
@@ -3684,7 +3801,7 @@ func (r *Resolver) ListWebhookSubscriptionsTool(ctx context.Context, req *mcp.Ca
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	page, err := prb.WebhookSubscriptions.ListForOrganizationID(ctx, input.OrganizationID, cursor)
+	page, err := prb.WebhookSubscriptions.ListForOrganizationID(ctx, scope, input.OrganizationID, cursor)
 	if err != nil {
 		panic(fmt.Errorf("cannot list webhook subscriptions: %w", err))
 	}
@@ -3695,9 +3812,10 @@ func (r *Resolver) ListWebhookSubscriptionsTool(ctx context.Context, req *mcp.Ca
 func (r *Resolver) GetWebhookSubscriptionTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetWebhookSubscriptionInput) (*mcp.CallToolResult, types.GetWebhookSubscriptionOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionWebhookSubscriptionGet)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
-	subscription, err := prb.WebhookSubscriptions.Get(ctx, input.ID)
+	subscription, err := prb.WebhookSubscriptions.Get(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.GetWebhookSubscriptionOutput{}, fmt.Errorf("failed to get webhook subscription: %w", err)
 	}
@@ -3710,10 +3828,11 @@ func (r *Resolver) GetWebhookSubscriptionTool(ctx context.Context, req *mcp.Call
 func (r *Resolver) CreateWebhookSubscriptionTool(ctx context.Context, req *mcp.CallToolRequest, input *types.CreateWebhookSubscriptionInput) (*mcp.CallToolResult, types.CreateWebhookSubscriptionOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionWebhookSubscriptionCreate)
 
-	prb := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.proboSvc
 
 	subscription, err := prb.WebhookSubscriptions.Create(
-		ctx,
+		ctx, scope,
 		probo.CreateWebhookSubscriptionRequest{
 			OrganizationID: input.OrganizationID,
 			EndpointURL:    input.EndpointURL,
@@ -3732,10 +3851,11 @@ func (r *Resolver) CreateWebhookSubscriptionTool(ctx context.Context, req *mcp.C
 func (r *Resolver) UpdateWebhookSubscriptionTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateWebhookSubscriptionInput) (*mcp.CallToolResult, types.UpdateWebhookSubscriptionOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionWebhookSubscriptionUpdate)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
 	subscription, err := prb.WebhookSubscriptions.Update(
-		ctx,
+		ctx, scope,
 		probo.UpdateWebhookSubscriptionRequest{
 			WebhookSubscriptionID: input.ID,
 			EndpointURL:           input.EndpointURL,
@@ -3754,9 +3874,10 @@ func (r *Resolver) UpdateWebhookSubscriptionTool(ctx context.Context, req *mcp.C
 func (r *Resolver) DeleteWebhookSubscriptionTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteWebhookSubscriptionInput) (*mcp.CallToolResult, types.DeleteWebhookSubscriptionOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionWebhookSubscriptionDelete)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
-	err := prb.WebhookSubscriptions.Delete(ctx, input.ID)
+	err := prb.WebhookSubscriptions.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteWebhookSubscriptionOutput{}, fmt.Errorf("failed to delete webhook subscription: %w", err)
 	}
@@ -3769,7 +3890,8 @@ func (r *Resolver) DeleteWebhookSubscriptionTool(ctx context.Context, req *mcp.C
 func (r *Resolver) ListWebhookEventsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListWebhookEventsInput) (*mcp.CallToolResult, types.ListWebhookEventsOutput, error) {
 	r.MustAuthorize(ctx, input.WebhookSubscriptionID, probo.ActionWebhookSubscriptionGet)
 
-	prb := r.ProboService(ctx, input.WebhookSubscriptionID)
+	scope := coredata.NewScopeFromObjectID(input.WebhookSubscriptionID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.WebhookEventOrderField]{
 		Field:     coredata.WebhookEventOrderFieldCreatedAt,
@@ -3784,7 +3906,7 @@ func (r *Resolver) ListWebhookEventsTool(ctx context.Context, req *mcp.CallToolR
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	page, err := prb.WebhookSubscriptions.ListEventsForSubscriptionID(ctx, input.WebhookSubscriptionID, cursor)
+	page, err := prb.WebhookSubscriptions.ListEventsForSubscriptionID(ctx, scope, input.WebhookSubscriptionID, cursor)
 	if err != nil {
 		panic(fmt.Errorf("cannot list webhook events: %w", err))
 	}
@@ -3795,7 +3917,8 @@ func (r *Resolver) ListWebhookEventsTool(ctx context.Context, req *mcp.CallToolR
 func (r *Resolver) ListDocumentVersionApprovalQuorumsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListDocumentVersionApprovalQuorumsInput) (*mcp.CallToolResult, types.ListDocumentVersionApprovalQuorumsOutput, error) {
 	r.MustAuthorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionApprovalList)
 
-	svc := r.ProboService(ctx, input.DocumentVersionID)
+	scope := coredata.NewScopeFromObjectID(input.DocumentVersionID)
+	svc := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.DocumentVersionApprovalQuorumOrderField]{
 		Field:     coredata.DocumentVersionApprovalQuorumOrderFieldCreatedAt,
@@ -3810,7 +3933,7 @@ func (r *Resolver) ListDocumentVersionApprovalQuorumsTool(ctx context.Context, r
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	p, err := svc.DocumentApprovals.ListQuorums(ctx, input.DocumentVersionID, cursor)
+	p, err := svc.DocumentApprovals.ListQuorums(ctx, scope, input.DocumentVersionID, cursor)
 	if err != nil {
 		panic(fmt.Errorf("cannot list approval quorums: %w", err))
 	}
@@ -3821,9 +3944,10 @@ func (r *Resolver) ListDocumentVersionApprovalQuorumsTool(ctx context.Context, r
 func (r *Resolver) GetDocumentVersionApprovalQuorumTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetDocumentVersionApprovalQuorumInput) (*mcp.CallToolResult, types.GetDocumentVersionApprovalQuorumOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionDocumentVersionApprovalList)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
-	quorum, err := svc.DocumentApprovals.GetQuorum(ctx, input.ID)
+	quorum, err := svc.DocumentApprovals.GetQuorum(ctx, scope, input.ID)
 	if err != nil {
 		panic(fmt.Errorf("cannot get approval quorum: %w", err))
 	}
@@ -3836,7 +3960,8 @@ func (r *Resolver) GetDocumentVersionApprovalQuorumTool(ctx context.Context, req
 func (r *Resolver) ListDocumentVersionApprovalDecisionsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListDocumentVersionApprovalDecisionsInput) (*mcp.CallToolResult, types.ListDocumentVersionApprovalDecisionsOutput, error) {
 	r.MustAuthorize(ctx, input.QuorumID, probo.ActionDocumentVersionApprovalList)
 
-	svc := r.ProboService(ctx, input.QuorumID)
+	scope := coredata.NewScopeFromObjectID(input.QuorumID)
+	svc := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.DocumentVersionApprovalDecisionOrderField]{
 		Field:     coredata.DocumentVersionApprovalDecisionOrderFieldCreatedAt,
@@ -3858,7 +3983,7 @@ func (r *Resolver) ListDocumentVersionApprovalDecisionsTool(ctx context.Context,
 
 	filter := coredata.NewDocumentVersionApprovalDecisionFilter(states)
 
-	p, err := svc.DocumentApprovals.ListDecisions(ctx, input.QuorumID, cursor, filter)
+	p, err := svc.DocumentApprovals.ListDecisions(ctx, scope, input.QuorumID, cursor, filter)
 	if err != nil {
 		panic(fmt.Errorf("cannot list approval decisions: %w", err))
 	}
@@ -3869,9 +3994,10 @@ func (r *Resolver) ListDocumentVersionApprovalDecisionsTool(ctx context.Context,
 func (r *Resolver) GetDocumentVersionApprovalDecisionTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetDocumentVersionApprovalDecisionInput) (*mcp.CallToolResult, types.GetDocumentVersionApprovalDecisionOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionDocumentVersionApprovalList)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
-	decision, err := svc.DocumentApprovals.GetDecision(ctx, input.ID)
+	decision, err := svc.DocumentApprovals.GetDecision(ctx, scope, input.ID)
 	if err != nil {
 		panic(fmt.Errorf("cannot get approval decision: %w", err))
 	}
@@ -3884,9 +4010,10 @@ func (r *Resolver) GetDocumentVersionApprovalDecisionTool(ctx context.Context, r
 func (r *Resolver) PublishDataListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishDataListInput) (*mcp.CallToolResult, types.PublishDataListOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionDatumPublish)
 
-	svc := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	svc := r.proboSvc
 
-	document, documentVersion, err := svc.GeneratedDocuments.PublishDataList(ctx, input.OrganizationID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := svc.GeneratedDocuments.PublishDataList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
 	if err != nil {
 		return nil, types.PublishDataListOutput{}, fmt.Errorf("cannot publish data list: %w", err)
 	}
@@ -3900,9 +4027,10 @@ func (r *Resolver) PublishDataListTool(ctx context.Context, req *mcp.CallToolReq
 func (r *Resolver) PublishAssetListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishAssetListInput) (*mcp.CallToolResult, types.PublishAssetListOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionAssetPublish)
 
-	svc := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	svc := r.proboSvc
 
-	document, documentVersion, err := svc.GeneratedDocuments.PublishAssetList(ctx, input.OrganizationID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := svc.GeneratedDocuments.PublishAssetList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
 	if err != nil {
 		return nil, types.PublishAssetListOutput{}, fmt.Errorf("cannot publish asset list: %w", err)
 	}
@@ -3918,7 +4046,8 @@ func (r *Resolver) PublishAssetListTool(ctx context.Context, req *mcp.CallToolRe
 func (r *Resolver) ListThirdPartyContactsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListThirdPartyContactsInput) (*mcp.CallToolResult, types.ListThirdPartyContactsOutput, error) {
 	r.MustAuthorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyContactList)
 
-	prb := r.ProboService(ctx, input.ThirdPartyID)
+	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyContactOrderField]{
 		Field:     coredata.ThirdPartyContactOrderFieldCreatedAt,
@@ -3933,7 +4062,7 @@ func (r *Resolver) ListThirdPartyContactsTool(ctx context.Context, req *mcp.Call
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	p, err := prb.ThirdPartyContacts.List(ctx, input.ThirdPartyID, cursor)
+	p, err := prb.ThirdPartyContacts.List(ctx, scope, input.ThirdPartyID, cursor)
 	if err != nil {
 		return nil, types.ListThirdPartyContactsOutput{}, fmt.Errorf("cannot list thirdParty contacts: %w", err)
 	}
@@ -3946,14 +4075,15 @@ func (r *Resolver) ListThirdPartyContactsTool(ctx context.Context, req *mcp.Call
 func (r *Resolver) AddThirdPartyContactTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddThirdPartyContactInput) (*mcp.CallToolResult, types.AddThirdPartyContactOutput, error) {
 	r.MustAuthorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyContactCreate)
 
-	prb := r.ProboService(ctx, input.ThirdPartyID)
+	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
+	prb := r.proboSvc
 
 	emailAddr, err := mail.ParseAddr(input.Email)
 	if err != nil {
 		return nil, types.AddThirdPartyContactOutput{}, fmt.Errorf("invalid email address: %w", err)
 	}
 
-	thirdPartyContact, err := prb.ThirdPartyContacts.Create(ctx, probo.CreateThirdPartyContactRequest{
+	thirdPartyContact, err := prb.ThirdPartyContacts.Create(ctx, scope, probo.CreateThirdPartyContactRequest{
 		ThirdPartyID: input.ThirdPartyID,
 		FullName:     &input.FullName,
 		Email:        &emailAddr,
@@ -3974,7 +4104,8 @@ func (r *Resolver) AddThirdPartyContactTool(ctx context.Context, req *mcp.CallTo
 func (r *Resolver) UpdateThirdPartyContactTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateThirdPartyContactInput) (*mcp.CallToolResult, types.UpdateThirdPartyContactOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionThirdPartyContactUpdate)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
 	updateReq := probo.UpdateThirdPartyContactRequest{
 		ID: input.ID,
@@ -4002,7 +4133,7 @@ func (r *Resolver) UpdateThirdPartyContactTool(ctx context.Context, req *mcp.Cal
 		updateReq.Role = &input.Role
 	}
 
-	thirdPartyContact, err := prb.ThirdPartyContacts.Update(ctx, updateReq)
+	thirdPartyContact, err := prb.ThirdPartyContacts.Update(ctx, scope, updateReq)
 	if err != nil {
 		return nil, types.UpdateThirdPartyContactOutput{}, fmt.Errorf("cannot update thirdParty contact: %w", err)
 	}
@@ -4017,9 +4148,10 @@ func (r *Resolver) UpdateThirdPartyContactTool(ctx context.Context, req *mcp.Cal
 func (r *Resolver) DeleteThirdPartyContactTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteThirdPartyContactInput) (*mcp.CallToolResult, types.DeleteThirdPartyContactOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionThirdPartyContactDelete)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
-	err := prb.ThirdPartyContacts.Delete(ctx, input.ID)
+	err := prb.ThirdPartyContacts.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteThirdPartyContactOutput{}, fmt.Errorf("cannot delete thirdParty contact: %w", err)
 	}
@@ -4034,7 +4166,8 @@ func (r *Resolver) DeleteThirdPartyContactTool(ctx context.Context, req *mcp.Cal
 func (r *Resolver) ListThirdPartyServicesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListThirdPartyServicesInput) (*mcp.CallToolResult, types.ListThirdPartyServicesOutput, error) {
 	r.MustAuthorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyServiceList)
 
-	prb := r.ProboService(ctx, input.ThirdPartyID)
+	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyServiceOrderField]{
 		Field:     coredata.ThirdPartyServiceOrderFieldCreatedAt,
@@ -4049,7 +4182,7 @@ func (r *Resolver) ListThirdPartyServicesTool(ctx context.Context, req *mcp.Call
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	p, err := prb.ThirdPartyServices.List(ctx, input.ThirdPartyID, cursor)
+	p, err := prb.ThirdPartyServices.List(ctx, scope, input.ThirdPartyID, cursor)
 	if err != nil {
 		return nil, types.ListThirdPartyServicesOutput{}, fmt.Errorf("cannot list thirdParty services: %w", err)
 	}
@@ -4062,9 +4195,10 @@ func (r *Resolver) ListThirdPartyServicesTool(ctx context.Context, req *mcp.Call
 func (r *Resolver) AddThirdPartyServiceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddThirdPartyServiceInput) (*mcp.CallToolResult, types.AddThirdPartyServiceOutput, error) {
 	r.MustAuthorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyServiceCreate)
 
-	prb := r.ProboService(ctx, input.ThirdPartyID)
+	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
+	prb := r.proboSvc
 
-	thirdPartyService, err := prb.ThirdPartyServices.Create(ctx, probo.CreateThirdPartyServiceRequest{
+	thirdPartyService, err := prb.ThirdPartyServices.Create(ctx, scope, probo.CreateThirdPartyServiceRequest{
 		ThirdPartyID: input.ThirdPartyID,
 		Name:         input.Name,
 		Description:  input.Description,
@@ -4083,7 +4217,8 @@ func (r *Resolver) AddThirdPartyServiceTool(ctx context.Context, req *mcp.CallTo
 func (r *Resolver) UpdateThirdPartyServiceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateThirdPartyServiceInput) (*mcp.CallToolResult, types.UpdateThirdPartyServiceOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionThirdPartyServiceUpdate)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
 	updateReq := probo.UpdateThirdPartyServiceRequest{
 		ID: input.ID,
@@ -4097,7 +4232,7 @@ func (r *Resolver) UpdateThirdPartyServiceTool(ctx context.Context, req *mcp.Cal
 		updateReq.Description = &input.Description
 	}
 
-	thirdPartyService, err := prb.ThirdPartyServices.Update(ctx, updateReq)
+	thirdPartyService, err := prb.ThirdPartyServices.Update(ctx, scope, updateReq)
 	if err != nil {
 		return nil, types.UpdateThirdPartyServiceOutput{}, fmt.Errorf("cannot update thirdParty service: %w", err)
 	}
@@ -4112,9 +4247,10 @@ func (r *Resolver) UpdateThirdPartyServiceTool(ctx context.Context, req *mcp.Cal
 func (r *Resolver) DeleteThirdPartyServiceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteThirdPartyServiceInput) (*mcp.CallToolResult, types.DeleteThirdPartyServiceOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionThirdPartyServiceDelete)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
-	err := prb.ThirdPartyServices.Delete(ctx, input.ID)
+	err := prb.ThirdPartyServices.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteThirdPartyServiceOutput{}, fmt.Errorf("cannot delete thirdParty service: %w", err)
 	}
@@ -4126,9 +4262,10 @@ func (r *Resolver) DeleteThirdPartyServiceTool(ctx context.Context, req *mcp.Cal
 func (r *Resolver) DeleteAssetTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteAssetInput) (*mcp.CallToolResult, types.DeleteAssetOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionAssetDelete)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
-	err := svc.Assets.Delete(ctx, input.ID)
+	err := svc.Assets.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteAssetOutput{}, fmt.Errorf("failed to delete asset: %w", err)
 	}
@@ -4140,9 +4277,10 @@ func (r *Resolver) DeleteAssetTool(ctx context.Context, req *mcp.CallToolRequest
 func (r *Resolver) DeleteDatumTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteDatumInput) (*mcp.CallToolResult, types.DeleteDatumOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionDatumDelete)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
-	err := svc.Data.Delete(ctx, input.ID)
+	err := svc.Data.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteDatumOutput{}, fmt.Errorf("failed to delete datum: %w", err)
 	}
@@ -4154,9 +4292,10 @@ func (r *Resolver) DeleteDatumTool(ctx context.Context, req *mcp.CallToolRequest
 func (r *Resolver) DeleteObligationTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteObligationInput) (*mcp.CallToolResult, types.DeleteObligationOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionObligationDelete)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
-	err := svc.Obligations.Delete(ctx, input.ID)
+	err := svc.Obligations.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteObligationOutput{}, fmt.Errorf("failed to delete obligation: %w", err)
 	}
@@ -4168,9 +4307,10 @@ func (r *Resolver) DeleteObligationTool(ctx context.Context, req *mcp.CallToolRe
 func (r *Resolver) DeleteAuditTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteAuditInput) (*mcp.CallToolResult, types.DeleteAuditOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionAuditDelete)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
-	err := svc.Audits.Delete(ctx, input.ID)
+	err := svc.Audits.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteAuditOutput{}, fmt.Errorf("failed to delete audit: %w", err)
 	}
@@ -4182,7 +4322,8 @@ func (r *Resolver) DeleteAuditTool(ctx context.Context, req *mcp.CallToolRequest
 func (r *Resolver) ListRightsRequestsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListRightsRequestsInput) (*mcp.CallToolResult, types.ListRightsRequestsOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionRightsRequestList)
 
-	prb := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.RightsRequestOrderField]{
 		Field:     coredata.RightsRequestOrderFieldCreatedAt,
@@ -4197,7 +4338,7 @@ func (r *Resolver) ListRightsRequestsTool(ctx context.Context, req *mcp.CallTool
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	page, err := prb.RightsRequests.ListForOrganizationID(ctx, input.OrganizationID, cursor)
+	page, err := prb.RightsRequests.ListForOrganizationID(ctx, scope, input.OrganizationID, cursor)
 	if err != nil {
 		panic(fmt.Errorf("cannot list organization rights requests: %w", err))
 	}
@@ -4207,9 +4348,10 @@ func (r *Resolver) ListRightsRequestsTool(ctx context.Context, req *mcp.CallTool
 func (r *Resolver) GetRightsRequestTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetRightsRequestInput) (*mcp.CallToolResult, types.GetRightsRequestOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionRightsRequestGet)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
-	rightsRequest, err := prb.RightsRequests.Get(ctx, input.ID)
+	rightsRequest, err := prb.RightsRequests.Get(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.GetRightsRequestOutput{}, fmt.Errorf("failed to get rights request: %w", err)
 	}
@@ -4221,10 +4363,11 @@ func (r *Resolver) GetRightsRequestTool(ctx context.Context, req *mcp.CallToolRe
 func (r *Resolver) AddRightsRequestTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddRightsRequestInput) (*mcp.CallToolResult, types.AddRightsRequestOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionRightsRequestCreate)
 
-	svc := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	svc := r.proboSvc
 
 	rightsRequest, err := svc.RightsRequests.Create(
-		ctx,
+		ctx, scope,
 		&probo.CreateRightsRequestRequest{
 			OrganizationID: input.OrganizationID,
 			RequestType:    &input.RequestType,
@@ -4247,7 +4390,8 @@ func (r *Resolver) AddRightsRequestTool(ctx context.Context, req *mcp.CallToolRe
 func (r *Resolver) UpdateRightsRequestTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateRightsRequestInput) (*mcp.CallToolResult, types.UpdateRightsRequestOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionRightsRequestUpdate)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
 	var dataSubject **string
 	if input.DataSubject != nil {
@@ -4255,7 +4399,7 @@ func (r *Resolver) UpdateRightsRequestTool(ctx context.Context, req *mcp.CallToo
 	}
 
 	rightsRequest, err := svc.RightsRequests.Update(
-		ctx,
+		ctx, scope,
 		&probo.UpdateRightsRequestRequest{
 			ID:           input.ID,
 			RequestType:  input.RequestType,
@@ -4278,9 +4422,10 @@ func (r *Resolver) UpdateRightsRequestTool(ctx context.Context, req *mcp.CallToo
 func (r *Resolver) DeleteRightsRequestTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteRightsRequestInput) (*mcp.CallToolResult, types.DeleteRightsRequestOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionRightsRequestDelete)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
-	err := svc.RightsRequests.Delete(ctx, input.ID)
+	err := svc.RightsRequests.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteRightsRequestOutput{}, fmt.Errorf("failed to delete rights request: %w", err)
 	}
@@ -4295,26 +4440,27 @@ func (r *Resolver) DeleteRightsRequestTool(ctx context.Context, req *mcp.CallToo
 func (r *Resolver) GetTrustCenterTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetTrustCenterInput) (*mcp.CallToolResult, types.GetTrustCenterOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionTrustCenterGet)
 
-	prb := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.proboSvc
 
-	trustCenter, err := prb.TrustCenters.GetByOrganizationID(ctx, input.OrganizationID)
+	trustCenter, err := prb.TrustCenters.GetByOrganizationID(ctx, scope, input.OrganizationID)
 	if err != nil {
 		return nil, types.GetTrustCenterOutput{}, fmt.Errorf("cannot get trust center: %w", err)
 	}
 
 	tc := types.NewTrustCenter(trustCenter)
 
-	logoURL, err := prb.TrustCenters.GenerateLogoURL(ctx, trustCenter.ID, 1*time.Hour)
+	logoURL, err := prb.TrustCenters.GenerateLogoURL(ctx, scope, trustCenter.ID, 1*time.Hour)
 	if err == nil {
 		tc.LogoFileURL = logoURL
 	}
 
-	darkLogoURL, err := prb.TrustCenters.GenerateDarkLogoURL(ctx, trustCenter.ID, 1*time.Hour)
+	darkLogoURL, err := prb.TrustCenters.GenerateDarkLogoURL(ctx, scope, trustCenter.ID, 1*time.Hour)
 	if err == nil {
 		tc.DarkLogoFileURL = darkLogoURL
 	}
 
-	ndaFileURL, err := prb.TrustCenters.GenerateNDAFileURL(ctx, trustCenter.ID, 15*time.Minute)
+	ndaFileURL, err := prb.TrustCenters.GenerateNDAFileURL(ctx, scope, trustCenter.ID, 15*time.Minute)
 	if err == nil {
 		tc.NdaFileURL = ndaFileURL
 	}
@@ -4327,7 +4473,8 @@ func (r *Resolver) GetTrustCenterTool(ctx context.Context, req *mcp.CallToolRequ
 func (r *Resolver) UpdateTrustCenterTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateTrustCenterInput) (*mcp.CallToolResult, types.UpdateTrustCenterOutput, error) {
 	r.MustAuthorize(ctx, input.TrustCenterID, probo.ActionTrustCenterUpdate)
 
-	prb := r.ProboService(ctx, input.TrustCenterID)
+	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
+	prb := r.proboSvc
 
 	updateReq := &probo.UpdateTrustCenterRequest{
 		ID: input.TrustCenterID,
@@ -4340,7 +4487,7 @@ func (r *Resolver) UpdateTrustCenterTool(ctx context.Context, req *mcp.CallToolR
 		updateReq.SearchEngineIndexing = *sei
 	}
 
-	trustCenter, _, err := prb.TrustCenters.Update(ctx, updateReq)
+	trustCenter, _, err := prb.TrustCenters.Update(ctx, scope, updateReq)
 	if err != nil {
 		return nil, types.UpdateTrustCenterOutput{}, fmt.Errorf("cannot update trust center: %w", err)
 	}
@@ -4353,7 +4500,8 @@ func (r *Resolver) UpdateTrustCenterTool(ctx context.Context, req *mcp.CallToolR
 func (r *Resolver) ListTrustCenterReferencesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListTrustCenterReferencesInput) (*mcp.CallToolResult, types.ListTrustCenterReferencesOutput, error) {
 	r.MustAuthorize(ctx, input.TrustCenterID, probo.ActionTrustCenterReferenceList)
 
-	prb := r.ProboService(ctx, input.TrustCenterID)
+	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.TrustCenterReferenceOrderField]{
 		Field:     coredata.TrustCenterReferenceOrderFieldRank,
@@ -4368,7 +4516,7 @@ func (r *Resolver) ListTrustCenterReferencesTool(ctx context.Context, req *mcp.C
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	p, err := prb.TrustCenterReferences.ListForTrustCenterID(ctx, input.TrustCenterID, cursor)
+	p, err := prb.TrustCenterReferences.ListForTrustCenterID(ctx, scope, input.TrustCenterID, cursor)
 	if err != nil {
 		return nil, types.ListTrustCenterReferencesOutput{}, fmt.Errorf("cannot list trust center references: %w", err)
 	}
@@ -4381,7 +4529,8 @@ func (r *Resolver) ListTrustCenterReferencesTool(ctx context.Context, req *mcp.C
 func (r *Resolver) AddTrustCenterReferenceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddTrustCenterReferenceInput) (*mcp.CallToolResult, types.AddTrustCenterReferenceOutput, error) {
 	r.MustAuthorize(ctx, input.TrustCenterID, probo.ActionTrustCenterReferenceCreate)
 
-	prb := r.ProboService(ctx, input.TrustCenterID)
+	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
+	prb := r.proboSvc
 
 	var websiteURL string
 	if input.WebsiteURL != nil {
@@ -4389,7 +4538,7 @@ func (r *Resolver) AddTrustCenterReferenceTool(ctx context.Context, req *mcp.Cal
 	}
 
 	reference, err := prb.TrustCenterReferences.Create(
-		ctx,
+		ctx, scope,
 		&probo.CreateTrustCenterReferenceRequest{
 			TrustCenterID: input.TrustCenterID,
 			Name:          input.Name,
@@ -4409,7 +4558,8 @@ func (r *Resolver) AddTrustCenterReferenceTool(ctx context.Context, req *mcp.Cal
 func (r *Resolver) UpdateTrustCenterReferenceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateTrustCenterReferenceInput) (*mcp.CallToolResult, types.UpdateTrustCenterReferenceOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionTrustCenterReferenceUpdate)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
 	updateRefReq := &probo.UpdateTrustCenterReferenceRequest{
 		ID:          input.ID,
@@ -4427,7 +4577,7 @@ func (r *Resolver) UpdateTrustCenterReferenceTool(ctx context.Context, req *mcp.
 		updateRefReq.Rank = *rank
 	}
 
-	reference, err := prb.TrustCenterReferences.Update(ctx, updateRefReq)
+	reference, err := prb.TrustCenterReferences.Update(ctx, scope, updateRefReq)
 	if err != nil {
 		return nil, types.UpdateTrustCenterReferenceOutput{}, fmt.Errorf("cannot update trust center reference: %w", err)
 	}
@@ -4440,9 +4590,10 @@ func (r *Resolver) UpdateTrustCenterReferenceTool(ctx context.Context, req *mcp.
 func (r *Resolver) DeleteTrustCenterReferenceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteTrustCenterReferenceInput) (*mcp.CallToolResult, types.DeleteTrustCenterReferenceOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionTrustCenterReferenceDelete)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
-	err := prb.TrustCenterReferences.Delete(ctx, input.ID)
+	err := prb.TrustCenterReferences.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteTrustCenterReferenceOutput{}, fmt.Errorf("cannot delete trust center reference: %w", err)
 	}
@@ -4455,7 +4606,8 @@ func (r *Resolver) DeleteTrustCenterReferenceTool(ctx context.Context, req *mcp.
 func (r *Resolver) ListTrustCenterFilesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListTrustCenterFilesInput) (*mcp.CallToolResult, types.ListTrustCenterFilesOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionTrustCenterFileList)
 
-	prb := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.TrustCenterFileOrderField]{
 		Field:     coredata.TrustCenterFileOrderFieldCreatedAt,
@@ -4471,14 +4623,14 @@ func (r *Resolver) ListTrustCenterFilesTool(ctx context.Context, req *mcp.CallTo
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 	filter := coredata.NewTrustCenterFileFilter()
 
-	p, err := prb.TrustCenterFiles.ListForOrganizationID(ctx, input.OrganizationID, cursor, filter)
+	p, err := prb.TrustCenterFiles.ListForOrganizationID(ctx, scope, input.OrganizationID, cursor, filter)
 	if err != nil {
 		return nil, types.ListTrustCenterFilesOutput{}, fmt.Errorf("cannot list trust center files: %w", err)
 	}
 
 	files := make([]*types.TrustCenterFile, 0, len(p.Data))
 	for _, f := range p.Data {
-		fileURL, err := prb.TrustCenterFiles.GenerateFileURL(ctx, f.ID, 1*time.Hour)
+		fileURL, err := prb.TrustCenterFiles.GenerateFileURL(ctx, scope, f.ID, 1*time.Hour)
 		if err != nil {
 			return nil, types.ListTrustCenterFilesOutput{}, fmt.Errorf("cannot generate file URL: %w", err)
 		}
@@ -4494,9 +4646,10 @@ func (r *Resolver) ListTrustCenterFilesTool(ctx context.Context, req *mcp.CallTo
 func (r *Resolver) DeleteTrustCenterFileTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteTrustCenterFileInput) (*mcp.CallToolResult, types.DeleteTrustCenterFileOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionTrustCenterFileDelete)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
-	err := prb.TrustCenterFiles.Delete(ctx, input.ID)
+	err := prb.TrustCenterFiles.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteTrustCenterFileOutput{}, fmt.Errorf("cannot delete trust center file: %w", err)
 	}
@@ -4509,7 +4662,8 @@ func (r *Resolver) DeleteTrustCenterFileTool(ctx context.Context, req *mcp.CallT
 func (r *Resolver) ListComplianceExternalURLsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListComplianceExternalURLsInput) (*mcp.CallToolResult, types.ListComplianceExternalURLsOutput, error) {
 	r.MustAuthorize(ctx, input.TrustCenterID, probo.ActionComplianceExternalURLList)
 
-	prb := r.ProboService(ctx, input.TrustCenterID)
+	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
+	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ComplianceExternalURLOrderField]{
 		Field:     coredata.ComplianceExternalURLOrderFieldRank,
@@ -4524,7 +4678,7 @@ func (r *Resolver) ListComplianceExternalURLsTool(ctx context.Context, req *mcp.
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
 
-	p, err := prb.ComplianceExternalURLs.List(ctx, input.TrustCenterID, cursor)
+	p, err := prb.ComplianceExternalURLs.List(ctx, scope, input.TrustCenterID, cursor)
 	if err != nil {
 		return nil, types.ListComplianceExternalURLsOutput{}, fmt.Errorf("cannot list compliance external URLs: %w", err)
 	}
@@ -4537,10 +4691,11 @@ func (r *Resolver) ListComplianceExternalURLsTool(ctx context.Context, req *mcp.
 func (r *Resolver) AddComplianceExternalURLTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddComplianceExternalURLInput) (*mcp.CallToolResult, types.AddComplianceExternalURLOutput, error) {
 	r.MustAuthorize(ctx, input.TrustCenterID, probo.ActionComplianceExternalURLCreate)
 
-	prb := r.ProboService(ctx, input.TrustCenterID)
+	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
+	prb := r.proboSvc
 
 	item, err := prb.ComplianceExternalURLs.Create(
-		ctx,
+		ctx, scope,
 		&probo.CreateComplianceExternalURLRequest{
 			TrustCenterID: input.TrustCenterID,
 			Name:          input.Name,
@@ -4559,7 +4714,8 @@ func (r *Resolver) AddComplianceExternalURLTool(ctx context.Context, req *mcp.Ca
 func (r *Resolver) UpdateComplianceExternalURLTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateComplianceExternalURLInput) (*mcp.CallToolResult, types.UpdateComplianceExternalURLOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionComplianceExternalURLUpdate)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
 	updateURLReq := &probo.UpdateComplianceExternalURLRequest{
 		ID: input.ID,
@@ -4577,7 +4733,7 @@ func (r *Resolver) UpdateComplianceExternalURLTool(ctx context.Context, req *mcp
 		updateURLReq.Rank = *rank
 	}
 
-	item, err := prb.ComplianceExternalURLs.Update(ctx, updateURLReq)
+	item, err := prb.ComplianceExternalURLs.Update(ctx, scope, updateURLReq)
 	if err != nil {
 		return nil, types.UpdateComplianceExternalURLOutput{}, fmt.Errorf("cannot update compliance external URL: %w", err)
 	}
@@ -4590,10 +4746,11 @@ func (r *Resolver) UpdateComplianceExternalURLTool(ctx context.Context, req *mcp
 func (r *Resolver) DeleteComplianceExternalURLTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteComplianceExternalURLInput) (*mcp.CallToolResult, types.DeleteComplianceExternalURLOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionComplianceExternalURLDelete)
 
-	prb := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	prb := r.proboSvc
 
 	err := prb.ComplianceExternalURLs.Delete(
-		ctx,
+		ctx, scope,
 		&probo.DeleteComplianceExternalURLRequest{
 			ID: input.ID,
 		},
@@ -4610,10 +4767,11 @@ func (r *Resolver) DeleteComplianceExternalURLTool(ctx context.Context, req *mcp
 func (r *Resolver) CreateCustomDomainTool(ctx context.Context, req *mcp.CallToolRequest, input *types.CreateCustomDomainInput) (*mcp.CallToolResult, types.CreateCustomDomainOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionCustomDomainCreate)
 
-	prb := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.proboSvc
 
 	domain, err := prb.CustomDomains.CreateCustomDomain(
-		ctx,
+		ctx, scope,
 		probo.CreateCustomDomainRequest{
 			OrganizationID: input.OrganizationID,
 			Domain:         input.Domain,
@@ -4631,9 +4789,10 @@ func (r *Resolver) CreateCustomDomainTool(ctx context.Context, req *mcp.CallTool
 func (r *Resolver) DeleteCustomDomainTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteCustomDomainInput) (*mcp.CallToolResult, types.DeleteCustomDomainOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionCustomDomainDelete)
 
-	prb := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	prb := r.proboSvc
 
-	domain, err := prb.CustomDomains.GetOrganizationCustomDomain(ctx, input.OrganizationID)
+	domain, err := prb.CustomDomains.GetOrganizationCustomDomain(ctx, scope, input.OrganizationID)
 	if err != nil {
 		return nil, types.DeleteCustomDomainOutput{}, fmt.Errorf("cannot get custom domain: %w", err)
 	}
@@ -4644,7 +4803,7 @@ func (r *Resolver) DeleteCustomDomainTool(ctx context.Context, req *mcp.CallTool
 
 	deletedDomain := types.NewCustomDomain(domain)
 
-	if err := prb.CustomDomains.DeleteCustomDomain(ctx, input.OrganizationID); err != nil {
+	if err := prb.CustomDomains.DeleteCustomDomain(ctx, scope, input.OrganizationID); err != nil {
 		return nil, types.DeleteCustomDomainOutput{}, fmt.Errorf("cannot delete custom domain: %w", err)
 	}
 
@@ -4654,10 +4813,11 @@ func (r *Resolver) DeleteCustomDomainTool(ctx context.Context, req *mcp.CallTool
 func (r *Resolver) AssessThirdPartyTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AssessThirdPartyInput) (*mcp.CallToolResult, types.AssessThirdPartyOutput, error) {
 	r.MustAuthorize(ctx, input.ID, probo.ActionThirdPartyAssess)
 
-	svc := r.ProboService(ctx, input.ID)
+	scope := coredata.NewScopeFromObjectID(input.ID)
+	svc := r.proboSvc
 
 	result, err := svc.ThirdParties.Assess(
-		ctx,
+		ctx, scope,
 		probo.AssessThirdPartyRequest{
 			ID:         input.ID,
 			WebsiteURL: input.WebsiteURL,
@@ -4674,9 +4834,10 @@ func (r *Resolver) AssessThirdPartyTool(ctx context.Context, req *mcp.CallToolRe
 func (r *Resolver) PublishFindingListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishFindingListInput) (*mcp.CallToolResult, types.PublishFindingListOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionFindingPublish)
 
-	svc := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	svc := r.proboSvc
 
-	document, documentVersion, err := svc.GeneratedDocuments.PublishFindingList(ctx, input.OrganizationID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := svc.GeneratedDocuments.PublishFindingList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
 	if err != nil {
 		return nil, types.PublishFindingListOutput{}, fmt.Errorf("cannot publish finding list: %w", err)
 	}
@@ -4690,9 +4851,10 @@ func (r *Resolver) PublishFindingListTool(ctx context.Context, req *mcp.CallTool
 func (r *Resolver) PublishObligationListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishObligationListInput) (*mcp.CallToolResult, types.PublishObligationListOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionObligationPublish)
 
-	svc := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	svc := r.proboSvc
 
-	document, documentVersion, err := svc.GeneratedDocuments.PublishObligationList(ctx, input.OrganizationID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := svc.GeneratedDocuments.PublishObligationList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
 	if err != nil {
 		return nil, types.PublishObligationListOutput{}, fmt.Errorf("cannot publish obligation list: %w", err)
 	}
@@ -4706,9 +4868,10 @@ func (r *Resolver) PublishObligationListTool(ctx context.Context, req *mcp.CallT
 func (r *Resolver) PublishProcessingActivityListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishProcessingActivityListInput) (*mcp.CallToolResult, types.PublishProcessingActivityListOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionProcessingActivityPublish)
 
-	svc := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	svc := r.proboSvc
 
-	document, documentVersion, err := svc.GeneratedDocuments.PublishProcessingActivityList(ctx, input.OrganizationID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := svc.GeneratedDocuments.PublishProcessingActivityList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
 	if err != nil {
 		return nil, types.PublishProcessingActivityListOutput{}, fmt.Errorf("cannot publish processing activity list: %w", err)
 	}
@@ -4722,9 +4885,10 @@ func (r *Resolver) PublishProcessingActivityListTool(ctx context.Context, req *m
 func (r *Resolver) PublishDataProtectionImpactAssessmentListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishDataProtectionImpactAssessmentListInput) (*mcp.CallToolResult, types.PublishDataProtectionImpactAssessmentListOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionDataProtectionImpactAssessmentPublish)
 
-	svc := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	svc := r.proboSvc
 
-	document, documentVersion, err := svc.GeneratedDocuments.PublishDataProtectionImpactAssessmentList(ctx, input.OrganizationID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := svc.GeneratedDocuments.PublishDataProtectionImpactAssessmentList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
 	if err != nil {
 		return nil, types.PublishDataProtectionImpactAssessmentListOutput{}, fmt.Errorf("cannot publish DPIA list: %w", err)
 	}
@@ -4738,9 +4902,10 @@ func (r *Resolver) PublishDataProtectionImpactAssessmentListTool(ctx context.Con
 func (r *Resolver) PublishTransferImpactAssessmentListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishTransferImpactAssessmentListInput) (*mcp.CallToolResult, types.PublishTransferImpactAssessmentListOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionTransferImpactAssessmentPublish)
 
-	svc := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	svc := r.proboSvc
 
-	document, documentVersion, err := svc.GeneratedDocuments.PublishTransferImpactAssessmentList(ctx, input.OrganizationID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := svc.GeneratedDocuments.PublishTransferImpactAssessmentList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
 	if err != nil {
 		return nil, types.PublishTransferImpactAssessmentListOutput{}, fmt.Errorf("cannot publish TIA list: %w", err)
 	}
@@ -4754,9 +4919,10 @@ func (r *Resolver) PublishTransferImpactAssessmentListTool(ctx context.Context, 
 func (r *Resolver) PublishThirdPartyListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishThirdPartyListInput) (*mcp.CallToolResult, types.PublishThirdPartyListOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionThirdPartyPublish)
 
-	svc := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	svc := r.proboSvc
 
-	document, documentVersion, err := svc.GeneratedDocuments.PublishThirdPartyList(ctx, input.OrganizationID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := svc.GeneratedDocuments.PublishThirdPartyList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
 	if err != nil {
 		return nil, types.PublishThirdPartyListOutput{}, fmt.Errorf("cannot publish thirdParty list: %w", err)
 	}
@@ -5163,9 +5329,10 @@ func (r *Resolver) GetCookieConsentRecordTool(ctx context.Context, req *mcp.Call
 func (r *Resolver) PublishRiskListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishRiskListInput) (*mcp.CallToolResult, types.PublishRiskListOutput, error) {
 	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionRiskPublish)
 
-	svc := r.ProboService(ctx, input.OrganizationID)
+	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	svc := r.proboSvc
 
-	document, documentVersion, err := svc.GeneratedDocuments.PublishRiskList(ctx, input.OrganizationID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := svc.GeneratedDocuments.PublishRiskList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
 	if err != nil {
 		return nil, types.PublishRiskListOutput{}, fmt.Errorf("cannot publish risk list: %w", err)
 	}
@@ -5299,9 +5466,10 @@ func (r *Resolver) PublishDocumentTool(ctx context.Context, req *mcp.CallToolReq
 
 	r.MustAuthorize(ctx, input.DocumentID, action)
 
-	svc := r.ProboService(ctx, input.DocumentID)
+	scope := coredata.NewScopeFromObjectID(input.DocumentID)
+	svc := r.proboSvc
 
-	result, err := svc.Documents.PublishVersion(ctx, probo.PublishDocumentRequest{
+	result, err := svc.Documents.PublishVersion(ctx, scope, probo.PublishDocumentRequest{
 		DocumentID:  input.DocumentID,
 		Minor:       input.Minor,
 		ApproverIDs: input.ApproverIds,

--- a/pkg/server/api/mcp/v1/v1_handler.go
+++ b/pkg/server/api/mcp/v1/v1_handler.go
@@ -15,7 +15,6 @@
 package mcp_v1
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -24,17 +23,12 @@ import (
 	mcpgenmcp "go.probo.inc/mcpgen/mcp"
 	"go.probo.inc/probo/pkg/accessreview"
 	"go.probo.inc/probo/pkg/cookiebanner"
-	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/iam"
 	"go.probo.inc/probo/pkg/probo"
 	"go.probo.inc/probo/pkg/server/api/authn"
 	"go.probo.inc/probo/pkg/server/api/mcp/mcputils"
 	"go.probo.inc/probo/pkg/server/api/mcp/v1/server"
 )
-
-func (r *Resolver) ProboService(ctx context.Context, objectID gid.GID) *probo.TenantService {
-	return r.proboSvc.WithTenant(objectID.TenantID())
-}
 
 func NewMux(logger *log.Logger, proboSvc *probo.Service, iamSvc *iam.Service, accessReviewSvc *accessreview.Service, cookieBannerSvc *cookiebanner.Service, tokenSecret string) *chi.Mux {
 	logger = logger.Named("mcp.v1")

--- a/pkg/server/api/slack/v1/slack_handler.go
+++ b/pkg/server/api/slack/v1/slack_handler.go
@@ -159,8 +159,7 @@ func SlackHandler(slackSvc *slack.Service, slackSigningSecret string, logger *lo
 		}
 
 		requesterEmail := *initialSlackMessage.RequesterEmail
-
-		tenantSvc := trustSvc.WithTenant(initialSlackMessage.OrganizationID.TenantID())
+		scope := coredata.NewScopeFromObjectID(initialSlackMessage.OrganizationID)
 
 		var (
 			documentIDs  []gid.GID
@@ -168,8 +167,6 @@ func SlackHandler(slackSvc *slack.Service, slackSigningSecret string, logger *lo
 			fileIDs      []gid.GID
 			statusAction string
 		)
-
-		tenantSlackSvc := slackSvc.WithTenant(initialSlackMessage.OrganizationID.TenantID())
 
 		// accept_all, reject_all
 		if strings.HasSuffix(action.ActionID, "_all") {
@@ -179,7 +176,7 @@ func SlackHandler(slackSvc *slack.Service, slackSigningSecret string, logger *lo
 				return
 			}
 
-			documentIDs, reportIDs, fileIDs, err = tenantSlackSvc.SlackMessages.GetSlackMessageDocumentIDs(ctx, currentMessageId)
+			documentIDs, reportIDs, fileIDs, err = slackSvc.GetSlackMessageDocumentIDs(ctx, scope, currentMessageId)
 			if err != nil {
 				logger.ErrorCtx(ctx, "cannot load slack message document ids", log.Error(err))
 				httpserver.RenderJSON(w, http.StatusInternalServerError, SlackInteractiveResponse{Success: false, Message: "internal server error"})
@@ -244,8 +241,9 @@ func SlackHandler(slackSvc *slack.Service, slackSigningSecret string, logger *lo
 
 		switch statusAction {
 		case StatusAccept:
-			if err := tenantSvc.TrustCenterAccesses.GrantByIDs(
+			if err := trustSvc.TrustCenterAccesses.GrantByIDs(
 				ctx,
+				scope,
 				initialSlackMessage.OrganizationID,
 				requesterEmail,
 				documentIDs,
@@ -258,8 +256,9 @@ func SlackHandler(slackSvc *slack.Service, slackSigningSecret string, logger *lo
 				return
 			}
 		case StatusReject:
-			if err := tenantSvc.TrustCenterAccesses.RejectOrRevokeByIDs(
+			if err := trustSvc.TrustCenterAccesses.RejectOrRevokeByIDs(
 				ctx,
+				scope,
 				initialSlackMessage.OrganizationID,
 				requesterEmail,
 				documentIDs,
@@ -278,8 +277,9 @@ func SlackHandler(slackSvc *slack.Service, slackSigningSecret string, logger *lo
 			return
 		}
 
-		if err := tenantSlackSvc.SlackMessages.UpdateSlackAccessMessage(
+		if err := slackSvc.UpdateSlackAccessMessage(
 			ctx,
+			scope,
 			initialSlackMessage.ID,
 			slackPayload.ResponseURL,
 			requesterEmail,

--- a/pkg/server/api/trust/v1/base_resolvers.go
+++ b/pkg/server/api/trust/v1/base_resolvers.go
@@ -41,11 +41,12 @@ func (r *queryResolver) Viewer(ctx context.Context) (*types.Identity, error) {
 
 // Node is the resolver for the node field.
 func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error) {
-	trustService := r.TrustService(ctx, id.TenantID())
+	scope := coredata.NewScopeFromObjectID(id)
+	trustService := r.trust
 
 	switch id.EntityType() {
 	case coredata.OrganizationEntityType:
-		organization, err := trustService.Organizations.Get(ctx, id)
+		organization, err := trustService.Organizations.Get(ctx, scope, id)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot get organization", log.Error(err))
 			return nil, gqlutils.Internal(ctx)
@@ -56,7 +57,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.DocumentEntityType:
 		trustCenter := compliancepage.CompliancePageFromContext(ctx)
 
-		document, err := trustService.Documents.Get(ctx, trustCenter.OrganizationID, id)
+		document, err := trustService.Documents.Get(ctx, scope, trustCenter.OrganizationID, id)
 		if err != nil {
 			if errors.Is(err, trust.ErrDocumentNotFound) || errors.Is(err, trust.ErrDocumentNotVisible) || errors.Is(err, coredata.ErrResourceNotFound) {
 				return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)
@@ -74,7 +75,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		return types.NewDocument(document), nil
 
 	case coredata.FrameworkEntityType:
-		framework, err := trustService.Frameworks.Get(ctx, id)
+		framework, err := trustService.Frameworks.Get(ctx, scope, id)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot get framework", log.Error(err))
 			return nil, gqlutils.Internal(ctx)
@@ -85,7 +86,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.ReportEntityType:
 		trustCenter := compliancepage.CompliancePageFromContext(ctx)
 
-		report, err := trustService.Reports.Get(ctx, trustCenter.OrganizationID, id)
+		report, err := trustService.Reports.Get(ctx, scope, trustCenter.OrganizationID, id)
 		if err != nil {
 			if errors.Is(err, trust.ErrReportNotFound) || errors.Is(err, coredata.ErrResourceNotFound) {
 				return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)
@@ -99,7 +100,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		return types.NewReport(report), nil
 
 	case coredata.AuditEntityType:
-		audit, err := trustService.Audits.Get(ctx, id)
+		audit, err := trustService.Audits.Get(ctx, scope, id)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot get audit", log.Error(err))
 			return nil, gqlutils.Internal(ctx)
@@ -108,7 +109,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		return types.NewAudit(audit), nil
 
 	case coredata.ThirdPartyEntityType:
-		thirdParty, err := trustService.ThirdParties.Get(ctx, id)
+		thirdParty, err := trustService.ThirdParties.Get(ctx, scope, id)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot get thirdParty", log.Error(err))
 			return nil, gqlutils.Internal(ctx)
@@ -117,7 +118,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		return types.NewSubprocessor(thirdParty), nil
 
 	case coredata.TrustCenterEntityType:
-		trustCenter, err := trustService.TrustCenters.Get(ctx, id)
+		trustCenter, err := trustService.TrustCenters.Get(ctx, scope, id)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot get trust center", log.Error(err))
 			return nil, gqlutils.Internal(ctx)
@@ -126,7 +127,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		return types.NewTrustCenter(trustCenter), nil
 
 	case coredata.TrustCenterReferenceEntityType:
-		reference, err := trustService.TrustCenterReferences.Get(ctx, id)
+		reference, err := trustService.TrustCenterReferences.Get(ctx, scope, id)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot get trust center reference", log.Error(err))
 			return nil, gqlutils.Internal(ctx)
@@ -137,7 +138,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.TrustCenterFileEntityType:
 		trustCenter := compliancepage.CompliancePageFromContext(ctx)
 
-		trustCenterFile, err := trustService.TrustCenterFiles.Get(ctx, trustCenter.OrganizationID, id)
+		trustCenterFile, err := trustService.TrustCenterFiles.Get(ctx, scope, trustCenter.OrganizationID, id)
 		if err != nil {
 			if errors.Is(err, trust.ErrTrustCenterFileNotFound) || errors.Is(err, trust.ErrTrustCenterFileNotVisible) {
 				return nil, gqlutils.NotFoundf(ctx, "node %q not found", id)
@@ -159,15 +160,16 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 func (r *queryResolver) CurrentTrustCenter(ctx context.Context) (*types.TrustCenter, error) {
 	trustCenter := compliancepage.CompliancePageFromContext(ctx)
 
-	trustService := r.TrustService(ctx, trustCenter.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(trustCenter.ID)
+	trustService := r.trust
 
-	org, err := trustService.Organizations.Get(ctx, trustCenter.OrganizationID)
+	org, err := trustService.Organizations.Get(ctx, scope, trustCenter.OrganizationID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get organization", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	trustCenter, err = trustService.TrustCenters.Get(ctx, trustCenter.ID)
+	trustCenter, err = trustService.TrustCenters.Get(ctx, scope, trustCenter.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get trust center", log.Error(err))
 		return nil, gqlutils.Internal(ctx)

--- a/pkg/server/api/trust/v1/nda_resolvers.go
+++ b/pkg/server/api/trust/v1/nda_resolvers.go
@@ -87,9 +87,10 @@ func (r *nonDisclosureAgreementResolver) FileURL(ctx context.Context, obj *types
 	trustCenter := compliancepage.CompliancePageFromContext(ctx)
 
 	if identity := authn.IdentityFromContext(ctx); identity != nil && r.esign != nil {
-		trustService := r.TrustService(ctx, trustCenter.ID.TenantID())
+		scope := coredata.NewScopeFromObjectID(trustCenter.ID)
+		trustService := r.trust
 
-		access, err := trustService.TrustCenterAccesses.GetAccess(ctx, trustCenter.ID, identity.ID)
+		access, err := trustService.TrustCenterAccesses.GetAccess(ctx, scope, trustCenter.ID, identity.ID)
 		if err == nil && access.ElectronicSignatureID != nil {
 			fileURL, err := r.esign.GenerateSignatureFileURL(ctx, *access.ElectronicSignatureID, 15*time.Minute)
 			if err == nil {
@@ -100,9 +101,10 @@ func (r *nonDisclosureAgreementResolver) FileURL(ctx context.Context, obj *types
 		}
 	}
 
-	trustService := r.TrustService(ctx, trustCenter.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(trustCenter.ID)
+	trustService := r.trust
 
-	fileURL, err := trustService.TrustCenters.GenerateNDAFileURL(ctx, trustCenter.ID, 15*time.Minute)
+	fileURL, err := trustService.TrustCenters.GenerateNDAFileURL(ctx, scope, trustCenter.ID, 15*time.Minute)
 	if err != nil {
 		return "", gqlutils.Internal(ctx)
 	}
@@ -118,9 +120,10 @@ func (r *nonDisclosureAgreementResolver) ViewerSignature(ctx context.Context, ob
 	}
 
 	trustCenter := compliancepage.CompliancePageFromContext(ctx)
-	trustService := r.TrustService(ctx, trustCenter.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(trustCenter.ID)
+	trustService := r.trust
 
-	access, err := trustService.TrustCenterAccesses.GetAccess(ctx, trustCenter.ID, identity.ID)
+	access, err := trustService.TrustCenterAccesses.GetAccess(ctx, scope, trustCenter.ID, identity.ID)
 	if err != nil {
 		return nil, nil
 	}

--- a/pkg/server/api/trust/v1/organization_resolvers.go
+++ b/pkg/server/api/trust/v1/organization_resolvers.go
@@ -9,15 +9,17 @@ import (
 	"context"
 	"time"
 
+	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/server/api/trust/v1/schema"
 	"go.probo.inc/probo/pkg/server/api/trust/v1/types"
 )
 
 // LogoURL is the resolver for the logoUrl field.
 func (r *organizationResolver) LogoURL(ctx context.Context, obj *types.Organization) (*string, error) {
-	trustService := r.TrustService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	trustService := r.trust
 
-	return trustService.Organizations.GenerateLogoURL(ctx, obj.ID, 1*time.Hour)
+	return trustService.Organizations.GenerateLogoURL(ctx, scope, obj.ID, 1*time.Hour)
 }
 
 // Organization returns schema.OrganizationResolver implementation.

--- a/pkg/server/api/trust/v1/resolver.go
+++ b/pkg/server/api/trust/v1/resolver.go
@@ -39,7 +39,6 @@ import (
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/baseurl"
 	"go.probo.inc/probo/pkg/esign"
-	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/iam"
 	"go.probo.inc/probo/pkg/mailman"
 	"go.probo.inc/probo/pkg/securecookie"
@@ -107,8 +106,4 @@ func NewMux(
 	)
 
 	return r
-}
-
-func (r *Resolver) TrustService(ctx context.Context, tenantID gid.TenantID) *trust.TenantService {
-	return r.trust.WithTenant(tenantID)
 }

--- a/pkg/server/api/trust/v1/trust_center_resolvers.go
+++ b/pkg/server/api/trust/v1/trust_center_resolvers.go
@@ -26,15 +26,16 @@ import (
 
 // Framework is the resolver for the framework field.
 func (r *auditResolver) Framework(ctx context.Context, obj *types.Audit) (*types.Framework, error) {
-	trustService := r.TrustService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	trustService := r.trust
 
-	audit, err := trustService.Audits.Get(ctx, obj.ID)
+	audit, err := trustService.Audits.Get(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot load audit", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	framework, err := trustService.Frameworks.Get(ctx, audit.FrameworkID)
+	framework, err := trustService.Frameworks.Get(ctx, scope, audit.FrameworkID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot load framework", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -45,9 +46,10 @@ func (r *auditResolver) Framework(ctx context.Context, obj *types.Audit) (*types
 
 // Report is the resolver for the report field.
 func (r *auditResolver) Report(ctx context.Context, obj *types.Audit) (*types.Report, error) {
-	trustService := r.TrustService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	trustService := r.trust
 
-	audit, err := trustService.Audits.Get(ctx, obj.ID)
+	audit, err := trustService.Audits.Get(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot load audit", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -59,7 +61,7 @@ func (r *auditResolver) Report(ctx context.Context, obj *types.Audit) (*types.Re
 
 	trustCenter := compliancepage.CompliancePageFromContext(ctx)
 
-	report, err := trustService.Reports.Get(ctx, trustCenter.OrganizationID, *audit.ReportID)
+	report, err := trustService.Reports.Get(ctx, scope, trustCenter.OrganizationID, *audit.ReportID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot load report", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -70,9 +72,10 @@ func (r *auditResolver) Report(ctx context.Context, obj *types.Audit) (*types.Re
 
 // Framework is the resolver for the framework field on ComplianceFramework.
 func (r *complianceFrameworkResolver) Framework(ctx context.Context, obj *types.ComplianceFramework) (*types.Framework, error) {
-	trustService := r.TrustService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	trustService := r.trust
 
-	framework, err := trustService.Frameworks.Get(ctx, obj.FrameworkID)
+	framework, err := trustService.Frameworks.Get(ctx, scope, obj.FrameworkID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot load framework", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -83,10 +86,11 @@ func (r *complianceFrameworkResolver) Framework(ctx context.Context, obj *types.
 
 // IsUserAuthorized is the resolver for the isUserAuthorized field.
 func (r *documentResolver) IsUserAuthorized(ctx context.Context, obj *types.Document) (bool, error) {
-	trustService := r.TrustService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	trustService := r.trust
 	trustCenter := compliancepage.CompliancePageFromContext(ctx)
 
-	document, err := trustService.Documents.Get(ctx, trustCenter.OrganizationID, obj.ID)
+	document, err := trustService.Documents.Get(ctx, scope, trustCenter.OrganizationID, obj.ID)
 	if err != nil {
 		if errors.Is(err, trust.ErrDocumentNotFound) || errors.Is(err, trust.ErrDocumentNotVisible) || errors.Is(err, coredata.ErrResourceNotFound) {
 			return false, gqlutils.NotFoundf(ctx, "document %q not found", obj.ID)
@@ -111,7 +115,7 @@ func (r *documentResolver) IsUserAuthorized(ctx context.Context, obj *types.Docu
 	}
 
 	documentAccess, err := trustService.TrustCenterAccesses.GetDocumentAccess(
-		ctx,
+		ctx, scope,
 		trustCenter.ID,
 		identity.ID,
 		obj.ID,
@@ -134,7 +138,8 @@ func (r *documentResolver) IsUserAuthorized(ctx context.Context, obj *types.Docu
 
 // Access is the resolver for the access field.
 func (r *documentResolver) Access(ctx context.Context, obj *types.Document) (*types.DocumentAccess, error) {
-	trustService := r.TrustService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	trustService := r.trust
 	trustCenter := compliancepage.CompliancePageFromContext(ctx)
 
 	identity := authn.IdentityFromContext(ctx)
@@ -143,7 +148,7 @@ func (r *documentResolver) Access(ctx context.Context, obj *types.Document) (*ty
 	}
 
 	access, err := trustService.TrustCenterAccesses.GetDocumentAccess(
-		ctx,
+		ctx, scope,
 		trustCenter.ID,
 		identity.ID,
 		obj.ID,
@@ -172,22 +177,25 @@ func (r *documentResolver) Access(ctx context.Context, obj *types.Document) (*ty
 
 // LightLogoURL is the resolver for the lightLogoURL field.
 func (r *frameworkResolver) LightLogoURL(ctx context.Context, obj *types.Framework) (*string, error) {
-	trustService := r.TrustService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	trustService := r.trust
 
-	return trustService.Frameworks.GenerateLightLogoURL(ctx, obj.ID, 1*time.Hour)
+	return trustService.Frameworks.GenerateLightLogoURL(ctx, scope, obj.ID, 1*time.Hour)
 }
 
 // DarkLogoURL is the resolver for the darkLogoURL field.
 func (r *frameworkResolver) DarkLogoURL(ctx context.Context, obj *types.Framework) (*string, error) {
-	trustService := r.TrustService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	trustService := r.trust
 
-	return trustService.Frameworks.GenerateDarkLogoURL(ctx, obj.ID, 1*time.Hour)
+	return trustService.Frameworks.GenerateDarkLogoURL(ctx, scope, obj.ID, 1*time.Hour)
 }
 
 // RequestAllAccesses is the resolver for the requestAllAccesses field.
 func (r *mutationResolver) RequestAllAccesses(ctx context.Context) (*types.RequestAccessesPayload, error) {
 	trustCenter := compliancepage.CompliancePageFromContext(ctx)
-	trustService := r.TrustService(ctx, trustCenter.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(trustCenter.ID)
+	trustService := r.trust
 
 	identity := authn.IdentityFromContext(ctx)
 	if identity == nil {
@@ -195,7 +203,7 @@ func (r *mutationResolver) RequestAllAccesses(ctx context.Context) (*types.Reque
 	}
 
 	access, err := trustService.TrustCenterAccesses.Request(
-		ctx,
+		ctx, scope,
 		&trust.TrustCenterAccessRequest{
 			TrustCenterID: trustCenter.ID,
 			IdentityID:    identity.ID,
@@ -219,10 +227,11 @@ func (r *mutationResolver) RequestAllAccesses(ctx context.Context) (*types.Reque
 
 // ExportDocumentPDF is the resolver for the exportDocumentPDF field.
 func (r *mutationResolver) ExportDocumentPDF(ctx context.Context, input types.ExportDocumentPDFInput) (*types.ExportDocumentPDFPayload, error) {
-	trustService := r.TrustService(ctx, input.DocumentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(input.DocumentID)
+	trustService := r.trust
 	trustCenter := compliancepage.CompliancePageFromContext(ctx)
 
-	document, err := trustService.Documents.Get(ctx, trustCenter.OrganizationID, input.DocumentID)
+	document, err := trustService.Documents.Get(ctx, scope, trustCenter.OrganizationID, input.DocumentID)
 	if err != nil {
 		if errors.Is(err, trust.ErrDocumentNotFound) || errors.Is(err, trust.ErrDocumentNotVisible) || errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFoundf(ctx, "document %q not found", input.DocumentID)
@@ -238,7 +247,7 @@ func (r *mutationResolver) ExportDocumentPDF(ctx context.Context, input types.Ex
 	}
 
 	if document.TrustCenterVisibility == coredata.TrustCenterVisibilityPublic {
-		pdf, err := trustService.Documents.ExportPDFWithoutWatermark(ctx, input.DocumentID)
+		pdf, err := trustService.Documents.ExportPDFWithoutWatermark(ctx, scope, input.DocumentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot export document PDF", log.Error(err))
 			return nil, gqlutils.Internal(ctx)
@@ -255,7 +264,7 @@ func (r *mutationResolver) ExportDocumentPDF(ctx context.Context, input types.Ex
 	}
 
 	documentAccess, err := trustService.TrustCenterAccesses.GetDocumentAccess(
-		ctx,
+		ctx, scope,
 		trustCenter.ID,
 		identity.ID,
 		input.DocumentID,
@@ -268,7 +277,7 @@ func (r *mutationResolver) ExportDocumentPDF(ctx context.Context, input types.Ex
 		return nil, gqlutils.Forbiddenf(ctx, "access denied: no permission to access this document")
 	}
 
-	pdf, err := trustService.Documents.ExportPDF(ctx, input.DocumentID, identity.EmailAddress)
+	pdf, err := trustService.Documents.ExportPDF(ctx, scope, input.DocumentID, identity.EmailAddress)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot export document PDF", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -281,18 +290,18 @@ func (r *mutationResolver) ExportDocumentPDF(ctx context.Context, input types.Ex
 
 // ExportReportPDF is the resolver for the exportReportPDF field.
 func (r *mutationResolver) ExportReportPDF(ctx context.Context, input types.ExportReportPDFInput) (*types.ExportReportPDFPayload, error) {
-	trustService := r.TrustService(ctx, input.ReportID.TenantID())
-
+	scope := coredata.NewScopeFromObjectID(input.ReportID)
+	trustService := r.trust
 	trustCenter := compliancepage.CompliancePageFromContext(ctx)
 
-	audit, err := trustService.Audits.GetByReportID(ctx, input.ReportID)
+	audit, err := trustService.Audits.GetByReportID(ctx, scope, input.ReportID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot load audit", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
 
 	if audit.TrustCenterVisibility == coredata.TrustCenterVisibilityPublic {
-		pdf, err := trustService.Reports.ExportPDFWithoutWatermark(ctx, input.ReportID)
+		pdf, err := trustService.Reports.ExportPDFWithoutWatermark(ctx, scope, input.ReportID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot export report PDF", log.Error(err))
 			return nil, gqlutils.Internal(ctx)
@@ -309,7 +318,7 @@ func (r *mutationResolver) ExportReportPDF(ctx context.Context, input types.Expo
 	}
 
 	reportAccess, err := trustService.TrustCenterAccesses.GetReportAccess(
-		ctx,
+		ctx, scope,
 		trustCenter.ID,
 		identity.ID,
 		input.ReportID,
@@ -322,7 +331,7 @@ func (r *mutationResolver) ExportReportPDF(ctx context.Context, input types.Expo
 		return nil, gqlutils.Forbiddenf(ctx, "access denied: no permission to access this report")
 	}
 
-	pdf, err := trustService.Reports.ExportPDF(ctx, input.ReportID, identity.EmailAddress)
+	pdf, err := trustService.Reports.ExportPDF(ctx, scope, input.ReportID, identity.EmailAddress)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot export report PDF", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -336,9 +345,10 @@ func (r *mutationResolver) ExportReportPDF(ctx context.Context, input types.Expo
 // ExportTrustCenterFile is the resolver for the exportTrustCenterFile field.
 func (r *mutationResolver) ExportTrustCenterFile(ctx context.Context, input types.ExportTrustCenterFileInput) (*types.ExportTrustCenterFilePayload, error) {
 	trustCenter := compliancepage.CompliancePageFromContext(ctx)
-	trustService := r.TrustService(ctx, trustCenter.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(trustCenter.ID)
+	trustService := r.trust
 
-	trustCenterFile, err := trustService.TrustCenterFiles.Get(ctx, trustCenter.OrganizationID, input.TrustCenterFileID)
+	trustCenterFile, err := trustService.TrustCenterFiles.Get(ctx, scope, trustCenter.OrganizationID, input.TrustCenterFileID)
 	if err != nil {
 		if errors.Is(err, trust.ErrTrustCenterFileNotFound) || errors.Is(err, trust.ErrTrustCenterFileNotVisible) {
 			return nil, gqlutils.NotFoundf(ctx, "trust center file %q not found", input.TrustCenterFileID)
@@ -350,7 +360,7 @@ func (r *mutationResolver) ExportTrustCenterFile(ctx context.Context, input type
 	}
 
 	if trustCenterFile.TrustCenterVisibility == coredata.TrustCenterVisibilityPublic {
-		fileData, mimeType, err := trustService.TrustCenterFiles.ExportFileWithoutWatermark(ctx, input.TrustCenterFileID)
+		fileData, mimeType, err := trustService.TrustCenterFiles.ExportFileWithoutWatermark(ctx, scope, input.TrustCenterFileID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot export trust center file", log.Error(err))
 			return nil, gqlutils.Internal(ctx)
@@ -366,7 +376,7 @@ func (r *mutationResolver) ExportTrustCenterFile(ctx context.Context, input type
 		return nil, gqlutils.Unauthenticatedf(ctx, "unauthenticated")
 	}
 
-	fileAccess, err := trustService.TrustCenterAccesses.GetTrustCenterFileAccess(ctx,
+	fileAccess, err := trustService.TrustCenterAccesses.GetTrustCenterFileAccess(ctx, scope,
 		trustCenter.ID,
 		identity.ID,
 		input.TrustCenterFileID,
@@ -379,7 +389,7 @@ func (r *mutationResolver) ExportTrustCenterFile(ctx context.Context, input type
 		return nil, gqlutils.Forbiddenf(ctx, "access denied: no permission to access this file")
 	}
 
-	fileData, mimeType, err := trustService.TrustCenterFiles.ExportFile(ctx, input.TrustCenterFileID, identity.EmailAddress)
+	fileData, mimeType, err := trustService.TrustCenterFiles.ExportFile(ctx, scope, input.TrustCenterFileID, identity.EmailAddress)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot export trust center file", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -393,9 +403,10 @@ func (r *mutationResolver) ExportTrustCenterFile(ctx context.Context, input type
 // RequestDocumentAccess is the resolver for the requestDocumentAccess field.
 func (r *mutationResolver) RequestDocumentAccess(ctx context.Context, input types.RequestDocumentAccessInput) (*types.RequestDocumentAccessPayload, error) {
 	trustCenter := compliancepage.CompliancePageFromContext(ctx)
-	trustService := r.TrustService(ctx, trustCenter.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(trustCenter.ID)
+	trustService := r.trust
 
-	document, err := trustService.Documents.Get(ctx, trustCenter.OrganizationID, input.DocumentID)
+	document, err := trustService.Documents.Get(ctx, scope, trustCenter.OrganizationID, input.DocumentID)
 	if err != nil {
 		if errors.Is(err, trust.ErrDocumentNotFound) || errors.Is(err, trust.ErrDocumentNotVisible) || errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFoundf(ctx, "document %q not found", input.DocumentID)
@@ -423,7 +434,7 @@ func (r *mutationResolver) RequestDocumentAccess(ctx context.Context, input type
 	}
 
 	if _, err := trustService.TrustCenterAccesses.Request(
-		ctx,
+		ctx, scope,
 		&trust.TrustCenterAccessRequest{
 			TrustCenterID:      trustCenter.ID,
 			IdentityID:         identity.ID,
@@ -444,9 +455,10 @@ func (r *mutationResolver) RequestDocumentAccess(ctx context.Context, input type
 // RequestReportAccess is the resolver for the requestReportAccess field.
 func (r *mutationResolver) RequestReportAccess(ctx context.Context, input types.RequestReportAccessInput) (*types.RequestReportAccessPayload, error) {
 	trustCenter := compliancepage.CompliancePageFromContext(ctx)
-	trustService := r.TrustService(ctx, trustCenter.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(trustCenter.ID)
+	trustService := r.trust
 
-	audit, err := trustService.Audits.GetByReportID(ctx, input.ReportID)
+	audit, err := trustService.Audits.GetByReportID(ctx, scope, input.ReportID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot load audit", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -465,7 +477,7 @@ func (r *mutationResolver) RequestReportAccess(ctx context.Context, input types.
 	}
 
 	if _, err := trustService.TrustCenterAccesses.Request(
-		ctx,
+		ctx, scope,
 		&trust.TrustCenterAccessRequest{
 			TrustCenterID:      trustCenter.ID,
 			IdentityID:         identity.ID,
@@ -486,9 +498,10 @@ func (r *mutationResolver) RequestReportAccess(ctx context.Context, input types.
 // RequestTrustCenterFileAccess is the resolver for the requestTrustCenterFileAccess field.
 func (r *mutationResolver) RequestTrustCenterFileAccess(ctx context.Context, input types.RequestTrustCenterFileAccessInput) (*types.RequestFileAccessPayload, error) {
 	trustCenter := compliancepage.CompliancePageFromContext(ctx)
-	trustService := r.TrustService(ctx, trustCenter.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(trustCenter.ID)
+	trustService := r.trust
 
-	trustCenterFile, err := trustService.TrustCenterFiles.Get(ctx, trustCenter.OrganizationID, input.TrustCenterFileID)
+	trustCenterFile, err := trustService.TrustCenterFiles.Get(ctx, scope, trustCenter.OrganizationID, input.TrustCenterFileID)
 	if err != nil {
 		if errors.Is(err, trust.ErrTrustCenterFileNotFound) || errors.Is(err, trust.ErrTrustCenterFileNotVisible) {
 			return nil, gqlutils.NotFoundf(ctx, "trust center file %q not found", input.TrustCenterFileID)
@@ -512,7 +525,7 @@ func (r *mutationResolver) RequestTrustCenterFileAccess(ctx context.Context, inp
 	}
 
 	if _, err := trustService.TrustCenterAccesses.Request(
-		ctx,
+		ctx, scope,
 		&trust.TrustCenterAccessRequest{
 			TrustCenterID:      trustCenter.ID,
 			IdentityID:         identity.ID,
@@ -532,11 +545,11 @@ func (r *mutationResolver) RequestTrustCenterFileAccess(ctx context.Context, inp
 
 // IsUserAuthorized is the resolver for the isUserAuthorized field.
 func (r *reportResolver) IsUserAuthorized(ctx context.Context, obj *types.Report) (bool, error) {
-	trustService := r.TrustService(ctx, obj.ID.TenantID())
-
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	trustService := r.trust
 	trustCenter := compliancepage.CompliancePageFromContext(ctx)
 
-	audit, err := trustService.Audits.GetByReportID(ctx, obj.ID)
+	audit, err := trustService.Audits.GetByReportID(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot load document", log.Error(err))
 		return false, gqlutils.Internal(ctx)
@@ -551,7 +564,7 @@ func (r *reportResolver) IsUserAuthorized(ctx context.Context, obj *types.Report
 		return false, nil
 	}
 
-	reportAccess, err := trustService.TrustCenterAccesses.GetReportAccess(ctx,
+	reportAccess, err := trustService.TrustCenterAccesses.GetReportAccess(ctx, scope,
 		trustCenter.ID,
 		identity.ID,
 		obj.ID,
@@ -574,7 +587,8 @@ func (r *reportResolver) IsUserAuthorized(ctx context.Context, obj *types.Report
 
 // Access is the resolver for the access field.
 func (r *reportResolver) Access(ctx context.Context, obj *types.Report) (*types.DocumentAccess, error) {
-	trustService := r.TrustService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	trustService := r.trust
 	trustCenter := compliancepage.CompliancePageFromContext(ctx)
 
 	identity := authn.IdentityFromContext(ctx)
@@ -583,7 +597,7 @@ func (r *reportResolver) Access(ctx context.Context, obj *types.Report) (*types.
 	}
 
 	access, err := trustService.TrustCenterAccesses.GetReportAccess(
-		ctx,
+		ctx, scope,
 		trustCenter.ID,
 		identity.ID,
 		obj.ID,
@@ -612,11 +626,12 @@ func (r *reportResolver) Access(ctx context.Context, obj *types.Report) (*types.
 
 // TotalCount is the resolver for the totalCount field.
 func (r *subprocessorConnectionResolver) TotalCount(ctx context.Context, obj *types.SubprocessorConnection) (int, error) {
-	trustService := r.TrustService(ctx, obj.ParentID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	trustService := r.trust
 
 	switch obj.Resolver.(type) {
 	case *trustCenterResolver:
-		count, err := trustService.ThirdParties.CountForTrustCenterId(ctx, obj.ParentID)
+		count, err := trustService.ThirdParties.CountForTrustCenterId(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count subprocessors", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -632,16 +647,18 @@ func (r *subprocessorConnectionResolver) TotalCount(ctx context.Context, obj *ty
 
 // LogoFileURL is the resolver for the logoFileUrl field.
 func (r *trustCenterResolver) LogoFileURL(ctx context.Context, obj *types.TrustCenter) (*string, error) {
-	trustService := r.TrustService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	trustService := r.trust
 
-	return trustService.TrustCenters.GenerateLogoURL(ctx, obj.ID, 1*time.Hour)
+	return trustService.TrustCenters.GenerateLogoURL(ctx, scope, obj.ID, 1*time.Hour)
 }
 
 // DarkLogoFileURL is the resolver for the darkLogoFileUrl field.
 func (r *trustCenterResolver) DarkLogoFileURL(ctx context.Context, obj *types.TrustCenter) (*string, error) {
-	trustService := r.TrustService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	trustService := r.trust
 
-	return trustService.TrustCenters.GenerateDarkLogoURL(ctx, obj.ID, 1*time.Hour)
+	return trustService.TrustCenters.GenerateDarkLogoURL(ctx, scope, obj.ID, 1*time.Hour)
 }
 
 // NonDisclosureAgreement is the resolver for the nonDisclosureAgreement field.
@@ -651,9 +668,10 @@ func (r *trustCenterResolver) NonDisclosureAgreement(ctx context.Context, obj *t
 		return nil, nil
 	}
 
-	trustService := r.TrustService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	trustService := r.trust
 
-	file, err := trustService.TrustCenters.GetNDAFile(ctx, obj.ID)
+	file, err := trustService.TrustCenters.GetNDAFile(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot load NDA file", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -698,15 +716,15 @@ func (r *trustCenterResolver) Organization(ctx context.Context, obj *types.Trust
 
 // Documents is the resolver for the documents field.
 func (r *trustCenterResolver) Documents(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.DocumentConnection, error) {
-	trustService := r.TrustService(ctx, obj.ID.TenantID())
-
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	trustService := r.trust
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
 		Field:     coredata.DocumentOrderFieldTitle,
 		Direction: page.OrderDirectionAsc,
 	}
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	documentPage, err := trustService.Documents.ListForOrganizationId(ctx, obj.Organization.ID, cursor)
+	documentPage, err := trustService.Documents.ListForOrganizationId(ctx, scope, obj.Organization.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list public documents", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -717,15 +735,15 @@ func (r *trustCenterResolver) Documents(ctx context.Context, obj *types.TrustCen
 
 // Audits is the resolver for the audits field.
 func (r *trustCenterResolver) Audits(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.AuditConnection, error) {
-	trustService := r.TrustService(ctx, obj.ID.TenantID())
-
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	trustService := r.trust
 	pageOrderBy := page.OrderBy[coredata.AuditOrderField]{
 		Field:     coredata.AuditOrderFieldValidFrom,
 		Direction: page.OrderDirectionDesc,
 	}
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	auditPage, err := trustService.Audits.ListForOrganizationId(ctx, obj.Organization.ID, cursor)
+	auditPage, err := trustService.Audits.ListForOrganizationId(ctx, scope, obj.Organization.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list public audits", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -736,15 +754,15 @@ func (r *trustCenterResolver) Audits(ctx context.Context, obj *types.TrustCenter
 
 // Subprocessors is the resolver for the subprocessors field.
 func (r *trustCenterResolver) Subprocessors(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.SubprocessorConnection, error) {
-	trustService := r.TrustService(ctx, obj.ID.TenantID())
-
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	trustService := r.trust
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyOrderField]{
 		Field:     coredata.ThirdPartyOrderFieldName,
 		Direction: page.OrderDirectionAsc,
 	}
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	thirdPartyPage, err := trustService.ThirdParties.ListForOrganizationId(ctx, obj.Organization.ID, cursor)
+	thirdPartyPage, err := trustService.ThirdParties.ListForOrganizationId(ctx, scope, obj.Organization.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list subprocessors", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -755,15 +773,15 @@ func (r *trustCenterResolver) Subprocessors(ctx context.Context, obj *types.Trus
 
 // References is the resolver for the references field.
 func (r *trustCenterResolver) References(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.TrustCenterReferenceConnection, error) {
-	trustService := r.TrustService(ctx, obj.ID.TenantID())
-
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	trustService := r.trust
 	pageOrderBy := page.OrderBy[coredata.TrustCenterReferenceOrderField]{
 		Field:     coredata.TrustCenterReferenceOrderFieldRank,
 		Direction: page.OrderDirectionAsc,
 	}
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	referencePage, err := trustService.TrustCenterReferences.ListForTrustCenterID(ctx, obj.ID, cursor)
+	referencePage, err := trustService.TrustCenterReferences.ListForTrustCenterID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list public trust center references", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -774,8 +792,8 @@ func (r *trustCenterResolver) References(ctx context.Context, obj *types.TrustCe
 
 // TrustCenterFiles is the resolver for the trustCenterFiles field.
 func (r *trustCenterResolver) TrustCenterFiles(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.TrustCenterFileConnection, error) {
-	trustService := r.TrustService(ctx, obj.ID.TenantID())
-
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	trustService := r.trust
 	pageOrderBy := page.OrderBy[coredata.TrustCenterFileOrderField]{
 		Field:     coredata.TrustCenterFileOrderFieldName,
 		Direction: page.OrderDirectionAsc,
@@ -789,7 +807,7 @@ func (r *trustCenterResolver) TrustCenterFiles(ctx context.Context, obj *types.T
 		),
 	)
 
-	trustCenterFilePage, err := trustService.TrustCenterFiles.ListForOrganizationId(ctx, obj.Organization.ID, cursor, filter)
+	trustCenterFilePage, err := trustService.TrustCenterFiles.ListForOrganizationId(ctx, scope, obj.Organization.ID, cursor, filter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list public trust center files", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -800,15 +818,15 @@ func (r *trustCenterResolver) TrustCenterFiles(ctx context.Context, obj *types.T
 
 // ComplianceFrameworks is the resolver for the complianceFrameworks field.
 func (r *trustCenterResolver) ComplianceFrameworks(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.ComplianceFrameworkConnection, error) {
-	trustService := r.TrustService(ctx, obj.ID.TenantID())
-
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	trustService := r.trust
 	pageOrderBy := page.OrderBy[coredata.ComplianceFrameworkOrderField]{
 		Field:     coredata.ComplianceFrameworkOrderFieldRank,
 		Direction: page.OrderDirectionAsc,
 	}
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	cfPage, err := trustService.ComplianceFrameworks.ListByTrustCenterID(ctx, obj.ID, cursor)
+	cfPage, err := trustService.ComplianceFrameworks.ListByTrustCenterID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list compliance frameworks", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -819,15 +837,15 @@ func (r *trustCenterResolver) ComplianceFrameworks(ctx context.Context, obj *typ
 
 // ExternalUrls is the resolver for the externalUrls field.
 func (r *trustCenterResolver) ExternalUrls(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.ComplianceExternalURLConnection, error) {
-	trustService := r.TrustService(ctx, obj.ID.TenantID())
-
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	trustService := r.trust
 	pageOrderBy := page.OrderBy[coredata.ComplianceExternalURLOrderField]{
 		Field:     coredata.ComplianceExternalURLOrderFieldRank,
 		Direction: page.OrderDirectionAsc,
 	}
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	result, err := trustService.ComplianceExternalURLs.ListForTrustCenterID(ctx, obj.ID, cursor)
+	result, err := trustService.ComplianceExternalURLs.ListForTrustCenterID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list compliance external URLs", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -838,9 +856,10 @@ func (r *trustCenterResolver) ExternalUrls(ctx context.Context, obj *types.Trust
 
 // Updates is the resolver for the updates field.
 func (r *trustCenterResolver) Updates(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.MailingListUpdateConnection, error) {
-	trustService := r.TrustService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	trustService := r.trust
 
-	tc, err := trustService.TrustCenters.Get(ctx, obj.ID)
+	tc, err := trustService.TrustCenters.Get(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot load trust center", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -867,11 +886,11 @@ func (r *trustCenterResolver) Updates(ctx context.Context, obj *types.TrustCente
 
 // IsUserAuthorized is the resolver for the isUserAuthorized field.
 func (r *trustCenterFileResolver) IsUserAuthorized(ctx context.Context, obj *types.TrustCenterFile) (bool, error) {
-	trustService := r.TrustService(ctx, obj.ID.TenantID())
-
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	trustService := r.trust
 	trustCenter := compliancepage.CompliancePageFromContext(ctx)
 
-	trustCenterFile, err := trustService.TrustCenterFiles.Get(ctx, trustCenter.OrganizationID, obj.ID)
+	trustCenterFile, err := trustService.TrustCenterFiles.Get(ctx, scope, trustCenter.OrganizationID, obj.ID)
 	if err != nil {
 		if errors.Is(err, trust.ErrTrustCenterFileNotFound) || errors.Is(err, trust.ErrTrustCenterFileNotVisible) {
 			return false, gqlutils.NotFoundf(ctx, "trust center file %q not found", obj.ID)
@@ -891,7 +910,7 @@ func (r *trustCenterFileResolver) IsUserAuthorized(ctx context.Context, obj *typ
 		return false, nil
 	}
 
-	fileAccess, err := trustService.TrustCenterAccesses.GetTrustCenterFileAccess(ctx,
+	fileAccess, err := trustService.TrustCenterAccesses.GetTrustCenterFileAccess(ctx, scope,
 		trustCenter.ID,
 		identity.ID,
 		obj.ID,
@@ -914,7 +933,8 @@ func (r *trustCenterFileResolver) IsUserAuthorized(ctx context.Context, obj *typ
 
 // Access is the resolver for the access field.
 func (r *trustCenterFileResolver) Access(ctx context.Context, obj *types.TrustCenterFile) (*types.DocumentAccess, error) {
-	trustService := r.TrustService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	trustService := r.trust
 	trustCenter := compliancepage.CompliancePageFromContext(ctx)
 
 	identity := authn.IdentityFromContext(ctx)
@@ -923,7 +943,7 @@ func (r *trustCenterFileResolver) Access(ctx context.Context, obj *types.TrustCe
 	}
 
 	access, err := trustService.TrustCenterAccesses.GetTrustCenterFileAccess(
-		ctx,
+		ctx, scope,
 		trustCenter.ID,
 		identity.ID,
 		obj.ID,
@@ -952,9 +972,10 @@ func (r *trustCenterFileResolver) Access(ctx context.Context, obj *types.TrustCe
 
 // LogoURL is the resolver for the logoUrl field.
 func (r *trustCenterReferenceResolver) LogoURL(ctx context.Context, obj *types.TrustCenterReference) (string, error) {
-	trustService := r.TrustService(ctx, obj.ID.TenantID())
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+	trustService := r.trust
 
-	logoURL, err := trustService.TrustCenterReferences.GenerateLogoURL(ctx, obj.ID, 1*time.Hour)
+	logoURL, err := trustService.TrustCenterReferences.GenerateLogoURL(ctx, scope, obj.ID, 1*time.Hour)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate logo URL", log.Error(err))
 		return "", gqlutils.Internal(ctx)

--- a/pkg/slack/service.go
+++ b/pkg/slack/service.go
@@ -21,7 +21,6 @@ import (
 	"go.gearno.de/kit/log"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/coredata"
-	"go.probo.inc/probo/pkg/gid"
 )
 
 type Service struct {
@@ -30,15 +29,6 @@ type Service struct {
 	slackSigningSecret string
 	baseURL            string
 	tokenSecret        string
-}
-
-type TenantService struct {
-	pg            *pg.Client
-	scope         coredata.Scoper
-	logger        *log.Logger
-	baseURL       string
-	tokenSecret   string
-	SlackMessages *SlackMessageService
 }
 
 func NewService(
@@ -57,25 +47,8 @@ func NewService(
 	}
 }
 
-func (s *Service) WithTenant(tenantID gid.TenantID) *TenantService {
-	tenantService := &TenantService{
-		pg:          s.pg,
-		scope:       coredata.NewScope(tenantID),
-		logger:      s.logger,
-		baseURL:     s.baseURL,
-		tokenSecret: s.tokenSecret,
-	}
-	tenantService.SlackMessages = &SlackMessageService{svc: tenantService}
-
-	return tenantService
-}
-
-func (s *TenantService) GetSlackClient() *Client {
+func (s *Service) GetSlackClient() *Client {
 	return NewClient(s.logger)
-}
-
-func (s *TenantService) GetSlackMessageService() *SlackMessageService {
-	return &SlackMessageService{svc: s}
 }
 
 func (s *Service) GetSlackSigningSecret() string {

--- a/pkg/slack/slack_message_service.go
+++ b/pkg/slack/slack_message_service.go
@@ -38,10 +38,6 @@ var (
 )
 
 type (
-	SlackMessageService struct {
-		svc *TenantService
-	}
-
 	SlackMessageDocument struct {
 		ID     string
 		Title  string
@@ -77,19 +73,23 @@ func (m SlackMessageMetadata) toMap() map[string]any {
 	}
 }
 
-func (s *SlackMessageService) GetSlackMessageDocumentIDs(
+func (s *Service) GetSlackMessageDocumentIDs(
 	ctx context.Context,
+	scope coredata.Scoper,
 	slackMessageID gid.GID,
 ) (documentIDs []gid.GID, reportIDs []gid.GID, fileIDs []gid.GID, err error) {
 	var slackMessage coredata.SlackMessage
 
-	err = s.svc.pg.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
-		if err := slackMessage.LoadById(ctx, conn, s.svc.scope, slackMessageID); err != nil {
-			return fmt.Errorf("cannot load slack message: %w", err)
-		}
+	err = s.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			if err := slackMessage.LoadById(ctx, conn, scope, slackMessageID); err != nil {
+				return fmt.Errorf("cannot load slack message: %w", err)
+			}
 
-		return nil
-	})
+			return nil
+		},
+	)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -101,93 +101,98 @@ func (s *SlackMessageService) GetSlackMessageDocumentIDs(
 	return documentIDs, reportIDs, fileIDs, nil
 }
 
-func (s *SlackMessageService) UpdateSlackAccessMessage(
+func (s *Service) UpdateSlackAccessMessage(
 	ctx context.Context,
+	scope coredata.Scoper,
 	slackMessageID gid.GID,
 	responseURL string,
 	requesterEmail mail.Addr,
 ) error {
-	return s.svc.pg.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
-		var slackMessage coredata.SlackMessage
-		if err := slackMessage.LoadById(ctx, tx, s.svc.scope, slackMessageID); err != nil {
-			return fmt.Errorf("cannot load slack message: %w", err)
-		}
+	return s.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			var slackMessage coredata.SlackMessage
+			if err := slackMessage.LoadById(ctx, tx, scope, slackMessageID); err != nil {
+				return fmt.Errorf("cannot load slack message: %w", err)
+			}
 
-		var trustCenter coredata.TrustCenter
-		if err := trustCenter.LoadByOrganizationID(ctx, tx, s.svc.scope, slackMessage.OrganizationID); err != nil {
-			return fmt.Errorf("cannot load trust center: %w", err)
-		}
+			var trustCenter coredata.TrustCenter
+			if err := trustCenter.LoadByOrganizationID(ctx, tx, scope, slackMessage.OrganizationID); err != nil {
+				return fmt.Errorf("cannot load trust center: %w", err)
+			}
 
-		identity := &coredata.Identity{}
-		if err := identity.LoadByEmail(ctx, tx, requesterEmail); err != nil {
-			return fmt.Errorf("cannot load identity: %w", err)
-		}
+			identity := &coredata.Identity{}
+			if err := identity.LoadByEmail(ctx, tx, requesterEmail); err != nil {
+				return fmt.Errorf("cannot load identity: %w", err)
+			}
 
-		var trustCenterAccess coredata.TrustCenterAccess
-		if err := trustCenterAccess.LoadByTrustCenterIDAndIdentityID(ctx, tx, s.svc.scope, trustCenter.ID, identity.ID); err != nil {
-			return fmt.Errorf("cannot load trust center access: %w", err)
-		}
+			var trustCenterAccess coredata.TrustCenterAccess
+			if err := trustCenterAccess.LoadByTrustCenterIDAndIdentityID(ctx, tx, scope, trustCenter.ID, identity.ID); err != nil {
+				return fmt.Errorf("cannot load trust center access: %w", err)
+			}
 
-		documents, reports, files, err := s.loadDocumentsReportsAndFilesFromAccesses(ctx, tx, trustCenterAccess.ID)
-		if err != nil {
-			return err
-		}
+			documents, reports, files, err := s.loadDocumentsReportsAndFilesFromAccesses(ctx, tx, scope, trustCenterAccess.ID)
+			if err != nil {
+				return err
+			}
 
-		newSlackMessageID := gid.New(s.svc.scope.GetTenantID(), coredata.SlackMessageEntityType)
+			newSlackMessageID := gid.New(scope.GetTenantID(), coredata.SlackMessageEntityType)
 
-		updatedBody, err := s.buildAccessRequestMessage(
-			newSlackMessageID,
-			identity.FullName,
-			requesterEmail,
-			trustCenter.OrganizationID,
-			documents,
-			reports,
-			files,
-		)
-		if err != nil {
-			return err
-		}
+			updatedBody, err := s.buildAccessRequestMessage(
+				newSlackMessageID,
+				identity.FullName,
+				requesterEmail,
+				trustCenter.OrganizationID,
+				documents,
+				reports,
+				files,
+			)
+			if err != nil {
+				return err
+			}
 
-		metadata := SlackMessageMetadata{
-			Documents: documents,
-			Reports:   reports,
-			Files:     files,
-		}
+			metadata := SlackMessageMetadata{
+				Documents: documents,
+				Reports:   reports,
+				Files:     files,
+			}
 
-		now := time.Now()
-		newSlackMessage := &coredata.SlackMessage{
-			ID:                    newSlackMessageID,
-			OrganizationID:        slackMessage.OrganizationID,
-			Type:                  slackMessage.Type,
-			Body:                  updatedBody,
-			MessageTS:             slackMessage.MessageTS,
-			ChannelID:             slackMessage.ChannelID,
-			RequesterEmail:        slackMessage.RequesterEmail,
-			Metadata:              metadata.toMap(),
-			InitialSlackMessageID: slackMessage.InitialSlackMessageID,
-			CreatedAt:             now,
-			UpdatedAt:             now,
-			SentAt:                &now,
-		}
+			now := time.Now()
+			newSlackMessage := &coredata.SlackMessage{
+				ID:                    newSlackMessageID,
+				OrganizationID:        slackMessage.OrganizationID,
+				Type:                  slackMessage.Type,
+				Body:                  updatedBody,
+				MessageTS:             slackMessage.MessageTS,
+				ChannelID:             slackMessage.ChannelID,
+				RequesterEmail:        slackMessage.RequesterEmail,
+				Metadata:              metadata.toMap(),
+				InitialSlackMessageID: slackMessage.InitialSlackMessageID,
+				CreatedAt:             now,
+				UpdatedAt:             now,
+				SentAt:                &now,
+			}
 
-		if err := newSlackMessage.Insert(ctx, tx, s.svc.scope); err != nil {
-			return fmt.Errorf("cannot insert slack message: %w", err)
-		}
+			if err := newSlackMessage.Insert(ctx, tx, scope); err != nil {
+				return fmt.Errorf("cannot insert slack message: %w", err)
+			}
 
-		if err := s.svc.GetSlackClient().UpdateInteractiveMessage(ctx, responseURL, updatedBody); err != nil {
-			return fmt.Errorf("cannot update Slack message: %w", err)
-		}
+			if err := s.GetSlackClient().UpdateInteractiveMessage(ctx, responseURL, updatedBody); err != nil {
+				return fmt.Errorf("cannot update Slack message: %w", err)
+			}
 
-		return nil
-	})
+			return nil
+		},
+	)
 }
 
-func (s *SlackMessageService) QueueSlackNotification(
+func (s *Service) QueueSlackNotification(
 	ctx context.Context,
+	scope coredata.Scoper,
 	identityID gid.GID,
 	trustCenterID gid.GID,
 ) error {
-	return s.svc.pg.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+	return s.pg.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
 		var (
 			identity          = &coredata.Identity{}
 			trustCenterAccess *coredata.TrustCenterAccess
@@ -198,12 +203,12 @@ func (s *SlackMessageService) QueueSlackNotification(
 		}
 
 		trustCenterAccess = &coredata.TrustCenterAccess{}
-		if err := trustCenterAccess.LoadByTrustCenterIDAndIdentityID(ctx, tx, s.svc.scope, trustCenterID, identityID); err != nil {
+		if err := trustCenterAccess.LoadByTrustCenterIDAndIdentityID(ctx, tx, scope, trustCenterID, identityID); err != nil {
 			return fmt.Errorf("cannot load trust center access: %w", err)
 		}
 
 		var trustCenter coredata.TrustCenter
-		if err := trustCenter.LoadByID(ctx, tx, s.svc.scope, trustCenterID); err != nil {
+		if err := trustCenter.LoadByID(ctx, tx, scope, trustCenterID); err != nil {
 			return fmt.Errorf("cannot load trust center: %w", err)
 		}
 
@@ -211,7 +216,7 @@ func (s *SlackMessageService) QueueSlackNotification(
 		if err := connectors.LoadAllByOrganizationIDWithoutDecryptedConnection(
 			ctx,
 			tx,
-			s.svc.scope,
+			scope,
 			trustCenter.OrganizationID,
 		); err != nil {
 			return fmt.Errorf("cannot load connectors: %w", err)
@@ -230,12 +235,12 @@ func (s *SlackMessageService) QueueSlackNotification(
 			return ErrNoSlackConnector
 		}
 
-		documents, reports, files, err := s.loadDocumentsReportsAndFilesFromAccesses(ctx, tx, trustCenterAccess.ID)
+		documents, reports, files, err := s.loadDocumentsReportsAndFilesFromAccesses(ctx, tx, scope, trustCenterAccess.ID)
 		if err != nil {
 			return fmt.Errorf("cannot load documents, reports and files: %w", err)
 		}
 
-		slackMessageID := gid.New(s.svc.scope.GetTenantID(), coredata.SlackMessageEntityType)
+		slackMessageID := gid.New(scope.GetTenantID(), coredata.SlackMessageEntityType)
 
 		body, err := s.buildAccessRequestMessage(
 			slackMessageID,
@@ -275,7 +280,7 @@ func (s *SlackMessageService) QueueSlackNotification(
 		err = existingMessage.LoadLatestByRequesterEmailAndType(
 			ctx,
 			tx,
-			s.svc.scope,
+			scope,
 			trustCenter.OrganizationID,
 			identity.EmailAddress,
 			coredata.SlackMessageTypeTrustCenterAccessRequest,
@@ -286,7 +291,7 @@ func (s *SlackMessageService) QueueSlackNotification(
 			slackMessage.ChannelID = existingMessage.ChannelID
 			slackMessage.InitialSlackMessageID = existingMessage.InitialSlackMessageID
 
-			if err := slackMessage.Insert(ctx, tx, s.svc.scope); err != nil {
+			if err := slackMessage.Insert(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot insert slack message: %w", err)
 			}
 
@@ -299,7 +304,7 @@ func (s *SlackMessageService) QueueSlackNotification(
 		}
 
 		slackMessage.InitialSlackMessageID = slackMessageID
-		if err := slackMessage.Insert(ctx, tx, s.svc.scope); err != nil {
+		if err := slackMessage.Insert(ctx, tx, scope); err != nil {
 			return fmt.Errorf("cannot insert slack message: %w", err)
 		}
 
@@ -307,9 +312,10 @@ func (s *SlackMessageService) QueueSlackNotification(
 	})
 }
 
-func (s *SlackMessageService) loadDocumentsReportsAndFilesFromAccesses(
+func (s *Service) loadDocumentsReportsAndFilesFromAccesses(
 	ctx context.Context,
 	conn pg.Querier,
+	scope coredata.Scoper,
 	trustCenterAccessID gid.GID,
 ) (
 	documents []SlackMessageDocument,
@@ -322,14 +328,14 @@ func (s *SlackMessageService) loadDocumentsReportsAndFilesFromAccesses(
 	files = []SlackMessageFile{}
 
 	var accesses coredata.TrustCenterDocumentAccesses
-	if err := accesses.LoadAllByTrustCenterAccessID(ctx, conn, s.svc.scope, trustCenterAccessID); err != nil {
+	if err := accesses.LoadAllByTrustCenterAccessID(ctx, conn, scope, trustCenterAccessID); err != nil {
 		return nil, nil, nil, fmt.Errorf("cannot load trust center document accesses: %w", err)
 	}
 
 	for _, access := range accesses {
 		if access.DocumentID != nil {
 			doc := &coredata.Document{}
-			if err := doc.LoadByID(ctx, conn, s.svc.scope, *access.DocumentID); err != nil {
+			if err := doc.LoadByID(ctx, conn, scope, *access.DocumentID); err != nil {
 				return nil, nil, nil, fmt.Errorf("cannot load document: %w", err)
 			}
 
@@ -345,17 +351,17 @@ func (s *SlackMessageService) loadDocumentsReportsAndFilesFromAccesses(
 
 		if access.ReportID != nil {
 			rep := &coredata.Report{}
-			if err := rep.LoadByID(ctx, conn, s.svc.scope, *access.ReportID); err != nil {
+			if err := rep.LoadByID(ctx, conn, scope, *access.ReportID); err != nil {
 				return nil, nil, nil, fmt.Errorf("cannot load report: %w", err)
 			}
 
 			audit := &coredata.Audit{}
-			if err := audit.LoadByReportID(ctx, conn, s.svc.scope, *access.ReportID); err != nil {
+			if err := audit.LoadByReportID(ctx, conn, scope, *access.ReportID); err != nil {
 				return nil, nil, nil, fmt.Errorf("cannot load audit: %w", err)
 			}
 
 			framework := &coredata.Framework{}
-			if err := framework.LoadByID(ctx, conn, s.svc.scope, audit.FrameworkID); err != nil {
+			if err := framework.LoadByID(ctx, conn, scope, audit.FrameworkID); err != nil {
 				return nil, nil, nil, fmt.Errorf("cannot load framework: %w", err)
 			}
 
@@ -377,7 +383,7 @@ func (s *SlackMessageService) loadDocumentsReportsAndFilesFromAccesses(
 
 		if access.TrustCenterFileID != nil {
 			file := &coredata.TrustCenterFile{}
-			if err := file.LoadByID(ctx, conn, s.svc.scope, *access.TrustCenterFileID); err != nil {
+			if err := file.LoadByID(ctx, conn, scope, *access.TrustCenterFileID); err != nil {
 				return nil, nil, nil, fmt.Errorf("cannot load trust center file: %w", err)
 			}
 
@@ -396,7 +402,7 @@ func (s *SlackMessageService) loadDocumentsReportsAndFilesFromAccesses(
 	return documents, reports, files, nil
 }
 
-func (s *SlackMessageService) buildAccessRequestMessage(
+func (s *Service) buildAccessRequestMessage(
 	slackMessageID gid.GID,
 	requesterName string,
 	requesterEmail mail.Addr,
@@ -405,7 +411,7 @@ func (s *SlackMessageService) buildAccessRequestMessage(
 	reports []SlackMessageReport,
 	files []SlackMessageFile,
 ) (map[string]any, error) {
-	base, err := baseurl.Parse(s.svc.baseURL)
+	base, err := baseurl.Parse(s.baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse base URL: %w", err)
 	}

--- a/pkg/trust/audit_service.go
+++ b/pkg/trust/audit_service.go
@@ -25,11 +25,12 @@ import (
 )
 
 type AuditService struct {
-	svc *TenantService
+	svc *Service
 }
 
 func (s AuditService) Get(
 	ctx context.Context,
+	scope coredata.Scoper,
 	auditID gid.GID,
 ) (*coredata.Audit, error) {
 	audit := &coredata.Audit{}
@@ -37,7 +38,7 @@ func (s AuditService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			err := audit.LoadByID(ctx, conn, s.svc.scope, auditID)
+			err := audit.LoadByID(ctx, conn, scope, auditID)
 			if err != nil {
 				return fmt.Errorf("cannot load audit: %w", err)
 			}
@@ -54,6 +55,7 @@ func (s AuditService) Get(
 
 func (s AuditService) GetByReportID(
 	ctx context.Context,
+	scope coredata.Scoper,
 	reportID gid.GID,
 ) (*coredata.Audit, error) {
 	audit := &coredata.Audit{}
@@ -61,7 +63,7 @@ func (s AuditService) GetByReportID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			err := audit.LoadByReportID(ctx, conn, s.svc.scope, reportID)
+			err := audit.LoadByReportID(ctx, conn, scope, reportID)
 			if err != nil {
 				return fmt.Errorf("cannot load audit: %w", err)
 			}
@@ -78,6 +80,7 @@ func (s AuditService) GetByReportID(
 
 func (s AuditService) ListForOrganizationId(
 	ctx context.Context,
+	scope coredata.Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.AuditOrderField],
 ) (*page.Page[*coredata.Audit, coredata.AuditOrderField], error) {
@@ -88,7 +91,7 @@ func (s AuditService) ListForOrganizationId(
 		func(ctx context.Context, conn pg.Querier) error {
 			filter := coredata.NewAuditTrustCenterFilter()
 
-			err := audits.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID, cursor, filter)
+			err := audits.LoadByOrganizationID(ctx, conn, scope, organizationID, cursor, filter)
 			if err != nil {
 				return fmt.Errorf("cannot load audits: %w", err)
 			}

--- a/pkg/trust/compliance_external_url_service.go
+++ b/pkg/trust/compliance_external_url_service.go
@@ -25,11 +25,12 @@ import (
 )
 
 type ComplianceExternalURLService struct {
-	svc *TenantService
+	svc *Service
 }
 
 func (s ComplianceExternalURLService) ListForTrustCenterID(
 	ctx context.Context,
+	scope coredata.Scoper,
 	trustCenterID gid.GID,
 	cursor *page.Cursor[coredata.ComplianceExternalURLOrderField],
 ) (*page.Page[*coredata.ComplianceExternalURL, coredata.ComplianceExternalURLOrderField], error) {
@@ -38,7 +39,7 @@ func (s ComplianceExternalURLService) ListForTrustCenterID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			err := items.LoadByTrustCenterID(ctx, conn, s.svc.scope, trustCenterID, cursor)
+			err := items.LoadByTrustCenterID(ctx, conn, scope, trustCenterID, cursor)
 			if err != nil {
 				return fmt.Errorf("cannot load compliance external URLs: %w", err)
 			}

--- a/pkg/trust/compliance_framework_service.go
+++ b/pkg/trust/compliance_framework_service.go
@@ -25,11 +25,12 @@ import (
 )
 
 type ComplianceFrameworkService struct {
-	svc *TenantService
+	svc *Service
 }
 
 func (s ComplianceFrameworkService) ListByTrustCenterID(
 	ctx context.Context,
+	scope coredata.Scoper,
 	trustCenterID gid.GID,
 	cursor *page.Cursor[coredata.ComplianceFrameworkOrderField],
 ) (*page.Page[*coredata.ComplianceFramework, coredata.ComplianceFrameworkOrderField], error) {
@@ -38,7 +39,7 @@ func (s ComplianceFrameworkService) ListByTrustCenterID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			err := complianceFrameworks.LoadByTrustCenterID(ctx, conn, s.svc.scope, trustCenterID, cursor)
+			err := complianceFrameworks.LoadByTrustCenterID(ctx, conn, scope, trustCenterID, cursor)
 			if err != nil {
 				return fmt.Errorf("cannot load compliance frameworks: %w", err)
 			}

--- a/pkg/trust/compliance_page_service.go
+++ b/pkg/trust/compliance_page_service.go
@@ -117,14 +117,12 @@ func (s *Service) RenderCompliancePageMarkdown(
 	ctx context.Context,
 	w io.Writer,
 	trustCenterID gid.GID,
-	tenantID gid.TenantID,
+	scope coredata.Scoper,
 ) error {
 	org, err := s.GetOrganizationByTrustCenterID(ctx, trustCenterID)
 	if err != nil {
 		return fmt.Errorf("cannot load organization for compliance page: %w", err)
 	}
-
-	tenantSvc := s.WithTenant(tenantID)
 
 	data := &compliancePageData{
 		OrgName: org.Name,
@@ -146,32 +144,32 @@ func (s *Service) RenderCompliancePageMarkdown(
 		data.Details = append(data.Details, compliancePageDetail{Label: "Headquarters", Value: *org.HeadquarterAddress})
 	}
 
-	data.Frameworks, err = s.fetchComplianceFrameworks(ctx, tenantSvc, trustCenterID)
+	data.Frameworks, err = s.fetchComplianceFrameworks(ctx, scope, trustCenterID)
 	if err != nil {
 		return fmt.Errorf("cannot fetch compliance frameworks: %w", err)
 	}
 
-	data.Documents, err = s.fetchDocuments(ctx, tenantSvc, org.ID)
+	data.Documents, err = s.fetchDocuments(ctx, scope, org.ID)
 	if err != nil {
 		return fmt.Errorf("cannot fetch documents: %w", err)
 	}
 
-	data.Audits, err = s.fetchAudits(ctx, tenantSvc, org.ID)
+	data.Audits, err = s.fetchAudits(ctx, scope, org.ID)
 	if err != nil {
 		return fmt.Errorf("cannot fetch audits: %w", err)
 	}
 
-	data.ThirdParties, err = s.fetchThirdParties(ctx, tenantSvc, org.ID)
+	data.ThirdParties, err = s.fetchThirdParties(ctx, scope, org.ID)
 	if err != nil {
 		return fmt.Errorf("cannot fetch thirdParties: %w", err)
 	}
 
-	data.References, err = s.fetchReferences(ctx, tenantSvc, trustCenterID)
+	data.References, err = s.fetchReferences(ctx, scope, trustCenterID)
 	if err != nil {
 		return fmt.Errorf("cannot fetch references: %w", err)
 	}
 
-	data.ExternalLinks, err = s.fetchExternalLinks(ctx, tenantSvc, trustCenterID)
+	data.ExternalLinks, err = s.fetchExternalLinks(ctx, scope, trustCenterID)
 	if err != nil {
 		return fmt.Errorf("cannot fetch external links: %w", err)
 	}
@@ -199,7 +197,7 @@ func (s *Service) RenderSitemap(
 	ctx context.Context,
 	w io.Writer,
 	trustCenterID gid.GID,
-	tenantID gid.TenantID,
+	scope coredata.Scoper,
 	baseURL string,
 ) error {
 	org, err := s.GetOrganizationByTrustCenterID(ctx, trustCenterID)
@@ -207,13 +205,11 @@ func (s *Service) RenderSitemap(
 		return fmt.Errorf("cannot load organization for sitemap: %w", err)
 	}
 
-	tenantSvc := s.WithTenant(tenantID)
-
 	data := &sitemapData{
 		BaseURL: baseURL,
 	}
 
-	data.Documents, err = s.fetchDocumentIDs(ctx, tenantSvc, org.ID)
+	data.Documents, err = s.fetchDocumentIDs(ctx, scope, org.ID)
 	if err != nil {
 		return fmt.Errorf("cannot fetch document IDs for sitemap: %w", err)
 	}
@@ -243,7 +239,7 @@ func (s *Service) RenderRobotsTxt(
 	return nil
 }
 
-func (s *Service) fetchDocumentIDs(ctx context.Context, tenantSvc *TenantService, orgID gid.GID) ([]string, error) {
+func (s *Service) fetchDocumentIDs(ctx context.Context, scope coredata.Scoper, orgID gid.GID) ([]string, error) {
 	var ids []string
 
 	var cursorKey *page.CursorKey
@@ -258,7 +254,7 @@ func (s *Service) fetchDocumentIDs(ctx context.Context, tenantSvc *TenantService
 			},
 		)
 
-		result, err := tenantSvc.Documents.ListForOrganizationId(ctx, orgID, cursor)
+		result, err := s.Documents.ListForOrganizationId(ctx, scope, orgID, cursor)
 		if err != nil {
 			return nil, fmt.Errorf("cannot list documents: %w", err)
 		}
@@ -283,7 +279,7 @@ func (s *Service) fetchDocumentIDs(ctx context.Context, tenantSvc *TenantService
 	return ids, nil
 }
 
-func (s *Service) fetchComplianceFrameworks(ctx context.Context, tenantSvc *TenantService, trustCenterID gid.GID) ([]compliancePageFramework, error) {
+func (s *Service) fetchComplianceFrameworks(ctx context.Context, scope coredata.Scoper, trustCenterID gid.GID) ([]compliancePageFramework, error) {
 	var frameworks []compliancePageFramework
 
 	var cursorKey *page.CursorKey
@@ -298,7 +294,7 @@ func (s *Service) fetchComplianceFrameworks(ctx context.Context, tenantSvc *Tena
 			},
 		)
 
-		result, err := tenantSvc.ComplianceFrameworks.ListByTrustCenterID(ctx, trustCenterID, cursor)
+		result, err := s.ComplianceFrameworks.ListByTrustCenterID(ctx, scope, trustCenterID, cursor)
 		if err != nil {
 			return nil, fmt.Errorf("cannot list compliance frameworks: %w", err)
 		}
@@ -308,7 +304,7 @@ func (s *Service) fetchComplianceFrameworks(ctx context.Context, tenantSvc *Tena
 				continue
 			}
 
-			fw, err := tenantSvc.Frameworks.Get(ctx, cf.FrameworkID)
+			fw, err := s.Frameworks.Get(ctx, scope, cf.FrameworkID)
 			if err != nil {
 				return nil, fmt.Errorf("cannot get framework %s: %w", cf.FrameworkID, err)
 			}
@@ -333,7 +329,7 @@ func (s *Service) fetchComplianceFrameworks(ctx context.Context, tenantSvc *Tena
 	return frameworks, nil
 }
 
-func (s *Service) fetchDocuments(ctx context.Context, tenantSvc *TenantService, orgID gid.GID) ([]compliancePageDocument, error) {
+func (s *Service) fetchDocuments(ctx context.Context, scope coredata.Scoper, orgID gid.GID) ([]compliancePageDocument, error) {
 	var docs []compliancePageDocument
 
 	var cursorKey *page.CursorKey
@@ -348,7 +344,7 @@ func (s *Service) fetchDocuments(ctx context.Context, tenantSvc *TenantService, 
 			},
 		)
 
-		result, err := tenantSvc.Documents.ListForOrganizationId(ctx, orgID, cursor)
+		result, err := s.Documents.ListForOrganizationId(ctx, scope, orgID, cursor)
 		if err != nil {
 			return nil, fmt.Errorf("cannot list documents: %w", err)
 		}
@@ -379,7 +375,7 @@ func (s *Service) fetchDocuments(ctx context.Context, tenantSvc *TenantService, 
 	return docs, nil
 }
 
-func (s *Service) fetchAudits(ctx context.Context, tenantSvc *TenantService, orgID gid.GID) ([]compliancePageAudit, error) {
+func (s *Service) fetchAudits(ctx context.Context, scope coredata.Scoper, orgID gid.GID) ([]compliancePageAudit, error) {
 	var audits []compliancePageAudit
 
 	var cursorKey *page.CursorKey
@@ -394,7 +390,7 @@ func (s *Service) fetchAudits(ctx context.Context, tenantSvc *TenantService, org
 			},
 		)
 
-		result, err := tenantSvc.Audits.ListForOrganizationId(ctx, orgID, cursor)
+		result, err := s.Audits.ListForOrganizationId(ctx, scope, orgID, cursor)
 		if err != nil {
 			return nil, fmt.Errorf("cannot list audits: %w", err)
 		}
@@ -406,7 +402,7 @@ func (s *Service) fetchAudits(ctx context.Context, tenantSvc *TenantService, org
 
 			frameworkName := ""
 
-			fw, err := tenantSvc.Frameworks.Get(ctx, audit.FrameworkID)
+			fw, err := s.Frameworks.Get(ctx, scope, audit.FrameworkID)
 			if err == nil {
 				frameworkName = fw.Name
 			}
@@ -438,7 +434,7 @@ func (s *Service) fetchAudits(ctx context.Context, tenantSvc *TenantService, org
 	return audits, nil
 }
 
-func (s *Service) fetchThirdParties(ctx context.Context, tenantSvc *TenantService, orgID gid.GID) ([]compliancePageThirdParty, error) {
+func (s *Service) fetchThirdParties(ctx context.Context, scope coredata.Scoper, orgID gid.GID) ([]compliancePageThirdParty, error) {
 	var thirdParties []compliancePageThirdParty
 
 	var cursorKey *page.CursorKey
@@ -453,7 +449,7 @@ func (s *Service) fetchThirdParties(ctx context.Context, tenantSvc *TenantServic
 			},
 		)
 
-		result, err := tenantSvc.ThirdParties.ListForOrganizationId(ctx, orgID, cursor)
+		result, err := s.ThirdParties.ListForOrganizationId(ctx, scope, orgID, cursor)
 		if err != nil {
 			return nil, fmt.Errorf("cannot list thirdParties: %w", err)
 		}
@@ -487,7 +483,7 @@ func (s *Service) fetchThirdParties(ctx context.Context, tenantSvc *TenantServic
 	return thirdParties, nil
 }
 
-func (s *Service) fetchReferences(ctx context.Context, tenantSvc *TenantService, trustCenterID gid.GID) ([]compliancePageReference, error) {
+func (s *Service) fetchReferences(ctx context.Context, scope coredata.Scoper, trustCenterID gid.GID) ([]compliancePageReference, error) {
 	var refs []compliancePageReference
 
 	var cursorKey *page.CursorKey
@@ -502,7 +498,7 @@ func (s *Service) fetchReferences(ctx context.Context, tenantSvc *TenantService,
 			},
 		)
 
-		result, err := tenantSvc.TrustCenterReferences.ListForTrustCenterID(ctx, trustCenterID, cursor)
+		result, err := s.TrustCenterReferences.ListForTrustCenterID(ctx, scope, trustCenterID, cursor)
 		if err != nil {
 			return nil, fmt.Errorf("cannot list references: %w", err)
 		}
@@ -531,7 +527,7 @@ func (s *Service) fetchReferences(ctx context.Context, tenantSvc *TenantService,
 	return refs, nil
 }
 
-func (s *Service) fetchExternalLinks(ctx context.Context, tenantSvc *TenantService, trustCenterID gid.GID) ([]compliancePageExternalLink, error) {
+func (s *Service) fetchExternalLinks(ctx context.Context, scope coredata.Scoper, trustCenterID gid.GID) ([]compliancePageExternalLink, error) {
 	var links []compliancePageExternalLink
 
 	var cursorKey *page.CursorKey
@@ -546,7 +542,7 @@ func (s *Service) fetchExternalLinks(ctx context.Context, tenantSvc *TenantServi
 			},
 		)
 
-		result, err := tenantSvc.ComplianceExternalURLs.ListForTrustCenterID(ctx, trustCenterID, cursor)
+		result, err := s.ComplianceExternalURLs.ListForTrustCenterID(ctx, scope, trustCenterID, cursor)
 		if err != nil {
 			return nil, fmt.Errorf("cannot list external links: %w", err)
 		}

--- a/pkg/trust/document_service.go
+++ b/pkg/trust/document_service.go
@@ -33,7 +33,7 @@ import (
 
 type (
 	DocumentService struct {
-		svc               *TenantService
+		svc               *Service
 		html2pdfConverter *html2pdf.Converter
 	}
 
@@ -46,6 +46,7 @@ func (e ErrDocumentArchived) Error() string {
 
 func (s *DocumentService) ListForOrganizationId(
 	ctx context.Context,
+	scope coredata.Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.DocumentOrderField],
 ) (*page.Page[*coredata.Document, coredata.DocumentOrderField], error) {
@@ -56,7 +57,7 @@ func (s *DocumentService) ListForOrganizationId(
 		func(ctx context.Context, conn pg.Querier) error {
 			filter := coredata.NewDocumentTrustCenterFilter()
 
-			if err := documents.LoadPublishedByOrganizationID(ctx, conn, s.svc.scope, organizationID, cursor, filter); err != nil {
+			if err := documents.LoadPublishedByOrganizationID(ctx, conn, scope, organizationID, cursor, filter); err != nil {
 				return fmt.Errorf("cannot load published documents: %w", err)
 			}
 
@@ -72,10 +73,11 @@ func (s *DocumentService) ListForOrganizationId(
 
 func (s *DocumentService) ExportPDF(
 	ctx context.Context,
+	scope coredata.Scoper,
 	documentID gid.GID,
 	email mail.Addr,
 ) ([]byte, error) {
-	pdfData, err := s.exportPDFData(ctx, documentID)
+	pdfData, err := s.exportPDFData(ctx, scope, documentID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot export document PDF: %w", err)
 	}
@@ -90,13 +92,15 @@ func (s *DocumentService) ExportPDF(
 
 func (s *DocumentService) ExportPDFWithoutWatermark(
 	ctx context.Context,
+	scope coredata.Scoper,
 	documentID gid.GID,
 ) ([]byte, error) {
-	return s.exportPDFData(ctx, documentID)
+	return s.exportPDFData(ctx, scope, documentID)
 }
 
 func (s DocumentService) Get(
 	ctx context.Context,
+	scope coredata.Scoper,
 	organizationID gid.GID,
 	documentID gid.GID,
 ) (*coredata.Document, error) {
@@ -105,7 +109,7 @@ func (s DocumentService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			err := document.LoadByID(ctx, conn, s.svc.scope, documentID)
+			err := document.LoadByID(ctx, conn, scope, documentID)
 			if err != nil {
 				return fmt.Errorf("cannot load document: %w", err)
 			}
@@ -134,6 +138,7 @@ func (s DocumentService) Get(
 
 func (s *DocumentService) exportPDFData(
 	ctx context.Context,
+	scope coredata.Scoper,
 	documentID gid.GID,
 ) ([]byte, error) {
 	document := &coredata.Document{}
@@ -143,7 +148,7 @@ func (s *DocumentService) exportPDFData(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := document.LoadByID(ctx, conn, s.svc.scope, documentID); err != nil {
+			if err := document.LoadByID(ctx, conn, scope, documentID); err != nil {
 				return fmt.Errorf("cannot load document: %w", err)
 			}
 
@@ -155,7 +160,7 @@ func (s *DocumentService) exportPDFData(
 				return fmt.Errorf("document not visible on trust center")
 			}
 
-			if err := version.LoadLatestPublishedVersion(ctx, conn, s.svc.scope, documentID); err != nil {
+			if err := version.LoadLatestPublishedVersion(ctx, conn, scope, documentID); err != nil {
 				return fmt.Errorf("cannot load latest published document version: %w", err)
 			}
 
@@ -163,7 +168,7 @@ func (s *DocumentService) exportPDFData(
 				return nil
 			}
 
-			if err := fileRecord.LoadByID(ctx, conn, s.svc.scope, *version.FileID); err != nil {
+			if err := fileRecord.LoadByID(ctx, conn, scope, *version.FileID); err != nil {
 				return fmt.Errorf("cannot load document version file: %w", err)
 			}
 
@@ -184,7 +189,7 @@ func (s *DocumentService) exportPDFData(
 	}
 
 	// TODO: remove on-the-fly fallback once all published versions have a stored PDF.
-	pdfData, err := s.generatePDFOnTheFly(ctx, document, version)
+	pdfData, err := s.generatePDFOnTheFly(ctx, scope, document, version)
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate PDF on the fly: %w", err)
 	}
@@ -197,6 +202,7 @@ func (s *DocumentService) exportPDFData(
 // processed by the document PDF worker.
 func (s *DocumentService) generatePDFOnTheFly(
 	ctx context.Context,
+	scope coredata.Scoper,
 	document *coredata.Document,
 	version *coredata.DocumentVersion,
 ) ([]byte, error) {
@@ -208,7 +214,7 @@ func (s *DocumentService) generatePDFOnTheFly(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			lastQuorum := &coredata.DocumentVersionApprovalQuorum{}
-			if err := lastQuorum.LoadLastByDocumentVersionID(ctx, conn, s.svc.scope, version.ID); err != nil {
+			if err := lastQuorum.LoadLastByDocumentVersionID(ctx, conn, scope, version.ID); err != nil {
 				if !errors.Is(err, coredata.ErrResourceNotFound) {
 					return fmt.Errorf("cannot load last approval quorum: %w", err)
 				}
@@ -221,7 +227,7 @@ func (s *DocumentService) generatePDFOnTheFly(
 				if err := approvedDecisions.LoadByQuorumID(
 					ctx,
 					conn,
-					s.svc.scope,
+					scope,
 					lastQuorum.ID,
 					page.NewCursor(
 						100,
@@ -244,7 +250,7 @@ func (s *DocumentService) generatePDFOnTheFly(
 
 				if len(approverProfileIDs) > 0 {
 					profiles := coredata.MembershipProfiles{}
-					if err := profiles.LoadByIDs(ctx, conn, s.svc.scope, approverProfileIDs); err != nil {
+					if err := profiles.LoadByIDs(ctx, conn, scope, approverProfileIDs); err != nil {
 						return fmt.Errorf("cannot load approver profiles: %w", err)
 					}
 
@@ -254,7 +260,7 @@ func (s *DocumentService) generatePDFOnTheFly(
 				}
 			}
 
-			if err := organization.LoadByID(ctx, conn, s.svc.scope, document.OrganizationID); err != nil {
+			if err := organization.LoadByID(ctx, conn, scope, document.OrganizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
@@ -282,7 +288,7 @@ func (s *DocumentService) generatePDFOnTheFly(
 		fileRecord := &coredata.File{}
 
 		fileErr := s.svc.pg.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
-			return fileRecord.LoadByID(ctx, conn, s.svc.scope, *organization.HorizontalLogoFileID)
+			return fileRecord.LoadByID(ctx, conn, scope, *organization.HorizontalLogoFileID)
 		})
 		if fileErr == nil {
 			base64Data, mimeType, logoErr := s.svc.fileManager.GetFileBase64(ctx, fileRecord)

--- a/pkg/trust/framework_service.go
+++ b/pkg/trust/framework_service.go
@@ -25,17 +25,18 @@ import (
 )
 
 type FrameworkService struct {
-	svc *TenantService
+	svc *Service
 }
 
 func (s FrameworkService) Get(
 	ctx context.Context,
+	scope coredata.Scoper,
 	frameworkID gid.GID,
 ) (*coredata.Framework, error) {
 	framework := &coredata.Framework{}
 
 	err := s.svc.pg.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
-		err := framework.LoadByID(ctx, conn, s.svc.scope, frameworkID)
+		err := framework.LoadByID(ctx, conn, scope, frameworkID)
 		if err != nil {
 			return fmt.Errorf("cannot load framework: %w", err)
 		}
@@ -51,6 +52,7 @@ func (s FrameworkService) Get(
 
 func (s FrameworkService) GenerateLightLogoURL(
 	ctx context.Context,
+	scope coredata.Scoper,
 	frameworkID gid.GID,
 	expiresIn time.Duration,
 ) (*string, error) {
@@ -60,7 +62,7 @@ func (s FrameworkService) GenerateLightLogoURL(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			framework := &coredata.Framework{}
-			if err := framework.LoadByID(ctx, conn, s.svc.scope, frameworkID); err != nil {
+			if err := framework.LoadByID(ctx, conn, scope, frameworkID); err != nil {
 				return fmt.Errorf("cannot load framework: %w", err)
 			}
 
@@ -68,7 +70,7 @@ func (s FrameworkService) GenerateLightLogoURL(
 				return nil
 			}
 
-			if err := file.LoadByID(ctx, conn, s.svc.scope, *framework.LightLogoFileID); err != nil {
+			if err := file.LoadByID(ctx, conn, scope, *framework.LightLogoFileID); err != nil {
 				return fmt.Errorf("cannot load file: %w", err)
 			}
 
@@ -93,6 +95,7 @@ func (s FrameworkService) GenerateLightLogoURL(
 
 func (s FrameworkService) GenerateDarkLogoURL(
 	ctx context.Context,
+	scope coredata.Scoper,
 	frameworkID gid.GID,
 	expiresIn time.Duration,
 ) (*string, error) {
@@ -102,7 +105,7 @@ func (s FrameworkService) GenerateDarkLogoURL(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			framework := &coredata.Framework{}
-			if err := framework.LoadByID(ctx, conn, s.svc.scope, frameworkID); err != nil {
+			if err := framework.LoadByID(ctx, conn, scope, frameworkID); err != nil {
 				return fmt.Errorf("cannot load framework: %w", err)
 			}
 
@@ -110,7 +113,7 @@ func (s FrameworkService) GenerateDarkLogoURL(
 				return nil
 			}
 
-			if err := file.LoadByID(ctx, conn, s.svc.scope, *framework.DarkLogoFileID); err != nil {
+			if err := file.LoadByID(ctx, conn, scope, *framework.DarkLogoFileID); err != nil {
 				return fmt.Errorf("cannot load file: %w", err)
 			}
 

--- a/pkg/trust/organization_service.go
+++ b/pkg/trust/organization_service.go
@@ -27,11 +27,12 @@ import (
 )
 
 type OrganizationService struct {
-	svc *TenantService
+	svc *Service
 }
 
 func (s OrganizationService) Get(
 	ctx context.Context,
+	scope coredata.Scoper,
 	organizationID gid.GID,
 ) (*coredata.Organization, error) {
 	organization := &coredata.Organization{}
@@ -42,7 +43,7 @@ func (s OrganizationService) Get(
 			err := organization.LoadByID(
 				ctx,
 				conn,
-				s.svc.scope,
+				scope,
 				organizationID,
 			)
 			if err != nil {
@@ -61,6 +62,7 @@ func (s OrganizationService) Get(
 
 func (s OrganizationService) GetOrganizationCustomDomain(
 	ctx context.Context,
+	scope coredata.Scoper,
 	organizationID gid.GID,
 ) (*coredata.CustomDomain, error) {
 	var domain *coredata.CustomDomain
@@ -69,7 +71,7 @@ func (s OrganizationService) GetOrganizationCustomDomain(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			var org coredata.Organization
-			if err := org.LoadByID(ctx, conn, s.svc.scope, organizationID); err != nil {
+			if err := org.LoadByID(ctx, conn, scope, organizationID); err != nil {
 				return fmt.Errorf("cannot load organization: %w", err)
 			}
 
@@ -78,7 +80,7 @@ func (s OrganizationService) GetOrganizationCustomDomain(
 			}
 
 			domain = &coredata.CustomDomain{}
-			if err := domain.LoadByID(ctx, conn, s.svc.scope, *org.CustomDomainID); err != nil {
+			if err := domain.LoadByID(ctx, conn, scope, *org.CustomDomainID); err != nil {
 				return fmt.Errorf("cannot load custom domain: %w", err)
 			}
 
@@ -94,10 +96,11 @@ func (s OrganizationService) GetOrganizationCustomDomain(
 
 func (s OrganizationService) GenerateLogoURL(
 	ctx context.Context,
+	scope coredata.Scoper,
 	organizationID gid.GID,
 	expiresIn time.Duration,
 ) (*string, error) {
-	organization, err := s.Get(ctx, organizationID)
+	organization, err := s.Get(ctx, scope, organizationID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get organization: %w", err)
 	}
@@ -111,7 +114,7 @@ func (s OrganizationService) GenerateLogoURL(
 	err = s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			return file.LoadByID(ctx, conn, s.svc.scope, *organization.LogoFileID)
+			return file.LoadByID(ctx, conn, scope, *organization.LogoFileID)
 		},
 	)
 	if err != nil {

--- a/pkg/trust/report_service.go
+++ b/pkg/trust/report_service.go
@@ -29,15 +29,16 @@ import (
 )
 
 type ReportService struct {
-	svc *TenantService
+	svc *Service
 }
 
 func (s ReportService) Get(
 	ctx context.Context,
+	scope coredata.Scoper,
 	organizationID gid.GID,
 	reportID gid.GID,
 ) (*coredata.Report, error) {
-	report, err := s.loadByID(ctx, reportID)
+	report, err := s.loadByID(ctx, scope, reportID)
 	if err != nil {
 		return nil, err
 	}
@@ -51,6 +52,7 @@ func (s ReportService) Get(
 
 func (s ReportService) loadByID(
 	ctx context.Context,
+	scope coredata.Scoper,
 	reportID gid.GID,
 ) (*coredata.Report, error) {
 	report := &coredata.Report{}
@@ -58,7 +60,7 @@ func (s ReportService) loadByID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			err := report.LoadByID(ctx, conn, s.svc.scope, reportID)
+			err := report.LoadByID(ctx, conn, scope, reportID)
 			if err != nil {
 				return fmt.Errorf("cannot load report: %w", err)
 			}
@@ -75,10 +77,11 @@ func (s ReportService) loadByID(
 
 func (s ReportService) GenerateDownloadURL(
 	ctx context.Context,
+	scope coredata.Scoper,
 	reportID gid.GID,
 	expiresIn time.Duration,
 ) (*string, error) {
-	report, err := s.loadByID(ctx, reportID)
+	report, err := s.loadByID(ctx, scope, reportID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get report: %w", err)
 	}
@@ -103,10 +106,11 @@ func (s ReportService) GenerateDownloadURL(
 
 func (s ReportService) ExportPDF(
 	ctx context.Context,
+	scope coredata.Scoper,
 	reportID gid.GID,
 	email mail.Addr,
 ) ([]byte, error) {
-	pdfData, err := s.exportPDFData(ctx, reportID)
+	pdfData, err := s.exportPDFData(ctx, scope, reportID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot export report PDF: %w", err)
 	}
@@ -121,16 +125,18 @@ func (s ReportService) ExportPDF(
 
 func (s ReportService) ExportPDFWithoutWatermark(
 	ctx context.Context,
+	scope coredata.Scoper,
 	reportID gid.GID,
 ) ([]byte, error) {
-	return s.exportPDFData(ctx, reportID)
+	return s.exportPDFData(ctx, scope, reportID)
 }
 
 func (s ReportService) exportPDFData(
 	ctx context.Context,
+	scope coredata.Scoper,
 	reportID gid.GID,
 ) ([]byte, error) {
-	report, err := s.loadByID(ctx, reportID)
+	report, err := s.loadByID(ctx, scope, reportID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get report: %w", err)
 	}

--- a/pkg/trust/service.go
+++ b/pkg/trust/service.go
@@ -36,32 +36,18 @@ import (
 
 type (
 	Service struct {
-		pg                 *pg.Client
-		s3                 *s3.Client
-		bucket             string
-		proboSvc           *probo.Service
-		slackSigningSecret string
-		baseURL            string
-		iam                *iam.Service
-		esign              *esign.Service
-		html2pdfConverter  *html2pdf.Converter
-		fileManager        *filemanager.Service
-		logger             *log.Logger
-		slack              *slack.Service
-	}
-
-	TenantService struct {
 		pg                     *pg.Client
 		s3                     *s3.Client
 		bucket                 string
-		scope                  coredata.Scoper
 		proboSvc               *probo.Service
+		slackSigningSecret     string
 		baseURL                string
 		iam                    *iam.Service
 		esign                  *esign.Service
 		html2pdfConverter      *html2pdf.Converter
 		fileManager            *filemanager.Service
 		logger                 *log.Logger
+		slack                  *slack.Service
 		TrustCenters           *TrustCenterService
 		Documents              *DocumentService
 		Audits                 *AuditService
@@ -74,7 +60,6 @@ type (
 		Reports                *ReportService
 		Organizations          *OrganizationService
 		ComplianceExternalURLs *ComplianceExternalURLService
-		SlackMessages          *slack.SlackMessageService
 	}
 )
 
@@ -91,7 +76,7 @@ func NewService(
 	logger *log.Logger,
 	slack *slack.Service,
 ) *Service {
-	return &Service{
+	svc := &Service{
 		pg:                 pgClient,
 		s3:                 s3Client,
 		bucket:             bucket,
@@ -104,38 +89,20 @@ func NewService(
 		logger:             logger,
 		slack:              slack,
 	}
-}
+	svc.TrustCenters = &TrustCenterService{svc: svc}
+	svc.Documents = &DocumentService{svc: svc, html2pdfConverter: html2pdfConverter}
+	svc.Audits = &AuditService{svc: svc}
+	svc.ThirdParties = &ThirdPartyService{svc: svc}
+	svc.Frameworks = &FrameworkService{svc: svc}
+	svc.ComplianceFrameworks = &ComplianceFrameworkService{svc: svc}
+	svc.TrustCenterAccesses = &TrustCenterAccessService{svc: svc, iamSvc: iam, logger: logger}
+	svc.TrustCenterReferences = &TrustCenterReferenceService{svc: svc}
+	svc.TrustCenterFiles = &TrustCenterFileService{svc: svc}
+	svc.Reports = &ReportService{svc: svc}
+	svc.Organizations = &OrganizationService{svc: svc}
+	svc.ComplianceExternalURLs = &ComplianceExternalURLService{svc: svc}
 
-func (s *Service) WithTenant(tenantID gid.TenantID) *TenantService {
-	tenantService := &TenantService{
-		pg:                s.pg,
-		s3:                s.s3,
-		bucket:            s.bucket,
-		scope:             coredata.NewScope(tenantID),
-		proboSvc:          s.proboSvc,
-		baseURL:           s.baseURL,
-		iam:               s.iam,
-		esign:             s.esign,
-		html2pdfConverter: s.html2pdfConverter,
-		fileManager:       s.fileManager,
-		logger:            s.logger,
-	}
-
-	tenantService.TrustCenters = &TrustCenterService{svc: tenantService}
-	tenantService.Documents = &DocumentService{svc: tenantService, html2pdfConverter: s.html2pdfConverter}
-	tenantService.Audits = &AuditService{svc: tenantService}
-	tenantService.ThirdParties = &ThirdPartyService{svc: tenantService}
-	tenantService.Frameworks = &FrameworkService{svc: tenantService}
-	tenantService.ComplianceFrameworks = &ComplianceFrameworkService{svc: tenantService}
-	tenantService.TrustCenterAccesses = &TrustCenterAccessService{svc: tenantService, iamSvc: s.iam, logger: s.logger}
-	tenantService.TrustCenterReferences = &TrustCenterReferenceService{svc: tenantService}
-	tenantService.TrustCenterFiles = &TrustCenterFileService{svc: tenantService}
-	tenantService.Reports = &ReportService{svc: tenantService}
-	tenantService.Organizations = &OrganizationService{svc: tenantService}
-	tenantService.ComplianceExternalURLs = &ComplianceExternalURLService{svc: tenantService}
-	tenantService.SlackMessages = s.slack.WithTenant(tenantID).SlackMessages
-
-	return tenantService
+	return svc
 }
 
 func (s *Service) Get(
@@ -272,7 +239,7 @@ func (s *Service) EmailPresenterConfigByOrganizationID(ctx context.Context, orgI
 		return emails.PresenterConfig{}, fmt.Errorf("cannot load trust center for org %s: %w", orgID, err)
 	}
 
-	return s.WithTenant(orgID.TenantID()).TrustCenters.EmailPresenterConfig(ctx, trustCenter.ID)
+	return s.TrustCenters.EmailPresenterConfig(ctx, scope, trustCenter.ID)
 }
 
 func (s *Service) GetOrganizationByTrustCenterID(

--- a/pkg/trust/third_party_service.go
+++ b/pkg/trust/third_party_service.go
@@ -25,11 +25,12 @@ import (
 )
 
 type ThirdPartyService struct {
-	svc *TenantService
+	svc *Service
 }
 
 func (s ThirdPartyService) Get(
 	ctx context.Context,
+	scope coredata.Scoper,
 	thirdPartyID gid.GID,
 ) (*coredata.ThirdParty, error) {
 	thirdParty := &coredata.ThirdParty{}
@@ -37,7 +38,7 @@ func (s ThirdPartyService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			err := thirdParty.LoadByID(ctx, conn, s.svc.scope, thirdPartyID)
+			err := thirdParty.LoadByID(ctx, conn, scope, thirdPartyID)
 			if err != nil {
 				return fmt.Errorf("cannot load thirdParty: %w", err)
 			}
@@ -54,6 +55,7 @@ func (s ThirdPartyService) Get(
 
 func (s ThirdPartyService) ListForOrganizationId(
 	ctx context.Context,
+	scope coredata.Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.ThirdPartyOrderField],
 ) (*page.Page[*coredata.ThirdParty, coredata.ThirdPartyOrderField], error) {
@@ -65,7 +67,7 @@ func (s ThirdPartyService) ListForOrganizationId(
 			showOnTrustCenter := true
 			filter := coredata.NewThirdPartyFilter(&showOnTrustCenter)
 
-			err := thirdParties.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID, cursor, filter)
+			err := thirdParties.LoadByOrganizationID(ctx, conn, scope, organizationID, cursor, filter)
 			if err != nil {
 				return fmt.Errorf("cannot load thirdParties: %w", err)
 			}
@@ -82,6 +84,7 @@ func (s ThirdPartyService) ListForOrganizationId(
 
 func (s ThirdPartyService) CountForTrustCenterId(
 	ctx context.Context,
+	scope coredata.Scoper,
 	trustCenterID gid.GID,
 ) (int, error) {
 	var count int
@@ -89,7 +92,7 @@ func (s ThirdPartyService) CountForTrustCenterId(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) (err error) {
-			trustCenter, err := s.svc.TrustCenters.Get(ctx, trustCenterID)
+			trustCenter, err := s.svc.TrustCenters.Get(ctx, scope, trustCenterID)
 			if err != nil {
 				return fmt.Errorf("cannot load trust center: %w", err)
 			}
@@ -98,7 +101,7 @@ func (s ThirdPartyService) CountForTrustCenterId(
 			showOnTrustCenter := true
 			filter := coredata.NewThirdPartyFilter(&showOnTrustCenter)
 
-			count, err = thirdParties.CountByOrganizationID(ctx, conn, s.svc.scope, trustCenter.OrganizationID, filter)
+			count, err = thirdParties.CountByOrganizationID(ctx, conn, scope, trustCenter.OrganizationID, filter)
 			if err != nil {
 				return fmt.Errorf("cannot count thirdParties: %w", err)
 			}

--- a/pkg/trust/trust_center_access_service.go
+++ b/pkg/trust/trust_center_access_service.go
@@ -31,7 +31,7 @@ import (
 
 type (
 	TrustCenterAccessService struct {
-		svc    *TenantService
+		svc    *Service
 		iamSvc *iam.Service
 		logger *log.Logger
 	}
@@ -51,6 +51,7 @@ const (
 
 func (s TrustCenterAccessService) Request(
 	ctx context.Context,
+	scope coredata.Scoper,
 	req *TrustCenterAccessRequest,
 ) (*coredata.TrustCenterAccess, error) {
 	var (
@@ -62,12 +63,12 @@ func (s TrustCenterAccessService) Request(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			trustCenter := &coredata.TrustCenter{}
-			if err := trustCenter.LoadByID(ctx, tx, s.svc.scope, req.TrustCenterID); err != nil {
+			if err := trustCenter.LoadByID(ctx, tx, scope, req.TrustCenterID); err != nil {
 				return fmt.Errorf("cannot load trust center: %w", err)
 			}
 
 			access = &coredata.TrustCenterAccess{}
-			if err := access.LoadByTrustCenterIDAndIdentityID(ctx, tx, s.svc.scope, req.TrustCenterID, req.IdentityID); err != nil {
+			if err := access.LoadByTrustCenterIDAndIdentityID(ctx, tx, scope, req.TrustCenterID, req.IdentityID); err != nil {
 				return fmt.Errorf("cannot load compliance page membership: %w", err)
 			}
 
@@ -79,7 +80,7 @@ func (s TrustCenterAccessService) Request(
 
 				filter := coredata.NewDocumentTrustCenterFilter()
 
-				if err := allDocuments.LoadAllByOrganizationID(ctx, tx, s.svc.scope, organizationID, filter); err != nil {
+				if err := allDocuments.LoadAllByOrganizationID(ctx, tx, scope, organizationID, filter); err != nil {
 					return fmt.Errorf("cannot list documents: %w", err)
 				}
 
@@ -94,7 +95,7 @@ func (s TrustCenterAccessService) Request(
 
 				auditFilter := coredata.NewAuditTrustCenterFilter()
 
-				if err := allAudits.LoadAllByOrganizationID(ctx, tx, s.svc.scope, organizationID, auditFilter); err != nil {
+				if err := allAudits.LoadAllByOrganizationID(ctx, tx, scope, organizationID, auditFilter); err != nil {
 					return fmt.Errorf("cannot list audits: %w", err)
 				}
 
@@ -113,7 +114,7 @@ func (s TrustCenterAccessService) Request(
 					coredata.WithTrustCenterFileVisibilities(coredata.TrustCenterVisibilityPrivate, coredata.TrustCenterVisibilityNone),
 				)
 
-				if err := allTrustCenterFiles.LoadAllByOrganizationID(ctx, tx, s.svc.scope, organizationID, filter); err != nil {
+				if err := allTrustCenterFiles.LoadAllByOrganizationID(ctx, tx, scope, organizationID, filter); err != nil {
 					return fmt.Errorf("cannot list trust center files: %w", err)
 				}
 
@@ -123,7 +124,7 @@ func (s TrustCenterAccessService) Request(
 			}
 
 			var existingAccesses coredata.TrustCenterDocumentAccesses
-			if err := existingAccesses.LoadAllByTrustCenterAccessID(ctx, tx, s.svc.scope, access.ID); err != nil {
+			if err := existingAccesses.LoadAllByTrustCenterAccessID(ctx, tx, scope, access.ID); err != nil {
 				return fmt.Errorf("cannot load existing access records: %w", err)
 			}
 
@@ -137,7 +138,7 @@ func (s TrustCenterAccessService) Request(
 			if err := accesses.BulkInsertDocumentAccesses(
 				ctx,
 				tx,
-				s.svc.scope,
+				scope,
 				access.ID,
 				access.OrganizationID,
 				newDocumentIDs,
@@ -150,7 +151,7 @@ func (s TrustCenterAccessService) Request(
 			if err := accesses.BulkInsertReportAccesses(
 				ctx,
 				tx,
-				s.svc.scope,
+				scope,
 				access.ID,
 				access.OrganizationID,
 				newReportIDs,
@@ -163,7 +164,7 @@ func (s TrustCenterAccessService) Request(
 			if err := accesses.BulkInsertTrustCenterFileAccesses(
 				ctx,
 				tx,
-				s.svc.scope,
+				scope,
 				access.ID,
 				access.OrganizationID,
 				newTrustCenterFileIDs,
@@ -180,7 +181,7 @@ func (s TrustCenterAccessService) Request(
 		return nil, err
 	}
 
-	if err := s.svc.SlackMessages.QueueSlackNotification(ctx, req.IdentityID, req.TrustCenterID); err != nil {
+	if err := s.svc.slack.QueueSlackNotification(ctx, scope, req.IdentityID, req.TrustCenterID); err != nil {
 		s.logger.ErrorCtx(ctx, "cannot queue slack notification", log.Error(err))
 	}
 
@@ -189,13 +190,14 @@ func (s TrustCenterAccessService) Request(
 
 func (s TrustCenterAccessService) GetAccess(
 	ctx context.Context,
+	scope coredata.Scoper,
 	trustCenterID gid.GID,
 	identityID gid.GID,
 ) (coredata.TrustCenterAccess, error) {
 	var access coredata.TrustCenterAccess
 
 	err := s.svc.pg.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
-		return access.LoadByTrustCenterIDAndIdentityID(ctx, conn, s.svc.scope, trustCenterID, identityID)
+		return access.LoadByTrustCenterIDAndIdentityID(ctx, conn, scope, trustCenterID, identityID)
 	})
 
 	return access, err
@@ -203,6 +205,7 @@ func (s TrustCenterAccessService) GetAccess(
 
 func (s TrustCenterAccessService) GetDocumentAccess(
 	ctx context.Context,
+	scope coredata.Scoper,
 	trustCenterID gid.GID,
 	identityID gid.GID,
 	documentID gid.GID,
@@ -212,7 +215,7 @@ func (s TrustCenterAccessService) GetDocumentAccess(
 	err := s.svc.pg.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
 		access := &coredata.TrustCenterAccess{}
 
-		err := access.LoadByTrustCenterIDAndIdentityID(ctx, conn, s.svc.scope, trustCenterID, identityID)
+		err := access.LoadByTrustCenterIDAndIdentityID(ctx, conn, scope, trustCenterID, identityID)
 		if err != nil {
 			if errors.Is(err, coredata.ErrResourceNotFound) {
 				return ErrMembershipNotFound
@@ -222,7 +225,7 @@ func (s TrustCenterAccessService) GetDocumentAccess(
 		}
 
 		profile := &coredata.MembershipProfile{}
-		if err := profile.LoadByIdentityIDAndOrganizationID(ctx, conn, s.svc.scope, identityID, access.OrganizationID); err != nil {
+		if err := profile.LoadByIdentityIDAndOrganizationID(ctx, conn, scope, identityID, access.OrganizationID); err != nil {
 			if errors.Is(err, coredata.ErrResourceNotFound) {
 				return ErrUserNotFound
 			}
@@ -234,7 +237,7 @@ func (s TrustCenterAccessService) GetDocumentAccess(
 
 		documentAccess = &coredata.TrustCenterDocumentAccess{}
 
-		err = documentAccess.LoadByTrustCenterAccessIDAndDocumentID(ctx, conn, s.svc.scope, access.ID, documentID)
+		err = documentAccess.LoadByTrustCenterAccessIDAndDocumentID(ctx, conn, scope, access.ID, documentID)
 		if err != nil {
 			if errors.Is(err, coredata.ErrResourceNotFound) {
 				return ErrDocumentAccessNotFound
@@ -254,6 +257,7 @@ func (s TrustCenterAccessService) GetDocumentAccess(
 
 func (s TrustCenterAccessService) GetReportAccess(
 	ctx context.Context,
+	scope coredata.Scoper,
 	trustCenterID gid.GID,
 	identityID gid.GID,
 	reportID gid.GID,
@@ -263,7 +267,7 @@ func (s TrustCenterAccessService) GetReportAccess(
 	err := s.svc.pg.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
 		access := &coredata.TrustCenterAccess{}
 
-		err := access.LoadByTrustCenterIDAndIdentityID(ctx, conn, s.svc.scope, trustCenterID, identityID)
+		err := access.LoadByTrustCenterIDAndIdentityID(ctx, conn, scope, trustCenterID, identityID)
 		if err != nil {
 			if errors.Is(err, coredata.ErrResourceNotFound) {
 				return ErrMembershipNotFound
@@ -273,7 +277,7 @@ func (s TrustCenterAccessService) GetReportAccess(
 		}
 
 		profile := &coredata.MembershipProfile{}
-		if err := profile.LoadByIdentityIDAndOrganizationID(ctx, conn, s.svc.scope, identityID, access.OrganizationID); err != nil {
+		if err := profile.LoadByIdentityIDAndOrganizationID(ctx, conn, scope, identityID, access.OrganizationID); err != nil {
 			if errors.Is(err, coredata.ErrResourceNotFound) {
 				return ErrUserNotFound
 			}
@@ -285,7 +289,7 @@ func (s TrustCenterAccessService) GetReportAccess(
 
 		reportAccess = &coredata.TrustCenterDocumentAccess{}
 
-		err = reportAccess.LoadByTrustCenterAccessIDAndReportID(ctx, conn, s.svc.scope, access.ID, reportID)
+		err = reportAccess.LoadByTrustCenterAccessIDAndReportID(ctx, conn, scope, access.ID, reportID)
 		if err != nil {
 			if errors.Is(err, coredata.ErrResourceNotFound) {
 				return ErrDocumentAccessNotFound
@@ -305,6 +309,7 @@ func (s TrustCenterAccessService) GetReportAccess(
 
 func (s TrustCenterAccessService) GetTrustCenterFileAccess(
 	ctx context.Context,
+	scope coredata.Scoper,
 	trustCenterID gid.GID,
 	identityID gid.GID,
 	trustCenterFileID gid.GID,
@@ -314,7 +319,7 @@ func (s TrustCenterAccessService) GetTrustCenterFileAccess(
 	err := s.svc.pg.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
 		access := &coredata.TrustCenterAccess{}
 
-		err := access.LoadByTrustCenterIDAndIdentityID(ctx, conn, s.svc.scope, trustCenterID, identityID)
+		err := access.LoadByTrustCenterIDAndIdentityID(ctx, conn, scope, trustCenterID, identityID)
 		if err != nil {
 			if errors.Is(err, coredata.ErrResourceNotFound) {
 				return ErrMembershipNotFound
@@ -324,7 +329,7 @@ func (s TrustCenterAccessService) GetTrustCenterFileAccess(
 		}
 
 		profile := &coredata.MembershipProfile{}
-		if err := profile.LoadByIdentityIDAndOrganizationID(ctx, conn, s.svc.scope, identityID, access.OrganizationID); err != nil {
+		if err := profile.LoadByIdentityIDAndOrganizationID(ctx, conn, scope, identityID, access.OrganizationID); err != nil {
 			if errors.Is(err, coredata.ErrResourceNotFound) {
 				return ErrUserNotFound
 			}
@@ -336,7 +341,7 @@ func (s TrustCenterAccessService) GetTrustCenterFileAccess(
 
 		fileAccess = &coredata.TrustCenterDocumentAccess{}
 
-		err = fileAccess.LoadByTrustCenterAccessIDAndTrustCenterFileID(ctx, conn, s.svc.scope, access.ID, trustCenterFileID)
+		err = fileAccess.LoadByTrustCenterAccessIDAndTrustCenterFileID(ctx, conn, scope, access.ID, trustCenterFileID)
 		if err != nil {
 			if errors.Is(err, coredata.ErrResourceNotFound) {
 				return ErrDocumentAccessNotFound
@@ -356,6 +361,7 @@ func (s TrustCenterAccessService) GetTrustCenterFileAccess(
 
 func (s *TrustCenterAccessService) GrantByIDs(
 	ctx context.Context,
+	scope coredata.Scoper,
 	organizationID gid.GID,
 	email mail.Addr,
 	documentIDs []gid.GID,
@@ -364,7 +370,7 @@ func (s *TrustCenterAccessService) GrantByIDs(
 ) error {
 	return s.svc.pg.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
 		trustCenter := &coredata.TrustCenter{}
-		if err := trustCenter.LoadByOrganizationID(ctx, tx, s.svc.scope, organizationID); err != nil {
+		if err := trustCenter.LoadByOrganizationID(ctx, tx, scope, organizationID); err != nil {
 			return fmt.Errorf("cannot load trust center: %w", err)
 		}
 
@@ -374,12 +380,12 @@ func (s *TrustCenterAccessService) GrantByIDs(
 		}
 
 		access := &coredata.TrustCenterAccess{}
-		if err := access.LoadByTrustCenterIDAndIdentityID(ctx, tx, s.svc.scope, trustCenter.ID, identity.ID); err != nil {
+		if err := access.LoadByTrustCenterIDAndIdentityID(ctx, tx, scope, trustCenter.ID, identity.ID); err != nil {
 			return fmt.Errorf("cannot load trust center access: %w", err)
 		}
 
 		profile := &coredata.MembershipProfile{}
-		if err := profile.LoadByIdentityIDAndOrganizationID(ctx, tx, s.svc.scope, identity.ID, access.OrganizationID); err != nil {
+		if err := profile.LoadByIdentityIDAndOrganizationID(ctx, tx, scope, identity.ID, access.OrganizationID); err != nil {
 			if errors.Is(err, coredata.ErrResourceNotFound) {
 				return ErrUserNotFound
 			}
@@ -393,19 +399,19 @@ func (s *TrustCenterAccessService) GrantByIDs(
 		now := time.Now()
 
 		if len(documentIDs) > 0 {
-			if err := coredata.GrantByDocumentIDs(ctx, tx, s.svc.scope, access.ID, documentIDs, now); err != nil {
+			if err := coredata.GrantByDocumentIDs(ctx, tx, scope, access.ID, documentIDs, now); err != nil {
 				return fmt.Errorf("cannot grant document accesses: %w", err)
 			}
 		}
 
 		if len(reportIDs) > 0 {
-			if err := coredata.GrantByReportIDs(ctx, tx, s.svc.scope, access.ID, reportIDs, now); err != nil {
+			if err := coredata.GrantByReportIDs(ctx, tx, scope, access.ID, reportIDs, now); err != nil {
 				return fmt.Errorf("cannot grant report accesses: %w", err)
 			}
 		}
 
 		if len(fileIDs) > 0 {
-			if err := coredata.GrantByTrustCenterFileIDs(ctx, tx, s.svc.scope, access.ID, fileIDs, now); err != nil {
+			if err := coredata.GrantByTrustCenterFileIDs(ctx, tx, scope, access.ID, fileIDs, now); err != nil {
 				return fmt.Errorf("cannot grant trust center file accesses: %w", err)
 			}
 		}
@@ -414,11 +420,11 @@ func (s *TrustCenterAccessService) GrantByIDs(
 			profile.State = coredata.ProfileStateActive
 
 			profile.UpdatedAt = now
-			if err := profile.Update(ctx, tx, s.svc.scope); err != nil {
+			if err := profile.Update(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot update profile: %w", err)
 			}
 
-			if err := s.sendAccessEmail(ctx, tx, access, profile); err != nil {
+			if err := s.sendAccessEmail(ctx, tx, scope, access, profile); err != nil {
 				return fmt.Errorf("cannot send access email: %w", err)
 			}
 		}
@@ -427,20 +433,26 @@ func (s *TrustCenterAccessService) GrantByIDs(
 	})
 }
 
-func (s *TrustCenterAccessService) sendAccessEmail(ctx context.Context, tx pg.Tx, access *coredata.TrustCenterAccess, profile *coredata.MembershipProfile) error {
+func (s *TrustCenterAccessService) sendAccessEmail(
+	ctx context.Context,
+	tx pg.Tx,
+	scope coredata.Scoper,
+	access *coredata.TrustCenterAccess,
+	profile *coredata.MembershipProfile,
+) error {
 	organization := &coredata.Organization{}
-	if err := organization.LoadByID(ctx, tx, s.svc.scope, access.OrganizationID); err != nil {
+	if err := organization.LoadByID(ctx, tx, scope, access.OrganizationID); err != nil {
 		return fmt.Errorf("cannot load organization: %w", err)
 	}
 
 	now := time.Now()
 	access.UpdatedAt = now
 
-	if err := access.Update(ctx, tx, s.svc.scope); err != nil {
+	if err := access.Update(ctx, tx, scope); err != nil {
 		return fmt.Errorf("cannot update trust center access with expiration: %w", err)
 	}
 
-	emailPresenterCfg, err := s.svc.TrustCenters.EmailPresenterConfig(ctx, access.TrustCenterID)
+	emailPresenterCfg, err := s.svc.TrustCenters.EmailPresenterConfig(ctx, scope, access.TrustCenterID)
 	if err != nil {
 		return fmt.Errorf("cannot get compliance page email presenter config: %w", err)
 	}
@@ -472,6 +484,7 @@ func (s *TrustCenterAccessService) sendAccessEmail(ctx context.Context, tx pg.Tx
 
 func (s *TrustCenterAccessService) RejectOrRevokeByIDs(
 	ctx context.Context,
+	scope coredata.Scoper,
 	organizationID gid.GID,
 	email mail.Addr,
 	documentIDs []gid.GID,
@@ -480,7 +493,7 @@ func (s *TrustCenterAccessService) RejectOrRevokeByIDs(
 ) error {
 	return s.svc.pg.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
 		trustCenter := &coredata.TrustCenter{}
-		if err := trustCenter.LoadByOrganizationID(ctx, tx, s.svc.scope, organizationID); err != nil {
+		if err := trustCenter.LoadByOrganizationID(ctx, tx, scope, organizationID); err != nil {
 			return fmt.Errorf("cannot load trust center: %w", err)
 		}
 
@@ -490,12 +503,12 @@ func (s *TrustCenterAccessService) RejectOrRevokeByIDs(
 		}
 
 		access := &coredata.TrustCenterAccess{}
-		if err := access.LoadByTrustCenterIDAndIdentityID(ctx, tx, s.svc.scope, trustCenter.ID, identity.ID); err != nil {
+		if err := access.LoadByTrustCenterIDAndIdentityID(ctx, tx, scope, trustCenter.ID, identity.ID); err != nil {
 			return fmt.Errorf("cannot load trust center access: %w", err)
 		}
 
 		profile := &coredata.MembershipProfile{}
-		if err := profile.LoadByIdentityIDAndOrganizationID(ctx, tx, s.svc.scope, identity.ID, access.OrganizationID); err != nil {
+		if err := profile.LoadByIdentityIDAndOrganizationID(ctx, tx, scope, identity.ID, access.OrganizationID); err != nil {
 			return fmt.Errorf("cannot load profile: %w", err)
 		}
 
@@ -505,7 +518,7 @@ func (s *TrustCenterAccessService) RejectOrRevokeByIDs(
 		if len(documentIDs) > 0 {
 			shouldSendEmail = true
 
-			if err := coredata.RejectOrRevokeByDocumentIDs(ctx, tx, s.svc.scope, access.ID, documentIDs, now); err != nil {
+			if err := coredata.RejectOrRevokeByDocumentIDs(ctx, tx, scope, access.ID, documentIDs, now); err != nil {
 				return fmt.Errorf("cannot reject/revoke document accesses: %w", err)
 			}
 		}
@@ -513,7 +526,7 @@ func (s *TrustCenterAccessService) RejectOrRevokeByIDs(
 		if len(reportIDs) > 0 {
 			shouldSendEmail = true
 
-			if err := coredata.RejectOrRevokeByReportIDs(ctx, tx, s.svc.scope, access.ID, reportIDs, now); err != nil {
+			if err := coredata.RejectOrRevokeByReportIDs(ctx, tx, scope, access.ID, reportIDs, now); err != nil {
 				return fmt.Errorf("cannot reject/revoke report accesses: %w", err)
 			}
 		}
@@ -521,13 +534,13 @@ func (s *TrustCenterAccessService) RejectOrRevokeByIDs(
 		if len(fileIDs) > 0 {
 			shouldSendEmail = true
 
-			if err := coredata.RejectOrRevokeByTrustCenterFileIDs(ctx, tx, s.svc.scope, access.ID, fileIDs, now); err != nil {
+			if err := coredata.RejectOrRevokeByTrustCenterFileIDs(ctx, tx, scope, access.ID, fileIDs, now); err != nil {
 				return fmt.Errorf("cannot reject/revoke trust center file accesses: %w", err)
 			}
 		}
 
 		if shouldSendEmail {
-			if err := s.sendDocumentAccessRejectedEmail(ctx, tx, access, profile, documentIDs, reportIDs, fileIDs); err != nil {
+			if err := s.sendDocumentAccessRejectedEmail(ctx, tx, scope, access, profile, documentIDs, reportIDs, fileIDs); err != nil {
 				return fmt.Errorf("cannot send access email: %w", err)
 			}
 		}
@@ -539,6 +552,7 @@ func (s *TrustCenterAccessService) RejectOrRevokeByIDs(
 func (s *TrustCenterAccessService) sendDocumentAccessRejectedEmail(
 	ctx context.Context,
 	tx pg.Tx,
+	scope coredata.Scoper,
 	access *coredata.TrustCenterAccess,
 	profile *coredata.MembershipProfile,
 	documentIDs []gid.GID,
@@ -546,7 +560,7 @@ func (s *TrustCenterAccessService) sendDocumentAccessRejectedEmail(
 	fileIDs []gid.GID,
 ) error {
 	organization := &coredata.Organization{}
-	if err := organization.LoadByID(ctx, tx, s.svc.scope, access.OrganizationID); err != nil {
+	if err := organization.LoadByID(ctx, tx, scope, access.OrganizationID); err != nil {
 		return fmt.Errorf("cannot load organization: %w", err)
 	}
 
@@ -556,7 +570,7 @@ func (s *TrustCenterAccessService) sendDocumentAccessRejectedEmail(
 	)
 
 	if len(documentIDs) > 0 {
-		if err := documents.LoadByIDs(ctx, tx, s.svc.scope, documentIDs); err != nil {
+		if err := documents.LoadByIDs(ctx, tx, scope, documentIDs); err != nil {
 			return fmt.Errorf("cannot load documents by IDs: %w", err)
 		}
 
@@ -567,7 +581,7 @@ func (s *TrustCenterAccessService) sendDocumentAccessRejectedEmail(
 
 	var reports coredata.Reports
 	if len(reportIDs) > 0 {
-		if err := reports.LoadByIDs(ctx, tx, s.svc.scope, reportIDs); err != nil {
+		if err := reports.LoadByIDs(ctx, tx, scope, reportIDs); err != nil {
 			return fmt.Errorf("cannot load reports by IDs: %w", err)
 		}
 
@@ -578,7 +592,7 @@ func (s *TrustCenterAccessService) sendDocumentAccessRejectedEmail(
 
 	var files coredata.TrustCenterFiles
 	if len(fileIDs) > 0 {
-		if err := files.LoadByIDs(ctx, tx, s.svc.scope, fileIDs); err != nil {
+		if err := files.LoadByIDs(ctx, tx, scope, fileIDs); err != nil {
 			return fmt.Errorf("cannot load files by IDs: %w", err)
 		}
 
@@ -587,7 +601,7 @@ func (s *TrustCenterAccessService) sendDocumentAccessRejectedEmail(
 		}
 	}
 
-	emailPresenterCfg, err := s.svc.TrustCenters.EmailPresenterConfig(ctx, access.TrustCenterID)
+	emailPresenterCfg, err := s.svc.TrustCenters.EmailPresenterConfig(ctx, scope, access.TrustCenterID)
 	if err != nil {
 		return fmt.Errorf("cannot get compliance page email presenter config: %w", err)
 	}

--- a/pkg/trust/trust_center_file_service.go
+++ b/pkg/trust/trust_center_file_service.go
@@ -29,11 +29,12 @@ import (
 )
 
 type TrustCenterFileService struct {
-	svc *TenantService
+	svc *Service
 }
 
 func (s *TrustCenterFileService) Get(
 	ctx context.Context,
+	scope coredata.Scoper,
 	organizationID gid.GID,
 	trustCenterFileID gid.GID,
 ) (*coredata.TrustCenterFile, error) {
@@ -42,7 +43,7 @@ func (s *TrustCenterFileService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			err := trustCenterFile.LoadByID(ctx, conn, s.svc.scope, trustCenterFileID)
+			err := trustCenterFile.LoadByID(ctx, conn, scope, trustCenterFileID)
 			if err != nil {
 				return fmt.Errorf("cannot load trust center file: %w", err)
 			}
@@ -67,6 +68,7 @@ func (s *TrustCenterFileService) Get(
 
 func (s *TrustCenterFileService) ListForOrganizationId(
 	ctx context.Context,
+	scope coredata.Scoper,
 	organizationID gid.GID,
 	cursor *page.Cursor[coredata.TrustCenterFileOrderField],
 	filter *coredata.TrustCenterFileFilter,
@@ -76,7 +78,7 @@ func (s *TrustCenterFileService) ListForOrganizationId(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			err := trustCenterFiles.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID, cursor, filter)
+			err := trustCenterFiles.LoadByOrganizationID(ctx, conn, scope, organizationID, cursor, filter)
 			if err != nil {
 				return fmt.Errorf("cannot load trust center files: %w", err)
 			}
@@ -93,10 +95,11 @@ func (s *TrustCenterFileService) ListForOrganizationId(
 
 func (s *TrustCenterFileService) ExportFile(
 	ctx context.Context,
+	scope coredata.Scoper,
 	trustCenterFileID gid.GID,
 	email mail.Addr,
 ) ([]byte, string, error) {
-	fileData, mimeType, err := s.exportFileData(ctx, trustCenterFileID)
+	fileData, mimeType, err := s.exportFileData(ctx, scope, trustCenterFileID)
 	if err != nil {
 		return nil, "", fmt.Errorf("cannot export trust center file: %w", err)
 	}
@@ -115,13 +118,15 @@ func (s *TrustCenterFileService) ExportFile(
 
 func (s *TrustCenterFileService) ExportFileWithoutWatermark(
 	ctx context.Context,
+	scope coredata.Scoper,
 	trustCenterFileID gid.GID,
 ) ([]byte, string, error) {
-	return s.exportFileData(ctx, trustCenterFileID)
+	return s.exportFileData(ctx, scope, trustCenterFileID)
 }
 
 func (s *TrustCenterFileService) exportFileData(
 	ctx context.Context,
+	scope coredata.Scoper,
 	trustCenterFileID gid.GID,
 ) ([]byte, string, error) {
 	var (
@@ -131,12 +136,12 @@ func (s *TrustCenterFileService) exportFileData(
 
 	err := s.svc.pg.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
 		trustCenterFile = &coredata.TrustCenterFile{}
-		if err := trustCenterFile.LoadByID(ctx, conn, s.svc.scope, trustCenterFileID); err != nil {
+		if err := trustCenterFile.LoadByID(ctx, conn, scope, trustCenterFileID); err != nil {
 			return fmt.Errorf("cannot load trust center file: %w", err)
 		}
 
 		file = &coredata.File{}
-		if err := file.LoadByID(ctx, conn, s.svc.scope, trustCenterFile.FileID); err != nil {
+		if err := file.LoadByID(ctx, conn, scope, trustCenterFile.FileID); err != nil {
 			return fmt.Errorf("cannot load file: %w", err)
 		}
 

--- a/pkg/trust/trust_center_reference_service.go
+++ b/pkg/trust/trust_center_reference_service.go
@@ -28,18 +28,19 @@ import (
 )
 
 type TrustCenterReferenceService struct {
-	svc *TenantService
+	svc *Service
 }
 
 func (s TrustCenterReferenceService) ListForTrustCenterID(
 	ctx context.Context,
+	scope coredata.Scoper,
 	trustCenterID gid.GID,
 	cursor *page.Cursor[coredata.TrustCenterReferenceOrderField],
 ) (*page.Page[*coredata.TrustCenterReference, coredata.TrustCenterReferenceOrderField], error) {
 	var references coredata.TrustCenterReferences
 
 	err := s.svc.pg.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
-		err := references.LoadByTrustCenterID(ctx, conn, s.svc.scope, trustCenterID, cursor)
+		err := references.LoadByTrustCenterID(ctx, conn, scope, trustCenterID, cursor)
 		if err != nil {
 			return fmt.Errorf("cannot load trust center references: %w", err)
 		}
@@ -55,6 +56,7 @@ func (s TrustCenterReferenceService) ListForTrustCenterID(
 
 func (s TrustCenterReferenceService) GenerateLogoURL(
 	ctx context.Context,
+	scope coredata.Scoper,
 	referenceID gid.GID,
 	duration time.Duration,
 ) (string, error) {
@@ -62,12 +64,12 @@ func (s TrustCenterReferenceService) GenerateLogoURL(
 	file := &coredata.File{}
 
 	err := s.svc.pg.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
-		err := reference.LoadByID(ctx, tx, s.svc.scope, referenceID)
+		err := reference.LoadByID(ctx, tx, scope, referenceID)
 		if err != nil {
 			return fmt.Errorf("cannot load trust center reference: %w", err)
 		}
 
-		err = file.LoadByID(ctx, tx, s.svc.scope, reference.LogoFileID)
+		err = file.LoadByID(ctx, tx, scope, reference.LogoFileID)
 		if err != nil {
 			return fmt.Errorf("cannot load logo file: %w", err)
 		}
@@ -101,6 +103,7 @@ func (s TrustCenterReferenceService) GenerateLogoURL(
 
 func (s TrustCenterReferenceService) Get(
 	ctx context.Context,
+	scope coredata.Scoper,
 	referenceID gid.GID,
 ) (*coredata.TrustCenterReference, error) {
 	reference := &coredata.TrustCenterReference{}
@@ -108,7 +111,7 @@ func (s TrustCenterReferenceService) Get(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			err := reference.LoadByID(ctx, conn, s.svc.scope, referenceID)
+			err := reference.LoadByID(ctx, conn, scope, referenceID)
 			if err != nil {
 				return fmt.Errorf("cannot load trust center reference: %w", err)
 			}

--- a/pkg/trust/trust_center_service.go
+++ b/pkg/trust/trust_center_service.go
@@ -28,11 +28,12 @@ import (
 )
 
 type TrustCenterService struct {
-	svc *TenantService
+	svc *Service
 }
 
 func (s TrustCenterService) Get(
 	ctx context.Context,
+	scope coredata.Scoper,
 	trustCenterID gid.GID,
 ) (*coredata.TrustCenter, error) {
 	var trustCenter *coredata.TrustCenter
@@ -41,7 +42,7 @@ func (s TrustCenterService) Get(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			trustCenter = &coredata.TrustCenter{}
-			if err := trustCenter.LoadByID(ctx, conn, s.svc.scope, trustCenterID); err != nil {
+			if err := trustCenter.LoadByID(ctx, conn, scope, trustCenterID); err != nil {
 				return fmt.Errorf("cannot load trust center: %w", err)
 			}
 
@@ -57,6 +58,7 @@ func (s TrustCenterService) Get(
 
 func (s TrustCenterService) GetByOrganizationID(
 	ctx context.Context,
+	scope coredata.Scoper,
 	organizationID gid.GID,
 ) (*coredata.TrustCenter, error) {
 	trustCenter := &coredata.TrustCenter{}
@@ -64,7 +66,7 @@ func (s TrustCenterService) GetByOrganizationID(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			err := trustCenter.LoadByOrganizationID(ctx, conn, s.svc.scope, organizationID)
+			err := trustCenter.LoadByOrganizationID(ctx, conn, scope, organizationID)
 			if err != nil {
 				return fmt.Errorf("cannot load trust center: %w", err)
 			}
@@ -81,6 +83,7 @@ func (s TrustCenterService) GetByOrganizationID(
 
 func (s TrustCenterService) GetNDAFile(
 	ctx context.Context,
+	scope coredata.Scoper,
 	trustCenterID gid.GID,
 ) (*coredata.File, error) {
 	var file *coredata.File
@@ -89,7 +92,7 @@ func (s TrustCenterService) GetNDAFile(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			trustCenter := &coredata.TrustCenter{}
-			if err := trustCenter.LoadByID(ctx, conn, s.svc.scope, trustCenterID); err != nil {
+			if err := trustCenter.LoadByID(ctx, conn, scope, trustCenterID); err != nil {
 				return fmt.Errorf("cannot load trust center: %w", err)
 			}
 
@@ -98,7 +101,7 @@ func (s TrustCenterService) GetNDAFile(
 			}
 
 			file = &coredata.File{}
-			if err := file.LoadByID(ctx, conn, s.svc.scope, *trustCenter.NonDisclosureAgreementFileID); err != nil {
+			if err := file.LoadByID(ctx, conn, scope, *trustCenter.NonDisclosureAgreementFileID); err != nil {
 				return fmt.Errorf("cannot load file: %w", err)
 			}
 
@@ -114,6 +117,7 @@ func (s TrustCenterService) GetNDAFile(
 
 func (s TrustCenterService) GenerateNDAFileURL(
 	ctx context.Context,
+	scope coredata.Scoper,
 	trustCenterID gid.GID,
 	expiresIn time.Duration,
 ) (string, error) {
@@ -123,7 +127,7 @@ func (s TrustCenterService) GenerateNDAFileURL(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			trustCenter := &coredata.TrustCenter{}
-			if err := trustCenter.LoadByID(ctx, conn, s.svc.scope, trustCenterID); err != nil {
+			if err := trustCenter.LoadByID(ctx, conn, scope, trustCenterID); err != nil {
 				return fmt.Errorf("cannot load trust center: %w", err)
 			}
 
@@ -132,7 +136,7 @@ func (s TrustCenterService) GenerateNDAFileURL(
 			}
 
 			file = &coredata.File{}
-			if err := file.LoadByID(ctx, conn, s.svc.scope, *trustCenter.NonDisclosureAgreementFileID); err != nil {
+			if err := file.LoadByID(ctx, conn, scope, *trustCenter.NonDisclosureAgreementFileID); err != nil {
 				return fmt.Errorf("cannot load file: %w", err)
 			}
 
@@ -153,6 +157,7 @@ func (s TrustCenterService) GenerateNDAFileURL(
 
 func (s TrustCenterService) GenerateLogoURL(
 	ctx context.Context,
+	scope coredata.Scoper,
 	compliancePageID gid.GID,
 	expiresIn time.Duration,
 ) (*string, error) {
@@ -162,7 +167,7 @@ func (s TrustCenterService) GenerateLogoURL(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := compliancePage.LoadByID(ctx, conn, s.svc.scope, compliancePageID); err != nil {
+			if err := compliancePage.LoadByID(ctx, conn, scope, compliancePageID); err != nil {
 				return fmt.Errorf("cannot load compliance page: %w", err)
 			}
 
@@ -170,7 +175,7 @@ func (s TrustCenterService) GenerateLogoURL(
 				return nil
 			}
 
-			if err := file.LoadByID(ctx, conn, s.svc.scope, *compliancePage.LogoFileID); err != nil {
+			if err := file.LoadByID(ctx, conn, scope, *compliancePage.LogoFileID); err != nil {
 				return fmt.Errorf("cannot load file: %w", err)
 			}
 
@@ -199,6 +204,7 @@ func (s TrustCenterService) GenerateLogoURL(
 
 func (s TrustCenterService) GenerateDarkLogoURL(
 	ctx context.Context,
+	scope coredata.Scoper,
 	compliancePageID gid.GID,
 	expiresIn time.Duration,
 ) (*string, error) {
@@ -208,7 +214,7 @@ func (s TrustCenterService) GenerateDarkLogoURL(
 	err := s.svc.pg.WithConn(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
-			if err := compliancePage.LoadByID(ctx, conn, s.svc.scope, compliancePageID); err != nil {
+			if err := compliancePage.LoadByID(ctx, conn, scope, compliancePageID); err != nil {
 				return fmt.Errorf("cannot load compliance page: %w", err)
 			}
 
@@ -216,7 +222,7 @@ func (s TrustCenterService) GenerateDarkLogoURL(
 				return nil
 			}
 
-			if err := file.LoadByID(ctx, conn, s.svc.scope, *compliancePage.DarkLogoFileID); err != nil {
+			if err := file.LoadByID(ctx, conn, scope, *compliancePage.DarkLogoFileID); err != nil {
 				return fmt.Errorf("cannot load file: %w", err)
 			}
 
@@ -243,7 +249,11 @@ func (s TrustCenterService) GenerateDarkLogoURL(
 	return &presignedURL, nil
 }
 
-func (s *TrustCenterService) EmailPresenterConfig(ctx context.Context, compliancePageID gid.GID) (emails.PresenterConfig, error) {
+func (s *TrustCenterService) EmailPresenterConfig(
+	ctx context.Context,
+	scope coredata.Scoper,
+	compliancePageID gid.GID,
+) (emails.PresenterConfig, error) {
 	var (
 		compliancePage    = &coredata.TrustCenter{}
 		organization      = &coredata.Organization{}
@@ -251,8 +261,6 @@ func (s *TrustCenterService) EmailPresenterConfig(ctx context.Context, complianc
 		logoFile          = &coredata.File{}
 		emailPresenterCfg = emails.DefaultPresenterConfig(s.svc.bucket, s.svc.baseURL)
 	)
-
-	scope := coredata.NewScopeFromObjectID(compliancePageID)
 
 	err := s.svc.pg.WithConn(
 		ctx,
@@ -334,6 +342,7 @@ func (s *TrustCenterService) EmailPresenterConfig(ctx context.Context, complianc
 
 func (s *TrustCenterService) GetMailingList(
 	ctx context.Context,
+	scope coredata.Scoper,
 	trustCenterID gid.GID,
 ) (*coredata.MailingList, error) {
 	var mailingList *coredata.MailingList
@@ -342,7 +351,7 @@ func (s *TrustCenterService) GetMailingList(
 		ctx,
 		func(ctx context.Context, conn pg.Querier) error {
 			trustCenter := &coredata.TrustCenter{}
-			if err := trustCenter.LoadByID(ctx, conn, s.svc.scope, trustCenterID); err != nil {
+			if err := trustCenter.LoadByID(ctx, conn, scope, trustCenterID); err != nil {
 				return fmt.Errorf("cannot load trust center: %w", err)
 			}
 
@@ -351,7 +360,7 @@ func (s *TrustCenterService) GetMailingList(
 			}
 
 			mailingList = &coredata.MailingList{}
-			if err := mailingList.LoadByID(ctx, conn, s.svc.scope, *trustCenter.MailingListID); err != nil {
+			if err := mailingList.LoadByID(ctx, conn, scope, *trustCenter.MailingListID); err != nil {
 				return fmt.Errorf("cannot load mailing list: %w", err)
 			}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the tenant-scoped service pattern across `probo`, `trust`, and `slack`. All services now take an explicit `coredata.Scoper` and use a shared `Service`, removing `.WithTenant(...)` and cutting per-request allocations.

- **Refactors**
  - Replaced `TenantService` with `Service` across `probo`, `trust`, and `slack`.
  - Added `scope coredata.Scoper` to service methods and `ExportService` (e.g., Get/List/Create/Update/Delete, URL generators, exports).
  - Updated GraphQL resolvers, HTTP handlers, workers, and MCP resolvers to build scope with `coredata.NewScopeFromObjectID(...)` or `coredata.NewScope(tenantID)`.
  - Removed resolver helpers like `r.ProboService(...)` and `r.TrustService(...)`; resolvers call `r.probo`/`r.trust` directly with scope.
  - Moved Slack message helpers into `slack.Service` and added scope to calls (e.g., `GetSlackMessageDocumentIDs(ctx, scope, ...)`).
  - Compliance page handlers now pass scope to `trust` methods (e.g., `RenderCompliancePageMarkdown`, `RenderSitemap`).

- **Migration**
  - Replace `svc.WithTenant(tenantID)` with `scope := coredata.NewScope(tenantID)` (or `coredata.NewScopeFromObjectID(id)`), then pass `scope` to service methods.
  - Update calls, for example:
    - `prb.Documents.Get(ctx, id)` → `prb.Documents.Get(ctx, scope, id)`
    - `prb.Files.GenerateFileTempURL(ctx, id, ttl)` → `prb.Files.GenerateFileTempURL(ctx, scope, id, ttl)`
    - `trustSvc.Documents.ListForOrganizationId(ctx, orgID, cursor)` → `trustSvc.Documents.ListForOrganizationId(ctx, scope, orgID, cursor)`
    - `slackSvc.SlackMessages.GetSlackMessageDocumentIDs(...)` → `slackSvc.GetSlackMessageDocumentIDs(ctx, scope, ...)`
    - `trust.RenderCompliancePageMarkdown(ctx, w, tcID, tenantID)` → `trust.RenderCompliancePageMarkdown(ctx, w, tcID, scope)`
    - `ExportService.BuildAndUploadExport(ctx, exportJobID)` → `ExportService.BuildAndUploadExport(ctx, scope, exportJobID)` (same for `SendExportEmail`)

<sup>Written for commit 3e4a9be7c0f7a5e4e4a0a1cde1d16f2348d29b85. Summary will update on new commits. <a href="https://cubic.dev/pr/getprobo/probo/pull/1210?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

