### PR TITLE
Iam authorize returns scope

### DIFF
--- a/contrib/claude/authorization.md
+++ b/contrib/claude/authorization.md
@@ -131,9 +131,11 @@ if err := authorize(ctx, thirdPartyID, probo.ActionThirdPartyGet); err != nil {
 }
 ```
 
-**MCP resolvers** use `MustAuthorize` which panics (caught by middleware):
+**MCP resolvers** use `Authorize` and return early on error:
 ```go
-r.MustAuthorize(ctx, input.ID, probo.ActionThirdPartyGet)
+if err := r.Authorize(ctx, input.ID, probo.ActionThirdPartyGet); err != nil {
+	return nil, types.GetThirdPartyOutput{}, err
+}
 ```
 
 ## File locations
@@ -181,7 +183,7 @@ When adding a new entity that needs authorization:
 2. **Role policies** — wire actions into the appropriate role policies in `pkg/probo/policies.go` (`OwnerPolicy`, `AdminPolicy`, `ViewerPolicy`, etc.) with `organization_id` condition
 3. **`AuthorizationAttributes`** — implement on the `coredata` entity struct, returning at minimum `{"organization_id": ...}` (use the denormalized `OrganizationID` field — see coredata doc)
 4. **Entity type registry** — register in `pkg/coredata/entity_type_reg.go` and `NewEntityFromID` so the authorizer can construct the entity from its GID
-5. **Resolver calls** — add `r.authorize(ctx, id, probo.ActionEntityGet)` in GraphQL resolvers and `r.MustAuthorize(ctx, id, probo.ActionEntityGet)` in MCP resolvers
+5. **Resolver calls** — add `r.authorize(ctx, id, probo.ActionEntityGet)` in GraphQL resolvers and `if err := r.Authorize(ctx, id, probo.ActionEntityGet); err != nil { return nil, types.GetEntityOutput{}, err }` in MCP resolvers
 
 ## Key patterns
 

--- a/contrib/claude/authorization.md
+++ b/contrib/claude/authorization.md
@@ -54,6 +54,35 @@ The flow:
 6. Return an authorization scope (`*coredata.Scope`) for downstream data access
 7. Return `ErrInsufficientPermissions` if no allow match
 
+## Batch authorization
+
+Use batch authorization when a caller needs all-or-nothing authorization across
+multiple resources for the same action:
+
+```go
+scope, err := iamService.Authorizer.AuthorizeBatch(ctx, iam.AuthorizeBatchParams{
+	Principal: identityID,
+	Action:    probo.ActionTaskDelete,
+	Resources: taskIDs, // all resources must have same entity type + organization
+})
+```
+
+Batch semantics:
+- **All-or-nothing** — the first denied resource returns `ErrInsufficientPermissions`
+- **Single-entity-type batch** — mixed entity types return `ErrMixedEntityTypeBatch`
+- **Single-organization batch** — mixed or missing `organization_id` attributes return `ErrMixedOrganizationBatch`
+- **Empty resource list** returns `ErrEmptyResourceBatch`
+- **Batch attributes are required** — each resource type in `AuthorizeBatch` must implement batch attributes loading or it returns `ErrBatchAuthorizationUnsupportedResourceType`
+- **Shared `ResourceAttributes` map** is applied to every resource in the batch
+- **Audit logs** are written per resource only when all resources are authorized (`DryRun` skips logs)
+
+GraphQL wrappers can use `authz.NewBatchAuthorizeFunc(...)` with
+`authz.WithBatchAttr`, `authz.WithBatchDryRun`, and
+`authz.WithBatchSkipAssumptionCheck`.
+
+MCP resolvers can use `Resolver.AuthorizeBatch(ctx, resourceIDs, action)` for
+the same behavior and error mapping as single-resource authorization.
+
 ## PolicySet
 
 Policies are organized into identity-scoped (applied to all authenticated users) and role-based:
@@ -98,20 +127,42 @@ Key paths use `principal.ATTR` or `resource.ATTR` (e.g., `principal.organization
 Resources that support authorization must implement this interface in `pkg/coredata/`:
 
 ```go
-func (v *ThirdParty) AuthorizationAttributes(ctx context.Context, conn pg.Conn) (map[string]string, error) {
-	q := `SELECT organization_id FROM thirdParties WHERE id = $1 LIMIT 1;`
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, v.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
+func (v *ThirdParty) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (map[gid.GID]map[string]string, error) {
+	q := `SELECT id, organization_id FROM third_parties WHERE id = ANY(@resource_ids::text[])`
+
+	rows, err := conn.Query(ctx, q, pgx.StrictNamedArgs{"resource_ids": resourceIDs})
+	if err != nil {
 		return nil, fmt.Errorf("cannot query third party authorization attributes: %w", err)
 	}
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	defer rows.Close()
+
+	attrsByID := make(map[gid.GID]map[string]string)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		if err := rows.Scan(&id, &organizationID); err != nil {
+			return nil, fmt.Errorf("cannot scan third party authorization attributes: %w", err)
+		}
+		attrsByID[id] = map[string]string{"organization_id": organizationID.String()}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate third party authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 ```
 
 The returned map provides attributes for condition evaluation (e.g., `resource.organization_id`).
+`AuthorizationAttributes` implementers should assume caller-side preconditions:
+- `resourceIDs` is non-empty
+- `resourceIDs` is deduplicated
+- in `AuthorizeBatch`, all resources are the same entity type
+
+Implementers should return only found rows keyed by id. Missing resources are handled by caller-side per-resource existence checks.
 
 ## Error types
 

--- a/contrib/claude/authorization.md
+++ b/contrib/claude/authorization.md
@@ -37,7 +37,7 @@ The evaluator processes all statements against a request:
 `Authorizer` is the main orchestrator in `pkg/iam/authorizer.go`:
 
 ```go
-err := iamService.Authorizer.Authorize(ctx, iam.AuthorizeParams{
+scope, err := iamService.Authorizer.Authorize(ctx, iam.AuthorizeParams{
 	Principal:          identityID,    // who
 	Resource:           thirdPartyID,      // what
 	Action:             probo.ActionThirdPartyGet,  // which action
@@ -51,7 +51,8 @@ The flow:
 3. Load resource attributes via `AuthorizationAttributes()` on the entity
 4. Build policies: identity-scoped + role-specific
 5. Evaluate all policies
-6. Return `ErrInsufficientPermissions` if no allow match
+6. Return an authorization scope (`*coredata.Scope`) for downstream data access
+7. Return `ErrInsufficientPermissions` if no allow match
 
 ## PolicySet
 
@@ -126,14 +127,16 @@ var (
 
 **GraphQL resolvers** use `AuthorizeFunc` from `pkg/server/api/authz/`:
 ```go
-if err := authorize(ctx, thirdPartyID, probo.ActionThirdPartyGet); err != nil {
+scope, err := authorize(ctx, thirdPartyID, probo.ActionThirdPartyGet)
+if err != nil {
 	return nil, err
 }
 ```
 
 **MCP resolvers** use `Authorize` and return early on error:
 ```go
-if err := r.Authorize(ctx, input.ID, probo.ActionThirdPartyGet); err != nil {
+scope, err := r.Authorize(ctx, input.ID, probo.ActionThirdPartyGet)
+if err != nil {
 	return nil, types.GetThirdPartyOutput{}, err
 }
 ```
@@ -183,7 +186,7 @@ When adding a new entity that needs authorization:
 2. **Role policies** — wire actions into the appropriate role policies in `pkg/probo/policies.go` (`OwnerPolicy`, `AdminPolicy`, `ViewerPolicy`, etc.) with `organization_id` condition
 3. **`AuthorizationAttributes`** — implement on the `coredata` entity struct, returning at minimum `{"organization_id": ...}` (use the denormalized `OrganizationID` field — see coredata doc)
 4. **Entity type registry** — register in `pkg/coredata/entity_type_reg.go` and `NewEntityFromID` so the authorizer can construct the entity from its GID
-5. **Resolver calls** — add `r.authorize(ctx, id, probo.ActionEntityGet)` in GraphQL resolvers and `if err := r.Authorize(ctx, id, probo.ActionEntityGet); err != nil { return nil, types.GetEntityOutput{}, err }` in MCP resolvers
+5. **Resolver calls** — add `scope, err := r.authorize(ctx, id, probo.ActionEntityGet)` in GraphQL resolvers and `scope, err := r.Authorize(ctx, id, probo.ActionEntityGet)` in MCP resolvers, then pass `scope` to services
 
 ## Key patterns
 

--- a/contrib/claude/mcp.md
+++ b/contrib/claude/mcp.md
@@ -6,7 +6,7 @@ MCP tools are defined in `pkg/server/api/mcp/v1/specification.yaml` and generate
 
 **Hand-written** (edit these):
 - `specification.yaml` — tool definitions, input/output schemas, component schemas
-- `resolver.go` — `Resolver` struct, `MustAuthorize`, service accessors
+- `resolver.go` — `Resolver` struct, `Authorize`, service accessors
 - `helpers.go` — pagination helpers, `UnwrapOmittable`
 - `types/*.go` (except `types/types.go`) — type conversion helpers (`NewThirdParty()`, `NewListThirdPartiesOutput()`, etc.)
 - `schema.resolvers.go` — tool implementation bodies (stubs generated, you edit the bodies)
@@ -58,14 +58,16 @@ func (r *Resolver) ListThirdPartiesTool(
 ) (*mcp.CallToolResult, types.ListThirdPartiesOutput, error)
 ```
 
-First return is always `nil`. Errors are either returned (for recoverable) or panicked (for authorization and unexpected failures).
+First return is always `nil`. Authorization errors are returned and handled like other recoverable tool errors.
 
 ## Authorization
 
-Use `MustAuthorize` which panics on failure (caught by middleware):
+Use `Authorize` with an early return:
 
 ```go
-r.MustAuthorize(ctx, input.OrganizationID, probo.ActionThirdPartyList)
+if err := r.Authorize(ctx, input.OrganizationID, probo.ActionThirdPartyList); err != nil {
+	return nil, types.ListThirdPartiesOutput{}, err
+}
 ```
 
 ## Common resolver patterns
@@ -73,7 +75,9 @@ r.MustAuthorize(ctx, input.OrganizationID, probo.ActionThirdPartyList)
 **List with pagination:**
 ```go
 func (r *Resolver) ListThirdPartiesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListThirdPartiesInput) (*mcp.CallToolResult, types.ListThirdPartiesOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionThirdPartyList)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionThirdPartyList); err != nil {
+		return nil, types.ListThirdPartiesOutput{}, err
+	}
 
 	prb := r.ProboService(ctx, input.OrganizationID)
 
@@ -102,7 +106,10 @@ func (r *Resolver) ListThirdPartiesTool(ctx context.Context, req *mcp.CallToolRe
 **Get single resource:**
 ```go
 func (r *Resolver) GetRiskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetRiskInput) (*mcp.CallToolResult, types.GetRiskOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionRiskGet)
+	if err := r.Authorize(ctx, input.ID, probo.ActionRiskGet); err != nil {
+		return nil, types.GetRiskOutput{}, err
+	}
+
 	prb := r.ProboService(ctx, input.ID)
 
 	risk, err := prb.Risks.Get(ctx, input.ID)
@@ -117,7 +124,10 @@ func (r *Resolver) GetRiskTool(ctx context.Context, req *mcp.CallToolRequest, in
 **Create:**
 ```go
 func (r *Resolver) AddRiskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddRiskInput) (*mcp.CallToolResult, types.AddRiskOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionRiskCreate)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionRiskCreate); err != nil {
+		return nil, types.AddRiskOutput{}, err
+	}
+
 	svc := r.ProboService(ctx, input.OrganizationID)
 
 	risk, err := svc.Risks.Create(ctx, probo.CreateRiskRequest{

--- a/contrib/claude/mcp.md
+++ b/contrib/claude/mcp.md
@@ -65,7 +65,8 @@ First return is always `nil`. Authorization errors are returned and handled like
 Use `Authorize` with an early return:
 
 ```go
-if err := r.Authorize(ctx, input.OrganizationID, probo.ActionThirdPartyList); err != nil {
+scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionThirdPartyList)
+if err != nil {
 	return nil, types.ListThirdPartiesOutput{}, err
 }
 ```
@@ -75,7 +76,7 @@ if err := r.Authorize(ctx, input.OrganizationID, probo.ActionThirdPartyList); er
 **List with pagination:**
 ```go
 func (r *Resolver) ListThirdPartiesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListThirdPartiesInput) (*mcp.CallToolResult, types.ListThirdPartiesOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionThirdPartyList); err != nil {
+	if _, err := r.Authorize(ctx, input.OrganizationID, probo.ActionThirdPartyList); err != nil {
 		return nil, types.ListThirdPartiesOutput{}, err
 	}
 
@@ -106,7 +107,7 @@ func (r *Resolver) ListThirdPartiesTool(ctx context.Context, req *mcp.CallToolRe
 **Get single resource:**
 ```go
 func (r *Resolver) GetRiskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetRiskInput) (*mcp.CallToolResult, types.GetRiskOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionRiskGet); err != nil {
+	if _, err := r.Authorize(ctx, input.ID, probo.ActionRiskGet); err != nil {
 		return nil, types.GetRiskOutput{}, err
 	}
 
@@ -124,7 +125,7 @@ func (r *Resolver) GetRiskTool(ctx context.Context, req *mcp.CallToolRequest, in
 **Create:**
 ```go
 func (r *Resolver) AddRiskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddRiskInput) (*mcp.CallToolResult, types.AddRiskOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionRiskCreate); err != nil {
+	if _, err := r.Authorize(ctx, input.OrganizationID, probo.ActionRiskCreate); err != nil {
 		return nil, types.AddRiskOutput{}, err
 	}
 

--- a/pkg/coredata/access_entry.go
+++ b/pkg/coredata/access_entry.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -69,19 +70,42 @@ func (e AccessEntry) CursorKey(orderBy AccessEntryOrderField) page.CursorKey {
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (e *AccessEntry) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM access_entries WHERE id = $1 LIMIT 1;`
+func (e *AccessEntry) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM access_entries WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, e.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query access entry authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (e *AccessEntry) LoadByID(

--- a/pkg/coredata/access_entry.go
+++ b/pkg/coredata/access_entry.go
@@ -89,10 +89,11 @@ func (e *AccessEntry) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/access_entry_decision_history.go
+++ b/pkg/coredata/access_entry_decision_history.go
@@ -16,7 +16,6 @@ package coredata
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"maps"
 	"time"
@@ -24,6 +23,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 )
 
 type (
@@ -92,19 +92,39 @@ INSERT INTO access_entry_decision_history (
 func (h *AccessEntryDecisionHistory) AuthorizationAttributes(
 	ctx context.Context,
 	conn pg.Querier,
-) (map[string]string, error) {
-	q := `SELECT organization_id FROM access_entry_decision_history WHERE id = $1 LIMIT 1;`
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM access_entry_decision_history WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, h.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot load authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (hs *AccessEntryDecisionHistories) LoadByEntryID(

--- a/pkg/coredata/access_entry_decision_history.go
+++ b/pkg/coredata/access_entry_decision_history.go
@@ -108,10 +108,11 @@ func (h *AccessEntryDecisionHistory) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/access_review_campaign.go
+++ b/pkg/coredata/access_review_campaign.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -53,19 +54,42 @@ func (c AccessReviewCampaign) CursorKey(orderBy AccessReviewCampaignOrderField) 
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (c *AccessReviewCampaign) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM access_review_campaigns WHERE id = $1 LIMIT 1;`
+func (c *AccessReviewCampaign) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM access_review_campaigns WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, c.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query access review campaign authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (c *AccessReviewCampaign) LoadByID(

--- a/pkg/coredata/access_review_campaign.go
+++ b/pkg/coredata/access_review_campaign.go
@@ -73,10 +73,11 @@ func (c *AccessReviewCampaign) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/access_source.go
+++ b/pkg/coredata/access_source.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -52,19 +53,42 @@ func (as AccessSource) CursorKey(orderBy AccessSourceOrderField) page.CursorKey 
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (as *AccessSource) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM access_sources WHERE id = $1 LIMIT 1;`
+func (as *AccessSource) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM access_sources WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, as.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query access source authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (as *AccessSource) LoadByID(

--- a/pkg/coredata/access_source.go
+++ b/pkg/coredata/access_source.go
@@ -72,10 +72,11 @@ func (as *AccessSource) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/agent_run.go
+++ b/pkg/coredata/agent_run.go
@@ -141,10 +141,11 @@ func (e *AgentRun) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/agent_run.go
+++ b/pkg/coredata/agent_run.go
@@ -27,6 +27,7 @@ import (
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/agent"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -121,30 +122,42 @@ func (e AgentRun) CursorKey(orderBy AgentRunOrderField) page.CursorKey {
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (e *AgentRun) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM agent_runs WHERE id = @id LIMIT 1;`
+func (e *AgentRun) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM agent_runs WHERE id = ANY(@resource_ids::text[])`
 
-	args := pgx.StrictNamedArgs{"id": e.ID.String()}
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
+	}
 
 	rows, err := conn.Query(ctx, q, args)
 	if err != nil {
-		return nil, fmt.Errorf("cannot query agent run authorization attributes: %w", err)
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
 	}
 
-	type row struct {
-		OrganizationID gid.GID `db:"organization_id"`
-	}
+	defer rows.Close()
 
-	r, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[row])
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 
-		return nil, fmt.Errorf("cannot load agent run authorization attributes: %w", err)
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
 	}
 
-	return map[string]string{"organization_id": r.OrganizationID.String()}, nil
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (e *AgentRun) LoadByID(

--- a/pkg/coredata/applicability_statement.go
+++ b/pkg/coredata/applicability_statement.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -57,19 +58,42 @@ func (s ApplicabilityStatement) CursorKey(orderBy ApplicabilityStatementOrderFie
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (s *ApplicabilityStatement) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM applicability_statements WHERE id = $1 LIMIT 1;`
+func (s *ApplicabilityStatement) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM applicability_statements WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, s.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query applicability statement authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (sac *ApplicabilityStatement) LoadByID(

--- a/pkg/coredata/applicability_statement.go
+++ b/pkg/coredata/applicability_statement.go
@@ -77,10 +77,11 @@ func (s *ApplicabilityStatement) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/asset.go
+++ b/pkg/coredata/asset.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -55,19 +56,42 @@ func (a *Asset) CursorKey(field AssetOrderField) page.CursorKey {
 }
 
 // AuthorizationAttributes returns the authorization attributes for policy evaluation.
-func (a *Asset) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM assets WHERE id = $1 LIMIT 1;`
+func (a *Asset) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM assets WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, a.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query asset authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (a *Asset) LoadByID(

--- a/pkg/coredata/asset.go
+++ b/pkg/coredata/asset.go
@@ -75,10 +75,11 @@ func (a *Asset) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/audit.go
+++ b/pkg/coredata/audit.go
@@ -81,10 +81,11 @@ func (a *Audit) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/audit.go
+++ b/pkg/coredata/audit.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -61,19 +62,42 @@ func (a *Audit) CursorKey(field AuditOrderField) page.CursorKey {
 }
 
 // AuthorizationAttributes returns the authorization attributes for policy evaluation.
-func (a *Audit) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM audits WHERE id = $1 LIMIT 1;`
+func (a *Audit) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM audits WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, a.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query audit authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (a *Audit) LoadByID(

--- a/pkg/coredata/audit_log_entry.go
+++ b/pkg/coredata/audit_log_entry.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -53,19 +54,42 @@ func (e AuditLogEntry) CursorKey(orderBy AuditLogEntryOrderField) page.CursorKey
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (e *AuditLogEntry) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM audit_log_entries WHERE id = $1 LIMIT 1;`
+func (e *AuditLogEntry) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM audit_log_entries WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, e.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query audit log entry authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (e *AuditLogEntry) Insert(
@@ -116,6 +140,61 @@ VALUES (
 	_, err := conn.Exec(ctx, q, args)
 	if err != nil {
 		return fmt.Errorf("cannot insert audit log entry: %w", err)
+	}
+
+	return nil
+}
+
+// BulkInsert writes all entries to audit_log_entries in a single PostgreSQL
+// COPY operation. Used by the authorizer's batch path to fold N per-resource
+// INSERTs into a single round trip.
+func (es AuditLogEntries) BulkInsert(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+) error {
+	if len(es) == 0 {
+		return nil
+	}
+
+	rows := make([][]any, 0, len(es))
+	for _, e := range es {
+		rows = append(
+			rows,
+			[]any{
+				e.ID,
+				scope.GetTenantID(),
+				e.OrganizationID,
+				e.ActorID,
+				e.ActorType,
+				e.Action,
+				e.ResourceType,
+				e.ResourceID,
+				e.Metadata,
+				e.CreatedAt,
+			},
+		)
+	}
+
+	_, err := conn.CopyFrom(
+		ctx,
+		pgx.Identifier{"audit_log_entries"},
+		[]string{
+			"id",
+			"tenant_id",
+			"organization_id",
+			"actor_id",
+			"actor_type",
+			"action",
+			"resource_type",
+			"resource_id",
+			"metadata",
+			"created_at",
+		},
+		pgx.CopyFromRows(rows),
+	)
+	if err != nil {
+		return fmt.Errorf("cannot bulk insert audit log entries: %w", err)
 	}
 
 	return nil

--- a/pkg/coredata/audit_log_entry.go
+++ b/pkg/coredata/audit_log_entry.go
@@ -73,10 +73,11 @@ func (e *AuditLogEntry) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/common_third_party.go
+++ b/pkg/coredata/common_third_party.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 )
 
 type (
@@ -53,6 +54,18 @@ type (
 
 	CommonThirdParties []*CommonThirdParty
 )
+
+// AuthorizationAttributes is a no-op resource-attribute loader: the
+// common third-party catalog is global (shared across every tenant) and
+// has no organization_id. Authorization for these rows is granted by an
+// identity-scoped policy that has no condition.
+func (t *CommonThirdParty) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	return map[gid.GID]policy.Attributes{}, nil
+}
 
 func (t *CommonThirdParty) LoadByID(
 	ctx context.Context,

--- a/pkg/coredata/compliance_external_url.go
+++ b/pkg/coredata/compliance_external_url.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -53,19 +54,42 @@ func (c ComplianceExternalURL) CursorKey(orderBy ComplianceExternalURLOrderField
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (c *ComplianceExternalURL) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM compliance_external_urls WHERE id = $1 LIMIT 1;`
+func (c *ComplianceExternalURL) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM compliance_external_urls WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, c.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query compliance external URL authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (c *ComplianceExternalURL) LoadByID(

--- a/pkg/coredata/compliance_external_url.go
+++ b/pkg/coredata/compliance_external_url.go
@@ -73,10 +73,11 @@ func (c *ComplianceExternalURL) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/compliance_framework.go
+++ b/pkg/coredata/compliance_framework.go
@@ -76,10 +76,11 @@ func (c *ComplianceFramework) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/compliance_framework.go
+++ b/pkg/coredata/compliance_framework.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -56,19 +57,42 @@ func (c ComplianceFramework) CursorKey(orderBy ComplianceFrameworkOrderField) pa
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (c *ComplianceFramework) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM compliance_frameworks WHERE id = $1 LIMIT 1;`
+func (c *ComplianceFramework) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM compliance_frameworks WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, c.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query compliance framework authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (c *ComplianceFramework) LoadByID(

--- a/pkg/coredata/connector.go
+++ b/pkg/coredata/connector.go
@@ -105,10 +105,11 @@ func (c *Connector) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/connector.go
+++ b/pkg/coredata/connector.go
@@ -28,6 +28,7 @@ import (
 	"go.probo.inc/probo/pkg/connector"
 	"go.probo.inc/probo/pkg/crypto/cipher"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -85,19 +86,42 @@ func (c *Connector) CursorKey(orderBy ConnectorOrderField) page.CursorKey {
 }
 
 // AuthorizationAttributes returns the authorization attributes for policy evaluation.
-func (c *Connector) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM connectors WHERE id = $1 LIMIT 1;`
+func (c *Connector) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM connectors WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, c.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query connector authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (c *Connectors) LoadAllByOrganizationIDProtocolAndProvider(

--- a/pkg/coredata/control.go
+++ b/pkg/coredata/control.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -58,19 +59,42 @@ func (c Control) CursorKey(orderBy ControlOrderField) page.CursorKey {
 }
 
 // AuthorizationAttributes returns the authorization attributes for policy evaluation.
-func (c *Control) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM controls WHERE id = $1 LIMIT 1;`
+func (c *Control) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM controls WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, c.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query control authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (c *Controls) CountByDocumentID(

--- a/pkg/coredata/control.go
+++ b/pkg/coredata/control.go
@@ -78,10 +78,11 @@ func (c *Control) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/cookie_banner.go
+++ b/pkg/coredata/cookie_banner.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -57,19 +58,42 @@ func (b *CookieBanner) CursorKey(field CookieBannerOrderField) page.CursorKey {
 	panic(fmt.Sprintf("unsupported order by: %s", field))
 }
 
-func (b *CookieBanner) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM cookie_banners WHERE id = $1 LIMIT 1;`
+func (b *CookieBanner) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM cookie_banners WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, b.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query cookie banner authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (b *CookieBanner) LoadByID(

--- a/pkg/coredata/cookie_banner.go
+++ b/pkg/coredata/cookie_banner.go
@@ -77,10 +77,11 @@ func (b *CookieBanner) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/cookie_banner_translation.go
+++ b/pkg/coredata/cookie_banner_translation.go
@@ -62,10 +62,11 @@ func (t *CookieBannerTranslation) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/cookie_banner_translation.go
+++ b/pkg/coredata/cookie_banner_translation.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 )
 
 type (
@@ -42,19 +43,42 @@ type (
 	CookieBannerTranslations []*CookieBannerTranslation
 )
 
-func (t *CookieBannerTranslation) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM cookie_banner_translations WHERE id = $1 LIMIT 1;`
+func (t *CookieBannerTranslation) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM cookie_banner_translations WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, t.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query cookie banner translation authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (t *CookieBannerTranslation) LoadByID(

--- a/pkg/coredata/cookie_banner_version.go
+++ b/pkg/coredata/cookie_banner_version.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -80,19 +81,42 @@ func (v *CookieBannerVersion) CursorKey(field CookieBannerVersionOrderField) pag
 	panic(fmt.Sprintf("unsupported order by: %s", field))
 }
 
-func (v *CookieBannerVersion) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM cookie_banner_versions WHERE id = $1 LIMIT 1;`
+func (v *CookieBannerVersion) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM cookie_banner_versions WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, v.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query cookie banner version authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (v *CookieBannerVersion) GetSnapshot() (CookieBannerVersionSnapshot, error) {

--- a/pkg/coredata/cookie_banner_version.go
+++ b/pkg/coredata/cookie_banner_version.go
@@ -100,10 +100,11 @@ func (v *CookieBannerVersion) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/cookie_category.go
+++ b/pkg/coredata/cookie_category.go
@@ -102,10 +102,11 @@ func (c *CookieCategory) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/cookie_category.go
+++ b/pkg/coredata/cookie_category.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -82,19 +83,42 @@ func (c *CookieCategory) CursorKey(field CookieCategoryOrderField) page.CursorKe
 	panic(fmt.Sprintf("unsupported order by: %s", field))
 }
 
-func (c *CookieCategory) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM cookie_categories WHERE id = $1 LIMIT 1;`
+func (c *CookieCategory) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM cookie_categories WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, c.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query cookie category authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (c *CookieCategory) LoadByID(

--- a/pkg/coredata/cookie_consent_record.go
+++ b/pkg/coredata/cookie_consent_record.go
@@ -78,10 +78,11 @@ func (r *CookieConsentRecord) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/cookie_consent_record.go
+++ b/pkg/coredata/cookie_consent_record.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -58,19 +59,42 @@ func (r *CookieConsentRecord) CursorKey(field CookieConsentRecordOrderField) pag
 	panic(fmt.Sprintf("unsupported order by: %s", field))
 }
 
-func (r *CookieConsentRecord) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM cookie_consent_records WHERE id = $1 LIMIT 1;`
+func (r *CookieConsentRecord) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM cookie_consent_records WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, r.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query consent record authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (r *CookieConsentRecords) LoadByCookieBannerID(

--- a/pkg/coredata/custom_domain.go
+++ b/pkg/coredata/custom_domain.go
@@ -88,10 +88,11 @@ func (cd *CustomDomain) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/custom_domain.go
+++ b/pkg/coredata/custom_domain.go
@@ -27,6 +27,7 @@ import (
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/crypto/cipher"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -68,19 +69,42 @@ func NewCustomDomain(tenantID gid.TenantID, domain string) *CustomDomain {
 }
 
 // AuthorizationAttributes returns the authorization attributes for policy evaluation.
-func (cd *CustomDomain) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM custom_domains WHERE id = $1 LIMIT 1;`
+func (cd *CustomDomain) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM custom_domains WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, cd.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query custom domain authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (cd *CustomDomain) CursorKey(field CustomDomainOrderField) page.CursorKey {

--- a/pkg/coredata/data_protection_impact_assessment.go
+++ b/pkg/coredata/data_protection_impact_assessment.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -163,19 +164,42 @@ func (dpia *DataProtectionImpactAssessment) CursorKey(field DataProtectionImpact
 }
 
 // AuthorizationAttributes returns the authorization attributes for policy evaluation.
-func (dpia *DataProtectionImpactAssessment) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM processing_activity_data_protection_impact_assessments WHERE id = $1 LIMIT 1;`
+func (dpia *DataProtectionImpactAssessment) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM processing_activity_data_protection_impact_assessments WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, dpia.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query data protection impact assessment authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (dpias *DataProtectionImpactAssessments) CountByOrganizationID(

--- a/pkg/coredata/data_protection_impact_assessment.go
+++ b/pkg/coredata/data_protection_impact_assessment.go
@@ -183,10 +183,11 @@ func (dpia *DataProtectionImpactAssessment) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/datum.go
+++ b/pkg/coredata/datum.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -55,19 +56,42 @@ func (d *Datum) CursorKey(field DatumOrderField) page.CursorKey {
 }
 
 // AuthorizationAttributes returns the authorization attributes for policy evaluation.
-func (d *Datum) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM data WHERE id = $1 LIMIT 1;`
+func (d *Datum) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM data WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, d.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query datum authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (d *Datum) LoadByID(

--- a/pkg/coredata/datum.go
+++ b/pkg/coredata/datum.go
@@ -75,10 +75,11 @@ func (d *Datum) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/document.go
+++ b/pkg/coredata/document.go
@@ -85,10 +85,11 @@ func (d *Document) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/document.go
+++ b/pkg/coredata/document.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/mail"
 	"go.probo.inc/probo/pkg/page"
 )
@@ -65,26 +66,42 @@ func (p Document) CursorKey(orderBy DocumentOrderField) page.CursorKey {
 }
 
 // AuthorizationAttributes returns the authorization attributes for policy evaluation.
-func (d *Document) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `
-SELECT organization_id
-FROM documents
-WHERE id = $1
-LIMIT 1;
-`
+func (d *Document) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM documents WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, d.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query document authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{
-		"organization_id": organizationID.String(),
-	}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (p *Document) LoadByID(

--- a/pkg/coredata/document_version.go
+++ b/pkg/coredata/document_version.go
@@ -73,10 +73,11 @@ func (dv *DocumentVersion) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/document_version.go
+++ b/pkg/coredata/document_version.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -53,27 +54,42 @@ type (
 )
 
 // AuthorizationAttributes returns the authorization attributes for policy evaluation.
-func (dv *DocumentVersion) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `
-SELECT organization_id
-FROM document_versions
-WHERE id = $1
-LIMIT 1;
-`
+func (dv *DocumentVersion) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM document_versions WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-
-	if err := conn.QueryRow(ctx, q, dv.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query document version authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{
-		"organization_id": organizationID.String(),
-	}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (dv *DocumentVersions) LoadByDocumentID(

--- a/pkg/coredata/document_version_approval_decision.go
+++ b/pkg/coredata/document_version_approval_decision.go
@@ -74,10 +74,11 @@ func (d *DocumentVersionApprovalDecision) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/document_version_approval_decision.go
+++ b/pkg/coredata/document_version_approval_decision.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -54,19 +55,42 @@ func (d DocumentVersionApprovalDecision) CursorKey(orderBy DocumentVersionApprov
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (d *DocumentVersionApprovalDecision) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM document_version_approval_decisions WHERE id = $1 LIMIT 1;`
+func (d *DocumentVersionApprovalDecision) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM document_version_approval_decisions WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, d.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query document version approval decision authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (d *DocumentVersionApprovalDecision) LoadByID(

--- a/pkg/coredata/document_version_approval_quorum.go
+++ b/pkg/coredata/document_version_approval_quorum.go
@@ -70,10 +70,11 @@ func (q *DocumentVersionApprovalQuorum) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/document_version_approval_quorum.go
+++ b/pkg/coredata/document_version_approval_quorum.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -50,19 +51,42 @@ func (q DocumentVersionApprovalQuorum) CursorKey(orderBy DocumentVersionApproval
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (q *DocumentVersionApprovalQuorum) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	query := `SELECT organization_id FROM document_version_approval_quorums WHERE id = $1 LIMIT 1;`
+func (q *DocumentVersionApprovalQuorum) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	query := `SELECT id, organization_id FROM document_version_approval_quorums WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, query, q.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query approval quorum authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, query, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (q *DocumentVersionApprovalQuorum) LoadByID(

--- a/pkg/coredata/document_version_signature.go
+++ b/pkg/coredata/document_version_signature.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/mail"
 	"go.probo.inc/probo/pkg/page"
 )
@@ -64,19 +65,42 @@ func (pvs DocumentVersionSignature) CursorKey(orderBy DocumentVersionSignatureOr
 }
 
 // AuthorizationAttributes returns the authorization attributes for policy evaluation.
-func (dvs *DocumentVersionSignature) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM document_version_signatures WHERE id = $1 LIMIT 1;`
+func (dvs *DocumentVersionSignature) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM document_version_signatures WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, dvs.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query document version signature authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (pvs *DocumentVersionSignature) LoadByDocumentVersionIDAndSignatory(

--- a/pkg/coredata/document_version_signature.go
+++ b/pkg/coredata/document_version_signature.go
@@ -84,10 +84,11 @@ func (dvs *DocumentVersionSignature) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/electronic_signature.go
+++ b/pkg/coredata/electronic_signature.go
@@ -27,6 +27,7 @@ import (
 	"go.gearno.de/x/ref"
 	"go.probo.inc/probo/pkg/crypto/hash"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 )
 
 type ElectronicSignature struct {
@@ -57,6 +58,42 @@ type ElectronicSignature struct {
 	ProcessingStartedAt            *time.Time                      `db:"processing_started_at"`
 	CreatedAt                      time.Time                       `db:"created_at"`
 	UpdatedAt                      time.Time                       `db:"updated_at"`
+}
+
+func (es *ElectronicSignature) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM electronic_signatures WHERE id = ANY(@resource_ids::text[])`
+
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
+	}
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query electronic signature authorization attributes: %w", err)
+	}
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		if err := rows.Scan(&id, &organizationID); err != nil {
+			return nil, fmt.Errorf("cannot scan electronic signature authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate electronic signature authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (es *ElectronicSignature) NewEvent(

--- a/pkg/coredata/electronic_signature.go
+++ b/pkg/coredata/electronic_signature.go
@@ -78,6 +78,7 @@ func (es *ElectronicSignature) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
 		if err := rows.Scan(&id, &organizationID); err != nil {

--- a/pkg/coredata/email.go
+++ b/pkg/coredata/email.go
@@ -91,10 +91,11 @@ WHERE
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID, len(resourceIDs))
+
 	for rows.Next() {
 		var id gid.GID
-		err = rows.Scan(&id)
-		if err != nil {
+
+		if err := rows.Scan(&id); err != nil {
 			return nil, fmt.Errorf("cannot scan email authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/email.go
+++ b/pkg/coredata/email.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/mail"
 )
 
@@ -65,8 +66,46 @@ var (
 
 // AuthorizationAttributes returns the authorization attributes for policy evaluation.
 // Email is identity-scoped (not org-scoped), so it returns an empty map.
-func (e *Email) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	return map[string]string{}, nil
+func (e *Email) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `
+SELECT
+    id
+FROM
+    emails
+WHERE
+    id = ANY(@resource_ids::text[])
+`
+
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
+	}
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query email authorization attributes: %w", err)
+	}
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID, len(resourceIDs))
+	for rows.Next() {
+		var id gid.GID
+		err = rows.Scan(&id)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan email authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{}
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate email authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func NewEmail(

--- a/pkg/coredata/evidence.go
+++ b/pkg/coredata/evidence.go
@@ -79,10 +79,11 @@ func (e *Evidence) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/evidence.go
+++ b/pkg/coredata/evidence.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -59,19 +60,42 @@ func (e Evidence) CursorKey(orderBy EvidenceOrderField) page.CursorKey {
 }
 
 // AuthorizationAttributes returns the authorization attributes for policy evaluation.
-func (e *Evidence) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM evidences WHERE id = $1 LIMIT 1;`
+func (e *Evidence) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM evidences WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, e.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query evidence authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (e Evidence) Upsert(

--- a/pkg/coredata/export_job.go
+++ b/pkg/coredata/export_job.go
@@ -83,10 +83,11 @@ func (ej *ExportJob) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/export_job.go
+++ b/pkg/coredata/export_job.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/mail"
 )
 
@@ -63,19 +64,42 @@ var (
 )
 
 // AuthorizationAttributes returns the authorization attributes for policy evaluation.
-func (ej *ExportJob) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM export_jobs WHERE id = $1 LIMIT 1;`
+func (ej *ExportJob) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM export_jobs WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, ej.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query export job authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (ej *ExportJob) Insert(

--- a/pkg/coredata/file.go
+++ b/pkg/coredata/file.go
@@ -85,10 +85,11 @@ func (f *File) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/file.go
+++ b/pkg/coredata/file.go
@@ -26,6 +26,7 @@ import (
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/filemanager"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 )
 
 type (
@@ -65,19 +66,42 @@ func (f *File) GetMimeType() string {
 var _ filemanager.File = (*File)(nil)
 
 // AuthorizationAttributes returns the authorization attributes for policy evaluation.
-func (f *File) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM files WHERE id = $1 LIMIT 1;`
+func (f *File) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM files WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, f.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query file authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (f *File) LoadByID(

--- a/pkg/coredata/finding.go
+++ b/pkg/coredata/finding.go
@@ -92,10 +92,11 @@ func (f *Finding) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/finding.go
+++ b/pkg/coredata/finding.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -72,19 +73,42 @@ func (f *Finding) CursorKey(field FindingOrderField) page.CursorKey {
 	panic(fmt.Sprintf("unsupported order by: %s", field))
 }
 
-func (f *Finding) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM findings WHERE id = $1 LIMIT 1;`
+func (f *Finding) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM findings WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, f.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query finding authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (f *Finding) LoadByID(

--- a/pkg/coredata/framework.go
+++ b/pkg/coredata/framework.go
@@ -80,6 +80,7 @@ WHERE
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var (
 			frameworkID    gid.GID
@@ -88,10 +89,12 @@ WHERE
 		if err := rows.Scan(&frameworkID, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan framework authorization attributes batch: %w", err)
 		}
+
 		attrsByID[frameworkID] = policy.Attributes{
 			"organization_id": organizationID.String(),
 		}
 	}
+
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("cannot iterate framework authorization attributes batch: %w", err)
 	}

--- a/pkg/coredata/framework.go
+++ b/pkg/coredata/framework.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -53,20 +54,49 @@ func (f *Framework) CursorKey(orderBy FrameworkOrderField) page.CursorKey {
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-// AuthorizationAttributes returns the authorization attributes for policy evaluation.
-func (f *Framework) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM frameworks WHERE id = $1 LIMIT 1;`
+func (f *Framework) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	frameworkIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `
+SELECT
+    id,
+    organization_id
+FROM
+    frameworks
+WHERE
+    id = ANY(@framework_ids::text[])
+`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, f.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query framework authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"framework_ids": frameworkIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query framework authorization attributes batch: %w", err)
+	}
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var (
+			frameworkID    gid.GID
+			organizationID gid.GID
+		)
+		if err := rows.Scan(&frameworkID, &organizationID); err != nil {
+			return nil, fmt.Errorf("cannot scan framework authorization attributes batch: %w", err)
+		}
+		attrsByID[frameworkID] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate framework authorization attributes batch: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (f *Frameworks) CountByOrganizationID(
@@ -98,6 +128,22 @@ WHERE
 	}
 
 	return count, nil
+}
+
+func uniqueGIDs(values []gid.GID) []gid.GID {
+	set := make(map[gid.GID]struct{}, len(values))
+	unique := make([]gid.GID, 0, len(values))
+
+	for _, value := range values {
+		if _, ok := set[value]; ok {
+			continue
+		}
+
+		set[value] = struct{}{}
+		unique = append(unique, value)
+	}
+
+	return unique
 }
 
 func (f *Frameworks) LoadByOrganizationID(

--- a/pkg/coredata/identity.go
+++ b/pkg/coredata/identity.go
@@ -170,6 +170,7 @@ WHERE
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID, len(resourceIDs))
+
 	for rows.Next() {
 		var (
 			id           gid.GID

--- a/pkg/coredata/identity.go
+++ b/pkg/coredata/identity.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/mail"
 	"go.probo.inc/probo/pkg/page"
 )
@@ -143,7 +144,11 @@ LIMIT 1;
 
 // AuthorizationAttributes loads the minimal authorization attributes for policy condition evaluation.
 // It is intentionally lightweight and does not populate the Identity struct.
-func (i *Identity) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
+func (i *Identity) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
 	q := `
 SELECT
     id,
@@ -151,25 +156,41 @@ SELECT
 FROM
     identities
 WHERE
-    id = $1
+    id = ANY(@resource_ids::text[])
 `
 
-	var (
-		id           gid.GID
-		emailAddress string
-	)
-	if err := conn.QueryRow(ctx, q, i.ID).Scan(&id, &emailAddress); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query identity iam attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{
-		"identity_id": id.String(),
-		"email":       emailAddress,
-	}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query identity authorization attributes: %w", err)
+	}
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID, len(resourceIDs))
+	for rows.Next() {
+		var (
+			id           gid.GID
+			emailAddress string
+		)
+
+		if err := rows.Scan(&id, &emailAddress); err != nil {
+			return nil, fmt.Errorf("cannot scan identity authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"identity_id": id.String(),
+			"email":       emailAddress,
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate identity authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (i *Identity) Insert(

--- a/pkg/coredata/invitation.go
+++ b/pkg/coredata/invitation.go
@@ -170,6 +170,7 @@ WHERE
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID, len(resourceIDs))
+
 	for rows.Next() {
 		var (
 			id             gid.GID

--- a/pkg/coredata/invitation.go
+++ b/pkg/coredata/invitation.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -142,34 +143,56 @@ WHERE
 
 // AuthorizationAttributes loads the minimal authorization attributes for policy condition evaluation.
 // It is intentionally lightweight and does not populate the Invitation struct.
-func (i *Invitation) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
+func (i *Invitation) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
 	q := `
 SELECT
-    email, organization_id
+    id,
+    email,
+    organization_id
 FROM
     iam_invitations
 WHERE
-    id = $1
-LIMIT 1;
+    id = ANY(@resource_ids::text[])
 `
 
-	var (
-		email          string
-		organizationID gid.GID
-	)
-
-	if err := conn.QueryRow(ctx, q, i.ID).Scan(&email, &organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query invitation iam attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{
-		"email":           email,
-		"organization_id": organizationID.String(),
-	}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query invitation authorization attributes: %w", err)
+	}
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID, len(resourceIDs))
+	for rows.Next() {
+		var (
+			id             gid.GID
+			email          string
+			organizationID gid.GID
+		)
+
+		err = rows.Scan(&id, &email, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan invitation authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"email":           email,
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate invitation authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (i *Invitation) Update(ctx context.Context, conn pg.Tx, scope Scoper) error {

--- a/pkg/coredata/mailing_list.go
+++ b/pkg/coredata/mailing_list.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/mail"
 )
 
@@ -35,19 +36,42 @@ type MailingList struct {
 	UpdatedAt      time.Time  `db:"updated_at"`
 }
 
-func (ml *MailingList) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM mailing_lists WHERE id = $1 LIMIT 1;`
+func (ml *MailingList) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM mailing_lists WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, ml.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query mailing list authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (ml *MailingList) LoadByID(

--- a/pkg/coredata/mailing_list.go
+++ b/pkg/coredata/mailing_list.go
@@ -55,10 +55,11 @@ func (ml *MailingList) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/mailing_list_subscriber.go
+++ b/pkg/coredata/mailing_list_subscriber.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/mail"
 	"go.probo.inc/probo/pkg/page"
 )
@@ -44,19 +45,42 @@ type (
 	MailingListSubscribers []*MailingListSubscriber
 )
 
-func (cns *MailingListSubscriber) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM mailing_list_subscribers WHERE id = $1 LIMIT 1;`
+func (cns *MailingListSubscriber) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM mailing_list_subscribers WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, cns.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query mailing list subscriber authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (cns *MailingListSubscriber) CursorKey(orderBy MailingListSubscriberOrderField) page.CursorKey {

--- a/pkg/coredata/mailing_list_subscriber.go
+++ b/pkg/coredata/mailing_list_subscriber.go
@@ -64,10 +64,11 @@ func (cns *MailingListSubscriber) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/mailing_list_update.go
+++ b/pkg/coredata/mailing_list_update.go
@@ -73,10 +73,11 @@ func (mlu *MailingListUpdate) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/mailing_list_update.go
+++ b/pkg/coredata/mailing_list_update.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -53,19 +54,42 @@ func (mlu *MailingListUpdate) CursorKey(orderBy MailingListUpdateOrderField) pag
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (mlu *MailingListUpdate) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM mailing_list_updates WHERE id = $1 LIMIT 1;`
+func (mlu *MailingListUpdate) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM mailing_list_updates WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, mlu.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query mailing list update authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (mlu *MailingListUpdate) Insert(ctx context.Context, conn pg.Tx, scope Scoper) error {

--- a/pkg/coredata/measure.go
+++ b/pkg/coredata/measure.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -56,19 +57,42 @@ func (m Measure) CursorKey(orderBy MeasureOrderField) page.CursorKey {
 }
 
 // AuthorizationAttributes returns the authorization attributes for policy evaluation.
-func (m *Measure) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM measures WHERE id = $1 LIMIT 1;`
+func (m *Measure) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM measures WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, m.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query measure authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (m *Measures) CountByRiskID(

--- a/pkg/coredata/measure.go
+++ b/pkg/coredata/measure.go
@@ -76,10 +76,11 @@ func (m *Measure) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/membership.go
+++ b/pkg/coredata/membership.go
@@ -228,6 +228,7 @@ WHERE
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID, len(resourceIDs))
+
 	for rows.Next() {
 		var (
 			id             gid.GID

--- a/pkg/coredata/membership.go
+++ b/pkg/coredata/membership.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -199,42 +200,64 @@ WHERE
 	return nil
 }
 
-func (m *Membership) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
+func (m *Membership) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
 	q := `
 SELECT
+    id,
     identity_id,
     organization_id,
     role
 FROM
     iam_memberships
 WHERE
-    id = $1
-LIMIT 1;
+    id = ANY(@resource_ids::text[])
 `
 
-	var (
-		identityID     gid.GID
-		organizationID gid.GID
-		role           MembershipRole
-	)
-
-	if err := conn.QueryRow(ctx, q, m.ID).Scan(
-		&identityID,
-		&organizationID,
-		&role,
-	); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query membership iam attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{
-		"identity_id":     identityID.String(),
-		"organization_id": organizationID.String(),
-		"role":            role.String(),
-	}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query membership authorization attributes: %w", err)
+	}
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID, len(resourceIDs))
+	for rows.Next() {
+		var (
+			id             gid.GID
+			identityID     gid.GID
+			organizationID gid.GID
+			role           MembershipRole
+		)
+
+		err = rows.Scan(
+			&id,
+			&identityID,
+			&organizationID,
+			&role,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan membership authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"identity_id":     identityID.String(),
+			"organization_id": organizationID.String(),
+			"role":            role.String(),
+		}
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate membership authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (m *Membership) LoadByIdentityAndOrg(

--- a/pkg/coredata/membership_profile.go
+++ b/pkg/coredata/membership_profile.go
@@ -115,6 +115,7 @@ WHERE
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID, len(resourceIDs))
+
 	for rows.Next() {
 		var (
 			id             gid.GID

--- a/pkg/coredata/membership_profile.go
+++ b/pkg/coredata/membership_profile.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/mail"
 	"go.probo.inc/probo/pkg/page"
 )
@@ -87,26 +88,56 @@ func (p MembershipProfile) CursorKey(orderBy MembershipProfileOrderField) page.C
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (p *MembershipProfile) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id, identity_id FROM iam_membership_profiles WHERE id = $1 LIMIT 1;`
+func (p *MembershipProfile) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `
+SELECT
+    id,
+    organization_id,
+    identity_id
+FROM
+    iam_membership_profiles
+WHERE
+    id = ANY(@resource_ids::text[])
+`
 
-	var (
-		organizationID gid.GID
-		identityID     gid.GID
-	)
-
-	if err := conn.QueryRow(ctx, q, p.ID).Scan(&organizationID, &identityID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query profile authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{
-		"organization_id": organizationID.String(),
-		"identity_id":     identityID.String(),
-	}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query profile authorization attributes: %w", err)
+	}
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID, len(resourceIDs))
+	for rows.Next() {
+		var (
+			id             gid.GID
+			organizationID gid.GID
+			identityID     gid.GID
+		)
+
+		err = rows.Scan(&id, &organizationID, &identityID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan profile authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+			"identity_id":     identityID.String(),
+		}
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate profile authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (p *MembershipProfile) LoadByID(

--- a/pkg/coredata/oauth2_client.go
+++ b/pkg/coredata/oauth2_client.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 	"go.probo.inc/probo/pkg/uri"
 )
@@ -72,32 +73,55 @@ func (c *OAuth2Client) CursorKey(orderBy OAuth2ClientOrderField) page.CursorKey 
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (c *OAuth2Client) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
+func (c *OAuth2Client) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
 	q := `
 SELECT
-	organization_id
+    id,
+    organization_id
 FROM
-	iam_oauth2_clients
+    iam_oauth2_clients
 WHERE
-	id = $1
-LIMIT 1;
+    id = ANY(@resource_ids::text[])
 `
 
-	var organizationID *gid.GID
-	if err := conn.QueryRow(ctx, q, c.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
+	}
 
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
 		return nil, fmt.Errorf("cannot query oauth2 client authorization attributes: %w", err)
 	}
+	defer rows.Close()
 
-	attrs := make(map[string]string)
-	if organizationID != nil {
-		attrs["organization_id"] = organizationID.String()
+	attrsByID := make(policy.AttributesByID, len(resourceIDs))
+	for rows.Next() {
+		var (
+			id             gid.GID
+			organizationID *gid.GID
+		)
+
+		err = rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan oauth2 client authorization attributes: %w", err)
+		}
+
+		attrs := make(map[string]string)
+		if organizationID != nil {
+			attrs["organization_id"] = organizationID.String()
+		}
+		attrsByID[id] = attrs
 	}
 
-	return attrs, nil
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate oauth2 client authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (c *OAuth2Client) LoadByID(

--- a/pkg/coredata/oauth2_client.go
+++ b/pkg/coredata/oauth2_client.go
@@ -99,6 +99,7 @@ WHERE
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID, len(resourceIDs))
+
 	for rows.Next() {
 		var (
 			id             gid.GID
@@ -114,6 +115,7 @@ WHERE
 		if organizationID != nil {
 			attrs["organization_id"] = organizationID.String()
 		}
+
 		attrsByID[id] = attrs
 	}
 

--- a/pkg/coredata/oauth2_consent.go
+++ b/pkg/coredata/oauth2_consent.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 	"go.probo.inc/probo/pkg/uri"
 )
@@ -58,31 +59,56 @@ func (c *OAuth2Consent) CursorKey(orderBy OAuth2ConsentOrderField) page.CursorKe
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (c *OAuth2Consent) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
+func (c *OAuth2Consent) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
 	q := `
 SELECT
-	identity_id,
-	session_id
+    id,
+    identity_id,
+    session_id
 FROM
-	iam_oauth2_consents
+    iam_oauth2_consents
 WHERE
-	id = $1
-LIMIT 1;
+    id = ANY(@resource_ids::text[])
 `
 
-	var identityID, sessionID gid.GID
-	if err := conn.QueryRow(ctx, q, c.ID).Scan(&identityID, &sessionID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query oauth2_consent authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{
-		"identity_id": identityID.String(),
-		"session_id":  sessionID.String(),
-	}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query oauth2 consent authorization attributes: %w", err)
+	}
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID, len(resourceIDs))
+	for rows.Next() {
+		var (
+			id         gid.GID
+			identityID gid.GID
+			sessionID  gid.GID
+		)
+
+		err = rows.Scan(&id, &identityID, &sessionID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan oauth2 consent authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"identity_id": identityID.String(),
+			"session_id":  sessionID.String(),
+		}
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate oauth2 consent authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (c *OAuth2Consent) LoadByID(

--- a/pkg/coredata/oauth2_consent.go
+++ b/pkg/coredata/oauth2_consent.go
@@ -86,6 +86,7 @@ WHERE
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID, len(resourceIDs))
+
 	for rows.Next() {
 		var (
 			id         gid.GID

--- a/pkg/coredata/obligation.go
+++ b/pkg/coredata/obligation.go
@@ -83,10 +83,11 @@ func (o *Obligation) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/obligation.go
+++ b/pkg/coredata/obligation.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -63,19 +64,42 @@ func (o *Obligation) CursorKey(field ObligationOrderField) page.CursorKey {
 	panic(fmt.Sprintf("unsupported order by: %s", field))
 }
 
-func (o *Obligation) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM obligations WHERE id = $1 LIMIT 1;`
+func (o *Obligation) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM obligations WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, o.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query obligation authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (o *Obligation) LoadByID(

--- a/pkg/coredata/organization.go
+++ b/pkg/coredata/organization.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -46,19 +47,41 @@ type (
 	Organizations []*Organization
 )
 
-func (o *Organization) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT id FROM organizations WHERE id = $1 LIMIT 1;`
+func (o *Organization) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id FROM organizations WHERE id = ANY(@resource_ids::text[])`
 
-	var id gid.GID
-	if err := conn.QueryRow(ctx, q, o.ID).Scan(&id); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query organization authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": o.ID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id gid.GID
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": id.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (o Organization) CursorKey(orderBy OrganizationOrderField) page.CursorKey {

--- a/pkg/coredata/organization.go
+++ b/pkg/coredata/organization.go
@@ -66,6 +66,7 @@ func (o *Organization) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id gid.GID
 		if err := rows.Scan(&id); err != nil {

--- a/pkg/coredata/personal_api_key.go
+++ b/pkg/coredata/personal_api_key.go
@@ -120,6 +120,7 @@ WHERE
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID, len(resourceIDs))
+
 	for rows.Next() {
 		var (
 			id         gid.GID

--- a/pkg/coredata/personal_api_key.go
+++ b/pkg/coredata/personal_api_key.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -93,19 +94,51 @@ LIMIT 1;
 	return nil
 }
 
-func (a *PersonalAPIKey) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := "SELECT identity_id FROM iam_personal_api_keys WHERE id = $1 LIMIT 1;"
+func (a *PersonalAPIKey) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `
+SELECT
+    id,
+    identity_id
+FROM
+    iam_personal_api_keys
+WHERE
+    id = ANY(@resource_ids::text[])
+`
 
-	var identityID gid.GID
-	if err := conn.QueryRow(ctx, q, a.ID).Scan(&identityID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query personal api key iam attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"identity_id": identityID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query personal api key authorization attributes: %w", err)
+	}
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID, len(resourceIDs))
+	for rows.Next() {
+		var (
+			id         gid.GID
+			identityID gid.GID
+		)
+
+		err = rows.Scan(&id, &identityID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan personal api key authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{"identity_id": identityID.String()}
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate personal api key authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (a *PersonalAPIKeys) LoadByIdentityID(

--- a/pkg/coredata/processing_activities.go
+++ b/pkg/coredata/processing_activities.go
@@ -196,10 +196,11 @@ func (p *ProcessingActivity) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/processing_activities.go
+++ b/pkg/coredata/processing_activities.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -176,19 +177,42 @@ func (p *ProcessingActivity) CursorKey(field ProcessingActivityOrderField) page.
 	panic(fmt.Sprintf("unsupported order by: %s", field))
 }
 
-func (p *ProcessingActivity) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM processing_activities WHERE id = $1 LIMIT 1;`
+func (p *ProcessingActivity) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM processing_activities WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, p.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query processing activity authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (p *ProcessingActivity) LoadByID(

--- a/pkg/coredata/report.go
+++ b/pkg/coredata/report.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -42,19 +43,42 @@ type (
 	Reports []*Report
 )
 
-func (r *Report) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM reports WHERE id = $1 LIMIT 1;`
+func (r *Report) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM reports WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, r.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query report authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (r *Report) LoadByID(

--- a/pkg/coredata/report.go
+++ b/pkg/coredata/report.go
@@ -62,10 +62,11 @@ func (r *Report) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/rights_requests.go
+++ b/pkg/coredata/rights_requests.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -61,19 +62,42 @@ func (rr *RightsRequest) CursorKey(field RightsRequestOrderField) page.CursorKey
 }
 
 // AuthorizationAttributes returns the authorization attributes for policy evaluation.
-func (rr *RightsRequest) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM rights_requests WHERE id = $1 LIMIT 1;`
+func (rr *RightsRequest) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM rights_requests WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, rr.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query rights request authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (rr *RightsRequest) LoadByID(

--- a/pkg/coredata/rights_requests.go
+++ b/pkg/coredata/rights_requests.go
@@ -81,10 +81,11 @@ func (rr *RightsRequest) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/risk.go
+++ b/pkg/coredata/risk.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -182,19 +183,42 @@ func (r *Risk) CursorKey(orderBy RiskOrderField) page.CursorKey {
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (r *Risk) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM risks WHERE id = $1 LIMIT 1;`
+func (r *Risk) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM risks WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, r.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query risk authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (r *Risks) CountByMeasureID(

--- a/pkg/coredata/risk.go
+++ b/pkg/coredata/risk.go
@@ -202,10 +202,11 @@ func (r *Risk) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/risk_assessment.go
+++ b/pkg/coredata/risk_assessment.go
@@ -71,10 +71,11 @@ func (ra *RiskAssessment) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/risk_assessment.go
+++ b/pkg/coredata/risk_assessment.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -51,19 +52,42 @@ func (ra *RiskAssessment) CursorKey(orderBy RiskAssessmentOrderField) page.Curso
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (ra *RiskAssessment) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM risk_assessments WHERE id = $1 LIMIT 1;`
+func (ra *RiskAssessment) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM risk_assessments WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, ra.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query risk assessment authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (ra *RiskAssessments) CountByOrganizationID(

--- a/pkg/coredata/risk_assessment_node.go
+++ b/pkg/coredata/risk_assessment_node.go
@@ -73,10 +73,11 @@ func (n *RiskAssessmentNode) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/risk_assessment_node.go
+++ b/pkg/coredata/risk_assessment_node.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -53,19 +54,42 @@ func (n *RiskAssessmentNode) CursorKey(orderBy RiskAssessmentNodeOrderField) pag
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (n *RiskAssessmentNode) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM risk_assessment_nodes WHERE id = $1 LIMIT 1;`
+func (n *RiskAssessmentNode) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM risk_assessment_nodes WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, n.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query risk assessment node authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (ns *RiskAssessmentNodes) LoadByRiskAssessmentScopeID(

--- a/pkg/coredata/risk_assessment_process.go
+++ b/pkg/coredata/risk_assessment_process.go
@@ -74,10 +74,11 @@ func (p *RiskAssessmentProcess) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/risk_assessment_process.go
+++ b/pkg/coredata/risk_assessment_process.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -54,19 +55,42 @@ func (p *RiskAssessmentProcess) CursorKey(orderBy RiskAssessmentProcessOrderFiel
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (p *RiskAssessmentProcess) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM risk_assessment_processes WHERE id = $1 LIMIT 1;`
+func (p *RiskAssessmentProcess) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM risk_assessment_processes WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, p.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query risk assessment process authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (ps *RiskAssessmentProcesses) LoadByRiskAssessmentScopeID(

--- a/pkg/coredata/risk_assessment_scenario.go
+++ b/pkg/coredata/risk_assessment_scenario.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -52,19 +53,42 @@ func (s *RiskAssessmentScenario) CursorKey(orderBy RiskAssessmentScenarioOrderFi
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (s *RiskAssessmentScenario) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM risk_assessment_scenarios WHERE id = $1 LIMIT 1;`
+func (s *RiskAssessmentScenario) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM risk_assessment_scenarios WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, s.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query risk scenario authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (ss *RiskAssessmentScenarios) LoadByOrganizationID(

--- a/pkg/coredata/risk_assessment_scenario.go
+++ b/pkg/coredata/risk_assessment_scenario.go
@@ -72,10 +72,11 @@ func (s *RiskAssessmentScenario) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/risk_assessment_scope.go
+++ b/pkg/coredata/risk_assessment_scope.go
@@ -71,10 +71,11 @@ func (s *RiskAssessmentScope) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/risk_assessment_scope.go
+++ b/pkg/coredata/risk_assessment_scope.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -51,19 +52,42 @@ func (s *RiskAssessmentScope) CursorKey(orderBy RiskAssessmentScopeOrderField) p
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (s *RiskAssessmentScope) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM risk_assessment_scopes WHERE id = $1 LIMIT 1;`
+func (s *RiskAssessmentScope) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM risk_assessment_scopes WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, s.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query risk assessment scope authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (ss *RiskAssessmentScopes) LoadByRiskAssessmentID(

--- a/pkg/coredata/risk_assessment_threat.go
+++ b/pkg/coredata/risk_assessment_threat.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -54,19 +55,42 @@ func (t *RiskAssessmentThreat) CursorKey(orderBy RiskAssessmentThreatOrderField)
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (t *RiskAssessmentThreat) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM risk_assessment_threats WHERE id = $1 LIMIT 1;`
+func (t *RiskAssessmentThreat) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM risk_assessment_threats WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, t.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query risk assessment threat authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (ts *RiskAssessmentThreats) LoadByRiskAssessmentScopeID(

--- a/pkg/coredata/risk_assessment_threat.go
+++ b/pkg/coredata/risk_assessment_threat.go
@@ -74,10 +74,11 @@ func (t *RiskAssessmentThreat) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/saml_configuration.go
+++ b/pkg/coredata/saml_configuration.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -63,19 +64,42 @@ func (s *SAMLConfiguration) CursorKey(orderBy SAMLConfigurationOrderField) page.
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (s *SAMLConfiguration) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM iam_saml_configurations WHERE id = $1 LIMIT 1;`
+func (s *SAMLConfiguration) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM iam_saml_configurations WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, s.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query saml configuration authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (s *SAMLConfiguration) GetIdPCertificate() (*x509.Certificate, error) {

--- a/pkg/coredata/saml_configuration.go
+++ b/pkg/coredata/saml_configuration.go
@@ -83,10 +83,11 @@ func (s *SAMLConfiguration) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/scim_bridge.go
+++ b/pkg/coredata/scim_bridge.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -60,19 +61,42 @@ func (s *SCIMBridge) CursorKey(orderBy SCIMBridgeOrderField) page.CursorKey {
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (s *SCIMBridge) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM iam_scim_bridges WHERE id = $1 LIMIT 1;`
+func (s *SCIMBridge) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM iam_scim_bridges WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, s.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query scim bridge authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (s *SCIMBridge) LoadByID(

--- a/pkg/coredata/scim_bridge.go
+++ b/pkg/coredata/scim_bridge.go
@@ -80,10 +80,11 @@ func (s *SCIMBridge) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/scim_configuration.go
+++ b/pkg/coredata/scim_configuration.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -50,19 +51,42 @@ func (s *SCIMConfiguration) CursorKey(orderBy SCIMConfigurationOrderField) page.
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (s *SCIMConfiguration) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM iam_scim_configurations WHERE id = $1 LIMIT 1;`
+func (s *SCIMConfiguration) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM iam_scim_configurations WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, s.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query scim configuration authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (s *SCIMConfiguration) LoadByID(

--- a/pkg/coredata/scim_configuration.go
+++ b/pkg/coredata/scim_configuration.go
@@ -70,10 +70,11 @@ func (s *SCIMConfiguration) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/scim_event.go
+++ b/pkg/coredata/scim_event.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -56,19 +57,42 @@ func (s *SCIMEvent) CursorKey(orderBy SCIMEventOrderField) page.CursorKey {
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (s *SCIMEvent) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM iam_scim_events WHERE id = $1 LIMIT 1;`
+func (s *SCIMEvent) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM iam_scim_events WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, s.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query scim event authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (s *SCIMEvent) LoadByID(

--- a/pkg/coredata/scim_event.go
+++ b/pkg/coredata/scim_event.go
@@ -76,10 +76,11 @@ func (s *SCIMEvent) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/session.go
+++ b/pkg/coredata/session.go
@@ -221,6 +221,7 @@ WHERE
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID, len(resourceIDs))
+
 	for rows.Next() {
 		var (
 			id         gid.GID

--- a/pkg/coredata/session.go
+++ b/pkg/coredata/session.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -194,27 +195,51 @@ LIMIT 1;
 
 // AuthorizationAttributes loads the minimal authorization attributes for policy condition evaluation.
 // It is intentionally lightweight and does not populate the Session struct.
-func (s *Session) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
+func (s *Session) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
 	q := `
 SELECT
+    id,
     identity_id
 FROM
     iam_sessions
 WHERE
-    id = $1
-LIMIT 1;
+    id = ANY(@resource_ids::text[])
 `
 
-	var identityID gid.GID
-	if err := conn.QueryRow(ctx, q, s.ID).Scan(&identityID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query session iam attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"identity_id": identityID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query session authorization attributes: %w", err)
+	}
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID, len(resourceIDs))
+	for rows.Next() {
+		var (
+			id         gid.GID
+			identityID gid.GID
+		)
+
+		err = rows.Scan(&id, &identityID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan session authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{"identity_id": identityID.String()}
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate session authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (s *Session) Insert(

--- a/pkg/coredata/slack_message.go
+++ b/pkg/coredata/slack_message.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/mail"
 )
 
@@ -57,19 +58,42 @@ func (e ErrSlackMessageNotFound) Error() string {
 	return "slack message not found"
 }
 
-func (sm *SlackMessage) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM slack_messages WHERE id = $1 LIMIT 1;`
+func (sm *SlackMessage) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM slack_messages WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, sm.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query slack message authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func NewSlackMessage(

--- a/pkg/coredata/slack_message.go
+++ b/pkg/coredata/slack_message.go
@@ -77,10 +77,11 @@ func (sm *SlackMessage) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/statement_of_applicability.go
+++ b/pkg/coredata/statement_of_applicability.go
@@ -72,10 +72,11 @@ func (s *StatementOfApplicability) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/statement_of_applicability.go
+++ b/pkg/coredata/statement_of_applicability.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -52,19 +53,42 @@ func (s StatementOfApplicability) CursorKey(orderBy StatementOfApplicabilityOrde
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (s *StatementOfApplicability) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM statements_of_applicability WHERE id = $1 LIMIT 1;`
+func (s *StatementOfApplicability) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM statements_of_applicability WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, s.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query statement of applicability authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (s *StatementOfApplicability) LoadByID(

--- a/pkg/coredata/task.go
+++ b/pkg/coredata/task.go
@@ -83,10 +83,11 @@ func (t *Task) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/task.go
+++ b/pkg/coredata/task.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -63,19 +64,42 @@ func (t Task) CursorKey(orderBy TaskOrderField) page.CursorKey {
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (t *Task) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM tasks WHERE id = $1 LIMIT 1;`
+func (t *Task) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM tasks WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, t.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query task authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (t *Task) LoadByID(

--- a/pkg/coredata/third_party.go
+++ b/pkg/coredata/third_party.go
@@ -201,10 +201,11 @@ func (v *ThirdParty) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/third_party.go
+++ b/pkg/coredata/third_party.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -181,19 +182,42 @@ func (v ThirdParty) CursorKey(orderBy ThirdPartyOrderField) page.CursorKey {
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (v *ThirdParty) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM third_parties WHERE id = $1 LIMIT 1;`
+func (v *ThirdParty) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM third_parties WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, v.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query thirdParty authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (v *ThirdParty) LoadByID(

--- a/pkg/coredata/third_party_business_associate_agreement.go
+++ b/pkg/coredata/third_party_business_associate_agreement.go
@@ -72,10 +72,11 @@ func (vbaa *ThirdPartyBusinessAssociateAgreement) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/third_party_business_associate_agreement.go
+++ b/pkg/coredata/third_party_business_associate_agreement.go
@@ -16,7 +16,6 @@ package coredata
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"maps"
 	"time"
@@ -24,6 +23,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -53,19 +53,42 @@ func (v ThirdPartyBusinessAssociateAgreement) CursorKey(orderBy ThirdPartyBusine
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (vbaa *ThirdPartyBusinessAssociateAgreement) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM third_party_business_associate_agreements WHERE id = $1 LIMIT 1;`
+func (vbaa *ThirdPartyBusinessAssociateAgreement) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM third_party_business_associate_agreements WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, vbaa.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query thirdParty business associate agreement authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (vbaa *ThirdPartyBusinessAssociateAgreement) LoadByThirdPartyID(

--- a/pkg/coredata/third_party_compliance_report.go
+++ b/pkg/coredata/third_party_compliance_report.go
@@ -16,7 +16,6 @@ package coredata
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"maps"
 	"time"
@@ -24,6 +23,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -54,19 +54,42 @@ func (c ThirdPartyComplianceReport) CursorKey(orderBy ThirdPartyComplianceReport
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (v *ThirdPartyComplianceReport) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM third_party_compliance_reports WHERE id = $1 LIMIT 1;`
+func (v *ThirdPartyComplianceReport) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM third_party_compliance_reports WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, v.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query thirdParty compliance report authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (vcs *ThirdPartyComplianceReports) LoadForThirdPartyID(

--- a/pkg/coredata/third_party_compliance_report.go
+++ b/pkg/coredata/third_party_compliance_report.go
@@ -73,10 +73,11 @@ func (v *ThirdPartyComplianceReport) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/third_party_contact.go
+++ b/pkg/coredata/third_party_contact.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/mail"
 	"go.probo.inc/probo/pkg/page"
 )
@@ -57,19 +58,42 @@ func (vc ThirdPartyContact) CursorKey(orderBy ThirdPartyContactOrderField) page.
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (vc *ThirdPartyContact) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM third_party_contacts WHERE id = $1 LIMIT 1;`
+func (vc *ThirdPartyContact) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM third_party_contacts WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, vc.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query thirdParty contact authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (vc *ThirdPartyContact) LoadByID(

--- a/pkg/coredata/third_party_contact.go
+++ b/pkg/coredata/third_party_contact.go
@@ -77,10 +77,11 @@ func (vc *ThirdPartyContact) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/third_party_data_privacy_agreement.go
+++ b/pkg/coredata/third_party_data_privacy_agreement.go
@@ -72,10 +72,11 @@ func (vdpa *ThirdPartyDataPrivacyAgreement) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/third_party_data_privacy_agreement.go
+++ b/pkg/coredata/third_party_data_privacy_agreement.go
@@ -16,7 +16,6 @@ package coredata
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"maps"
 	"time"
@@ -24,6 +23,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -53,19 +53,42 @@ func (v ThirdPartyDataPrivacyAgreement) CursorKey(orderBy ThirdPartyDataPrivacyA
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (vdpa *ThirdPartyDataPrivacyAgreement) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM third_party_data_privacy_agreements WHERE id = $1 LIMIT 1;`
+func (vdpa *ThirdPartyDataPrivacyAgreement) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM third_party_data_privacy_agreements WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, vdpa.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query thirdParty data privacy agreement authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (vdpa *ThirdPartyDataPrivacyAgreement) LoadByThirdPartyID(

--- a/pkg/coredata/third_party_risk_assessment.go
+++ b/pkg/coredata/third_party_risk_assessment.go
@@ -74,10 +74,11 @@ func (v *ThirdPartyRiskAssessment) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/third_party_risk_assessment.go
+++ b/pkg/coredata/third_party_risk_assessment.go
@@ -16,7 +16,6 @@ package coredata
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"maps"
 	"time"
@@ -24,6 +23,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -55,19 +55,42 @@ func (v ThirdPartyRiskAssessment) CursorKey(orderBy ThirdPartyRiskAssessmentOrde
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (v *ThirdPartyRiskAssessment) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM third_party_risk_assessments WHERE id = $1 LIMIT 1;`
+func (v *ThirdPartyRiskAssessment) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM third_party_risk_assessments WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, v.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query thirdParty risk assessment authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 // Insert adds a new risk assessment to the database

--- a/pkg/coredata/third_party_service.go
+++ b/pkg/coredata/third_party_service.go
@@ -72,10 +72,11 @@ func (vs *ThirdPartyService) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/third_party_service.go
+++ b/pkg/coredata/third_party_service.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -52,19 +53,42 @@ func (vs ThirdPartyService) CursorKey(orderBy ThirdPartyServiceOrderField) page.
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (vs *ThirdPartyService) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM third_party_services WHERE id = $1 LIMIT 1;`
+func (vs *ThirdPartyService) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM third_party_services WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, vs.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query thirdParty service authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (vs *ThirdPartyService) LoadByID(

--- a/pkg/coredata/tracker_pattern.go
+++ b/pkg/coredata/tracker_pattern.go
@@ -99,10 +99,11 @@ func (tp *TrackerPattern) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/tracker_pattern.go
+++ b/pkg/coredata/tracker_pattern.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -79,19 +80,42 @@ func (tp *TrackerPattern) CursorKey(field TrackerPatternOrderField) page.CursorK
 	panic(fmt.Sprintf("unsupported order by: %s", field))
 }
 
-func (tp *TrackerPattern) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM tracker_patterns WHERE id = $1 LIMIT 1;`
+func (tp *TrackerPattern) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM tracker_patterns WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, tp.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query tracker pattern authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (tp *TrackerPattern) LoadByID(

--- a/pkg/coredata/tracker_resource.go
+++ b/pkg/coredata/tracker_resource.go
@@ -87,10 +87,11 @@ func (tr *TrackerResource) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/tracker_resource.go
+++ b/pkg/coredata/tracker_resource.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -67,19 +68,42 @@ func (tr *TrackerResource) CursorKey(field TrackerResourceOrderField) page.Curso
 	panic(fmt.Sprintf("unsupported order by: %s", field))
 }
 
-func (tr *TrackerResource) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM tracker_resources WHERE id = $1 LIMIT 1;`
+func (tr *TrackerResource) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM tracker_resources WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, tr.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query tracker resource authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (tr *TrackerResource) LoadByID(

--- a/pkg/coredata/transfer_impact_assessment.go
+++ b/pkg/coredata/transfer_impact_assessment.go
@@ -182,10 +182,11 @@ func (tia *TransferImpactAssessment) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/transfer_impact_assessment.go
+++ b/pkg/coredata/transfer_impact_assessment.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -162,19 +163,42 @@ func (tia *TransferImpactAssessment) CursorKey(field TransferImpactAssessmentOrd
 	panic(fmt.Sprintf("unsupported order by: %s", field))
 }
 
-func (tia *TransferImpactAssessment) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM processing_activity_transfer_impact_assessments WHERE id = $1 LIMIT 1;`
+func (tia *TransferImpactAssessment) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM processing_activity_transfer_impact_assessments WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, tia.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query transfer impact assessment authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (tias *TransferImpactAssessments) CountByOrganizationID(

--- a/pkg/coredata/trust_center.go
+++ b/pkg/coredata/trust_center.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -56,19 +57,42 @@ func (tc *TrustCenter) CursorKey(orderBy TrustCenterOrderField) page.CursorKey {
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (tc *TrustCenter) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM trust_centers WHERE id = $1 LIMIT 1;`
+func (tc *TrustCenter) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM trust_centers WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, tc.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query trust center authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (tc *TrustCenter) LoadByID(

--- a/pkg/coredata/trust_center.go
+++ b/pkg/coredata/trust_center.go
@@ -76,10 +76,11 @@ func (tc *TrustCenter) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/trust_center_access.go
+++ b/pkg/coredata/trust_center_access.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -52,19 +53,42 @@ func (tca *TrustCenterAccess) CursorKey(orderBy TrustCenterAccessOrderField) pag
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (tca *TrustCenterAccess) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM trust_center_accesses WHERE id = $1 LIMIT 1;`
+func (tca *TrustCenterAccess) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM trust_center_accesses WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, tca.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query trust center access authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (tca *TrustCenterAccess) LoadByID(

--- a/pkg/coredata/trust_center_access.go
+++ b/pkg/coredata/trust_center_access.go
@@ -72,10 +72,11 @@ func (tca *TrustCenterAccess) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/trust_center_document_access.go
+++ b/pkg/coredata/trust_center_document_access.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -53,19 +54,42 @@ func (tcda *TrustCenterDocumentAccess) CursorKey(orderBy TrustCenterDocumentAcce
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (tcda *TrustCenterDocumentAccess) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM trust_center_document_accesses WHERE id = $1 LIMIT 1;`
+func (tcda *TrustCenterDocumentAccess) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM trust_center_document_accesses WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, tcda.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query trust center document access authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (tcda *TrustCenterDocumentAccess) LoadByID(

--- a/pkg/coredata/trust_center_document_access.go
+++ b/pkg/coredata/trust_center_document_access.go
@@ -73,10 +73,11 @@ func (tcda *TrustCenterDocumentAccess) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/trust_center_file.go
+++ b/pkg/coredata/trust_center_file.go
@@ -74,10 +74,11 @@ func (t *TrustCenterFile) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/trust_center_file.go
+++ b/pkg/coredata/trust_center_file.go
@@ -16,7 +16,6 @@ package coredata
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"maps"
 	"time"
@@ -24,6 +23,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -55,19 +55,42 @@ func (t TrustCenterFile) CursorKey(orderBy TrustCenterFileOrderField) page.Curso
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (t *TrustCenterFile) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM trust_center_files WHERE id = $1 LIMIT 1;`
+func (t *TrustCenterFile) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM trust_center_files WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, t.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query trust center file authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (t *TrustCenterFile) LoadByID(

--- a/pkg/coredata/trust_center_reference.go
+++ b/pkg/coredata/trust_center_reference.go
@@ -80,10 +80,11 @@ func (t *TrustCenterReference) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/trust_center_reference.go
+++ b/pkg/coredata/trust_center_reference.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"go.gearno.de/kit/pg"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -60,19 +61,42 @@ func (t TrustCenterReference) CursorKey(orderBy TrustCenterReferenceOrderField) 
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
 }
 
-func (t *TrustCenterReference) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM trust_center_references WHERE id = $1 LIMIT 1;`
+func (t *TrustCenterReference) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM trust_center_references WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, t.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query trust center reference authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (t *TrustCenterReference) LoadByID(

--- a/pkg/coredata/webhook_subscription.go
+++ b/pkg/coredata/webhook_subscription.go
@@ -104,10 +104,11 @@ func (w *WebhookSubscription) AuthorizationAttributes(
 	defer rows.Close()
 
 	attrsByID := make(policy.AttributesByID)
+
 	for rows.Next() {
 		var id, organizationID gid.GID
-		err := rows.Scan(&id, &organizationID)
-		if err != nil {
+
+		if err := rows.Scan(&id, &organizationID); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 

--- a/pkg/coredata/webhook_subscription.go
+++ b/pkg/coredata/webhook_subscription.go
@@ -26,6 +26,7 @@ import (
 	"go.probo.inc/probo/pkg/crypto/cipher"
 	"go.probo.inc/probo/pkg/crypto/rand"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/page"
 )
 
@@ -84,19 +85,42 @@ func (w WebhookSubscription) CursorKey(orderBy WebhookSubscriptionOrderField) pa
 }
 
 // AuthorizationAttributes returns the authorization attributes for policy evaluation.
-func (w *WebhookSubscription) AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error) {
-	q := `SELECT organization_id FROM webhook_subscriptions WHERE id = $1 LIMIT 1;`
+func (w *WebhookSubscription) AuthorizationAttributes(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	q := `SELECT id, organization_id FROM webhook_subscriptions WHERE id = ANY(@resource_ids::text[])`
 
-	var organizationID gid.GID
-	if err := conn.QueryRow(ctx, q, w.ID).Scan(&organizationID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrResourceNotFound
-		}
-
-		return nil, fmt.Errorf("cannot query webhook subscription authorization attributes: %w", err)
+	args := pgx.StrictNamedArgs{
+		"resource_ids": resourceIDs,
 	}
 
-	return map[string]string{"organization_id": organizationID.String()}, nil
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query authorization attributes: %w", err)
+	}
+
+	defer rows.Close()
+
+	attrsByID := make(policy.AttributesByID)
+	for rows.Next() {
+		var id, organizationID gid.GID
+		err := rows.Scan(&id, &organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
+		}
+
+		attrsByID[id] = policy.Attributes{
+			"organization_id": organizationID.String(),
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("cannot iterate authorization attributes: %w", err)
+	}
+
+	return attrsByID, nil
 }
 
 func (w *WebhookSubscription) LoadByID(

--- a/pkg/iam/authorizer.go
+++ b/pkg/iam/authorizer.go
@@ -16,10 +16,10 @@ package iam
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
+	"slices"
 	"strings"
 	"time"
 
@@ -30,10 +30,14 @@ import (
 	"go.probo.inc/probo/pkg/iam/policy"
 )
 
-// AuthorizationAttributer is implemented by entities that provide attributes
-// for policy condition evaluation.
+// AuthorizationAttributer is implemented by entities that can provide
+// authorization attributes for multiple resources in one query.
 type AuthorizationAttributer interface {
-	AuthorizationAttributes(ctx context.Context, conn pg.Querier) (map[string]string, error)
+	AuthorizationAttributes(
+		ctx context.Context,
+		conn pg.Querier,
+		resourceIDs []gid.GID,
+	) (policy.AttributesByID, error)
 }
 
 // AuthorizeParams contains the parameters for an authorization request.
@@ -42,9 +46,38 @@ type AuthorizeParams struct {
 	Resource            gid.GID
 	Session             *gid.GID
 	Action              string
-	ResourceAttributes  map[string]string
+	ResourceAttributes  policy.Attributes
 	DryRun              bool
 	SkipAssumptionCheck bool
+}
+
+// AuthorizeBatchParams contains the parameters for a batch authorization request.
+type AuthorizeBatchParams struct {
+	Principal           gid.GID
+	Session             *gid.GID
+	Action              string
+	Resources           []gid.GID
+	ResourceAttributes  policy.Attributes
+	DryRun              bool
+	SkipAssumptionCheck bool
+}
+
+// MultiAuthorizeItem contains one authorization request in a multi-authorization batch.
+// ResourceAttributes are merged on top of the resource attributes loaded
+// for the resource before the policy is evaluated.
+type MultiAuthorizeItem struct {
+	Resource            gid.GID
+	Action              string
+	ResourceAttributes  policy.Attributes
+	DryRun              bool
+	SkipAssumptionCheck bool
+}
+
+// AuthorizeMultiParams contains the parameters for a multi-authorization request.
+type AuthorizeMultiParams struct {
+	Principal gid.GID
+	Session   *gid.GID
+	Items     []MultiAuthorizeItem
 }
 
 // Authorizer evaluates authorization requests against registered policies.
@@ -72,58 +105,303 @@ func (a *Authorizer) RegisterPolicySet(ps *PolicySet) {
 
 // Authorize checks if the principal is allowed to perform the action on the resource.
 func (a *Authorizer) Authorize(ctx context.Context, params AuthorizeParams) (*coredata.Scope, error) {
+	return a.AuthorizeBatch(
+		ctx,
+		AuthorizeBatchParams{
+			Principal:           params.Principal,
+			Session:             params.Session,
+			Action:              params.Action,
+			Resources:           []gid.GID{params.Resource},
+			ResourceAttributes:  params.ResourceAttributes,
+			DryRun:              params.DryRun,
+			SkipAssumptionCheck: params.SkipAssumptionCheck,
+		},
+	)
+}
+
+// AuthorizeBatch checks whether the principal is allowed to perform the action
+// on all provided resources.
+func (a *Authorizer) AuthorizeBatch(ctx context.Context, params AuthorizeBatchParams) (*coredata.Scope, error) {
 	if params.Principal.EntityType() != coredata.IdentityEntityType {
 		return nil, NewUnsupportedPrincipalTypeError(params.Principal.EntityType())
 	}
 
-	var scope *coredata.Scope
+	if len(params.Resources) == 0 {
+		return nil, NewEmptyResourceBatchError(params.Action)
+	}
 
-	if err := a.pg.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
-		authorizedScope, err := a.authorize(ctx, tx, params)
-		if err != nil {
-			return err
+	expectedEntityType := params.Resources[0].EntityType()
+	items := make([]MultiAuthorizeItem, 0, len(params.Resources))
+
+	for _, resourceID := range params.Resources {
+		if resourceID.EntityType() != expectedEntityType {
+			entityTypes := make([]uint16, 0, len(params.Resources))
+			for _, r := range params.Resources {
+				entityTypes = append(entityTypes, r.EntityType())
+			}
+
+			return nil, NewMixedEntityTypeBatchError(
+				params.Action,
+				uniqueSortedEntityTypes(entityTypes),
+			)
 		}
 
-		scope = authorizedScope
-		return nil
-	}); err != nil {
+		items = append(
+			items,
+			MultiAuthorizeItem{
+				Resource:            resourceID,
+				Action:              params.Action,
+				DryRun:              params.DryRun,
+				SkipAssumptionCheck: params.SkipAssumptionCheck,
+			},
+		)
+	}
+
+	var scope *coredata.Scope
+
+	if err := a.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			authorizedScope, err := a.authorizeMulti(
+				ctx,
+				tx,
+				AuthorizeMultiParams{
+					Principal: params.Principal,
+					Session:   params.Session,
+					Items:     items,
+				},
+				params.ResourceAttributes,
+			)
+			if err != nil {
+				return err
+			}
+
+			scope = authorizedScope
+
+			return nil
+		},
+	); err != nil {
 		return nil, err
 	}
 
 	return scope, nil
 }
 
-func (a *Authorizer) authorize(ctx context.Context, tx pg.Tx, params AuthorizeParams) (*coredata.Scope, error) {
-	resourceAttrs, err := a.buildResourceAttributes(ctx, tx, params)
-	if err != nil {
-		return nil, fmt.Errorf("cannot build resource attributes: %w", err)
+// AuthorizeMulti evaluates each item independently and returns one decision
+// per item: a nil entry means allowed, a non-nil entry carries the iam
+// error explaining the denial (typically *ErrInsufficientPermissions).
+//
+// Audit log entries for allowed, non-dry-run items are written in a single
+// bulk insert. Use AuthorizeBatch instead when callers want all-or-nothing
+// semantics for a homogeneous batch.
+func (a *Authorizer) AuthorizeMulti(
+	ctx context.Context,
+	params AuthorizeMultiParams,
+) (*coredata.Scope, []error, error) {
+	if params.Principal.EntityType() != coredata.IdentityEntityType {
+		return nil, nil, NewUnsupportedPrincipalTypeError(params.Principal.EntityType())
 	}
 
-	resourceOrgID := resourceAttrs["organization_id"]
+	if len(params.Items) == 0 {
+		return nil, nil, NewEmptyResourceBatchError("")
+	}
 
-	// Find role for resource's organization
+	var (
+		scope     *coredata.Scope
+		decisions []error
+	)
+
+	if err := a.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			s, itemAttrs, d, err := a.evaluateMultiInTx(ctx, tx, params, nil)
+			if err != nil {
+				return err
+			}
+
+			entries := make(coredata.AuditLogEntries, 0, len(params.Items))
+			for i, item := range params.Items {
+				if d[i] != nil {
+					continue
+				}
+
+				entry := a.buildAuditLogEntry(
+					ctx,
+					AuthorizeParams{
+						Principal: params.Principal,
+						Resource:  item.Resource,
+						Session:   params.Session,
+						Action:    item.Action,
+						DryRun:    item.DryRun,
+					},
+					itemAttrs[i],
+				)
+				if entry == nil {
+					continue
+				}
+
+				entries = append(entries, entry)
+			}
+
+			if len(entries) > 0 {
+				if err := entries.BulkInsert(ctx, tx, s); err != nil {
+					a.logger.ErrorCtx(
+						ctx,
+						"cannot bulk insert audit log entries",
+						log.Error(err),
+						log.String("action", params.Items[0].Action),
+					)
+				}
+			}
+
+			scope = s
+			decisions = d
+
+			return nil
+		},
+	); err != nil {
+		return nil, nil, err
+	}
+
+	return scope, decisions, nil
+}
+
+func (a *Authorizer) authorizeMulti(
+	ctx context.Context,
+	tx pg.Tx,
+	params AuthorizeMultiParams,
+	extraResourceAttributes policy.Attributes,
+) (*coredata.Scope, error) {
+	scope, itemAttrs, decisions, err := a.evaluateMultiInTx(
+		ctx,
+		tx,
+		params,
+		extraResourceAttributes,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, decision := range decisions {
+		if decision != nil {
+			return nil, decision
+		}
+	}
+
+	entries := make(coredata.AuditLogEntries, 0, len(params.Items))
+	for i, item := range params.Items {
+		entry := a.buildAuditLogEntry(
+			ctx,
+			AuthorizeParams{
+				Principal: params.Principal,
+				Resource:  item.Resource,
+				Session:   params.Session,
+				Action:    item.Action,
+				DryRun:    item.DryRun,
+			},
+			itemAttrs[i],
+		)
+		if entry == nil {
+			continue
+		}
+
+		entries = append(entries, entry)
+	}
+
+	if len(entries) > 0 {
+		if err := entries.BulkInsert(ctx, tx, scope); err != nil {
+			a.logger.ErrorCtx(
+				ctx,
+				"cannot bulk insert audit log entries",
+				log.Error(err),
+				log.String("action", params.Items[0].Action),
+			)
+		}
+	}
+
+	return scope, nil
+}
+
+// evaluateMultiInTx evaluates every item in params against the loaded
+// policies and resource attributes. It returns the shared scope, the merged
+// per-item resource attributes (used for both evaluation and audit log
+// building), and a parallel slice of per-item decisions (nil = allowed).
+// Callers decide which decisions to persist to the audit log.
+func (a *Authorizer) evaluateMultiInTx(
+	ctx context.Context,
+	tx pg.Tx,
+	params AuthorizeMultiParams,
+	extraResourceAttributes policy.Attributes,
+) (*coredata.Scope, []policy.Attributes, []error, error) {
+	uniqueResourceIDs := make([]gid.GID, 0, len(params.Items))
+	seenResourceIDs := make(map[gid.GID]struct{}, len(params.Items))
+	requiresAssumptionCheck := false
+
+	for _, item := range params.Items {
+		if !item.SkipAssumptionCheck {
+			requiresAssumptionCheck = true
+		}
+
+		if _, ok := seenResourceIDs[item.Resource]; ok {
+			continue
+		}
+
+		seenResourceIDs[item.Resource] = struct{}{}
+		uniqueResourceIDs = append(uniqueResourceIDs, item.Resource)
+	}
+
+	resourceAttrsByResourceID, err := a.buildResourceAttributesBatch(
+		ctx,
+		tx,
+		uniqueResourceIDs,
+		extraResourceAttributes,
+	)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("cannot build resource attributes batch: %w", err)
+	}
+
+	actionForErrors := params.Items[0].Action
+
+	resourceOrgID := resourceAttrsByResourceID[uniqueResourceIDs[0]]["organization_id"]
+	for _, resourceID := range uniqueResourceIDs[1:] {
+		if resourceAttrsByResourceID[resourceID]["organization_id"] != resourceOrgID {
+			orgIDs := make([]string, 0, len(uniqueResourceIDs))
+			for _, id := range uniqueResourceIDs {
+				orgIDs = append(orgIDs, resourceAttrsByResourceID[id]["organization_id"])
+			}
+
+			return nil, nil, nil, NewMixedOrganizationBatchError(
+				actionForErrors,
+				uniqueSortedStrings(orgIDs),
+			)
+		}
+	}
+
 	membership, err := a.loadMembership(ctx, tx, params.Principal, resourceOrgID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot load memberships for principal: %w", err)
+		return nil, nil, nil, fmt.Errorf("cannot load memberships for principal: %w", err)
 	}
 
-	// Check whether the viewer is currently assuming the org of the accessed resource
-	if membership != nil && params.Session != nil && !params.SkipAssumptionCheck {
-		if _, err := a.getActiveChildSessionForMembership(
+	// The assumption check is a property of (principal, membership, session),
+	// so it only runs once even though SkipAssumptionCheck is per-item.
+	// On failure, ErrAssumptionRequired is recorded only against items that
+	// did not opt out.
+	var assumptionErr error
+	if requiresAssumptionCheck {
+		err := a.checkAssumption(
 			ctx,
 			tx,
-			*params.Session,
-			membership.ID,
-		); err != nil {
-			if _, ok := errors.AsType[*ErrSessionNotFound](err); ok {
-				return nil, NewAssumptionRequiredError(params.Principal, membership.ID)
+			params.Principal,
+			params.Session,
+			membership,
+			false,
+		)
+		if err != nil {
+			if _, ok := errors.AsType[*ErrAssumptionRequired](err); !ok {
+				return nil, nil, nil, err
 			}
 
-			if _, ok := errors.AsType[*ErrSessionExpired](err); ok {
-				return nil, NewAssumptionRequiredError(params.Principal, membership.ID)
-			}
-
-			return nil, fmt.Errorf("cannot get active child session for membership: %w", err)
+			assumptionErr = err
 		}
 	}
 
@@ -132,10 +410,9 @@ func (a *Authorizer) authorize(ctx context.Context, tx pg.Tx, params AuthorizePa
 		role = membership.Role.String()
 	}
 
-	// Only set principal.organization_id if they have a role in this org
-	var scopedPrincipalAttrs map[string]string
+	var scopedPrincipalAttrs policy.Attributes
 	if membership != nil && role != "" {
-		scopedPrincipalAttrs = map[string]string{
+		scopedPrincipalAttrs = policy.Attributes{
 			"organization_id": membership.OrganizationID.String(),
 			"role":            membership.Role.String(),
 		}
@@ -143,7 +420,7 @@ func (a *Authorizer) authorize(ctx context.Context, tx pg.Tx, params AuthorizePa
 
 	principalAttrs, err := a.buildPrincipalAttributes(ctx, tx, params.Principal, scopedPrincipalAttrs)
 	if err != nil {
-		return nil, fmt.Errorf("cannot build principal attributes: %w", err)
+		return nil, nil, nil, fmt.Errorf("cannot build principal attributes: %w", err)
 	}
 
 	if params.Session != nil {
@@ -152,32 +429,162 @@ func (a *Authorizer) authorize(ctx context.Context, tx pg.Tx, params AuthorizePa
 
 	policies := a.buildPoliciesForRole(role)
 
-	req := policy.AuthorizationRequest{
-		Principal: params.Principal,
-		Resource:  params.Resource,
-		Action:    params.Action,
-		ConditionContext: policy.ConditionContext{
-			Principal: principalAttrs,
-			Resource:  resourceAttrs,
-		},
-	}
+	decisions := make([]error, len(params.Items))
+	itemAttrs := make([]policy.Attributes, len(params.Items))
+	for i, item := range params.Items {
+		resAttrs := resourceAttrsByResourceID[item.Resource]
+		if len(item.ResourceAttributes) > 0 {
+			merged := maps.Clone(resAttrs)
+			maps.Copy(merged, item.ResourceAttributes)
+			resAttrs = merged
+		}
+		itemAttrs[i] = resAttrs
 
-	if a.evaluator.Evaluate(req, policies).IsAllowed() {
-		scope := coredata.NewScopeFromObjectID(params.Resource)
-		if resourceOrgID != "" {
-			orgID, err := gid.ParseGID(resourceOrgID)
-			if err != nil {
-				return nil, fmt.Errorf("cannot parse organization id from resource attributes: %w", err)
-			}
-
-			scope = coredata.NewScope(orgID.TenantID())
+		if assumptionErr != nil && !item.SkipAssumptionCheck {
+			decisions[i] = assumptionErr
+			continue
 		}
 
-		a.recordAuditLog(ctx, tx, params, resourceAttrs)
-		return scope, nil
+		req := policy.AuthorizationRequest{
+			Principal: params.Principal,
+			Resource:  item.Resource,
+			Action:    item.Action,
+			ConditionContext: policy.ConditionContext{
+				Principal: principalAttrs,
+				Resource:  resAttrs,
+			},
+		}
+
+		if !a.evaluator.Evaluate(req, policies).IsAllowed() {
+			decisions[i] = NewInsufficientPermissionsError(params.Principal, item.Resource, item.Action)
+		}
 	}
 
-	return nil, NewInsufficientPermissionsError(params.Principal, params.Resource, params.Action)
+	scope := coredata.NewScopeFromObjectID(uniqueResourceIDs[0])
+
+	if resourceOrgID != "" {
+		orgID, _ := gid.ParseGID(resourceOrgID)
+		scope = coredata.NewScope(orgID.TenantID())
+	}
+
+	return scope, itemAttrs, decisions, nil
+}
+
+func (a *Authorizer) buildResourceAttributesBatch(
+	ctx context.Context,
+	conn pg.Querier,
+	uniqueResourceIDs []gid.GID,
+	extraResourceAttributes policy.Attributes,
+) (policy.AttributesByID, error) {
+	resourceAttrsByID, err := a.loadResourceAttributesByType(ctx, conn, uniqueResourceIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceAttrsByResourceID := make(policy.AttributesByID, len(uniqueResourceIDs))
+	for _, resourceID := range uniqueResourceIDs {
+		resourceAttrs := resourceAttrsByID[resourceID]
+
+		attrs := policy.Attributes{
+			"id": resourceID.String(),
+		}
+		maps.Copy(attrs, resourceAttrs)
+
+		if extraResourceAttributes != nil {
+			maps.Copy(attrs, extraResourceAttributes)
+		}
+
+		resourceAttrsByResourceID[resourceID] = attrs
+	}
+
+	return resourceAttrsByResourceID, nil
+}
+
+func (a *Authorizer) loadResourceAttributesByType(
+	ctx context.Context,
+	conn pg.Querier,
+	resourceIDs []gid.GID,
+) (policy.AttributesByID, error) {
+	resourceIDsByEntityType := make(map[uint16][]gid.GID)
+	orderedEntityTypes := make([]uint16, 0, len(resourceIDs))
+
+	for _, resourceID := range resourceIDs {
+		entityType := resourceID.EntityType()
+
+		if _, ok := resourceIDsByEntityType[entityType]; !ok {
+			orderedEntityTypes = append(orderedEntityTypes, entityType)
+		}
+
+		resourceIDsByEntityType[entityType] = append(resourceIDsByEntityType[entityType], resourceID)
+	}
+
+	resourceAttrsByID := make(policy.AttributesByID, len(resourceIDs))
+
+	for _, entityType := range orderedEntityTypes {
+		groupResourceIDs := resourceIDsByEntityType[entityType]
+
+		entity, ok := coredata.NewEntityFromID(groupResourceIDs[0])
+		if !ok {
+			return nil, fmt.Errorf("unsupported resource type: %d", groupResourceIDs[0].EntityType())
+		}
+
+		attributer, ok := entity.(AuthorizationAttributer)
+		if !ok {
+			return nil, NewBatchAuthorizationUnsupportedResourceTypeError(entityType)
+		}
+
+		groupAttrsByID, err := attributer.AuthorizationAttributes(ctx, conn, groupResourceIDs)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"cannot load batched resource attributes for entity type %d: %w",
+				entityType,
+				err,
+			)
+		}
+
+		for _, resourceID := range groupResourceIDs {
+			resourceAttrs, ok := groupAttrsByID[resourceID]
+			if !ok {
+				return nil, coredata.ErrResourceNotFound
+			}
+
+			resourceAttrsByID[resourceID] = resourceAttrs
+		}
+	}
+
+	return resourceAttrsByID, nil
+}
+
+func (a *Authorizer) checkAssumption(
+	ctx context.Context,
+	tx pg.Tx,
+	principalID gid.GID,
+	sessionID *gid.GID,
+	membership *coredata.Membership,
+	skipAssumptionCheck bool,
+) error {
+	if membership == nil || sessionID == nil || skipAssumptionCheck {
+		return nil
+	}
+
+	if _, err := a.getActiveChildSessionForMembership(
+		ctx,
+		tx,
+		*sessionID,
+		membership.ID,
+	); err != nil {
+		if _, ok := errors.AsType[*ErrSessionNotFound](err); ok {
+			return NewAssumptionRequiredError(principalID, membership.ID)
+		}
+
+		if _, ok := errors.AsType[*ErrSessionExpired](err); ok {
+			return NewAssumptionRequiredError(principalID, membership.ID)
+		}
+
+		return fmt.Errorf("cannot get active child session for membership: %w", err)
+	}
+
+	return nil
 }
 
 func (a *Authorizer) loadMembership(
@@ -234,55 +641,30 @@ func (a *Authorizer) buildPrincipalAttributes(
 	ctx context.Context,
 	conn pg.Querier,
 	principalID gid.GID,
-	defaultAttrs map[string]string,
-) (map[string]string, error) {
-	attrs := map[string]string{
+	defaultAttrs policy.Attributes,
+) (policy.Attributes, error) {
+	attrs := policy.Attributes{
 		"id": principalID.String(),
 	}
 	maps.Copy(attrs, defaultAttrs)
 
 	if entity, ok := coredata.NewEntityFromID(principalID); ok {
-		if attributer, ok := entity.(AuthorizationAttributer); ok {
-			entityAttrs, err := attributer.AuthorizationAttributes(ctx, conn)
-			if err != nil {
-				return nil, fmt.Errorf("cannot load principal attributes: %w", err)
-			}
-
-			maps.Copy(attrs, entityAttrs)
+		attributer, ok := entity.(AuthorizationAttributer)
+		if !ok {
+			return nil, NewBatchAuthorizationUnsupportedResourceTypeError(principalID.EntityType())
 		}
-	}
 
-	return attrs, nil
-}
+		entityAttrsByID, err := attributer.AuthorizationAttributes(ctx, conn, []gid.GID{principalID})
+		if err != nil {
+			return nil, fmt.Errorf("cannot load principal attributes: %w", err)
+		}
 
-func (a *Authorizer) buildResourceAttributes(
-	ctx context.Context,
-	conn pg.Querier,
-	params AuthorizeParams,
-) (map[string]string, error) {
-	attrs := map[string]string{
-		"id": params.Resource.String(),
-	}
+		entityAttrs, ok := entityAttrsByID[principalID]
+		if !ok {
+			return nil, coredata.ErrResourceNotFound
+		}
 
-	entity, ok := coredata.NewEntityFromID(params.Resource)
-	if !ok {
-		return nil, fmt.Errorf("unsupported resource type: %d", params.Resource.EntityType())
-	}
-
-	attributer, ok := entity.(AuthorizationAttributer)
-	if !ok {
-		return nil, fmt.Errorf("resource %d does not implement AuthorizationAttributer", params.Resource.EntityType())
-	}
-
-	entityAttrs, err := attributer.AuthorizationAttributes(ctx, conn)
-	if err != nil {
-		return nil, fmt.Errorf("cannot load resource attributes: %w", err)
-	}
-
-	maps.Copy(attrs, entityAttrs)
-
-	if params.ResourceAttributes != nil {
-		maps.Copy(attrs, params.ResourceAttributes)
+		maps.Copy(attrs, entityAttrs)
 	}
 
 	return attrs, nil
@@ -298,9 +680,44 @@ func (a *Authorizer) buildPoliciesForRole(role string) []*policy.Policy {
 	return policies
 }
 
-// resourceTypeFromAction extracts the resource type name from an action
-// string. For example, "core:thirdParty:create" returns "ThirdParty" and
-// "core:webhook-subscription:delete" returns "WebhookSubscription".
+func uniqueSortedStrings(values []string) []string {
+	set := make(map[string]struct{}, len(values))
+	unique := make([]string, 0, len(values))
+
+	for _, value := range values {
+		if _, ok := set[value]; ok {
+			continue
+		}
+
+		set[value] = struct{}{}
+		unique = append(unique, value)
+	}
+
+	slices.Sort(unique)
+
+	return unique
+}
+
+func uniqueSortedEntityTypes(values []uint16) []uint16 {
+	set := make(map[uint16]struct{}, len(values))
+	unique := make([]uint16, 0, len(values))
+
+	for _, value := range values {
+		if _, ok := set[value]; ok {
+			continue
+		}
+
+		set[value] = struct{}{}
+		unique = append(unique, value)
+	}
+
+	slices.Sort(unique)
+
+	return unique
+}
+
+// resourceTypeFromAction extracts the PascalCase resource type from an
+// action string, e.g. "core:webhook-subscription:delete" -> "WebhookSubscription".
 func resourceTypeFromAction(action string) string {
 	parts := strings.Split(action, ":")
 	if len(parts) < 3 {
@@ -317,19 +734,20 @@ func resourceTypeFromAction(action string) string {
 	return strings.Join(segments, "")
 }
 
-func (a *Authorizer) recordAuditLog(
+// buildAuditLogEntry returns nil when no entry should be recorded
+// (dry run or missing/invalid organization id).
+func (a *Authorizer) buildAuditLogEntry(
 	ctx context.Context,
-	tx pg.Tx,
 	params AuthorizeParams,
-	resourceAttrs map[string]string,
-) {
+	resourceAttrs policy.Attributes,
+) *coredata.AuditLogEntry {
 	if params.DryRun {
-		return
+		return nil
 	}
 
 	orgIDStr := resourceAttrs["organization_id"]
 	if orgIDStr == "" {
-		return
+		return nil
 	}
 
 	orgID, err := gid.ParseGID(orgIDStr)
@@ -340,7 +758,7 @@ func (a *Authorizer) recordAuditLog(
 			log.Error(err),
 		)
 
-		return
+		return nil
 	}
 
 	var actorType coredata.AuditLogActorType
@@ -352,18 +770,9 @@ func (a *Authorizer) recordAuditLog(
 
 	resourceType := resourceTypeFromAction(params.Action)
 
-	metadata, err := json.Marshal(map[string]any{})
-	if err != nil {
-		a.logger.ErrorCtx(
-			ctx,
-			"cannot marshal audit log metadata",
-			log.Error(err),
-		)
+	metadata := []byte("{}")
 
-		return
-	}
-
-	entry := &coredata.AuditLogEntry{
+	return &coredata.AuditLogEntry{
 		ID:             gid.New(orgID.TenantID(), coredata.AuditLogEntryEntityType),
 		OrganizationID: orgID,
 		ActorID:        params.Principal,
@@ -373,17 +782,5 @@ func (a *Authorizer) recordAuditLog(
 		ResourceID:     params.Resource,
 		Metadata:       metadata,
 		CreatedAt:      time.Now(),
-	}
-
-	scope := coredata.NewScope(orgID.TenantID())
-
-	if err := entry.Insert(ctx, tx, scope); err != nil {
-		a.logger.ErrorCtx(
-			ctx,
-			"cannot insert audit log entry",
-			log.Error(err),
-			log.String("action", params.Action),
-			log.String("resource_id", params.Resource.String()),
-		)
 	}
 }

--- a/pkg/iam/authorizer.go
+++ b/pkg/iam/authorizer.go
@@ -71,18 +71,32 @@ func (a *Authorizer) RegisterPolicySet(ps *PolicySet) {
 }
 
 // Authorize checks if the principal is allowed to perform the action on the resource.
-func (a *Authorizer) Authorize(ctx context.Context, params AuthorizeParams) error {
+func (a *Authorizer) Authorize(ctx context.Context, params AuthorizeParams) (*coredata.Scope, error) {
 	if params.Principal.EntityType() != coredata.IdentityEntityType {
-		return NewUnsupportedPrincipalTypeError(params.Principal.EntityType())
+		return nil, NewUnsupportedPrincipalTypeError(params.Principal.EntityType())
 	}
 
-	return a.pg.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error { return a.authorize(ctx, tx, params) })
+	var scope *coredata.Scope
+
+	if err := a.pg.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		authorizedScope, err := a.authorize(ctx, tx, params)
+		if err != nil {
+			return err
+		}
+
+		scope = authorizedScope
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return scope, nil
 }
 
-func (a *Authorizer) authorize(ctx context.Context, tx pg.Tx, params AuthorizeParams) error {
+func (a *Authorizer) authorize(ctx context.Context, tx pg.Tx, params AuthorizeParams) (*coredata.Scope, error) {
 	resourceAttrs, err := a.buildResourceAttributes(ctx, tx, params)
 	if err != nil {
-		return fmt.Errorf("cannot build resource attributes: %w", err)
+		return nil, fmt.Errorf("cannot build resource attributes: %w", err)
 	}
 
 	resourceOrgID := resourceAttrs["organization_id"]
@@ -90,7 +104,7 @@ func (a *Authorizer) authorize(ctx context.Context, tx pg.Tx, params AuthorizePa
 	// Find role for resource's organization
 	membership, err := a.loadMembership(ctx, tx, params.Principal, resourceOrgID)
 	if err != nil {
-		return fmt.Errorf("cannot load memberships for principal: %w", err)
+		return nil, fmt.Errorf("cannot load memberships for principal: %w", err)
 	}
 
 	// Check whether the viewer is currently assuming the org of the accessed resource
@@ -102,14 +116,14 @@ func (a *Authorizer) authorize(ctx context.Context, tx pg.Tx, params AuthorizePa
 			membership.ID,
 		); err != nil {
 			if _, ok := errors.AsType[*ErrSessionNotFound](err); ok {
-				return NewAssumptionRequiredError(params.Principal, membership.ID)
+				return nil, NewAssumptionRequiredError(params.Principal, membership.ID)
 			}
 
 			if _, ok := errors.AsType[*ErrSessionExpired](err); ok {
-				return NewAssumptionRequiredError(params.Principal, membership.ID)
+				return nil, NewAssumptionRequiredError(params.Principal, membership.ID)
 			}
 
-			return fmt.Errorf("cannot get active child session for membership: %w", err)
+			return nil, fmt.Errorf("cannot get active child session for membership: %w", err)
 		}
 	}
 
@@ -129,7 +143,7 @@ func (a *Authorizer) authorize(ctx context.Context, tx pg.Tx, params AuthorizePa
 
 	principalAttrs, err := a.buildPrincipalAttributes(ctx, tx, params.Principal, scopedPrincipalAttrs)
 	if err != nil {
-		return fmt.Errorf("cannot build principal attributes: %w", err)
+		return nil, fmt.Errorf("cannot build principal attributes: %w", err)
 	}
 
 	if params.Session != nil {
@@ -149,11 +163,21 @@ func (a *Authorizer) authorize(ctx context.Context, tx pg.Tx, params AuthorizePa
 	}
 
 	if a.evaluator.Evaluate(req, policies).IsAllowed() {
+		scope := coredata.NewScopeFromObjectID(params.Resource)
+		if resourceOrgID != "" {
+			orgID, err := gid.ParseGID(resourceOrgID)
+			if err != nil {
+				return nil, fmt.Errorf("cannot parse organization id from resource attributes: %w", err)
+			}
+
+			scope = coredata.NewScope(orgID.TenantID())
+		}
+
 		a.recordAuditLog(ctx, tx, params, resourceAttrs)
-		return nil
+		return scope, nil
 	}
 
-	return NewInsufficientPermissionsError(params.Principal, params.Resource, params.Action)
+	return nil, NewInsufficientPermissionsError(params.Principal, params.Resource, params.Action)
 }
 
 func (a *Authorizer) loadMembership(

--- a/pkg/iam/authorizer.go
+++ b/pkg/iam/authorizer.go
@@ -387,6 +387,7 @@ func (a *Authorizer) evaluateMultiInTx(
 	// On failure, ErrAssumptionRequired is recorded only against items that
 	// did not opt out.
 	var assumptionErr error
+
 	if requiresAssumptionCheck {
 		err := a.checkAssumption(
 			ctx,
@@ -431,6 +432,7 @@ func (a *Authorizer) evaluateMultiInTx(
 
 	decisions := make([]error, len(params.Items))
 	itemAttrs := make([]policy.Attributes, len(params.Items))
+
 	for i, item := range params.Items {
 		resAttrs := resourceAttrsByResourceID[item.Resource]
 		if len(item.ResourceAttributes) > 0 {
@@ -438,6 +440,7 @@ func (a *Authorizer) evaluateMultiInTx(
 			maps.Copy(merged, item.ResourceAttributes)
 			resAttrs = merged
 		}
+
 		itemAttrs[i] = resAttrs
 
 		if assumptionErr != nil && !item.SkipAssumptionCheck {

--- a/pkg/iam/authorizer_batch_test.go
+++ b/pkg/iam/authorizer_batch_test.go
@@ -1,0 +1,1104 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package iam_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.gearno.de/kit/log"
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam"
+	"go.probo.inc/probo/pkg/iam/policy"
+	"go.probo.inc/probo/pkg/mail"
+)
+
+const testPgDSNEnvVar = "PROBO_TEST_PG_URL"
+
+type batchAuthorizeFixture struct {
+	tenantID        gid.TenantID
+	identityID      gid.GID
+	membershipID    gid.GID
+	organizationID  gid.GID
+	organization2ID gid.GID
+	frameworkID1    gid.GID
+	frameworkID2    gid.GID
+	frameworkID3    gid.GID
+}
+
+func TestAuthorizer_AuthorizeBatch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("happy path", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestPgClient(t)
+		fixture := seedBatchAuthorizeFixture(t, context.Background(), client)
+		action := newBatchTestAction()
+		authorizer := newTestAuthorizer(client, action, nil)
+
+		scope, err := authorizer.AuthorizeBatch(
+			context.Background(),
+			iam.AuthorizeBatchParams{
+				Principal: fixture.identityID,
+				Action:    action,
+				Resources: []gid.GID{
+					fixture.frameworkID1,
+					fixture.frameworkID2,
+				},
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, scope)
+		assert.Equal(t, fixture.tenantID, scope.GetTenantID())
+		assert.Equal(t, 2, countAuditLogsForAction(t, context.Background(), client, action))
+	})
+
+	t.Run("mixed organization batch", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestPgClient(t)
+		fixture := seedBatchAuthorizeFixture(t, context.Background(), client)
+		action := newBatchTestAction()
+		authorizer := newTestAuthorizer(client, action, nil)
+
+		_, err := authorizer.AuthorizeBatch(
+			context.Background(),
+			iam.AuthorizeBatchParams{
+				Principal: fixture.identityID,
+				Action:    action,
+				Resources: []gid.GID{
+					fixture.frameworkID1,
+					fixture.frameworkID3,
+				},
+			},
+		)
+		require.Error(t, err)
+
+		errMixedOrg, ok := err.(*iam.ErrMixedOrganizationBatch)
+		require.True(t, ok)
+		assert.ElementsMatch(
+			t,
+			[]string{
+				fixture.organizationID.String(),
+				fixture.organization2ID.String(),
+			},
+			errMixedOrg.OrganizationIDs,
+		)
+	})
+
+	t.Run("mixed entity type batch", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestPgClient(t)
+		fixture := seedBatchAuthorizeFixture(t, context.Background(), client)
+		action := newBatchTestAction()
+		authorizer := newTestAuthorizer(client, action, nil)
+
+		_, err := authorizer.AuthorizeBatch(
+			context.Background(),
+			iam.AuthorizeBatchParams{
+				Principal: fixture.identityID,
+				Action:    action,
+				Resources: []gid.GID{
+					fixture.frameworkID1,
+					fixture.organizationID,
+				},
+			},
+		)
+		require.Error(t, err)
+
+		errMixedEntityType, ok := err.(*iam.ErrMixedEntityTypeBatch)
+		require.True(t, ok)
+		assert.Equal(
+			t,
+			[]uint16{coredata.OrganizationEntityType, coredata.FrameworkEntityType},
+			errMixedEntityType.EntityTypes,
+		)
+	})
+
+	t.Run("unsupported resource type for batch attributes", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestPgClient(t)
+		fixture := seedBatchAuthorizeFixture(t, context.Background(), client)
+		action := newBatchTestAction()
+		authorizer := newTestAuthorizer(client, action, nil)
+
+		_, err := authorizer.AuthorizeBatch(
+			context.Background(),
+			iam.AuthorizeBatchParams{
+				Principal: fixture.identityID,
+				Action:    action,
+				Resources: []gid.GID{
+					gid.New(fixture.tenantID, coredata.OAuth2AccessTokenEntityType),
+				},
+			},
+		)
+		require.Error(t, err)
+
+		errUnsupported, ok := errors.AsType[*iam.ErrBatchAuthorizationUnsupportedResourceType](err)
+		require.True(t, ok)
+		assert.Equal(t, coredata.OAuth2AccessTokenEntityType, errUnsupported.EntityType)
+	})
+
+	t.Run("single deny rolls back entire batch", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestPgClient(t)
+		fixture := seedBatchAuthorizeFixture(t, context.Background(), client)
+		action := newBatchTestAction()
+		authorizer := newTestAuthorizer(client, action, &fixture.frameworkID1)
+
+		_, err := authorizer.AuthorizeBatch(
+			context.Background(),
+			iam.AuthorizeBatchParams{
+				Principal: fixture.identityID,
+				Action:    action,
+				Resources: []gid.GID{
+					fixture.frameworkID1,
+					fixture.frameworkID2,
+				},
+			},
+		)
+		require.Error(t, err)
+
+		_, ok := err.(*iam.ErrInsufficientPermissions)
+		require.True(t, ok)
+		assert.Equal(t, 0, countAuditLogsForAction(t, context.Background(), client, action))
+	})
+
+	t.Run("duplicate resources in batch", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestPgClient(t)
+		fixture := seedBatchAuthorizeFixture(t, context.Background(), client)
+		action := newBatchTestAction()
+		authorizer := newTestAuthorizer(client, action, nil)
+
+		scope, err := authorizer.AuthorizeBatch(
+			context.Background(),
+			iam.AuthorizeBatchParams{
+				Principal: fixture.identityID,
+				Action:    action,
+				Resources: []gid.GID{
+					fixture.frameworkID1,
+					fixture.frameworkID1,
+				},
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, scope)
+		assert.Equal(t, fixture.tenantID, scope.GetTenantID())
+		assert.Equal(t, 2, countAuditLogsForAction(t, context.Background(), client, action))
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		t.Parallel()
+
+		authorizer := iam.NewAuthorizer(nil, log.NewLogger(log.WithOutput(io.Discard)))
+
+		_, err := authorizer.AuthorizeBatch(
+			context.Background(),
+			iam.AuthorizeBatchParams{
+				Principal: gid.New(gid.NilTenant, coredata.IdentityEntityType),
+				Action:    newBatchTestAction(),
+			},
+		)
+		require.Error(t, err)
+
+		_, ok := err.(*iam.ErrEmptyResourceBatch)
+		require.True(t, ok)
+	})
+
+	t.Run("dry-run does not write audit logs", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestPgClient(t)
+		fixture := seedBatchAuthorizeFixture(t, context.Background(), client)
+		action := newBatchTestAction()
+		authorizer := newTestAuthorizer(client, action, nil)
+
+		scope, err := authorizer.AuthorizeBatch(
+			context.Background(),
+			iam.AuthorizeBatchParams{
+				Principal: fixture.identityID,
+				Action:    action,
+				Resources: []gid.GID{
+					fixture.frameworkID1,
+					fixture.frameworkID2,
+				},
+				DryRun: true,
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, scope)
+		assert.Equal(t, fixture.tenantID, scope.GetTenantID())
+		assert.Equal(t, 0, countAuditLogsForAction(t, context.Background(), client, action))
+	})
+
+	t.Run("missing principal identity returns wrapped principal attributes error", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestPgClient(t)
+		fixture := seedBatchAuthorizeFixture(t, context.Background(), client)
+		action := newBatchTestAction()
+		authorizer := newTestAuthorizer(client, action, nil)
+		missingPrincipalID := gid.New(gid.NilTenant, coredata.IdentityEntityType)
+
+		_, err := authorizer.AuthorizeBatch(
+			context.Background(),
+			iam.AuthorizeBatchParams{
+				Principal: missingPrincipalID,
+				Action:    action,
+				Resources: []gid.GID{
+					fixture.frameworkID1,
+				},
+			},
+		)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "cannot build principal attributes")
+		assert.ErrorIs(t, err, coredata.ErrResourceNotFound)
+	})
+
+	t.Run("bulk insert failure aborts transaction", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestPgClient(t)
+		fixture := seedBatchAuthorizeFixture(t, context.Background(), client)
+		action := newBatchTestAction()
+		authorizer := newTestAuthorizerWithIdentityScopedStatements(
+			client,
+			policy.Allow(action).WithSID("allow-audit-log-failure"),
+		)
+		nonExistentOrgID := gid.New(gid.NewTenantID(), coredata.OrganizationEntityType)
+
+		scope, err := authorizer.AuthorizeBatch(
+			context.Background(),
+			iam.AuthorizeBatchParams{
+				Principal: fixture.identityID,
+				Action:    action,
+				Resources: []gid.GID{
+					fixture.frameworkID1,
+					fixture.frameworkID2,
+				},
+				ResourceAttributes: policy.Attributes{
+					"organization_id": nonExistentOrgID.String(),
+				},
+			},
+		)
+		require.Error(t, err)
+		assert.Nil(t, scope)
+		assert.ErrorContains(t, err, "cannot commit transaction")
+		assert.Equal(t, 0, countAuditLogsForAction(t, context.Background(), client, action))
+	})
+
+	t.Run("assumption required", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestPgClient(t)
+		fixture := seedBatchAuthorizeFixture(t, context.Background(), client)
+		action := newBatchTestAction()
+		authorizer := newTestAuthorizer(client, action, nil)
+		sessionID := gid.New(gid.NilTenant, coredata.SessionEntityType)
+
+		_, err := authorizer.AuthorizeBatch(
+			context.Background(),
+			iam.AuthorizeBatchParams{
+				Principal: fixture.identityID,
+				Session:   &sessionID,
+				Action:    action,
+				Resources: []gid.GID{
+					fixture.frameworkID1,
+					fixture.frameworkID2,
+				},
+			},
+		)
+		require.Error(t, err)
+
+		_, ok := err.(*iam.ErrAssumptionRequired)
+		require.True(t, ok)
+		assert.Equal(t, 0, countAuditLogsForAction(t, context.Background(), client, action))
+	})
+
+	t.Run("assumption succeeds with active child session", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestPgClient(t)
+		fixture := seedBatchAuthorizeFixture(t, context.Background(), client)
+		action := newBatchTestAction()
+		authorizer := newTestAuthorizer(client, action, nil)
+		rootSessionID := gid.New(gid.NilTenant, coredata.SessionEntityType)
+
+		insertBatchTestChildSession(
+			t,
+			context.Background(),
+			client,
+			fixture,
+			rootSessionID,
+			false,
+		)
+
+		scope, err := authorizer.AuthorizeBatch(
+			context.Background(),
+			iam.AuthorizeBatchParams{
+				Principal: fixture.identityID,
+				Session:   &rootSessionID,
+				Action:    action,
+				Resources: []gid.GID{
+					fixture.frameworkID1,
+					fixture.frameworkID2,
+				},
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, scope)
+		assert.Equal(t, fixture.tenantID, scope.GetTenantID())
+		assert.Equal(t, 2, countAuditLogsForAction(t, context.Background(), client, action))
+	})
+
+	t.Run("assumption fails when child session is expired", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestPgClient(t)
+		fixture := seedBatchAuthorizeFixture(t, context.Background(), client)
+		action := newBatchTestAction()
+		authorizer := newTestAuthorizer(client, action, nil)
+		rootSessionID := gid.New(gid.NilTenant, coredata.SessionEntityType)
+
+		insertBatchTestChildSession(
+			t,
+			context.Background(),
+			client,
+			fixture,
+			rootSessionID,
+			true,
+		)
+
+		_, err := authorizer.AuthorizeBatch(
+			context.Background(),
+			iam.AuthorizeBatchParams{
+				Principal: fixture.identityID,
+				Session:   &rootSessionID,
+				Action:    action,
+				Resources: []gid.GID{
+					fixture.frameworkID1,
+					fixture.frameworkID2,
+				},
+			},
+		)
+		require.Error(t, err)
+
+		_, ok := errors.AsType[*iam.ErrAssumptionRequired](err)
+		require.True(t, ok)
+		assert.Equal(t, 0, countAuditLogsForAction(t, context.Background(), client, action))
+	})
+
+	t.Run("no membership ignores assumption check", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestPgClient(t)
+		fixture := seedBatchAuthorizeFixture(t, context.Background(), client)
+		action := newBatchTestAction()
+		authorizer := newTestAuthorizer(client, action, nil)
+		rootSessionID := gid.New(gid.NilTenant, coredata.SessionEntityType)
+		identityWithoutMembershipID := insertBatchTestIdentity(
+			t,
+			context.Background(),
+			client,
+			fixture.tenantID,
+		)
+
+		_, err := authorizer.AuthorizeBatch(
+			context.Background(),
+			iam.AuthorizeBatchParams{
+				Principal: identityWithoutMembershipID,
+				Session:   &rootSessionID,
+				Action:    action,
+				Resources: []gid.GID{
+					fixture.frameworkID1,
+				},
+			},
+		)
+		require.Error(t, err)
+
+		_, hasAssumptionErr := errors.AsType[*iam.ErrAssumptionRequired](err)
+		assert.False(t, hasAssumptionErr)
+
+		insufficientPermissionsErr, ok := errors.AsType[*iam.ErrInsufficientPermissions](err)
+		require.True(t, ok)
+		assert.Equal(t, identityWithoutMembershipID, insufficientPermissionsErr.IdentityID)
+		assert.Equal(t, 0, countAuditLogsForAction(t, context.Background(), client, action))
+	})
+}
+
+func TestAuthorizer_AuthorizeMulti(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns nil decisions when every item is allowed", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestPgClient(t)
+		fixture := seedBatchAuthorizeFixture(t, context.Background(), client)
+		action := newBatchTestAction()
+		authorizer := newTestAuthorizerWithStatements(
+			client,
+			policy.Allow(action).WithSID("allow-evaluate-multi-all"),
+		)
+
+		scope, decisions, err := authorizer.AuthorizeMulti(
+			context.Background(),
+			iam.AuthorizeMultiParams{
+				Principal: fixture.identityID,
+				Items: []iam.MultiAuthorizeItem{
+					{
+						Resource: fixture.frameworkID1,
+						Action:   action,
+					},
+					{
+						Resource: fixture.frameworkID2,
+						Action:   action,
+					},
+				},
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, scope)
+		assert.Equal(t, fixture.tenantID, scope.GetTenantID())
+		require.Len(t, decisions, 2)
+		assert.NoError(t, decisions[0])
+		assert.NoError(t, decisions[1])
+		assert.Equal(t, 2, countAuditLogsForAction(t, context.Background(), client, action))
+	})
+
+	t.Run("returns per-item decisions on partial denial without aborting", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestPgClient(t)
+		fixture := seedBatchAuthorizeFixture(t, context.Background(), client)
+		action := newBatchTestAction()
+		authorizer := newTestAuthorizerWithStatements(
+			client,
+			policy.Allow(action).
+				WithSID("allow-only-first-framework").
+				When(policy.Equals("resource.id", fixture.frameworkID1.String())),
+		)
+
+		scope, decisions, err := authorizer.AuthorizeMulti(
+			context.Background(),
+			iam.AuthorizeMultiParams{
+				Principal: fixture.identityID,
+				Items: []iam.MultiAuthorizeItem{
+					{
+						Resource: fixture.frameworkID1,
+						Action:   action,
+					},
+					{
+						Resource: fixture.frameworkID2,
+						Action:   action,
+					},
+				},
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, scope)
+		assert.Equal(t, fixture.tenantID, scope.GetTenantID())
+		require.Len(t, decisions, 2)
+		assert.NoError(t, decisions[0])
+		require.Error(t, decisions[1])
+
+		denied, ok := errors.AsType[*iam.ErrInsufficientPermissions](decisions[1])
+		require.True(t, ok)
+		assert.Equal(t, fixture.frameworkID2, denied.EntityID)
+
+		assert.Equal(t, 1, countAuditLogsForAction(t, context.Background(), client, action))
+	})
+
+	t.Run("writes no audit logs when every item is denied", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestPgClient(t)
+		fixture := seedBatchAuthorizeFixture(t, context.Background(), client)
+		action := newBatchTestAction()
+		authorizer := newTestAuthorizerWithStatements(
+			client,
+			policy.Allow(action).
+				WithSID("allow-no-frameworks").
+				When(policy.Equals("resource.id", "missing")),
+		)
+
+		scope, decisions, err := authorizer.AuthorizeMulti(
+			context.Background(),
+			iam.AuthorizeMultiParams{
+				Principal: fixture.identityID,
+				Items: []iam.MultiAuthorizeItem{
+					{
+						Resource: fixture.frameworkID1,
+						Action:   action,
+					},
+					{
+						Resource: fixture.frameworkID2,
+						Action:   action,
+					},
+				},
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, scope)
+		require.Len(t, decisions, 2)
+		require.Error(t, decisions[0])
+		require.Error(t, decisions[1])
+		assert.Equal(t, 0, countAuditLogsForAction(t, context.Background(), client, action))
+	})
+
+	t.Run("skips audit log entries for dry-run allowed items", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestPgClient(t)
+		fixture := seedBatchAuthorizeFixture(t, context.Background(), client)
+		action := newBatchTestAction()
+		authorizer := newTestAuthorizerWithStatements(
+			client,
+			policy.Allow(action).WithSID("allow-evaluate-dry-run"),
+		)
+
+		_, decisions, err := authorizer.AuthorizeMulti(
+			context.Background(),
+			iam.AuthorizeMultiParams{
+				Principal: fixture.identityID,
+				Items: []iam.MultiAuthorizeItem{
+					{
+						Resource: fixture.frameworkID1,
+						Action:   action,
+						DryRun:   true,
+					},
+					{
+						Resource: fixture.frameworkID2,
+						Action:   action,
+					},
+				},
+			},
+		)
+		require.NoError(t, err)
+		require.Len(t, decisions, 2)
+		assert.NoError(t, decisions[0])
+		assert.NoError(t, decisions[1])
+		assert.Equal(t, 1, countAuditLogsForAction(t, context.Background(), client, action))
+	})
+
+	t.Run("rejects mixed organization batch", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestPgClient(t)
+		fixture := seedBatchAuthorizeFixture(t, context.Background(), client)
+		action := newBatchTestAction()
+		authorizer := newTestAuthorizerWithStatements(
+			client,
+			policy.Allow(action).WithSID("allow-evaluate-mixed-org"),
+		)
+
+		scope, decisions, err := authorizer.AuthorizeMulti(
+			context.Background(),
+			iam.AuthorizeMultiParams{
+				Principal: fixture.identityID,
+				Items: []iam.MultiAuthorizeItem{
+					{
+						Resource: fixture.frameworkID1,
+						Action:   action,
+					},
+					{
+						Resource: fixture.frameworkID3,
+						Action:   action,
+					},
+				},
+			},
+		)
+		require.Error(t, err)
+		assert.Nil(t, scope)
+		assert.Nil(t, decisions)
+
+		_, ok := errors.AsType[*iam.ErrMixedOrganizationBatch](err)
+		require.True(t, ok)
+	})
+
+	t.Run("rejects empty items", func(t *testing.T) {
+		t.Parallel()
+
+		authorizer := iam.NewAuthorizer(nil, log.NewLogger(log.WithOutput(io.Discard)))
+
+		scope, decisions, err := authorizer.AuthorizeMulti(
+			context.Background(),
+			iam.AuthorizeMultiParams{
+				Principal: gid.New(gid.NilTenant, coredata.IdentityEntityType),
+			},
+		)
+		require.Error(t, err)
+		assert.Nil(t, scope)
+		assert.Nil(t, decisions)
+
+		_, ok := errors.AsType[*iam.ErrEmptyResourceBatch](err)
+		require.True(t, ok)
+	})
+
+	t.Run("rejects unsupported principal type", func(t *testing.T) {
+		t.Parallel()
+
+		authorizer := iam.NewAuthorizer(nil, log.NewLogger(log.WithOutput(io.Discard)))
+
+		scope, decisions, err := authorizer.AuthorizeMulti(
+			context.Background(),
+			iam.AuthorizeMultiParams{
+				Principal: gid.New(gid.NewTenantID(), coredata.OrganizationEntityType),
+				Items: []iam.MultiAuthorizeItem{
+					{
+						Resource: gid.New(gid.NewTenantID(), coredata.FrameworkEntityType),
+						Action:   "core:test:get",
+					},
+				},
+			},
+		)
+		require.Error(t, err)
+		assert.Nil(t, scope)
+		assert.Nil(t, decisions)
+
+		_, ok := errors.AsType[*iam.ErrUnsupportedPrincipalType](err)
+		require.True(t, ok)
+	})
+
+	t.Run("assumption error is recorded only on items that require the check", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestPgClient(t)
+		fixture := seedBatchAuthorizeFixture(t, context.Background(), client)
+		action := newBatchTestAction()
+		authorizer := newTestAuthorizerWithStatements(
+			client,
+			policy.Allow(action).WithSID("allow-evaluate-mixed-skip-assumption"),
+		)
+		sessionID := gid.New(gid.NilTenant, coredata.SessionEntityType)
+
+		scope, decisions, err := authorizer.AuthorizeMulti(
+			context.Background(),
+			iam.AuthorizeMultiParams{
+				Principal: fixture.identityID,
+				Session:   &sessionID,
+				Items: []iam.MultiAuthorizeItem{
+					{
+						Resource:            fixture.frameworkID1,
+						Action:              action,
+						SkipAssumptionCheck: true,
+					},
+					{
+						Resource: fixture.frameworkID2,
+						Action:   action,
+					},
+				},
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, scope)
+		require.Len(t, decisions, 2)
+		assert.NoError(t, decisions[0])
+		require.Error(t, decisions[1])
+
+		_, ok := errors.AsType[*iam.ErrAssumptionRequired](decisions[1])
+		require.True(t, ok)
+
+		assert.Equal(t, 1, countAuditLogsForAction(t, context.Background(), client, action))
+	})
+
+	t.Run("per-item resource attributes are honoured by the policy", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestPgClient(t)
+		fixture := seedBatchAuthorizeFixture(t, context.Background(), client)
+		action := newBatchTestAction()
+		authorizer := newTestAuthorizerWithStatements(
+			client,
+			policy.Allow(action).
+				WithSID("allow-when-resource-flag-set").
+				When(policy.Equals("resource.flag", "on")),
+		)
+
+		scope, decisions, err := authorizer.AuthorizeMulti(
+			context.Background(),
+			iam.AuthorizeMultiParams{
+				Principal: fixture.identityID,
+				Items: []iam.MultiAuthorizeItem{
+					{
+						Resource:           fixture.frameworkID1,
+						Action:             action,
+						ResourceAttributes: policy.Attributes{"flag": "on"},
+					},
+					{
+						Resource:           fixture.frameworkID2,
+						Action:             action,
+						ResourceAttributes: policy.Attributes{"flag": "off"},
+					},
+				},
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, scope)
+		require.Len(t, decisions, 2)
+		assert.NoError(t, decisions[0])
+		require.Error(t, decisions[1])
+
+		denied, ok := errors.AsType[*iam.ErrInsufficientPermissions](decisions[1])
+		require.True(t, ok)
+		assert.Equal(t, fixture.frameworkID2, denied.EntityID)
+
+		assert.Equal(t, 1, countAuditLogsForAction(t, context.Background(), client, action))
+	})
+}
+
+func newTestAuthorizer(client *pg.Client, action string, allowResourceID *gid.GID) *iam.Authorizer {
+	statement := policy.Allow(action).WithSID("allow-test-action")
+	if allowResourceID != nil {
+		statement = statement.When(policy.Equals("resource.id", allowResourceID.String()))
+	}
+
+	return newTestAuthorizerWithStatements(client, statement)
+}
+
+func newTestAuthorizerWithStatements(client *pg.Client, statements ...policy.Statement) *iam.Authorizer {
+	authorizer := iam.NewAuthorizer(client, log.NewLogger(log.WithOutput(io.Discard)))
+	authorizer.RegisterPolicySet(
+		iam.NewPolicySet().AddRolePolicy(
+			string(coredata.MembershipRoleOwner),
+			policy.NewPolicy("batch-authorize-test", "Batch Authorize Test", statements...),
+		),
+	)
+
+	return authorizer
+}
+
+func newTestAuthorizerWithIdentityScopedStatements(client *pg.Client, statements ...policy.Statement) *iam.Authorizer {
+	authorizer := iam.NewAuthorizer(client, log.NewLogger(log.WithOutput(io.Discard)))
+	authorizer.RegisterPolicySet(
+		iam.NewPolicySet().AddIdentityScopedPolicy(
+			policy.NewPolicy("batch-authorize-identity-test", "Batch Authorize Identity Test", statements...),
+		),
+	)
+
+	return authorizer
+}
+
+func seedBatchAuthorizeFixture(t *testing.T, ctx context.Context, client *pg.Client) batchAuthorizeFixture {
+	t.Helper()
+
+	tenantID := gid.NewTenantID()
+	scope := coredata.NewScope(tenantID)
+	identityID := gid.New(gid.NilTenant, coredata.IdentityEntityType)
+	organizationID := gid.New(tenantID, coredata.OrganizationEntityType)
+	organization2ID := gid.New(tenantID, coredata.OrganizationEntityType)
+	membershipID := gid.New(tenantID, coredata.MembershipEntityType)
+	profileID := gid.New(tenantID, coredata.MembershipProfileEntityType)
+	frameworkID1 := gid.New(tenantID, coredata.FrameworkEntityType)
+	frameworkID2 := gid.New(tenantID, coredata.FrameworkEntityType)
+	frameworkID3 := gid.New(tenantID, coredata.FrameworkEntityType)
+	now := time.Now().UTC()
+
+	emailAddress, err := mail.ParseAddr(fmt.Sprintf("%s@example.com", tenantID))
+	require.NoError(t, err)
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		identity := coredata.Identity{
+			ID:                   identityID,
+			EmailAddress:         emailAddress,
+			FullName:             "Batch Test User",
+			EmailAddressVerified: true,
+			CreatedAt:            now,
+			UpdatedAt:            now,
+		}
+		if err := identity.Insert(ctx, tx); err != nil {
+			return fmt.Errorf("cannot insert identity: %w", err)
+		}
+
+		organization := coredata.Organization{
+			ID:        organizationID,
+			TenantID:  tenantID,
+			Name:      "Batch Test Org A",
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		if err := organization.Insert(ctx, tx); err != nil {
+			return fmt.Errorf("cannot insert first organization: %w", err)
+		}
+
+		organization2 := coredata.Organization{
+			ID:        organization2ID,
+			TenantID:  tenantID,
+			Name:      "Batch Test Org B",
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		if err := organization2.Insert(ctx, tx); err != nil {
+			return fmt.Errorf("cannot insert second organization: %w", err)
+		}
+
+		membership := coredata.Membership{
+			ID:             membershipID,
+			IdentityID:     identityID,
+			OrganizationID: organizationID,
+			Role:           coredata.MembershipRoleOwner,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}
+		if err := membership.Insert(ctx, tx, scope); err != nil {
+			return fmt.Errorf("cannot insert membership: %w", err)
+		}
+
+		profile := coredata.MembershipProfile{
+			ID:             profileID,
+			IdentityID:     identityID,
+			OrganizationID: organizationID,
+			Source:         coredata.ProfileSourceManual,
+			State:          coredata.ProfileStateActive,
+			FullName:       "Batch Test User",
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}
+		if err := profile.Insert(ctx, tx); err != nil {
+			return fmt.Errorf("cannot insert membership profile: %w", err)
+		}
+
+		framework1 := coredata.Framework{
+			ID:             frameworkID1,
+			OrganizationID: organizationID,
+			ReferenceID:    fmt.Sprintf("batch-test-framework-1-%s", tenantID),
+			Name:           "Batch Test Framework 1",
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}
+		if err := framework1.Insert(ctx, tx, scope); err != nil {
+			return fmt.Errorf("cannot insert first framework: %w", err)
+		}
+
+		framework2 := coredata.Framework{
+			ID:             frameworkID2,
+			OrganizationID: organizationID,
+			ReferenceID:    fmt.Sprintf("batch-test-framework-2-%s", tenantID),
+			Name:           "Batch Test Framework 2",
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}
+		if err := framework2.Insert(ctx, tx, scope); err != nil {
+			return fmt.Errorf("cannot insert second framework: %w", err)
+		}
+
+		framework3 := coredata.Framework{
+			ID:             frameworkID3,
+			OrganizationID: organization2ID,
+			ReferenceID:    fmt.Sprintf("batch-test-framework-3-%s", tenantID),
+			Name:           "Batch Test Framework 3",
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}
+		if err := framework3.Insert(ctx, tx, scope); err != nil {
+			return fmt.Errorf("cannot insert third framework: %w", err)
+		}
+
+		return nil
+	}))
+
+	return batchAuthorizeFixture{
+		tenantID:        tenantID,
+		identityID:      identityID,
+		membershipID:    membershipID,
+		organizationID:  organizationID,
+		organization2ID: organization2ID,
+		frameworkID1:    frameworkID1,
+		frameworkID2:    frameworkID2,
+		frameworkID3:    frameworkID3,
+	}
+}
+
+func insertBatchTestIdentity(
+	t *testing.T,
+	ctx context.Context,
+	client *pg.Client,
+	tenantID gid.TenantID,
+) gid.GID {
+	t.Helper()
+
+	identityID := gid.New(gid.NilTenant, coredata.IdentityEntityType)
+	now := time.Now().UTC()
+
+	emailAddress, err := mail.ParseAddr(fmt.Sprintf("%s-no-membership@example.com", tenantID))
+	require.NoError(t, err)
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		identity := coredata.Identity{
+			ID:                   identityID,
+			EmailAddress:         emailAddress,
+			FullName:             "Batch Test No Membership User",
+			EmailAddressVerified: true,
+			CreatedAt:            now,
+			UpdatedAt:            now,
+		}
+		if err := identity.Insert(ctx, tx); err != nil {
+			return fmt.Errorf("cannot insert identity without membership: %w", err)
+		}
+
+		return nil
+	}))
+
+	return identityID
+}
+
+func insertBatchTestChildSession(
+	t *testing.T,
+	ctx context.Context,
+	client *pg.Client,
+	fixture batchAuthorizeFixture,
+	rootSessionID gid.GID,
+	expired bool,
+) gid.GID {
+	t.Helper()
+
+	childSessionID := gid.New(gid.NilTenant, coredata.SessionEntityType)
+	now := time.Now().UTC()
+	expiredAt := now.Add(30 * time.Minute)
+
+	var expireReason *coredata.ExpireReason
+	if expired {
+		reason := coredata.ExpireReasonRevoked
+		expireReason = &reason
+		expiredAt = now.Add(-1 * time.Minute)
+	}
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		rootSession := coredata.Session{
+			ID:              rootSessionID,
+			IdentityID:      fixture.identityID,
+			Data:            coredata.SessionData{},
+			AuthMethod:      coredata.AuthMethodPassword,
+			AuthenticatedAt: now,
+			UserAgent:       "batch-test-root-agent",
+			IPAddress:       net.ParseIP("127.0.0.1"),
+			ExpiredAt:       now.Add(30 * time.Minute),
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		}
+		if err := rootSession.Insert(ctx, tx); err != nil {
+			return fmt.Errorf("cannot insert root session: %w", err)
+		}
+
+		session := coredata.Session{
+			ID:              childSessionID,
+			IdentityID:      fixture.identityID,
+			TenantID:        &fixture.tenantID,
+			MembershipID:    &fixture.membershipID,
+			ParentSessionID: &rootSessionID,
+			Data:            coredata.SessionData{},
+			AuthMethod:      coredata.AuthMethodPassword,
+			AuthenticatedAt: now,
+			UserAgent:       "batch-test-agent",
+			IPAddress:       net.ParseIP("127.0.0.1"),
+			ExpireReason:    expireReason,
+			ExpiredAt:       expiredAt,
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		}
+		if err := session.Insert(ctx, tx); err != nil {
+			return fmt.Errorf("cannot insert child session: %w", err)
+		}
+
+		return nil
+	}))
+
+	return childSessionID
+}
+
+func countAuditLogsForAction(t *testing.T, ctx context.Context, client *pg.Client, action string) int {
+	t.Helper()
+
+	var count int
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		if err := tx.QueryRow(
+			ctx,
+			"SELECT COUNT(id) FROM audit_log_entries WHERE action = $1",
+			action,
+		).Scan(&count); err != nil {
+			return fmt.Errorf("cannot query audit log count: %w", err)
+		}
+
+		return nil
+	}))
+
+	return count
+}
+
+func newBatchTestAction() string {
+	return fmt.Sprintf("test:framework-%d:get", time.Now().UnixNano())
+}
+
+func newTestPgClient(t *testing.T) *pg.Client {
+	t.Helper()
+
+	dsn := os.Getenv(testPgDSNEnvVar)
+	if dsn == "" {
+		t.Skipf("skipping: %s not set (requires a migrated test database)", testPgDSNEnvVar)
+	}
+
+	u, err := url.Parse(dsn)
+	require.NoError(t, err, "invalid %s value", testPgDSNEnvVar)
+
+	opts := []pg.Option{
+		pg.WithRegisterer(prometheus.NewRegistry()),
+	}
+
+	if u.Host != "" {
+		host := u.Host
+		if u.Port() == "" {
+			host = net.JoinHostPort(u.Hostname(), "5432")
+		}
+
+		opts = append(opts, pg.WithAddr(host))
+	}
+
+	if u.User != nil {
+		opts = append(opts, pg.WithUser(u.User.Username()))
+		if password, ok := u.User.Password(); ok {
+			opts = append(opts, pg.WithPassword(password))
+		}
+	}
+
+	if len(u.Path) > 1 {
+		opts = append(opts, pg.WithDatabase(u.Path[1:]))
+	}
+
+	client, err := pg.NewClient(opts...)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		client.Close()
+	})
+
+	return client
+}

--- a/pkg/iam/authorizer_batch_test.go
+++ b/pkg/iam/authorizer_batch_test.go
@@ -986,6 +986,7 @@ func insertBatchTestChildSession(
 	expiredAt := now.Add(30 * time.Minute)
 
 	var expireReason *coredata.ExpireReason
+
 	if expired {
 		reason := coredata.ExpireReasonRevoked
 		expireReason = &reason
@@ -1039,6 +1040,7 @@ func countAuditLogsForAction(t *testing.T, ctx context.Context, client *pg.Clien
 	t.Helper()
 
 	var count int
+
 	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
 		if err := tx.QueryRow(
 			ctx,

--- a/pkg/iam/authorizer_unit_test.go
+++ b/pkg/iam/authorizer_unit_test.go
@@ -354,7 +354,6 @@ func TestAuthorizer_BuildAuditLogEntry(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/iam/authorizer_unit_test.go
+++ b/pkg/iam/authorizer_unit_test.go
@@ -83,7 +83,6 @@ func TestAuthorizer_ValidateInputs(t *testing.T) {
 		_, ok := errors.AsType[*ErrEmptyResourceBatch](err)
 		require.True(t, ok)
 	})
-
 }
 
 func TestAuthorizer_InternalErrorPaths(t *testing.T) {

--- a/pkg/iam/authorizer_unit_test.go
+++ b/pkg/iam/authorizer_unit_test.go
@@ -1,0 +1,489 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package iam
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.gearno.de/kit/log"
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam/policy"
+)
+
+func TestAuthorizer_ValidateInputs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("authorize rejects unsupported principal type", func(t *testing.T) {
+		t.Parallel()
+
+		a := &Authorizer{}
+		_, err := a.Authorize(
+			context.Background(),
+			AuthorizeParams{
+				Principal: gid.New(gid.NewTenantID(), coredata.OrganizationEntityType),
+			},
+		)
+		require.Error(t, err)
+
+		errUnsupported, ok := errors.AsType[*ErrUnsupportedPrincipalType](err)
+		require.True(t, ok)
+		assert.Equal(t, coredata.OrganizationEntityType, errUnsupported.EntityType)
+	})
+
+	t.Run("authorize batch rejects unsupported principal type", func(t *testing.T) {
+		t.Parallel()
+
+		a := &Authorizer{}
+		_, err := a.AuthorizeBatch(
+			context.Background(),
+			AuthorizeBatchParams{
+				Principal: gid.New(gid.NewTenantID(), coredata.OrganizationEntityType),
+				Resources: []gid.GID{gid.New(gid.NewTenantID(), coredata.FrameworkEntityType)},
+			},
+		)
+		require.Error(t, err)
+
+		errUnsupported, ok := errors.AsType[*ErrUnsupportedPrincipalType](err)
+		require.True(t, ok)
+		assert.Equal(t, coredata.OrganizationEntityType, errUnsupported.EntityType)
+	})
+
+	t.Run("authorize batch rejects empty resources", func(t *testing.T) {
+		t.Parallel()
+
+		a := &Authorizer{}
+		_, err := a.AuthorizeBatch(
+			context.Background(),
+			AuthorizeBatchParams{
+				Principal: gid.New(gid.NilTenant, coredata.IdentityEntityType),
+			},
+		)
+		require.Error(t, err)
+		_, ok := errors.AsType[*ErrEmptyResourceBatch](err)
+		require.True(t, ok)
+	})
+
+}
+
+func TestAuthorizer_InternalErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	identityID := gid.New(gid.NilTenant, coredata.IdentityEntityType)
+	unknownResourceID := gid.New(gid.NewTenantID(), 65535)
+	unsupportedResourceID := gid.New(gid.NewTenantID(), coredata.OAuth2AccessTokenEntityType)
+
+	a := &Authorizer{
+		evaluator: policy.NewEvaluator(),
+		policySet: NewPolicySet(),
+	}
+
+	t.Run("authorize batch returns wrapped resource attributes batch error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := a.authorizeMulti(
+			ctx,
+			nil,
+			AuthorizeMultiParams{
+				Principal: identityID,
+				Items: []MultiAuthorizeItem{
+					{
+						Resource: unknownResourceID,
+						Action:   "core:test:list",
+					},
+				},
+			},
+			nil,
+		)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "cannot build resource attributes batch")
+	})
+
+	t.Run("authorize batch rejects mixed entity types", func(t *testing.T) {
+		t.Parallel()
+
+		firstResourceID := gid.New(gid.NewTenantID(), coredata.FrameworkEntityType)
+		secondResourceID := gid.New(gid.NewTenantID(), coredata.OrganizationEntityType)
+
+		_, err := a.AuthorizeBatch(
+			ctx,
+			AuthorizeBatchParams{
+				Principal: identityID,
+				Action:    "core:test:list",
+				Resources: []gid.GID{firstResourceID, secondResourceID},
+			},
+		)
+		require.Error(t, err)
+
+		errMixedEntityType, ok := errors.AsType[*ErrMixedEntityTypeBatch](err)
+		require.True(t, ok)
+		assert.Equal(
+			t,
+			[]uint16{coredata.OrganizationEntityType, coredata.FrameworkEntityType},
+			errMixedEntityType.EntityTypes,
+		)
+	})
+
+	t.Run("build principal attributes rejects unsupported batch interface type", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := a.buildPrincipalAttributes(
+			ctx,
+			nil,
+			unsupportedResourceID,
+			map[string]string{"role": "OWNER"},
+		)
+		require.Error(t, err)
+		errUnsupported, ok := errors.AsType[*ErrBatchAuthorizationUnsupportedResourceType](err)
+		require.True(t, ok)
+		assert.Equal(t, coredata.OAuth2AccessTokenEntityType, errUnsupported.EntityType)
+	})
+
+	t.Run("build principal attributes keeps defaults when entity type is unknown", func(t *testing.T) {
+		t.Parallel()
+
+		attrs, err := a.buildPrincipalAttributes(
+			ctx,
+			nil,
+			unknownResourceID,
+			map[string]string{"role": "OWNER"},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, unknownResourceID.String(), attrs["id"])
+		assert.Equal(t, "OWNER", attrs["role"])
+	})
+}
+
+func TestAuthorizer_HelperMethods(t *testing.T) {
+	t.Parallel()
+
+	t.Run("check assumption short-circuits", func(t *testing.T) {
+		t.Parallel()
+
+		a := &Authorizer{}
+		identityID := gid.New(gid.NilTenant, coredata.IdentityEntityType)
+		sessionID := gid.New(gid.NilTenant, coredata.SessionEntityType)
+		membership := &coredata.Membership{ID: gid.New(gid.NewTenantID(), coredata.MembershipEntityType)}
+
+		require.NoError(t, a.checkAssumption(context.Background(), nil, identityID, nil, membership, false))
+		require.NoError(t, a.checkAssumption(context.Background(), nil, identityID, &sessionID, nil, false))
+		require.NoError(t, a.checkAssumption(context.Background(), nil, identityID, &sessionID, membership, true))
+	})
+
+	t.Run("build policies for role includes identity scoped policies", func(t *testing.T) {
+		t.Parallel()
+
+		a := &Authorizer{
+			policySet: NewPolicySet().
+				AddIdentityScopedPolicy(policy.NewPolicy("identity", "Identity", policy.Allow("identity:read"))).
+				AddRolePolicy("OWNER", policy.NewPolicy("owner", "Owner", policy.Allow("core:*"))),
+		}
+
+		withRole := a.buildPoliciesForRole("OWNER")
+		require.Len(t, withRole, 2)
+
+		withoutRole := a.buildPoliciesForRole("VIEWER")
+		require.Len(t, withoutRole, 1)
+	})
+
+	t.Run("unique sorted strings deduplicates and sorts", func(t *testing.T) {
+		t.Parallel()
+
+		got := uniqueSortedStrings([]string{"b", "a", "b", "", "c", "a"})
+		assert.Equal(t, []string{"", "a", "b", "c"}, got)
+	})
+
+	t.Run("unique sorted entity types deduplicates and sorts", func(t *testing.T) {
+		t.Parallel()
+
+		got := uniqueSortedEntityTypes(
+			[]uint16{
+				coredata.FrameworkEntityType,
+				coredata.OrganizationEntityType,
+				coredata.FrameworkEntityType,
+				coredata.OrganizationEntityType,
+			},
+		)
+		assert.Equal(
+			t,
+			[]uint16{coredata.OrganizationEntityType, coredata.FrameworkEntityType},
+			got,
+		)
+	})
+
+	t.Run("resource type from action parses segments", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, "ThirdParty", resourceTypeFromAction("core:third-party:get"))
+		assert.Equal(t, "WebhookSubscription", resourceTypeFromAction("core:webhook-subscription:delete"))
+		assert.Equal(t, "Unknown", resourceTypeFromAction("invalid-action"))
+	})
+}
+
+func TestAuthorizer_LoadMembership(t *testing.T) {
+	t.Parallel()
+
+	a := &Authorizer{}
+
+	t.Run("empty organization id returns nil membership", func(t *testing.T) {
+		t.Parallel()
+
+		membership, err := a.loadMembership(
+			context.Background(),
+			nil,
+			gid.New(gid.NilTenant, coredata.IdentityEntityType),
+			"",
+		)
+		require.NoError(t, err)
+		assert.Nil(t, membership)
+	})
+
+	t.Run("invalid organization id returns parse error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := a.loadMembership(
+			context.Background(),
+			nil,
+			gid.New(gid.NilTenant, coredata.IdentityEntityType),
+			"not-a-gid",
+		)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "cannot parse gid")
+	})
+}
+
+func TestAuthorizer_BuildAuditLogEntry(t *testing.T) {
+	t.Parallel()
+
+	tenantID := gid.NewTenantID()
+	orgID := gid.New(tenantID, coredata.OrganizationEntityType)
+	principalID := gid.New(gid.NilTenant, coredata.IdentityEntityType)
+	resourceID := gid.New(tenantID, coredata.FrameworkEntityType)
+	sessionID := gid.New(gid.NilTenant, coredata.SessionEntityType)
+
+	tests := []struct {
+		name          string
+		params        AuthorizeParams
+		resourceAttrs policy.Attributes
+		wantNil       bool
+		wantActorType coredata.AuditLogActorType
+	}{
+		{
+			name: "dry run returns nil",
+			params: AuthorizeParams{
+				Principal: principalID,
+				Resource:  resourceID,
+				Action:    "core:framework:get",
+				DryRun:    true,
+			},
+			resourceAttrs: policy.Attributes{
+				"organization_id": orgID.String(),
+			},
+			wantNil: true,
+		},
+		{
+			name: "missing organization id returns nil",
+			params: AuthorizeParams{
+				Principal: principalID,
+				Resource:  resourceID,
+				Action:    "core:framework:get",
+			},
+			resourceAttrs: policy.Attributes{
+				"id": resourceID.String(),
+			},
+			wantNil: true,
+		},
+		{
+			name: "unparseable organization id returns nil",
+			params: AuthorizeParams{
+				Principal: principalID,
+				Resource:  resourceID,
+				Action:    "core:framework:get",
+			},
+			resourceAttrs: policy.Attributes{
+				"organization_id": "invalid-gid",
+			},
+			wantNil: true,
+		},
+		{
+			name: "session present sets user actor type",
+			params: AuthorizeParams{
+				Principal: principalID,
+				Resource:  resourceID,
+				Action:    "core:framework:get",
+				Session:   &sessionID,
+			},
+			resourceAttrs: policy.Attributes{
+				"organization_id": orgID.String(),
+			},
+			wantActorType: coredata.AuditLogActorTypeUser,
+		},
+		{
+			name: "nil session sets api key actor type",
+			params: AuthorizeParams{
+				Principal: principalID,
+				Resource:  resourceID,
+				Action:    "core:framework:get",
+			},
+			resourceAttrs: policy.Attributes{
+				"organization_id": orgID.String(),
+			},
+			wantActorType: coredata.AuditLogActorTypeAPIKey,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := &Authorizer{
+				logger: log.NewLogger(log.WithOutput(io.Discard)),
+			}
+
+			entry := a.buildAuditLogEntry(context.Background(), tt.params, tt.resourceAttrs)
+			if tt.wantNil {
+				assert.Nil(t, entry)
+
+				return
+			}
+
+			require.NotNil(t, entry)
+			assert.Equal(t, tt.wantActorType, entry.ActorType)
+			assert.Equal(t, tt.params.Principal, entry.ActorID)
+			assert.Equal(t, tt.params.Resource, entry.ResourceID)
+			assert.Equal(t, tt.params.Action, entry.Action)
+		})
+	}
+}
+
+func TestAuthorizer_WrappedInternalErrors(t *testing.T) {
+	t.Parallel()
+
+	a := &Authorizer{
+		logger: log.NewLogger(log.WithOutput(io.Discard)),
+	}
+
+	queryErr := errors.New("query failed")
+	tx := &errorTx{queryErr: queryErr}
+	principalID := gid.New(gid.NilTenant, coredata.IdentityEntityType)
+	membershipID := gid.New(gid.NewTenantID(), coredata.MembershipEntityType)
+	sessionID := gid.New(gid.NilTenant, coredata.SessionEntityType)
+	resourceOrgID := gid.New(gid.NewTenantID(), coredata.OrganizationEntityType).String()
+
+	t.Run("load membership wraps load errors", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := a.loadMembership(context.Background(), tx, principalID, resourceOrgID)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "cannot load active membership")
+	})
+
+	t.Run("get active child session wraps load errors", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := a.getActiveChildSessionForMembership(
+			context.Background(),
+			tx,
+			sessionID,
+			membershipID,
+		)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "cannot load child session")
+	})
+
+	t.Run("check assumption wraps non-assumption errors", func(t *testing.T) {
+		t.Parallel()
+
+		err := a.checkAssumption(
+			context.Background(),
+			tx,
+			principalID,
+			&sessionID,
+			&coredata.Membership{ID: membershipID},
+			false,
+		)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "cannot get active child session for membership")
+
+		_, ok := errors.AsType[*ErrAssumptionRequired](err)
+		assert.False(t, ok)
+	})
+
+	t.Run("build principal attributes wraps load errors", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := a.buildPrincipalAttributes(context.Background(), tx, principalID, nil)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "cannot load principal attributes")
+	})
+
+	t.Run("load resource attributes by type wraps load errors", func(t *testing.T) {
+		t.Parallel()
+
+		resourceID := gid.New(gid.NewTenantID(), coredata.FrameworkEntityType)
+
+		_, err := a.loadResourceAttributesByType(context.Background(), tx, []gid.GID{resourceID})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "cannot load batched resource attributes")
+	})
+}
+
+type errorRow struct {
+	err error
+}
+
+func (r *errorRow) Scan(...any) error {
+	return r.err
+}
+
+type errorTx struct {
+	queryErr error
+}
+
+var _ pg.Tx = (*errorTx)(nil)
+
+func (tx *errorTx) Exec(context.Context, string, ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, tx.queryErr
+}
+
+func (tx *errorTx) Query(context.Context, string, ...any) (pgx.Rows, error) {
+	return nil, tx.queryErr
+}
+
+func (tx *errorTx) QueryRow(context.Context, string, ...any) pgx.Row {
+	return &errorRow{err: tx.queryErr}
+}
+
+func (tx *errorTx) CopyFrom(context.Context, pgx.Identifier, []string, pgx.CopyFromSource) (int64, error) {
+	return 0, tx.queryErr
+}
+
+func (tx *errorTx) SendBatch(context.Context, *pgx.Batch) pgx.BatchResults {
+	return nil
+}
+
+func (tx *errorTx) Savepoint(context.Context, pg.ExecFunc[pg.Tx]) error {
+	return tx.queryErr
+}

--- a/pkg/iam/errors.go
+++ b/pkg/iam/errors.go
@@ -193,6 +193,64 @@ func (e ErrInsufficientPermissions) Error() string {
 	return fmt.Sprintf("identity %q does not have sufficient permissions to perform action %s on entity %q", e.IdentityID, e.Action, e.EntityID)
 }
 
+type ErrMixedOrganizationBatch struct {
+	Action          Action
+	OrganizationIDs []string
+}
+
+func NewMixedOrganizationBatchError(action Action, organizationIDs []string) error {
+	return &ErrMixedOrganizationBatch{Action: action, OrganizationIDs: organizationIDs}
+}
+
+func (e ErrMixedOrganizationBatch) Error() string {
+	return fmt.Sprintf(
+		"cannot authorize batch action %s across organization ids %q",
+		e.Action,
+		e.OrganizationIDs,
+	)
+}
+
+type ErrMixedEntityTypeBatch struct {
+	Action      Action
+	EntityTypes []uint16
+}
+
+func NewMixedEntityTypeBatchError(action Action, entityTypes []uint16) error {
+	return &ErrMixedEntityTypeBatch{Action: action, EntityTypes: entityTypes}
+}
+
+func (e ErrMixedEntityTypeBatch) Error() string {
+	return fmt.Sprintf(
+		"cannot authorize batch action %s across entity types %v",
+		e.Action,
+		e.EntityTypes,
+	)
+}
+
+type ErrEmptyResourceBatch struct {
+	Action Action
+}
+
+func NewEmptyResourceBatchError(action Action) error {
+	return &ErrEmptyResourceBatch{Action: action}
+}
+
+func (e ErrEmptyResourceBatch) Error() string {
+	return fmt.Sprintf("cannot authorize batch action %s with an empty resource set", e.Action)
+}
+
+type ErrBatchAuthorizationUnsupportedResourceType struct {
+	EntityType uint16
+}
+
+func NewBatchAuthorizationUnsupportedResourceTypeError(entityType uint16) error {
+	return &ErrBatchAuthorizationUnsupportedResourceType{EntityType: entityType}
+}
+
+func (e ErrBatchAuthorizationUnsupportedResourceType) Error() string {
+	return fmt.Sprintf("resource type %d does not support batch authorization attributes", e.EntityType)
+}
+
 type ErrAssumptionRequired struct {
 	IdentityID   gid.GID
 	MembershipID gid.GID

--- a/pkg/iam/errors_test.go
+++ b/pkg/iam/errors_test.go
@@ -104,7 +104,6 @@ func TestAuthorizeRelatedErrors_Error(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if tt.err.Error() != tt.want {

--- a/pkg/iam/errors_test.go
+++ b/pkg/iam/errors_test.go
@@ -106,6 +106,7 @@ func TestAuthorizeRelatedErrors_Error(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+
 			if tt.err.Error() != tt.want {
 				t.Errorf("Error() = %q, want %q", tt.err.Error(), tt.want)
 			}

--- a/pkg/iam/errors_test.go
+++ b/pkg/iam/errors_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package iam_test
+
+import (
+	"fmt"
+	"testing"
+
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam"
+)
+
+func TestAuthorizeRelatedErrors_Error(t *testing.T) {
+	t.Parallel()
+
+	tenantID := gid.NewTenantID()
+	identityID := gid.New(gid.NilTenant, coredata.IdentityEntityType)
+	resourceID := gid.New(tenantID, coredata.FrameworkEntityType)
+	membershipID := gid.New(tenantID, coredata.MembershipEntityType)
+	sessionID := gid.New(gid.NilTenant, coredata.SessionEntityType)
+	action := iam.Action("core:framework:get")
+	mixedOrgIDs := []string{
+		gid.New(tenantID, coredata.OrganizationEntityType).String(),
+		gid.New(tenantID, coredata.OrganizationEntityType).String(),
+	}
+	mixedEntityTypes := []uint16{coredata.OrganizationEntityType, coredata.FrameworkEntityType}
+
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "insufficient permissions",
+			err:  iam.NewInsufficientPermissionsError(identityID, resourceID, action),
+			want: fmt.Sprintf(
+				"identity %q does not have sufficient permissions to perform action %s on entity %q",
+				identityID,
+				action,
+				resourceID,
+			),
+		},
+		{
+			name: "unsupported principal type",
+			err:  iam.NewUnsupportedPrincipalTypeError(coredata.OrganizationEntityType),
+			want: fmt.Sprintf("unsupported principal type: %d", coredata.OrganizationEntityType),
+		},
+		{
+			name: "empty resource batch",
+			err:  iam.NewEmptyResourceBatchError(action),
+			want: fmt.Sprintf("cannot authorize batch action %s with an empty resource set", action),
+		},
+		{
+			name: "mixed entity type batch",
+			err:  iam.NewMixedEntityTypeBatchError(action, mixedEntityTypes),
+			want: fmt.Sprintf("cannot authorize batch action %s across entity types %v", action, mixedEntityTypes),
+		},
+		{
+			name: "mixed organization batch",
+			err:  iam.NewMixedOrganizationBatchError(action, mixedOrgIDs),
+			want: fmt.Sprintf("cannot authorize batch action %s across organization ids %q", action, mixedOrgIDs),
+		},
+		{
+			name: "batch unsupported resource type",
+			err:  iam.NewBatchAuthorizationUnsupportedResourceTypeError(coredata.OAuth2AccessTokenEntityType),
+			want: fmt.Sprintf(
+				"resource type %d does not support batch authorization attributes",
+				coredata.OAuth2AccessTokenEntityType,
+			),
+		},
+		{
+			name: "assumption required",
+			err:  iam.NewAssumptionRequiredError(identityID, membershipID),
+			want: fmt.Sprintf("assumption for identity %q required for membership %q", identityID, membershipID),
+		},
+		{
+			name: "session not found with nil id",
+			err:  iam.NewSessionNotFoundError(gid.Nil),
+			want: "session not found",
+		},
+		{
+			name: "session not found with specific id",
+			err:  iam.NewSessionNotFoundError(sessionID),
+			want: fmt.Sprintf("session %q not found", sessionID),
+		},
+		{
+			name: "session expired",
+			err:  iam.NewSessionExpiredError(sessionID),
+			want: fmt.Sprintf("session %q expired", sessionID),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if tt.err.Error() != tt.want {
+				t.Errorf("Error() = %q, want %q", tt.err.Error(), tt.want)
+			}
+		})
+	}
+}

--- a/pkg/iam/policy/matcher_test.go
+++ b/pkg/iam/policy/matcher_test.go
@@ -166,8 +166,26 @@ func TestActionMatcher_Matches(t *testing.T) {
 			target:  "documents:document:read",
 			want:    false,
 		},
+		{
+			name:    "two-part pattern without wildcard is invalid",
+			pattern: "iam:identity",
+			target:  "iam:identity:get",
+			want:    false,
+		},
 
 		// Invalid targets
+		{
+			name:    "single-part non-wildcard pattern is invalid",
+			pattern: "iam",
+			target:  "iam:identity:get",
+			want:    false,
+		},
+		{
+			name:    "pattern with too many parts is invalid",
+			pattern: "iam:identity:get:extra",
+			target:  "iam:identity:get",
+			want:    false,
+		},
 		{
 			name:    "invalid target - too few parts",
 			pattern: "iam:identity:get",

--- a/pkg/iam/policy/policy_test.go
+++ b/pkg/iam/policy/policy_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package policy
+
+import (
+	"testing"
+
+	"go.probo.inc/probo/pkg/gid"
+)
+
+func TestPolicy_AddStatement(t *testing.T) {
+	p := NewPolicy("test", "Test")
+
+	stmt := Allow("iam:identity:get").WithSID("allow-identity-get")
+	p.AddStatement(stmt)
+
+	if len(p.Statements) != 1 {
+		t.Fatalf("expected 1 statement, got %d", len(p.Statements))
+	}
+
+	if p.Statements[0].SID != "allow-identity-get" {
+		t.Errorf("expected SID %q, got %q", "allow-identity-get", p.Statements[0].SID)
+	}
+}
+
+func TestStatement_WithResources(t *testing.T) {
+	tenantID := gid.NewTenantID()
+	entityType := uint16(1001)
+
+	stmt := Allow("core:framework:get").WithResources(
+		ResourcePattern{
+			TenantID:   &tenantID,
+			EntityType: &entityType,
+		},
+	)
+
+	if len(stmt.Resources) != 1 {
+		t.Fatalf("expected 1 resource pattern, got %d", len(stmt.Resources))
+	}
+
+	if stmt.Resources[0].TenantID == nil || *stmt.Resources[0].TenantID != tenantID {
+		t.Fatalf("expected tenant id %q in resource pattern", tenantID)
+	}
+
+	if stmt.Resources[0].EntityType == nil || *stmt.Resources[0].EntityType != entityType {
+		t.Fatalf("expected entity type %d in resource pattern", entityType)
+	}
+}
+
+func TestEvaluator_Evaluate_ResourcePatternFilters(t *testing.T) {
+	evaluator := NewEvaluator()
+	tenantID := gid.NewTenantID()
+	otherTenantID := gid.NewTenantID()
+	entityType := uint16(1001)
+	otherEntityType := uint16(1002)
+
+	p := NewPolicy(
+		"resource-filter",
+		"Resource Filter",
+		Allow("core:framework:get").WithResources(
+			ResourcePattern{
+				TenantID:   &tenantID,
+				EntityType: &entityType,
+			},
+		),
+	)
+
+	tests := []struct {
+		name     string
+		resource gid.GID
+		want     Decision
+	}{
+		{
+			name:     "matching tenant and entity type allows",
+			resource: gid.New(tenantID, entityType),
+			want:     DecisionAllow,
+		},
+		{
+			name:     "different tenant does not match",
+			resource: gid.New(otherTenantID, entityType),
+			want:     DecisionNoMatch,
+		},
+		{
+			name:     "different entity type does not match",
+			resource: gid.New(tenantID, otherEntityType),
+			want:     DecisionNoMatch,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := evaluator.Evaluate(
+				AuthorizationRequest{
+					Action:   "core:framework:get",
+					Resource: tt.resource,
+				},
+				[]*Policy{p},
+			)
+			if result.Decision != tt.want {
+				t.Errorf("Evaluate() decision = %v, want %v", result.Decision, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/iam/policy/statement.go
+++ b/pkg/iam/policy/statement.go
@@ -104,18 +104,26 @@ const (
 	ConditionNotIn ConditionOperator = "NotIn"
 )
 
+type (
+	// Attributes is a flat key/value bag consumed by policy condition
+	// evaluation (e.g. "organization_id", "role", "id").
+	Attributes = map[string]string
+
+	// AttributesByID groups Attributes by resource id, as returned by
+	// batch attribute loaders.
+	AttributesByID = map[gid.GID]Attributes
+)
+
 // ConditionContext provides attribute values for condition evaluation.
 type ConditionContext struct {
-	Principal map[string]string
-	Resource  map[string]string
+	Principal Attributes
+	Resource  Attributes
 }
 
 // Evaluate checks if the condition is satisfied given the context.
 func (c Condition) Evaluate(ctx ConditionContext) bool {
-	// Resolve the key value from context
 	value, ok := resolveKey(c.Key, ctx)
 	if !ok {
-		// Key not found - condition fails
 		return false
 	}
 
@@ -198,7 +206,6 @@ func (c Condition) Evaluate(ctx ConditionContext) bool {
 // resolveKey extracts a value from the context based on a key path.
 // Key format: "principal.id", "resource.owner_id", etc.
 func resolveKey(key string, ctx ConditionContext) (string, bool) {
-	// Simple implementation - can be extended for nested paths
 	if len(key) > 10 && key[:10] == "principal." {
 		attrKey := key[10:]
 		val, ok := ctx.Principal[attrKey]
@@ -216,9 +223,9 @@ func resolveKey(key string, ctx ConditionContext) (string, bool) {
 	return "", false
 }
 
-// resolveValue resolves a value, which can be a literal or a reference to context.
+// resolveValue returns either a context reference (e.g. "principal.id")
+// resolved against ctx, or the value itself when it is a literal.
 func resolveValue(value string, ctx ConditionContext) (string, bool) {
-	// Check if value is a reference (e.g., "principal.id")
 	if len(value) > 10 && value[:10] == "principal." {
 		return resolveKey(value, ctx)
 	}
@@ -227,6 +234,5 @@ func resolveValue(value string, ctx ConditionContext) (string, bool) {
 		return resolveKey(value, ctx)
 	}
 
-	// Literal value
 	return value, true
 }

--- a/pkg/iam/policy/statement_test.go
+++ b/pkg/iam/policy/statement_test.go
@@ -16,7 +16,92 @@ package policy
 
 import (
 	"testing"
+
+	"go.probo.inc/probo/pkg/gid"
 )
+
+func TestResourcePattern_MatchesResource(t *testing.T) {
+	tenantID := gid.NewTenantID()
+	otherTenantID := gid.NewTenantID()
+	frameworkEntityType := uint16(1001)
+	organizationEntityType := uint16(1002)
+	resource := gid.New(tenantID, frameworkEntityType)
+	otherTenantResource := gid.New(otherTenantID, frameworkEntityType)
+	otherEntityResource := gid.New(tenantID, organizationEntityType)
+
+	tests := []struct {
+		name     string
+		pattern  ResourcePattern
+		resource gid.GID
+		want     bool
+	}{
+		{
+			name:     "empty pattern matches all resources",
+			pattern:  ResourcePattern{},
+			resource: resource,
+			want:     true,
+		},
+		{
+			name: "tenant only pattern matches same tenant",
+			pattern: ResourcePattern{
+				TenantID: &tenantID,
+			},
+			resource: resource,
+			want:     true,
+		},
+		{
+			name: "tenant only pattern does not match different tenant",
+			pattern: ResourcePattern{
+				TenantID: &tenantID,
+			},
+			resource: otherTenantResource,
+			want:     false,
+		},
+		{
+			name: "entity type only pattern matches same type",
+			pattern: ResourcePattern{
+				EntityType: &frameworkEntityType,
+			},
+			resource: resource,
+			want:     true,
+		},
+		{
+			name: "entity type only pattern does not match different type",
+			pattern: ResourcePattern{
+				EntityType: &frameworkEntityType,
+			},
+			resource: otherEntityResource,
+			want:     false,
+		},
+		{
+			name: "tenant and entity type pattern matches when both match",
+			pattern: ResourcePattern{
+				TenantID:   &tenantID,
+				EntityType: &frameworkEntityType,
+			},
+			resource: resource,
+			want:     true,
+		},
+		{
+			name: "tenant and entity type pattern fails when one mismatches",
+			pattern: ResourcePattern{
+				TenantID:   &tenantID,
+				EntityType: &frameworkEntityType,
+			},
+			resource: otherEntityResource,
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.pattern.MatchesResource(tt.resource)
+			if got != tt.want {
+				t.Errorf("MatchesResource() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestCondition_Evaluate_Equals(t *testing.T) {
 	tests := []struct {
@@ -223,6 +308,45 @@ func TestCondition_Evaluate_In(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "in - matches value inside comma-separated set",
+			condition: Condition{
+				Operator: ConditionIn,
+				Key:      "principal.organization_id",
+				Values:   []string{"resource.organization_ids"},
+			},
+			ctx: ConditionContext{
+				Principal: map[string]string{"organization_id": "org_2"},
+				Resource:  map[string]string{"organization_ids": "org_1, org_2, org_3"},
+			},
+			want: true,
+		},
+		{
+			name: "in - does not match comma-separated set",
+			condition: Condition{
+				Operator: ConditionIn,
+				Key:      "principal.organization_id",
+				Values:   []string{"resource.organization_ids"},
+			},
+			ctx: ConditionContext{
+				Principal: map[string]string{"organization_id": "org_9"},
+				Resource:  map[string]string{"organization_ids": "org_1,org_2"},
+			},
+			want: false,
+		},
+		{
+			name: "in - skips unresolved references",
+			condition: Condition{
+				Operator: ConditionIn,
+				Key:      "principal.organization_id",
+				Values:   []string{"resource.missing_ids"},
+			},
+			ctx: ConditionContext{
+				Principal: map[string]string{"organization_id": "org_2"},
+				Resource:  map[string]string{"organization_ids": "org_1,org_2"},
+			},
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -265,6 +389,57 @@ func TestCondition_Evaluate_NotIn(t *testing.T) {
 				Principal: map[string]string{"role": "admin"},
 			},
 			want: false,
+		},
+		{
+			name: "not in - comma-separated set contains value",
+			condition: Condition{
+				Operator: ConditionNotIn,
+				Key:      "principal.organization_id",
+				Values:   []string{"resource.organization_ids"},
+			},
+			ctx: ConditionContext{
+				Principal: map[string]string{"organization_id": "org_2"},
+				Resource:  map[string]string{"organization_ids": "org_1, org_2, org_3"},
+			},
+			want: false,
+		},
+		{
+			name: "not in - comma-separated set does not contain value",
+			condition: Condition{
+				Operator: ConditionNotIn,
+				Key:      "principal.organization_id",
+				Values:   []string{"resource.organization_ids"},
+			},
+			ctx: ConditionContext{
+				Principal: map[string]string{"organization_id": "org_9"},
+				Resource:  map[string]string{"organization_ids": "org_1,org_2"},
+			},
+			want: true,
+		},
+		{
+			name: "unknown operator returns false",
+			condition: Condition{
+				Operator: ConditionOperator("Unknown"),
+				Key:      "principal.role",
+				Values:   []string{"admin"},
+			},
+			ctx: ConditionContext{
+				Principal: map[string]string{"role": "admin"},
+			},
+			want: false,
+		},
+		{
+			name: "not in - skips unresolved references",
+			condition: Condition{
+				Operator: ConditionNotIn,
+				Key:      "principal.organization_id",
+				Values:   []string{"resource.missing_ids"},
+			},
+			ctx: ConditionContext{
+				Principal: map[string]string{"organization_id": "org_9"},
+				Resource:  map[string]string{"organization_ids": "org_1,org_2"},
+			},
+			want: true,
 		},
 	}
 
@@ -311,4 +486,104 @@ func TestConditionHelpers(t *testing.T) {
 			t.Errorf("Expected ConditionNotIn, got %v", c.Operator)
 		}
 	})
+}
+
+func TestResolveKey(t *testing.T) {
+	ctx := ConditionContext{
+		Principal: map[string]string{
+			"id": "principal-id",
+		},
+		Resource: map[string]string{
+			"id": "resource-id",
+		},
+	}
+
+	tests := []struct {
+		name   string
+		key    string
+		want   string
+		wantOK bool
+	}{
+		{
+			name:   "resolves principal key",
+			key:    "principal.id",
+			want:   "principal-id",
+			wantOK: true,
+		},
+		{
+			name:   "resolves resource key",
+			key:    "resource.id",
+			want:   "resource-id",
+			wantOK: true,
+		},
+		{
+			name:   "returns false for unknown namespace",
+			key:    "unknown.id",
+			want:   "",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := resolveKey(tt.key, ctx)
+			if ok != tt.wantOK {
+				t.Fatalf("resolveKey() ok = %v, want %v", ok, tt.wantOK)
+			}
+
+			if got != tt.want {
+				t.Fatalf("resolveKey() value = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveValue(t *testing.T) {
+	ctx := ConditionContext{
+		Principal: map[string]string{
+			"id": "principal-id",
+		},
+		Resource: map[string]string{
+			"id": "resource-id",
+		},
+	}
+
+	tests := []struct {
+		name   string
+		value  string
+		want   string
+		wantOK bool
+	}{
+		{
+			name:   "resolves principal reference",
+			value:  "principal.id",
+			want:   "principal-id",
+			wantOK: true,
+		},
+		{
+			name:   "resolves resource reference",
+			value:  "resource.id",
+			want:   "resource-id",
+			wantOK: true,
+		},
+		{
+			name:   "keeps literal values",
+			value:  "literal",
+			want:   "literal",
+			wantOK: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := resolveValue(tt.value, ctx)
+			if ok != tt.wantOK {
+				t.Fatalf("resolveValue() ok = %v, want %v", ok, tt.wantOK)
+			}
+
+			if got != tt.want {
+				t.Fatalf("resolveValue() value = %q, want %q", got, tt.want)
+			}
+		})
+	}
 }

--- a/pkg/probo/actions.go
+++ b/pkg/probo/actions.go
@@ -469,4 +469,12 @@ const (
 
 	// CookieConsentRecord actions
 	ActionCookieConsentRecordList = "core:cookie-consent-record:list"
+
+	// CommonThirdParty actions (global catalog, no organization scope).
+	ActionCommonThirdPartyGet  = "core:common-third-party:get"
+	ActionCommonThirdPartyList = "core:common-third-party:list"
+
+	// ElectronicSignature actions (tenant-scoped via the related document
+	// version signature / trust center access).
+	ActionElectronicSignatureGet = "core:electronic-signature:get"
 )

--- a/pkg/probo/policies.go
+++ b/pkg/probo/policies.go
@@ -64,6 +64,7 @@ var ViewerPolicy = policy.NewPolicy(
 		ActionDocumentVersionGet, ActionDocumentVersionList,
 		ActionDocumentVersionSignatureGet, ActionDocumentVersionSignatureList,
 		ActionDocumentVersionApprovalList,
+		ActionElectronicSignatureGet,
 		ActionRiskGet, ActionRiskList,
 		ActionAssetGet, ActionAssetList,
 		ActionDatumGet, ActionDatumList,
@@ -147,6 +148,7 @@ var AuditorPolicy = policy.NewPolicy(
 		ActionDocumentVersionGet, ActionDocumentVersionList,
 		ActionDocumentVersionSignatureGet, ActionDocumentVersionSignatureList,
 		ActionDocumentVersionApprovalList,
+		ActionElectronicSignatureGet,
 		ActionRiskGet, ActionRiskList,
 		ActionAssetGet, ActionAssetList,
 		ActionDatumGet, ActionDatumList,
@@ -177,6 +179,19 @@ var AuditorPolicy = policy.NewPolicy(
 		ActionEmployeeDocumentVersionExportPDF,
 	).WithSID("employee-document-access").When(organizationCondition),
 ).WithDescription("Read-only probo access for auditors (excludes internal/employee content)")
+
+// CommonThirdPartyCatalogPolicy grants every authenticated identity
+// read access to the global common third-party catalog. The catalog is
+// shared across all tenants and has no organization scoping, so the
+// allow has no condition.
+var CommonThirdPartyCatalogPolicy = policy.NewPolicy(
+	"probo:common-third-party-catalog",
+	"Probo Common Third-Party Catalog",
+	policy.Allow(
+		ActionCommonThirdPartyGet,
+		ActionCommonThirdPartyList,
+	).WithSID("read-common-third-party-catalog"),
+).WithDescription("Allows every authenticated user to read the global common third-party catalog")
 
 // EmployeePolicy defines permissions for employee role.
 var EmployeePolicy = policy.NewPolicy(
@@ -210,5 +225,6 @@ func ProboPolicySet() *iam.PolicySet {
 		AddRolePolicy("ADMIN", AdminPolicy).
 		AddRolePolicy("VIEWER", ViewerPolicy).
 		AddRolePolicy("AUDITOR", AuditorPolicy).
-		AddRolePolicy("EMPLOYEE", EmployeePolicy)
+		AddRolePolicy("EMPLOYEE", EmployeePolicy).
+		AddIdentityScopedPolicy(CommonThirdPartyCatalogPolicy)
 }

--- a/pkg/server/api/authz/authorization.go
+++ b/pkg/server/api/authz/authorization.go
@@ -27,8 +27,10 @@ import (
 )
 
 type (
-	AuthorizeFuncOption func(*iam.AuthorizeParams)
-	AuthorizeFunc       func(context.Context, gid.GID, string, ...AuthorizeFuncOption) (*coredata.Scope, error)
+	AuthorizeFuncOption      func(*iam.AuthorizeParams)
+	AuthorizeFunc            func(context.Context, gid.GID, string, ...AuthorizeFuncOption) (*coredata.Scope, error)
+	BatchAuthorizeFuncOption func(*iam.AuthorizeBatchParams)
+	BatchAuthorizeFunc       func(context.Context, string, []gid.GID, ...BatchAuthorizeFuncOption) (*coredata.Scope, error)
 )
 
 func WithAttr(key, value string) AuthorizeFuncOption {
@@ -47,6 +49,24 @@ func WithSkipAssumptionCheck() AuthorizeFuncOption {
 
 func WithDryRun() AuthorizeFuncOption {
 	return func(params *iam.AuthorizeParams) {
+		params.DryRun = true
+	}
+}
+
+func WithBatchAttr(key, value string) BatchAuthorizeFuncOption {
+	return func(params *iam.AuthorizeBatchParams) {
+		params.ResourceAttributes[key] = value
+	}
+}
+
+func WithBatchSkipAssumptionCheck() BatchAuthorizeFuncOption {
+	return func(params *iam.AuthorizeBatchParams) {
+		params.SkipAssumptionCheck = true
+	}
+}
+
+func WithBatchDryRun() BatchAuthorizeFuncOption {
+	return func(params *iam.AuthorizeBatchParams) {
 		params.DryRun = true
 	}
 }
@@ -93,6 +113,68 @@ func NewAuthorizeFunc(
 			}
 
 			logger.ErrorCtx(ctx, "cannot authorize", log.Error(err))
+
+			return nil, gqlutils.Internal(ctx)
+		}
+
+		return scope, nil
+	}
+}
+
+func NewBatchAuthorizeFunc(
+	svc *iam.Service,
+	logger *log.Logger,
+) BatchAuthorizeFunc {
+	return func(
+		ctx context.Context,
+		action string,
+		objectIDs []gid.GID,
+		options ...BatchAuthorizeFuncOption,
+	) (*coredata.Scope, error) {
+		identity := authn.IdentityFromContext(ctx)
+		session := authn.SessionFromContext(ctx)
+
+		params := iam.AuthorizeBatchParams{
+			Principal:          identity.ID,
+			Action:             action,
+			Resources:          objectIDs,
+			ResourceAttributes: make(map[string]string),
+		}
+		if session != nil {
+			params.Session = &session.ID
+		}
+
+		for _, option := range options {
+			option(&params)
+		}
+
+		scope, err := svc.Authorizer.AuthorizeBatch(ctx, params)
+		if err != nil {
+			if _, ok := errors.AsType[*iam.ErrAssumptionRequired](err); ok {
+				return nil, gqlutils.AssumptionRequired(ctx, err)
+			}
+
+			if _, ok := errors.AsType[*iam.ErrInsufficientPermissions](err); ok {
+				return nil, gqlutils.Forbidden(ctx, err)
+			}
+
+			if _, ok := errors.AsType[*iam.ErrMixedOrganizationBatch](err); ok {
+				return nil, gqlutils.Invalid(ctx, err)
+			}
+
+			if _, ok := errors.AsType[*iam.ErrEmptyResourceBatch](err); ok {
+				return nil, gqlutils.Invalid(ctx, err)
+			}
+
+			if _, ok := errors.AsType[*iam.ErrBatchAuthorizationUnsupportedResourceType](err); ok {
+				return nil, gqlutils.Invalid(ctx, err)
+			}
+
+			if errors.Is(err, coredata.ErrResourceNotFound) {
+				return nil, gqlutils.NotFoundf(ctx, "resource not found")
+			}
+
+			logger.ErrorCtx(ctx, "cannot batch authorize", log.Error(err))
 
 			return nil, gqlutils.Internal(ctx)
 		}

--- a/pkg/server/api/authz/authorization.go
+++ b/pkg/server/api/authz/authorization.go
@@ -28,7 +28,7 @@ import (
 
 type (
 	AuthorizeFuncOption func(*iam.AuthorizeParams)
-	AuthorizeFunc       func(context.Context, gid.GID, string, ...AuthorizeFuncOption) error
+	AuthorizeFunc       func(context.Context, gid.GID, string, ...AuthorizeFuncOption) (*coredata.Scope, error)
 )
 
 func WithAttr(key, value string) AuthorizeFuncOption {
@@ -60,7 +60,7 @@ func NewAuthorizeFunc(
 		objectID gid.GID,
 		action string,
 		options ...AuthorizeFuncOption,
-	) error {
+	) (*coredata.Scope, error) {
 		identity := authn.IdentityFromContext(ctx)
 		session := authn.SessionFromContext(ctx)
 
@@ -78,24 +78,25 @@ func NewAuthorizeFunc(
 			option(&params)
 		}
 
-		if err := svc.Authorizer.Authorize(ctx, params); err != nil {
+		scope, err := svc.Authorizer.Authorize(ctx, params)
+		if err != nil {
 			if _, ok := errors.AsType[*iam.ErrAssumptionRequired](err); ok {
-				return gqlutils.AssumptionRequired(ctx, err)
+				return nil, gqlutils.AssumptionRequired(ctx, err)
 			}
 
 			if _, ok := errors.AsType[*iam.ErrInsufficientPermissions](err); ok {
-				return gqlutils.Forbidden(ctx, err)
+				return nil, gqlutils.Forbidden(ctx, err)
 			}
 
 			if errors.Is(err, coredata.ErrResourceNotFound) {
-				return gqlutils.NotFoundf(ctx, "resource not found")
+				return nil, gqlutils.NotFoundf(ctx, "resource not found")
 			}
 
 			logger.ErrorCtx(ctx, "cannot authorize", log.Error(err))
 
-			return gqlutils.Internal(ctx)
+			return nil, gqlutils.Internal(ctx)
 		}
 
-		return nil
+		return scope, nil
 	}
 }

--- a/pkg/server/api/connect/v1/base_resolvers.go
+++ b/pkg/server/api/connect/v1/base_resolvers.go
@@ -146,7 +146,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		return nil, fmt.Errorf("unsupported entity type: %d", id.EntityType())
 	}
 
-	if err := r.authorize(ctx, id, action); err != nil {
+	if _, err := r.authorize(ctx, id, action); err != nil {
 		return nil, err
 	}
 

--- a/pkg/server/api/connect/v1/graphql_handler.go
+++ b/pkg/server/api/connect/v1/graphql_handler.go
@@ -31,11 +31,12 @@ import (
 func NewGraphQLHandler(svc *iam.Service, logger *log.Logger, baseURL *baseurl.BaseURL, cookieConfig securecookie.Config) http.Handler {
 	config := schema.Config{
 		Resolvers: &Resolver{
-			authorize:     authz.NewAuthorizeFunc(svc, logger),
-			logger:        logger,
-			iam:           svc,
-			baseURL:       baseURL,
-			sessionCookie: authn.NewCookie(&cookieConfig),
+			authorize:      authz.NewAuthorizeFunc(svc, logger),
+			batchAuthorize: authz.NewBatchAuthorizeFunc(svc, logger),
+			logger:         logger,
+			iam:            svc,
+			baseURL:        baseURL,
+			sessionCookie:  authn.NewCookie(&cookieConfig),
 		},
 		Directives: schema.DirectiveRoot{
 			Session: session.Directive,

--- a/pkg/server/api/connect/v1/identity_resolvers.go
+++ b/pkg/server/api/connect/v1/identity_resolvers.go
@@ -24,7 +24,7 @@ import (
 
 // Profiles is the resolver for the profiles field.
 func (r *identityResolver) Profiles(ctx context.Context, obj *types.Identity, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ProfileOrderBy, filter *types.ProfileFilter) (*types.ProfileConnection, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileList, authz.WithSkipAssumptionCheck()); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileList, authz.WithSkipAssumptionCheck()); err != nil {
 		return nil, err
 	}
 
@@ -68,7 +68,7 @@ func (r *identityResolver) Profiles(ctx context.Context, obj *types.Identity, fi
 
 // Sessions is the resolver for the sessions field.
 func (r *identityResolver) Sessions(ctx context.Context, obj *types.Identity, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.SessionOrder) (*types.SessionConnection, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionSessionList); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionSessionList); err != nil {
 		return nil, err
 	}
 
@@ -103,7 +103,7 @@ func (r *identityResolver) Sessions(ctx context.Context, obj *types.Identity, fi
 
 // PersonalAPIKeys is the resolver for the personalAPIKeys field.
 func (r *identityResolver) PersonalAPIKeys(ctx context.Context, obj *types.Identity, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.PersonalAPIKeyConnection, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionPersonalAPIKeyList); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionPersonalAPIKeyList); err != nil {
 		return nil, err
 	}
 
@@ -132,7 +132,7 @@ func (r *identityResolver) PersonalAPIKeys(ctx context.Context, obj *types.Ident
 
 // SsoLoginURL is the resolver for the ssoLoginURL field.
 func (r *identityResolver) SsoLoginURL(ctx context.Context, obj *types.Identity) (*string, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionIdentityGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionIdentityGet); err != nil {
 		return nil, err
 	}
 

--- a/pkg/server/api/connect/v1/invitation_resolvers.go
+++ b/pkg/server/api/connect/v1/invitation_resolvers.go
@@ -24,7 +24,7 @@ func (r *invitationResolver) Permission(ctx context.Context, obj *types.Invitati
 
 // InviteUser is the resolver for the inviteUser field.
 func (r *mutationResolver) InviteUser(ctx context.Context, input types.InviteUserInput) (*types.InviteUserPayload, error) {
-	if err := r.authorize(ctx, input.ProfileID, iam.ActionInvitationCreate); err != nil {
+	if _, err := r.authorize(ctx, input.ProfileID, iam.ActionInvitationCreate); err != nil {
 		return nil, err
 	}
 

--- a/pkg/server/api/connect/v1/membership_resolvers.go
+++ b/pkg/server/api/connect/v1/membership_resolvers.go
@@ -21,7 +21,7 @@ import (
 
 // LastSession is the resolver for the lastSession field.
 func (r *membershipResolver) LastSession(ctx context.Context, obj *types.Membership) (*types.Session, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionMembershipGet, authz.WithSkipAssumptionCheck()); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionMembershipGet, authz.WithSkipAssumptionCheck()); err != nil {
 		return nil, err
 	}
 
@@ -51,12 +51,12 @@ func (r *membershipResolver) Permission(ctx context.Context, obj *types.Membersh
 
 // UpdateMembership is the resolver for the updateMembership field.
 func (r *mutationResolver) UpdateMembership(ctx context.Context, input types.UpdateMembershipInput) (*types.UpdateMembershipPayload, error) {
-	if err := r.authorize(ctx, input.MembershipID, iam.ActionMembershipUpdate); err != nil {
+	if _, err := r.authorize(ctx, input.MembershipID, iam.ActionMembershipUpdate); err != nil {
 		return nil, err
 	}
 
 	if input.Role == coredata.MembershipRoleOwner {
-		if err := r.authorize(ctx, input.MembershipID, iam.ActionMembershipRoleSetOwner); err != nil {
+		if _, err := r.authorize(ctx, input.MembershipID, iam.ActionMembershipRoleSetOwner); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/server/api/connect/v1/organization_resolvers.go
+++ b/pkg/server/api/connect/v1/organization_resolvers.go
@@ -84,7 +84,7 @@ func (r *mutationResolver) CreateOrganization(ctx context.Context, input types.C
 
 // UpdateOrganization is the resolver for the updateOrganization field.
 func (r *mutationResolver) UpdateOrganization(ctx context.Context, input types.UpdateOrganizationInput) (*types.UpdateOrganizationPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, iam.ActionOrganizationUpdate); err != nil {
+	if _, err := r.authorize(ctx, input.OrganizationID, iam.ActionOrganizationUpdate); err != nil {
 		return nil, err
 	}
 
@@ -140,7 +140,7 @@ func (r *mutationResolver) UpdateOrganization(ctx context.Context, input types.U
 
 // DeleteOrganization is the resolver for the deleteOrganization field.
 func (r *mutationResolver) DeleteOrganization(ctx context.Context, input types.DeleteOrganizationInput) (*types.DeleteOrganizationPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, iam.ActionOrganizationDelete); err != nil {
+	if _, err := r.authorize(ctx, input.OrganizationID, iam.ActionOrganizationDelete); err != nil {
 		return nil, err
 	}
 
@@ -160,7 +160,7 @@ func (r *mutationResolver) DeleteOrganizationHorizontalLogo(ctx context.Context,
 
 // LogoURL is the resolver for the logoUrl field.
 func (r *organizationResolver) LogoURL(ctx context.Context, obj *types.Organization) (*string, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionOrganizationGet, authz.WithSkipAssumptionCheck()); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionOrganizationGet, authz.WithSkipAssumptionCheck()); err != nil {
 		return nil, err
 	}
 
@@ -175,7 +175,7 @@ func (r *organizationResolver) LogoURL(ctx context.Context, obj *types.Organizat
 
 // HorizontalLogoURL is the resolver for the horizontalLogoUrl field.
 func (r *organizationResolver) HorizontalLogoURL(ctx context.Context, obj *types.Organization) (*string, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionOrganizationGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionOrganizationGet); err != nil {
 		return nil, err
 	}
 
@@ -190,7 +190,7 @@ func (r *organizationResolver) HorizontalLogoURL(ctx context.Context, obj *types
 
 // Profiles is the resolver for the profiles field.
 func (r *organizationResolver) Profiles(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ProfileOrderBy) (*types.ProfileConnection, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileList); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileList); err != nil {
 		return nil, err
 	}
 
@@ -228,7 +228,7 @@ func (r *organizationResolver) Profiles(ctx context.Context, obj *types.Organiza
 
 // SamlConfigurations is the resolver for the samlConfigurations field.
 func (r *organizationResolver) SamlConfigurations(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.SAMLConfigurationConnection, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionSAMLConfigurationList); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionSAMLConfigurationList); err != nil {
 		return nil, err
 	}
 
@@ -257,7 +257,7 @@ func (r *organizationResolver) SamlConfigurations(ctx context.Context, obj *type
 
 // ScimConfiguration is the resolver for the scimConfiguration field.
 func (r *organizationResolver) ScimConfiguration(ctx context.Context, obj *types.Organization) (*types.SCIMConfiguration, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionSCIMConfigurationGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionSCIMConfigurationGet); err != nil {
 		return nil, err
 	}
 
@@ -291,7 +291,7 @@ func (r *organizationResolver) ScimBridgeTypes(ctx context.Context, obj *types.O
 
 // AuditLogEntries is the resolver for the auditLogEntries field.
 func (r *organizationResolver) AuditLogEntries(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AuditLogEntryOrderBy, filter *types.AuditLogEntryFilter) (*types.AuditLogEntryConnection, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionAuditLogEntryList); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionAuditLogEntryList); err != nil {
 		return nil, err
 	}
 
@@ -339,7 +339,7 @@ func (r *organizationResolver) AuditLogEntries(ctx context.Context, obj *types.O
 
 // Viewer is the resolver for the viewer field.
 func (r *organizationResolver) Viewer(ctx context.Context, obj *types.Organization) (*types.Profile, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileGet); err != nil {
 		return nil, err
 	}
 

--- a/pkg/server/api/connect/v1/personal_api_key_resolvers.go
+++ b/pkg/server/api/connect/v1/personal_api_key_resolvers.go
@@ -21,7 +21,7 @@ import (
 func (r *mutationResolver) CreatePersonalAPIKey(ctx context.Context, input types.CreatePersonalAPIKeyInput) (*types.CreatePersonalAPIKeyPayload, error) {
 	identity := authn.IdentityFromContext(ctx)
 
-	if err := r.authorize(ctx, identity.ID, iam.ActionPersonalAPIKeyCreate); err != nil {
+	if _, err := r.authorize(ctx, identity.ID, iam.ActionPersonalAPIKeyCreate); err != nil {
 		return nil, err
 	}
 
@@ -44,7 +44,7 @@ func (r *mutationResolver) CreatePersonalAPIKey(ctx context.Context, input types
 
 // RevokePersonalAPIKey is the resolver for the revokePersonalAPIKey field.
 func (r *mutationResolver) RevokePersonalAPIKey(ctx context.Context, input types.RevokePersonalAPIKeyInput) (*types.RevokePersonalAPIKeyPayload, error) {
-	if err := r.authorize(ctx, input.PersonalAPIKeyID, iam.ActionPersonalAPIKeyDelete); err != nil {
+	if _, err := r.authorize(ctx, input.PersonalAPIKeyID, iam.ActionPersonalAPIKeyDelete); err != nil {
 		return nil, err
 	}
 
@@ -61,7 +61,7 @@ func (r *mutationResolver) RevokePersonalAPIKey(ctx context.Context, input types
 
 // Token is the resolver for the token field.
 func (r *personalAPIKeyResolver) Token(ctx context.Context, obj *types.PersonalAPIKey) (*string, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionPersonalAPIKeyGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionPersonalAPIKeyGet); err != nil {
 		return nil, err
 	}
 
@@ -85,7 +85,7 @@ func (r *personalAPIKeyResolver) Permission(ctx context.Context, obj *types.Pers
 func (r *personalAPIKeyConnectionResolver) TotalCount(ctx context.Context, obj *types.PersonalAPIKeyConnection) (*int, error) {
 	switch obj.Resolver.(type) {
 	case *identityResolver:
-		if err := r.authorize(ctx, obj.ParentID, iam.ActionPersonalAPIKeyList); err != nil {
+		if _, err := r.authorize(ctx, obj.ParentID, iam.ActionPersonalAPIKeyList); err != nil {
 			return nil, err
 		}
 

--- a/pkg/server/api/connect/v1/profile_resolvers.go
+++ b/pkg/server/api/connect/v1/profile_resolvers.go
@@ -22,7 +22,7 @@ import (
 
 // CreateUser is the resolver for the createUser field.
 func (r *mutationResolver) CreateUser(ctx context.Context, input types.CreateUserInput) (*types.CreateUserPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, iam.ActionMembershipProfileCreate); err != nil {
+	if _, err := r.authorize(ctx, input.OrganizationID, iam.ActionMembershipProfileCreate); err != nil {
 		return nil, err
 	}
 
@@ -57,7 +57,7 @@ func (r *mutationResolver) CreateUser(ctx context.Context, input types.CreateUse
 
 // DeactivateUser is the resolver for the deactivateUser field.
 func (r *mutationResolver) DeactivateUser(ctx context.Context, input types.DeactivateUserInput) (*types.DeactivateUserPayload, error) {
-	if err := r.authorize(ctx, input.ProfileID, iam.ActionMembershipProfileDeactivate); err != nil {
+	if _, err := r.authorize(ctx, input.ProfileID, iam.ActionMembershipProfileDeactivate); err != nil {
 		return nil, err
 	}
 
@@ -78,7 +78,7 @@ func (r *mutationResolver) DeactivateUser(ctx context.Context, input types.Deact
 
 // UpdateUser is the resolver for the updateUser field.
 func (r *mutationResolver) UpdateUser(ctx context.Context, input types.UpdateUserInput) (*types.UpdateUserPayload, error) {
-	if err := r.authorize(ctx, input.ID, iam.ActionMembershipProfileUpdate); err != nil {
+	if _, err := r.authorize(ctx, input.ID, iam.ActionMembershipProfileUpdate); err != nil {
 		return nil, err
 	}
 
@@ -106,7 +106,7 @@ func (r *mutationResolver) UpdateUser(ctx context.Context, input types.UpdateUse
 
 // RemoveUser is the resolver for the removeUser field.
 func (r *mutationResolver) RemoveUser(ctx context.Context, input types.RemoveUserInput) (*types.RemoveUserPayload, error) {
-	if err := r.authorize(ctx, input.ProfileID, iam.ActionMembershipProfileDelete); err != nil {
+	if _, err := r.authorize(ctx, input.ProfileID, iam.ActionMembershipProfileDelete); err != nil {
 		return nil, err
 	}
 
@@ -134,7 +134,7 @@ func (r *mutationResolver) RemoveUser(ctx context.Context, input types.RemoveUse
 
 // Identity is the resolver for the identity field.
 func (r *profileResolver) Identity(ctx context.Context, obj *types.Profile) (*types.Identity, error) {
-	if err := r.authorize(
+	if _, err := r.authorize(
 		ctx,
 		obj.ID,
 		iam.ActionMembershipProfileGet,
@@ -159,7 +159,7 @@ func (r *profileResolver) Identity(ctx context.Context, obj *types.Profile) (*ty
 
 // Organization is the resolver for the organization field.
 func (r *profileResolver) Organization(ctx context.Context, obj *types.Profile) (*types.Organization, error) {
-	if err := r.authorize(ctx, obj.Organization.ID, iam.ActionOrganizationGet, authz.WithSkipAssumptionCheck()); err != nil {
+	if _, err := r.authorize(ctx, obj.Organization.ID, iam.ActionOrganizationGet, authz.WithSkipAssumptionCheck()); err != nil {
 		return nil, err
 	}
 
@@ -179,7 +179,7 @@ func (r *profileResolver) Organization(ctx context.Context, obj *types.Profile) 
 
 // Membership is the resolver for the membership field.
 func (r *profileResolver) Membership(ctx context.Context, obj *types.Profile) (*types.Membership, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionMembershipGet, authz.WithSkipAssumptionCheck()); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionMembershipGet, authz.WithSkipAssumptionCheck()); err != nil {
 		return nil, err
 	}
 
@@ -199,7 +199,7 @@ func (r *profileResolver) Membership(ctx context.Context, obj *types.Profile) (*
 
 // PendingInvitations is the resolver for the pendingInvitations field.
 func (r *profileResolver) PendingInvitations(ctx context.Context, obj *types.Profile, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.InvitationOrderBy) (*types.InvitationConnection, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionInvitationList); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionInvitationList); err != nil {
 		return nil, err
 	}
 

--- a/pkg/server/api/connect/v1/resolver.go
+++ b/pkg/server/api/connect/v1/resolver.go
@@ -48,11 +48,12 @@ import (
 
 type (
 	Resolver struct {
-		authorize     authz.AuthorizeFunc
-		logger        *log.Logger
-		iam           *iam.Service
-		baseURL       *baseurl.BaseURL
-		sessionCookie *authn.Cookie
+		authorize      authz.AuthorizeFunc
+		batchAuthorize authz.BatchAuthorizeFunc
+		logger         *log.Logger
+		iam            *iam.Service
+		baseURL        *baseurl.BaseURL
+		sessionCookie  *authn.Cookie
 	}
 )
 

--- a/pkg/server/api/connect/v1/resolver.go
+++ b/pkg/server/api/connect/v1/resolver.go
@@ -116,7 +116,8 @@ func NewMux(
 }
 
 func (r *Resolver) Permission(ctx context.Context, obj types.Node, action string) (bool, error) {
-	return r.authorize(ctx, obj.GetID(), action, authz.WithDryRun()) == nil, nil
+	_, err := r.authorize(ctx, obj.GetID(), action, authz.WithDryRun())
+	return err == nil, nil
 }
 
 func (r *Resolver) SSOLoginURL(samlConfigID gid.GID) string {

--- a/pkg/server/api/connect/v1/saml_resolvers.go
+++ b/pkg/server/api/connect/v1/saml_resolvers.go
@@ -19,7 +19,7 @@ import (
 
 // CreateSAMLConfiguration is the resolver for the createSAMLConfiguration field.
 func (r *mutationResolver) CreateSAMLConfiguration(ctx context.Context, input types.CreateSAMLConfigurationInput) (*types.CreateSAMLConfigurationPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, iam.ActionSAMLConfigurationCreate); err != nil {
+	if _, err := r.authorize(ctx, input.OrganizationID, iam.ActionSAMLConfigurationCreate); err != nil {
 		return nil, err
 	}
 
@@ -63,7 +63,7 @@ func (r *mutationResolver) CreateSAMLConfiguration(ctx context.Context, input ty
 
 // UpdateSAMLConfiguration is the resolver for the updateSAMLConfiguration field.
 func (r *mutationResolver) UpdateSAMLConfiguration(ctx context.Context, input types.UpdateSAMLConfigurationInput) (*types.UpdateSAMLConfigurationPayload, error) {
-	if err := r.authorize(ctx, input.SamlConfigurationID, iam.ActionSAMLConfigurationUpdate); err != nil {
+	if _, err := r.authorize(ctx, input.SamlConfigurationID, iam.ActionSAMLConfigurationUpdate); err != nil {
 		return nil, err
 	}
 
@@ -100,7 +100,7 @@ func (r *mutationResolver) UpdateSAMLConfiguration(ctx context.Context, input ty
 
 // DeleteSAMLConfiguration is the resolver for the deleteSAMLConfiguration field.
 func (r *mutationResolver) DeleteSAMLConfiguration(ctx context.Context, input types.DeleteSAMLConfigurationInput) (*types.DeleteSAMLConfigurationPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, iam.ActionSAMLConfigurationDelete); err != nil {
+	if _, err := r.authorize(ctx, input.OrganizationID, iam.ActionSAMLConfigurationDelete); err != nil {
 		return nil, err
 	}
 

--- a/pkg/server/api/connect/v1/scim_resolvers.go
+++ b/pkg/server/api/connect/v1/scim_resolvers.go
@@ -26,7 +26,7 @@ func (r *connectorResolver) Permission(ctx context.Context, obj *types.Connector
 
 // CreateSCIMConfiguration is the resolver for the createSCIMConfiguration field.
 func (r *mutationResolver) CreateSCIMConfiguration(ctx context.Context, input types.CreateSCIMConfigurationInput) (*types.CreateSCIMConfigurationPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, iam.ActionSCIMConfigurationCreate); err != nil {
+	if _, err := r.authorize(ctx, input.OrganizationID, iam.ActionSCIMConfigurationCreate); err != nil {
 		return nil, err
 	}
 
@@ -59,7 +59,7 @@ func (r *mutationResolver) CreateSCIMConfiguration(ctx context.Context, input ty
 
 // DeleteSCIMConfiguration is the resolver for the deleteSCIMConfiguration field.
 func (r *mutationResolver) DeleteSCIMConfiguration(ctx context.Context, input types.DeleteSCIMConfigurationInput) (*types.DeleteSCIMConfigurationPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, iam.ActionSCIMConfigurationDelete); err != nil {
+	if _, err := r.authorize(ctx, input.OrganizationID, iam.ActionSCIMConfigurationDelete); err != nil {
 		return nil, err
 	}
 
@@ -74,7 +74,7 @@ func (r *mutationResolver) DeleteSCIMConfiguration(ctx context.Context, input ty
 
 // RegenerateSCIMToken is the resolver for the regenerateSCIMToken field.
 func (r *mutationResolver) RegenerateSCIMToken(ctx context.Context, input types.RegenerateSCIMTokenInput) (*types.RegenerateSCIMTokenPayload, error) {
-	if err := r.authorize(ctx, input.ScimConfigurationID, iam.ActionSCIMConfigurationUpdate); err != nil {
+	if _, err := r.authorize(ctx, input.ScimConfigurationID, iam.ActionSCIMConfigurationUpdate); err != nil {
 		return nil, err
 	}
 
@@ -92,7 +92,7 @@ func (r *mutationResolver) RegenerateSCIMToken(ctx context.Context, input types.
 
 // UpdateSCIMBridge is the resolver for the updateSCIMBridge field.
 func (r *mutationResolver) UpdateSCIMBridge(ctx context.Context, input types.UpdateSCIMBridgeInput) (*types.UpdateSCIMBridgePayload, error) {
-	if err := r.authorize(ctx, input.ScimBridgeID, iam.ActionSCIMBridgeUpdate); err != nil {
+	if _, err := r.authorize(ctx, input.ScimBridgeID, iam.ActionSCIMBridgeUpdate); err != nil {
 		return nil, err
 	}
 
@@ -109,7 +109,7 @@ func (r *mutationResolver) UpdateSCIMBridge(ctx context.Context, input types.Upd
 
 // ScimConfiguration is the resolver for the scimConfiguration field.
 func (r *sCIMBridgeResolver) ScimConfiguration(ctx context.Context, obj *types.SCIMBridge) (*types.SCIMConfiguration, error) {
-	if err := r.authorize(ctx, obj.ScimConfiguration.ID, iam.ActionSCIMConfigurationGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ScimConfiguration.ID, iam.ActionSCIMConfigurationGet); err != nil {
 		return nil, err
 	}
 
@@ -138,7 +138,7 @@ func (r *sCIMBridgeResolver) Connector(ctx context.Context, obj *types.SCIMBridg
 	}
 
 	// Authorize based on the SCIM configuration (connector accessed via bridge is a sub-resource)
-	if err := r.authorize(ctx, obj.ScimConfiguration.ID, iam.ActionSCIMConfigurationGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ScimConfiguration.ID, iam.ActionSCIMConfigurationGet); err != nil {
 		return nil, err
 	}
 
@@ -170,7 +170,7 @@ func (r *sCIMConfigurationResolver) EndpointURL(ctx context.Context, obj *types.
 
 // Organization is the resolver for the organization field.
 func (r *sCIMConfigurationResolver) Organization(ctx context.Context, obj *types.SCIMConfiguration) (*types.Organization, error) {
-	if err := r.authorize(ctx, obj.Organization.ID, iam.ActionOrganizationGet); err != nil {
+	if _, err := r.authorize(ctx, obj.Organization.ID, iam.ActionOrganizationGet); err != nil {
 		return nil, err
 	}
 
@@ -200,7 +200,7 @@ func (r *sCIMConfigurationResolver) Bridge(ctx context.Context, obj *types.SCIMC
 		return nil, nil
 	}
 
-	if err := r.authorize(ctx, obj.ID, iam.ActionSCIMConfigurationGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionSCIMConfigurationGet); err != nil {
 		return nil, err
 	}
 
@@ -220,7 +220,7 @@ func (r *sCIMConfigurationResolver) Bridge(ctx context.Context, obj *types.SCIMC
 
 // Events is the resolver for the events field.
 func (r *sCIMConfigurationResolver) Events(ctx context.Context, obj *types.SCIMConfiguration, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.SCIMEventOrderBy) (*types.SCIMEventConnection, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionSCIMEventList); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionSCIMEventList); err != nil {
 		return nil, err
 	}
 
@@ -256,7 +256,7 @@ func (r *sCIMEventResolver) Permission(ctx context.Context, obj *types.SCIMEvent
 
 // TotalCount is the resolver for the totalCount field.
 func (r *sCIMEventConnectionResolver) TotalCount(ctx context.Context, obj *types.SCIMEventConnection) (*int, error) {
-	if err := r.authorize(ctx, obj.ParentID, iam.ActionSCIMEventList); err != nil {
+	if _, err := r.authorize(ctx, obj.ParentID, iam.ActionSCIMEventList); err != nil {
 		return nil, err
 	}
 

--- a/pkg/server/api/connect/v1/session_resolvers.go
+++ b/pkg/server/api/connect/v1/session_resolvers.go
@@ -416,7 +416,7 @@ func (r *mutationResolver) AssumeOrganizationSession(ctx context.Context, input 
 
 // RevokeSession is the resolver for the revokeSession field.
 func (r *mutationResolver) RevokeSession(ctx context.Context, input types.RevokeSessionInput) (*types.RevokeSessionPayload, error) {
-	if err := r.authorize(ctx, input.SessionID, iam.ActionSessionRevoke); err != nil {
+	if _, err := r.authorize(ctx, input.SessionID, iam.ActionSessionRevoke); err != nil {
 		return nil, err
 	}
 
@@ -438,7 +438,7 @@ func (r *mutationResolver) RevokeSession(ctx context.Context, input types.Revoke
 
 // RevokeAllSessions is the resolver for the revokeAllSessions field.
 func (r *mutationResolver) RevokeAllSessions(ctx context.Context) (*types.RevokeAllSessionsPayload, error) {
-	if err := r.authorize(ctx, authn.SessionFromContext(ctx).ID, iam.ActionSessionRevokeAll); err != nil {
+	if _, err := r.authorize(ctx, authn.SessionFromContext(ctx).ID, iam.ActionSessionRevokeAll); err != nil {
 		return nil, err
 	}
 

--- a/pkg/server/api/console/v1/access_review_campaign_resolvers.go
+++ b/pkg/server/api/console/v1/access_review_campaign_resolvers.go
@@ -362,9 +362,7 @@ func (r *accessSourceResolver) Connector(ctx context.Context, obj *types.AccessS
 	}
 
 	scope := coredata.NewScopeFromObjectID(obj.ID)
-	prb := r.probo
-
-	connector, err := prb.Connectors.Get(ctx, scope, *obj.ConnectorID)
+	connector, err := r.probo.Connectors.Get(ctx, scope, *obj.ConnectorID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil
@@ -430,9 +428,7 @@ func (r *accessSourceResolver) NeedsConfiguration(ctx context.Context, obj *type
 		return false, nil
 	}
 
-	prb := r.probo
-
-	dbConnector, err := prb.Connectors.Get(ctx, scope, *obj.ConnectorID)
+	dbConnector, err := r.probo.Connectors.Get(ctx, scope, *obj.ConnectorID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return false, nil
@@ -492,9 +488,7 @@ func (r *accessSourceResolver) SelectedOrganization(ctx context.Context, obj *ty
 		return nil, nil
 	}
 
-	prb := r.probo
-
-	dbConnector, err := prb.Connectors.Get(ctx, scope, *obj.ConnectorID)
+	dbConnector, err := r.probo.Connectors.Get(ctx, scope, *obj.ConnectorID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil

--- a/pkg/server/api/console/v1/access_review_campaign_resolvers.go
+++ b/pkg/server/api/console/v1/access_review_campaign_resolvers.go
@@ -23,11 +23,10 @@ import (
 
 // Campaign is the resolver for the campaign field.
 func (r *accessEntryResolver) Campaign(ctx context.Context, obj *types.AccessEntry) (*types.AccessReviewCampaign, error) {
-	if err := r.authorize(ctx, obj.Campaign.ID, probo.ActionAccessReviewCampaignGet); err != nil {
+	scope, err := r.authorize(ctx, obj.Campaign.ID, probo.ActionAccessReviewCampaignGet)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.Campaign.ID)
 
 	campaign, err := r.accessReview.Campaigns(scope).Get(ctx, obj.Campaign.ID)
 	if err != nil {
@@ -43,11 +42,10 @@ func (r *accessEntryResolver) Campaign(ctx context.Context, obj *types.AccessEnt
 
 // AccessSource is the resolver for the accessSource field.
 func (r *accessEntryResolver) AccessSource(ctx context.Context, obj *types.AccessEntry) (*types.AccessSource, error) {
-	if err := r.authorize(ctx, obj.AccessSource.ID, probo.ActionAccessSourceGet); err != nil {
+	scope, err := r.authorize(ctx, obj.AccessSource.ID, probo.ActionAccessSourceGet)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.AccessSource.ID)
 
 	source, err := r.accessReview.Sources(scope).Get(ctx, obj.AccessSource.ID)
 	if err != nil {
@@ -63,11 +61,10 @@ func (r *accessEntryResolver) AccessSource(ctx context.Context, obj *types.Acces
 
 // DecisionHistory is the resolver for the decisionHistory field.
 func (r *accessEntryResolver) DecisionHistory(ctx context.Context, obj *types.AccessEntry) ([]*types.AccessEntryDecisionHistoryEntry, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionAccessEntryGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionAccessEntryGet)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	histories, err := r.accessReview.Entries(scope).DecisionHistory(ctx, obj.ID)
 	if err != nil {
@@ -125,11 +122,10 @@ func (r *accessReviewResolver) IdentitySource(ctx context.Context, obj *types.Ac
 
 // AccessSources is the resolver for the accessSources field.
 func (r *accessReviewResolver) AccessSources(ctx context.Context, obj *types.AccessReview, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AccessSourceOrder) (*types.AccessSourceConnection, error) {
-	if err := r.authorize(ctx, obj.Organization.ID, probo.ActionAccessSourceList); err != nil {
+	scope, err := r.authorize(ctx, obj.Organization.ID, probo.ActionAccessSourceList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.Organization.ID)
 
 	pageOrderBy := page.OrderBy[coredata.AccessSourceOrderField]{
 		Field:     coredata.AccessSourceOrderFieldCreatedAt,
@@ -154,11 +150,10 @@ func (r *accessReviewResolver) AccessSources(ctx context.Context, obj *types.Acc
 
 // Campaigns is the resolver for the campaigns field.
 func (r *accessReviewResolver) Campaigns(ctx context.Context, obj *types.AccessReview, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AccessReviewCampaignOrder) (*types.AccessReviewCampaignConnection, error) {
-	if err := r.authorize(ctx, obj.Organization.ID, probo.ActionAccessReviewCampaignList); err != nil {
+	scope, err := r.authorize(ctx, obj.Organization.ID, probo.ActionAccessReviewCampaignList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.Organization.ID)
 
 	pageOrderBy := page.OrderBy[coredata.AccessReviewCampaignOrderField]{
 		Field:     coredata.AccessReviewCampaignOrderFieldCreatedAt,
@@ -193,11 +188,10 @@ func (r *accessReviewCampaignResolver) Organization(ctx context.Context, obj *ty
 
 // ScopeSources is the resolver for the scopeSources field.
 func (r *accessReviewCampaignResolver) ScopeSources(ctx context.Context, obj *types.AccessReviewCampaign) ([]*types.AccessReviewCampaignScopeSource, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionAccessSourceList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionAccessSourceList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	sources, err := r.accessReview.Sources(scope).ListScopeSourcesForCampaignID(ctx, obj.ID)
 	if err != nil {
@@ -224,11 +218,10 @@ func (r *accessReviewCampaignResolver) ScopeSources(ctx context.Context, obj *ty
 
 // Entries is the resolver for the entries field.
 func (r *accessReviewCampaignResolver) Entries(ctx context.Context, obj *types.AccessReviewCampaign, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AccessEntryOrder, accessSourceID *gid.GID, filter *coredata.AccessEntryFilter) (*types.AccessEntryConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionAccessEntryList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionAccessEntryList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	pageOrderBy := page.OrderBy[coredata.AccessEntryOrderField]{
 		Field:     coredata.AccessEntryOrderFieldCreatedAt,
@@ -244,8 +237,7 @@ func (r *accessReviewCampaignResolver) Entries(ctx context.Context, obj *types.A
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
 	var (
-		p   *page.Page[*coredata.AccessEntry, coredata.AccessEntryOrderField]
-		err error
+		p *page.Page[*coredata.AccessEntry, coredata.AccessEntryOrderField]
 	)
 
 	if accessSourceID != nil {
@@ -263,11 +255,10 @@ func (r *accessReviewCampaignResolver) Entries(ctx context.Context, obj *types.A
 
 // PendingEntryCount is the resolver for the pendingEntryCount field.
 func (r *accessReviewCampaignResolver) PendingEntryCount(ctx context.Context, obj *types.AccessReviewCampaign) (int, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionAccessEntryList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionAccessEntryList)
+	if err != nil {
 		return 0, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	count, err := r.accessReview.Entries(scope).CountPendingForCampaignID(ctx, obj.ID)
 	if err != nil {
@@ -279,11 +270,10 @@ func (r *accessReviewCampaignResolver) PendingEntryCount(ctx context.Context, ob
 
 // Statistics is the resolver for the statistics field.
 func (r *accessReviewCampaignResolver) Statistics(ctx context.Context, obj *types.AccessReviewCampaign) (*types.AccessReviewCampaignStatistics, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionAccessEntryList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionAccessEntryList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	stats, err := r.accessReview.Entries(scope).Statistics(ctx, obj.ID)
 	if err != nil {
@@ -317,11 +307,10 @@ func (r *accessReviewCampaignConnectionResolver) TotalCount(ctx context.Context,
 
 // Entries is the resolver for the entries field.
 func (r *accessReviewCampaignScopeSourceResolver) Entries(ctx context.Context, obj *types.AccessReviewCampaignScopeSource, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AccessEntryOrder, filter *coredata.AccessEntryFilter) (*types.AccessEntryConnection, error) {
-	if err := r.authorize(ctx, obj.CampaignID, probo.ActionAccessEntryList); err != nil {
+	scope, err := r.authorize(ctx, obj.CampaignID, probo.ActionAccessEntryList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.CampaignID)
 
 	pageOrderBy := page.OrderBy[coredata.AccessEntryOrderField]{
 		Field:     coredata.AccessEntryOrderFieldCreatedAt,
@@ -348,11 +337,10 @@ func (r *accessReviewCampaignScopeSourceResolver) Entries(ctx context.Context, o
 
 // Statistics is the resolver for the statistics field.
 func (r *accessReviewCampaignScopeSourceResolver) Statistics(ctx context.Context, obj *types.AccessReviewCampaignScopeSource) (*types.AccessReviewCampaignStatistics, error) {
-	if err := r.authorize(ctx, obj.CampaignID, probo.ActionAccessEntryList); err != nil {
+	scope, err := r.authorize(ctx, obj.CampaignID, probo.ActionAccessEntryList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.CampaignID)
 
 	stats, err := r.accessReview.Entries(scope).StatisticsForSource(ctx, obj.CampaignID, obj.ID)
 	if err != nil {
@@ -390,15 +378,14 @@ func (r *accessSourceResolver) Connector(ctx context.Context, obj *types.AccessS
 
 // ProviderOrganizations is the resolver for the providerOrganizations field.
 func (r *accessSourceResolver) ProviderOrganizations(ctx context.Context, obj *types.AccessSource) ([]*types.ProviderOrganization, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionAccessSourceGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionAccessSourceGet)
+	if err != nil {
 		return nil, err
 	}
 
 	if obj.ConnectorID == nil {
 		return []*types.ProviderOrganization{}, nil
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	httpClient, dbConnector, err := r.accessReview.Sources(scope).ConnectorHTTPClient(ctx, *obj.ConnectorID)
 	if err != nil {
@@ -434,7 +421,8 @@ func (r *accessSourceResolver) ProviderOrganizations(ctx context.Context, obj *t
 // return false: the identifier is captured during the OAuth callback,
 // not via a follow-up configure mutation.
 func (r *accessSourceResolver) NeedsConfiguration(ctx context.Context, obj *types.AccessSource) (bool, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionAccessSourceGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionAccessSourceGet)
+	if err != nil {
 		return false, err
 	}
 
@@ -442,7 +430,6 @@ func (r *accessSourceResolver) NeedsConfiguration(ctx context.Context, obj *type
 		return false, nil
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	dbConnector, err := prb.Connectors.Get(ctx, scope, *obj.ConnectorID)
@@ -496,7 +483,8 @@ func (r *accessSourceResolver) ConnectionStatus(ctx context.Context, obj *types.
 
 // SelectedOrganization is the resolver for the selectedOrganization field.
 func (r *accessSourceResolver) SelectedOrganization(ctx context.Context, obj *types.AccessSource) (*string, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionAccessSourceGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionAccessSourceGet)
+	if err != nil {
 		return nil, err
 	}
 
@@ -504,7 +492,6 @@ func (r *accessSourceResolver) SelectedOrganization(ctx context.Context, obj *ty
 		return nil, nil
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	dbConnector, err := prb.Connectors.Get(ctx, scope, *obj.ConnectorID)
@@ -553,11 +540,10 @@ func (r *accessSourceConnectionResolver) TotalCount(ctx context.Context, obj *ty
 
 // CreateAccessSource is the resolver for the createAccessSource field.
 func (r *mutationResolver) CreateAccessSource(ctx context.Context, input types.CreateAccessSourceInput) (*types.CreateAccessSourcePayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionAccessSourceCreate); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionAccessSourceCreate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 
 	source, err := r.accessReview.Sources(scope).Create(ctx, accessreview.CreateAccessSourceRequest{
 		OrganizationID: input.OrganizationID,
@@ -577,11 +563,10 @@ func (r *mutationResolver) CreateAccessSource(ctx context.Context, input types.C
 
 // UpdateAccessSource is the resolver for the updateAccessSource field.
 func (r *mutationResolver) UpdateAccessSource(ctx context.Context, input types.UpdateAccessSourceInput) (*types.UpdateAccessSourcePayload, error) {
-	if err := r.authorize(ctx, input.AccessSourceID, probo.ActionAccessSourceUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.AccessSourceID, probo.ActionAccessSourceUpdate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.AccessSourceID)
 
 	req := accessreview.UpdateAccessSourceRequest{
 		AccessSourceID: input.AccessSourceID,
@@ -614,11 +599,10 @@ func (r *mutationResolver) UpdateAccessSource(ctx context.Context, input types.U
 
 // DeleteAccessSource is the resolver for the deleteAccessSource field.
 func (r *mutationResolver) DeleteAccessSource(ctx context.Context, input types.DeleteAccessSourceInput) (*types.DeleteAccessSourcePayload, error) {
-	if err := r.authorize(ctx, input.AccessSourceID, probo.ActionAccessSourceDelete); err != nil {
+	scope, err := r.authorize(ctx, input.AccessSourceID, probo.ActionAccessSourceDelete)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.AccessSourceID)
 
 	if err := r.accessReview.Sources(scope).Delete(ctx, input.AccessSourceID); err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
@@ -635,11 +619,10 @@ func (r *mutationResolver) DeleteAccessSource(ctx context.Context, input types.D
 
 // ConfigureAccessSource is the resolver for the configureAccessSource field.
 func (r *mutationResolver) ConfigureAccessSource(ctx context.Context, input types.ConfigureAccessSourceInput) (*types.ConfigureAccessSourcePayload, error) {
-	if err := r.authorize(ctx, input.AccessSourceID, probo.ActionAccessSourceUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.AccessSourceID, probo.ActionAccessSourceUpdate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.AccessSourceID)
 
 	source, err := r.accessReview.Sources(scope).ConfigureAccessSource(
 		ctx,
@@ -663,11 +646,10 @@ func (r *mutationResolver) ConfigureAccessSource(ctx context.Context, input type
 
 // CreateAccessReviewCampaign is the resolver for the createAccessReviewCampaign field.
 func (r *mutationResolver) CreateAccessReviewCampaign(ctx context.Context, input types.CreateAccessReviewCampaignInput) (*types.CreateAccessReviewCampaignPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionAccessReviewCampaignCreate); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionAccessReviewCampaignCreate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 
 	var description string
 	if input.Description != nil {
@@ -692,11 +674,10 @@ func (r *mutationResolver) CreateAccessReviewCampaign(ctx context.Context, input
 
 // UpdateAccessReviewCampaign is the resolver for the updateAccessReviewCampaign field.
 func (r *mutationResolver) UpdateAccessReviewCampaign(ctx context.Context, input types.UpdateAccessReviewCampaignInput) (*types.UpdateAccessReviewCampaignPayload, error) {
-	if err := r.authorize(ctx, input.AccessReviewCampaignID, probo.ActionAccessReviewCampaignUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.AccessReviewCampaignID, probo.ActionAccessReviewCampaignUpdate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.AccessReviewCampaignID)
 
 	req := accessreview.UpdateAccessReviewCampaignRequest{
 		CampaignID: input.AccessReviewCampaignID,
@@ -730,11 +711,10 @@ func (r *mutationResolver) UpdateAccessReviewCampaign(ctx context.Context, input
 
 // DeleteAccessReviewCampaign is the resolver for the deleteAccessReviewCampaign field.
 func (r *mutationResolver) DeleteAccessReviewCampaign(ctx context.Context, input types.DeleteAccessReviewCampaignInput) (*types.DeleteAccessReviewCampaignPayload, error) {
-	if err := r.authorize(ctx, input.AccessReviewCampaignID, probo.ActionAccessReviewCampaignDelete); err != nil {
+	scope, err := r.authorize(ctx, input.AccessReviewCampaignID, probo.ActionAccessReviewCampaignDelete)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.AccessReviewCampaignID)
 
 	if err := r.accessReview.Campaigns(scope).Delete(ctx, input.AccessReviewCampaignID); err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
@@ -751,11 +731,10 @@ func (r *mutationResolver) DeleteAccessReviewCampaign(ctx context.Context, input
 
 // StartAccessReviewCampaign is the resolver for the startAccessReviewCampaign field.
 func (r *mutationResolver) StartAccessReviewCampaign(ctx context.Context, input types.StartAccessReviewCampaignInput) (*types.StartAccessReviewCampaignPayload, error) {
-	if err := r.authorize(ctx, input.AccessReviewCampaignID, probo.ActionAccessReviewCampaignStart); err != nil {
+	scope, err := r.authorize(ctx, input.AccessReviewCampaignID, probo.ActionAccessReviewCampaignStart)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.AccessReviewCampaignID)
 
 	campaign, err := r.accessReview.Campaigns(scope).Start(ctx, input.AccessReviewCampaignID)
 	if err != nil {
@@ -769,11 +748,10 @@ func (r *mutationResolver) StartAccessReviewCampaign(ctx context.Context, input 
 
 // CloseAccessReviewCampaign is the resolver for the closeAccessReviewCampaign field.
 func (r *mutationResolver) CloseAccessReviewCampaign(ctx context.Context, input types.CloseAccessReviewCampaignInput) (*types.CloseAccessReviewCampaignPayload, error) {
-	if err := r.authorize(ctx, input.AccessReviewCampaignID, probo.ActionAccessReviewCampaignClose); err != nil {
+	scope, err := r.authorize(ctx, input.AccessReviewCampaignID, probo.ActionAccessReviewCampaignClose)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.AccessReviewCampaignID)
 
 	campaign, err := r.accessReview.Campaigns(scope).Close(ctx, input.AccessReviewCampaignID)
 	if err != nil {
@@ -787,11 +765,10 @@ func (r *mutationResolver) CloseAccessReviewCampaign(ctx context.Context, input 
 
 // CancelAccessReviewCampaign is the resolver for the cancelAccessReviewCampaign field.
 func (r *mutationResolver) CancelAccessReviewCampaign(ctx context.Context, input types.CancelAccessReviewCampaignInput) (*types.CancelAccessReviewCampaignPayload, error) {
-	if err := r.authorize(ctx, input.AccessReviewCampaignID, probo.ActionAccessReviewCampaignCancel); err != nil {
+	scope, err := r.authorize(ctx, input.AccessReviewCampaignID, probo.ActionAccessReviewCampaignCancel)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.AccessReviewCampaignID)
 
 	campaign, err := r.accessReview.Campaigns(scope).Cancel(ctx, input.AccessReviewCampaignID)
 	if err != nil {
@@ -805,11 +782,10 @@ func (r *mutationResolver) CancelAccessReviewCampaign(ctx context.Context, input
 
 // AddAccessReviewCampaignScopeSource is the resolver for the addAccessReviewCampaignScopeSource field.
 func (r *mutationResolver) AddAccessReviewCampaignScopeSource(ctx context.Context, input types.AddAccessReviewCampaignScopeSourceInput) (*types.AddAccessReviewCampaignScopeSourcePayload, error) {
-	if err := r.authorize(ctx, input.AccessReviewCampaignID, probo.ActionAccessReviewCampaignAddScopeSource); err != nil {
+	scope, err := r.authorize(ctx, input.AccessReviewCampaignID, probo.ActionAccessReviewCampaignAddScopeSource)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.AccessReviewCampaignID)
 
 	campaign, err := r.accessReview.Campaigns(scope).AddScopeSource(ctx, accessreview.AddCampaignScopeSourceRequest{
 		CampaignID:     input.AccessReviewCampaignID,
@@ -826,11 +802,10 @@ func (r *mutationResolver) AddAccessReviewCampaignScopeSource(ctx context.Contex
 
 // RemoveAccessReviewCampaignScopeSource is the resolver for the removeAccessReviewCampaignScopeSource field.
 func (r *mutationResolver) RemoveAccessReviewCampaignScopeSource(ctx context.Context, input types.RemoveAccessReviewCampaignScopeSourceInput) (*types.RemoveAccessReviewCampaignScopeSourcePayload, error) {
-	if err := r.authorize(ctx, input.AccessReviewCampaignID, probo.ActionAccessReviewCampaignRemoveScopeSource); err != nil {
+	scope, err := r.authorize(ctx, input.AccessReviewCampaignID, probo.ActionAccessReviewCampaignRemoveScopeSource)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.AccessReviewCampaignID)
 
 	campaign, err := r.accessReview.Campaigns(scope).RemoveScopeSource(ctx, accessreview.RemoveCampaignScopeSourceRequest{
 		CampaignID:     input.AccessReviewCampaignID,
@@ -847,11 +822,10 @@ func (r *mutationResolver) RemoveAccessReviewCampaignScopeSource(ctx context.Con
 
 // RecordAccessEntryDecision is the resolver for the recordAccessEntryDecision field.
 func (r *mutationResolver) RecordAccessEntryDecision(ctx context.Context, input types.RecordAccessEntryDecisionInput) (*types.RecordAccessEntryDecisionPayload, error) {
-	if err := r.authorize(ctx, input.AccessEntryID, probo.ActionAccessEntryDecide); err != nil {
+	scope, err := r.authorize(ctx, input.AccessEntryID, probo.ActionAccessEntryDecide)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.AccessEntryID)
 
 	// Resolve the profile ID from the session's identity.
 	// The profile may not exist for every identity, in which
@@ -904,7 +878,8 @@ func (r *mutationResolver) RecordAccessEntryDecisions(ctx context.Context, input
 
 	// Authorize each entry individually to prevent cross-org bypass.
 	for _, d := range input.Decisions {
-		if err := r.authorize(ctx, d.AccessEntryID, probo.ActionAccessEntryDecide); err != nil {
+		_, err := r.authorize(ctx, d.AccessEntryID, probo.ActionAccessEntryDecide)
+		if err != nil {
 			return nil, err
 		}
 	}
@@ -968,11 +943,10 @@ func (r *mutationResolver) RecordAccessEntryDecisions(ctx context.Context, input
 
 // FlagAccessEntry is the resolver for the flagAccessEntry field.
 func (r *mutationResolver) FlagAccessEntry(ctx context.Context, input types.FlagAccessEntryInput) (*types.FlagAccessEntryPayload, error) {
-	if err := r.authorize(ctx, input.AccessEntryID, probo.ActionAccessEntryFlag); err != nil {
+	scope, err := r.authorize(ctx, input.AccessEntryID, probo.ActionAccessEntryFlag)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.AccessEntryID)
 
 	entry, err := r.accessReview.Entries(scope).FlagEntry(ctx, accessreview.FlagAccessEntryRequest{
 		EntryID:     input.AccessEntryID,

--- a/pkg/server/api/console/v1/access_review_campaign_resolvers.go
+++ b/pkg/server/api/console/v1/access_review_campaign_resolvers.go
@@ -131,6 +131,7 @@ func (r *accessReviewResolver) AccessSources(ctx context.Context, obj *types.Acc
 		Field:     coredata.AccessSourceOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.AccessSourceOrderField]{
 			Field:     orderBy.Field,
@@ -159,6 +160,7 @@ func (r *accessReviewResolver) Campaigns(ctx context.Context, obj *types.AccessR
 		Field:     coredata.AccessReviewCampaignOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.AccessReviewCampaignOrderField]{
 			Field:     orderBy.Field,
@@ -227,6 +229,7 @@ func (r *accessReviewCampaignResolver) Entries(ctx context.Context, obj *types.A
 		Field:     coredata.AccessEntryOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.AccessEntryOrderField]{
 			Field:     orderBy.Field,
@@ -316,6 +319,7 @@ func (r *accessReviewCampaignScopeSourceResolver) Entries(ctx context.Context, o
 		Field:     coredata.AccessEntryOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.AccessEntryOrderField]{
 			Field:     orderBy.Field,
@@ -362,6 +366,7 @@ func (r *accessSourceResolver) Connector(ctx context.Context, obj *types.AccessS
 	}
 
 	scope := coredata.NewScopeFromObjectID(obj.ID)
+
 	connector, err := r.probo.Connectors.Get(ctx, scope, *obj.ConnectorID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
@@ -565,6 +570,7 @@ func (r *mutationResolver) UpdateAccessSource(ctx context.Context, input types.U
 	req := accessreview.UpdateAccessSourceRequest{
 		AccessSourceID: input.AccessSourceID,
 	}
+
 	if input.Name.IsSet() {
 		req.Name = input.Name.Value()
 	}
@@ -676,6 +682,7 @@ func (r *mutationResolver) UpdateAccessReviewCampaign(ctx context.Context, input
 	req := accessreview.UpdateAccessReviewCampaignRequest{
 		CampaignID: input.AccessReviewCampaignID,
 	}
+
 	if input.Name.IsSet() {
 		req.Name = input.Name.Value()
 	}

--- a/pkg/server/api/console/v1/access_review_campaign_resolvers.go
+++ b/pkg/server/api/console/v1/access_review_campaign_resolvers.go
@@ -10,12 +10,15 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/vikstrous/dataloadgen"
+	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/accessreview"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/page"
 	"go.probo.inc/probo/pkg/probo"
 	"go.probo.inc/probo/pkg/server/api/authn"
+	"go.probo.inc/probo/pkg/server/api/console/v1/dataloader"
 	"go.probo.inc/probo/pkg/server/api/console/v1/schema"
 	"go.probo.inc/probo/pkg/server/api/console/v1/types"
 	"go.probo.inc/probo/pkg/server/gqlutils"
@@ -86,7 +89,10 @@ func (r *accessEntryResolver) Permission(ctx context.Context, obj *types.AccessE
 
 // TotalCount is the resolver for the totalCount field.
 func (r *accessEntryConnectionResolver) TotalCount(ctx context.Context, obj *types.AccessEntryConnection) (int, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionAccessEntryList)
+	if err != nil {
+		return 0, err
+	}
 
 	switch obj.Resolver.(type) {
 	case *accessReviewCampaignResolver:
@@ -111,81 +117,25 @@ func (r *accessEntryConnectionResolver) TotalCount(ctx context.Context, obj *typ
 }
 
 // Organization is the resolver for the organization field.
-func (r *accessReviewResolver) Organization(ctx context.Context, obj *types.AccessReview) (*types.Organization, error) {
-	return obj.Organization, nil
-}
-
-// IdentitySource is the resolver for the identitySource field.
-func (r *accessReviewResolver) IdentitySource(ctx context.Context, obj *types.AccessReview) (*types.AccessSource, error) {
-	return obj.IdentitySource, nil
-}
-
-// AccessSources is the resolver for the accessSources field.
-func (r *accessReviewResolver) AccessSources(ctx context.Context, obj *types.AccessReview, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AccessSourceOrder) (*types.AccessSourceConnection, error) {
-	scope, err := r.authorize(ctx, obj.Organization.ID, probo.ActionAccessSourceList)
-	if err != nil {
-		return nil, err
-	}
-
-	pageOrderBy := page.OrderBy[coredata.AccessSourceOrderField]{
-		Field:     coredata.AccessSourceOrderFieldCreatedAt,
-		Direction: page.OrderDirectionDesc,
-	}
-
-	if orderBy != nil {
-		pageOrderBy = page.OrderBy[coredata.AccessSourceOrderField]{
-			Field:     orderBy.Field,
-			Direction: orderBy.Direction,
-		}
-	}
-
-	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
-
-	p, err := r.accessReview.Sources(scope).ListForOrganizationID(ctx, obj.Organization.ID, cursor)
-	if err != nil {
-		panic(fmt.Errorf("cannot list access sources: %w", err))
-	}
-
-	return types.NewAccessSourceConnection(p, r, obj.Organization.ID), nil
-}
-
-// Campaigns is the resolver for the campaigns field.
-func (r *accessReviewResolver) Campaigns(ctx context.Context, obj *types.AccessReview, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AccessReviewCampaignOrder) (*types.AccessReviewCampaignConnection, error) {
-	scope, err := r.authorize(ctx, obj.Organization.ID, probo.ActionAccessReviewCampaignList)
-	if err != nil {
-		return nil, err
-	}
-
-	pageOrderBy := page.OrderBy[coredata.AccessReviewCampaignOrderField]{
-		Field:     coredata.AccessReviewCampaignOrderFieldCreatedAt,
-		Direction: page.OrderDirectionDesc,
-	}
-
-	if orderBy != nil {
-		pageOrderBy = page.OrderBy[coredata.AccessReviewCampaignOrderField]{
-			Field:     orderBy.Field,
-			Direction: orderBy.Direction,
-		}
-	}
-
-	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
-
-	p, err := r.accessReview.Campaigns(scope).ListForOrganizationID(ctx, obj.Organization.ID, cursor)
-	if err != nil {
-		panic(fmt.Errorf("cannot list access review campaigns: %w", err))
-	}
-
-	return types.NewAccessReviewCampaignConnection(p, r, obj.Organization.ID), nil
-}
-
-// Permission is the resolver for the permission field.
-func (r *accessReviewResolver) Permission(ctx context.Context, obj *types.AccessReview, action string) (bool, error) {
-	return r.Resolver.Permission(ctx, obj, action)
-}
-
-// Organization is the resolver for the organization field.
 func (r *accessReviewCampaignResolver) Organization(ctx context.Context, obj *types.AccessReviewCampaign) (*types.Organization, error) {
-	return obj.Organization, nil
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
+		return nil, err
+	}
+
+	loaders := dataloader.FromContext(ctx)
+
+	organization, err := loaders.Organization.Load(ctx, obj.Organization.ID)
+	if err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) || errors.Is(err, dataloadgen.ErrNotFound) {
+			return nil, gqlutils.NotFound(ctx, err)
+		}
+
+		r.logger.ErrorCtx(ctx, "cannot load organization", log.Error(err))
+
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	return types.NewOrganization(organization), nil
 }
 
 // ScopeSources is the resolver for the scopeSources field.
@@ -293,7 +243,10 @@ func (r *accessReviewCampaignResolver) Permission(ctx context.Context, obj *type
 
 // TotalCount is the resolver for the totalCount field.
 func (r *accessReviewCampaignConnectionResolver) TotalCount(ctx context.Context, obj *types.AccessReviewCampaignConnection) (int, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionAccessReviewCampaignList)
+	if err != nil {
+		return 0, err
+	}
 
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
@@ -356,7 +309,24 @@ func (r *accessReviewCampaignScopeSourceResolver) Statistics(ctx context.Context
 
 // Organization is the resolver for the organization field.
 func (r *accessSourceResolver) Organization(ctx context.Context, obj *types.AccessSource) (*types.Organization, error) {
-	return obj.Organization, nil
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
+		return nil, err
+	}
+
+	loaders := dataloader.FromContext(ctx)
+
+	organization, err := loaders.Organization.Load(ctx, obj.Organization.ID)
+	if err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) || errors.Is(err, dataloadgen.ErrNotFound) {
+			return nil, gqlutils.NotFound(ctx, err)
+		}
+
+		r.logger.ErrorCtx(ctx, "cannot load organization", log.Error(err))
+
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	return types.NewOrganization(organization), nil
 }
 
 // Connector is the resolver for the connector field.
@@ -365,7 +335,10 @@ func (r *accessSourceResolver) Connector(ctx context.Context, obj *types.AccessS
 		return nil, nil
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionAccessSourceGet)
+	if err != nil {
+		return nil, err
+	}
 
 	connector, err := r.probo.Connectors.Get(ctx, scope, *obj.ConnectorID)
 	if err != nil {
@@ -456,7 +429,10 @@ func (r *accessSourceResolver) ConnectionStatus(ctx context.Context, obj *types.
 		return types.AccessSourceConnectionStatusNotApplicable, nil
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionAccessSourceGet)
+	if err != nil {
+		return types.AccessSourceConnectionStatusNotApplicable, err
+	}
 
 	httpClient, dbConnector, err := r.accessReview.Sources(scope).ConnectorHTTPClient(ctx, *obj.ConnectorID)
 	if err != nil {
@@ -522,7 +498,10 @@ func (r *accessSourceResolver) Permission(ctx context.Context, obj *types.Access
 
 // TotalCount is the resolver for the totalCount field.
 func (r *accessSourceConnectionResolver) TotalCount(ctx context.Context, obj *types.AccessSourceConnection) (int, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionAccessSourceList)
+	if err != nil {
+		return 0, err
+	}
 
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
@@ -975,9 +954,6 @@ func (r *Resolver) AccessEntryConnection() schema.AccessEntryConnectionResolver 
 	return &accessEntryConnectionResolver{r}
 }
 
-// AccessReview returns schema.AccessReviewResolver implementation.
-func (r *Resolver) AccessReview() schema.AccessReviewResolver { return &accessReviewResolver{r} }
-
 // AccessReviewCampaign returns schema.AccessReviewCampaignResolver implementation.
 func (r *Resolver) AccessReviewCampaign() schema.AccessReviewCampaignResolver {
 	return &accessReviewCampaignResolver{r}
@@ -1003,7 +979,6 @@ func (r *Resolver) AccessSourceConnection() schema.AccessSourceConnectionResolve
 
 type accessEntryResolver struct{ *Resolver }
 type accessEntryConnectionResolver struct{ *Resolver }
-type accessReviewResolver struct{ *Resolver }
 type accessReviewCampaignResolver struct{ *Resolver }
 type accessReviewCampaignConnectionResolver struct{ *Resolver }
 type accessReviewCampaignScopeSourceResolver struct{ *Resolver }

--- a/pkg/server/api/console/v1/asset_resolvers.go
+++ b/pkg/server/api/console/v1/asset_resolvers.go
@@ -56,6 +56,7 @@ func (r *assetResolver) ThirdParties(ctx context.Context, obj *types.Asset, firs
 		Field:     coredata.ThirdPartyOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ThirdPartyOrderField]{
 			Field:     orderBy.Field,
@@ -160,6 +161,7 @@ func (r *datumResolver) ThirdParties(ctx context.Context, obj *types.Datum, firs
 		Field:     coredata.ThirdPartyOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ThirdPartyOrderField]{
 			Field:     orderBy.Field,

--- a/pkg/server/api/console/v1/asset_resolvers.go
+++ b/pkg/server/api/console/v1/asset_resolvers.go
@@ -25,7 +25,7 @@ import (
 
 // Owner is the resolver for the owner field.
 func (r *assetResolver) Owner(ctx context.Context, obj *types.Asset) (*types.Profile, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileGet); err != nil {
 		return nil, err
 	}
 
@@ -47,11 +47,11 @@ func (r *assetResolver) Owner(ctx context.Context, obj *types.Asset) (*types.Pro
 
 // ThirdParties is the resolver for the thirdParties field.
 func (r *assetResolver) ThirdParties(ctx context.Context, obj *types.Asset, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ThirdPartyOrderBy) (*types.ThirdPartyConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyOrderField]{
@@ -78,11 +78,11 @@ func (r *assetResolver) ThirdParties(ctx context.Context, obj *types.Asset, firs
 
 // Organization is the resolver for the organization field.
 func (r *assetResolver) Organization(ctx context.Context, obj *types.Asset) (*types.Organization, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	asset, err := prb.Assets.Get(ctx, scope, obj.ID)
@@ -112,11 +112,11 @@ func (r *assetResolver) Permission(ctx context.Context, obj *types.Asset, action
 
 // TotalCount is the resolver for the totalCount field.
 func (r *assetConnectionResolver) TotalCount(ctx context.Context, obj *types.AssetConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionAssetList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionAssetList)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 	prb := r.probo
 
 	switch obj.Resolver.(type) {
@@ -137,7 +137,7 @@ func (r *assetConnectionResolver) TotalCount(ctx context.Context, obj *types.Ass
 
 // Owner is the resolver for the owner field.
 func (r *datumResolver) Owner(ctx context.Context, obj *types.Datum) (*types.Profile, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileGet); err != nil {
 		return nil, err
 	}
 
@@ -157,11 +157,11 @@ func (r *datumResolver) Owner(ctx context.Context, obj *types.Datum) (*types.Pro
 
 // ThirdParties is the resolver for the thirdParties field.
 func (r *datumResolver) ThirdParties(ctx context.Context, obj *types.Datum, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ThirdPartyOrderBy) (*types.ThirdPartyConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyOrderField]{
@@ -188,7 +188,7 @@ func (r *datumResolver) ThirdParties(ctx context.Context, obj *types.Datum, firs
 
 // Organization is the resolver for the organization field.
 func (r *datumResolver) Organization(ctx context.Context, obj *types.Datum) (*types.Organization, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
 		return nil, err
 	}
 
@@ -215,11 +215,11 @@ func (r *datumResolver) Permission(ctx context.Context, obj *types.Datum, action
 
 // TotalCount is the resolver for the totalCount field.
 func (r *datumConnectionResolver) TotalCount(ctx context.Context, obj *types.DatumConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionDatumList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionDatumList)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 	prb := r.probo
 
 	switch obj.Resolver.(type) {
@@ -240,11 +240,11 @@ func (r *datumConnectionResolver) TotalCount(ctx context.Context, obj *types.Dat
 
 // CreateAsset is the resolver for the createAsset field.
 func (r *mutationResolver) CreateAsset(ctx context.Context, input types.CreateAssetInput) (*types.CreateAssetPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionAssetCreate); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionAssetCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	asset, err := prb.Assets.Create(
@@ -276,11 +276,11 @@ func (r *mutationResolver) CreateAsset(ctx context.Context, input types.CreateAs
 
 // UpdateAsset is the resolver for the updateAsset field.
 func (r *mutationResolver) UpdateAsset(ctx context.Context, input types.UpdateAssetInput) (*types.UpdateAssetPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionAssetUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionAssetUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
 	asset, err := prb.Assets.Update(
@@ -312,15 +312,14 @@ func (r *mutationResolver) UpdateAsset(ctx context.Context, input types.UpdateAs
 
 // DeleteAsset is the resolver for the deleteAsset field.
 func (r *mutationResolver) DeleteAsset(ctx context.Context, input types.DeleteAssetInput) (*types.DeleteAssetPayload, error) {
-	if err := r.authorize(ctx, input.AssetID, probo.ActionAssetDelete); err != nil {
+	scope, err := r.authorize(ctx, input.AssetID, probo.ActionAssetDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.AssetID)
 	prb := r.probo
 
-	err := prb.Assets.Delete(ctx, scope, input.AssetID)
-	if err != nil {
+	if err := prb.Assets.Delete(ctx, scope, input.AssetID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete asset", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -332,11 +331,11 @@ func (r *mutationResolver) DeleteAsset(ctx context.Context, input types.DeleteAs
 
 // CreateDatum is the resolver for the createDatum field.
 func (r *mutationResolver) CreateDatum(ctx context.Context, input types.CreateDatumInput) (*types.CreateDatumPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionDatumCreate); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionDatumCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	data, err := prb.Data.Create(
@@ -366,11 +365,11 @@ func (r *mutationResolver) CreateDatum(ctx context.Context, input types.CreateDa
 
 // UpdateDatum is the resolver for the updateDatum field.
 func (r *mutationResolver) UpdateDatum(ctx context.Context, input types.UpdateDatumInput) (*types.UpdateDatumPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionDatumUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionDatumUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
 	datum, err := prb.Data.Update(
@@ -400,11 +399,11 @@ func (r *mutationResolver) UpdateDatum(ctx context.Context, input types.UpdateDa
 
 // DeleteDatum is the resolver for the deleteDatum field.
 func (r *mutationResolver) DeleteDatum(ctx context.Context, input types.DeleteDatumInput) (*types.DeleteDatumPayload, error) {
-	if err := r.authorize(ctx, input.DatumID, probo.ActionDatumDelete); err != nil {
+	scope, err := r.authorize(ctx, input.DatumID, probo.ActionDatumDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.DatumID)
 	prb := r.probo
 
 	if err := prb.Data.Delete(ctx, scope, input.DatumID); err != nil {
@@ -419,11 +418,11 @@ func (r *mutationResolver) DeleteDatum(ctx context.Context, input types.DeleteDa
 
 // PublishDataList is the resolver for the publishDataList field.
 func (r *mutationResolver) PublishDataList(ctx context.Context, input types.PublishDataListInput) (*types.PublishDataListPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionDatumPublish); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionDatumPublish)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	document, documentVersion, err := prb.GeneratedDocuments.PublishDataList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
@@ -449,11 +448,11 @@ func (r *mutationResolver) PublishDataList(ctx context.Context, input types.Publ
 
 // PublishAssetList is the resolver for the publishAssetList field.
 func (r *mutationResolver) PublishAssetList(ctx context.Context, input types.PublishAssetListInput) (*types.PublishAssetListPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionAssetPublish); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionAssetPublish)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	document, documentVersion, err := prb.GeneratedDocuments.PublishAssetList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)

--- a/pkg/server/api/console/v1/asset_resolvers.go
+++ b/pkg/server/api/console/v1/asset_resolvers.go
@@ -52,8 +52,6 @@ func (r *assetResolver) ThirdParties(ctx context.Context, obj *types.Asset, firs
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyOrderField]{
 		Field:     coredata.ThirdPartyOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -67,7 +65,7 @@ func (r *assetResolver) ThirdParties(ctx context.Context, obj *types.Asset, firs
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.ThirdParties.ListForAssetID(ctx, scope, obj.ID, cursor)
+	page, err := r.probo.ThirdParties.ListForAssetID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list asset thirdParties", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -83,15 +81,13 @@ func (r *assetResolver) Organization(ctx context.Context, obj *types.Asset) (*ty
 		return nil, err
 	}
 
-	prb := r.probo
-
-	asset, err := prb.Assets.Get(ctx, scope, obj.ID)
+	asset, err := r.probo.Assets.Get(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot load audit", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	org, err := prb.Organizations.Get(ctx, scope, asset.OrganizationID)
+	org, err := r.probo.Organizations.Get(ctx, scope, asset.OrganizationID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -117,11 +113,9 @@ func (r *assetConnectionResolver) TotalCount(ctx context.Context, obj *types.Ass
 		return 0, err
 	}
 
-	prb := r.probo
-
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.Assets.CountForOrganizationID(ctx, scope, obj.ParentID)
+		count, err := r.probo.Assets.CountForOrganizationID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count assets", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -162,8 +156,6 @@ func (r *datumResolver) ThirdParties(ctx context.Context, obj *types.Datum, firs
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyOrderField]{
 		Field:     coredata.ThirdPartyOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -177,7 +169,7 @@ func (r *datumResolver) ThirdParties(ctx context.Context, obj *types.Datum, firs
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Data.ListThirdParties(ctx, scope, obj.ID, cursor)
+	page, err := r.probo.Data.ListThirdParties(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list data thirdParties", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -220,11 +212,9 @@ func (r *datumConnectionResolver) TotalCount(ctx context.Context, obj *types.Dat
 		return 0, err
 	}
 
-	prb := r.probo
-
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.Data.CountForOrganizationID(ctx, scope, obj.ParentID)
+		count, err := r.probo.Data.CountForOrganizationID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count data", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -245,9 +235,7 @@ func (r *mutationResolver) CreateAsset(ctx context.Context, input types.CreateAs
 		return nil, err
 	}
 
-	prb := r.probo
-
-	asset, err := prb.Assets.Create(
+	asset, err := r.probo.Assets.Create(
 		ctx, scope,
 		probo.CreateAssetRequest{
 			OrganizationID:  input.OrganizationID,
@@ -281,9 +269,7 @@ func (r *mutationResolver) UpdateAsset(ctx context.Context, input types.UpdateAs
 		return nil, err
 	}
 
-	prb := r.probo
-
-	asset, err := prb.Assets.Update(
+	asset, err := r.probo.Assets.Update(
 		ctx, scope,
 		probo.UpdateAssetRequest{
 			ID:              input.ID,
@@ -317,9 +303,7 @@ func (r *mutationResolver) DeleteAsset(ctx context.Context, input types.DeleteAs
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.Assets.Delete(ctx, scope, input.AssetID); err != nil {
+	if err := r.probo.Assets.Delete(ctx, scope, input.AssetID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete asset", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -336,9 +320,7 @@ func (r *mutationResolver) CreateDatum(ctx context.Context, input types.CreateDa
 		return nil, err
 	}
 
-	prb := r.probo
-
-	data, err := prb.Data.Create(
+	data, err := r.probo.Data.Create(
 		ctx, scope,
 		probo.CreateDatumRequest{
 			OrganizationID:     input.OrganizationID,
@@ -370,9 +352,7 @@ func (r *mutationResolver) UpdateDatum(ctx context.Context, input types.UpdateDa
 		return nil, err
 	}
 
-	prb := r.probo
-
-	datum, err := prb.Data.Update(
+	datum, err := r.probo.Data.Update(
 		ctx, scope,
 		probo.UpdateDatumRequest{
 			ID:                 input.ID,
@@ -404,9 +384,7 @@ func (r *mutationResolver) DeleteDatum(ctx context.Context, input types.DeleteDa
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.Data.Delete(ctx, scope, input.DatumID); err != nil {
+	if err := r.probo.Data.Delete(ctx, scope, input.DatumID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete datum", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -423,9 +401,7 @@ func (r *mutationResolver) PublishDataList(ctx context.Context, input types.Publ
 		return nil, err
 	}
 
-	prb := r.probo
-
-	document, documentVersion, err := prb.GeneratedDocuments.PublishDataList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := r.probo.GeneratedDocuments.PublishDataList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -453,9 +429,7 @@ func (r *mutationResolver) PublishAssetList(ctx context.Context, input types.Pub
 		return nil, err
 	}
 
-	prb := r.probo
-
-	document, documentVersion, err := prb.GeneratedDocuments.PublishAssetList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := r.probo.GeneratedDocuments.PublishAssetList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)

--- a/pkg/server/api/console/v1/audit_log_resolvers.go
+++ b/pkg/server/api/console/v1/audit_log_resolvers.go
@@ -7,9 +7,14 @@ package console_v1
 
 import (
 	"context"
+	"errors"
 
+	"github.com/vikstrous/dataloadgen"
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/iam"
+	"go.probo.inc/probo/pkg/probo"
+	"go.probo.inc/probo/pkg/server/api/console/v1/dataloader"
 	"go.probo.inc/probo/pkg/server/api/console/v1/schema"
 	"go.probo.inc/probo/pkg/server/api/console/v1/types"
 	"go.probo.inc/probo/pkg/server/gqlutils"
@@ -17,7 +22,24 @@ import (
 
 // Organization is the resolver for the organization field.
 func (r *auditLogEntryResolver) Organization(ctx context.Context, obj *types.AuditLogEntry) (*types.Organization, error) {
-	return obj.Organization, nil
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
+		return nil, err
+	}
+
+	loaders := dataloader.FromContext(ctx)
+
+	organization, err := loaders.Organization.Load(ctx, obj.Organization.ID)
+	if err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) || errors.Is(err, dataloadgen.ErrNotFound) {
+			return nil, gqlutils.NotFound(ctx, err)
+		}
+
+		r.logger.ErrorCtx(ctx, "cannot load organization", log.Error(err))
+
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	return types.NewOrganization(organization), nil
 }
 
 // Permission is the resolver for the permission field.
@@ -27,6 +49,10 @@ func (r *auditLogEntryResolver) Permission(ctx context.Context, obj *types.Audit
 
 // TotalCount is the resolver for the totalCount field.
 func (r *auditLogEntryConnectionResolver) TotalCount(ctx context.Context, obj *types.AuditLogEntryConnection) (int, error) {
+	if _, err := r.authorize(ctx, obj.ParentID, iam.ActionAuditLogEntryList); err != nil {
+		return 0, err
+	}
+
 	filter := coredata.NewAuditLogEntryFilter()
 	if obj.Filter != nil {
 		filter = obj.Filter

--- a/pkg/server/api/console/v1/audit_resolvers.go
+++ b/pkg/server/api/console/v1/audit_resolvers.go
@@ -26,7 +26,7 @@ import (
 
 // Organization is the resolver for the organization field.
 func (r *auditResolver) Organization(ctx context.Context, obj *types.Audit) (*types.Organization, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
 		return nil, err
 	}
 
@@ -48,7 +48,7 @@ func (r *auditResolver) Organization(ctx context.Context, obj *types.Audit) (*ty
 
 // Framework is the resolver for the framework field.
 func (r *auditResolver) Framework(ctx context.Context, obj *types.Audit) (*types.Framework, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionFrameworkGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionFrameworkGet); err != nil {
 		return nil, err
 	}
 
@@ -70,7 +70,7 @@ func (r *auditResolver) Framework(ctx context.Context, obj *types.Audit) (*types
 
 // Report is the resolver for the report field.
 func (r *auditResolver) Report(ctx context.Context, obj *types.Audit) (*types.Report, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionReportGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionReportGet); err != nil {
 		return nil, err
 	}
 
@@ -96,7 +96,8 @@ func (r *auditResolver) Report(ctx context.Context, obj *types.Audit) (*types.Re
 
 // ReportURL is the resolver for the reportUrl field.
 func (r *auditResolver) ReportURL(ctx context.Context, obj *types.Audit) (*string, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionReportGetReportUrl); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionReportGetReportUrl)
+	if err != nil {
 		return nil, err
 	}
 
@@ -104,7 +105,6 @@ func (r *auditResolver) ReportURL(ctx context.Context, obj *types.Audit) (*strin
 		return nil, nil
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	url, err := prb.Audits.GenerateReportURL(ctx, scope, obj.ID, 15*time.Minute)
@@ -118,11 +118,11 @@ func (r *auditResolver) ReportURL(ctx context.Context, obj *types.Audit) (*strin
 
 // Controls is the resolver for the controls field.
 func (r *auditResolver) Controls(ctx context.Context, obj *types.Audit, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ControlOrderBy, filter *types.ControlFilter) (*types.ControlConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionControlList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionControlList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ControlOrderField]{
@@ -154,11 +154,11 @@ func (r *auditResolver) Controls(ctx context.Context, obj *types.Audit, first *i
 
 // Findings is the resolver for the findings field.
 func (r *auditResolver) Findings(ctx context.Context, obj *types.Audit, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.FindingOrder, filter *types.FindingFilter) (*types.FindingConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionFindingList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionFindingList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.FindingOrderField]{
@@ -205,11 +205,11 @@ func (r *auditResolver) Permission(ctx context.Context, obj *types.Audit, action
 
 // TotalCount is the resolver for the totalCount field.
 func (r *auditConnectionResolver) TotalCount(ctx context.Context, obj *types.AuditConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionAuditList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionAuditList)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 	prb := r.probo
 
 	switch obj.Resolver.(type) {
@@ -245,7 +245,7 @@ func (r *auditConnectionResolver) TotalCount(ctx context.Context, obj *types.Aud
 
 // Organization is the resolver for the organization field.
 func (r *findingResolver) Organization(ctx context.Context, obj *types.Finding) (*types.Organization, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
 		return nil, err
 	}
 
@@ -267,11 +267,11 @@ func (r *findingResolver) Organization(ctx context.Context, obj *types.Finding) 
 
 // Audits is the resolver for the audits field.
 func (r *findingResolver) Audits(ctx context.Context, obj *types.Finding, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AuditOrderBy) (*types.AuditConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionAuditList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionAuditList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.AuditOrderField]{
@@ -302,7 +302,7 @@ func (r *findingResolver) Owner(ctx context.Context, obj *types.Finding) (*types
 		return nil, nil
 	}
 
-	if err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileGet); err != nil {
 		return nil, err
 	}
 
@@ -328,7 +328,7 @@ func (r *findingResolver) Risk(ctx context.Context, obj *types.Finding) (*types.
 		return nil, nil
 	}
 
-	if err := r.authorize(ctx, obj.ID, probo.ActionRiskGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionRiskGet); err != nil {
 		return nil, err
 	}
 
@@ -355,11 +355,11 @@ func (r *findingResolver) Permission(ctx context.Context, obj *types.Finding, ac
 
 // TotalCount is the resolver for the totalCount field.
 func (r *findingConnectionResolver) TotalCount(ctx context.Context, obj *types.FindingConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionFindingList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionFindingList)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 	prb := r.probo
 
 	var (
@@ -403,11 +403,11 @@ func (r *findingConnectionResolver) TotalCount(ctx context.Context, obj *types.F
 
 // CreateAudit is the resolver for the createAudit field.
 func (r *mutationResolver) CreateAudit(ctx context.Context, input types.CreateAuditInput) (*types.CreateAuditPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionAuditCreate); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionAuditCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	req := probo.CreateAuditRequest{
@@ -461,11 +461,11 @@ func (r *mutationResolver) CreateAudit(ctx context.Context, input types.CreateAu
 
 // UpdateAudit is the resolver for the updateAudit field.
 func (r *mutationResolver) UpdateAudit(ctx context.Context, input types.UpdateAuditInput) (*types.UpdateAuditPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionAuditUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionAuditUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
 	req := probo.UpdateAuditRequest{
@@ -495,15 +495,14 @@ func (r *mutationResolver) UpdateAudit(ctx context.Context, input types.UpdateAu
 
 // DeleteAudit is the resolver for the deleteAudit field.
 func (r *mutationResolver) DeleteAudit(ctx context.Context, input types.DeleteAuditInput) (*types.DeleteAuditPayload, error) {
-	if err := r.authorize(ctx, input.AuditID, probo.ActionAuditDelete); err != nil {
+	scope, err := r.authorize(ctx, input.AuditID, probo.ActionAuditDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.AuditID)
 	prb := r.probo
 
-	err := prb.Audits.Delete(ctx, scope, input.AuditID)
-	if err != nil {
+	if err := prb.Audits.Delete(ctx, scope, input.AuditID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete audit", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -515,11 +514,11 @@ func (r *mutationResolver) DeleteAudit(ctx context.Context, input types.DeleteAu
 
 // UploadAuditReport is the resolver for the uploadAuditReport field.
 func (r *mutationResolver) UploadAuditReport(ctx context.Context, input types.UploadAuditReportInput) (*types.UploadAuditReportPayload, error) {
-	if err := r.authorize(ctx, input.AuditID, probo.ActionAuditReportUpload); err != nil {
+	scope, err := r.authorize(ctx, input.AuditID, probo.ActionAuditReportUpload)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.AuditID)
 	prb := r.probo
 
 	req := probo.UploadAuditReportRequest{
@@ -550,11 +549,11 @@ func (r *mutationResolver) UploadAuditReport(ctx context.Context, input types.Up
 
 // DeleteAuditReport is the resolver for the deleteAuditReport field.
 func (r *mutationResolver) DeleteAuditReport(ctx context.Context, input types.DeleteAuditReportInput) (*types.DeleteAuditReportPayload, error) {
-	if err := r.authorize(ctx, input.AuditID, probo.ActionAuditReportDelete); err != nil {
+	scope, err := r.authorize(ctx, input.AuditID, probo.ActionAuditReportDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.AuditID)
 	prb := r.probo
 
 	audit, err := prb.Audits.DeleteReport(ctx, scope, input.AuditID)
@@ -570,11 +569,11 @@ func (r *mutationResolver) DeleteAuditReport(ctx context.Context, input types.De
 
 // CreateFinding is the resolver for the createFinding field.
 func (r *mutationResolver) CreateFinding(ctx context.Context, input types.CreateFindingInput) (*types.CreateFindingPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionFindingCreate); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionFindingCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	req := probo.CreateFindingRequest{
@@ -611,11 +610,11 @@ func (r *mutationResolver) CreateFinding(ctx context.Context, input types.Create
 
 // UpdateFinding is the resolver for the updateFinding field.
 func (r *mutationResolver) UpdateFinding(ctx context.Context, input types.UpdateFindingInput) (*types.UpdateFindingPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionFindingUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionFindingUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
 	req := probo.UpdateFindingRequest{
@@ -651,15 +650,14 @@ func (r *mutationResolver) UpdateFinding(ctx context.Context, input types.Update
 
 // DeleteFinding is the resolver for the deleteFinding field.
 func (r *mutationResolver) DeleteFinding(ctx context.Context, input types.DeleteFindingInput) (*types.DeleteFindingPayload, error) {
-	if err := r.authorize(ctx, input.FindingID, probo.ActionFindingDelete); err != nil {
+	scope, err := r.authorize(ctx, input.FindingID, probo.ActionFindingDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.FindingID)
 	prb := r.probo
 
-	err := prb.Findings.Delete(ctx, scope, input.FindingID)
-	if err != nil {
+	if err := prb.Findings.Delete(ctx, scope, input.FindingID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete finding", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -671,11 +669,11 @@ func (r *mutationResolver) DeleteFinding(ctx context.Context, input types.Delete
 
 // CreateFindingAuditMapping is the resolver for the createFindingAuditMapping field.
 func (r *mutationResolver) CreateFindingAuditMapping(ctx context.Context, input types.CreateFindingAuditMappingInput) (*types.CreateFindingAuditMappingPayload, error) {
-	if err := r.authorize(ctx, input.FindingID, probo.ActionFindingAuditMappingCreate); err != nil {
+	scope, err := r.authorize(ctx, input.FindingID, probo.ActionFindingAuditMappingCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.FindingID)
 	prb := r.probo
 
 	finding, audit, err := prb.Findings.CreateAuditMapping(ctx, scope, input.FindingID, input.AuditID, input.ReferenceID)
@@ -692,11 +690,11 @@ func (r *mutationResolver) CreateFindingAuditMapping(ctx context.Context, input 
 
 // DeleteFindingAuditMapping is the resolver for the deleteFindingAuditMapping field.
 func (r *mutationResolver) DeleteFindingAuditMapping(ctx context.Context, input types.DeleteFindingAuditMappingInput) (*types.DeleteFindingAuditMappingPayload, error) {
-	if err := r.authorize(ctx, input.FindingID, probo.ActionFindingAuditMappingDelete); err != nil {
+	scope, err := r.authorize(ctx, input.FindingID, probo.ActionFindingAuditMappingDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.FindingID)
 	prb := r.probo
 
 	finding, audit, err := prb.Findings.DeleteAuditMapping(ctx, scope, input.FindingID, input.AuditID)
@@ -713,11 +711,11 @@ func (r *mutationResolver) DeleteFindingAuditMapping(ctx context.Context, input 
 
 // PublishFindingList is the resolver for the publishFindingList field.
 func (r *mutationResolver) PublishFindingList(ctx context.Context, input types.PublishFindingListInput) (*types.PublishFindingListPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionFindingPublish); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionFindingPublish)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	document, documentVersion, err := prb.GeneratedDocuments.PublishFindingList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
@@ -743,11 +741,11 @@ func (r *mutationResolver) PublishFindingList(ctx context.Context, input types.P
 
 // DownloadURL is the resolver for the downloadUrl field.
 func (r *reportResolver) DownloadURL(ctx context.Context, obj *types.Report) (*string, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionReportDownloadUrlGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionReportDownloadUrlGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	url, err := prb.Reports.GenerateDownloadURL(ctx, scope, obj.ID, 15*time.Minute)
@@ -761,11 +759,11 @@ func (r *reportResolver) DownloadURL(ctx context.Context, obj *types.Report) (*s
 
 // Audit is the resolver for the audit field.
 func (r *reportResolver) Audit(ctx context.Context, obj *types.Report) (*types.Audit, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionAuditGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionAuditGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	audit, err := prb.Audits.GetByReportID(ctx, scope, obj.ID)

--- a/pkg/server/api/console/v1/audit_resolvers.go
+++ b/pkg/server/api/console/v1/audit_resolvers.go
@@ -125,6 +125,7 @@ func (r *auditResolver) Controls(ctx context.Context, obj *types.Audit, first *i
 		Field:     coredata.ControlOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ControlOrderField]{
 			Field:     orderBy.Field,
@@ -159,6 +160,7 @@ func (r *auditResolver) Findings(ctx context.Context, obj *types.Audit, first *i
 		Field:     coredata.FindingOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.FindingOrderField]{
 			Field:     orderBy.Field,
@@ -268,6 +270,7 @@ func (r *findingResolver) Audits(ctx context.Context, obj *types.Finding, first 
 		Field:     coredata.AuditOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.AuditOrderField]{
 			Field:     orderBy.Field,

--- a/pkg/server/api/console/v1/audit_resolvers.go
+++ b/pkg/server/api/console/v1/audit_resolvers.go
@@ -105,9 +105,7 @@ func (r *auditResolver) ReportURL(ctx context.Context, obj *types.Audit) (*strin
 		return nil, nil
 	}
 
-	prb := r.probo
-
-	url, err := prb.Audits.GenerateReportURL(ctx, scope, obj.ID, 15*time.Minute)
+	url, err := r.probo.Audits.GenerateReportURL(ctx, scope, obj.ID, 15*time.Minute)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate report URL", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -122,8 +120,6 @@ func (r *auditResolver) Controls(ctx context.Context, obj *types.Audit, first *i
 	if err != nil {
 		return nil, err
 	}
-
-	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ControlOrderField]{
 		Field:     coredata.ControlOrderFieldCreatedAt,
@@ -143,7 +139,7 @@ func (r *auditResolver) Controls(ctx context.Context, obj *types.Audit, first *i
 		controlFilter = coredata.NewControlFilter(filter.Query)
 	}
 
-	page, err := prb.Controls.ListForAuditID(ctx, scope, obj.ID, cursor, controlFilter)
+	page, err := r.probo.Controls.ListForAuditID(ctx, scope, obj.ID, cursor, controlFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list audit controls", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -158,8 +154,6 @@ func (r *auditResolver) Findings(ctx context.Context, obj *types.Audit, first *i
 	if err != nil {
 		return nil, err
 	}
-
-	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.FindingOrderField]{
 		Field:     coredata.FindingOrderFieldCreatedAt,
@@ -189,7 +183,7 @@ func (r *auditResolver) Findings(ctx context.Context, obj *types.Audit, first *i
 
 	findingFilter := coredata.NewFindingFilter(kind, status, priority, ownerID)
 
-	p, err := prb.Findings.ListForAuditID(ctx, scope, obj.ID, cursor, findingFilter)
+	p, err := r.probo.Findings.ListForAuditID(ctx, scope, obj.ID, cursor, findingFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list audit findings", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -210,11 +204,9 @@ func (r *auditConnectionResolver) TotalCount(ctx context.Context, obj *types.Aud
 		return 0, err
 	}
 
-	prb := r.probo
-
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.Audits.CountForOrganizationID(ctx, scope, obj.ParentID)
+		count, err := r.probo.Audits.CountForOrganizationID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count audits", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -222,7 +214,7 @@ func (r *auditConnectionResolver) TotalCount(ctx context.Context, obj *types.Aud
 
 		return count, nil
 	case *findingResolver:
-		count, err := prb.Audits.CountForFindingID(ctx, scope, obj.ParentID)
+		count, err := r.probo.Audits.CountForFindingID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count audits", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -230,7 +222,7 @@ func (r *auditConnectionResolver) TotalCount(ctx context.Context, obj *types.Aud
 
 		return count, nil
 	case *controlResolver:
-		count, err := prb.Audits.CountForControlID(ctx, scope, obj.ParentID)
+		count, err := r.probo.Audits.CountForControlID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count audits", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -272,8 +264,6 @@ func (r *findingResolver) Audits(ctx context.Context, obj *types.Finding, first 
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.AuditOrderField]{
 		Field:     coredata.AuditOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -287,7 +277,7 @@ func (r *findingResolver) Audits(ctx context.Context, obj *types.Finding, first 
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	p, err := prb.Audits.ListForFindingID(ctx, scope, obj.ID, cursor)
+	p, err := r.probo.Audits.ListForFindingID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list finding audits", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -360,8 +350,6 @@ func (r *findingConnectionResolver) TotalCount(ctx context.Context, obj *types.F
 		return 0, err
 	}
 
-	prb := r.probo
-
 	var (
 		kind     *coredata.FindingKind
 		status   *coredata.FindingStatus
@@ -379,7 +367,7 @@ func (r *findingConnectionResolver) TotalCount(ctx context.Context, obj *types.F
 
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.Findings.CountForOrganizationID(ctx, scope, obj.ParentID, findingFilter)
+		count, err := r.probo.Findings.CountForOrganizationID(ctx, scope, obj.ParentID, findingFilter)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count findings", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -387,7 +375,7 @@ func (r *findingConnectionResolver) TotalCount(ctx context.Context, obj *types.F
 
 		return count, nil
 	case *auditResolver:
-		count, err := prb.Findings.CountForAuditID(ctx, scope, obj.ParentID, findingFilter)
+		count, err := r.probo.Findings.CountForAuditID(ctx, scope, obj.ParentID, findingFilter)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count findings", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -408,8 +396,6 @@ func (r *mutationResolver) CreateAudit(ctx context.Context, input types.CreateAu
 		return nil, err
 	}
 
-	prb := r.probo
-
 	req := probo.CreateAuditRequest{
 		OrganizationID:        input.OrganizationID,
 		FrameworkID:           input.FrameworkID,
@@ -420,7 +406,7 @@ func (r *mutationResolver) CreateAudit(ctx context.Context, input types.CreateAu
 		TrustCenterVisibility: input.TrustCenterVisibility,
 	}
 
-	audit, err := prb.Audits.Create(ctx, scope, &req)
+	audit, err := r.probo.Audits.Create(ctx, scope, &req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -442,7 +428,7 @@ func (r *mutationResolver) CreateAudit(ctx context.Context, input types.CreateAu
 			},
 		}
 
-		audit, err = prb.Audits.UploadReport(ctx, scope, uploadReq)
+		audit, err = r.probo.Audits.UploadReport(ctx, scope, uploadReq)
 		if err != nil {
 			if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 				return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -466,8 +452,6 @@ func (r *mutationResolver) UpdateAudit(ctx context.Context, input types.UpdateAu
 		return nil, err
 	}
 
-	prb := r.probo
-
 	req := probo.UpdateAuditRequest{
 		ID:                    input.ID,
 		Name:                  gqlutils.UnwrapOmittable(input.Name),
@@ -477,7 +461,7 @@ func (r *mutationResolver) UpdateAudit(ctx context.Context, input types.UpdateAu
 		TrustCenterVisibility: input.TrustCenterVisibility,
 	}
 
-	audit, err := prb.Audits.Update(ctx, scope, &req)
+	audit, err := r.probo.Audits.Update(ctx, scope, &req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -500,9 +484,7 @@ func (r *mutationResolver) DeleteAudit(ctx context.Context, input types.DeleteAu
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.Audits.Delete(ctx, scope, input.AuditID); err != nil {
+	if err := r.probo.Audits.Delete(ctx, scope, input.AuditID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete audit", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -519,8 +501,6 @@ func (r *mutationResolver) UploadAuditReport(ctx context.Context, input types.Up
 		return nil, err
 	}
 
-	prb := r.probo
-
 	req := probo.UploadAuditReportRequest{
 		AuditID: input.AuditID,
 		File: probo.File{
@@ -531,7 +511,7 @@ func (r *mutationResolver) UploadAuditReport(ctx context.Context, input types.Up
 		},
 	}
 
-	audit, err := prb.Audits.UploadReport(ctx, scope, req)
+	audit, err := r.probo.Audits.UploadReport(ctx, scope, req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -554,9 +534,7 @@ func (r *mutationResolver) DeleteAuditReport(ctx context.Context, input types.De
 		return nil, err
 	}
 
-	prb := r.probo
-
-	audit, err := prb.Audits.DeleteReport(ctx, scope, input.AuditID)
+	audit, err := r.probo.Audits.DeleteReport(ctx, scope, input.AuditID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete audit report", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -574,8 +552,6 @@ func (r *mutationResolver) CreateFinding(ctx context.Context, input types.Create
 		return nil, err
 	}
 
-	prb := r.probo
-
 	req := probo.CreateFindingRequest{
 		OrganizationID:     input.OrganizationID,
 		Kind:               input.Kind,
@@ -592,7 +568,7 @@ func (r *mutationResolver) CreateFinding(ctx context.Context, input types.Create
 		EffectivenessCheck: input.EffectivenessCheck,
 	}
 
-	finding, err := prb.Findings.Create(ctx, scope, &req)
+	finding, err := r.probo.Findings.Create(ctx, scope, &req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -615,8 +591,6 @@ func (r *mutationResolver) UpdateFinding(ctx context.Context, input types.Update
 		return nil, err
 	}
 
-	prb := r.probo
-
 	req := probo.UpdateFindingRequest{
 		ID:                 input.ID,
 		Description:        gqlutils.UnwrapOmittable(input.Description),
@@ -632,7 +606,7 @@ func (r *mutationResolver) UpdateFinding(ctx context.Context, input types.Update
 		EffectivenessCheck: gqlutils.UnwrapOmittable(input.EffectivenessCheck),
 	}
 
-	finding, err := prb.Findings.Update(ctx, scope, &req)
+	finding, err := r.probo.Findings.Update(ctx, scope, &req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -655,9 +629,7 @@ func (r *mutationResolver) DeleteFinding(ctx context.Context, input types.Delete
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.Findings.Delete(ctx, scope, input.FindingID); err != nil {
+	if err := r.probo.Findings.Delete(ctx, scope, input.FindingID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete finding", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -674,9 +646,7 @@ func (r *mutationResolver) CreateFindingAuditMapping(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.probo
-
-	finding, audit, err := prb.Findings.CreateAuditMapping(ctx, scope, input.FindingID, input.AuditID, input.ReferenceID)
+	finding, audit, err := r.probo.Findings.CreateAuditMapping(ctx, scope, input.FindingID, input.AuditID, input.ReferenceID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot create finding audit mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -695,9 +665,7 @@ func (r *mutationResolver) DeleteFindingAuditMapping(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.probo
-
-	finding, audit, err := prb.Findings.DeleteAuditMapping(ctx, scope, input.FindingID, input.AuditID)
+	finding, audit, err := r.probo.Findings.DeleteAuditMapping(ctx, scope, input.FindingID, input.AuditID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete finding audit mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -716,9 +684,7 @@ func (r *mutationResolver) PublishFindingList(ctx context.Context, input types.P
 		return nil, err
 	}
 
-	prb := r.probo
-
-	document, documentVersion, err := prb.GeneratedDocuments.PublishFindingList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := r.probo.GeneratedDocuments.PublishFindingList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -746,9 +712,7 @@ func (r *reportResolver) DownloadURL(ctx context.Context, obj *types.Report) (*s
 		return nil, err
 	}
 
-	prb := r.probo
-
-	url, err := prb.Reports.GenerateDownloadURL(ctx, scope, obj.ID, 15*time.Minute)
+	url, err := r.probo.Reports.GenerateDownloadURL(ctx, scope, obj.ID, 15*time.Minute)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate download URL", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -764,9 +728,7 @@ func (r *reportResolver) Audit(ctx context.Context, obj *types.Report) (*types.A
 		return nil, err
 	}
 
-	prb := r.probo
-
-	audit, err := prb.Audits.GetByReportID(ctx, scope, obj.ID)
+	audit, err := r.probo.Audits.GetByReportID(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot load audit for report", log.Error(err))
 		return nil, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/base_resolvers.go
+++ b/pkg/server/api/console/v1/base_resolvers.go
@@ -24,15 +24,14 @@ import (
 // Node is the resolver for the node field.
 func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error) {
 	var (
-		loadNode func(ctx context.Context, id gid.GID) (types.Node, error)
+		loadNode func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error)
 		action   string
-		scope    = coredata.NewScopeFromObjectID(id)
 	)
 
 	switch id.EntityType() {
 	case coredata.OrganizationEntityType:
 		action = iam.ActionOrganizationGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			organization, err := r.probo.Organizations.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -42,7 +41,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.ThirdPartyEntityType:
 		action = probo.ActionThirdPartyGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			thirdParty, err := r.probo.ThirdParties.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -52,7 +51,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.FrameworkEntityType:
 		action = probo.ActionFrameworkGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			framework, err := r.probo.Frameworks.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -62,7 +61,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.MeasureEntityType:
 		action = probo.ActionMeasureGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			measure, err := r.probo.Measures.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -72,7 +71,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.TaskEntityType:
 		action = probo.ActionTaskGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			task, err := r.probo.Tasks.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -82,7 +81,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.EvidenceEntityType:
 		action = probo.ActionEvidenceList
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			evidence, err := r.probo.Evidences.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -92,7 +91,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.DocumentEntityType:
 		action = probo.ActionDocumentGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			document, err := r.probo.Documents.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -102,7 +101,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.ControlEntityType:
 		action = probo.ActionControlList
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			control, err := r.probo.Controls.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -112,7 +111,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.RiskEntityType:
 		action = probo.ActionRiskGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			risk, err := r.probo.Risks.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -122,9 +121,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.RiskAssessmentEntityType:
 		action = probo.ActionRiskAssessmentGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			scope := coredata.NewScopeFromObjectID(id)
-
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			ra, err := r.riskManagement.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -134,9 +131,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.RiskAssessmentNodeEntityType:
 		action = probo.ActionRiskAssessmentNodeGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			scope := coredata.NewScopeFromObjectID(id)
-
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			n, err := r.riskManagement.GetNode(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -146,9 +141,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.RiskAssessmentProcessEntityType:
 		action = probo.ActionRiskAssessmentProcessGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			scope := coredata.NewScopeFromObjectID(id)
-
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			p, err := r.riskManagement.GetProcess(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -158,9 +151,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.RiskAssessmentThreatEntityType:
 		action = probo.ActionRiskAssessmentThreatGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			scope := coredata.NewScopeFromObjectID(id)
-
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			t, err := r.riskManagement.GetThreat(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -170,9 +161,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.RiskAssessmentScopeEntityType:
 		action = probo.ActionRiskAssessmentScopeGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			scope := coredata.NewScopeFromObjectID(id)
-
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			s, err := r.riskManagement.GetScope(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -182,9 +171,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.RiskAssessmentScenarioEntityType:
 		action = probo.ActionRiskAssessmentScenarioGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			scope := coredata.NewScopeFromObjectID(id)
-
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			s, err := r.riskManagement.GetScenario(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -194,7 +181,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.ThirdPartyComplianceReportEntityType:
 		action = probo.ActionThirdPartyComplianceReportGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			thirdPartyComplianceReport, err := r.probo.ThirdPartyComplianceReports.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -204,7 +191,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.ThirdPartyContactEntityType:
 		action = probo.ActionThirdPartyContactGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			thirdPartyContact, err := r.probo.ThirdPartyContacts.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -214,7 +201,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.ThirdPartyServiceEntityType:
 		action = probo.ActionThirdPartyServiceGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			thirdPartyService, err := r.probo.ThirdPartyServices.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -224,7 +211,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.DocumentVersionEntityType:
 		action = probo.ActionDocumentVersionList
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			documentVersion, err := r.probo.Documents.GetVersion(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -234,7 +221,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.DocumentVersionSignatureEntityType:
 		action = probo.ActionDocumentVersionSignatureList
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			documentVersionSignature, err := r.probo.Documents.GetVersionSignature(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -244,7 +231,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.AssetEntityType:
 		action = probo.ActionAssetList
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			asset, err := r.probo.Assets.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -254,7 +241,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.DatumEntityType:
 		action = probo.ActionDatumList
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			datum, err := r.probo.Data.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -264,7 +251,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.AuditEntityType:
 		action = probo.ActionAuditList
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			audit, err := r.probo.Audits.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -274,7 +261,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.FindingEntityType:
 		action = probo.ActionFindingList
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			finding, err := r.probo.Findings.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -284,7 +271,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.ObligationEntityType:
 		action = probo.ActionObligationList
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			obligation, err := r.probo.Obligations.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -294,7 +281,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.ReportEntityType:
 		action = probo.ActionReportGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			report, err := r.probo.Reports.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -304,7 +291,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.ProcessingActivityEntityType:
 		action = probo.ActionProcessingActivityList
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			processingActivity, err := r.probo.ProcessingActivities.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -315,7 +302,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.DataProtectionImpactAssessmentEntityType:
 		// TODO: add action
 		// action = probo.ActionDataProtectionImpactAssessmentGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			dpia, err := r.probo.DataProtectionImpactAssessments.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -326,7 +313,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.TransferImpactAssessmentEntityType:
 		// TODO: add action
 		//action = probo.ActionTransferImpactAssessmentGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			tia, err := r.probo.TransferImpactAssessments.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -336,7 +323,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.TrustCenterEntityType:
 		action = probo.ActionTrustCenterGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			trustCenter, err := r.probo.TrustCenters.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -354,7 +341,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.TrustCenterAccessEntityType:
 		action = probo.ActionTrustCenterAccessGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			trustCenterAccess, err := r.probo.TrustCenterAccesses.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -364,7 +351,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.RightsRequestEntityType:
 		action = probo.ActionRightsRequestGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			rightsRequest, err := r.probo.RightsRequests.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -374,7 +361,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.StatementOfApplicabilityEntityType:
 		action = probo.ActionStatementOfApplicabilityGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			statementOfApplicability, err := r.probo.StatementsOfApplicability.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -384,7 +371,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.WebhookSubscriptionEntityType:
 		action = probo.ActionWebhookSubscriptionGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			wc, err := r.probo.WebhookSubscriptions.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -394,9 +381,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.AccessReviewCampaignEntityType:
 		action = probo.ActionAccessReviewCampaignGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			scope := coredata.NewScopeFromObjectID(id)
-
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			campaign, err := r.accessReview.Campaigns(scope).Get(ctx, id)
 			if err != nil {
 				return nil, err
@@ -406,9 +391,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.AccessSourceEntityType:
 		action = probo.ActionAccessSourceGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			scope := coredata.NewScopeFromObjectID(id)
-
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			source, err := r.accessReview.Sources(scope).Get(ctx, id)
 			if err != nil {
 				return nil, err
@@ -418,9 +401,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.AccessEntryEntityType:
 		action = probo.ActionAccessEntryGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			scope := coredata.NewScopeFromObjectID(id)
-
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			entry, err := r.accessReview.Entries(scope).Get(ctx, id)
 			if err != nil {
 				return nil, err
@@ -430,9 +411,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.CookieBannerEntityType:
 		action = probo.ActionCookieBannerGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			scope := coredata.NewScopeFromObjectID(id)
-
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			banner, err := r.cookieBanner.GetCookieBanner(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -442,9 +421,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.CookieCategoryEntityType:
 		action = probo.ActionCookieCategoryGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			scope := coredata.NewScopeFromObjectID(id)
-
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			category, err := r.cookieBanner.GetCookieCategory(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -454,9 +431,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.CookieConsentRecordEntityType:
 		action = probo.ActionCookieConsentRecordList
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			scope := coredata.NewScopeFromObjectID(id)
-
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			record, err := r.cookieBanner.GetCookieConsentRecord(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -478,9 +453,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.CookieBannerVersionEntityType:
 		action = probo.ActionCookieBannerVersionGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			scope := coredata.NewScopeFromObjectID(id)
-
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			version, err := r.cookieBanner.GetCookieBannerVersion(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -497,11 +470,12 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	default:
 	}
 
-	if _, err := r.authorize(ctx, id, action); err != nil {
+	scope, err := r.authorize(ctx, id, action)
+	if err != nil {
 		return nil, err
 	}
 
-	node, err := loadNode(ctx, id)
+	node, err := loadNode(ctx, scope, id)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)

--- a/pkg/server/api/console/v1/base_resolvers.go
+++ b/pkg/server/api/console/v1/base_resolvers.go
@@ -27,14 +27,13 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		loadNode func(ctx context.Context, id gid.GID) (types.Node, error)
 		action   string
 		scope    = coredata.NewScopeFromObjectID(id)
-		prb      = r.probo
 	)
 
 	switch id.EntityType() {
 	case coredata.OrganizationEntityType:
 		action = iam.ActionOrganizationGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			organization, err := prb.Organizations.Get(ctx, scope, id)
+			organization, err := r.probo.Organizations.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -44,7 +43,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.ThirdPartyEntityType:
 		action = probo.ActionThirdPartyGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			thirdParty, err := prb.ThirdParties.Get(ctx, scope, id)
+			thirdParty, err := r.probo.ThirdParties.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -54,7 +53,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.FrameworkEntityType:
 		action = probo.ActionFrameworkGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			framework, err := prb.Frameworks.Get(ctx, scope, id)
+			framework, err := r.probo.Frameworks.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -64,7 +63,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.MeasureEntityType:
 		action = probo.ActionMeasureGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			measure, err := prb.Measures.Get(ctx, scope, id)
+			measure, err := r.probo.Measures.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -74,7 +73,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.TaskEntityType:
 		action = probo.ActionTaskGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			task, err := prb.Tasks.Get(ctx, scope, id)
+			task, err := r.probo.Tasks.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -84,7 +83,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.EvidenceEntityType:
 		action = probo.ActionEvidenceList
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			evidence, err := prb.Evidences.Get(ctx, scope, id)
+			evidence, err := r.probo.Evidences.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -94,7 +93,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.DocumentEntityType:
 		action = probo.ActionDocumentGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			document, err := prb.Documents.Get(ctx, scope, id)
+			document, err := r.probo.Documents.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -104,7 +103,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.ControlEntityType:
 		action = probo.ActionControlList
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			control, err := prb.Controls.Get(ctx, scope, id)
+			control, err := r.probo.Controls.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -114,7 +113,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.RiskEntityType:
 		action = probo.ActionRiskGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			risk, err := prb.Risks.Get(ctx, scope, id)
+			risk, err := r.probo.Risks.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -196,7 +195,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.ThirdPartyComplianceReportEntityType:
 		action = probo.ActionThirdPartyComplianceReportGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			thirdPartyComplianceReport, err := prb.ThirdPartyComplianceReports.Get(ctx, scope, id)
+			thirdPartyComplianceReport, err := r.probo.ThirdPartyComplianceReports.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -206,7 +205,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.ThirdPartyContactEntityType:
 		action = probo.ActionThirdPartyContactGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			thirdPartyContact, err := prb.ThirdPartyContacts.Get(ctx, scope, id)
+			thirdPartyContact, err := r.probo.ThirdPartyContacts.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -216,7 +215,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.ThirdPartyServiceEntityType:
 		action = probo.ActionThirdPartyServiceGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			thirdPartyService, err := prb.ThirdPartyServices.Get(ctx, scope, id)
+			thirdPartyService, err := r.probo.ThirdPartyServices.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -226,7 +225,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.DocumentVersionEntityType:
 		action = probo.ActionDocumentVersionList
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			documentVersion, err := prb.Documents.GetVersion(ctx, scope, id)
+			documentVersion, err := r.probo.Documents.GetVersion(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -236,7 +235,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.DocumentVersionSignatureEntityType:
 		action = probo.ActionDocumentVersionSignatureList
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			documentVersionSignature, err := prb.Documents.GetVersionSignature(ctx, scope, id)
+			documentVersionSignature, err := r.probo.Documents.GetVersionSignature(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -246,7 +245,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.AssetEntityType:
 		action = probo.ActionAssetList
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			asset, err := prb.Assets.Get(ctx, scope, id)
+			asset, err := r.probo.Assets.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -256,7 +255,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.DatumEntityType:
 		action = probo.ActionDatumList
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			datum, err := prb.Data.Get(ctx, scope, id)
+			datum, err := r.probo.Data.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -266,7 +265,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.AuditEntityType:
 		action = probo.ActionAuditList
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			audit, err := prb.Audits.Get(ctx, scope, id)
+			audit, err := r.probo.Audits.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -276,7 +275,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.FindingEntityType:
 		action = probo.ActionFindingList
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			finding, err := prb.Findings.Get(ctx, scope, id)
+			finding, err := r.probo.Findings.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -286,7 +285,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.ObligationEntityType:
 		action = probo.ActionObligationList
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			obligation, err := prb.Obligations.Get(ctx, scope, id)
+			obligation, err := r.probo.Obligations.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -296,7 +295,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.ReportEntityType:
 		action = probo.ActionReportGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			report, err := prb.Reports.Get(ctx, scope, id)
+			report, err := r.probo.Reports.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -306,7 +305,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.ProcessingActivityEntityType:
 		action = probo.ActionProcessingActivityList
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			processingActivity, err := prb.ProcessingActivities.Get(ctx, scope, id)
+			processingActivity, err := r.probo.ProcessingActivities.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -317,7 +316,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		// TODO: add action
 		// action = probo.ActionDataProtectionImpactAssessmentGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			dpia, err := prb.DataProtectionImpactAssessments.Get(ctx, scope, id)
+			dpia, err := r.probo.DataProtectionImpactAssessments.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -328,7 +327,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		// TODO: add action
 		//action = probo.ActionTransferImpactAssessmentGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			tia, err := prb.TransferImpactAssessments.Get(ctx, scope, id)
+			tia, err := r.probo.TransferImpactAssessments.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -338,14 +337,14 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.TrustCenterEntityType:
 		action = probo.ActionTrustCenterGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			trustCenter, err := prb.TrustCenters.Get(ctx, scope, id)
+			trustCenter, err := r.probo.TrustCenters.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
 
 			var file *coredata.File
 			if trustCenter.NonDisclosureAgreementFileID != nil {
-				file, err = prb.Files.Get(ctx, scope, *trustCenter.NonDisclosureAgreementFileID)
+				file, err = r.probo.Files.Get(ctx, scope, *trustCenter.NonDisclosureAgreementFileID)
 				if err != nil {
 					return nil, fmt.Errorf("cannot get NDA file: %w", err)
 				}
@@ -356,7 +355,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.TrustCenterAccessEntityType:
 		action = probo.ActionTrustCenterAccessGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			trustCenterAccess, err := prb.TrustCenterAccesses.Get(ctx, scope, id)
+			trustCenterAccess, err := r.probo.TrustCenterAccesses.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -366,7 +365,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.RightsRequestEntityType:
 		action = probo.ActionRightsRequestGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			rightsRequest, err := prb.RightsRequests.Get(ctx, scope, id)
+			rightsRequest, err := r.probo.RightsRequests.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -376,7 +375,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.StatementOfApplicabilityEntityType:
 		action = probo.ActionStatementOfApplicabilityGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			statementOfApplicability, err := prb.StatementsOfApplicability.Get(ctx, scope, id)
+			statementOfApplicability, err := r.probo.StatementsOfApplicability.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}
@@ -386,7 +385,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	case coredata.WebhookSubscriptionEntityType:
 		action = probo.ActionWebhookSubscriptionGet
 		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			wc, err := prb.WebhookSubscriptions.Get(ctx, scope, id)
+			wc, err := r.probo.WebhookSubscriptions.Get(ctx, scope, id)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/server/api/console/v1/base_resolvers.go
+++ b/pkg/server/api/console/v1/base_resolvers.go
@@ -498,7 +498,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 	default:
 	}
 
-	if err := r.authorize(ctx, id, action); err != nil {
+	if _, err := r.authorize(ctx, id, action); err != nil {
 		return nil, err
 	}
 

--- a/pkg/server/api/console/v1/base_resolvers.go
+++ b/pkg/server/api/console/v1/base_resolvers.go
@@ -441,9 +441,7 @@ func (r *queryResolver) Node(ctx context.Context, id gid.GID) (types.Node, error
 		}
 	case coredata.TrackerPatternEntityType:
 		action = probo.ActionTrackerPatternGet
-		loadNode = func(ctx context.Context, id gid.GID) (types.Node, error) {
-			scope := coredata.NewScopeFromObjectID(id)
-
+		loadNode = func(ctx context.Context, scope *coredata.Scope, id gid.GID) (types.Node, error) {
 			pattern, err := r.cookieBanner.GetTrackerPattern(ctx, scope, id)
 			if err != nil {
 				return nil, err
@@ -510,6 +508,12 @@ func (r *queryResolver) Viewer(ctx context.Context) (*types.Viewer, error) {
 
 // CommonThirdParties is the resolver for the commonThirdParties field.
 func (r *queryResolver) CommonThirdParties(ctx context.Context, name string) ([]*types.CommonThirdParty, error) {
+	identity := authn.IdentityFromContext(ctx)
+
+	if _, err := r.authorize(ctx, identity.ID, probo.ActionCommonThirdPartyList); err != nil {
+		return nil, err
+	}
+
 	parties, err := r.thirdParty.Search(ctx, name)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot search common third parties", log.Error(err))

--- a/pkg/server/api/console/v1/common_third_party_resolvers.go
+++ b/pkg/server/api/console/v1/common_third_party_resolvers.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/probo"
 	"go.probo.inc/probo/pkg/server/api/console/v1/schema"
 	"go.probo.inc/probo/pkg/server/api/console/v1/types"
 	"go.probo.inc/probo/pkg/server/gqlutils"
@@ -17,6 +18,10 @@ import (
 
 // LogoURL is the resolver for the logoUrl field.
 func (r *commonThirdPartyResolver) LogoURL(ctx context.Context, obj *types.CommonThirdParty) (*string, error) {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionCommonThirdPartyGet); err != nil {
+		return nil, err
+	}
+
 	if obj.LogoFileID == nil {
 		return nil, nil
 	}

--- a/pkg/server/api/console/v1/connector_initiate.go
+++ b/pkg/server/api/console/v1/connector_initiate.go
@@ -72,18 +72,18 @@ func handleConnectorInitiate(
 			return
 		}
 
-		if err := iamSvc.Authorizer.Authorize(r.Context(), iam.AuthorizeParams{
+		scope, err := iamSvc.Authorizer.Authorize(r.Context(), iam.AuthorizeParams{
 			Principal: identity.ID,
 			Resource:  organizationID,
 			Session:   &session.ID,
 			Action:    probo.ActionConnectorInitiate,
-		}); err != nil {
+		})
+		if err != nil {
 			httpserver.RenderError(w, http.StatusForbidden, err)
 			return
 		}
 
 		requestedScopes := r.URL.Query()["scope"]
-		scope := coredata.NewScopeFromObjectID(organizationID)
 		prb := proboSvc
 
 		// Look up any existing connector so we can union its stored scopes

--- a/pkg/server/api/console/v1/connector_resolvers.go
+++ b/pkg/server/api/console/v1/connector_resolvers.go
@@ -101,6 +101,7 @@ func (r *mutationResolver) CreateClientCredentialsConnector(ctx context.Context,
 		ClientSecret: input.ClientSecret,
 		TokenURL:     input.TokenURL,
 	}
+
 	if input.Scope != nil {
 		oauth2Conn.Scope = *input.Scope
 	}

--- a/pkg/server/api/console/v1/connector_resolvers.go
+++ b/pkg/server/api/console/v1/connector_resolvers.go
@@ -32,11 +32,11 @@ func (r *connectorResolver) Oauth2Scopes(ctx context.Context, obj *types.Connect
 
 // CreateAPIKeyConnector is the resolver for the createAPIKeyConnector field.
 func (r *mutationResolver) CreateAPIKeyConnector(ctx context.Context, input types.CreateAPIKeyConnectorInput) (*types.CreateAPIKeyConnectorPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionConnectorCreate); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionConnectorCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	req := probo.CreateConnectorRequest{
@@ -92,11 +92,11 @@ func (r *mutationResolver) CreateAPIKeyConnector(ctx context.Context, input type
 
 // CreateClientCredentialsConnector is the resolver for the createClientCredentialsConnector field.
 func (r *mutationResolver) CreateClientCredentialsConnector(ctx context.Context, input types.CreateClientCredentialsConnectorInput) (*types.CreateClientCredentialsConnectorPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionConnectorCreate); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionConnectorCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	oauth2Conn := &connector.OAuth2Connection{
@@ -139,11 +139,11 @@ func (r *mutationResolver) CreateClientCredentialsConnector(ctx context.Context,
 
 // DeleteConnector is the resolver for the deleteConnector field.
 func (r *mutationResolver) DeleteConnector(ctx context.Context, input types.DeleteConnectorInput) (*types.DeleteConnectorPayload, error) {
-	if err := r.authorize(ctx, input.ConnectorID, probo.ActionConnectorDelete); err != nil {
+	scope, err := r.authorize(ctx, input.ConnectorID, probo.ActionConnectorDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ConnectorID)
 	prb := r.probo
 
 	if err := prb.Connectors.Delete(ctx, scope, input.ConnectorID); err != nil {
@@ -157,15 +157,14 @@ func (r *mutationResolver) DeleteConnector(ctx context.Context, input types.Dele
 
 // DeleteSlackConnection is the resolver for the deleteSlackConnection field.
 func (r *mutationResolver) DeleteSlackConnection(ctx context.Context, input types.DeleteSlackConnectionInput) (*types.DeleteSlackConnectionPayload, error) {
-	if err := r.authorize(ctx, input.SlackConnectionID, probo.ActionConnectorDelete); err != nil {
+	scope, err := r.authorize(ctx, input.SlackConnectionID, probo.ActionConnectorDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.SlackConnectionID)
 	prb := r.probo
 
-	err := prb.Connectors.Delete(ctx, scope, input.SlackConnectionID)
-	if err != nil {
+	if err := prb.Connectors.Delete(ctx, scope, input.SlackConnectionID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete slack connection", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}

--- a/pkg/server/api/console/v1/connector_resolvers.go
+++ b/pkg/server/api/console/v1/connector_resolvers.go
@@ -37,8 +37,6 @@ func (r *mutationResolver) CreateAPIKeyConnector(ctx context.Context, input type
 		return nil, err
 	}
 
-	prb := r.probo
-
 	req := probo.CreateConnectorRequest{
 		OrganizationID: input.OrganizationID,
 		Provider:       input.Provider,
@@ -76,7 +74,7 @@ func (r *mutationResolver) CreateAPIKeyConnector(ctx context.Context, input type
 		}
 	}
 
-	cnnctr, err := prb.Connectors.Create(ctx, scope, req)
+	cnnctr, err := r.probo.Connectors.Create(ctx, scope, req)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -96,8 +94,6 @@ func (r *mutationResolver) CreateClientCredentialsConnector(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-
-	prb := r.probo
 
 	oauth2Conn := &connector.OAuth2Connection{
 		GrantType:    connector.OAuth2GrantTypeClientCredentials,
@@ -123,7 +119,7 @@ func (r *mutationResolver) CreateClientCredentialsConnector(ctx context.Context,
 		}
 	}
 
-	cnnctr, err := prb.Connectors.Create(ctx, scope, req)
+	cnnctr, err := r.probo.Connectors.Create(ctx, scope, req)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -144,9 +140,7 @@ func (r *mutationResolver) DeleteConnector(ctx context.Context, input types.Dele
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.Connectors.Delete(ctx, scope, input.ConnectorID); err != nil {
+	if err := r.probo.Connectors.Delete(ctx, scope, input.ConnectorID); err != nil {
 		panic(fmt.Errorf("cannot delete connector: %w", err))
 	}
 
@@ -162,9 +156,7 @@ func (r *mutationResolver) DeleteSlackConnection(ctx context.Context, input type
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.Connectors.Delete(ctx, scope, input.SlackConnectionID); err != nil {
+	if err := r.probo.Connectors.Delete(ctx, scope, input.SlackConnectionID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete slack connection", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}

--- a/pkg/server/api/console/v1/control_resolvers.go
+++ b/pkg/server/api/console/v1/control_resolvers.go
@@ -29,9 +29,7 @@ func (r *applicabilityStatementResolver) StatementOfApplicability(ctx context.Co
 		return nil, err
 	}
 
-	prb := r.probo
-
-	soa, err := prb.StatementsOfApplicability.Get(ctx, scope, obj.StatementOfApplicability.ID)
+	soa, err := r.probo.StatementsOfApplicability.Get(ctx, scope, obj.StatementOfApplicability.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get statement of applicability", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -74,11 +72,9 @@ func (r *applicabilityStatementConnectionResolver) TotalCount(ctx context.Contex
 		return 0, err
 	}
 
-	prb := r.probo
-
 	switch obj.Resolver.(type) {
 	case *statementOfApplicabilityResolver:
-		count, err := prb.StatementsOfApplicability.CountApplicabilityStatements(ctx, scope, obj.ParentID)
+		count, err := r.probo.StatementsOfApplicability.CountApplicabilityStatements(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count applicability statements", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -117,9 +113,7 @@ func (r *controlResolver) Organization(ctx context.Context, obj *types.Control) 
 // Regulatory is the resolver for the regulatory field.
 func (r *controlResolver) Regulatory(ctx context.Context, obj *types.Control) (bool, error) {
 	scope := coredata.NewScopeFromObjectID(obj.ID)
-	prb := r.probo
-
-	hasRegulatory, err := prb.Controls.HasRegulatoryObligation(ctx, scope, obj.ID)
+	hasRegulatory, err := r.probo.Controls.HasRegulatoryObligation(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot check regulatory obligation", log.Error(err))
 		return false, gqlutils.Internal(ctx)
@@ -131,9 +125,7 @@ func (r *controlResolver) Regulatory(ctx context.Context, obj *types.Control) (b
 // Contractual is the resolver for the contractual field.
 func (r *controlResolver) Contractual(ctx context.Context, obj *types.Control) (bool, error) {
 	scope := coredata.NewScopeFromObjectID(obj.ID)
-	prb := r.probo
-
-	hasContractual, err := prb.Controls.HasContractualObligation(ctx, scope, obj.ID)
+	hasContractual, err := r.probo.Controls.HasContractualObligation(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot check contractual obligation", log.Error(err))
 		return false, gqlutils.Internal(ctx)
@@ -145,9 +137,7 @@ func (r *controlResolver) Contractual(ctx context.Context, obj *types.Control) (
 // RiskAssessment is the resolver for the riskAssessment field.
 func (r *controlResolver) RiskAssessment(ctx context.Context, obj *types.Control) (bool, error) {
 	scope := coredata.NewScopeFromObjectID(obj.ID)
-	prb := r.probo
-
-	hasRisk, err := prb.Controls.HasRiskAssessment(ctx, scope, obj.ID)
+	hasRisk, err := r.probo.Controls.HasRiskAssessment(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot check risk assessment", log.Error(err))
 		return false, gqlutils.Internal(ctx)
@@ -185,8 +175,6 @@ func (r *controlResolver) Measures(ctx context.Context, obj *types.Control, firs
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.MeasureOrderField]{
 		Field:     coredata.MeasureOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -205,7 +193,7 @@ func (r *controlResolver) Measures(ctx context.Context, obj *types.Control, firs
 		measureFilter = coredata.NewMeasureFilter(filter.Query, filter.State, filter.Category)
 	}
 
-	page, err := prb.Measures.ListForControlID(ctx, scope, obj.ID, cursor, measureFilter)
+	page, err := r.probo.Measures.ListForControlID(ctx, scope, obj.ID, cursor, measureFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list measures", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -220,8 +208,6 @@ func (r *controlResolver) Documents(ctx context.Context, obj *types.Control, fir
 	if err != nil {
 		return nil, err
 	}
-
-	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
 		Field:     coredata.DocumentOrderFieldCreatedAt,
@@ -244,7 +230,7 @@ func (r *controlResolver) Documents(ctx context.Context, obj *types.Control, fir
 			WithClassifications(filter.Classifications)
 	}
 
-	page, err := prb.Documents.ListForControlID(ctx, scope, obj.ID, cursor, documentFilter)
+	page, err := r.probo.Documents.ListForControlID(ctx, scope, obj.ID, cursor, documentFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list documents", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -260,8 +246,6 @@ func (r *controlResolver) Audits(ctx context.Context, obj *types.Control, first 
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.AuditOrderField]{
 		Field:     coredata.AuditOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -275,7 +259,7 @@ func (r *controlResolver) Audits(ctx context.Context, obj *types.Control, first 
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Audits.ListForControlID(ctx, scope, obj.ID, cursor)
+	page, err := r.probo.Audits.ListForControlID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list control audits", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -291,8 +275,6 @@ func (r *controlResolver) Obligations(ctx context.Context, obj *types.Control, f
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.ObligationOrderField]{
 		Field:     coredata.ObligationOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -306,7 +288,7 @@ func (r *controlResolver) Obligations(ctx context.Context, obj *types.Control, f
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Obligations.ListForControlID(ctx, scope, obj.ID, cursor)
+	page, err := r.probo.Obligations.ListForControlID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list control obligations", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -327,11 +309,9 @@ func (r *controlConnectionResolver) TotalCount(ctx context.Context, obj *types.C
 		return 0, err
 	}
 
-	prb := r.probo
-
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.Controls.CountForOrganizationID(ctx, scope, obj.ParentID, obj.Filters)
+		count, err := r.probo.Controls.CountForOrganizationID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count controls", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -339,7 +319,7 @@ func (r *controlConnectionResolver) TotalCount(ctx context.Context, obj *types.C
 
 		return count, nil
 	case *frameworkResolver:
-		count, err := prb.Controls.CountForFrameworkID(ctx, scope, obj.ParentID, obj.Filters)
+		count, err := r.probo.Controls.CountForFrameworkID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count controls", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -347,7 +327,7 @@ func (r *controlConnectionResolver) TotalCount(ctx context.Context, obj *types.C
 
 		return count, nil
 	case *documentResolver:
-		count, err := prb.Controls.CountForDocumentID(ctx, scope, obj.ParentID, obj.Filters)
+		count, err := r.probo.Controls.CountForDocumentID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count controls", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -355,7 +335,7 @@ func (r *controlConnectionResolver) TotalCount(ctx context.Context, obj *types.C
 
 		return count, nil
 	case *measureResolver:
-		count, err := prb.Controls.CountForMeasureID(ctx, scope, obj.ParentID, obj.Filters)
+		count, err := r.probo.Controls.CountForMeasureID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count controls", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -363,7 +343,7 @@ func (r *controlConnectionResolver) TotalCount(ctx context.Context, obj *types.C
 
 		return count, nil
 	case *riskResolver:
-		count, err := prb.Controls.CountForRiskID(ctx, scope, obj.ParentID, obj.Filters)
+		count, err := r.probo.Controls.CountForRiskID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count controls", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -371,7 +351,7 @@ func (r *controlConnectionResolver) TotalCount(ctx context.Context, obj *types.C
 
 		return count, nil
 	case *statementOfApplicabilityResolver:
-		count, err := prb.Controls.CountForStatementOfApplicabilityID(ctx, scope, obj.ParentID, obj.Filters)
+		count, err := r.probo.Controls.CountForStatementOfApplicabilityID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count controls", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -392,9 +372,7 @@ func (r *mutationResolver) CreateControl(ctx context.Context, input types.Create
 		return nil, err
 	}
 
-	prb := r.probo
-
-	control, err := prb.Controls.Create(
+	control, err := r.probo.Controls.Create(
 		ctx, scope,
 		probo.CreateControlRequest{
 			FrameworkID:                 input.FrameworkID,
@@ -432,9 +410,7 @@ func (r *mutationResolver) UpdateControl(ctx context.Context, input types.Update
 		return nil, err
 	}
 
-	prb := r.probo
-
-	control, err := prb.Controls.Update(
+	control, err := r.probo.Controls.Update(
 		ctx, scope,
 		probo.UpdateControlRequest{
 			ID:                          input.ID,
@@ -472,9 +448,7 @@ func (r *mutationResolver) DeleteControl(ctx context.Context, input types.Delete
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.Controls.Delete(ctx, scope, input.ControlID); err != nil {
+	if err := r.probo.Controls.Delete(ctx, scope, input.ControlID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete control", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -491,9 +465,7 @@ func (r *mutationResolver) CreateControlMeasureMapping(ctx context.Context, inpu
 		return nil, err
 	}
 
-	prb := r.probo
-
-	control, measure, err := prb.Controls.CreateMeasureMapping(ctx, scope, input.ControlID, input.MeasureID)
+	control, measure, err := r.probo.Controls.CreateMeasureMapping(ctx, scope, input.ControlID, input.MeasureID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot create control measure mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -512,9 +484,7 @@ func (r *mutationResolver) CreateControlDocumentMapping(ctx context.Context, inp
 		return nil, err
 	}
 
-	prb := r.probo
-
-	control, document, err := prb.Controls.CreateDocumentMapping(ctx, scope, input.ControlID, input.DocumentID)
+	control, document, err := r.probo.Controls.CreateDocumentMapping(ctx, scope, input.ControlID, input.DocumentID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -538,9 +508,7 @@ func (r *mutationResolver) DeleteControlMeasureMapping(ctx context.Context, inpu
 		return nil, err
 	}
 
-	prb := r.probo
-
-	control, measure, err := prb.Controls.DeleteMeasureMapping(ctx, scope, input.ControlID, input.MeasureID)
+	control, measure, err := r.probo.Controls.DeleteMeasureMapping(ctx, scope, input.ControlID, input.MeasureID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete control measure mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -559,9 +527,7 @@ func (r *mutationResolver) DeleteControlDocumentMapping(ctx context.Context, inp
 		return nil, err
 	}
 
-	prb := r.probo
-
-	control, document, err := prb.Controls.DeleteDocumentMapping(ctx, scope, input.ControlID, input.DocumentID)
+	control, document, err := r.probo.Controls.DeleteDocumentMapping(ctx, scope, input.ControlID, input.DocumentID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete control document mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -580,9 +546,7 @@ func (r *mutationResolver) CreateApplicabilityStatement(ctx context.Context, inp
 		return nil, err
 	}
 
-	prb := r.probo
-
-	applicabilityStatement, err := prb.StatementsOfApplicability.CreateApplicabilityStatement(ctx, scope, input.StatementOfApplicabilityID, input.ControlID, input.Applicability, input.Justification)
+	applicabilityStatement, err := r.probo.StatementsOfApplicability.CreateApplicabilityStatement(ctx, scope, input.StatementOfApplicabilityID, input.ControlID, input.Applicability, input.Justification)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot create applicability statement", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -600,9 +564,7 @@ func (r *mutationResolver) UpdateApplicabilityStatement(ctx context.Context, inp
 		return nil, err
 	}
 
-	prb := r.probo
-
-	applicabilityStatement, err := prb.StatementsOfApplicability.UpdateApplicabilityStatement(ctx, scope, input.ApplicabilityStatementID, input.Applicability, input.Justification)
+	applicabilityStatement, err := r.probo.StatementsOfApplicability.UpdateApplicabilityStatement(ctx, scope, input.ApplicabilityStatementID, input.Applicability, input.Justification)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot update applicability statement", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -620,9 +582,7 @@ func (r *mutationResolver) DeleteApplicabilityStatement(ctx context.Context, inp
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.StatementsOfApplicability.DeleteApplicabilityStatement(ctx, scope, input.ApplicabilityStatementID); err != nil {
+	if err := r.probo.StatementsOfApplicability.DeleteApplicabilityStatement(ctx, scope, input.ApplicabilityStatementID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete applicability statement", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -639,9 +599,7 @@ func (r *mutationResolver) CreateControlAuditMapping(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.probo
-
-	control, audit, err := prb.Controls.CreateAuditMapping(ctx, scope, input.ControlID, input.AuditID)
+	control, audit, err := r.probo.Controls.CreateAuditMapping(ctx, scope, input.ControlID, input.AuditID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot create control audit mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -660,9 +618,7 @@ func (r *mutationResolver) DeleteControlAuditMapping(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.probo
-
-	control, audit, err := prb.Controls.DeleteAuditMapping(ctx, scope, input.ControlID, input.AuditID)
+	control, audit, err := r.probo.Controls.DeleteAuditMapping(ctx, scope, input.ControlID, input.AuditID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete control audit mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -681,9 +637,7 @@ func (r *mutationResolver) CreateControlObligationMapping(ctx context.Context, i
 		return nil, err
 	}
 
-	prb := r.probo
-
-	control, obligation, err := prb.Controls.CreateObligationMapping(ctx, scope, input.ControlID, input.ObligationID)
+	control, obligation, err := r.probo.Controls.CreateObligationMapping(ctx, scope, input.ControlID, input.ObligationID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot create control obligation mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -702,9 +656,7 @@ func (r *mutationResolver) DeleteControlObligationMapping(ctx context.Context, i
 		return nil, err
 	}
 
-	prb := r.probo
-
-	control, obligation, err := prb.Controls.DeleteObligationMapping(ctx, scope, input.ControlID, input.ObligationID)
+	control, obligation, err := r.probo.Controls.DeleteObligationMapping(ctx, scope, input.ControlID, input.ObligationID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete control obligation mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -723,9 +675,7 @@ func (r *mutationResolver) CreateStatementOfApplicability(ctx context.Context, i
 		return nil, err
 	}
 
-	prb := r.probo
-
-	statementOfApplicability, err := prb.StatementsOfApplicability.Create(
+	statementOfApplicability, err := r.probo.StatementsOfApplicability.Create(
 		ctx, scope,
 		probo.CreateStatementOfApplicabilityRequest{
 			OrganizationID: input.OrganizationID,
@@ -758,14 +708,12 @@ func (r *mutationResolver) UpdateStatementOfApplicability(ctx context.Context, i
 		return nil, err
 	}
 
-	prb := r.probo
-
 	var name *string
 	if input.Name != nil {
 		name = input.Name
 	}
 
-	statementOfApplicability, err := prb.StatementsOfApplicability.Update(
+	statementOfApplicability, err := r.probo.StatementsOfApplicability.Update(
 		ctx, scope,
 		probo.UpdateStatementOfApplicabilityRequest{
 			StatementOfApplicabilityID: input.ID,
@@ -798,9 +746,7 @@ func (r *mutationResolver) DeleteStatementOfApplicability(ctx context.Context, i
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.StatementsOfApplicability.Delete(ctx, scope, input.StatementOfApplicabilityID); err != nil {
+	if err := r.probo.StatementsOfApplicability.Delete(ctx, scope, input.StatementOfApplicabilityID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete statement_of_applicability", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -817,9 +763,7 @@ func (r *mutationResolver) PublishStatementOfApplicability(ctx context.Context, 
 		return nil, err
 	}
 
-	prb := r.probo
-
-	document, documentVersion, err := prb.GeneratedDocuments.PublishStatementOfApplicability(ctx, scope, input.StatementOfApplicabilityID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := r.probo.GeneratedDocuments.PublishStatementOfApplicability(ctx, scope, input.StatementOfApplicabilityID, input.ApproverIds, input.Minor)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -851,9 +795,7 @@ func (r *statementOfApplicabilityResolver) Document(ctx context.Context, obj *ty
 		return nil, err
 	}
 
-	prb := r.probo
-
-	document, err := prb.Documents.Get(ctx, scope, obj.Document.ID)
+	document, err := r.probo.Documents.Get(ctx, scope, obj.Document.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil
@@ -896,8 +838,6 @@ func (r *statementOfApplicabilityResolver) ApplicabilityStatements(ctx context.C
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.ApplicabilityStatementOrderField]{
 		Field:     coredata.ApplicabilityStatementOrderFieldCreatedAt,
 		Direction: page.OrderDirectionAsc,
@@ -911,7 +851,7 @@ func (r *statementOfApplicabilityResolver) ApplicabilityStatements(ctx context.C
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	p, err := prb.StatementsOfApplicability.ListApplicabilityStatements(ctx, scope, obj.ID, cursor)
+	p, err := r.probo.StatementsOfApplicability.ListApplicabilityStatements(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list applicability statements", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -928,11 +868,9 @@ func (r *statementOfApplicabilityResolver) Permission(ctx context.Context, obj *
 // TotalCount is the resolver for the totalCount field.
 func (r *statementOfApplicabilityConnectionResolver) TotalCount(ctx context.Context, obj *types.StatementOfApplicabilityConnection) (int, error) {
 	scope := coredata.NewScopeFromObjectID(obj.ParentID)
-	prb := r.probo
-
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.StatementsOfApplicability.CountForOrganizationID(ctx, scope, obj.ParentID)
+		count, err := r.probo.StatementsOfApplicability.CountForOrganizationID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count statements_of_applicability", log.Error(err))
 			return 0, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/control_resolvers.go
+++ b/pkg/server/api/console/v1/control_resolvers.go
@@ -113,6 +113,7 @@ func (r *controlResolver) Organization(ctx context.Context, obj *types.Control) 
 // Regulatory is the resolver for the regulatory field.
 func (r *controlResolver) Regulatory(ctx context.Context, obj *types.Control) (bool, error) {
 	scope := coredata.NewScopeFromObjectID(obj.ID)
+
 	hasRegulatory, err := r.probo.Controls.HasRegulatoryObligation(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot check regulatory obligation", log.Error(err))
@@ -125,6 +126,7 @@ func (r *controlResolver) Regulatory(ctx context.Context, obj *types.Control) (b
 // Contractual is the resolver for the contractual field.
 func (r *controlResolver) Contractual(ctx context.Context, obj *types.Control) (bool, error) {
 	scope := coredata.NewScopeFromObjectID(obj.ID)
+
 	hasContractual, err := r.probo.Controls.HasContractualObligation(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot check contractual obligation", log.Error(err))
@@ -137,6 +139,7 @@ func (r *controlResolver) Contractual(ctx context.Context, obj *types.Control) (
 // RiskAssessment is the resolver for the riskAssessment field.
 func (r *controlResolver) RiskAssessment(ctx context.Context, obj *types.Control) (bool, error) {
 	scope := coredata.NewScopeFromObjectID(obj.ID)
+
 	hasRisk, err := r.probo.Controls.HasRiskAssessment(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot check risk assessment", log.Error(err))
@@ -179,6 +182,7 @@ func (r *controlResolver) Measures(ctx context.Context, obj *types.Control, firs
 		Field:     coredata.MeasureOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.MeasureOrderField]{
 			Field:     orderBy.Field,
@@ -213,6 +217,7 @@ func (r *controlResolver) Documents(ctx context.Context, obj *types.Control, fir
 		Field:     coredata.DocumentOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.DocumentOrderField]{
 			Field:     orderBy.Field,
@@ -250,6 +255,7 @@ func (r *controlResolver) Audits(ctx context.Context, obj *types.Control, first 
 		Field:     coredata.AuditOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.AuditOrderField]{
 			Field:     orderBy.Field,
@@ -279,6 +285,7 @@ func (r *controlResolver) Obligations(ctx context.Context, obj *types.Control, f
 		Field:     coredata.ObligationOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ObligationOrderField]{
 			Field:     orderBy.Field,
@@ -842,6 +849,7 @@ func (r *statementOfApplicabilityResolver) ApplicabilityStatements(ctx context.C
 		Field:     coredata.ApplicabilityStatementOrderFieldCreatedAt,
 		Direction: page.OrderDirectionAsc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ApplicabilityStatementOrderField]{
 			Field:     coredata.ApplicabilityStatementOrderField(orderBy.Field),

--- a/pkg/server/api/console/v1/control_resolvers.go
+++ b/pkg/server/api/console/v1/control_resolvers.go
@@ -112,7 +112,10 @@ func (r *controlResolver) Organization(ctx context.Context, obj *types.Control) 
 
 // Regulatory is the resolver for the regulatory field.
 func (r *controlResolver) Regulatory(ctx context.Context, obj *types.Control) (bool, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionControlGet)
+	if err != nil {
+		return false, err
+	}
 
 	hasRegulatory, err := r.probo.Controls.HasRegulatoryObligation(ctx, scope, obj.ID)
 	if err != nil {
@@ -125,7 +128,10 @@ func (r *controlResolver) Regulatory(ctx context.Context, obj *types.Control) (b
 
 // Contractual is the resolver for the contractual field.
 func (r *controlResolver) Contractual(ctx context.Context, obj *types.Control) (bool, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionControlGet)
+	if err != nil {
+		return false, err
+	}
 
 	hasContractual, err := r.probo.Controls.HasContractualObligation(ctx, scope, obj.ID)
 	if err != nil {
@@ -138,7 +144,10 @@ func (r *controlResolver) Contractual(ctx context.Context, obj *types.Control) (
 
 // RiskAssessment is the resolver for the riskAssessment field.
 func (r *controlResolver) RiskAssessment(ctx context.Context, obj *types.Control) (bool, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionControlGet)
+	if err != nil {
+		return false, err
+	}
 
 	hasRisk, err := r.probo.Controls.HasRiskAssessment(ctx, scope, obj.ID)
 	if err != nil {
@@ -875,7 +884,11 @@ func (r *statementOfApplicabilityResolver) Permission(ctx context.Context, obj *
 
 // TotalCount is the resolver for the totalCount field.
 func (r *statementOfApplicabilityConnectionResolver) TotalCount(ctx context.Context, obj *types.StatementOfApplicabilityConnection) (int, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionStatementOfApplicabilityList)
+	if err != nil {
+		return 0, err
+	}
+
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
 		count, err := r.probo.StatementsOfApplicability.CountForOrganizationID(ctx, scope, obj.ParentID)

--- a/pkg/server/api/console/v1/control_resolvers.go
+++ b/pkg/server/api/console/v1/control_resolvers.go
@@ -24,11 +24,11 @@ import (
 
 // StatementOfApplicability is the resolver for the statementOfApplicability field.
 func (r *applicabilityStatementResolver) StatementOfApplicability(ctx context.Context, obj *types.ApplicabilityStatement) (*types.StatementOfApplicability, error) {
-	if err := r.authorize(ctx, obj.StatementOfApplicability.ID, probo.ActionStatementOfApplicabilityGet); err != nil {
+	scope, err := r.authorize(ctx, obj.StatementOfApplicability.ID, probo.ActionStatementOfApplicabilityGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.StatementOfApplicability.ID)
 	prb := r.probo
 
 	soa, err := prb.StatementsOfApplicability.Get(ctx, scope, obj.StatementOfApplicability.ID)
@@ -42,7 +42,7 @@ func (r *applicabilityStatementResolver) StatementOfApplicability(ctx context.Co
 
 // Control is the resolver for the control field.
 func (r *applicabilityStatementResolver) Control(ctx context.Context, obj *types.ApplicabilityStatement) (*types.Control, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionControlGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionControlGet); err != nil {
 		return nil, err
 	}
 
@@ -69,11 +69,11 @@ func (r *applicabilityStatementResolver) Permission(ctx context.Context, obj *ty
 
 // TotalCount is the resolver for the totalCount field.
 func (r *applicabilityStatementConnectionResolver) TotalCount(ctx context.Context, obj *types.ApplicabilityStatementConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionApplicabilityStatementList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionApplicabilityStatementList)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 	prb := r.probo
 
 	switch obj.Resolver.(type) {
@@ -94,7 +94,7 @@ func (r *applicabilityStatementConnectionResolver) TotalCount(ctx context.Contex
 
 // Organization is the resolver for the organization field.
 func (r *controlResolver) Organization(ctx context.Context, obj *types.Control) (*types.Organization, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
 		return nil, err
 	}
 
@@ -158,7 +158,7 @@ func (r *controlResolver) RiskAssessment(ctx context.Context, obj *types.Control
 
 // Framework is the resolver for the framework field.
 func (r *controlResolver) Framework(ctx context.Context, obj *types.Control) (*types.Framework, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionFrameworkGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionFrameworkGet); err != nil {
 		return nil, err
 	}
 
@@ -180,11 +180,11 @@ func (r *controlResolver) Framework(ctx context.Context, obj *types.Control) (*t
 
 // Measures is the resolver for the measures field.
 func (r *controlResolver) Measures(ctx context.Context, obj *types.Control, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy, filter *types.MeasureFilter) (*types.MeasureConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionMeasureList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionMeasureList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.MeasureOrderField]{
@@ -216,11 +216,11 @@ func (r *controlResolver) Measures(ctx context.Context, obj *types.Control, firs
 
 // Documents is the resolver for the documents field.
 func (r *controlResolver) Documents(ctx context.Context, obj *types.Control, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy, filter *types.DocumentFilter) (*types.DocumentConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDocumentList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionDocumentList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
@@ -255,11 +255,11 @@ func (r *controlResolver) Documents(ctx context.Context, obj *types.Control, fir
 
 // Audits is the resolver for the audits field.
 func (r *controlResolver) Audits(ctx context.Context, obj *types.Control, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AuditOrderBy) (*types.AuditConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionAuditList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionAuditList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.AuditOrderField]{
@@ -286,11 +286,11 @@ func (r *controlResolver) Audits(ctx context.Context, obj *types.Control, first 
 
 // Obligations is the resolver for the obligations field.
 func (r *controlResolver) Obligations(ctx context.Context, obj *types.Control, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ObligationOrderBy) (*types.ObligationConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionObligationList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionObligationList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ObligationOrderField]{
@@ -322,11 +322,11 @@ func (r *controlResolver) Permission(ctx context.Context, obj *types.Control, ac
 
 // TotalCount is the resolver for the totalCount field.
 func (r *controlConnectionResolver) TotalCount(ctx context.Context, obj *types.ControlConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionControlList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionControlList)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 	prb := r.probo
 
 	switch obj.Resolver.(type) {
@@ -387,11 +387,11 @@ func (r *controlConnectionResolver) TotalCount(ctx context.Context, obj *types.C
 
 // CreateControl is the resolver for the createControl field.
 func (r *mutationResolver) CreateControl(ctx context.Context, input types.CreateControlInput) (*types.CreateControlPayload, error) {
-	if err := r.authorize(ctx, input.FrameworkID, probo.ActionControlCreate); err != nil {
+	scope, err := r.authorize(ctx, input.FrameworkID, probo.ActionControlCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.FrameworkID)
 	prb := r.probo
 
 	control, err := prb.Controls.Create(
@@ -427,11 +427,11 @@ func (r *mutationResolver) CreateControl(ctx context.Context, input types.Create
 
 // UpdateControl is the resolver for the updateControl field.
 func (r *mutationResolver) UpdateControl(ctx context.Context, input types.UpdateControlInput) (*types.UpdateControlPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionControlUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionControlUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
 	control, err := prb.Controls.Update(
@@ -467,15 +467,14 @@ func (r *mutationResolver) UpdateControl(ctx context.Context, input types.Update
 
 // DeleteControl is the resolver for the deleteControl field.
 func (r *mutationResolver) DeleteControl(ctx context.Context, input types.DeleteControlInput) (*types.DeleteControlPayload, error) {
-	if err := r.authorize(ctx, input.ControlID, probo.ActionControlDelete); err != nil {
+	scope, err := r.authorize(ctx, input.ControlID, probo.ActionControlDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ControlID)
 	prb := r.probo
 
-	err := prb.Controls.Delete(ctx, scope, input.ControlID)
-	if err != nil {
+	if err := prb.Controls.Delete(ctx, scope, input.ControlID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete control", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -487,11 +486,11 @@ func (r *mutationResolver) DeleteControl(ctx context.Context, input types.Delete
 
 // CreateControlMeasureMapping is the resolver for the createControlMeasureMapping field.
 func (r *mutationResolver) CreateControlMeasureMapping(ctx context.Context, input types.CreateControlMeasureMappingInput) (*types.CreateControlMeasureMappingPayload, error) {
-	if err := r.authorize(ctx, input.ControlID, probo.ActionControlMeasureMappingCreate); err != nil {
+	scope, err := r.authorize(ctx, input.ControlID, probo.ActionControlMeasureMappingCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.MeasureID)
 	prb := r.probo
 
 	control, measure, err := prb.Controls.CreateMeasureMapping(ctx, scope, input.ControlID, input.MeasureID)
@@ -508,11 +507,11 @@ func (r *mutationResolver) CreateControlMeasureMapping(ctx context.Context, inpu
 
 // CreateControlDocumentMapping is the resolver for the createControlDocumentMapping field.
 func (r *mutationResolver) CreateControlDocumentMapping(ctx context.Context, input types.CreateControlDocumentMappingInput) (*types.CreateControlDocumentMappingPayload, error) {
-	if err := r.authorize(ctx, input.ControlID, probo.ActionControlDocumentMappingCreate); err != nil {
+	scope, err := r.authorize(ctx, input.ControlID, probo.ActionControlDocumentMappingCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.DocumentID)
 	prb := r.probo
 
 	control, document, err := prb.Controls.CreateDocumentMapping(ctx, scope, input.ControlID, input.DocumentID)
@@ -534,11 +533,11 @@ func (r *mutationResolver) CreateControlDocumentMapping(ctx context.Context, inp
 
 // DeleteControlMeasureMapping is the resolver for the deleteControlMeasureMapping field.
 func (r *mutationResolver) DeleteControlMeasureMapping(ctx context.Context, input types.DeleteControlMeasureMappingInput) (*types.DeleteControlMeasureMappingPayload, error) {
-	if err := r.authorize(ctx, input.ControlID, probo.ActionControlMeasureMappingDelete); err != nil {
+	scope, err := r.authorize(ctx, input.ControlID, probo.ActionControlMeasureMappingDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.MeasureID)
 	prb := r.probo
 
 	control, measure, err := prb.Controls.DeleteMeasureMapping(ctx, scope, input.ControlID, input.MeasureID)
@@ -555,11 +554,11 @@ func (r *mutationResolver) DeleteControlMeasureMapping(ctx context.Context, inpu
 
 // DeleteControlDocumentMapping is the resolver for the deleteControlDocumentMapping field.
 func (r *mutationResolver) DeleteControlDocumentMapping(ctx context.Context, input types.DeleteControlDocumentMappingInput) (*types.DeleteControlDocumentMappingPayload, error) {
-	if err := r.authorize(ctx, input.ControlID, probo.ActionControlDocumentMappingDelete); err != nil {
+	scope, err := r.authorize(ctx, input.ControlID, probo.ActionControlDocumentMappingDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.DocumentID)
 	prb := r.probo
 
 	control, document, err := prb.Controls.DeleteDocumentMapping(ctx, scope, input.ControlID, input.DocumentID)
@@ -576,11 +575,11 @@ func (r *mutationResolver) DeleteControlDocumentMapping(ctx context.Context, inp
 
 // CreateApplicabilityStatement is the resolver for the createApplicabilityStatement field.
 func (r *mutationResolver) CreateApplicabilityStatement(ctx context.Context, input types.CreateApplicabilityStatementInput) (*types.CreateApplicabilityStatementPayload, error) {
-	if err := r.authorize(ctx, input.ControlID, probo.ActionApplicabilityStatementCreate); err != nil {
+	scope, err := r.authorize(ctx, input.ControlID, probo.ActionApplicabilityStatementCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.StatementOfApplicabilityID)
 	prb := r.probo
 
 	applicabilityStatement, err := prb.StatementsOfApplicability.CreateApplicabilityStatement(ctx, scope, input.StatementOfApplicabilityID, input.ControlID, input.Applicability, input.Justification)
@@ -596,11 +595,11 @@ func (r *mutationResolver) CreateApplicabilityStatement(ctx context.Context, inp
 
 // UpdateApplicabilityStatement is the resolver for the updateApplicabilityStatement field.
 func (r *mutationResolver) UpdateApplicabilityStatement(ctx context.Context, input types.UpdateApplicabilityStatementInput) (*types.UpdateApplicabilityStatementPayload, error) {
-	if err := r.authorize(ctx, input.ApplicabilityStatementID, probo.ActionApplicabilityStatementUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ApplicabilityStatementID, probo.ActionApplicabilityStatementUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ApplicabilityStatementID)
 	prb := r.probo
 
 	applicabilityStatement, err := prb.StatementsOfApplicability.UpdateApplicabilityStatement(ctx, scope, input.ApplicabilityStatementID, input.Applicability, input.Justification)
@@ -616,15 +615,14 @@ func (r *mutationResolver) UpdateApplicabilityStatement(ctx context.Context, inp
 
 // DeleteApplicabilityStatement is the resolver for the deleteApplicabilityStatement field.
 func (r *mutationResolver) DeleteApplicabilityStatement(ctx context.Context, input types.DeleteApplicabilityStatementInput) (*types.DeleteApplicabilityStatementPayload, error) {
-	if err := r.authorize(ctx, input.ApplicabilityStatementID, probo.ActionApplicabilityStatementDelete); err != nil {
+	scope, err := r.authorize(ctx, input.ApplicabilityStatementID, probo.ActionApplicabilityStatementDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ApplicabilityStatementID)
 	prb := r.probo
 
-	err := prb.StatementsOfApplicability.DeleteApplicabilityStatement(ctx, scope, input.ApplicabilityStatementID)
-	if err != nil {
+	if err := prb.StatementsOfApplicability.DeleteApplicabilityStatement(ctx, scope, input.ApplicabilityStatementID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete applicability statement", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -636,11 +634,11 @@ func (r *mutationResolver) DeleteApplicabilityStatement(ctx context.Context, inp
 
 // CreateControlAuditMapping is the resolver for the createControlAuditMapping field.
 func (r *mutationResolver) CreateControlAuditMapping(ctx context.Context, input types.CreateControlAuditMappingInput) (*types.CreateControlAuditMappingPayload, error) {
-	if err := r.authorize(ctx, input.ControlID, probo.ActionControlAuditMappingCreate); err != nil {
+	scope, err := r.authorize(ctx, input.ControlID, probo.ActionControlAuditMappingCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.AuditID)
 	prb := r.probo
 
 	control, audit, err := prb.Controls.CreateAuditMapping(ctx, scope, input.ControlID, input.AuditID)
@@ -657,11 +655,11 @@ func (r *mutationResolver) CreateControlAuditMapping(ctx context.Context, input 
 
 // DeleteControlAuditMapping is the resolver for the deleteControlAuditMapping field.
 func (r *mutationResolver) DeleteControlAuditMapping(ctx context.Context, input types.DeleteControlAuditMappingInput) (*types.DeleteControlAuditMappingPayload, error) {
-	if err := r.authorize(ctx, input.ControlID, probo.ActionControlAuditMappingDelete); err != nil {
+	scope, err := r.authorize(ctx, input.ControlID, probo.ActionControlAuditMappingDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.AuditID)
 	prb := r.probo
 
 	control, audit, err := prb.Controls.DeleteAuditMapping(ctx, scope, input.ControlID, input.AuditID)
@@ -678,11 +676,11 @@ func (r *mutationResolver) DeleteControlAuditMapping(ctx context.Context, input 
 
 // CreateControlObligationMapping is the resolver for the createControlObligationMapping field.
 func (r *mutationResolver) CreateControlObligationMapping(ctx context.Context, input types.CreateControlObligationMappingInput) (*types.CreateControlObligationMappingPayload, error) {
-	if err := r.authorize(ctx, input.ControlID, probo.ActionControlObligationMappingCreate); err != nil {
+	scope, err := r.authorize(ctx, input.ControlID, probo.ActionControlObligationMappingCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ObligationID)
 	prb := r.probo
 
 	control, obligation, err := prb.Controls.CreateObligationMapping(ctx, scope, input.ControlID, input.ObligationID)
@@ -699,11 +697,11 @@ func (r *mutationResolver) CreateControlObligationMapping(ctx context.Context, i
 
 // DeleteControlObligationMapping is the resolver for the deleteControlObligationMapping field.
 func (r *mutationResolver) DeleteControlObligationMapping(ctx context.Context, input types.DeleteControlObligationMappingInput) (*types.DeleteControlObligationMappingPayload, error) {
-	if err := r.authorize(ctx, input.ControlID, probo.ActionControlObligationMappingDelete); err != nil {
+	scope, err := r.authorize(ctx, input.ControlID, probo.ActionControlObligationMappingDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ObligationID)
 	prb := r.probo
 
 	control, obligation, err := prb.Controls.DeleteObligationMapping(ctx, scope, input.ControlID, input.ObligationID)
@@ -720,11 +718,11 @@ func (r *mutationResolver) DeleteControlObligationMapping(ctx context.Context, i
 
 // CreateStatementOfApplicability is the resolver for the createStatementOfApplicability field.
 func (r *mutationResolver) CreateStatementOfApplicability(ctx context.Context, input types.CreateStatementOfApplicabilityInput) (*types.CreateStatementOfApplicabilityPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionStatementOfApplicabilityCreate); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionStatementOfApplicabilityCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	statementOfApplicability, err := prb.StatementsOfApplicability.Create(
@@ -755,11 +753,11 @@ func (r *mutationResolver) CreateStatementOfApplicability(ctx context.Context, i
 
 // UpdateStatementOfApplicability is the resolver for the updateStatementOfApplicability field.
 func (r *mutationResolver) UpdateStatementOfApplicability(ctx context.Context, input types.UpdateStatementOfApplicabilityInput) (*types.UpdateStatementOfApplicabilityPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionStatementOfApplicabilityUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionStatementOfApplicabilityUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
 	var name *string
@@ -795,15 +793,14 @@ func (r *mutationResolver) UpdateStatementOfApplicability(ctx context.Context, i
 
 // DeleteStatementOfApplicability is the resolver for the deleteStatementOfApplicability field.
 func (r *mutationResolver) DeleteStatementOfApplicability(ctx context.Context, input types.DeleteStatementOfApplicabilityInput) (*types.DeleteStatementOfApplicabilityPayload, error) {
-	if err := r.authorize(ctx, input.StatementOfApplicabilityID, probo.ActionStatementOfApplicabilityDelete); err != nil {
+	scope, err := r.authorize(ctx, input.StatementOfApplicabilityID, probo.ActionStatementOfApplicabilityDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.StatementOfApplicabilityID)
 	prb := r.probo
 
-	err := prb.StatementsOfApplicability.Delete(ctx, scope, input.StatementOfApplicabilityID)
-	if err != nil {
+	if err := prb.StatementsOfApplicability.Delete(ctx, scope, input.StatementOfApplicabilityID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete statement_of_applicability", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -815,11 +812,11 @@ func (r *mutationResolver) DeleteStatementOfApplicability(ctx context.Context, i
 
 // PublishStatementOfApplicability is the resolver for the publishStatementOfApplicability field.
 func (r *mutationResolver) PublishStatementOfApplicability(ctx context.Context, input types.PublishStatementOfApplicabilityInput) (*types.PublishStatementOfApplicabilityPayload, error) {
-	if err := r.authorize(ctx, input.StatementOfApplicabilityID, probo.ActionStatementOfApplicabilityPublish); err != nil {
+	scope, err := r.authorize(ctx, input.StatementOfApplicabilityID, probo.ActionStatementOfApplicabilityPublish)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.StatementOfApplicabilityID)
 	prb := r.probo
 
 	document, documentVersion, err := prb.GeneratedDocuments.PublishStatementOfApplicability(ctx, scope, input.StatementOfApplicabilityID, input.ApproverIds, input.Minor)
@@ -849,11 +846,11 @@ func (r *statementOfApplicabilityResolver) Document(ctx context.Context, obj *ty
 		return nil, nil
 	}
 
-	if err := r.authorize(ctx, obj.Document.ID, probo.ActionDocumentGet); err != nil {
+	scope, err := r.authorize(ctx, obj.Document.ID, probo.ActionDocumentGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.Document.ID)
 	prb := r.probo
 
 	document, err := prb.Documents.Get(ctx, scope, obj.Document.ID)
@@ -872,7 +869,7 @@ func (r *statementOfApplicabilityResolver) Document(ctx context.Context, obj *ty
 
 // Organization is the resolver for the organization field.
 func (r *statementOfApplicabilityResolver) Organization(ctx context.Context, obj *types.StatementOfApplicability) (*types.Organization, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
 		return nil, err
 	}
 
@@ -894,11 +891,11 @@ func (r *statementOfApplicabilityResolver) Organization(ctx context.Context, obj
 
 // ApplicabilityStatements is the resolver for the applicabilityStatements field.
 func (r *statementOfApplicabilityResolver) ApplicabilityStatements(ctx context.Context, obj *types.StatementOfApplicability, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ApplicabilityStatementOrderBy) (*types.ApplicabilityStatementConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionApplicabilityStatementList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionApplicabilityStatementList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ApplicabilityStatementOrderField]{

--- a/pkg/server/api/console/v1/cookie_banner_resolvers.go
+++ b/pkg/server/api/console/v1/cookie_banner_resolvers.go
@@ -432,7 +432,10 @@ func (r *cookieCategoryConnectionResolver) TotalCount(ctx context.Context, obj *
 
 // TotalCount is the resolver for the totalCount field.
 func (r *detectedTrackerConnectionResolver) TotalCount(ctx context.Context, obj *types.DetectedTrackerConnection) (int, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionTrackerPatternGet)
+	if err != nil {
+		return 0, err
+	}
 
 	count, err := r.cookieBanner.CountDetectedTrackersByPatternID(ctx, scope, obj.ParentID)
 	if err != nil {
@@ -1256,7 +1259,10 @@ func (r *trackerPatternResolver) CookieCategory(ctx context.Context, obj *types.
 
 // DetectedCount is the resolver for the detectedCount field.
 func (r *trackerPatternResolver) DetectedCount(ctx context.Context, obj *types.TrackerPattern) (int, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ID)
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionTrackerPatternGet)
+	if err != nil {
+		return 0, err
+	}
 
 	count, err := r.cookieBanner.CountDetectedTrackersByPatternID(ctx, scope, obj.ID)
 	if err != nil {
@@ -1269,7 +1275,8 @@ func (r *trackerPatternResolver) DetectedCount(ctx context.Context, obj *types.T
 
 // DetectedTrackers is the resolver for the detectedTrackers field.
 func (r *trackerPatternResolver) DetectedTrackers(ctx context.Context, obj *types.TrackerPattern, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DetectedTrackerOrderBy) (*types.DetectedTrackerConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionTrackerPatternGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionTrackerPatternGet)
+	if err != nil {
 		return nil, err
 	}
 
@@ -1285,7 +1292,6 @@ func (r *trackerPatternResolver) DetectedTrackers(ctx context.Context, obj *type
 	}
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	trackers, err := r.cookieBanner.ListDetectedTrackersForPattern(ctx, scope, obj.ID, cursor)
 	if err != nil {
@@ -1305,12 +1311,12 @@ func (r *trackerPatternResolver) Permission(ctx context.Context, obj *types.Trac
 
 // TotalCount is the resolver for the totalCount field.
 func (r *trackerPatternConnectionResolver) TotalCount(ctx context.Context, obj *types.TrackerPatternConnection) (int, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionTrackerPatternList)
+	if err != nil {
+		return 0, err
+	}
 
-	var (
-		count int
-		err   error
-	)
+	var count int
 
 	switch obj.Resolver.(type) {
 	case *cookieCategoryResolver:
@@ -1362,12 +1368,12 @@ func (r *trackerResourceResolver) Permission(ctx context.Context, obj *types.Tra
 
 // TotalCount is the resolver for the totalCount field.
 func (r *trackerResourceConnectionResolver) TotalCount(ctx context.Context, obj *types.TrackerResourceConnection) (int, error) {
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionTrackerResourceList)
+	if err != nil {
+		return 0, err
+	}
 
-	var (
-		count int
-		err   error
-	)
+	var count int
 
 	switch obj.Resolver.(type) {
 	case *cookieCategoryResolver:

--- a/pkg/server/api/console/v1/cookie_banner_resolvers.go
+++ b/pkg/server/api/console/v1/cookie_banner_resolvers.go
@@ -25,7 +25,7 @@ import (
 
 // Organization is the resolver for the organization field.
 func (r *cookieBannerResolver) Organization(ctx context.Context, obj *types.CookieBanner) (*types.Organization, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
 		return nil, err
 	}
 
@@ -47,7 +47,7 @@ func (r *cookieBannerResolver) Organization(ctx context.Context, obj *types.Cook
 
 // Categories is the resolver for the categories field.
 func (r *cookieBannerResolver) Categories(ctx context.Context, obj *types.CookieBanner, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.CookieCategoryOrderBy, filter *types.CookieCategoryFilter) (*types.CookieCategoryConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionCookieCategoryList); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionCookieCategoryList); err != nil {
 		return nil, err
 	}
 
@@ -85,11 +85,10 @@ func (r *cookieBannerResolver) Categories(ctx context.Context, obj *types.Cookie
 
 // Translations is the resolver for the translations field.
 func (r *cookieBannerResolver) Translations(ctx context.Context, obj *types.CookieBanner) ([]*types.CookieBannerTranslation, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionCookieBannerGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionCookieBannerGet)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	translations, err := r.cookieBanner.ListCookieBannerTranslations(ctx, scope, obj.ID)
 	if err != nil {
@@ -107,11 +106,10 @@ func (r *cookieBannerResolver) Translations(ctx context.Context, obj *types.Cook
 
 // LatestVersion is the resolver for the latestVersion field.
 func (r *cookieBannerResolver) LatestVersion(ctx context.Context, obj *types.CookieBanner) (*types.CookieBannerVersion, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionCookieBannerVersionList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionCookieBannerVersionList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	cursor := &page.Cursor[coredata.CookieBannerVersionOrderField]{
 		Size:     1,
@@ -145,7 +143,8 @@ func (r *cookieBannerResolver) LatestVersion(ctx context.Context, obj *types.Coo
 
 // ConsentRecords is the resolver for the consentRecords field.
 func (r *cookieBannerResolver) ConsentRecords(ctx context.Context, obj *types.CookieBanner, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.CookieConsentRecordOrderBy, filter *types.CookieConsentRecordFilter) (*types.CookieConsentRecordConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionCookieConsentRecordList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionCookieConsentRecordList)
+	if err != nil {
 		return nil, err
 	}
 
@@ -161,7 +160,6 @@ func (r *cookieBannerResolver) ConsentRecords(ctx context.Context, obj *types.Co
 	}
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	var (
 		action    *coredata.CookieConsentAction
@@ -189,7 +187,7 @@ func (r *cookieBannerResolver) ConsentRecords(ctx context.Context, obj *types.Co
 
 // TrackerPatterns is the resolver for the trackerPatterns field.
 func (r *cookieBannerResolver) TrackerPatterns(ctx context.Context, obj *types.CookieBanner, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TrackerPatternOrderBy, filter *types.TrackerPatternFilter) (*types.TrackerPatternConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionTrackerPatternList); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionTrackerPatternList); err != nil {
 		return nil, err
 	}
 
@@ -226,7 +224,7 @@ func (r *cookieBannerResolver) TrackerPatterns(ctx context.Context, obj *types.C
 
 // UncategorisedTrackerResources is the resolver for the uncategorisedTrackerResources field.
 func (r *cookieBannerResolver) UncategorisedTrackerResources(ctx context.Context, obj *types.CookieBanner, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TrackerResourceOrderBy, filter *types.TrackerResourceFilter) (*types.TrackerResourceConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionTrackerResourceList); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionTrackerResourceList); err != nil {
 		return nil, err
 	}
 
@@ -267,11 +265,10 @@ func (r *cookieBannerResolver) Permission(ctx context.Context, obj *types.Cookie
 
 // TotalCount is the resolver for the totalCount field.
 func (r *cookieBannerConnectionResolver) TotalCount(ctx context.Context, obj *types.CookieBannerConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionCookieBannerList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionCookieBannerList)
+	if err != nil {
 		return 0, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 
 	count, err := r.cookieBanner.CountCookieBannersForOrganization(ctx, scope, obj.ParentID, coredata.NewCookieBannerFilter(nil))
 	if err != nil {
@@ -284,11 +281,10 @@ func (r *cookieBannerConnectionResolver) TotalCount(ctx context.Context, obj *ty
 
 // Categories is the resolver for the categories field.
 func (r *cookieBannerVersionResolver) Categories(ctx context.Context, obj *types.CookieBannerVersion) ([]*types.CookieBannerVersionCategory, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionCookieBannerVersionGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionCookieBannerVersionGet)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	version, err := r.cookieBanner.GetCookieBannerVersion(ctx, scope, obj.ID)
 	if err != nil {
@@ -331,7 +327,7 @@ func (r *cookieCategoryResolver) CookieBanner(ctx context.Context, obj *types.Co
 		return nil, nil
 	}
 
-	if err := r.authorize(ctx, obj.CookieBanner.ID, probo.ActionCookieBannerGet); err != nil {
+	if _, err := r.authorize(ctx, obj.CookieBanner.ID, probo.ActionCookieBannerGet); err != nil {
 		return nil, err
 	}
 
@@ -353,7 +349,7 @@ func (r *cookieCategoryResolver) CookieBanner(ctx context.Context, obj *types.Co
 
 // TrackerPatterns is the resolver for the trackerPatterns field.
 func (r *cookieCategoryResolver) TrackerPatterns(ctx context.Context, obj *types.CookieCategory, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TrackerPatternOrderBy) (*types.TrackerPatternConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionTrackerPatternList); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionTrackerPatternList); err != nil {
 		return nil, err
 	}
 
@@ -384,7 +380,7 @@ func (r *cookieCategoryResolver) TrackerPatterns(ctx context.Context, obj *types
 
 // TrackerResources is the resolver for the trackerResources field.
 func (r *cookieCategoryResolver) TrackerResources(ctx context.Context, obj *types.CookieCategory, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TrackerResourceOrderBy) (*types.TrackerResourceConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionTrackerResourceList); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionTrackerResourceList); err != nil {
 		return nil, err
 	}
 
@@ -420,11 +416,10 @@ func (r *cookieCategoryResolver) Permission(ctx context.Context, obj *types.Cook
 
 // TotalCount is the resolver for the totalCount field.
 func (r *cookieCategoryConnectionResolver) TotalCount(ctx context.Context, obj *types.CookieCategoryConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionCookieCategoryList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionCookieCategoryList)
+	if err != nil {
 		return 0, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 
 	count, err := r.cookieBanner.CountCategoriesForBanner(ctx, scope, obj.ParentID, obj.Filter)
 	if err != nil {
@@ -450,11 +445,10 @@ func (r *detectedTrackerConnectionResolver) TotalCount(ctx context.Context, obj 
 
 // CreateCookieBanner is the resolver for the createCookieBanner field.
 func (r *mutationResolver) CreateCookieBanner(ctx context.Context, input types.CreateCookieBannerInput) (*types.CreateCookieBannerPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionCookieBannerCreate); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionCookieBannerCreate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 
 	banner, err := r.cookieBanner.CreateCookieBanner(
 		ctx,
@@ -489,11 +483,10 @@ func (r *mutationResolver) CreateCookieBanner(ctx context.Context, input types.C
 
 // UpdateCookieBanner is the resolver for the updateCookieBanner field.
 func (r *mutationResolver) UpdateCookieBanner(ctx context.Context, input types.UpdateCookieBannerInput) (*types.UpdateCookieBannerPayload, error) {
-	if err := r.authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerUpdate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 
 	banner, err := r.cookieBanner.UpdateCookieBanner(
 		ctx,
@@ -528,14 +521,12 @@ func (r *mutationResolver) UpdateCookieBanner(ctx context.Context, input types.U
 
 // DeleteCookieBanner is the resolver for the deleteCookieBanner field.
 func (r *mutationResolver) DeleteCookieBanner(ctx context.Context, input types.DeleteCookieBannerInput) (*types.DeleteCookieBannerPayload, error) {
-	if err := r.authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerDelete); err != nil {
+	scope, err := r.authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
-
-	err := r.cookieBanner.DeleteCookieBanner(ctx, scope, input.CookieBannerID)
-	if err != nil {
+	if err := r.cookieBanner.DeleteCookieBanner(ctx, scope, input.CookieBannerID); err != nil {
 		if errors.Is(err, cookiebanner.ErrBannerNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
 		}
@@ -552,11 +543,10 @@ func (r *mutationResolver) DeleteCookieBanner(ctx context.Context, input types.D
 
 // ActivateCookieBanner is the resolver for the activateCookieBanner field.
 func (r *mutationResolver) ActivateCookieBanner(ctx context.Context, input types.ActivateCookieBannerInput) (*types.ActivateCookieBannerPayload, error) {
-	if err := r.authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerActivate); err != nil {
+	scope, err := r.authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerActivate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 
 	banner, err := r.cookieBanner.ActivateCookieBanner(ctx, scope, input.CookieBannerID)
 	if err != nil {
@@ -584,11 +574,10 @@ func (r *mutationResolver) ActivateCookieBanner(ctx context.Context, input types
 
 // DeactivateCookieBanner is the resolver for the deactivateCookieBanner field.
 func (r *mutationResolver) DeactivateCookieBanner(ctx context.Context, input types.DeactivateCookieBannerInput) (*types.DeactivateCookieBannerPayload, error) {
-	if err := r.authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerDeactivate); err != nil {
+	scope, err := r.authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerDeactivate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 
 	banner, err := r.cookieBanner.DeactivateCookieBanner(ctx, scope, input.CookieBannerID)
 	if err != nil {
@@ -612,11 +601,10 @@ func (r *mutationResolver) DeactivateCookieBanner(ctx context.Context, input typ
 
 // PublishCookieBannerVersion is the resolver for the publishCookieBannerVersion field.
 func (r *mutationResolver) PublishCookieBannerVersion(ctx context.Context, input types.PublishCookieBannerVersionInput) (*types.PublishCookieBannerVersionPayload, error) {
-	if err := r.authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerVersionPublish); err != nil {
+	scope, err := r.authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerVersionPublish)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 
 	version, err := r.cookieBanner.PublishCookieBannerVersion(ctx, scope, input.CookieBannerID)
 	if err != nil {
@@ -649,11 +637,10 @@ func (r *mutationResolver) PublishCookieBannerVersion(ctx context.Context, input
 
 // CreateCookieCategory is the resolver for the createCookieCategory field.
 func (r *mutationResolver) CreateCookieCategory(ctx context.Context, input types.CreateCookieCategoryInput) (*types.CreateCookieCategoryPayload, error) {
-	if err := r.authorize(ctx, input.CookieBannerID, probo.ActionCookieCategoryCreate); err != nil {
+	scope, err := r.authorize(ctx, input.CookieBannerID, probo.ActionCookieCategoryCreate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 
 	category, err := r.cookieBanner.CreateCookieCategory(
 		ctx,
@@ -698,11 +685,10 @@ func (r *mutationResolver) CreateCookieCategory(ctx context.Context, input types
 
 // UpdateCookieCategory is the resolver for the updateCookieCategory field.
 func (r *mutationResolver) UpdateCookieCategory(ctx context.Context, input types.UpdateCookieCategoryInput) (*types.UpdateCookieCategoryPayload, error) {
-	if err := r.authorize(ctx, input.CookieCategoryID, probo.ActionCookieCategoryUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.CookieCategoryID, probo.ActionCookieCategoryUpdate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
 
 	var gcmConsentTypes *[]string
 	if input.GcmConsentTypes != nil {
@@ -759,11 +745,10 @@ func (r *mutationResolver) UpdateCookieCategory(ctx context.Context, input types
 
 // DeleteCookieCategory is the resolver for the deleteCookieCategory field.
 func (r *mutationResolver) DeleteCookieCategory(ctx context.Context, input types.DeleteCookieCategoryInput) (*types.DeleteCookieCategoryPayload, error) {
-	if err := r.authorize(ctx, input.CookieCategoryID, probo.ActionCookieCategoryDelete); err != nil {
+	scope, err := r.authorize(ctx, input.CookieCategoryID, probo.ActionCookieCategoryDelete)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
 
 	category, err := r.cookieBanner.GetCookieCategory(ctx, scope, input.CookieCategoryID)
 	if err != nil {
@@ -809,11 +794,10 @@ func (r *mutationResolver) DeleteCookieCategory(ctx context.Context, input types
 
 // ReorderCookieCategory is the resolver for the reorderCookieCategory field.
 func (r *mutationResolver) ReorderCookieCategory(ctx context.Context, input types.ReorderCookieCategoryInput) (*types.ReorderCookieCategoryPayload, error) {
-	if err := r.authorize(ctx, input.CookieCategoryID, probo.ActionCookieCategoryUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.CookieCategoryID, probo.ActionCookieCategoryUpdate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
 
 	banner, err := r.cookieBanner.ReorderCookieCategory(
 		ctx,
@@ -844,11 +828,10 @@ func (r *mutationResolver) ReorderCookieCategory(ctx context.Context, input type
 
 // UpsertCookieBannerTranslation is the resolver for the upsertCookieBannerTranslation field.
 func (r *mutationResolver) UpsertCookieBannerTranslation(ctx context.Context, input types.UpsertCookieBannerTranslationInput) (*types.UpsertCookieBannerTranslationPayload, error) {
-	if err := r.authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerUpdate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 
 	translation, err := r.cookieBanner.UpsertCookieBannerTranslation(
 		ctx,
@@ -887,11 +870,10 @@ func (r *mutationResolver) UpsertCookieBannerTranslation(ctx context.Context, in
 
 // CreateTrackerPattern is the resolver for the createTrackerPattern field.
 func (r *mutationResolver) CreateTrackerPattern(ctx context.Context, input types.CreateTrackerPatternInput) (*types.CreateTrackerPatternPayload, error) {
-	if err := r.authorize(ctx, input.CookieCategoryID, probo.ActionTrackerPatternCreate); err != nil {
+	scope, err := r.authorize(ctx, input.CookieCategoryID, probo.ActionTrackerPatternCreate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
 
 	trackerType := coredata.TrackerTypeCookie
 	if input.TrackerType != nil {
@@ -946,11 +928,10 @@ func (r *mutationResolver) CreateTrackerPattern(ctx context.Context, input types
 
 // UpdateTrackerPattern is the resolver for the updateTrackerPattern field.
 func (r *mutationResolver) UpdateTrackerPattern(ctx context.Context, input types.UpdateTrackerPatternInput) (*types.UpdateTrackerPatternPayload, error) {
-	if err := r.authorize(ctx, input.TrackerPatternID, probo.ActionTrackerPatternUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.TrackerPatternID, probo.ActionTrackerPatternUpdate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.TrackerPatternID)
 
 	pattern, err := r.cookieBanner.UpdateTrackerPattern(
 		ctx,
@@ -988,11 +969,10 @@ func (r *mutationResolver) UpdateTrackerPattern(ctx context.Context, input types
 
 // DeleteTrackerPattern is the resolver for the deleteTrackerPattern field.
 func (r *mutationResolver) DeleteTrackerPattern(ctx context.Context, input types.DeleteTrackerPatternInput) (*types.DeleteTrackerPatternPayload, error) {
-	if err := r.authorize(ctx, input.TrackerPatternID, probo.ActionTrackerPatternDelete); err != nil {
+	scope, err := r.authorize(ctx, input.TrackerPatternID, probo.ActionTrackerPatternDelete)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.TrackerPatternID)
 
 	pattern, err := r.cookieBanner.GetTrackerPattern(ctx, scope, input.TrackerPatternID)
 	if err != nil {
@@ -1033,15 +1013,14 @@ func (r *mutationResolver) DeleteTrackerPattern(ctx context.Context, input types
 
 // MoveTrackerPatternToCategory is the resolver for the moveTrackerPatternToCategory field.
 func (r *mutationResolver) MoveTrackerPatternToCategory(ctx context.Context, input types.MoveTrackerPatternToCategoryInput) (*types.MoveTrackerPatternToCategoryPayload, error) {
-	if err := r.authorize(ctx, input.TrackerPatternID, probo.ActionTrackerPatternUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.TrackerPatternID, probo.ActionTrackerPatternUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	if err := r.authorize(ctx, input.TargetCookieCategoryID, probo.ActionCookieCategoryUpdate); err != nil {
+	if _, err := r.authorize(ctx, input.TargetCookieCategoryID, probo.ActionCookieCategoryUpdate); err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.TrackerPatternID)
 
 	result, err := r.cookieBanner.MoveTrackerPatternToCategory(
 		ctx,
@@ -1073,11 +1052,10 @@ func (r *mutationResolver) MoveTrackerPatternToCategory(ctx context.Context, inp
 
 // CreateTrackerResource is the resolver for the createTrackerResource field.
 func (r *mutationResolver) CreateTrackerResource(ctx context.Context, input types.CreateTrackerResourceInput) (*types.CreateTrackerResourcePayload, error) {
-	if err := r.authorize(ctx, input.CookieCategoryID, probo.ActionTrackerResourceCreate); err != nil {
+	scope, err := r.authorize(ctx, input.CookieCategoryID, probo.ActionTrackerResourceCreate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
 
 	var description string
 	if input.Description != nil {
@@ -1126,11 +1104,10 @@ func (r *mutationResolver) CreateTrackerResource(ctx context.Context, input type
 
 // UpdateTrackerResource is the resolver for the updateTrackerResource field.
 func (r *mutationResolver) UpdateTrackerResource(ctx context.Context, input types.UpdateTrackerResourceInput) (*types.UpdateTrackerResourcePayload, error) {
-	if err := r.authorize(ctx, input.TrackerResourceID, probo.ActionTrackerResourceUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.TrackerResourceID, probo.ActionTrackerResourceUpdate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.TrackerResourceID)
 
 	resource, err := r.cookieBanner.UpdateTrackerResource(
 		ctx,
@@ -1172,11 +1149,10 @@ func (r *mutationResolver) UpdateTrackerResource(ctx context.Context, input type
 
 // DeleteTrackerResource is the resolver for the deleteTrackerResource field.
 func (r *mutationResolver) DeleteTrackerResource(ctx context.Context, input types.DeleteTrackerResourceInput) (*types.DeleteTrackerResourcePayload, error) {
-	if err := r.authorize(ctx, input.TrackerResourceID, probo.ActionTrackerResourceDelete); err != nil {
+	scope, err := r.authorize(ctx, input.TrackerResourceID, probo.ActionTrackerResourceDelete)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.TrackerResourceID)
 
 	resource, err := r.cookieBanner.GetTrackerResource(ctx, scope, input.TrackerResourceID)
 	if err != nil {
@@ -1217,15 +1193,14 @@ func (r *mutationResolver) DeleteTrackerResource(ctx context.Context, input type
 
 // MoveTrackerResourceToCategory is the resolver for the moveTrackerResourceToCategory field.
 func (r *mutationResolver) MoveTrackerResourceToCategory(ctx context.Context, input types.MoveTrackerResourceToCategoryInput) (*types.MoveTrackerResourceToCategoryPayload, error) {
-	if err := r.authorize(ctx, input.TrackerResourceID, probo.ActionTrackerResourceUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.TrackerResourceID, probo.ActionTrackerResourceUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	if err := r.authorize(ctx, input.TargetCookieCategoryID, probo.ActionCookieCategoryUpdate); err != nil {
+	if _, err := r.authorize(ctx, input.TargetCookieCategoryID, probo.ActionCookieCategoryUpdate); err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.TrackerResourceID)
 
 	result, err := r.cookieBanner.MoveTrackerResourceToCategory(
 		ctx,
@@ -1259,7 +1234,7 @@ func (r *mutationResolver) MoveTrackerResourceToCategory(ctx context.Context, in
 
 // CookieCategory is the resolver for the cookieCategory field.
 func (r *trackerPatternResolver) CookieCategory(ctx context.Context, obj *types.TrackerPattern) (*types.CookieCategory, error) {
-	if err := r.authorize(ctx, obj.CookieCategory.ID, probo.ActionCookieCategoryGet); err != nil {
+	if _, err := r.authorize(ctx, obj.CookieCategory.ID, probo.ActionCookieCategoryGet); err != nil {
 		return nil, err
 	}
 
@@ -1360,7 +1335,7 @@ func (r *trackerPatternConnectionResolver) TotalCount(ctx context.Context, obj *
 
 // CookieCategory is the resolver for the cookieCategory field.
 func (r *trackerResourceResolver) CookieCategory(ctx context.Context, obj *types.TrackerResource) (*types.CookieCategory, error) {
-	if err := r.authorize(ctx, obj.CookieCategory.ID, probo.ActionCookieCategoryGet); err != nil {
+	if _, err := r.authorize(ctx, obj.CookieCategory.ID, probo.ActionCookieCategoryGet); err != nil {
 		return nil, err
 	}
 

--- a/pkg/server/api/console/v1/cookie_consent_record_resolvers.go
+++ b/pkg/server/api/console/v1/cookie_consent_record_resolvers.go
@@ -22,7 +22,7 @@ import (
 
 // CookieBanner is the resolver for the cookieBanner field.
 func (r *cookieConsentRecordResolver) CookieBanner(ctx context.Context, obj *types.CookieConsentRecord) (*types.CookieBanner, error) {
-	if err := r.authorize(ctx, obj.CookieBanner.ID, probo.ActionCookieBannerGet); err != nil {
+	if _, err := r.authorize(ctx, obj.CookieBanner.ID, probo.ActionCookieBannerGet); err != nil {
 		return nil, err
 	}
 
@@ -44,11 +44,10 @@ func (r *cookieConsentRecordResolver) CookieBanner(ctx context.Context, obj *typ
 
 // CookieBannerVersion is the resolver for the cookieBannerVersion field.
 func (r *cookieConsentRecordResolver) CookieBannerVersion(ctx context.Context, obj *types.CookieConsentRecord) (*types.CookieBannerVersion, error) {
-	if err := r.authorize(ctx, obj.CookieBannerVersion.ID, probo.ActionCookieBannerVersionGet); err != nil {
+	scope, err := r.authorize(ctx, obj.CookieBannerVersion.ID, probo.ActionCookieBannerVersionGet)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.CookieBannerVersion.ID)
 
 	version, err := r.cookieBanner.GetCookieBannerVersion(ctx, scope, obj.CookieBannerVersion.ID)
 	if err != nil {
@@ -72,11 +71,10 @@ func (r *cookieConsentRecordResolver) CookieBannerVersion(ctx context.Context, o
 
 // TotalCount is the resolver for the totalCount field.
 func (r *cookieConsentRecordConnectionResolver) TotalCount(ctx context.Context, obj *types.CookieConsentRecordConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionCookieConsentRecordList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionCookieConsentRecordList)
+	if err != nil {
 		return 0, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 
 	count, err := r.cookieBanner.CountCookieConsentRecordsForBanner(ctx, scope, obj.ParentID, obj.Filter)
 	if err != nil {

--- a/pkg/server/api/console/v1/data_protection_impact_assessment_resolvers.go
+++ b/pkg/server/api/console/v1/data_protection_impact_assessment_resolvers.go
@@ -27,15 +27,13 @@ func (r *dataProtectionImpactAssessmentResolver) ProcessingActivity(ctx context.
 		return nil, err
 	}
 
-	prb := r.probo
-
-	dpia, err := prb.DataProtectionImpactAssessments.Get(ctx, scope, obj.ID)
+	dpia, err := r.probo.DataProtectionImpactAssessments.Get(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get processing activity dpia", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	processingActivity, err := prb.ProcessingActivities.Get(ctx, scope, dpia.ProcessingActivityID)
+	processingActivity, err := r.probo.ProcessingActivities.Get(ctx, scope, dpia.ProcessingActivityID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get processing activity", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -51,15 +49,13 @@ func (r *dataProtectionImpactAssessmentResolver) Organization(ctx context.Contex
 		return nil, err
 	}
 
-	prb := r.probo
-
-	dpia, err := prb.DataProtectionImpactAssessments.Get(ctx, scope, obj.ID)
+	dpia, err := r.probo.DataProtectionImpactAssessments.Get(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get processing activity dpia", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	organization, err := prb.Organizations.Get(ctx, scope, dpia.OrganizationID)
+	organization, err := r.probo.Organizations.Get(ctx, scope, dpia.OrganizationID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -85,11 +81,9 @@ func (r *dataProtectionImpactAssessmentConnectionResolver) TotalCount(ctx contex
 		return 0, err
 	}
 
-	prb := r.probo
-
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.DataProtectionImpactAssessments.CountForOrganizationID(ctx, scope, obj.ParentID)
+		count, err := r.probo.DataProtectionImpactAssessments.CountForOrganizationID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count organization data protection impact assessments", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -110,8 +104,6 @@ func (r *mutationResolver) CreateDataProtectionImpactAssessment(ctx context.Cont
 		return nil, err
 	}
 
-	prb := r.probo
-
 	req := probo.CreateDataProtectionImpactAssessmentRequest{
 		ProcessingActivityID:        input.ProcessingActivityID,
 		Description:                 input.Description,
@@ -121,7 +113,7 @@ func (r *mutationResolver) CreateDataProtectionImpactAssessment(ctx context.Cont
 		ResidualRisk:                input.ResidualRisk,
 	}
 
-	dpia, err := prb.DataProtectionImpactAssessments.Create(ctx, scope, &req)
+	dpia, err := r.probo.DataProtectionImpactAssessments.Create(ctx, scope, &req)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -148,8 +140,6 @@ func (r *mutationResolver) UpdateDataProtectionImpactAssessment(ctx context.Cont
 		return nil, err
 	}
 
-	prb := r.probo
-
 	req := probo.UpdateDataProtectionImpactAssessmentRequest{
 		ID:                          input.ID,
 		Description:                 gqlutils.UnwrapOmittable(input.Description),
@@ -159,7 +149,7 @@ func (r *mutationResolver) UpdateDataProtectionImpactAssessment(ctx context.Cont
 		ResidualRisk:                input.ResidualRisk,
 	}
 
-	dpia, err := prb.DataProtectionImpactAssessments.Update(ctx, scope, &req)
+	dpia, err := r.probo.DataProtectionImpactAssessments.Update(ctx, scope, &req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -182,9 +172,7 @@ func (r *mutationResolver) DeleteDataProtectionImpactAssessment(ctx context.Cont
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.DataProtectionImpactAssessments.Delete(ctx, scope, input.DataProtectionImpactAssessmentID); err != nil {
+	if err := r.probo.DataProtectionImpactAssessments.Delete(ctx, scope, input.DataProtectionImpactAssessmentID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete data protection impact assessment", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -201,8 +189,6 @@ func (r *mutationResolver) CreateTransferImpactAssessment(ctx context.Context, i
 		return nil, err
 	}
 
-	prb := r.probo
-
 	req := probo.CreateTransferImpactAssessmentRequest{
 		ProcessingActivityID:  input.ProcessingActivityID,
 		DataSubjects:          input.DataSubjects,
@@ -212,7 +198,7 @@ func (r *mutationResolver) CreateTransferImpactAssessment(ctx context.Context, i
 		SupplementaryMeasures: input.SupplementaryMeasures,
 	}
 
-	tia, err := prb.TransferImpactAssessments.Create(ctx, scope, &req)
+	tia, err := r.probo.TransferImpactAssessments.Create(ctx, scope, &req)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -239,8 +225,6 @@ func (r *mutationResolver) UpdateTransferImpactAssessment(ctx context.Context, i
 		return nil, err
 	}
 
-	prb := r.probo
-
 	req := probo.UpdateTransferImpactAssessmentRequest{
 		ID:                    input.ID,
 		DataSubjects:          gqlutils.UnwrapOmittable(input.DataSubjects),
@@ -250,7 +234,7 @@ func (r *mutationResolver) UpdateTransferImpactAssessment(ctx context.Context, i
 		SupplementaryMeasures: gqlutils.UnwrapOmittable(input.SupplementaryMeasures),
 	}
 
-	tia, err := prb.TransferImpactAssessments.Update(ctx, scope, &req)
+	tia, err := r.probo.TransferImpactAssessments.Update(ctx, scope, &req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -273,9 +257,7 @@ func (r *mutationResolver) DeleteTransferImpactAssessment(ctx context.Context, i
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.TransferImpactAssessments.Delete(ctx, scope, input.TransferImpactAssessmentID); err != nil {
+	if err := r.probo.TransferImpactAssessments.Delete(ctx, scope, input.TransferImpactAssessmentID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete transfer impact assessment", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -292,9 +274,7 @@ func (r *mutationResolver) PublishDataProtectionImpactAssessmentList(ctx context
 		return nil, err
 	}
 
-	prb := r.probo
-
-	document, documentVersion, err := prb.GeneratedDocuments.PublishDataProtectionImpactAssessmentList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := r.probo.GeneratedDocuments.PublishDataProtectionImpactAssessmentList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -322,9 +302,7 @@ func (r *mutationResolver) PublishTransferImpactAssessmentList(ctx context.Conte
 		return nil, err
 	}
 
-	prb := r.probo
-
-	document, documentVersion, err := prb.GeneratedDocuments.PublishTransferImpactAssessmentList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := r.probo.GeneratedDocuments.PublishTransferImpactAssessmentList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -352,9 +330,7 @@ func (r *transferImpactAssessmentResolver) ProcessingActivity(ctx context.Contex
 		return nil, err
 	}
 
-	prb := r.probo
-
-	processingActivity, err := prb.ProcessingActivities.Get(ctx, scope, obj.ProcessingActivity.ID)
+	processingActivity, err := r.probo.ProcessingActivities.Get(ctx, scope, obj.ProcessingActivity.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get processing activity", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -397,11 +373,9 @@ func (r *transferImpactAssessmentConnectionResolver) TotalCount(ctx context.Cont
 		return 0, err
 	}
 
-	prb := r.probo
-
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.TransferImpactAssessments.CountForOrganizationID(ctx, scope, obj.ParentID)
+		count, err := r.probo.TransferImpactAssessments.CountForOrganizationID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count organization transfer impact assessments", log.Error(err))
 			return 0, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/data_protection_impact_assessment_resolvers.go
+++ b/pkg/server/api/console/v1/data_protection_impact_assessment_resolvers.go
@@ -22,11 +22,11 @@ import (
 
 // ProcessingActivity is the resolver for the processingActivity field.
 func (r *dataProtectionImpactAssessmentResolver) ProcessingActivity(ctx context.Context, obj *types.DataProtectionImpactAssessment) (*types.ProcessingActivity, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionProcessingActivityList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionProcessingActivityList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	dpia, err := prb.DataProtectionImpactAssessments.Get(ctx, scope, obj.ID)
@@ -46,11 +46,11 @@ func (r *dataProtectionImpactAssessmentResolver) ProcessingActivity(ctx context.
 
 // Organization is the resolver for the organization field.
 func (r *dataProtectionImpactAssessmentResolver) Organization(ctx context.Context, obj *types.DataProtectionImpactAssessment) (*types.Organization, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	dpia, err := prb.DataProtectionImpactAssessments.Get(ctx, scope, obj.ID)
@@ -80,11 +80,11 @@ func (r *dataProtectionImpactAssessmentResolver) Permission(ctx context.Context,
 
 // TotalCount is the resolver for the totalCount field.
 func (r *dataProtectionImpactAssessmentConnectionResolver) TotalCount(ctx context.Context, obj *types.DataProtectionImpactAssessmentConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionDataProtectionImpactAssessmentList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionDataProtectionImpactAssessmentList)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 	prb := r.probo
 
 	switch obj.Resolver.(type) {
@@ -105,11 +105,11 @@ func (r *dataProtectionImpactAssessmentConnectionResolver) TotalCount(ctx contex
 
 // CreateDataProtectionImpactAssessment is the resolver for the createDataProtectionImpactAssessment field.
 func (r *mutationResolver) CreateDataProtectionImpactAssessment(ctx context.Context, input types.CreateDataProtectionImpactAssessmentInput) (*types.CreateDataProtectionImpactAssessmentPayload, error) {
-	if err := r.authorize(ctx, input.ProcessingActivityID, probo.ActionDataProtectionImpactAssessmentCreate); err != nil {
+	scope, err := r.authorize(ctx, input.ProcessingActivityID, probo.ActionDataProtectionImpactAssessmentCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ProcessingActivityID)
 	prb := r.probo
 
 	req := probo.CreateDataProtectionImpactAssessmentRequest{
@@ -143,11 +143,11 @@ func (r *mutationResolver) CreateDataProtectionImpactAssessment(ctx context.Cont
 
 // UpdateDataProtectionImpactAssessment is the resolver for the updateDataProtectionImpactAssessment field.
 func (r *mutationResolver) UpdateDataProtectionImpactAssessment(ctx context.Context, input types.UpdateDataProtectionImpactAssessmentInput) (*types.UpdateDataProtectionImpactAssessmentPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionDataProtectionImpactAssessmentUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionDataProtectionImpactAssessmentUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
 	req := probo.UpdateDataProtectionImpactAssessmentRequest{
@@ -177,15 +177,14 @@ func (r *mutationResolver) UpdateDataProtectionImpactAssessment(ctx context.Cont
 
 // DeleteDataProtectionImpactAssessment is the resolver for the deleteDataProtectionImpactAssessment field.
 func (r *mutationResolver) DeleteDataProtectionImpactAssessment(ctx context.Context, input types.DeleteDataProtectionImpactAssessmentInput) (*types.DeleteDataProtectionImpactAssessmentPayload, error) {
-	if err := r.authorize(ctx, input.DataProtectionImpactAssessmentID, probo.ActionDataProtectionImpactAssessmentDelete); err != nil {
+	scope, err := r.authorize(ctx, input.DataProtectionImpactAssessmentID, probo.ActionDataProtectionImpactAssessmentDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.DataProtectionImpactAssessmentID)
 	prb := r.probo
 
-	err := prb.DataProtectionImpactAssessments.Delete(ctx, scope, input.DataProtectionImpactAssessmentID)
-	if err != nil {
+	if err := prb.DataProtectionImpactAssessments.Delete(ctx, scope, input.DataProtectionImpactAssessmentID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete data protection impact assessment", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -197,11 +196,11 @@ func (r *mutationResolver) DeleteDataProtectionImpactAssessment(ctx context.Cont
 
 // CreateTransferImpactAssessment is the resolver for the createTransferImpactAssessment field.
 func (r *mutationResolver) CreateTransferImpactAssessment(ctx context.Context, input types.CreateTransferImpactAssessmentInput) (*types.CreateTransferImpactAssessmentPayload, error) {
-	if err := r.authorize(ctx, input.ProcessingActivityID, probo.ActionTransferImpactAssessmentCreate); err != nil {
+	scope, err := r.authorize(ctx, input.ProcessingActivityID, probo.ActionTransferImpactAssessmentCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ProcessingActivityID)
 	prb := r.probo
 
 	req := probo.CreateTransferImpactAssessmentRequest{
@@ -235,11 +234,11 @@ func (r *mutationResolver) CreateTransferImpactAssessment(ctx context.Context, i
 
 // UpdateTransferImpactAssessment is the resolver for the updateTransferImpactAssessment field.
 func (r *mutationResolver) UpdateTransferImpactAssessment(ctx context.Context, input types.UpdateTransferImpactAssessmentInput) (*types.UpdateTransferImpactAssessmentPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionTransferImpactAssessmentUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionTransferImpactAssessmentUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
 	req := probo.UpdateTransferImpactAssessmentRequest{
@@ -269,15 +268,14 @@ func (r *mutationResolver) UpdateTransferImpactAssessment(ctx context.Context, i
 
 // DeleteTransferImpactAssessment is the resolver for the deleteTransferImpactAssessment field.
 func (r *mutationResolver) DeleteTransferImpactAssessment(ctx context.Context, input types.DeleteTransferImpactAssessmentInput) (*types.DeleteTransferImpactAssessmentPayload, error) {
-	if err := r.authorize(ctx, input.TransferImpactAssessmentID, probo.ActionTransferImpactAssessmentDelete); err != nil {
+	scope, err := r.authorize(ctx, input.TransferImpactAssessmentID, probo.ActionTransferImpactAssessmentDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.TransferImpactAssessmentID)
 	prb := r.probo
 
-	err := prb.TransferImpactAssessments.Delete(ctx, scope, input.TransferImpactAssessmentID)
-	if err != nil {
+	if err := prb.TransferImpactAssessments.Delete(ctx, scope, input.TransferImpactAssessmentID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete transfer impact assessment", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -289,11 +287,11 @@ func (r *mutationResolver) DeleteTransferImpactAssessment(ctx context.Context, i
 
 // PublishDataProtectionImpactAssessmentList is the resolver for the publishDataProtectionImpactAssessmentList field.
 func (r *mutationResolver) PublishDataProtectionImpactAssessmentList(ctx context.Context, input types.PublishDataProtectionImpactAssessmentListInput) (*types.PublishDataProtectionImpactAssessmentListPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionDataProtectionImpactAssessmentPublish); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionDataProtectionImpactAssessmentPublish)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	document, documentVersion, err := prb.GeneratedDocuments.PublishDataProtectionImpactAssessmentList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
@@ -319,11 +317,11 @@ func (r *mutationResolver) PublishDataProtectionImpactAssessmentList(ctx context
 
 // PublishTransferImpactAssessmentList is the resolver for the publishTransferImpactAssessmentList field.
 func (r *mutationResolver) PublishTransferImpactAssessmentList(ctx context.Context, input types.PublishTransferImpactAssessmentListInput) (*types.PublishTransferImpactAssessmentListPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionTransferImpactAssessmentPublish); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionTransferImpactAssessmentPublish)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	document, documentVersion, err := prb.GeneratedDocuments.PublishTransferImpactAssessmentList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
@@ -349,11 +347,11 @@ func (r *mutationResolver) PublishTransferImpactAssessmentList(ctx context.Conte
 
 // ProcessingActivity is the resolver for the processingActivity field.
 func (r *transferImpactAssessmentResolver) ProcessingActivity(ctx context.Context, obj *types.TransferImpactAssessment) (*types.ProcessingActivity, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionProcessingActivityGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionProcessingActivityGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	processingActivity, err := prb.ProcessingActivities.Get(ctx, scope, obj.ProcessingActivity.ID)
@@ -367,7 +365,7 @@ func (r *transferImpactAssessmentResolver) ProcessingActivity(ctx context.Contex
 
 // Organization is the resolver for the organization field.
 func (r *transferImpactAssessmentResolver) Organization(ctx context.Context, obj *types.TransferImpactAssessment) (*types.Organization, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
 		return nil, err
 	}
 
@@ -394,11 +392,11 @@ func (r *transferImpactAssessmentResolver) Permission(ctx context.Context, obj *
 
 // TotalCount is the resolver for the totalCount field.
 func (r *transferImpactAssessmentConnectionResolver) TotalCount(ctx context.Context, obj *types.TransferImpactAssessmentConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionTransferImpactAssessmentList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionTransferImpactAssessmentList)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 	prb := r.probo
 
 	switch obj.Resolver.(type) {

--- a/pkg/server/api/console/v1/dataloader/authorize.go
+++ b/pkg/server/api/console/v1/dataloader/authorize.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package dataloader
+
+import (
+	"context"
+	"errors"
+
+	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam"
+	"go.probo.inc/probo/pkg/server/api/authz"
+	"go.probo.inc/probo/pkg/server/gqlutils"
+)
+
+// NewAuthorizeFunc returns an authz.AuthorizeFunc that batches authorize
+// calls through the per-request dataloader. Parallel field resolvers within
+// the same request collapse into a single iam.Authorizer.AuthorizeMulti
+// call. Requires the dataloader middleware to have populated Loaders in
+// context.
+func NewAuthorizeFunc(logger *log.Logger) authz.AuthorizeFunc {
+	return func(
+		ctx context.Context,
+		objectID gid.GID,
+		action string,
+		options ...authz.AuthorizeFuncOption,
+	) (*coredata.Scope, error) {
+		loaders := FromContext(ctx)
+
+		applied := iam.AuthorizeParams{
+			ResourceAttributes: make(map[string]string),
+		}
+		for _, opt := range options {
+			opt(&applied)
+		}
+
+		result, err := loaders.Authorize.Load(
+			ctx,
+			AuthorizeKey{
+				ResourceID:          objectID,
+				Action:              action,
+				ResourceAttributes:  EncodeAuthorizeKeyAttributes(applied.ResourceAttributes),
+				DryRun:              applied.DryRun,
+				SkipAssumptionCheck: applied.SkipAssumptionCheck,
+			},
+		)
+		if err != nil {
+			if _, ok := errors.AsType[*iam.ErrAssumptionRequired](err); ok {
+				return nil, gqlutils.AssumptionRequired(ctx, err)
+			}
+
+			if _, ok := errors.AsType[*iam.ErrInsufficientPermissions](err); ok {
+				return nil, gqlutils.Forbidden(ctx, err)
+			}
+
+			if errors.Is(err, coredata.ErrResourceNotFound) {
+				return nil, gqlutils.NotFoundf(ctx, "resource not found")
+			}
+
+			logger.ErrorCtx(ctx, "cannot authorize", log.Error(err))
+
+			return nil, gqlutils.Internal(ctx)
+		}
+
+		return result.Scope, nil
+	}
+}

--- a/pkg/server/api/console/v1/dataloader/dataloader.go
+++ b/pkg/server/api/console/v1/dataloader/dataloader.go
@@ -16,19 +16,41 @@ package dataloader
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
+	"slices"
+	"strings"
 
 	"github.com/vikstrous/dataloadgen"
 	"go.probo.inc/probo/pkg/cookiebanner"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/iam"
+	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/probo"
+	"go.probo.inc/probo/pkg/server/api/authn"
 )
 
 type (
 	ctxKey struct{ name string }
+
+	// AuthorizeKey identifies an authorize call. ResourceAttributes is the
+	// canonical (sorted-key) JSON encoding of the attributes passed via
+	// authz.WithAttr, so calls with the same logical inputs share a key and
+	// batch together.
+	AuthorizeKey struct {
+		ResourceID          gid.GID
+		Action              string
+		ResourceAttributes  string
+		DryRun              bool
+		SkipAssumptionCheck bool
+	}
+
+	AuthorizeResult struct {
+		Scope *coredata.Scope
+	}
 
 	Loaders struct {
 		Organization   *dataloadgen.Loader[gid.GID, *coredata.Organization]
@@ -44,6 +66,7 @@ type (
 		Report         *dataloadgen.Loader[gid.GID, *coredata.Report]
 		CookieBanner   *dataloadgen.Loader[gid.GID, *coredata.CookieBanner]
 		CookieCategory *dataloadgen.Loader[gid.GID, *coredata.CookieCategory]
+		Authorize      *dataloadgen.Loader[AuthorizeKey, AuthorizeResult]
 	}
 
 	batchFetcher struct {
@@ -87,6 +110,10 @@ func (f *batchFetcher) newLoaders() *Loaders {
 		Report:         dataloadgen.NewMappedLoader(f.fetchReports),
 		CookieBanner:   dataloadgen.NewMappedLoader(f.fetchCookieBanners),
 		CookieCategory: dataloadgen.NewMappedLoader(f.fetchCookieCategories),
+		Authorize: dataloadgen.NewMappedLoader(
+			f.fetchAuthorizes,
+			dataloadgen.WithoutCache(),
+		),
 	}
 }
 
@@ -296,4 +323,160 @@ func (f *batchFetcher) fetchCookieCategories(ctx context.Context, keys []gid.GID
 	}
 
 	return result, nil
+}
+
+// fetchAuthorizes evaluates the batch with a single AuthorizeMulti call and
+// surfaces per-key denials via dataloadgen.MappedFetchError. When
+// AuthorizeMulti cannot evaluate the batch as a whole (e.g. mixed
+// organizations), we fall back to per-item Authorize so every key still
+// gets a scope or iam error.
+//
+// The Authorize loader is created with WithoutCache() so repeated calls
+// with the same (resource, action) within a single request still produce
+// one audit log entry per call.
+func (f *batchFetcher) fetchAuthorizes(
+	ctx context.Context,
+	keys []AuthorizeKey,
+) (map[AuthorizeKey]AuthorizeResult, error) {
+	identity := authn.IdentityFromContext(ctx)
+	if identity == nil {
+		return nil, fmt.Errorf("cannot authorize without an identity in context")
+	}
+
+	session := authn.SessionFromContext(ctx)
+
+	items := make([]iam.MultiAuthorizeItem, 0, len(keys))
+	for _, key := range keys {
+		attrs, err := decodeAuthorizeKeyAttributes(key.ResourceAttributes)
+		if err != nil {
+			return nil, fmt.Errorf("cannot decode authorize key attributes: %w", err)
+		}
+
+		items = append(items, iam.MultiAuthorizeItem{
+			Resource:            key.ResourceID,
+			Action:              key.Action,
+			ResourceAttributes:  attrs,
+			DryRun:              key.DryRun,
+			SkipAssumptionCheck: key.SkipAssumptionCheck,
+		})
+	}
+
+	multiParams := iam.AuthorizeMultiParams{
+		Principal: identity.ID,
+		Items:     items,
+	}
+	if session != nil {
+		multiParams.Session = &session.ID
+	}
+
+	scope, decisions, err := f.iam.Authorizer.AuthorizeMulti(ctx, multiParams)
+	if err != nil {
+		return f.fetchAuthorizesIndividually(ctx, keys, identity.ID, session)
+	}
+
+	result := make(map[AuthorizeKey]AuthorizeResult, len(keys))
+	perKeyErrs := make(dataloadgen.MappedFetchError[AuthorizeKey])
+
+	for i, key := range keys {
+		if decisions[i] != nil {
+			perKeyErrs[key] = decisions[i]
+			continue
+		}
+
+		result[key] = AuthorizeResult{Scope: scope}
+	}
+
+	if len(perKeyErrs) > 0 {
+		return result, perKeyErrs
+	}
+
+	return result, nil
+}
+
+// fetchAuthorizesIndividually is the per-item fallback used when
+// AuthorizeMulti cannot evaluate the batch as a whole.
+func (f *batchFetcher) fetchAuthorizesIndividually(
+	ctx context.Context,
+	keys []AuthorizeKey,
+	principalID gid.GID,
+	session *coredata.Session,
+) (map[AuthorizeKey]AuthorizeResult, error) {
+	result := make(map[AuthorizeKey]AuthorizeResult, len(keys))
+	perKeyErrs := make(dataloadgen.MappedFetchError[AuthorizeKey])
+
+	for _, key := range keys {
+		attrs, err := decodeAuthorizeKeyAttributes(key.ResourceAttributes)
+		if err != nil {
+			return nil, fmt.Errorf("cannot decode authorize key attributes: %w", err)
+		}
+
+		params := iam.AuthorizeParams{
+			Principal:           principalID,
+			Resource:            key.ResourceID,
+			Action:              key.Action,
+			ResourceAttributes:  make(map[string]string, len(attrs)),
+			DryRun:              key.DryRun,
+			SkipAssumptionCheck: key.SkipAssumptionCheck,
+		}
+		maps.Copy(params.ResourceAttributes, attrs)
+
+		if session != nil {
+			params.Session = &session.ID
+		}
+
+		scope, err := f.iam.Authorizer.Authorize(ctx, params)
+		if err != nil {
+			perKeyErrs[key] = err
+			continue
+		}
+
+		result[key] = AuthorizeResult{Scope: scope}
+	}
+
+	if len(perKeyErrs) > 0 {
+		return result, perKeyErrs
+	}
+
+	return result, nil
+}
+
+// EncodeAuthorizeKeyAttributes returns a canonical (sorted-key) JSON
+// encoding of attrs for use as AuthorizeKey.ResourceAttributes. Maps that
+// compare equal produce identical strings; nil or empty attrs encode to "".
+func EncodeAuthorizeKeyAttributes(attrs policy.Attributes) string {
+	if len(attrs) == 0 {
+		return ""
+	}
+
+	keys := slices.Sorted(maps.Keys(attrs))
+
+	var sb strings.Builder
+	sb.WriteByte('{')
+	for i, k := range keys {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+
+		kb, _ := json.Marshal(k)
+		sb.Write(kb)
+		sb.WriteByte(':')
+		vb, _ := json.Marshal(attrs[k])
+		sb.Write(vb)
+	}
+	sb.WriteByte('}')
+
+	return sb.String()
+}
+
+func decodeAuthorizeKeyAttributes(s string) (policy.Attributes, error) {
+	if s == "" {
+		return nil, nil
+	}
+
+	attrs := policy.Attributes{}
+	if err := json.Unmarshal([]byte(s), &attrs); err != nil {
+		return nil, err
+	}
+
+	return attrs, nil
 }

--- a/pkg/server/api/console/v1/dataloader/dataloader.go
+++ b/pkg/server/api/console/v1/dataloader/dataloader.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"maps"
 	"net/http"
-	"slices"
-	"strings"
 
 	"github.com/vikstrous/dataloadgen"
 	"go.probo.inc/probo/pkg/cookiebanner"
@@ -440,39 +438,17 @@ func (f *batchFetcher) fetchAuthorizesIndividually(
 	return result, nil
 }
 
-// EncodeAuthorizeKeyAttributes returns a canonical (sorted-key) JSON
-// encoding of attrs for use as AuthorizeKey.ResourceAttributes. Maps that
-// compare equal produce identical strings; nil or empty attrs encode to "".
 func EncodeAuthorizeKeyAttributes(attrs policy.Attributes) string {
 	if len(attrs) == 0 {
 		return ""
 	}
 
-	keys := slices.Sorted(maps.Keys(attrs))
+	b, _ := json.Marshal(attrs)
 
-	var sb strings.Builder
-	sb.WriteByte('{')
-	for i, k := range keys {
-		if i > 0 {
-			sb.WriteByte(',')
-		}
-
-		kb, _ := json.Marshal(k)
-		sb.Write(kb)
-		sb.WriteByte(':')
-		vb, _ := json.Marshal(attrs[k])
-		sb.Write(vb)
-	}
-	sb.WriteByte('}')
-
-	return sb.String()
+	return string(b)
 }
 
 func decodeAuthorizeKeyAttributes(s string) (policy.Attributes, error) {
-	if s == "" {
-		return nil, nil
-	}
-
 	attrs := policy.Attributes{}
 	if err := json.Unmarshal([]byte(s), &attrs); err != nil {
 		return nil, err

--- a/pkg/server/api/console/v1/dataloader/dataloader.go
+++ b/pkg/server/api/console/v1/dataloader/dataloader.go
@@ -450,6 +450,10 @@ func EncodeAuthorizeKeyAttributes(attrs policy.Attributes) string {
 
 func decodeAuthorizeKeyAttributes(s string) (policy.Attributes, error) {
 	attrs := policy.Attributes{}
+	if s == "" {
+		return attrs, nil
+	}
+
 	if err := json.Unmarshal([]byte(s), &attrs); err != nil {
 		return nil, err
 	}

--- a/pkg/server/api/console/v1/document_resolvers.go
+++ b/pkg/server/api/console/v1/document_resolvers.go
@@ -56,8 +56,6 @@ func (r *documentResolver) Versions(ctx context.Context, obj *types.Document, fi
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.DocumentVersionOrderField]{
 		Field:     coredata.DocumentVersionOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -76,7 +74,7 @@ func (r *documentResolver) Versions(ctx context.Context, obj *types.Document, fi
 		versionFilter = versionFilter.WithStatuses(filter.Statuses...)
 	}
 
-	page, err := prb.Documents.ListVersions(ctx, scope, obj.ID, cursor, versionFilter)
+	page, err := r.probo.Documents.ListVersions(ctx, scope, obj.ID, cursor, versionFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list document versions", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -91,8 +89,6 @@ func (r *documentResolver) Controls(ctx context.Context, obj *types.Document, fi
 	if err != nil {
 		return nil, err
 	}
-
-	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ControlOrderField]{
 		Field:     coredata.ControlOrderFieldCreatedAt,
@@ -112,7 +108,7 @@ func (r *documentResolver) Controls(ctx context.Context, obj *types.Document, fi
 		controlFilter = coredata.NewControlFilter(filter.Query)
 	}
 
-	page, err := prb.Controls.ListForDocumentID(ctx, scope, obj.ID, cursor, controlFilter)
+	page, err := r.probo.Controls.ListForDocumentID(ctx, scope, obj.ID, cursor, controlFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list document controls", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -128,9 +124,7 @@ func (r *documentResolver) DefaultApprovers(ctx context.Context, obj *types.Docu
 		return nil, err
 	}
 
-	prb := r.probo
-
-	profiles, err := prb.Documents.GetDefaultApprovers(ctx, scope, obj.ID)
+	profiles, err := r.probo.Documents.GetDefaultApprovers(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get default approvers", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -156,11 +150,9 @@ func (r *documentConnectionResolver) TotalCount(ctx context.Context, obj *types.
 		return 0, err
 	}
 
-	prb := r.probo
-
 	switch obj.Resolver.(type) {
 	case *controlResolver:
-		count, err := prb.Documents.CountForControlID(ctx, scope, obj.ParentID, obj.Filters)
+		count, err := r.probo.Documents.CountForControlID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count controls", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -168,7 +160,7 @@ func (r *documentConnectionResolver) TotalCount(ctx context.Context, obj *types.
 
 		return count, nil
 	case *organizationResolver:
-		count, err := prb.Documents.CountForOrganizationID(ctx, scope, obj.ParentID, obj.Filters)
+		count, err := r.probo.Documents.CountForOrganizationID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count documents", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -176,7 +168,7 @@ func (r *documentConnectionResolver) TotalCount(ctx context.Context, obj *types.
 
 		return count, nil
 	case *riskResolver:
-		count, err := prb.Documents.CountForRiskID(ctx, scope, obj.ParentID, obj.Filters)
+		count, err := r.probo.Documents.CountForRiskID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count risks", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -184,7 +176,7 @@ func (r *documentConnectionResolver) TotalCount(ctx context.Context, obj *types.
 
 		return count, nil
 	case *measureResolver:
-		count, err := prb.Documents.CountForMeasureID(ctx, scope, obj.ParentID, obj.Filters)
+		count, err := r.probo.Documents.CountForMeasureID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count documents", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -234,8 +226,6 @@ func (r *documentVersionResolver) Approvers(ctx context.Context, obj *types.Docu
 		}, nil
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.MembershipProfileOrderField]{
 		Field:     coredata.MembershipProfileOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -247,7 +237,7 @@ func (r *documentVersionResolver) Approvers(ctx context.Context, obj *types.Docu
 
 	c := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	p, err := prb.Documents.ListVersionApprovers(ctx, scope, obj.ID, c)
+	p, err := r.probo.Documents.ListVersionApprovers(ctx, scope, obj.ID, c)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list document version approvers", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -262,8 +252,6 @@ func (r *documentVersionResolver) Signatures(ctx context.Context, obj *types.Doc
 	if err != nil {
 		return nil, err
 	}
-
-	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentVersionSignatureOrderField]{
 		Field:     coredata.DocumentVersionSignatureOrderFieldCreatedAt,
@@ -300,7 +288,7 @@ func (r *documentVersionResolver) Signatures(ctx context.Context, obj *types.Doc
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Documents.ListSignatures(ctx, scope, obj.ID, cursor, signatureFilter)
+	page, err := r.probo.Documents.ListSignatures(ctx, scope, obj.ID, cursor, signatureFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list document version signatures", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -316,8 +304,6 @@ func (r *documentVersionResolver) ApprovalQuorums(ctx context.Context, obj *type
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.DocumentVersionApprovalQuorumOrderField]{
 		Field:     coredata.DocumentVersionApprovalQuorumOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -331,7 +317,7 @@ func (r *documentVersionResolver) ApprovalQuorums(ctx context.Context, obj *type
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	p, err := prb.DocumentApprovals.ListQuorums(ctx, scope, obj.ID, cursor)
+	p, err := r.probo.DocumentApprovals.ListQuorums(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list approval quorums", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -348,9 +334,7 @@ func (r *documentVersionResolver) Signed(ctx context.Context, obj *types.Documen
 	}
 
 	identity := authn.IdentityFromContext(ctx)
-	prb := r.probo
-
-	signed, err := prb.Documents.IsVersionSignedByUserEmail(ctx, scope, obj.ID, identity.EmailAddress)
+	signed, err := r.probo.Documents.IsVersionSignedByUserEmail(ctx, scope, obj.ID, identity.EmailAddress)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot check if document version is signed", log.Error(err))
 		return false, gqlutils.Internal(ctx)
@@ -371,9 +355,7 @@ func (r *documentVersionApprovalDecisionResolver) Quorum(ctx context.Context, ob
 		return nil, err
 	}
 
-	prb := r.probo
-
-	quorum, err := prb.DocumentApprovals.GetQuorum(ctx, scope, obj.Quorum.ID)
+	quorum, err := r.probo.DocumentApprovals.GetQuorum(ctx, scope, obj.Quorum.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -394,9 +376,7 @@ func (r *documentVersionApprovalDecisionResolver) DocumentVersion(ctx context.Co
 		return nil, err
 	}
 
-	prb := r.probo
-
-	quorum, err := prb.DocumentApprovals.GetQuorum(ctx, scope, obj.Quorum.ID)
+	quorum, err := r.probo.DocumentApprovals.GetQuorum(ctx, scope, obj.Quorum.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -407,7 +387,7 @@ func (r *documentVersionApprovalDecisionResolver) DocumentVersion(ctx context.Co
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	documentVersion, err := prb.Documents.GetVersion(ctx, scope, quorum.VersionID)
+	documentVersion, err := r.probo.Documents.GetVersion(ctx, scope, quorum.VersionID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -475,14 +455,12 @@ func (r *documentVersionApprovalDecisionConnectionResolver) TotalCount(ctx conte
 		return 0, err
 	}
 
-	prb := r.probo
-
 	filter := coredata.NewDocumentVersionApprovalDecisionFilter(nil)
 	if obj.Filters != nil {
 		filter = obj.Filters
 	}
 
-	count, err := prb.DocumentApprovals.CountDecisions(ctx, scope, obj.ParentID, filter)
+	count, err := r.probo.DocumentApprovals.CountDecisions(ctx, scope, obj.ParentID, filter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot count approval decisions", log.Error(err))
 		return 0, gqlutils.Internal(ctx)
@@ -498,9 +476,7 @@ func (r *documentVersionApprovalQuorumResolver) DocumentVersion(ctx context.Cont
 		return nil, err
 	}
 
-	prb := r.probo
-
-	documentVersion, err := prb.Documents.GetVersion(ctx, scope, obj.DocumentVersion.ID)
+	documentVersion, err := r.probo.Documents.GetVersion(ctx, scope, obj.DocumentVersion.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -520,8 +496,6 @@ func (r *documentVersionApprovalQuorumResolver) Decisions(ctx context.Context, o
 	if err != nil {
 		return nil, err
 	}
-
-	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentVersionApprovalDecisionOrderField]{
 		Field:     coredata.DocumentVersionApprovalDecisionOrderFieldCreatedAt,
@@ -543,7 +517,7 @@ func (r *documentVersionApprovalQuorumResolver) Decisions(ctx context.Context, o
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	p, err := prb.DocumentApprovals.ListDecisions(ctx, scope, obj.ID, cursor, approvalFilter)
+	p, err := r.probo.DocumentApprovals.ListDecisions(ctx, scope, obj.ID, cursor, approvalFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list approval decisions", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -564,9 +538,7 @@ func (r *documentVersionApprovalQuorumConnectionResolver) TotalCount(ctx context
 		return 0, err
 	}
 
-	prb := r.probo
-
-	count, err := prb.DocumentApprovals.CountQuorums(ctx, scope, obj.ParentID)
+	count, err := r.probo.DocumentApprovals.CountQuorums(ctx, scope, obj.ParentID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot count approval quorums", log.Error(err))
 		return 0, gqlutils.Internal(ctx)
@@ -582,8 +554,6 @@ func (r *documentVersionConnectionResolver) TotalCount(ctx context.Context, obj 
 		return 0, err
 	}
 
-	prb := r.probo
-
 	switch obj.Resolver.(type) {
 	case *documentResolver:
 		filter := &coredata.DocumentVersionFilter{}
@@ -591,7 +561,7 @@ func (r *documentVersionConnectionResolver) TotalCount(ctx context.Context, obj 
 			filter = obj.Filters
 		}
 
-		count, err := prb.Documents.CountVersionsForDocumentID(ctx, scope, obj.ParentID, filter)
+		count, err := r.probo.Documents.CountVersionsForDocumentID(ctx, scope, obj.ParentID, filter)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count document versions", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -612,9 +582,7 @@ func (r *documentVersionSignatureResolver) DocumentVersion(ctx context.Context, 
 		return nil, err
 	}
 
-	prb := r.probo
-
-	documentVersion, err := prb.Documents.GetVersion(ctx, scope, obj.DocumentVersion.ID)
+	documentVersion, err := r.probo.Documents.GetVersion(ctx, scope, obj.DocumentVersion.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -662,8 +630,6 @@ func (r *documentVersionSignatureConnectionResolver) TotalCount(ctx context.Cont
 		return 0, err
 	}
 
-	prb := r.probo
-
 	switch obj.Resolver.(type) {
 	case *documentVersionResolver:
 		filter := &coredata.DocumentVersionSignatureFilter{}
@@ -671,7 +637,7 @@ func (r *documentVersionSignatureConnectionResolver) TotalCount(ctx context.Cont
 			filter = obj.Filters
 		}
 
-		count, err := prb.Documents.CountSignaturesForVersionID(ctx, scope, obj.ParentID, filter)
+		count, err := r.probo.Documents.CountSignaturesForVersionID(ctx, scope, obj.ParentID, filter)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count signatures", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -693,9 +659,7 @@ func (r *employeeDocumentResolver) Signed(ctx context.Context, obj *types.Employ
 	}
 
 	identity := authn.IdentityFromContext(ctx)
-	prb := r.probo
-
-	signed, err := prb.Documents.IsSigned(ctx, scope, obj.ID, identity.EmailAddress)
+	signed, err := r.probo.Documents.IsSigned(ctx, scope, obj.ID, identity.EmailAddress)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil
@@ -718,9 +682,7 @@ func (r *employeeDocumentResolver) ApprovalState(ctx context.Context, obj *types
 	identity := authn.IdentityFromContext(ctx)
 
 	scope := coredata.NewScopeFromObjectID(obj.ID)
-	prb := r.probo
-
-	state, err := prb.Documents.GetViewerApprovalState(ctx, scope, obj.ID, identity.ID)
+	state, err := r.probo.Documents.GetViewerApprovalState(ctx, scope, obj.ID, identity.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil
@@ -740,8 +702,6 @@ func (r *employeeDocumentResolver) Versions(ctx context.Context, obj *types.Empl
 	if err != nil {
 		return nil, err
 	}
-
-	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentVersionOrderField]{
 		Field:     coredata.DocumentVersionOrderFieldCreatedAt,
@@ -773,7 +733,7 @@ func (r *employeeDocumentResolver) Versions(ctx context.Context, obj *types.Empl
 	versionFilter := coredata.NewDocumentVersionFilter().
 		WithEmployeeIdentityID(&identity.ID, filterMode)
 
-	versionsPage, err := prb.Documents.ListVersions(ctx, scope, obj.ID, cursor, versionFilter)
+	versionsPage, err := r.probo.Documents.ListVersions(ctx, scope, obj.ID, cursor, versionFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list employee document versions", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -809,9 +769,7 @@ func (r *employeeDocumentVersionResolver) Signed(ctx context.Context, obj *types
 	}
 
 	identity := authn.IdentityFromContext(ctx)
-	prb := r.probo
-
-	signed, err := prb.Documents.IsVersionSignedByUserEmail(ctx, scope, obj.ID, identity.EmailAddress)
+	signed, err := r.probo.Documents.IsVersionSignedByUserEmail(ctx, scope, obj.ID, identity.EmailAddress)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot check if version is signed", log.Error(err))
 		return false, gqlutils.Internal(ctx)
@@ -828,9 +786,7 @@ func (r *employeeDocumentVersionResolver) ApprovalDecision(ctx context.Context, 
 
 	identity := authn.IdentityFromContext(ctx)
 	scope := coredata.NewScopeFromObjectID(obj.ID)
-	prb := r.probo
-
-	decision, err := prb.DocumentApprovals.GetViewerDecision(ctx, scope, obj.ID, identity.ID)
+	decision, err := r.probo.DocumentApprovals.GetViewerDecision(ctx, scope, obj.ID, identity.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil
@@ -851,14 +807,12 @@ func (r *mutationResolver) CreateDocument(ctx context.Context, input types.Creat
 		return nil, err
 	}
 
-	prb := r.probo
-
 	var content string
 	if input.Content != nil {
 		content = *input.Content
 	}
 
-	document, documentVersion, err := prb.Documents.Create(
+	document, documentVersion, err := r.probo.Documents.Create(
 		ctx, scope,
 		probo.CreateDocumentRequest{
 			OrganizationID:        input.OrganizationID,
@@ -897,14 +851,12 @@ func (r *mutationResolver) UpdateDocument(ctx context.Context, input types.Updat
 		return nil, err
 	}
 
-	prb := r.probo
-
 	var defaultApproverIDs *[]gid.GID
 	if input.DefaultApproverIds != nil {
 		defaultApproverIDs = &input.DefaultApproverIds
 	}
 
-	document, documentVersion, draftCreated, err := prb.Documents.Update(
+	document, documentVersion, draftCreated, err := r.probo.Documents.Update(
 		ctx, scope,
 		probo.UpdateDocumentRequest{
 			DocumentID:            input.ID,
@@ -963,9 +915,7 @@ func (r *mutationResolver) DeleteDocumentDraft(ctx context.Context, input types.
 		return nil, err
 	}
 
-	prb := r.probo
-
-	document, err := prb.Documents.DeleteDraft(ctx, scope, input.DocumentID)
+	document, err := r.probo.Documents.DeleteDraft(ctx, scope, input.DocumentID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -996,9 +946,7 @@ func (r *mutationResolver) ArchiveDocument(ctx context.Context, input types.Arch
 		return nil, err
 	}
 
-	prb := r.probo
-
-	document, err := prb.Documents.Archive(ctx, scope, input.DocumentID)
+	document, err := r.probo.Documents.Archive(ctx, scope, input.DocumentID)
 	if err != nil {
 		if errArchived, ok := errors.AsType[*probo.ErrDocumentArchived](err); ok {
 			return nil, gqlutils.Conflict(ctx, errArchived)
@@ -1021,9 +969,7 @@ func (r *mutationResolver) UnarchiveDocument(ctx context.Context, input types.Un
 		return nil, err
 	}
 
-	prb := r.probo
-
-	document, err := prb.Documents.Unarchive(ctx, scope, input.DocumentID)
+	document, err := r.probo.Documents.Unarchive(ctx, scope, input.DocumentID)
 	if err != nil {
 		if errNotArchived, ok := errors.AsType[*probo.ErrDocumentNotArchived](err); ok {
 			return nil, gqlutils.Conflict(ctx, errNotArchived)
@@ -1046,9 +992,7 @@ func (r *mutationResolver) DeleteDocument(ctx context.Context, input types.Delet
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.Documents.SoftDelete(ctx, scope, input.DocumentID); err != nil {
+	if err := r.probo.Documents.SoftDelete(ctx, scope, input.DocumentID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot soft delete document", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -1070,9 +1014,7 @@ func (r *mutationResolver) PublishDocument(ctx context.Context, input types.Publ
 		return nil, err
 	}
 
-	prb := r.probo
-
-	result, err := prb.Documents.PublishVersion(ctx, scope, probo.PublishDocumentRequest{
+	result, err := r.probo.Documents.PublishVersion(ctx, scope, probo.PublishDocumentRequest{
 		DocumentID:  input.DocumentID,
 		Minor:       input.Minor,
 		ApproverIDs: input.ApproverIds,
@@ -1135,9 +1077,7 @@ func (r *mutationResolver) BulkPublishDocuments(ctx context.Context, input types
 	}
 
 	scope := coredata.NewScopeFromObjectID(input.DocumentIds[0])
-	prb := r.probo
-
-	versions, documents, err := prb.DocumentApprovals.BulkPublishVersions(ctx, scope, probo.BulkPublishVersionsRequest{
+	versions, documents, err := r.probo.DocumentApprovals.BulkPublishVersions(ctx, scope, probo.BulkPublishVersionsRequest{
 		DocumentIDs: input.DocumentIds,
 		Minor:       input.Minor,
 		Changelog:   input.Changelog,
@@ -1183,9 +1123,7 @@ func (r *mutationResolver) VoidDocumentVersionApproval(ctx context.Context, inpu
 		return nil, err
 	}
 
-	prb := r.probo
-
-	quorum, documentVersion, err := prb.DocumentApprovals.VoidApproval(ctx, scope, input.DocumentVersionID)
+	quorum, documentVersion, err := r.probo.DocumentApprovals.VoidApproval(ctx, scope, input.DocumentVersionID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -1225,9 +1163,7 @@ func (r *mutationResolver) BulkDeleteDocuments(ctx context.Context, input types.
 	}
 
 	scope := coredata.NewScopeFromObjectID(input.DocumentIds[0])
-	prb := r.probo
-
-	if err := prb.Documents.BulkSoftDelete(ctx, scope, input.DocumentIds); err != nil {
+	if err := r.probo.Documents.BulkSoftDelete(ctx, scope, input.DocumentIds); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot bulk delete documents", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -1252,9 +1188,7 @@ func (r *mutationResolver) BulkArchiveDocuments(ctx context.Context, input types
 	}
 
 	scope := coredata.NewScopeFromObjectID(input.DocumentIds[0])
-	prb := r.probo
-
-	if err := prb.Documents.BulkArchive(ctx, scope, input.DocumentIds); err != nil {
+	if err := r.probo.Documents.BulkArchive(ctx, scope, input.DocumentIds); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot bulk archive documents", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -1279,9 +1213,7 @@ func (r *mutationResolver) BulkUnarchiveDocuments(ctx context.Context, input typ
 	}
 
 	scope := coredata.NewScopeFromObjectID(input.DocumentIds[0])
-	prb := r.probo
-
-	if err := prb.Documents.BulkUnarchive(ctx, scope, input.DocumentIds); err != nil {
+	if err := r.probo.Documents.BulkUnarchive(ctx, scope, input.DocumentIds); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot bulk unarchive documents", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -1306,8 +1238,6 @@ func (r *mutationResolver) BulkExportDocuments(ctx context.Context, input types.
 	}
 
 	scope := coredata.NewScopeFromObjectID(input.DocumentIds[0])
-	prb := r.probo
-
 	identity := authn.IdentityFromContext(ctx)
 
 	options := probo.ExportPDFOptions{
@@ -1316,7 +1246,7 @@ func (r *mutationResolver) BulkExportDocuments(ctx context.Context, input types.
 		WatermarkEmail: input.WatermarkEmail,
 	}
 
-	documentExport, exportErr := prb.Documents.RequestExport(ctx, scope, input.DocumentIds, identity.EmailAddress, identity.FullName, options)
+	documentExport, exportErr := r.probo.Documents.RequestExport(ctx, scope, input.DocumentIds, identity.EmailAddress, identity.FullName, options)
 	if exportErr != nil {
 		r.logger.ErrorCtx(ctx, "cannot request document export", log.Error(exportErr))
 		return nil, gqlutils.Internal(ctx)
@@ -1334,9 +1264,7 @@ func (r *mutationResolver) GenerateDocumentChangelog(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.probo
-
-	changelog, err := prb.Documents.GenerateChangelog(ctx, scope, input.DocumentID)
+	changelog, err := r.probo.Documents.GenerateChangelog(ctx, scope, input.DocumentID)
 	if err != nil {
 		if errArchived, ok := errors.AsType[*probo.ErrDocumentArchived](err); ok {
 			return nil, gqlutils.Conflict(ctx, errArchived)
@@ -1359,9 +1287,7 @@ func (r *mutationResolver) RequestSignature(ctx context.Context, input types.Req
 		return nil, err
 	}
 
-	prb := r.probo
-
-	documentVersionSignature, err := prb.Documents.RequestSignature(
+	documentVersionSignature, err := r.probo.Documents.RequestSignature(
 		ctx, scope,
 		probo.RequestSignatureRequest{
 			DocumentVersionID: input.DocumentVersionID,
@@ -1410,9 +1336,7 @@ func (r *mutationResolver) BulkRequestSignatures(ctx context.Context, input type
 	}
 
 	scope := coredata.NewScopeFromObjectID(input.DocumentIds[0])
-	prb := r.probo
-
-	documentVersionSignatures, err := prb.Documents.BulkRequestSignatures(
+	documentVersionSignatures, err := r.probo.Documents.BulkRequestSignatures(
 		ctx, scope,
 		probo.BulkRequestSignaturesRequest{
 			DocumentIDs:  input.DocumentIds,
@@ -1449,9 +1373,7 @@ func (r *mutationResolver) SendSigningNotifications(ctx context.Context, input t
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.Documents.SendSigningNotifications(ctx, scope, input.OrganizationID); err != nil {
+	if err := r.probo.Documents.SendSigningNotifications(ctx, scope, input.OrganizationID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot send signing notifications", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -1468,9 +1390,7 @@ func (r *mutationResolver) CancelSignatureRequest(ctx context.Context, input typ
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.Documents.CancelSignatureRequest(ctx, scope, input.DocumentVersionSignatureID); err != nil {
+	if err := r.probo.Documents.CancelSignatureRequest(ctx, scope, input.DocumentVersionSignatureID); err != nil {
 		if errArchived, ok := errors.AsType[*probo.ErrDocumentArchived](err); ok {
 			return nil, gqlutils.Conflict(ctx, errArchived)
 		}
@@ -1493,9 +1413,7 @@ func (r *mutationResolver) SignDocument(ctx context.Context, input types.SignDoc
 	}
 
 	identity := authn.IdentityFromContext(ctx)
-	prb := r.probo
-
-	documentVersionSignature, err := prb.Documents.SignDocumentVersionByIdentity(ctx, scope, input.DocumentVersionID, identity.ID)
+	documentVersionSignature, err := r.probo.Documents.SignDocumentVersionByIdentity(ctx, scope, input.DocumentVersionID, identity.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -1526,9 +1444,7 @@ func (r *mutationResolver) ApproveDocumentVersion(ctx context.Context, input typ
 		signerIP = httpReq.RemoteAddr
 	}
 
-	prb := r.probo
-
-	decision, err := prb.DocumentApprovals.Approve(ctx, scope, probo.ApproveDocumentVersionRequest{
+	decision, err := r.probo.DocumentApprovals.Approve(ctx, scope, probo.ApproveDocumentVersionRequest{
 		DocumentVersionID: input.DocumentVersionID,
 		IdentityID:        identity.ID,
 		Comment:           input.Comment,
@@ -1572,9 +1488,7 @@ func (r *mutationResolver) RejectDocumentVersion(ctx context.Context, input type
 	}
 
 	identity := authn.IdentityFromContext(ctx)
-	prb := r.probo
-
-	decision, err := prb.DocumentApprovals.Reject(ctx, scope, probo.RejectDocumentVersionRequest{
+	decision, err := r.probo.DocumentApprovals.Reject(ctx, scope, probo.RejectDocumentVersionRequest{
 		DocumentVersionID: input.DocumentVersionID,
 		IdentityID:        identity.ID,
 		Comment:           input.Comment,
@@ -1613,8 +1527,6 @@ func (r *mutationResolver) ExportDocumentVersionPDF(ctx context.Context, input t
 		return nil, err
 	}
 
-	prb := r.probo
-
 	watermarkEmail := input.WatermarkEmail
 	if input.WithWatermark && watermarkEmail == nil {
 		identity := authn.IdentityFromContext(ctx)
@@ -1627,7 +1539,7 @@ func (r *mutationResolver) ExportDocumentVersionPDF(ctx context.Context, input t
 		WatermarkEmail: watermarkEmail,
 	}
 
-	pdf, err := prb.Documents.ExportPDF(ctx, scope, input.DocumentVersionID, options)
+	pdf, err := r.probo.Documents.ExportPDF(ctx, scope, input.DocumentVersionID, options)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot export document version PDF", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1645,9 +1557,7 @@ func (r *mutationResolver) ExportEmployeeDocumentVersionPDF(ctx context.Context,
 		return nil, err
 	}
 
-	prb := r.probo
-
-	documentVersion, err := prb.Documents.GetVersion(ctx, scope, input.DocumentVersionID)
+	documentVersion, err := r.probo.Documents.GetVersion(ctx, scope, input.DocumentVersionID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get document version", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1660,7 +1570,7 @@ func (r *mutationResolver) ExportEmployeeDocumentVersionPDF(ctx context.Context,
 		coredata.EmployeeFilterModeApproval,
 	)
 
-	_, err = prb.Documents.GetWithFilter(ctx, scope, documentVersion.DocumentID, documentFilter)
+	_, err = r.probo.Documents.GetWithFilter(ctx, scope, documentVersion.DocumentID, documentFilter)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -1677,7 +1587,7 @@ func (r *mutationResolver) ExportEmployeeDocumentVersionPDF(ctx context.Context,
 		WatermarkEmail: &identity.EmailAddress,
 	}
 
-	pdf, err := prb.Documents.ExportPDF(ctx, scope, input.DocumentVersionID, options)
+	pdf, err := r.probo.Documents.ExportPDF(ctx, scope, input.DocumentVersionID, options)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot export employee document PDF", log.Error(err))
 		return nil, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/document_resolvers.go
+++ b/pkg/server/api/console/v1/document_resolvers.go
@@ -60,6 +60,7 @@ func (r *documentResolver) Versions(ctx context.Context, obj *types.Document, fi
 		Field:     coredata.DocumentVersionOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.DocumentVersionOrderField]{
 			Field:     orderBy.Field,
@@ -94,6 +95,7 @@ func (r *documentResolver) Controls(ctx context.Context, obj *types.Document, fi
 		Field:     coredata.ControlOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ControlOrderField]{
 			Field:     orderBy.Field,
@@ -230,6 +232,7 @@ func (r *documentVersionResolver) Approvers(ctx context.Context, obj *types.Docu
 		Field:     coredata.MembershipProfileOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy.Field = coredata.MembershipProfileOrderField(orderBy.Field)
 		pageOrderBy.Direction = page.OrderDirection(orderBy.Direction)
@@ -257,6 +260,7 @@ func (r *documentVersionResolver) Signatures(ctx context.Context, obj *types.Doc
 		Field:     coredata.DocumentVersionSignatureOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.DocumentVersionSignatureOrderField]{
 			Field:     orderBy.Field,
@@ -308,6 +312,7 @@ func (r *documentVersionResolver) ApprovalQuorums(ctx context.Context, obj *type
 		Field:     coredata.DocumentVersionApprovalQuorumOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.DocumentVersionApprovalQuorumOrderField]{
 			Field:     orderBy.Field,
@@ -334,6 +339,7 @@ func (r *documentVersionResolver) Signed(ctx context.Context, obj *types.Documen
 	}
 
 	identity := authn.IdentityFromContext(ctx)
+
 	signed, err := r.probo.Documents.IsVersionSignedByUserEmail(ctx, scope, obj.ID, identity.EmailAddress)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot check if document version is signed", log.Error(err))
@@ -501,6 +507,7 @@ func (r *documentVersionApprovalQuorumResolver) Decisions(ctx context.Context, o
 		Field:     coredata.DocumentVersionApprovalDecisionOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.DocumentVersionApprovalDecisionOrderField]{
 			Field:     orderBy.Field,
@@ -659,6 +666,7 @@ func (r *employeeDocumentResolver) Signed(ctx context.Context, obj *types.Employ
 	}
 
 	identity := authn.IdentityFromContext(ctx)
+
 	signed, err := r.probo.Documents.IsSigned(ctx, scope, obj.ID, identity.EmailAddress)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
@@ -682,6 +690,7 @@ func (r *employeeDocumentResolver) ApprovalState(ctx context.Context, obj *types
 	identity := authn.IdentityFromContext(ctx)
 
 	scope := coredata.NewScopeFromObjectID(obj.ID)
+
 	state, err := r.probo.Documents.GetViewerApprovalState(ctx, scope, obj.ID, identity.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
@@ -707,6 +716,7 @@ func (r *employeeDocumentResolver) Versions(ctx context.Context, obj *types.Empl
 		Field:     coredata.DocumentVersionOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.DocumentVersionOrderField]{
 			Field:     orderBy.Field,
@@ -769,6 +779,7 @@ func (r *employeeDocumentVersionResolver) Signed(ctx context.Context, obj *types
 	}
 
 	identity := authn.IdentityFromContext(ctx)
+
 	signed, err := r.probo.Documents.IsVersionSignedByUserEmail(ctx, scope, obj.ID, identity.EmailAddress)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot check if version is signed", log.Error(err))
@@ -786,6 +797,7 @@ func (r *employeeDocumentVersionResolver) ApprovalDecision(ctx context.Context, 
 
 	identity := authn.IdentityFromContext(ctx)
 	scope := coredata.NewScopeFromObjectID(obj.ID)
+
 	decision, err := r.probo.DocumentApprovals.GetViewerDecision(ctx, scope, obj.ID, identity.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
@@ -1054,6 +1066,7 @@ func (r *mutationResolver) PublishDocument(ctx context.Context, input types.Publ
 		Document:        types.NewDocument(result.Document),
 		DocumentVersion: types.NewDocumentVersion(result.Version),
 	}
+
 	if result.Quorum != nil {
 		payload.ApprovalQuorum = types.NewDocumentVersionApprovalQuorum(result.Quorum)
 	}
@@ -1077,6 +1090,7 @@ func (r *mutationResolver) BulkPublishDocuments(ctx context.Context, input types
 	}
 
 	scope := coredata.NewScopeFromObjectID(input.DocumentIds[0])
+
 	versions, documents, err := r.probo.DocumentApprovals.BulkPublishVersions(ctx, scope, probo.BulkPublishVersionsRequest{
 		DocumentIDs: input.DocumentIds,
 		Minor:       input.Minor,
@@ -1336,6 +1350,7 @@ func (r *mutationResolver) BulkRequestSignatures(ctx context.Context, input type
 	}
 
 	scope := coredata.NewScopeFromObjectID(input.DocumentIds[0])
+
 	documentVersionSignatures, err := r.probo.Documents.BulkRequestSignatures(
 		ctx, scope,
 		probo.BulkRequestSignaturesRequest{
@@ -1413,6 +1428,7 @@ func (r *mutationResolver) SignDocument(ctx context.Context, input types.SignDoc
 	}
 
 	identity := authn.IdentityFromContext(ctx)
+
 	documentVersionSignature, err := r.probo.Documents.SignDocumentVersionByIdentity(ctx, scope, input.DocumentVersionID, identity.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
@@ -1488,6 +1504,7 @@ func (r *mutationResolver) RejectDocumentVersion(ctx context.Context, input type
 	}
 
 	identity := authn.IdentityFromContext(ctx)
+
 	decision, err := r.probo.DocumentApprovals.Reject(ctx, scope, probo.RejectDocumentVersionRequest{
 		DocumentVersionID: input.DocumentVersionID,
 		IdentityID:        identity.ID,

--- a/pkg/server/api/console/v1/document_resolvers.go
+++ b/pkg/server/api/console/v1/document_resolvers.go
@@ -29,7 +29,7 @@ import (
 
 // Organization is the resolver for the organization field.
 func (r *documentResolver) Organization(ctx context.Context, obj *types.Document) (*types.Organization, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
 		return nil, err
 	}
 
@@ -51,11 +51,11 @@ func (r *documentResolver) Organization(ctx context.Context, obj *types.Document
 
 // Versions is the resolver for the versions field.
 func (r *documentResolver) Versions(ctx context.Context, obj *types.Document, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentVersionOrderBy, filter *types.DocumentVersionFilter) (*types.DocumentVersionConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDocumentVersionList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionDocumentVersionList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentVersionOrderField]{
@@ -87,11 +87,11 @@ func (r *documentResolver) Versions(ctx context.Context, obj *types.Document, fi
 
 // Controls is the resolver for the controls field.
 func (r *documentResolver) Controls(ctx context.Context, obj *types.Document, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ControlOrderBy, filter *types.ControlFilter) (*types.ControlConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionControlList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionControlList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ControlOrderField]{
@@ -123,11 +123,11 @@ func (r *documentResolver) Controls(ctx context.Context, obj *types.Document, fi
 
 // DefaultApprovers is the resolver for the defaultApprovers field.
 func (r *documentResolver) DefaultApprovers(ctx context.Context, obj *types.Document) ([]*types.Profile, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDocumentGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionDocumentGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	profiles, err := prb.Documents.GetDefaultApprovers(ctx, scope, obj.ID)
@@ -151,11 +151,11 @@ func (r *documentResolver) Permission(ctx context.Context, obj *types.Document, 
 
 // TotalCount is the resolver for the totalCount field.
 func (r *documentConnectionResolver) TotalCount(ctx context.Context, obj *types.DocumentConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionDocumentList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionDocumentList)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 	prb := r.probo
 
 	switch obj.Resolver.(type) {
@@ -200,7 +200,7 @@ func (r *documentConnectionResolver) TotalCount(ctx context.Context, obj *types.
 
 // Document is the resolver for the document field.
 func (r *documentVersionResolver) Document(ctx context.Context, obj *types.DocumentVersion) (*types.Document, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDocumentGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionDocumentGet); err != nil {
 		return nil, err
 	}
 
@@ -222,7 +222,8 @@ func (r *documentVersionResolver) Document(ctx context.Context, obj *types.Docum
 
 // Approvers is the resolver for the approvers field.
 func (r *documentVersionResolver) Approvers(ctx context.Context, obj *types.DocumentVersion, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ProfileOrderBy) (*types.ProfileConnection, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileList)
+	if err != nil {
 		return nil, err
 	}
 
@@ -233,7 +234,6 @@ func (r *documentVersionResolver) Approvers(ctx context.Context, obj *types.Docu
 		}, nil
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.MembershipProfileOrderField]{
@@ -258,11 +258,11 @@ func (r *documentVersionResolver) Approvers(ctx context.Context, obj *types.Docu
 
 // Signatures is the resolver for the signatures field.
 func (r *documentVersionResolver) Signatures(ctx context.Context, obj *types.DocumentVersion, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentVersionSignatureOrder, filter *types.DocumentVersionSignatureFilter) (*types.DocumentVersionSignatureConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDocumentVersionSignatureList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionDocumentVersionSignatureList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentVersionSignatureOrderField]{
@@ -311,11 +311,11 @@ func (r *documentVersionResolver) Signatures(ctx context.Context, obj *types.Doc
 
 // ApprovalQuorums is the resolver for the approvalQuorums field.
 func (r *documentVersionResolver) ApprovalQuorums(ctx context.Context, obj *types.DocumentVersion, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentVersionApprovalQuorumOrder) (*types.DocumentVersionApprovalQuorumConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDocumentVersionApprovalList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionDocumentVersionApprovalList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentVersionApprovalQuorumOrderField]{
@@ -342,13 +342,12 @@ func (r *documentVersionResolver) ApprovalQuorums(ctx context.Context, obj *type
 
 // Signed is the resolver for the signed field.
 func (r *documentVersionResolver) Signed(ctx context.Context, obj *types.DocumentVersion) (bool, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDocumentVersionGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionDocumentVersionGet)
+	if err != nil {
 		return false, err
 	}
 
 	identity := authn.IdentityFromContext(ctx)
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	signed, err := prb.Documents.IsVersionSignedByUserEmail(ctx, scope, obj.ID, identity.EmailAddress)
@@ -367,11 +366,11 @@ func (r *documentVersionResolver) Permission(ctx context.Context, obj *types.Doc
 
 // Quorum is the resolver for the quorum field.
 func (r *documentVersionApprovalDecisionResolver) Quorum(ctx context.Context, obj *types.DocumentVersionApprovalDecision) (*types.DocumentVersionApprovalQuorum, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDocumentVersionApprovalList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionDocumentVersionApprovalList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	quorum, err := prb.DocumentApprovals.GetQuorum(ctx, scope, obj.Quorum.ID)
@@ -390,11 +389,11 @@ func (r *documentVersionApprovalDecisionResolver) Quorum(ctx context.Context, ob
 
 // DocumentVersion is the resolver for the documentVersion field.
 func (r *documentVersionApprovalDecisionResolver) DocumentVersion(ctx context.Context, obj *types.DocumentVersionApprovalDecision) (*types.DocumentVersion, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDocumentVersionGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionDocumentVersionGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	quorum, err := prb.DocumentApprovals.GetQuorum(ctx, scope, obj.Quorum.ID)
@@ -424,7 +423,7 @@ func (r *documentVersionApprovalDecisionResolver) DocumentVersion(ctx context.Co
 
 // Approver is the resolver for the approver field.
 func (r *documentVersionApprovalDecisionResolver) Approver(ctx context.Context, obj *types.DocumentVersionApprovalDecision) (*types.Profile, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileGet); err != nil {
 		return nil, err
 	}
 
@@ -471,11 +470,11 @@ func (r *documentVersionApprovalDecisionConnectionResolver) TotalCount(ctx conte
 		return 0, nil
 	}
 
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionDocumentVersionApprovalList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionDocumentVersionApprovalList)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 	prb := r.probo
 
 	filter := coredata.NewDocumentVersionApprovalDecisionFilter(nil)
@@ -494,11 +493,11 @@ func (r *documentVersionApprovalDecisionConnectionResolver) TotalCount(ctx conte
 
 // DocumentVersion is the resolver for the documentVersion field.
 func (r *documentVersionApprovalQuorumResolver) DocumentVersion(ctx context.Context, obj *types.DocumentVersionApprovalQuorum) (*types.DocumentVersion, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDocumentVersionGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionDocumentVersionGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	documentVersion, err := prb.Documents.GetVersion(ctx, scope, obj.DocumentVersion.ID)
@@ -517,11 +516,11 @@ func (r *documentVersionApprovalQuorumResolver) DocumentVersion(ctx context.Cont
 
 // Decisions is the resolver for the decisions field.
 func (r *documentVersionApprovalQuorumResolver) Decisions(ctx context.Context, obj *types.DocumentVersionApprovalQuorum, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentVersionApprovalDecisionOrder, filter *types.DocumentVersionApprovalDecisionFilter) (*types.DocumentVersionApprovalDecisionConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDocumentVersionApprovalList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionDocumentVersionApprovalList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentVersionApprovalDecisionOrderField]{
@@ -560,11 +559,11 @@ func (r *documentVersionApprovalQuorumResolver) Permission(ctx context.Context, 
 
 // TotalCount is the resolver for the totalCount field.
 func (r *documentVersionApprovalQuorumConnectionResolver) TotalCount(ctx context.Context, obj *types.DocumentVersionApprovalQuorumConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionDocumentVersionApprovalList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionDocumentVersionApprovalList)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 	prb := r.probo
 
 	count, err := prb.DocumentApprovals.CountQuorums(ctx, scope, obj.ParentID)
@@ -578,11 +577,11 @@ func (r *documentVersionApprovalQuorumConnectionResolver) TotalCount(ctx context
 
 // TotalCount is the resolver for the totalCount field.
 func (r *documentVersionConnectionResolver) TotalCount(ctx context.Context, obj *types.DocumentVersionConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionDocumentVersionList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionDocumentVersionList)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 	prb := r.probo
 
 	switch obj.Resolver.(type) {
@@ -608,11 +607,11 @@ func (r *documentVersionConnectionResolver) TotalCount(ctx context.Context, obj 
 
 // DocumentVersion is the resolver for the documentVersion field.
 func (r *documentVersionSignatureResolver) DocumentVersion(ctx context.Context, obj *types.DocumentVersionSignature) (*types.DocumentVersion, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDocumentVersionGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionDocumentVersionGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	documentVersion, err := prb.Documents.GetVersion(ctx, scope, obj.DocumentVersion.ID)
@@ -631,7 +630,7 @@ func (r *documentVersionSignatureResolver) DocumentVersion(ctx context.Context, 
 
 // SignedBy is the resolver for the signedBy field.
 func (r *documentVersionSignatureResolver) SignedBy(ctx context.Context, obj *types.DocumentVersionSignature) (*types.Profile, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileGet); err != nil {
 		return nil, err
 	}
 
@@ -658,11 +657,11 @@ func (r *documentVersionSignatureResolver) Permission(ctx context.Context, obj *
 
 // TotalCount is the resolver for the totalCount field.
 func (r *documentVersionSignatureConnectionResolver) TotalCount(ctx context.Context, obj *types.DocumentVersionSignatureConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionDocumentVersionSignatureList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionDocumentVersionSignatureList)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 	prb := r.probo
 
 	switch obj.Resolver.(type) {
@@ -688,13 +687,12 @@ func (r *documentVersionSignatureConnectionResolver) TotalCount(ctx context.Cont
 
 // Signed is the resolver for the signed field.
 func (r *employeeDocumentResolver) Signed(ctx context.Context, obj *types.EmployeeDocument) (*bool, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionEmployeeDocumentGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionEmployeeDocumentGet)
+	if err != nil {
 		return nil, err
 	}
 
 	identity := authn.IdentityFromContext(ctx)
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	signed, err := prb.Documents.IsSigned(ctx, scope, obj.ID, identity.EmailAddress)
@@ -713,7 +711,7 @@ func (r *employeeDocumentResolver) Signed(ctx context.Context, obj *types.Employ
 
 // ApprovalState is the resolver for the approvalState field.
 func (r *employeeDocumentResolver) ApprovalState(ctx context.Context, obj *types.EmployeeDocument) (*coredata.DocumentVersionApprovalDecisionState, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionEmployeeDocumentGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionEmployeeDocumentGet); err != nil {
 		return nil, err
 	}
 
@@ -738,11 +736,11 @@ func (r *employeeDocumentResolver) ApprovalState(ctx context.Context, obj *types
 
 // Versions is the resolver for the versions field.
 func (r *employeeDocumentResolver) Versions(ctx context.Context, obj *types.EmployeeDocument, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentVersionOrderBy) (*types.EmployeeDocumentVersionConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionEmployeeDocumentGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionEmployeeDocumentGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentVersionOrderField]{
@@ -805,13 +803,12 @@ func (r *employeeDocumentResolver) Versions(ctx context.Context, obj *types.Empl
 
 // Signed is the resolver for the signed field.
 func (r *employeeDocumentVersionResolver) Signed(ctx context.Context, obj *types.EmployeeDocumentVersion) (bool, error) {
-	if err := r.authorize(ctx, obj.DocumentID, probo.ActionEmployeeDocumentGet); err != nil {
+	scope, err := r.authorize(ctx, obj.DocumentID, probo.ActionEmployeeDocumentGet)
+	if err != nil {
 		return false, err
 	}
 
 	identity := authn.IdentityFromContext(ctx)
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	signed, err := prb.Documents.IsVersionSignedByUserEmail(ctx, scope, obj.ID, identity.EmailAddress)
@@ -825,7 +822,7 @@ func (r *employeeDocumentVersionResolver) Signed(ctx context.Context, obj *types
 
 // ApprovalDecision is the resolver for the approvalDecision field.
 func (r *employeeDocumentVersionResolver) ApprovalDecision(ctx context.Context, obj *types.EmployeeDocumentVersion) (*types.DocumentVersionApprovalDecision, error) {
-	if err := r.authorize(ctx, obj.DocumentID, probo.ActionEmployeeDocumentGet); err != nil {
+	if _, err := r.authorize(ctx, obj.DocumentID, probo.ActionEmployeeDocumentGet); err != nil {
 		return nil, err
 	}
 
@@ -849,11 +846,11 @@ func (r *employeeDocumentVersionResolver) ApprovalDecision(ctx context.Context, 
 
 // CreateDocument is the resolver for the createDocument field.
 func (r *mutationResolver) CreateDocument(ctx context.Context, input types.CreateDocumentInput) (*types.CreateDocumentPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionDocumentCreate); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionDocumentCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	var content string
@@ -895,11 +892,11 @@ func (r *mutationResolver) CreateDocument(ctx context.Context, input types.Creat
 
 // UpdateDocument is the resolver for the updateDocument field.
 func (r *mutationResolver) UpdateDocument(ctx context.Context, input types.UpdateDocumentInput) (*types.UpdateDocumentPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionDocumentUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionDocumentUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
 	var defaultApproverIDs *[]gid.GID
@@ -961,11 +958,11 @@ func (r *mutationResolver) UpdateDocument(ctx context.Context, input types.Updat
 
 // DeleteDocumentDraft is the resolver for the deleteDocumentDraft field.
 func (r *mutationResolver) DeleteDocumentDraft(ctx context.Context, input types.DeleteDocumentDraftInput) (*types.DeleteDocumentDraftPayload, error) {
-	if err := r.authorize(ctx, input.DocumentID, probo.ActionDocumentDeleteDraft); err != nil {
+	scope, err := r.authorize(ctx, input.DocumentID, probo.ActionDocumentDeleteDraft)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.DocumentID)
 	prb := r.probo
 
 	document, err := prb.Documents.DeleteDraft(ctx, scope, input.DocumentID)
@@ -994,11 +991,11 @@ func (r *mutationResolver) DeleteDocumentDraft(ctx context.Context, input types.
 
 // ArchiveDocument is the resolver for the archiveDocument field.
 func (r *mutationResolver) ArchiveDocument(ctx context.Context, input types.ArchiveDocumentInput) (*types.ArchiveDocumentPayload, error) {
-	if err := r.authorize(ctx, input.DocumentID, probo.ActionDocumentArchive); err != nil {
+	scope, err := r.authorize(ctx, input.DocumentID, probo.ActionDocumentArchive)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.DocumentID)
 	prb := r.probo
 
 	document, err := prb.Documents.Archive(ctx, scope, input.DocumentID)
@@ -1019,11 +1016,11 @@ func (r *mutationResolver) ArchiveDocument(ctx context.Context, input types.Arch
 
 // UnarchiveDocument is the resolver for the unarchiveDocument field.
 func (r *mutationResolver) UnarchiveDocument(ctx context.Context, input types.UnarchiveDocumentInput) (*types.UnarchiveDocumentPayload, error) {
-	if err := r.authorize(ctx, input.DocumentID, probo.ActionDocumentUnarchive); err != nil {
+	scope, err := r.authorize(ctx, input.DocumentID, probo.ActionDocumentUnarchive)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.DocumentID)
 	prb := r.probo
 
 	document, err := prb.Documents.Unarchive(ctx, scope, input.DocumentID)
@@ -1044,15 +1041,14 @@ func (r *mutationResolver) UnarchiveDocument(ctx context.Context, input types.Un
 
 // DeleteDocument is the resolver for the deleteDocument field.
 func (r *mutationResolver) DeleteDocument(ctx context.Context, input types.DeleteDocumentInput) (*types.DeleteDocumentPayload, error) {
-	if err := r.authorize(ctx, input.DocumentID, probo.ActionDocumentDelete); err != nil {
+	scope, err := r.authorize(ctx, input.DocumentID, probo.ActionDocumentDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.DocumentID)
 	prb := r.probo
 
-	err := prb.Documents.SoftDelete(ctx, scope, input.DocumentID)
-	if err != nil {
+	if err := prb.Documents.SoftDelete(ctx, scope, input.DocumentID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot soft delete document", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -1069,11 +1065,11 @@ func (r *mutationResolver) PublishDocument(ctx context.Context, input types.Publ
 		action = probo.ActionDocumentVersionRequestApproval
 	}
 
-	if err := r.authorize(ctx, input.DocumentID, action); err != nil {
+	scope, err := r.authorize(ctx, input.DocumentID, action)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.DocumentID)
 	prb := r.probo
 
 	result, err := prb.Documents.PublishVersion(ctx, scope, probo.PublishDocumentRequest{
@@ -1133,7 +1129,7 @@ func (r *mutationResolver) BulkPublishDocuments(ctx context.Context, input types
 	}
 
 	for _, documentID := range input.DocumentIds {
-		if err := r.authorize(ctx, documentID, probo.ActionDocumentVersionPublish); err != nil {
+		if _, err := r.authorize(ctx, documentID, probo.ActionDocumentVersionPublish); err != nil {
 			return nil, err
 		}
 	}
@@ -1182,11 +1178,11 @@ func (r *mutationResolver) BulkPublishDocuments(ctx context.Context, input types
 
 // VoidDocumentVersionApproval is the resolver for the voidDocumentVersionApproval field.
 func (r *mutationResolver) VoidDocumentVersionApproval(ctx context.Context, input types.VoidDocumentVersionApprovalInput) (*types.VoidDocumentVersionApprovalPayload, error) {
-	if err := r.authorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionVoidApproval); err != nil {
+	scope, err := r.authorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionVoidApproval)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.DocumentVersionID)
 	prb := r.probo
 
 	quorum, documentVersion, err := prb.DocumentApprovals.VoidApproval(ctx, scope, input.DocumentVersionID)
@@ -1223,7 +1219,7 @@ func (r *mutationResolver) BulkDeleteDocuments(ctx context.Context, input types.
 	}
 
 	for _, documentID := range input.DocumentIds {
-		if err := r.authorize(ctx, documentID, probo.ActionDocumentDelete); err != nil {
+		if _, err := r.authorize(ctx, documentID, probo.ActionDocumentDelete); err != nil {
 			return nil, err
 		}
 	}
@@ -1231,8 +1227,7 @@ func (r *mutationResolver) BulkDeleteDocuments(ctx context.Context, input types.
 	scope := coredata.NewScopeFromObjectID(input.DocumentIds[0])
 	prb := r.probo
 
-	err := prb.Documents.BulkSoftDelete(ctx, scope, input.DocumentIds)
-	if err != nil {
+	if err := prb.Documents.BulkSoftDelete(ctx, scope, input.DocumentIds); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot bulk delete documents", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -1251,7 +1246,7 @@ func (r *mutationResolver) BulkArchiveDocuments(ctx context.Context, input types
 	}
 
 	for _, documentID := range input.DocumentIds {
-		if err := r.authorize(ctx, documentID, probo.ActionDocumentArchive); err != nil {
+		if _, err := r.authorize(ctx, documentID, probo.ActionDocumentArchive); err != nil {
 			return nil, err
 		}
 	}
@@ -1278,7 +1273,7 @@ func (r *mutationResolver) BulkUnarchiveDocuments(ctx context.Context, input typ
 	}
 
 	for _, documentID := range input.DocumentIds {
-		if err := r.authorize(ctx, documentID, probo.ActionDocumentUnarchive); err != nil {
+		if _, err := r.authorize(ctx, documentID, probo.ActionDocumentUnarchive); err != nil {
 			return nil, err
 		}
 	}
@@ -1305,7 +1300,7 @@ func (r *mutationResolver) BulkExportDocuments(ctx context.Context, input types.
 
 	// TODO have a way to batch authorize for resources
 	for _, documentID := range input.DocumentIds {
-		if err := r.authorize(ctx, documentID, probo.ActionDocumentVersionExport); err != nil {
+		if _, err := r.authorize(ctx, documentID, probo.ActionDocumentVersionExport); err != nil {
 			return nil, err
 		}
 	}
@@ -1334,11 +1329,11 @@ func (r *mutationResolver) BulkExportDocuments(ctx context.Context, input types.
 
 // GenerateDocumentChangelog is the resolver for the generateDocumentChangelog field.
 func (r *mutationResolver) GenerateDocumentChangelog(ctx context.Context, input types.GenerateDocumentChangelogInput) (*types.GenerateDocumentChangelogPayload, error) {
-	if err := r.authorize(ctx, input.DocumentID, probo.ActionDocumentChangelogGenerate); err != nil {
+	scope, err := r.authorize(ctx, input.DocumentID, probo.ActionDocumentChangelogGenerate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.DocumentID)
 	prb := r.probo
 
 	changelog, err := prb.Documents.GenerateChangelog(ctx, scope, input.DocumentID)
@@ -1359,11 +1354,11 @@ func (r *mutationResolver) GenerateDocumentChangelog(ctx context.Context, input 
 
 // RequestSignature is the resolver for the requestSignature field.
 func (r *mutationResolver) RequestSignature(ctx context.Context, input types.RequestSignatureInput) (*types.RequestSignaturePayload, error) {
-	if err := r.authorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionSignatureRequest); err != nil {
+	scope, err := r.authorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionSignatureRequest)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.DocumentVersionID)
 	prb := r.probo
 
 	documentVersionSignature, err := prb.Documents.RequestSignature(
@@ -1409,7 +1404,7 @@ func (r *mutationResolver) BulkRequestSignatures(ctx context.Context, input type
 	}
 
 	for _, documentID := range input.DocumentIds {
-		if err := r.authorize(ctx, documentID, probo.ActionDocumentVersionSignatureRequest); err != nil {
+		if _, err := r.authorize(ctx, documentID, probo.ActionDocumentVersionSignatureRequest); err != nil {
 			return nil, err
 		}
 	}
@@ -1449,15 +1444,14 @@ func (r *mutationResolver) BulkRequestSignatures(ctx context.Context, input type
 
 // SendSigningNotifications is the resolver for the sendSigningNotifications field.
 func (r *mutationResolver) SendSigningNotifications(ctx context.Context, input types.SendSigningNotificationsInput) (*types.SendSigningNotificationsPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionDocumentSendSigningNotifications); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionDocumentSendSigningNotifications)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
-	err := prb.Documents.SendSigningNotifications(ctx, scope, input.OrganizationID)
-	if err != nil {
+	if err := prb.Documents.SendSigningNotifications(ctx, scope, input.OrganizationID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot send signing notifications", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -1469,15 +1463,14 @@ func (r *mutationResolver) SendSigningNotifications(ctx context.Context, input t
 
 // CancelSignatureRequest is the resolver for the cancelSignatureRequest field.
 func (r *mutationResolver) CancelSignatureRequest(ctx context.Context, input types.CancelSignatureRequestInput) (*types.CancelSignatureRequestPayload, error) {
-	if err := r.authorize(ctx, input.DocumentVersionSignatureID, probo.ActionDocumentVersionCancelSignature); err != nil {
+	scope, err := r.authorize(ctx, input.DocumentVersionSignatureID, probo.ActionDocumentVersionCancelSignature)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.DocumentVersionSignatureID)
 	prb := r.probo
 
-	err := prb.Documents.CancelSignatureRequest(ctx, scope, input.DocumentVersionSignatureID)
-	if err != nil {
+	if err := prb.Documents.CancelSignatureRequest(ctx, scope, input.DocumentVersionSignatureID); err != nil {
 		if errArchived, ok := errors.AsType[*probo.ErrDocumentArchived](err); ok {
 			return nil, gqlutils.Conflict(ctx, errArchived)
 		}
@@ -1494,12 +1487,12 @@ func (r *mutationResolver) CancelSignatureRequest(ctx context.Context, input typ
 
 // SignDocument is the resolver for the signDocument field.
 func (r *mutationResolver) SignDocument(ctx context.Context, input types.SignDocumentInput) (*types.SignDocumentPayload, error) {
-	if err := r.authorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionSign); err != nil {
+	scope, err := r.authorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionSign)
+	if err != nil {
 		return nil, err
 	}
 
 	identity := authn.IdentityFromContext(ctx)
-	scope := coredata.NewScopeFromObjectID(input.DocumentVersionID)
 	prb := r.probo
 
 	documentVersionSignature, err := prb.Documents.SignDocumentVersionByIdentity(ctx, scope, input.DocumentVersionID, identity.ID)
@@ -1520,7 +1513,8 @@ func (r *mutationResolver) SignDocument(ctx context.Context, input types.SignDoc
 
 // ApproveDocumentVersion is the resolver for the approveDocumentVersion field.
 func (r *mutationResolver) ApproveDocumentVersion(ctx context.Context, input types.ApproveDocumentVersionInput) (*types.ApproveDocumentVersionPayload, error) {
-	if err := r.authorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionApprove); err != nil {
+	scope, err := r.authorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionApprove)
+	if err != nil {
 		return nil, err
 	}
 
@@ -1532,7 +1526,6 @@ func (r *mutationResolver) ApproveDocumentVersion(ctx context.Context, input typ
 		signerIP = httpReq.RemoteAddr
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.DocumentVersionID)
 	prb := r.probo
 
 	decision, err := prb.DocumentApprovals.Approve(ctx, scope, probo.ApproveDocumentVersionRequest{
@@ -1573,13 +1566,12 @@ func (r *mutationResolver) ApproveDocumentVersion(ctx context.Context, input typ
 
 // RejectDocumentVersion is the resolver for the rejectDocumentVersion field.
 func (r *mutationResolver) RejectDocumentVersion(ctx context.Context, input types.RejectDocumentVersionInput) (*types.RejectDocumentVersionPayload, error) {
-	if err := r.authorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionReject); err != nil {
+	scope, err := r.authorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionReject)
+	if err != nil {
 		return nil, err
 	}
 
 	identity := authn.IdentityFromContext(ctx)
-
-	scope := coredata.NewScopeFromObjectID(input.DocumentVersionID)
 	prb := r.probo
 
 	decision, err := prb.DocumentApprovals.Reject(ctx, scope, probo.RejectDocumentVersionRequest{
@@ -1616,11 +1608,11 @@ func (r *mutationResolver) RejectDocumentVersion(ctx context.Context, input type
 
 // ExportDocumentVersionPDF is the resolver for the exportDocumentVersionPDF field.
 func (r *mutationResolver) ExportDocumentVersionPDF(ctx context.Context, input types.ExportDocumentVersionPDFInput) (*types.ExportDocumentVersionPDFPayload, error) {
-	if err := r.authorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionExportPDF); err != nil {
+	scope, err := r.authorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionExportPDF)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.DocumentVersionID)
 	prb := r.probo
 
 	watermarkEmail := input.WatermarkEmail
@@ -1648,11 +1640,11 @@ func (r *mutationResolver) ExportDocumentVersionPDF(ctx context.Context, input t
 
 // ExportEmployeeDocumentVersionPDF is the resolver for the exportEmployeeDocumentVersionPDF field.
 func (r *mutationResolver) ExportEmployeeDocumentVersionPDF(ctx context.Context, input types.ExportEmployeeDocumentVersionPDFInput) (*types.ExportEmployeeDocumentVersionPDFPayload, error) {
-	if err := r.authorize(ctx, input.DocumentVersionID, probo.ActionEmployeeDocumentVersionExportPDF); err != nil {
+	scope, err := r.authorize(ctx, input.DocumentVersionID, probo.ActionEmployeeDocumentVersionExportPDF)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.DocumentVersionID)
 	prb := r.probo
 
 	documentVersion, err := prb.Documents.GetVersion(ctx, scope, input.DocumentVersionID)

--- a/pkg/server/api/console/v1/electronic_signature_resolvers.go
+++ b/pkg/server/api/console/v1/electronic_signature_resolvers.go
@@ -10,12 +10,17 @@ import (
 	"fmt"
 	"time"
 
+	"go.probo.inc/probo/pkg/probo"
 	"go.probo.inc/probo/pkg/server/api/console/v1/schema"
 	"go.probo.inc/probo/pkg/server/api/console/v1/types"
 )
 
 // CertificateFileURL is the resolver for the certificateFileUrl field.
 func (r *electronicSignatureResolver) CertificateFileURL(ctx context.Context, obj *types.ElectronicSignature) (*string, error) {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionElectronicSignatureGet); err != nil {
+		return nil, err
+	}
+
 	signature, err := r.esign.GetSignatureByID(ctx, obj.ID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot load signature: %w", err)
@@ -35,6 +40,10 @@ func (r *electronicSignatureResolver) CertificateFileURL(ctx context.Context, ob
 
 // Events is the resolver for the events field.
 func (r *electronicSignatureResolver) Events(ctx context.Context, obj *types.ElectronicSignature) ([]*types.ElectronicSignatureEvent, error) {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionElectronicSignatureGet); err != nil {
+		return nil, err
+	}
+
 	events, err := r.esign.GetEventsBySignatureID(ctx, obj.ID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot load signature events: %w", err)

--- a/pkg/server/api/console/v1/evidence_resolvers.go
+++ b/pkg/server/api/console/v1/evidence_resolvers.go
@@ -22,7 +22,7 @@ import (
 
 // File is the resolver for the file field.
 func (r *evidenceResolver) File(ctx context.Context, obj *types.Evidence) (*types.File, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionFileGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionFileGet); err != nil {
 		return nil, err
 	}
 
@@ -48,7 +48,7 @@ func (r *evidenceResolver) File(ctx context.Context, obj *types.Evidence) (*type
 
 // Task is the resolver for the task field.
 func (r *evidenceResolver) Task(ctx context.Context, obj *types.Evidence) (*types.Task, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionTaskGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionTaskGet); err != nil {
 		return nil, err
 	}
 
@@ -75,7 +75,7 @@ func (r *evidenceResolver) Task(ctx context.Context, obj *types.Evidence) (*type
 
 // Measure is the resolver for the measure field.
 func (r *evidenceResolver) Measure(ctx context.Context, obj *types.Evidence) (*types.Measure, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionMeasureGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionMeasureGet); err != nil {
 		return nil, err
 	}
 
@@ -102,11 +102,11 @@ func (r *evidenceResolver) Permission(ctx context.Context, obj *types.Evidence, 
 
 // TotalCount is the resolver for the totalCount field.
 func (r *evidenceConnectionResolver) TotalCount(ctx context.Context, obj *types.EvidenceConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionEvidenceList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionEvidenceList)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 	prb := r.probo
 
 	switch obj.Resolver.(type) {
@@ -135,15 +135,14 @@ func (r *evidenceConnectionResolver) TotalCount(ctx context.Context, obj *types.
 
 // DeleteEvidence is the resolver for the deleteEvidence field.
 func (r *mutationResolver) DeleteEvidence(ctx context.Context, input types.DeleteEvidenceInput) (*types.DeleteEvidencePayload, error) {
-	if err := r.authorize(ctx, input.EvidenceID, probo.ActionEvidenceDelete); err != nil {
+	scope, err := r.authorize(ctx, input.EvidenceID, probo.ActionEvidenceDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.EvidenceID)
 	prb := r.probo
 
-	err := prb.Evidences.Delete(ctx, scope, input.EvidenceID)
-	if err != nil {
+	if err := prb.Evidences.Delete(ctx, scope, input.EvidenceID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete evidence", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -155,11 +154,11 @@ func (r *mutationResolver) DeleteEvidence(ctx context.Context, input types.Delet
 
 // UploadMeasureEvidence is the resolver for the uploadMeasureEvidence field.
 func (r *mutationResolver) UploadMeasureEvidence(ctx context.Context, input types.UploadMeasureEvidenceInput) (*types.UploadMeasureEvidencePayload, error) {
-	if err := r.authorize(ctx, input.MeasureID, probo.ActionMeasureEvidenceUpload); err != nil {
+	scope, err := r.authorize(ctx, input.MeasureID, probo.ActionMeasureEvidenceUpload)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.MeasureID)
 	prb := r.probo
 
 	evidence, err := prb.Evidences.UploadMeasureEvidence(

--- a/pkg/server/api/console/v1/evidence_resolvers.go
+++ b/pkg/server/api/console/v1/evidence_resolvers.go
@@ -107,11 +107,9 @@ func (r *evidenceConnectionResolver) TotalCount(ctx context.Context, obj *types.
 		return 0, err
 	}
 
-	prb := r.probo
-
 	switch obj.Resolver.(type) {
 	case *measureResolver:
-		count, err := prb.Evidences.CountForMeasureID(ctx, scope, obj.ParentID)
+		count, err := r.probo.Evidences.CountForMeasureID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count measure evidence", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -119,7 +117,7 @@ func (r *evidenceConnectionResolver) TotalCount(ctx context.Context, obj *types.
 
 		return count, nil
 	case *taskResolver:
-		count, err := prb.Evidences.CountForTaskID(ctx, scope, obj.ParentID)
+		count, err := r.probo.Evidences.CountForTaskID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count task evidence", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -140,9 +138,7 @@ func (r *mutationResolver) DeleteEvidence(ctx context.Context, input types.Delet
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.Evidences.Delete(ctx, scope, input.EvidenceID); err != nil {
+	if err := r.probo.Evidences.Delete(ctx, scope, input.EvidenceID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete evidence", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -159,9 +155,7 @@ func (r *mutationResolver) UploadMeasureEvidence(ctx context.Context, input type
 		return nil, err
 	}
 
-	prb := r.probo
-
-	evidence, err := prb.Evidences.UploadMeasureEvidence(
+	evidence, err := r.probo.Evidences.UploadMeasureEvidence(
 		ctx, scope,
 		probo.UploadMeasureEvidenceRequest{
 			MeasureID: input.MeasureID,

--- a/pkg/server/api/console/v1/file_resolvers.go
+++ b/pkg/server/api/console/v1/file_resolvers.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"go.gearno.de/kit/log"
-	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/probo"
 	"go.probo.inc/probo/pkg/server/api/console/v1/schema"
 	"go.probo.inc/probo/pkg/server/api/console/v1/types"
@@ -19,11 +18,11 @@ import (
 
 // DownloadURL is the resolver for the downloadUrl field.
 func (r *fileResolver) DownloadURL(ctx context.Context, obj *types.File) (string, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionFileDownloadUrl); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionFileDownloadUrl)
+	if err != nil {
 		return "", err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	downloadUrl, err := prb.Files.GenerateFileTempURL(ctx, scope, obj.ID, 60*time.Second)

--- a/pkg/server/api/console/v1/file_resolvers.go
+++ b/pkg/server/api/console/v1/file_resolvers.go
@@ -23,9 +23,7 @@ func (r *fileResolver) DownloadURL(ctx context.Context, obj *types.File) (string
 		return "", err
 	}
 
-	prb := r.probo
-
-	downloadUrl, err := prb.Files.GenerateFileTempURL(ctx, scope, obj.ID, 60*time.Second)
+	downloadUrl, err := r.probo.Files.GenerateFileTempURL(ctx, scope, obj.ID, 60*time.Second)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate download URL", log.Error(err))
 		return "", gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/framework_resolvers.go
+++ b/pkg/server/api/console/v1/framework_resolvers.go
@@ -53,8 +53,6 @@ func (r *frameworkResolver) Controls(ctx context.Context, obj *types.Framework, 
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.ControlOrderField]{
 		Field:     coredata.ControlOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -73,7 +71,7 @@ func (r *frameworkResolver) Controls(ctx context.Context, obj *types.Framework, 
 		controlFilter = coredata.NewControlFilter(filter.Query)
 	}
 
-	page, err := prb.Controls.ListForFrameworkID(ctx, scope, obj.ID, cursor, controlFilter)
+	page, err := r.probo.Controls.ListForFrameworkID(ctx, scope, obj.ID, cursor, controlFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list controls", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -89,9 +87,7 @@ func (r *frameworkResolver) LightLogoURL(ctx context.Context, obj *types.Framewo
 		return nil, err
 	}
 
-	prb := r.probo
-
-	return prb.Frameworks.GenerateLightLogoURL(ctx, scope, obj.ID, 1*time.Hour)
+	return r.probo.Frameworks.GenerateLightLogoURL(ctx, scope, obj.ID, 1*time.Hour)
 }
 
 // DarkLogoURL is the resolver for the darkLogoURL field.
@@ -101,9 +97,7 @@ func (r *frameworkResolver) DarkLogoURL(ctx context.Context, obj *types.Framewor
 		return nil, err
 	}
 
-	prb := r.probo
-
-	return prb.Frameworks.GenerateDarkLogoURL(ctx, scope, obj.ID, 1*time.Hour)
+	return r.probo.Frameworks.GenerateDarkLogoURL(ctx, scope, obj.ID, 1*time.Hour)
 }
 
 // Permission is the resolver for the permission field.
@@ -120,9 +114,7 @@ func (r *frameworkConnectionResolver) TotalCount(ctx context.Context, obj *types
 
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		prb := r.probo
-
-		count, err := prb.Frameworks.CountForOrganizationID(ctx, scope, obj.ParentID)
+		count, err := r.probo.Frameworks.CountForOrganizationID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count frameworks", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -143,9 +135,7 @@ func (r *mutationResolver) CreateFramework(ctx context.Context, input types.Crea
 		return nil, err
 	}
 
-	prb := r.probo
-
-	framework, err := prb.Frameworks.Create(
+	framework, err := r.probo.Frameworks.Create(
 		ctx, scope,
 		probo.CreateFrameworkRequest{
 			OrganizationID: input.OrganizationID,
@@ -174,9 +164,7 @@ func (r *mutationResolver) UpdateFramework(ctx context.Context, input types.Upda
 		return nil, err
 	}
 
-	prb := r.probo
-
-	framework, err := prb.Frameworks.Update(
+	framework, err := r.probo.Frameworks.Update(
 		ctx, scope,
 		probo.UpdateFrameworkRequest{
 			ID:          input.ID,
@@ -206,15 +194,13 @@ func (r *mutationResolver) ImportFramework(ctx context.Context, input types.Impo
 		return nil, err
 	}
 
-	prb := r.probo
-
 	req := probo.ImportFrameworkRequest{}
 	if err := json.NewDecoder(input.File.File).Decode(&req.Framework); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot decode framework", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	framework, err := prb.Frameworks.Import(ctx, scope, input.OrganizationID, req)
+	framework, err := r.probo.Frameworks.Import(ctx, scope, input.OrganizationID, req)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -237,9 +223,7 @@ func (r *mutationResolver) DeleteFramework(ctx context.Context, input types.Dele
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.Frameworks.Delete(ctx, scope, input.FrameworkID); err != nil {
+	if err := r.probo.Frameworks.Delete(ctx, scope, input.FrameworkID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete framework", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -256,11 +240,9 @@ func (r *mutationResolver) ExportFramework(ctx context.Context, input types.Expo
 		return nil, err
 	}
 
-	prb := r.probo
-
 	identity := authn.IdentityFromContext(ctx)
 
-	exportJob, exportErr := prb.Frameworks.RequestExport(
+	exportJob, exportErr := r.probo.Frameworks.RequestExport(
 		ctx, scope,
 		input.FrameworkID,
 		identity.EmailAddress,

--- a/pkg/server/api/console/v1/framework_resolvers.go
+++ b/pkg/server/api/console/v1/framework_resolvers.go
@@ -57,6 +57,7 @@ func (r *frameworkResolver) Controls(ctx context.Context, obj *types.Framework, 
 		Field:     coredata.ControlOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ControlOrderField]{
 			Field:     orderBy.Field,

--- a/pkg/server/api/console/v1/framework_resolvers.go
+++ b/pkg/server/api/console/v1/framework_resolvers.go
@@ -26,7 +26,7 @@ import (
 
 // Organization is the resolver for the organization field.
 func (r *frameworkResolver) Organization(ctx context.Context, obj *types.Framework) (*types.Organization, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
 		return nil, err
 	}
 
@@ -48,11 +48,11 @@ func (r *frameworkResolver) Organization(ctx context.Context, obj *types.Framewo
 
 // Controls is the resolver for the controls field.
 func (r *frameworkResolver) Controls(ctx context.Context, obj *types.Framework, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ControlOrderBy, filter *types.ControlFilter) (*types.ControlConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionControlList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionControlList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ControlOrderField]{
@@ -84,11 +84,11 @@ func (r *frameworkResolver) Controls(ctx context.Context, obj *types.Framework, 
 
 // LightLogoURL is the resolver for the lightLogoURL field.
 func (r *frameworkResolver) LightLogoURL(ctx context.Context, obj *types.Framework) (*string, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionFrameworkGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionFrameworkGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	return prb.Frameworks.GenerateLightLogoURL(ctx, scope, obj.ID, 1*time.Hour)
@@ -96,11 +96,11 @@ func (r *frameworkResolver) LightLogoURL(ctx context.Context, obj *types.Framewo
 
 // DarkLogoURL is the resolver for the darkLogoURL field.
 func (r *frameworkResolver) DarkLogoURL(ctx context.Context, obj *types.Framework) (*string, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionFrameworkGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionFrameworkGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	return prb.Frameworks.GenerateDarkLogoURL(ctx, scope, obj.ID, 1*time.Hour)
@@ -113,13 +113,13 @@ func (r *frameworkResolver) Permission(ctx context.Context, obj *types.Framework
 
 // TotalCount is the resolver for the totalCount field.
 func (r *frameworkConnectionResolver) TotalCount(ctx context.Context, obj *types.FrameworkConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionFrameworkList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionFrameworkList)
+	if err != nil {
 		return 0, err
 	}
 
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		scope := coredata.NewScopeFromObjectID(obj.ParentID)
 		prb := r.probo
 
 		count, err := prb.Frameworks.CountForOrganizationID(ctx, scope, obj.ParentID)
@@ -138,11 +138,11 @@ func (r *frameworkConnectionResolver) TotalCount(ctx context.Context, obj *types
 
 // CreateFramework is the resolver for the createFramework field.
 func (r *mutationResolver) CreateFramework(ctx context.Context, input types.CreateFrameworkInput) (*types.CreateFrameworkPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionFrameworkCreate); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionFrameworkCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	framework, err := prb.Frameworks.Create(
@@ -169,11 +169,11 @@ func (r *mutationResolver) CreateFramework(ctx context.Context, input types.Crea
 
 // UpdateFramework is the resolver for the updateFramework field.
 func (r *mutationResolver) UpdateFramework(ctx context.Context, input types.UpdateFrameworkInput) (*types.UpdateFrameworkPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionFrameworkUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionFrameworkUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
 	framework, err := prb.Frameworks.Update(
@@ -201,11 +201,11 @@ func (r *mutationResolver) UpdateFramework(ctx context.Context, input types.Upda
 
 // ImportFramework is the resolver for the importFramework field.
 func (r *mutationResolver) ImportFramework(ctx context.Context, input types.ImportFrameworkInput) (*types.ImportFrameworkPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionFrameworkImport); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionFrameworkImport)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	req := probo.ImportFrameworkRequest{}
@@ -232,15 +232,14 @@ func (r *mutationResolver) ImportFramework(ctx context.Context, input types.Impo
 
 // DeleteFramework is the resolver for the deleteFramework field.
 func (r *mutationResolver) DeleteFramework(ctx context.Context, input types.DeleteFrameworkInput) (*types.DeleteFrameworkPayload, error) {
-	if err := r.authorize(ctx, input.FrameworkID, probo.ActionFrameworkDelete); err != nil {
+	scope, err := r.authorize(ctx, input.FrameworkID, probo.ActionFrameworkDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.FrameworkID)
 	prb := r.probo
 
-	err := prb.Frameworks.Delete(ctx, scope, input.FrameworkID)
-	if err != nil {
+	if err := prb.Frameworks.Delete(ctx, scope, input.FrameworkID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete framework", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -252,11 +251,11 @@ func (r *mutationResolver) DeleteFramework(ctx context.Context, input types.Dele
 
 // ExportFramework is the resolver for the exportFramework field.
 func (r *mutationResolver) ExportFramework(ctx context.Context, input types.ExportFrameworkInput) (*types.ExportFrameworkPayload, error) {
-	if err := r.authorize(ctx, input.FrameworkID, probo.ActionFrameworkExport); err != nil {
+	scope, err := r.authorize(ctx, input.FrameworkID, probo.ActionFrameworkExport)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.FrameworkID)
 	prb := r.probo
 
 	identity := authn.IdentityFromContext(ctx)

--- a/pkg/server/api/console/v1/graphql/access_review_campaign.graphql
+++ b/pkg/server/api/console/v1/graphql/access_review_campaign.graphql
@@ -284,32 +284,6 @@ input AccessEntryFilter
     accountType: AccessEntryAccountType
 }
 
-type AccessReview implements Node {
-    id: ID!
-    organization: Organization! @goField(forceResolver: true)
-    identitySource: AccessSource @goField(forceResolver: true)
-    createdAt: Datetime!
-    updatedAt: Datetime!
-
-    accessSources(
-        first: Int
-        after: CursorKey
-        last: Int
-        before: CursorKey
-        orderBy: AccessSourceOrder
-    ): AccessSourceConnection! @goField(forceResolver: true)
-
-    campaigns(
-        first: Int
-        after: CursorKey
-        last: Int
-        before: CursorKey
-        orderBy: AccessReviewCampaignOrder
-    ): AccessReviewCampaignConnection! @goField(forceResolver: true)
-
-    permission(action: String!): Boolean! @goField(forceResolver: true)
-}
-
 type ProviderOrganization {
     slug: String!
     displayName: String!

--- a/pkg/server/api/console/v1/graphql/organization.graphql
+++ b/pkg/server/api/console/v1/graphql/organization.graphql
@@ -227,14 +227,6 @@ type Organization implements Node {
         filter: DocumentFilter
     ): DocumentConnection! @goField(forceResolver: true)
 
-    evidences(
-        first: Int
-        after: CursorKey
-        last: Int
-        before: CursorKey
-        orderBy: EvidenceOrder
-    ): EvidenceConnection! @goField(forceResolver: true)
-
     frameworks(
         first: Int
         after: CursorKey

--- a/pkg/server/api/console/v1/graphql_handler.go
+++ b/pkg/server/api/console/v1/graphql_handler.go
@@ -27,6 +27,7 @@ import (
 	"go.probo.inc/probo/pkg/probo"
 	"go.probo.inc/probo/pkg/riskmanagement"
 	"go.probo.inc/probo/pkg/server/api/authz"
+	"go.probo.inc/probo/pkg/server/api/console/v1/dataloader"
 	"go.probo.inc/probo/pkg/server/api/console/v1/schema"
 	"go.probo.inc/probo/pkg/server/gqlutils"
 	"go.probo.inc/probo/pkg/thirdparty"
@@ -47,7 +48,8 @@ func NewGraphQLHandler(
 ) http.Handler {
 	config := schema.Config{
 		Resolvers: &Resolver{
-			authorize:         authz.NewAuthorizeFunc(iamSvc, logger),
+			authorize:         dataloader.NewAuthorizeFunc(logger),
+			batchAuthorize:    authz.NewBatchAuthorizeFunc(iamSvc, logger),
 			probo:             proboSvc,
 			iam:               iamSvc,
 			esign:             esignSvc,

--- a/pkg/server/api/console/v1/mailing_list_resolvers.go
+++ b/pkg/server/api/console/v1/mailing_list_resolvers.go
@@ -23,7 +23,7 @@ import (
 
 // Subscribers is the resolver for the subscribers field on MailingList.
 func (r *mailingListResolver) Subscribers(ctx context.Context, obj *types.MailingList, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.MailingListSubscriberConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionMailingListSubscriberList); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionMailingListSubscriberList); err != nil {
 		return nil, err
 	}
 
@@ -45,7 +45,7 @@ func (r *mailingListResolver) Subscribers(ctx context.Context, obj *types.Mailin
 
 // Updates is the resolver for the updates field on MailingList.
 func (r *mailingListResolver) Updates(ctx context.Context, obj *types.MailingList, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.MailingListUpdateConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionMailingListUpdateList); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionMailingListUpdateList); err != nil {
 		return nil, err
 	}
 
@@ -67,7 +67,7 @@ func (r *mailingListResolver) Updates(ctx context.Context, obj *types.MailingLis
 
 // TotalCount is the resolver for the totalCount field.
 func (r *mailingListSubscriberConnectionResolver) TotalCount(ctx context.Context, obj *types.MailingListSubscriberConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionMailingListSubscriberList); err != nil {
+	if _, err := r.authorize(ctx, obj.ParentID, probo.ActionMailingListSubscriberList); err != nil {
 		return 0, err
 	}
 
@@ -89,7 +89,7 @@ func (r *mailingListSubscriberConnectionResolver) TotalCount(ctx context.Context
 
 // TotalCount is the resolver for the totalCount field on MailingListUpdateConnection.
 func (r *mailingListUpdateConnectionResolver) TotalCount(ctx context.Context, obj *types.MailingListUpdateConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionMailingListUpdateList); err != nil {
+	if _, err := r.authorize(ctx, obj.ParentID, probo.ActionMailingListUpdateList); err != nil {
 		return 0, err
 	}
 
@@ -104,7 +104,7 @@ func (r *mailingListUpdateConnectionResolver) TotalCount(ctx context.Context, ob
 
 // CreateMailingListUpdate is the resolver for the createMailingListUpdate field.
 func (r *mutationResolver) CreateMailingListUpdate(ctx context.Context, input types.CreateMailingListUpdateInput) (*types.CreateMailingListUpdatePayload, error) {
-	if err := r.authorize(ctx, input.MailingListID, probo.ActionMailingListUpdateCreate); err != nil {
+	if _, err := r.authorize(ctx, input.MailingListID, probo.ActionMailingListUpdateCreate); err != nil {
 		return nil, err
 	}
 
@@ -133,7 +133,7 @@ func (r *mutationResolver) CreateMailingListUpdate(ctx context.Context, input ty
 
 // UpdateMailingListUpdate is the resolver for the updateMailingListUpdate field.
 func (r *mutationResolver) UpdateMailingListUpdate(ctx context.Context, input types.UpdateMailingListUpdateInput) (*types.UpdateMailingListUpdatePayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionMailingListUpdateUpdate); err != nil {
+	if _, err := r.authorize(ctx, input.ID, probo.ActionMailingListUpdateUpdate); err != nil {
 		return nil, err
 	}
 
@@ -170,7 +170,7 @@ func (r *mutationResolver) UpdateMailingListUpdate(ctx context.Context, input ty
 
 // SendMailingListUpdate is the resolver for the sendMailingListUpdate field.
 func (r *mutationResolver) SendMailingListUpdate(ctx context.Context, input types.SendMailingListUpdateInput) (*types.SendMailingListUpdatePayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionMailingListUpdateUpdate); err != nil {
+	if _, err := r.authorize(ctx, input.ID, probo.ActionMailingListUpdateUpdate); err != nil {
 		return nil, err
 	}
 
@@ -196,7 +196,7 @@ func (r *mutationResolver) SendMailingListUpdate(ctx context.Context, input type
 
 // DeleteMailingListUpdate is the resolver for the deleteMailingListUpdate field.
 func (r *mutationResolver) DeleteMailingListUpdate(ctx context.Context, input types.DeleteMailingListUpdateInput) (*types.DeleteMailingListUpdatePayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionMailingListUpdateDelete); err != nil {
+	if _, err := r.authorize(ctx, input.ID, probo.ActionMailingListUpdateDelete); err != nil {
 		return nil, err
 	}
 
@@ -217,7 +217,7 @@ func (r *mutationResolver) DeleteMailingListUpdate(ctx context.Context, input ty
 
 // UpdateMailingList is the resolver for the updateMailingList field.
 func (r *mutationResolver) UpdateMailingList(ctx context.Context, input types.UpdateMailingListInput) (*types.UpdateMailingListPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionMailingListUpdate); err != nil {
+	if _, err := r.authorize(ctx, input.ID, probo.ActionMailingListUpdate); err != nil {
 		return nil, err
 	}
 
@@ -234,7 +234,7 @@ func (r *mutationResolver) UpdateMailingList(ctx context.Context, input types.Up
 
 // CreateMailingListSubscriber is the resolver for the createMailingListSubscriber field.
 func (r *mutationResolver) CreateMailingListSubscriber(ctx context.Context, input types.CreateMailingListSubscriberInput) (*types.CreateMailingListSubscriberPayload, error) {
-	if err := r.authorize(ctx, input.MailingListID, probo.ActionMailingListSubscriberCreate); err != nil {
+	if _, err := r.authorize(ctx, input.MailingListID, probo.ActionMailingListSubscriberCreate); err != nil {
 		return nil, err
 	}
 
@@ -268,7 +268,7 @@ func (r *mutationResolver) CreateMailingListSubscriber(ctx context.Context, inpu
 
 // DeleteMailingListSubscriber is the resolver for the deleteMailingListSubscriber field.
 func (r *mutationResolver) DeleteMailingListSubscriber(ctx context.Context, input types.DeleteMailingListSubscriberInput) (*types.DeleteMailingListSubscriberPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionMailingListSubscriberDelete); err != nil {
+	if _, err := r.authorize(ctx, input.ID, probo.ActionMailingListSubscriberDelete); err != nil {
 		return nil, err
 	}
 

--- a/pkg/server/api/console/v1/measure_resolvers.go
+++ b/pkg/server/api/console/v1/measure_resolvers.go
@@ -31,6 +31,7 @@ func (r *measureResolver) Evidences(ctx context.Context, obj *types.Measure, fir
 		Field:     coredata.EvidenceOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.EvidenceOrderField]{
 			Field:     orderBy.Field,
@@ -60,6 +61,7 @@ func (r *measureResolver) Tasks(ctx context.Context, obj *types.Measure, first *
 		Field:     coredata.TaskOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.TaskOrderField]{
 			Field:     orderBy.Field,
@@ -89,6 +91,7 @@ func (r *measureResolver) Risks(ctx context.Context, obj *types.Measure, first *
 		Field:     coredata.RiskOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.RiskOrderField]{
 			Field:     orderBy.Field,
@@ -123,6 +126,7 @@ func (r *measureResolver) Controls(ctx context.Context, obj *types.Measure, firs
 		Field:     coredata.ControlOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ControlOrderField]{
 			Field:     orderBy.Field,
@@ -157,6 +161,7 @@ func (r *measureResolver) Documents(ctx context.Context, obj *types.Measure, fir
 		Field:     coredata.DocumentOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.DocumentOrderField]{
 			Field:     orderBy.Field,

--- a/pkg/server/api/console/v1/measure_resolvers.go
+++ b/pkg/server/api/console/v1/measure_resolvers.go
@@ -22,11 +22,11 @@ import (
 
 // Evidences is the resolver for the evidences field.
 func (r *measureResolver) Evidences(ctx context.Context, obj *types.Measure, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.EvidenceOrderBy) (*types.EvidenceConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionEvidenceList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionEvidenceList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.EvidenceOrderField]{
@@ -53,11 +53,11 @@ func (r *measureResolver) Evidences(ctx context.Context, obj *types.Measure, fir
 
 // Tasks is the resolver for the tasks field.
 func (r *measureResolver) Tasks(ctx context.Context, obj *types.Measure, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TaskOrderBy) (*types.TaskConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionTaskList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionTaskList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.TaskOrderField]{
@@ -84,11 +84,11 @@ func (r *measureResolver) Tasks(ctx context.Context, obj *types.Measure, first *
 
 // Risks is the resolver for the risks field.
 func (r *measureResolver) Risks(ctx context.Context, obj *types.Measure, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskOrderBy, filter *types.RiskFilter) (*types.RiskConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionRiskList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionRiskList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.RiskOrderField]{
@@ -120,11 +120,11 @@ func (r *measureResolver) Risks(ctx context.Context, obj *types.Measure, first *
 
 // Controls is the resolver for the controls field.
 func (r *measureResolver) Controls(ctx context.Context, obj *types.Measure, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ControlOrderBy, filter *types.ControlFilter) (*types.ControlConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionControlList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionControlList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ControlOrderField]{
@@ -156,11 +156,11 @@ func (r *measureResolver) Controls(ctx context.Context, obj *types.Measure, firs
 
 // Documents is the resolver for the documents field.
 func (r *measureResolver) Documents(ctx context.Context, obj *types.Measure, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy, filter *types.DocumentFilter) (*types.DocumentConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDocumentList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionDocumentList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
@@ -200,11 +200,11 @@ func (r *measureResolver) Permission(ctx context.Context, obj *types.Measure, ac
 
 // TotalCount is the resolver for the totalCount field.
 func (r *measureConnectionResolver) TotalCount(ctx context.Context, obj *types.MeasureConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionMeasureList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionMeasureList)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 	prb := r.probo
 
 	switch obj.Resolver.(type) {
@@ -241,11 +241,11 @@ func (r *measureConnectionResolver) TotalCount(ctx context.Context, obj *types.M
 
 // // CreateMeasure is the resolver for the createMeasure field.
 func (r *mutationResolver) CreateMeasure(ctx context.Context, input types.CreateMeasureInput) (*types.CreateMeasurePayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionMeasureCreate); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionMeasureCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	measure, err := prb.Measures.Create(
@@ -278,11 +278,11 @@ func (r *mutationResolver) CreateMeasure(ctx context.Context, input types.Create
 
 // UpdateMeasure is the resolver for the updateMeasure field.
 func (r *mutationResolver) UpdateMeasure(ctx context.Context, input types.UpdateMeasureInput) (*types.UpdateMeasurePayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionMeasureUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionMeasureUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
 	measure, err := prb.Measures.Update(
@@ -312,11 +312,11 @@ func (r *mutationResolver) UpdateMeasure(ctx context.Context, input types.Update
 
 // ImportMeasure is the resolver for the importMeasure field.
 func (r *mutationResolver) ImportMeasure(ctx context.Context, input types.ImportMeasureInput) (*types.ImportMeasurePayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionMeasureImport); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionMeasureImport)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	var req probo.ImportMeasureRequest
@@ -343,15 +343,14 @@ func (r *mutationResolver) ImportMeasure(ctx context.Context, input types.Import
 
 // DeleteMeasure is the resolver for the deleteMeasure field.
 func (r *mutationResolver) DeleteMeasure(ctx context.Context, input types.DeleteMeasureInput) (*types.DeleteMeasurePayload, error) {
-	if err := r.authorize(ctx, input.MeasureID, probo.ActionMeasureDelete); err != nil {
+	scope, err := r.authorize(ctx, input.MeasureID, probo.ActionMeasureDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.MeasureID)
 	prb := r.probo
 
-	err := prb.Measures.Delete(ctx, scope, input.MeasureID)
-	if err != nil {
+	if err := prb.Measures.Delete(ctx, scope, input.MeasureID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete measure", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -363,11 +362,11 @@ func (r *mutationResolver) DeleteMeasure(ctx context.Context, input types.Delete
 
 // CreateMeasureDocumentMapping is the resolver for the createMeasureDocumentMapping field.
 func (r *mutationResolver) CreateMeasureDocumentMapping(ctx context.Context, input types.CreateMeasureDocumentMappingInput) (*types.CreateMeasureDocumentMappingPayload, error) {
-	if err := r.authorize(ctx, input.MeasureID, probo.ActionMeasureDocumentMappingCreate); err != nil {
+	scope, err := r.authorize(ctx, input.MeasureID, probo.ActionMeasureDocumentMappingCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.MeasureID)
 	prb := r.probo
 
 	measure, document, err := prb.Measures.CreateDocumentMapping(ctx, scope, input.MeasureID, input.DocumentID)
@@ -389,11 +388,11 @@ func (r *mutationResolver) CreateMeasureDocumentMapping(ctx context.Context, inp
 
 // DeleteMeasureDocumentMapping is the resolver for the deleteMeasureDocumentMapping field.
 func (r *mutationResolver) DeleteMeasureDocumentMapping(ctx context.Context, input types.DeleteMeasureDocumentMappingInput) (*types.DeleteMeasureDocumentMappingPayload, error) {
-	if err := r.authorize(ctx, input.MeasureID, probo.ActionMeasureDocumentMappingDelete); err != nil {
+	scope, err := r.authorize(ctx, input.MeasureID, probo.ActionMeasureDocumentMappingDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.MeasureID)
 	prb := r.probo
 
 	measure, document, err := prb.Measures.DeleteDocumentMapping(ctx, scope, input.MeasureID, input.DocumentID)

--- a/pkg/server/api/console/v1/measure_resolvers.go
+++ b/pkg/server/api/console/v1/measure_resolvers.go
@@ -27,8 +27,6 @@ func (r *measureResolver) Evidences(ctx context.Context, obj *types.Measure, fir
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.EvidenceOrderField]{
 		Field:     coredata.EvidenceOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -42,7 +40,7 @@ func (r *measureResolver) Evidences(ctx context.Context, obj *types.Measure, fir
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Evidences.ListForMeasureID(ctx, scope, obj.ID, cursor)
+	page, err := r.probo.Evidences.ListForMeasureID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list measure evidences", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -58,8 +56,6 @@ func (r *measureResolver) Tasks(ctx context.Context, obj *types.Measure, first *
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.TaskOrderField]{
 		Field:     coredata.TaskOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -73,7 +69,7 @@ func (r *measureResolver) Tasks(ctx context.Context, obj *types.Measure, first *
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Tasks.ListForMeasureID(ctx, scope, obj.ID, cursor)
+	page, err := r.probo.Tasks.ListForMeasureID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list measure tasks", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -88,8 +84,6 @@ func (r *measureResolver) Risks(ctx context.Context, obj *types.Measure, first *
 	if err != nil {
 		return nil, err
 	}
-
-	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.RiskOrderField]{
 		Field:     coredata.RiskOrderFieldCreatedAt,
@@ -109,7 +103,7 @@ func (r *measureResolver) Risks(ctx context.Context, obj *types.Measure, first *
 		riskFilter = coredata.NewRiskFilter(filter.Query)
 	}
 
-	page, err := prb.Risks.ListForMeasureID(ctx, scope, obj.ID, cursor, riskFilter)
+	page, err := r.probo.Risks.ListForMeasureID(ctx, scope, obj.ID, cursor, riskFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list measure risks", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -124,8 +118,6 @@ func (r *measureResolver) Controls(ctx context.Context, obj *types.Measure, firs
 	if err != nil {
 		return nil, err
 	}
-
-	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ControlOrderField]{
 		Field:     coredata.ControlOrderFieldCreatedAt,
@@ -145,7 +137,7 @@ func (r *measureResolver) Controls(ctx context.Context, obj *types.Measure, firs
 		controlFilter = coredata.NewControlFilter(filter.Query)
 	}
 
-	page, err := prb.Controls.ListForMeasureID(ctx, scope, obj.ID, cursor, controlFilter)
+	page, err := r.probo.Controls.ListForMeasureID(ctx, scope, obj.ID, cursor, controlFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list measure controls", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -160,8 +152,6 @@ func (r *measureResolver) Documents(ctx context.Context, obj *types.Measure, fir
 	if err != nil {
 		return nil, err
 	}
-
-	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
 		Field:     coredata.DocumentOrderFieldCreatedAt,
@@ -184,7 +174,7 @@ func (r *measureResolver) Documents(ctx context.Context, obj *types.Measure, fir
 			WithClassifications(filter.Classifications)
 	}
 
-	pg, err := prb.Documents.ListForMeasureID(ctx, scope, obj.ID, cursor, documentFilter)
+	pg, err := r.probo.Documents.ListForMeasureID(ctx, scope, obj.ID, cursor, documentFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list documents", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -205,11 +195,9 @@ func (r *measureConnectionResolver) TotalCount(ctx context.Context, obj *types.M
 		return 0, err
 	}
 
-	prb := r.probo
-
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.Measures.CountForOrganizationID(ctx, scope, obj.ParentID, obj.Filters)
+		count, err := r.probo.Measures.CountForOrganizationID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count measures", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -217,7 +205,7 @@ func (r *measureConnectionResolver) TotalCount(ctx context.Context, obj *types.M
 
 		return count, nil
 	case *controlResolver:
-		count, err := prb.Measures.CountForControlID(ctx, scope, obj.ParentID, obj.Filters)
+		count, err := r.probo.Measures.CountForControlID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count measures", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -225,7 +213,7 @@ func (r *measureConnectionResolver) TotalCount(ctx context.Context, obj *types.M
 
 		return count, nil
 	case *riskResolver:
-		count, err := prb.Measures.CountForRiskID(ctx, scope, obj.ParentID, obj.Filters)
+		count, err := r.probo.Measures.CountForRiskID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count measures", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -246,9 +234,7 @@ func (r *mutationResolver) CreateMeasure(ctx context.Context, input types.Create
 		return nil, err
 	}
 
-	prb := r.probo
-
-	measure, err := prb.Measures.Create(
+	measure, err := r.probo.Measures.Create(
 		ctx, scope,
 		probo.CreateMeasureRequest{
 			OrganizationID: input.OrganizationID,
@@ -283,9 +269,7 @@ func (r *mutationResolver) UpdateMeasure(ctx context.Context, input types.Update
 		return nil, err
 	}
 
-	prb := r.probo
-
-	measure, err := prb.Measures.Update(
+	measure, err := r.probo.Measures.Update(
 		ctx, scope,
 		probo.UpdateMeasureRequest{
 			ID:          input.ID,
@@ -317,15 +301,13 @@ func (r *mutationResolver) ImportMeasure(ctx context.Context, input types.Import
 		return nil, err
 	}
 
-	prb := r.probo
-
 	var req probo.ImportMeasureRequest
 	if err := json.NewDecoder(input.File.File).Decode(&req.Measures); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot unmarshal measure", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	measures, err := prb.Measures.Import(ctx, scope, input.OrganizationID, req)
+	measures, err := r.probo.Measures.Import(ctx, scope, input.OrganizationID, req)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot import measure", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -348,9 +330,7 @@ func (r *mutationResolver) DeleteMeasure(ctx context.Context, input types.Delete
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.Measures.Delete(ctx, scope, input.MeasureID); err != nil {
+	if err := r.probo.Measures.Delete(ctx, scope, input.MeasureID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete measure", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -367,9 +347,7 @@ func (r *mutationResolver) CreateMeasureDocumentMapping(ctx context.Context, inp
 		return nil, err
 	}
 
-	prb := r.probo
-
-	measure, document, err := prb.Measures.CreateDocumentMapping(ctx, scope, input.MeasureID, input.DocumentID)
+	measure, document, err := r.probo.Measures.CreateDocumentMapping(ctx, scope, input.MeasureID, input.DocumentID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -393,9 +371,7 @@ func (r *mutationResolver) DeleteMeasureDocumentMapping(ctx context.Context, inp
 		return nil, err
 	}
 
-	prb := r.probo
-
-	measure, document, err := prb.Measures.DeleteDocumentMapping(ctx, scope, input.MeasureID, input.DocumentID)
+	measure, document, err := r.probo.Measures.DeleteDocumentMapping(ctx, scope, input.MeasureID, input.DocumentID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete measure document mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/obligation_resolvers.go
+++ b/pkg/server/api/console/v1/obligation_resolvers.go
@@ -28,8 +28,6 @@ func (r *mutationResolver) CreateObligation(ctx context.Context, input types.Cre
 		return nil, err
 	}
 
-	prb := r.probo
-
 	req := probo.CreateObligationRequest{
 		OrganizationID:         input.OrganizationID,
 		Area:                   input.Area,
@@ -44,7 +42,7 @@ func (r *mutationResolver) CreateObligation(ctx context.Context, input types.Cre
 		Type:                   input.Type,
 	}
 
-	obligation, err := prb.Obligations.Create(ctx, scope, &req)
+	obligation, err := r.probo.Obligations.Create(ctx, scope, &req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -67,8 +65,6 @@ func (r *mutationResolver) UpdateObligation(ctx context.Context, input types.Upd
 		return nil, err
 	}
 
-	prb := r.probo
-
 	req := probo.UpdateObligationRequest{
 		ID:                     input.ID,
 		Area:                   gqlutils.UnwrapOmittable(input.Area),
@@ -83,7 +79,7 @@ func (r *mutationResolver) UpdateObligation(ctx context.Context, input types.Upd
 		Type:                   input.Type,
 	}
 
-	obligation, err := prb.Obligations.Update(ctx, scope, &req)
+	obligation, err := r.probo.Obligations.Update(ctx, scope, &req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -106,9 +102,7 @@ func (r *mutationResolver) DeleteObligation(ctx context.Context, input types.Del
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.Obligations.Delete(ctx, scope, input.ObligationID); err != nil {
+	if err := r.probo.Obligations.Delete(ctx, scope, input.ObligationID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete obligation", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -125,9 +119,7 @@ func (r *mutationResolver) PublishObligationList(ctx context.Context, input type
 		return nil, err
 	}
 
-	prb := r.probo
-
-	document, documentVersion, err := prb.GeneratedDocuments.PublishObligationList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := r.probo.GeneratedDocuments.PublishObligationList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -204,11 +196,9 @@ func (r *obligationConnectionResolver) TotalCount(ctx context.Context, obj *type
 		return 0, err
 	}
 
-	prb := r.probo
-
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.Obligations.CountForOrganizationID(ctx, scope, obj.ParentID)
+		count, err := r.probo.Obligations.CountForOrganizationID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count obligations", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -216,7 +206,7 @@ func (r *obligationConnectionResolver) TotalCount(ctx context.Context, obj *type
 
 		return count, nil
 	case *riskResolver:
-		count, err := prb.Obligations.CountForRiskID(ctx, scope, obj.ParentID)
+		count, err := r.probo.Obligations.CountForRiskID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count risk obligations", log.Error(err))
 			return 0, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/obligation_resolvers.go
+++ b/pkg/server/api/console/v1/obligation_resolvers.go
@@ -23,11 +23,11 @@ import (
 
 // CreateObligation is the resolver for the createObligation field.
 func (r *mutationResolver) CreateObligation(ctx context.Context, input types.CreateObligationInput) (*types.CreateObligationPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionObligationCreate); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionObligationCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	req := probo.CreateObligationRequest{
@@ -62,11 +62,11 @@ func (r *mutationResolver) CreateObligation(ctx context.Context, input types.Cre
 
 // UpdateObligation is the resolver for the updateObligation field.
 func (r *mutationResolver) UpdateObligation(ctx context.Context, input types.UpdateObligationInput) (*types.UpdateObligationPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionObligationUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionObligationUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
 	req := probo.UpdateObligationRequest{
@@ -101,15 +101,14 @@ func (r *mutationResolver) UpdateObligation(ctx context.Context, input types.Upd
 
 // DeleteObligation is the resolver for the deleteObligation field.
 func (r *mutationResolver) DeleteObligation(ctx context.Context, input types.DeleteObligationInput) (*types.DeleteObligationPayload, error) {
-	if err := r.authorize(ctx, input.ObligationID, probo.ActionObligationDelete); err != nil {
+	scope, err := r.authorize(ctx, input.ObligationID, probo.ActionObligationDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ObligationID)
 	prb := r.probo
 
-	err := prb.Obligations.Delete(ctx, scope, input.ObligationID)
-	if err != nil {
+	if err := prb.Obligations.Delete(ctx, scope, input.ObligationID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete obligation", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -121,11 +120,11 @@ func (r *mutationResolver) DeleteObligation(ctx context.Context, input types.Del
 
 // PublishObligationList is the resolver for the publishObligationList field.
 func (r *mutationResolver) PublishObligationList(ctx context.Context, input types.PublishObligationListInput) (*types.PublishObligationListPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionObligationPublish); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionObligationPublish)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	document, documentVersion, err := prb.GeneratedDocuments.PublishObligationList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
@@ -151,7 +150,7 @@ func (r *mutationResolver) PublishObligationList(ctx context.Context, input type
 
 // Organization is the resolver for the organization field.
 func (r *obligationResolver) Organization(ctx context.Context, obj *types.Obligation) (*types.Organization, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
 		return nil, err
 	}
 
@@ -173,7 +172,7 @@ func (r *obligationResolver) Organization(ctx context.Context, obj *types.Obliga
 
 // Owner is the resolver for the owner field.
 func (r *obligationResolver) Owner(ctx context.Context, obj *types.Obligation) (*types.Profile, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileGet); err != nil {
 		return nil, err
 	}
 
@@ -200,11 +199,11 @@ func (r *obligationResolver) Permission(ctx context.Context, obj *types.Obligati
 
 // TotalCount is the resolver for the totalCount field.
 func (r *obligationConnectionResolver) TotalCount(ctx context.Context, obj *types.ObligationConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionObligationList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionObligationList)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 	prb := r.probo
 
 	switch obj.Resolver.(type) {

--- a/pkg/server/api/console/v1/organization_resolvers.go
+++ b/pkg/server/api/console/v1/organization_resolvers.go
@@ -33,8 +33,6 @@ func (r *mutationResolver) UpdateOrganizationContext(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.probo
-
 	req := probo.UpdateOrganizationContextRequest{
 		OrganizationID: input.OrganizationID,
 		Product:        gqlutils.UnwrapOmittable(input.Product),
@@ -44,7 +42,7 @@ func (r *mutationResolver) UpdateOrganizationContext(ctx context.Context, input 
 		Customers:      gqlutils.UnwrapOmittable(input.Customers),
 	}
 
-	organizationContext, err := prb.Organizations.UpdateContext(ctx, scope, req)
+	organizationContext, err := r.probo.Organizations.UpdateContext(ctx, scope, req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -67,9 +65,7 @@ func (r *organizationResolver) LogoURL(ctx context.Context, obj *types.Organizat
 		return nil, err
 	}
 
-	prb := r.probo
-
-	logoURL, err := prb.Organizations.GenerateLogoURL(ctx, scope, obj.ID, 1*time.Hour)
+	logoURL, err := r.probo.Organizations.GenerateLogoURL(ctx, scope, obj.ID, 1*time.Hour)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate logo url", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -85,9 +81,7 @@ func (r *organizationResolver) HorizontalLogoURL(ctx context.Context, obj *types
 		return nil, err
 	}
 
-	prb := r.probo
-
-	horizontalLogoURL, err := prb.Organizations.GenerateHorizontalLogoURL(ctx, scope, obj.ID, 1*time.Hour)
+	horizontalLogoURL, err := r.probo.Organizations.GenerateHorizontalLogoURL(ctx, scope, obj.ID, 1*time.Hour)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate horizontal logo url", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -103,9 +97,7 @@ func (r *organizationResolver) Context(ctx context.Context, obj *types.Organizat
 		return nil, err
 	}
 
-	prb := r.probo
-
-	orgContext, err := prb.Organizations.GetContext(ctx, scope, obj.ID)
+	orgContext, err := r.probo.Organizations.GetContext(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot load organization context", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -162,9 +154,7 @@ func (r *organizationResolver) MeasureCategories(ctx context.Context, obj *types
 		return nil, err
 	}
 
-	prb := r.probo
-
-	categories, err := prb.Measures.ListDistinctCategoriesForOrganizationID(ctx, scope, obj.ID)
+	categories, err := r.probo.Measures.ListDistinctCategoriesForOrganizationID(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list measure categories", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -236,9 +226,7 @@ func (r *organizationResolver) AssetListDocument(ctx context.Context, obj *types
 		return nil, err
 	}
 
-	prb := r.probo
-
-	assetDocumentID, err := prb.GeneratedDocuments.GetAssetListDocumentID(ctx, scope, obj.ID)
+	assetDocumentID, err := r.probo.GeneratedDocuments.GetAssetListDocumentID(ctx, scope, obj.ID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get asset list document ID: %w", err)
 	}
@@ -247,7 +235,7 @@ func (r *organizationResolver) AssetListDocument(ctx context.Context, obj *types
 		return nil, nil
 	}
 
-	doc, err := prb.Documents.Get(ctx, scope, *assetDocumentID)
+	doc, err := r.probo.Documents.Get(ctx, scope, *assetDocumentID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get asset list document: %w", err)
 	}
@@ -262,8 +250,6 @@ func (r *organizationResolver) Assets(ctx context.Context, obj *types.Organizati
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.AssetOrderField]{
 		Field:     coredata.AssetOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -277,7 +263,7 @@ func (r *organizationResolver) Assets(ctx context.Context, obj *types.Organizati
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Assets.ListForOrganizationID(ctx, scope, obj.ID, cursor)
+	page, err := r.probo.Assets.ListForOrganizationID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization assets", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -293,9 +279,7 @@ func (r *organizationResolver) DataListDocument(ctx context.Context, obj *types.
 		return nil, err
 	}
 
-	prb := r.probo
-
-	dataDocumentID, err := prb.GeneratedDocuments.GetDataListDocumentID(ctx, scope, obj.ID)
+	dataDocumentID, err := r.probo.GeneratedDocuments.GetDataListDocumentID(ctx, scope, obj.ID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get data export document ID: %w", err)
 	}
@@ -304,7 +288,7 @@ func (r *organizationResolver) DataListDocument(ctx context.Context, obj *types.
 		return nil, nil
 	}
 
-	doc, err := prb.Documents.Get(ctx, scope, *dataDocumentID)
+	doc, err := r.probo.Documents.Get(ctx, scope, *dataDocumentID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get data export document: %w", err)
 	}
@@ -319,8 +303,6 @@ func (r *organizationResolver) Data(ctx context.Context, obj *types.Organization
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.DatumOrderField]{
 		Field:     coredata.DatumOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -334,7 +316,7 @@ func (r *organizationResolver) Data(ctx context.Context, obj *types.Organization
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Data.ListForOrganizationID(ctx, scope, obj.ID, cursor)
+	page, err := r.probo.Data.ListForOrganizationID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization data", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -350,8 +332,6 @@ func (r *organizationResolver) Audits(ctx context.Context, obj *types.Organizati
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.AuditOrderField]{
 		Field:     coredata.AuditOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -365,7 +345,7 @@ func (r *organizationResolver) Audits(ctx context.Context, obj *types.Organizati
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Audits.ListForOrganizationID(ctx, scope, obj.ID, cursor)
+	page, err := r.probo.Audits.ListForOrganizationID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization audits", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -381,9 +361,7 @@ func (r *organizationResolver) FindingsDocument(ctx context.Context, obj *types.
 		return nil, err
 	}
 
-	prb := r.probo
-
-	findingDocumentID, err := prb.GeneratedDocuments.GetFindingsDocumentID(ctx, scope, obj.ID)
+	findingDocumentID, err := r.probo.GeneratedDocuments.GetFindingsDocumentID(ctx, scope, obj.ID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get finding list document ID: %w", err)
 	}
@@ -392,7 +370,7 @@ func (r *organizationResolver) FindingsDocument(ctx context.Context, obj *types.
 		return nil, nil
 	}
 
-	doc, err := prb.Documents.Get(ctx, scope, *findingDocumentID)
+	doc, err := r.probo.Documents.Get(ctx, scope, *findingDocumentID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get finding list document: %w", err)
 	}
@@ -406,8 +384,6 @@ func (r *organizationResolver) Findings(ctx context.Context, obj *types.Organiza
 	if err != nil {
 		return nil, err
 	}
-
-	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.FindingOrderField]{
 		Field:     coredata.FindingOrderFieldCreatedAt,
@@ -438,7 +414,7 @@ func (r *organizationResolver) Findings(ctx context.Context, obj *types.Organiza
 
 	findingFilter := coredata.NewFindingFilter(kind, status, priority, ownerID)
 
-	page, err := prb.Findings.ListForOrganizationID(ctx, scope, obj.ID, cursor, findingFilter)
+	page, err := r.probo.Findings.ListForOrganizationID(ctx, scope, obj.ID, cursor, findingFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization findings", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -502,8 +478,6 @@ func (r *organizationResolver) SlackConnections(ctx context.Context, obj *types.
 		return nil, err
 	}
 
-	prb := r.probo
-
 	slackProvider := coredata.ConnectorProviderSlack
 	filter := coredata.NewConnectorProviderFilter(&slackProvider)
 
@@ -514,7 +488,7 @@ func (r *organizationResolver) SlackConnections(ctx context.Context, obj *types.
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Connectors.ListForOrganizationID(ctx, scope, obj.ID, cursor, filter)
+	page, err := r.probo.Connectors.ListForOrganizationID(ctx, scope, obj.ID, cursor, filter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization slack connections", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -535,9 +509,7 @@ func (r *organizationResolver) Connectors(ctx context.Context, obj *types.Organi
 		return nil, err
 	}
 
-	prb := r.probo
-
-	connectors, err := prb.Connectors.ListAllForOrganizationID(ctx, scope, obj.ID)
+	connectors, err := r.probo.Connectors.ListAllForOrganizationID(ctx, scope, obj.ID)
 	if err != nil {
 		panic(fmt.Errorf("cannot list organization connectors: %w", err))
 	}
@@ -599,8 +571,6 @@ func (r *organizationResolver) Controls(ctx context.Context, obj *types.Organiza
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.ControlOrderField]{
 		Field:     coredata.ControlOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -619,7 +589,7 @@ func (r *organizationResolver) Controls(ctx context.Context, obj *types.Organiza
 		controlFilter = coredata.NewControlFilter(filter.Query)
 	}
 
-	page, err := prb.Controls.ListForOrganizationID(ctx, scope, obj.ID, cursor, controlFilter)
+	page, err := r.probo.Controls.ListForOrganizationID(ctx, scope, obj.ID, cursor, controlFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list controls", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -635,8 +605,6 @@ func (r *organizationResolver) StatementsOfApplicability(ctx context.Context, ob
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.StatementOfApplicabilityOrderField]{
 		Field:     coredata.StatementOfApplicabilityOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -650,7 +618,7 @@ func (r *organizationResolver) StatementsOfApplicability(ctx context.Context, ob
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.StatementsOfApplicability.ListForOrganizationID(ctx, scope, obj.ID, cursor)
+	page, err := r.probo.StatementsOfApplicability.ListForOrganizationID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization statements_of_applicability", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -666,8 +634,6 @@ func (r *organizationResolver) DataProtectionImpactAssessments(ctx context.Conte
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.DataProtectionImpactAssessmentOrderField]{
 		Field:     coredata.DataProtectionImpactAssessmentOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -682,7 +648,7 @@ func (r *organizationResolver) DataProtectionImpactAssessments(ctx context.Conte
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.DataProtectionImpactAssessments.ListForOrganizationID(ctx, scope, obj.ID, cursor)
+	page, err := r.probo.DataProtectionImpactAssessments.ListForOrganizationID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization data protection impact assessments", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -698,9 +664,7 @@ func (r *organizationResolver) DataProtectionImpactAssessmentsDocument(ctx conte
 		return nil, err
 	}
 
-	prb := r.probo
-
-	documentID, err := prb.GeneratedDocuments.GetDataProtectionImpactAssessmentsDocumentID(ctx, scope, obj.ID)
+	documentID, err := r.probo.GeneratedDocuments.GetDataProtectionImpactAssessmentsDocumentID(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get DPIA list document ID", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -710,7 +674,7 @@ func (r *organizationResolver) DataProtectionImpactAssessmentsDocument(ctx conte
 		return nil, nil
 	}
 
-	document, err := prb.Documents.Get(ctx, scope, *documentID)
+	document, err := r.probo.Documents.Get(ctx, scope, *documentID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil
@@ -731,8 +695,6 @@ func (r *organizationResolver) TransferImpactAssessments(ctx context.Context, ob
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.TransferImpactAssessmentOrderField]{
 		Field:     coredata.TransferImpactAssessmentOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -747,7 +709,7 @@ func (r *organizationResolver) TransferImpactAssessments(ctx context.Context, ob
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.TransferImpactAssessments.ListForOrganizationID(ctx, scope, obj.ID, cursor)
+	page, err := r.probo.TransferImpactAssessments.ListForOrganizationID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization transfer impact assessments", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -763,9 +725,7 @@ func (r *organizationResolver) TransferImpactAssessmentsDocument(ctx context.Con
 		return nil, err
 	}
 
-	prb := r.probo
-
-	documentID, err := prb.GeneratedDocuments.GetTransferImpactAssessmentsDocumentID(ctx, scope, obj.ID)
+	documentID, err := r.probo.GeneratedDocuments.GetTransferImpactAssessmentsDocumentID(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get TIA list document ID", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -775,7 +735,7 @@ func (r *organizationResolver) TransferImpactAssessmentsDocument(ctx context.Con
 		return nil, nil
 	}
 
-	document, err := prb.Documents.Get(ctx, scope, *documentID)
+	document, err := r.probo.Documents.Get(ctx, scope, *documentID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil
@@ -795,8 +755,6 @@ func (r *organizationResolver) Documents(ctx context.Context, obj *types.Organiz
 	if err != nil {
 		return nil, err
 	}
-
-	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
 		Field:     coredata.DocumentOrderFieldTitle,
@@ -820,7 +778,7 @@ func (r *organizationResolver) Documents(ctx context.Context, obj *types.Organiz
 			WithStatus(filter.Status)
 	}
 
-	page, err := prb.Documents.ListByOrganizationID(ctx, scope, obj.ID, cursor, documentFilter)
+	page, err := r.probo.Documents.ListByOrganizationID(ctx, scope, obj.ID, cursor, documentFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization documents", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -841,8 +799,6 @@ func (r *organizationResolver) Frameworks(ctx context.Context, obj *types.Organi
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.FrameworkOrderField]{
 		Field:     coredata.FrameworkOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -856,7 +812,7 @@ func (r *organizationResolver) Frameworks(ctx context.Context, obj *types.Organi
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Frameworks.ListForOrganizationID(ctx, scope, obj.ID, cursor)
+	page, err := r.probo.Frameworks.ListForOrganizationID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization frameworks", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -871,8 +827,6 @@ func (r *organizationResolver) Measures(ctx context.Context, obj *types.Organiza
 	if err != nil {
 		return nil, err
 	}
-
-	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.MeasureOrderField]{
 		Field:     coredata.MeasureOrderFieldCreatedAt,
@@ -892,7 +846,7 @@ func (r *organizationResolver) Measures(ctx context.Context, obj *types.Organiza
 		measureFilter = coredata.NewMeasureFilter(filter.Query, filter.State, filter.Category)
 	}
 
-	page, err := prb.Measures.ListForOrganizationID(ctx, scope, obj.ID, cursor, measureFilter)
+	page, err := r.probo.Measures.ListForOrganizationID(ctx, scope, obj.ID, cursor, measureFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization measures", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -908,9 +862,7 @@ func (r *organizationResolver) ObligationsDocument(ctx context.Context, obj *typ
 		return nil, err
 	}
 
-	prb := r.probo
-
-	obligationDocumentID, err := prb.GeneratedDocuments.GetObligationsDocumentID(ctx, scope, obj.ID)
+	obligationDocumentID, err := r.probo.GeneratedDocuments.GetObligationsDocumentID(ctx, scope, obj.ID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get obligation list document ID: %w", err)
 	}
@@ -919,7 +871,7 @@ func (r *organizationResolver) ObligationsDocument(ctx context.Context, obj *typ
 		return nil, nil
 	}
 
-	doc, err := prb.Documents.Get(ctx, scope, *obligationDocumentID)
+	doc, err := r.probo.Documents.Get(ctx, scope, *obligationDocumentID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get obligation list document: %w", err)
 	}
@@ -933,8 +885,6 @@ func (r *organizationResolver) Obligations(ctx context.Context, obj *types.Organ
 	if err != nil {
 		return nil, err
 	}
-
-	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ObligationOrderField]{
 		Field:     coredata.ObligationOrderFieldCreatedAt,
@@ -950,7 +900,7 @@ func (r *organizationResolver) Obligations(ctx context.Context, obj *types.Organ
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Obligations.ListForOrganizationID(ctx, scope, obj.ID, cursor)
+	page, err := r.probo.Obligations.ListForOrganizationID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization obligations", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -966,8 +916,6 @@ func (r *organizationResolver) ProcessingActivities(ctx context.Context, obj *ty
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.ProcessingActivityOrderField]{
 		Field:     coredata.ProcessingActivityOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -982,7 +930,7 @@ func (r *organizationResolver) ProcessingActivities(ctx context.Context, obj *ty
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.ProcessingActivities.ListForOrganizationID(ctx, scope, obj.ID, cursor)
+	page, err := r.probo.ProcessingActivities.ListForOrganizationID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization processing activities", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -998,9 +946,7 @@ func (r *organizationResolver) ProcessingActivitiesDocument(ctx context.Context,
 		return nil, err
 	}
 
-	prb := r.probo
-
-	documentID, err := prb.GeneratedDocuments.GetProcessingActivitiesDocumentID(ctx, scope, obj.ID)
+	documentID, err := r.probo.GeneratedDocuments.GetProcessingActivitiesDocumentID(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get processing activities document ID", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1010,7 +956,7 @@ func (r *organizationResolver) ProcessingActivitiesDocument(ctx context.Context,
 		return nil, nil
 	}
 
-	document, err := prb.Documents.Get(ctx, scope, *documentID)
+	document, err := r.probo.Documents.Get(ctx, scope, *documentID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil
@@ -1031,8 +977,6 @@ func (r *organizationResolver) RightsRequests(ctx context.Context, obj *types.Or
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.RightsRequestOrderField]{
 		Field:     coredata.RightsRequestOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -1047,7 +991,7 @@ func (r *organizationResolver) RightsRequests(ctx context.Context, obj *types.Or
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.RightsRequests.ListForOrganizationID(ctx, scope, obj.ID, cursor)
+	page, err := r.probo.RightsRequests.ListForOrganizationID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization rights requests", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1062,8 +1006,6 @@ func (r *organizationResolver) Risks(ctx context.Context, obj *types.Organizatio
 	if err != nil {
 		return nil, err
 	}
-
-	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.RiskOrderField]{
 		Field:     coredata.RiskOrderFieldCreatedAt,
@@ -1083,7 +1025,7 @@ func (r *organizationResolver) Risks(ctx context.Context, obj *types.Organizatio
 		riskFilter = coredata.NewRiskFilter(filter.Query)
 	}
 
-	page, err := prb.Risks.ListForOrganizationID(ctx, scope, obj.ID, cursor, riskFilter)
+	page, err := r.probo.Risks.ListForOrganizationID(ctx, scope, obj.ID, cursor, riskFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization risks", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1099,9 +1041,7 @@ func (r *organizationResolver) RisksDocument(ctx context.Context, obj *types.Org
 		return nil, err
 	}
 
-	prb := r.probo
-
-	documentID, err := prb.GeneratedDocuments.GetRisksDocumentID(ctx, scope, obj.ID)
+	documentID, err := r.probo.GeneratedDocuments.GetRisksDocumentID(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get risks document ID", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1111,7 +1051,7 @@ func (r *organizationResolver) RisksDocument(ctx context.Context, obj *types.Org
 		return nil, nil
 	}
 
-	document, err := prb.Documents.Get(ctx, scope, *documentID)
+	document, err := r.probo.Documents.Get(ctx, scope, *documentID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil
@@ -1190,8 +1130,6 @@ func (r *organizationResolver) Tasks(ctx context.Context, obj *types.Organizatio
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.TaskOrderField]{
 		Field:     coredata.TaskOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -1205,7 +1143,7 @@ func (r *organizationResolver) Tasks(ctx context.Context, obj *types.Organizatio
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Tasks.ListForOrganizationID(ctx, scope, obj.ID, cursor)
+	page, err := r.probo.Tasks.ListForOrganizationID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization tasks", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1221,9 +1159,7 @@ func (r *organizationResolver) TrustCenter(ctx context.Context, obj *types.Organ
 		return nil, err
 	}
 
-	prb := r.probo
-
-	trustCenter, err := prb.TrustCenters.GetByOrganizationID(ctx, scope, obj.ID)
+	trustCenter, err := r.probo.TrustCenters.GetByOrganizationID(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get trust center", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1231,7 +1167,7 @@ func (r *organizationResolver) TrustCenter(ctx context.Context, obj *types.Organ
 
 	var file *coredata.File
 	if trustCenter.NonDisclosureAgreementFileID != nil {
-		file, err = prb.Files.Get(ctx, scope, *trustCenter.NonDisclosureAgreementFileID)
+		file, err = r.probo.Files.Get(ctx, scope, *trustCenter.NonDisclosureAgreementFileID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot get NDA file", log.Error(err))
 			return nil, gqlutils.Internal(ctx)
@@ -1248,9 +1184,7 @@ func (r *organizationResolver) CustomDomain(ctx context.Context, obj *types.Orga
 		return nil, err
 	}
 
-	prb := r.probo
-
-	domain, err := prb.CustomDomains.GetOrganizationCustomDomain(ctx, scope, obj.ID)
+	domain, err := r.probo.CustomDomains.GetOrganizationCustomDomain(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get custom domain", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1270,8 +1204,6 @@ func (r *organizationResolver) TrustCenterFiles(ctx context.Context, obj *types.
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.TrustCenterFileOrderField]{
 		Field:     coredata.TrustCenterFileOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -1285,7 +1217,7 @@ func (r *organizationResolver) TrustCenterFiles(ctx context.Context, obj *types.
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	pageResult, err := prb.TrustCenterFiles.ListForOrganizationID(ctx, scope, obj.ID, cursor, &coredata.TrustCenterFileFilter{})
+	pageResult, err := r.probo.TrustCenterFiles.ListForOrganizationID(ctx, scope, obj.ID, cursor, &coredata.TrustCenterFileFilter{})
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization trust center files", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1332,8 +1264,6 @@ func (r *organizationResolver) ThirdParties(ctx context.Context, obj *types.Orga
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyOrderField]{
 		Field:     coredata.ThirdPartyOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -1349,7 +1279,7 @@ func (r *organizationResolver) ThirdParties(ctx context.Context, obj *types.Orga
 
 	thirdPartyFilter := coredata.NewThirdPartyFilter(nil)
 
-	page, err := prb.ThirdParties.ListForOrganizationID(ctx, scope, obj.ID, cursor, thirdPartyFilter)
+	page, err := r.probo.ThirdParties.ListForOrganizationID(ctx, scope, obj.ID, cursor, thirdPartyFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization thirdParties", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1365,9 +1295,7 @@ func (r *organizationResolver) ThirdPartiesDocument(ctx context.Context, obj *ty
 		return nil, err
 	}
 
-	prb := r.probo
-
-	documentID, err := prb.GeneratedDocuments.GetThirdPartiesDocumentID(ctx, scope, obj.ID)
+	documentID, err := r.probo.GeneratedDocuments.GetThirdPartiesDocumentID(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get thirdParties document ID", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1377,7 +1305,7 @@ func (r *organizationResolver) ThirdPartiesDocument(ctx context.Context, obj *ty
 		return nil, nil
 	}
 
-	document, err := prb.Documents.Get(ctx, scope, *documentID)
+	document, err := r.probo.Documents.Get(ctx, scope, *documentID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil
@@ -1398,8 +1326,6 @@ func (r *organizationResolver) WebhookSubscriptions(ctx context.Context, obj *ty
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.WebhookSubscriptionOrderField]{
 		Field:     coredata.WebhookSubscriptionOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -1413,7 +1339,7 @@ func (r *organizationResolver) WebhookSubscriptions(ctx context.Context, obj *ty
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.WebhookSubscriptions.ListForOrganizationID(ctx, scope, obj.ID, cursor)
+	page, err := r.probo.WebhookSubscriptions.ListForOrganizationID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization webhook subscriptions", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1449,9 +1375,7 @@ func (r *profileConnectionResolver) TotalCount(ctx context.Context, obj *types.P
 		return count, nil
 	case *documentVersionResolver:
 		scope := coredata.NewScopeFromObjectID(obj.ParentID)
-		prb := r.probo
-
-		count, err := prb.Documents.CountVersionApprovers(ctx, scope, obj.ParentID)
+		count, err := r.probo.Documents.CountVersionApprovers(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count document version approvers", log.Error(err))
 			return 0, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/organization_resolvers.go
+++ b/pkg/server/api/console/v1/organization_resolvers.go
@@ -797,11 +797,6 @@ func (r *organizationResolver) Documents(ctx context.Context, obj *types.Organiz
 	return types.NewDocumentConnection(page, r, obj.ID, documentFilter), nil
 }
 
-// Evidences is the resolver for the evidences field.
-func (r *organizationResolver) Evidences(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.EvidenceOrderBy) (*types.EvidenceConnection, error) {
-	panic(fmt.Errorf("not implemented: Evidences - evidences"))
-}
-
 // Frameworks is the resolver for the frameworks field.
 func (r *organizationResolver) Frameworks(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.FrameworkOrderBy) (*types.FrameworkConnection, error) {
 	scope, err := r.authorize(ctx, obj.ID, probo.ActionFrameworkList)

--- a/pkg/server/api/console/v1/organization_resolvers.go
+++ b/pkg/server/api/console/v1/organization_resolvers.go
@@ -131,6 +131,7 @@ func (r *organizationResolver) Profiles(ctx context.Context, obj *types.Organiza
 		Field:     coredata.MembershipProfileOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy.Field = coredata.MembershipProfileOrderField(orderBy.Field)
 		pageOrderBy.Direction = page.OrderDirection(orderBy.Direction)
@@ -174,6 +175,7 @@ func (r *organizationResolver) AccessSources(ctx context.Context, obj *types.Org
 		Field:     coredata.AccessSourceOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.AccessSourceOrderField]{
 			Field:     orderBy.Field,
@@ -202,6 +204,7 @@ func (r *organizationResolver) AccessReviewCampaigns(ctx context.Context, obj *t
 		Field:     coredata.AccessReviewCampaignOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.AccessReviewCampaignOrderField]{
 			Field:     orderBy.Field,
@@ -254,6 +257,7 @@ func (r *organizationResolver) Assets(ctx context.Context, obj *types.Organizati
 		Field:     coredata.AssetOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.AssetOrderField]{
 			Field:     orderBy.Field,
@@ -307,6 +311,7 @@ func (r *organizationResolver) Data(ctx context.Context, obj *types.Organization
 		Field:     coredata.DatumOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.DatumOrderField]{
 			Field:     orderBy.Field,
@@ -336,6 +341,7 @@ func (r *organizationResolver) Audits(ctx context.Context, obj *types.Organizati
 		Field:     coredata.AuditOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.AuditOrderField]{
 			Field:     orderBy.Field,
@@ -433,6 +439,7 @@ func (r *organizationResolver) AuditLogEntries(ctx context.Context, obj *types.O
 		Field:     coredata.AuditLogEntryOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.AuditLogEntryOrderField]{
 			Field:     orderBy.Field,
@@ -575,6 +582,7 @@ func (r *organizationResolver) Controls(ctx context.Context, obj *types.Organiza
 		Field:     coredata.ControlOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ControlOrderField]{
 			Field:     orderBy.Field,
@@ -609,6 +617,7 @@ func (r *organizationResolver) StatementsOfApplicability(ctx context.Context, ob
 		Field:     coredata.StatementOfApplicabilityOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.StatementOfApplicabilityOrderField]{
 			Field:     orderBy.Field,
@@ -760,6 +769,7 @@ func (r *organizationResolver) Documents(ctx context.Context, obj *types.Organiz
 		Field:     coredata.DocumentOrderFieldTitle,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.DocumentOrderField]{
 			Field:     orderBy.Field,
@@ -803,6 +813,7 @@ func (r *organizationResolver) Frameworks(ctx context.Context, obj *types.Organi
 		Field:     coredata.FrameworkOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.FrameworkOrderField]{
 			Field:     orderBy.Field,
@@ -832,6 +843,7 @@ func (r *organizationResolver) Measures(ctx context.Context, obj *types.Organiza
 		Field:     coredata.MeasureOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.MeasureOrderField]{
 			Field:     orderBy.Field,
@@ -1011,6 +1023,7 @@ func (r *organizationResolver) Risks(ctx context.Context, obj *types.Organizatio
 		Field:     coredata.RiskOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.RiskOrderField]{
 			Field:     orderBy.Field,
@@ -1076,6 +1089,7 @@ func (r *organizationResolver) RiskAssessments(ctx context.Context, obj *types.O
 		Field:     coredata.RiskAssessmentOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.RiskAssessmentOrderField]{
 			Field:     orderBy.Field,
@@ -1105,6 +1119,7 @@ func (r *organizationResolver) RiskAssessmentScenarios(ctx context.Context, obj 
 		Field:     coredata.RiskAssessmentScenarioOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.RiskAssessmentScenarioOrderField]{
 			Field:     orderBy.Field,
@@ -1134,6 +1149,7 @@ func (r *organizationResolver) Tasks(ctx context.Context, obj *types.Organizatio
 		Field:     coredata.TaskOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.TaskOrderField]{
 			Field:     orderBy.Field,
@@ -1208,6 +1224,7 @@ func (r *organizationResolver) TrustCenterFiles(ctx context.Context, obj *types.
 		Field:     coredata.TrustCenterFileOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.TrustCenterFileOrderField]{
 			Field:     orderBy.Field,
@@ -1237,6 +1254,7 @@ func (r *organizationResolver) CookieBanners(ctx context.Context, obj *types.Org
 		Field:     coredata.CookieBannerOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.CookieBannerOrderField]{
 			Field:     orderBy.Field,
@@ -1268,6 +1286,7 @@ func (r *organizationResolver) ThirdParties(ctx context.Context, obj *types.Orga
 		Field:     coredata.ThirdPartyOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ThirdPartyOrderField]{
 			Field:     orderBy.Field,
@@ -1330,6 +1349,7 @@ func (r *organizationResolver) WebhookSubscriptions(ctx context.Context, obj *ty
 		Field:     coredata.WebhookSubscriptionOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.WebhookSubscriptionOrderField]{
 			Field:     orderBy.Field,
@@ -1375,6 +1395,7 @@ func (r *profileConnectionResolver) TotalCount(ctx context.Context, obj *types.P
 		return count, nil
 	case *documentVersionResolver:
 		scope := coredata.NewScopeFromObjectID(obj.ParentID)
+
 		count, err := r.probo.Documents.CountVersionApprovers(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count document version approvers", log.Error(err))

--- a/pkg/server/api/console/v1/organization_resolvers.go
+++ b/pkg/server/api/console/v1/organization_resolvers.go
@@ -28,11 +28,11 @@ import (
 
 // UpdateOrganizationContext is the resolver for the updateOrganizationContext field.
 func (r *mutationResolver) UpdateOrganizationContext(ctx context.Context, input types.UpdateOrganizationContextInput) (*types.UpdateOrganizationContextPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionOrganizationContextUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionOrganizationContextUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	req := probo.UpdateOrganizationContextRequest{
@@ -62,11 +62,11 @@ func (r *mutationResolver) UpdateOrganizationContext(ctx context.Context, input 
 
 // LogoURL is the resolver for the logoUrl field.
 func (r *organizationResolver) LogoURL(ctx context.Context, obj *types.Organization) (*string, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGetLogoUrl); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGetLogoUrl)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	logoURL, err := prb.Organizations.GenerateLogoURL(ctx, scope, obj.ID, 1*time.Hour)
@@ -80,11 +80,11 @@ func (r *organizationResolver) LogoURL(ctx context.Context, obj *types.Organizat
 
 // HorizontalLogoURL is the resolver for the horizontalLogoUrl field.
 func (r *organizationResolver) HorizontalLogoURL(ctx context.Context, obj *types.Organization) (*string, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGetHorizontalLogoUrl); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGetHorizontalLogoUrl)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	horizontalLogoURL, err := prb.Organizations.GenerateHorizontalLogoURL(ctx, scope, obj.ID, 1*time.Hour)
@@ -98,11 +98,11 @@ func (r *organizationResolver) HorizontalLogoURL(ctx context.Context, obj *types
 
 // Context is the resolver for the context field.
 func (r *organizationResolver) Context(ctx context.Context, obj *types.Organization) (*types.OrganizationContext, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionOrganizationContextGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationContextGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	orgContext, err := prb.Organizations.GetContext(ctx, scope, obj.ID)
@@ -116,7 +116,7 @@ func (r *organizationResolver) Context(ctx context.Context, obj *types.Organizat
 
 // Profiles is the resolver for the profiles field.
 func (r *organizationResolver) Profiles(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ProfileOrderBy, filter *types.ProfileFilter) (*types.ProfileConnection, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileList); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileList); err != nil {
 		return nil, err
 	}
 
@@ -157,11 +157,11 @@ func (r *organizationResolver) Profiles(ctx context.Context, obj *types.Organiza
 
 // MeasureCategories is the resolver for the measureCategories field.
 func (r *organizationResolver) MeasureCategories(ctx context.Context, obj *types.Organization) ([]string, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionMeasureList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionMeasureList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	categories, err := prb.Measures.ListDistinctCategoriesForOrganizationID(ctx, scope, obj.ID)
@@ -175,11 +175,10 @@ func (r *organizationResolver) MeasureCategories(ctx context.Context, obj *types
 
 // AccessSources is the resolver for the accessSources field.
 func (r *organizationResolver) AccessSources(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AccessSourceOrder) (*types.AccessSourceConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionAccessSourceList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionAccessSourceList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	pageOrderBy := page.OrderBy[coredata.AccessSourceOrderField]{
 		Field:     coredata.AccessSourceOrderFieldCreatedAt,
@@ -204,11 +203,10 @@ func (r *organizationResolver) AccessSources(ctx context.Context, obj *types.Org
 
 // AccessReviewCampaigns is the resolver for the accessReviewCampaigns field.
 func (r *organizationResolver) AccessReviewCampaigns(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AccessReviewCampaignOrder) (*types.AccessReviewCampaignConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionAccessReviewCampaignList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionAccessReviewCampaignList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	pageOrderBy := page.OrderBy[coredata.AccessReviewCampaignOrderField]{
 		Field:     coredata.AccessReviewCampaignOrderFieldCreatedAt,
@@ -233,11 +231,11 @@ func (r *organizationResolver) AccessReviewCampaigns(ctx context.Context, obj *t
 
 // AssetListDocument is the resolver for the assetListDocument field.
 func (r *organizationResolver) AssetListDocument(ctx context.Context, obj *types.Organization) (*types.Document, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDocumentGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionDocumentGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	assetDocumentID, err := prb.GeneratedDocuments.GetAssetListDocumentID(ctx, scope, obj.ID)
@@ -259,11 +257,11 @@ func (r *organizationResolver) AssetListDocument(ctx context.Context, obj *types
 
 // Assets is the resolver for the assets field.
 func (r *organizationResolver) Assets(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AssetOrderBy) (*types.AssetConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionAssetList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionAssetList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.AssetOrderField]{
@@ -290,11 +288,11 @@ func (r *organizationResolver) Assets(ctx context.Context, obj *types.Organizati
 
 // DataListDocument is the resolver for the dataListDocument field.
 func (r *organizationResolver) DataListDocument(ctx context.Context, obj *types.Organization) (*types.Document, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDocumentGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionDocumentGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	dataDocumentID, err := prb.GeneratedDocuments.GetDataListDocumentID(ctx, scope, obj.ID)
@@ -316,11 +314,11 @@ func (r *organizationResolver) DataListDocument(ctx context.Context, obj *types.
 
 // Data is the resolver for the data field.
 func (r *organizationResolver) Data(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DatumOrderBy) (*types.DatumConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDatumList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionDatumList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DatumOrderField]{
@@ -347,11 +345,11 @@ func (r *organizationResolver) Data(ctx context.Context, obj *types.Organization
 
 // Audits is the resolver for the audits field.
 func (r *organizationResolver) Audits(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AuditOrderBy) (*types.AuditConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionAuditList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionAuditList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.AuditOrderField]{
@@ -378,11 +376,11 @@ func (r *organizationResolver) Audits(ctx context.Context, obj *types.Organizati
 
 // FindingsDocument is the resolver for the findingsDocument field.
 func (r *organizationResolver) FindingsDocument(ctx context.Context, obj *types.Organization) (*types.Document, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDocumentGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionDocumentGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	findingDocumentID, err := prb.GeneratedDocuments.GetFindingsDocumentID(ctx, scope, obj.ID)
@@ -404,11 +402,11 @@ func (r *organizationResolver) FindingsDocument(ctx context.Context, obj *types.
 
 // Findings is the resolver for the findings field.
 func (r *organizationResolver) Findings(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.FindingOrder, filter *types.FindingFilter) (*types.FindingConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionFindingList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionFindingList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.FindingOrderField]{
@@ -451,7 +449,7 @@ func (r *organizationResolver) Findings(ctx context.Context, obj *types.Organiza
 
 // AuditLogEntries is the resolver for the auditLogEntries field.
 func (r *organizationResolver) AuditLogEntries(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.AuditLogEntryOrderBy, filter *types.AuditLogEntryFilter) (*types.AuditLogEntryConnection, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionAuditLogEntryList); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionAuditLogEntryList); err != nil {
 		return nil, err
 	}
 
@@ -499,11 +497,11 @@ func (r *organizationResolver) AuditLogEntries(ctx context.Context, obj *types.O
 
 // SlackConnections is the resolver for the slackConnections field.
 func (r *organizationResolver) SlackConnections(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey) (*types.SlackConnectionConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionSlackConnectionList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionSlackConnectionList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	slackProvider := coredata.ConnectorProviderSlack
@@ -532,11 +530,11 @@ func (r *organizationResolver) SlackOAuth2Scopes(ctx context.Context, obj *types
 
 // Connectors is the resolver for the connectors field.
 func (r *organizationResolver) Connectors(ctx context.Context, obj *types.Organization, filter *types.ConnectorFilter) ([]*types.Connector, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionConnectorList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionConnectorList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	connectors, err := prb.Connectors.ListAllForOrganizationID(ctx, scope, obj.ID)
@@ -565,7 +563,7 @@ func (r *organizationResolver) Connectors(ctx context.Context, obj *types.Organi
 
 // ConnectorProviderInfos is the resolver for the connectorProviderInfos field.
 func (r *organizationResolver) ConnectorProviderInfos(ctx context.Context, obj *types.Organization) ([]*types.ConnectorProviderInfo, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionConnectorList); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionConnectorList); err != nil {
 		return nil, err
 	}
 
@@ -596,11 +594,11 @@ func (r *organizationResolver) ConnectorProviderInfos(ctx context.Context, obj *
 
 // Controls is the resolver for the controls field.
 func (r *organizationResolver) Controls(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ControlOrderBy, filter *types.ControlFilter) (*types.ControlConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionControlList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionControlList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ControlOrderField]{
@@ -632,11 +630,11 @@ func (r *organizationResolver) Controls(ctx context.Context, obj *types.Organiza
 
 // StatementsOfApplicability is the resolver for the statementsOfApplicability field.
 func (r *organizationResolver) StatementsOfApplicability(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.StatementOfApplicabilityOrderBy) (*types.StatementOfApplicabilityConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionStatementOfApplicabilityList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionStatementOfApplicabilityList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.StatementOfApplicabilityOrderField]{
@@ -663,11 +661,11 @@ func (r *organizationResolver) StatementsOfApplicability(ctx context.Context, ob
 
 // DataProtectionImpactAssessments is the resolver for the dataProtectionImpactAssessments field.
 func (r *organizationResolver) DataProtectionImpactAssessments(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DataProtectionImpactAssessmentOrderBy) (*types.DataProtectionImpactAssessmentConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDataProtectionImpactAssessmentList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionDataProtectionImpactAssessmentList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DataProtectionImpactAssessmentOrderField]{
@@ -695,11 +693,11 @@ func (r *organizationResolver) DataProtectionImpactAssessments(ctx context.Conte
 
 // DataProtectionImpactAssessmentsDocument is the resolver for the dataProtectionImpactAssessmentsDocument field.
 func (r *organizationResolver) DataProtectionImpactAssessmentsDocument(ctx context.Context, obj *types.Organization) (*types.Document, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDocumentGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionDocumentGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	documentID, err := prb.GeneratedDocuments.GetDataProtectionImpactAssessmentsDocumentID(ctx, scope, obj.ID)
@@ -728,11 +726,11 @@ func (r *organizationResolver) DataProtectionImpactAssessmentsDocument(ctx conte
 
 // TransferImpactAssessments is the resolver for the transferImpactAssessments field.
 func (r *organizationResolver) TransferImpactAssessments(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TransferImpactAssessmentOrderBy) (*types.TransferImpactAssessmentConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionTransferImpactAssessmentList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionTransferImpactAssessmentList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.TransferImpactAssessmentOrderField]{
@@ -760,11 +758,11 @@ func (r *organizationResolver) TransferImpactAssessments(ctx context.Context, ob
 
 // TransferImpactAssessmentsDocument is the resolver for the transferImpactAssessmentsDocument field.
 func (r *organizationResolver) TransferImpactAssessmentsDocument(ctx context.Context, obj *types.Organization) (*types.Document, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDocumentGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionDocumentGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	documentID, err := prb.GeneratedDocuments.GetTransferImpactAssessmentsDocumentID(ctx, scope, obj.ID)
@@ -793,11 +791,11 @@ func (r *organizationResolver) TransferImpactAssessmentsDocument(ctx context.Con
 
 // Documents is the resolver for the documents field.
 func (r *organizationResolver) Documents(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy, filter *types.DocumentFilter) (*types.DocumentConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDocumentList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionDocumentList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
@@ -838,11 +836,11 @@ func (r *organizationResolver) Evidences(ctx context.Context, obj *types.Organiz
 
 // Frameworks is the resolver for the frameworks field.
 func (r *organizationResolver) Frameworks(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.FrameworkOrderBy) (*types.FrameworkConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionFrameworkList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionFrameworkList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.FrameworkOrderField]{
@@ -869,11 +867,11 @@ func (r *organizationResolver) Frameworks(ctx context.Context, obj *types.Organi
 
 // Measures is the resolver for the measures field.
 func (r *organizationResolver) Measures(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy, filter *types.MeasureFilter) (*types.MeasureConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionMeasureList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionMeasureList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.MeasureOrderField]{
@@ -905,11 +903,11 @@ func (r *organizationResolver) Measures(ctx context.Context, obj *types.Organiza
 
 // ObligationsDocument is the resolver for the obligationsDocument field.
 func (r *organizationResolver) ObligationsDocument(ctx context.Context, obj *types.Organization) (*types.Document, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDocumentGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionDocumentGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	obligationDocumentID, err := prb.GeneratedDocuments.GetObligationsDocumentID(ctx, scope, obj.ID)
@@ -931,11 +929,11 @@ func (r *organizationResolver) ObligationsDocument(ctx context.Context, obj *typ
 
 // Obligations is the resolver for the obligations field.
 func (r *organizationResolver) Obligations(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ObligationOrderBy) (*types.ObligationConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionObligationList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionObligationList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ObligationOrderField]{
@@ -963,11 +961,11 @@ func (r *organizationResolver) Obligations(ctx context.Context, obj *types.Organ
 
 // ProcessingActivities is the resolver for the processingActivities field.
 func (r *organizationResolver) ProcessingActivities(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ProcessingActivityOrderBy) (*types.ProcessingActivityConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionProcessingActivityList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionProcessingActivityList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ProcessingActivityOrderField]{
@@ -995,11 +993,11 @@ func (r *organizationResolver) ProcessingActivities(ctx context.Context, obj *ty
 
 // ProcessingActivitiesDocument is the resolver for the processingActivitiesDocument field.
 func (r *organizationResolver) ProcessingActivitiesDocument(ctx context.Context, obj *types.Organization) (*types.Document, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDocumentGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionDocumentGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	documentID, err := prb.GeneratedDocuments.GetProcessingActivitiesDocumentID(ctx, scope, obj.ID)
@@ -1028,11 +1026,11 @@ func (r *organizationResolver) ProcessingActivitiesDocument(ctx context.Context,
 
 // RightsRequests is the resolver for the rightsRequests field.
 func (r *organizationResolver) RightsRequests(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RightsRequestOrderBy) (*types.RightsRequestConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionRightsRequestList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionRightsRequestList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.RightsRequestOrderField]{
@@ -1060,11 +1058,11 @@ func (r *organizationResolver) RightsRequests(ctx context.Context, obj *types.Or
 
 // Risks is the resolver for the risks field.
 func (r *organizationResolver) Risks(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskOrderBy, filter *types.RiskFilter) (*types.RiskConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionRiskList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionRiskList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.RiskOrderField]{
@@ -1096,11 +1094,11 @@ func (r *organizationResolver) Risks(ctx context.Context, obj *types.Organizatio
 
 // RisksDocument is the resolver for the risksDocument field.
 func (r *organizationResolver) RisksDocument(ctx context.Context, obj *types.Organization) (*types.Document, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDocumentGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionDocumentGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	documentID, err := prb.GeneratedDocuments.GetRisksDocumentID(ctx, scope, obj.ID)
@@ -1129,11 +1127,10 @@ func (r *organizationResolver) RisksDocument(ctx context.Context, obj *types.Org
 
 // RiskAssessments is the resolver for the riskAssessments field.
 func (r *organizationResolver) RiskAssessments(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskAssessmentOrderBy) (*types.RiskAssessmentConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionRiskAssessmentList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionRiskAssessmentList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	pageOrderBy := page.OrderBy[coredata.RiskAssessmentOrderField]{
 		Field:     coredata.RiskAssessmentOrderFieldCreatedAt,
@@ -1159,11 +1156,10 @@ func (r *organizationResolver) RiskAssessments(ctx context.Context, obj *types.O
 
 // RiskAssessmentScenarios is the resolver for the riskAssessmentScenarios field.
 func (r *organizationResolver) RiskAssessmentScenarios(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskAssessmentScenarioOrderBy) (*types.RiskAssessmentScenarioConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionRiskAssessmentScenarioList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionRiskAssessmentScenarioList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	pageOrderBy := page.OrderBy[coredata.RiskAssessmentScenarioOrderField]{
 		Field:     coredata.RiskAssessmentScenarioOrderFieldCreatedAt,
@@ -1189,11 +1185,11 @@ func (r *organizationResolver) RiskAssessmentScenarios(ctx context.Context, obj 
 
 // Tasks is the resolver for the tasks field.
 func (r *organizationResolver) Tasks(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TaskOrderBy) (*types.TaskConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionTaskList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionTaskList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.TaskOrderField]{
@@ -1220,11 +1216,11 @@ func (r *organizationResolver) Tasks(ctx context.Context, obj *types.Organizatio
 
 // TrustCenter is the resolver for the trustCenter field.
 func (r *organizationResolver) TrustCenter(ctx context.Context, obj *types.Organization) (*types.TrustCenter, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionTrustCenterGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionTrustCenterGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	trustCenter, err := prb.TrustCenters.GetByOrganizationID(ctx, scope, obj.ID)
@@ -1247,11 +1243,11 @@ func (r *organizationResolver) TrustCenter(ctx context.Context, obj *types.Organ
 
 // CustomDomain is the resolver for the customDomain field.
 func (r *organizationResolver) CustomDomain(ctx context.Context, obj *types.Organization) (*types.CustomDomain, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionCustomDomainGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionCustomDomainGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	domain, err := prb.CustomDomains.GetOrganizationCustomDomain(ctx, scope, obj.ID)
@@ -1269,11 +1265,11 @@ func (r *organizationResolver) CustomDomain(ctx context.Context, obj *types.Orga
 
 // TrustCenterFiles is the resolver for the trustCenterFiles field.
 func (r *organizationResolver) TrustCenterFiles(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.OrderBy[coredata.TrustCenterFileOrderField]) (*types.TrustCenterFileConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionTrustCenterFileList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionTrustCenterFileList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.TrustCenterFileOrderField]{
@@ -1300,7 +1296,8 @@ func (r *organizationResolver) TrustCenterFiles(ctx context.Context, obj *types.
 
 // CookieBanners is the resolver for the cookieBanners field.
 func (r *organizationResolver) CookieBanners(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.CookieBannerOrderBy) (*types.CookieBannerConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionCookieBannerList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionCookieBannerList)
+	if err != nil {
 		return nil, err
 	}
 
@@ -1316,7 +1313,6 @@ func (r *organizationResolver) CookieBanners(ctx context.Context, obj *types.Org
 	}
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	banners, err := r.cookieBanner.ListCookieBannersForOrganization(ctx, scope, obj.ID, cursor, coredata.NewCookieBannerFilter(nil))
 	if err != nil {
@@ -1331,11 +1327,11 @@ func (r *organizationResolver) CookieBanners(ctx context.Context, obj *types.Org
 
 // ThirdParties is the resolver for the thirdParties field.
 func (r *organizationResolver) ThirdParties(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ThirdPartyOrderBy) (*types.ThirdPartyConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyOrderField]{
@@ -1364,11 +1360,11 @@ func (r *organizationResolver) ThirdParties(ctx context.Context, obj *types.Orga
 
 // ThirdPartiesDocument is the resolver for the thirdPartiesDocument field.
 func (r *organizationResolver) ThirdPartiesDocument(ctx context.Context, obj *types.Organization) (*types.Document, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDocumentGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionDocumentGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	documentID, err := prb.GeneratedDocuments.GetThirdPartiesDocumentID(ctx, scope, obj.ID)
@@ -1397,11 +1393,11 @@ func (r *organizationResolver) ThirdPartiesDocument(ctx context.Context, obj *ty
 
 // WebhookSubscriptions is the resolver for the webhookSubscriptions field.
 func (r *organizationResolver) WebhookSubscriptions(ctx context.Context, obj *types.Organization, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.WebhookSubscriptionOrderBy) (*types.WebhookSubscriptionConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionWebhookSubscriptionList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionWebhookSubscriptionList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.WebhookSubscriptionOrderField]{
@@ -1438,7 +1434,7 @@ func (r *profileResolver) Permission(ctx context.Context, obj *types.Profile, ac
 
 // TotalCount is the resolver for the totalCount field.
 func (r *profileConnectionResolver) TotalCount(ctx context.Context, obj *types.ProfileConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, iam.ActionMembershipProfileList); err != nil {
+	if _, err := r.authorize(ctx, obj.ParentID, iam.ActionMembershipProfileList); err != nil {
 		return 0, err
 	}
 

--- a/pkg/server/api/console/v1/processing_activity_resolvers.go
+++ b/pkg/server/api/console/v1/processing_activity_resolvers.go
@@ -23,11 +23,11 @@ import (
 
 // CreateProcessingActivity is the resolver for the createProcessingActivity field.
 func (r *mutationResolver) CreateProcessingActivity(ctx context.Context, input types.CreateProcessingActivityInput) (*types.CreateProcessingActivityPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionProcessingActivityCreate); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionProcessingActivityCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	req := probo.CreateProcessingActivityRequest{
@@ -66,11 +66,11 @@ func (r *mutationResolver) CreateProcessingActivity(ctx context.Context, input t
 
 // UpdateProcessingActivity is the resolver for the updateProcessingActivity field.
 func (r *mutationResolver) UpdateProcessingActivity(ctx context.Context, input types.UpdateProcessingActivityInput) (*types.UpdateProcessingActivityPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionProcessingActivityUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionProcessingActivityUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
 	req := probo.UpdateProcessingActivityRequest{
@@ -109,15 +109,14 @@ func (r *mutationResolver) UpdateProcessingActivity(ctx context.Context, input t
 
 // DeleteProcessingActivity is the resolver for the deleteProcessingActivity field.
 func (r *mutationResolver) DeleteProcessingActivity(ctx context.Context, input types.DeleteProcessingActivityInput) (*types.DeleteProcessingActivityPayload, error) {
-	if err := r.authorize(ctx, input.ProcessingActivityID, probo.ActionProcessingActivityDelete); err != nil {
+	scope, err := r.authorize(ctx, input.ProcessingActivityID, probo.ActionProcessingActivityDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ProcessingActivityID)
 	prb := r.probo
 
-	err := prb.ProcessingActivities.Delete(ctx, scope, input.ProcessingActivityID)
-	if err != nil {
+	if err := prb.ProcessingActivities.Delete(ctx, scope, input.ProcessingActivityID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete processing activity", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -129,11 +128,11 @@ func (r *mutationResolver) DeleteProcessingActivity(ctx context.Context, input t
 
 // PublishProcessingActivityList is the resolver for the publishProcessingActivityList field.
 func (r *mutationResolver) PublishProcessingActivityList(ctx context.Context, input types.PublishProcessingActivityListInput) (*types.PublishProcessingActivityListPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionProcessingActivityPublish); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionProcessingActivityPublish)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	document, documentVersion, err := prb.GeneratedDocuments.PublishProcessingActivityList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
@@ -159,7 +158,7 @@ func (r *mutationResolver) PublishProcessingActivityList(ctx context.Context, in
 
 // Organization is the resolver for the organization field.
 func (r *processingActivityResolver) Organization(ctx context.Context, obj *types.ProcessingActivity) (*types.Organization, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
 		return nil, err
 	}
 
@@ -181,7 +180,7 @@ func (r *processingActivityResolver) Organization(ctx context.Context, obj *type
 
 // DataProtectionOfficer is the resolver for the dataProtectionOfficer field.
 func (r *processingActivityResolver) DataProtectionOfficer(ctx context.Context, obj *types.ProcessingActivity) (*types.Profile, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileGet); err != nil {
 		return nil, err
 	}
 
@@ -207,11 +206,11 @@ func (r *processingActivityResolver) DataProtectionOfficer(ctx context.Context, 
 
 // ThirdParties is the resolver for the thirdParties field.
 func (r *processingActivityResolver) ThirdParties(ctx context.Context, obj *types.ProcessingActivity, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ThirdPartyOrderBy) (*types.ThirdPartyConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyOrderField]{
@@ -238,11 +237,11 @@ func (r *processingActivityResolver) ThirdParties(ctx context.Context, obj *type
 
 // DataProtectionImpactAssessment is the resolver for the dataProtectionImpactAssessment field.
 func (r *processingActivityResolver) DataProtectionImpactAssessment(ctx context.Context, obj *types.ProcessingActivity) (*types.DataProtectionImpactAssessment, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDataProtectionImpactAssessmentGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionDataProtectionImpactAssessmentGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	dpia, err := prb.DataProtectionImpactAssessments.GetByProcessingActivityID(ctx, scope, obj.ID)
@@ -261,11 +260,11 @@ func (r *processingActivityResolver) DataProtectionImpactAssessment(ctx context.
 
 // TransferImpactAssessment is the resolver for the transferImpactAssessment field.
 func (r *processingActivityResolver) TransferImpactAssessment(ctx context.Context, obj *types.ProcessingActivity) (*types.TransferImpactAssessment, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionTransferImpactAssessmentGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionTransferImpactAssessmentGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	tia, err := prb.TransferImpactAssessments.GetByProcessingActivityID(ctx, scope, obj.ID)
@@ -289,11 +288,11 @@ func (r *processingActivityResolver) Permission(ctx context.Context, obj *types.
 
 // TotalCount is the resolver for the totalCount field.
 func (r *processingActivityConnectionResolver) TotalCount(ctx context.Context, obj *types.ProcessingActivityConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionProcessingActivityList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionProcessingActivityList)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 	prb := r.probo
 
 	switch obj.Resolver.(type) {

--- a/pkg/server/api/console/v1/processing_activity_resolvers.go
+++ b/pkg/server/api/console/v1/processing_activity_resolvers.go
@@ -28,8 +28,6 @@ func (r *mutationResolver) CreateProcessingActivity(ctx context.Context, input t
 		return nil, err
 	}
 
-	prb := r.probo
-
 	req := probo.CreateProcessingActivityRequest{
 		OrganizationID:                       input.OrganizationID,
 		Name:                                 input.Name,
@@ -53,7 +51,7 @@ func (r *mutationResolver) CreateProcessingActivity(ctx context.Context, input t
 		ThirdPartyIDs:                        input.ThirdPartyIds,
 	}
 
-	activity, err := prb.ProcessingActivities.Create(ctx, scope, &req)
+	activity, err := r.probo.ProcessingActivities.Create(ctx, scope, &req)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot create processing activity", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -70,8 +68,6 @@ func (r *mutationResolver) UpdateProcessingActivity(ctx context.Context, input t
 	if err != nil {
 		return nil, err
 	}
-
-	prb := r.probo
 
 	req := probo.UpdateProcessingActivityRequest{
 		ID:                                   input.ID,
@@ -96,7 +92,7 @@ func (r *mutationResolver) UpdateProcessingActivity(ctx context.Context, input t
 		ThirdPartyIDs:                        &input.ThirdPartyIds,
 	}
 
-	activity, err := prb.ProcessingActivities.Update(ctx, scope, &req)
+	activity, err := r.probo.ProcessingActivities.Update(ctx, scope, &req)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot update processing activity", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -114,9 +110,7 @@ func (r *mutationResolver) DeleteProcessingActivity(ctx context.Context, input t
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.ProcessingActivities.Delete(ctx, scope, input.ProcessingActivityID); err != nil {
+	if err := r.probo.ProcessingActivities.Delete(ctx, scope, input.ProcessingActivityID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete processing activity", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -133,9 +127,7 @@ func (r *mutationResolver) PublishProcessingActivityList(ctx context.Context, in
 		return nil, err
 	}
 
-	prb := r.probo
-
-	document, documentVersion, err := prb.GeneratedDocuments.PublishProcessingActivityList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := r.probo.GeneratedDocuments.PublishProcessingActivityList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -211,8 +203,6 @@ func (r *processingActivityResolver) ThirdParties(ctx context.Context, obj *type
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyOrderField]{
 		Field:     coredata.ThirdPartyOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -226,7 +216,7 @@ func (r *processingActivityResolver) ThirdParties(ctx context.Context, obj *type
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.ThirdParties.ListForProcessingActivityID(ctx, scope, obj.ID, cursor)
+	page, err := r.probo.ThirdParties.ListForProcessingActivityID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list processing activity thirdParties", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -242,9 +232,7 @@ func (r *processingActivityResolver) DataProtectionImpactAssessment(ctx context.
 		return nil, err
 	}
 
-	prb := r.probo
-
-	dpia, err := prb.DataProtectionImpactAssessments.GetByProcessingActivityID(ctx, scope, obj.ID)
+	dpia, err := r.probo.DataProtectionImpactAssessments.GetByProcessingActivityID(ctx, scope, obj.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil
@@ -265,9 +253,7 @@ func (r *processingActivityResolver) TransferImpactAssessment(ctx context.Contex
 		return nil, err
 	}
 
-	prb := r.probo
-
-	tia, err := prb.TransferImpactAssessments.GetByProcessingActivityID(ctx, scope, obj.ID)
+	tia, err := r.probo.TransferImpactAssessments.GetByProcessingActivityID(ctx, scope, obj.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, nil
@@ -293,11 +279,9 @@ func (r *processingActivityConnectionResolver) TotalCount(ctx context.Context, o
 		return 0, err
 	}
 
-	prb := r.probo
-
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.ProcessingActivities.CountForOrganizationID(ctx, scope, obj.ParentID)
+		count, err := r.probo.ProcessingActivities.CountForOrganizationID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count organization processing activities", log.Error(err))
 			return 0, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/processing_activity_resolvers.go
+++ b/pkg/server/api/console/v1/processing_activity_resolvers.go
@@ -207,6 +207,7 @@ func (r *processingActivityResolver) ThirdParties(ctx context.Context, obj *type
 		Field:     coredata.ThirdPartyOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ThirdPartyOrderField]{
 			Field:     orderBy.Field,

--- a/pkg/server/api/console/v1/resolver.go
+++ b/pkg/server/api/console/v1/resolver.go
@@ -48,6 +48,7 @@ import (
 type (
 	Resolver struct {
 		authorize         authz.AuthorizeFunc
+		batchAuthorize    authz.BatchAuthorizeFunc
 		probo             *probo.Service
 		iam               *iam.Service
 		esign             *esign.Service

--- a/pkg/server/api/console/v1/resolver.go
+++ b/pkg/server/api/console/v1/resolver.go
@@ -360,5 +360,6 @@ func isValidPagerDutySubdomain(s string) bool {
 }
 
 func (r *Resolver) Permission(ctx context.Context, obj types.Node, action string) (bool, error) {
-	return r.authorize(ctx, obj.GetID(), action, authz.WithDryRun()) == nil, nil
+	_, err := r.authorize(ctx, obj.GetID(), action, authz.WithDryRun())
+	return err == nil, nil
 }

--- a/pkg/server/api/console/v1/rights_request_resolvers.go
+++ b/pkg/server/api/console/v1/rights_request_resolvers.go
@@ -26,8 +26,6 @@ func (r *mutationResolver) CreateRightsRequest(ctx context.Context, input types.
 		return nil, err
 	}
 
-	prb := r.probo
-
 	req := probo.CreateRightsRequestRequest{
 		OrganizationID: input.OrganizationID,
 		RequestType:    &input.RequestType,
@@ -39,7 +37,7 @@ func (r *mutationResolver) CreateRightsRequest(ctx context.Context, input types.
 		ActionTaken:    input.ActionTaken,
 	}
 
-	rightsRequest, err := prb.RightsRequests.Create(ctx, scope, &req)
+	rightsRequest, err := r.probo.RightsRequests.Create(ctx, scope, &req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -62,8 +60,6 @@ func (r *mutationResolver) UpdateRightsRequest(ctx context.Context, input types.
 		return nil, err
 	}
 
-	prb := r.probo
-
 	req := probo.UpdateRightsRequestRequest{
 		ID:           input.ID,
 		RequestType:  input.RequestType,
@@ -75,7 +71,7 @@ func (r *mutationResolver) UpdateRightsRequest(ctx context.Context, input types.
 		ActionTaken:  gqlutils.UnwrapOmittable(input.ActionTaken),
 	}
 
-	rightsRequest, err := prb.RightsRequests.Update(ctx, scope, &req)
+	rightsRequest, err := r.probo.RightsRequests.Update(ctx, scope, &req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -98,9 +94,7 @@ func (r *mutationResolver) DeleteRightsRequest(ctx context.Context, input types.
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.RightsRequests.Delete(ctx, scope, input.RightsRequestID); err != nil {
+	if err := r.probo.RightsRequests.Delete(ctx, scope, input.RightsRequestID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete rights request", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -117,15 +111,13 @@ func (r *rightsRequestResolver) Organization(ctx context.Context, obj *types.Rig
 		return nil, err
 	}
 
-	prb := r.probo
-
-	rightsRequest, err := prb.RightsRequests.Get(ctx, scope, obj.ID)
+	rightsRequest, err := r.probo.RightsRequests.Get(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get rights request", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	organization, err := prb.Organizations.Get(ctx, scope, rightsRequest.OrganizationID)
+	organization, err := r.probo.Organizations.Get(ctx, scope, rightsRequest.OrganizationID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -151,11 +143,9 @@ func (r *rightsRequestConnectionResolver) TotalCount(ctx context.Context, obj *t
 		return 0, err
 	}
 
-	prb := r.probo
-
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.RightsRequests.CountByOrganizationID(ctx, scope, obj.ParentID)
+		count, err := r.probo.RightsRequests.CountByOrganizationID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count rights requests", log.Error(err))
 			return 0, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/rights_request_resolvers.go
+++ b/pkg/server/api/console/v1/rights_request_resolvers.go
@@ -21,11 +21,11 @@ import (
 
 // CreateRightsRequest is the resolver for the createRightsRequest field.
 func (r *mutationResolver) CreateRightsRequest(ctx context.Context, input types.CreateRightsRequestInput) (*types.CreateRightsRequestPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionRightsRequestCreate); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionRightsRequestCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	req := probo.CreateRightsRequestRequest{
@@ -57,11 +57,11 @@ func (r *mutationResolver) CreateRightsRequest(ctx context.Context, input types.
 
 // UpdateRightsRequest is the resolver for the updateRightsRequest field.
 func (r *mutationResolver) UpdateRightsRequest(ctx context.Context, input types.UpdateRightsRequestInput) (*types.UpdateRightsRequestPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionRightsRequestUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionRightsRequestUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
 	req := probo.UpdateRightsRequestRequest{
@@ -93,15 +93,14 @@ func (r *mutationResolver) UpdateRightsRequest(ctx context.Context, input types.
 
 // DeleteRightsRequest is the resolver for the deleteRightsRequest field.
 func (r *mutationResolver) DeleteRightsRequest(ctx context.Context, input types.DeleteRightsRequestInput) (*types.DeleteRightsRequestPayload, error) {
-	if err := r.authorize(ctx, input.RightsRequestID, probo.ActionRightsRequestDelete); err != nil {
+	scope, err := r.authorize(ctx, input.RightsRequestID, probo.ActionRightsRequestDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.RightsRequestID)
 	prb := r.probo
 
-	err := prb.RightsRequests.Delete(ctx, scope, input.RightsRequestID)
-	if err != nil {
+	if err := prb.RightsRequests.Delete(ctx, scope, input.RightsRequestID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete rights request", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -113,11 +112,11 @@ func (r *mutationResolver) DeleteRightsRequest(ctx context.Context, input types.
 
 // Organization is the resolver for the organization field.
 func (r *rightsRequestResolver) Organization(ctx context.Context, obj *types.RightsRequest) (*types.Organization, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionOrganizationGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, iam.ActionOrganizationGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	rightsRequest, err := prb.RightsRequests.Get(ctx, scope, obj.ID)
@@ -147,11 +146,11 @@ func (r *rightsRequestResolver) Permission(ctx context.Context, obj *types.Right
 
 // TotalCount is the resolver for the totalCount field.
 func (r *rightsRequestConnectionResolver) TotalCount(ctx context.Context, obj *types.RightsRequestConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionRightsRequestList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionRightsRequestList)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 	prb := r.probo
 
 	switch obj.Resolver.(type) {

--- a/pkg/server/api/console/v1/risk_assessment_resolvers.go
+++ b/pkg/server/api/console/v1/risk_assessment_resolvers.go
@@ -24,11 +24,10 @@ import (
 
 // CreateRiskAssessment is the resolver for the createRiskAssessment field.
 func (r *mutationResolver) CreateRiskAssessment(ctx context.Context, input types.CreateRiskAssessmentInput) (*types.CreateRiskAssessmentPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionRiskAssessmentCreate); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionRiskAssessmentCreate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 
 	ra, err := r.riskManagement.Create(
 		ctx,
@@ -60,11 +59,10 @@ func (r *mutationResolver) CreateRiskAssessment(ctx context.Context, input types
 
 // UpdateRiskAssessment is the resolver for the updateRiskAssessment field.
 func (r *mutationResolver) UpdateRiskAssessment(ctx context.Context, input types.UpdateRiskAssessmentInput) (*types.UpdateRiskAssessmentPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionRiskAssessmentUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionRiskAssessmentUpdate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	ra, err := r.riskManagement.Update(
 		ctx,
@@ -90,11 +88,11 @@ func (r *mutationResolver) UpdateRiskAssessment(ctx context.Context, input types
 
 // DeleteRiskAssessment is the resolver for the deleteRiskAssessment field.
 func (r *mutationResolver) DeleteRiskAssessment(ctx context.Context, input types.DeleteRiskAssessmentInput) (*types.DeleteRiskAssessmentPayload, error) {
-	if err := r.authorize(ctx, input.RiskAssessmentID, probo.ActionRiskAssessmentDelete); err != nil {
+	scope, err := r.authorize(ctx, input.RiskAssessmentID, probo.ActionRiskAssessmentDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentID)
 	if err := r.riskManagement.Delete(ctx, scope, input.RiskAssessmentID); err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -110,11 +108,10 @@ func (r *mutationResolver) DeleteRiskAssessment(ctx context.Context, input types
 
 // CreateRiskAssessmentScope is the resolver for the createRiskAssessmentScope field.
 func (r *mutationResolver) CreateRiskAssessmentScope(ctx context.Context, input types.CreateRiskAssessmentScopeInput) (*types.CreateRiskAssessmentScopePayload, error) {
-	if err := r.authorize(ctx, input.RiskAssessmentID, probo.ActionRiskAssessmentScopeCreate); err != nil {
+	scope, err := r.authorize(ctx, input.RiskAssessmentID, probo.ActionRiskAssessmentScopeCreate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentID)
 
 	raScope, err := r.riskManagement.CreateScope(
 		ctx,
@@ -145,11 +142,10 @@ func (r *mutationResolver) CreateRiskAssessmentScope(ctx context.Context, input 
 
 // UpdateRiskAssessmentScope is the resolver for the updateRiskAssessmentScope field.
 func (r *mutationResolver) UpdateRiskAssessmentScope(ctx context.Context, input types.UpdateRiskAssessmentScopeInput) (*types.UpdateRiskAssessmentScopePayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionRiskAssessmentScopeUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionRiskAssessmentScopeUpdate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	raScope, err := r.riskManagement.UpdateScope(
 		ctx,
@@ -174,11 +170,11 @@ func (r *mutationResolver) UpdateRiskAssessmentScope(ctx context.Context, input 
 
 // DeleteRiskAssessmentScope is the resolver for the deleteRiskAssessmentScope field.
 func (r *mutationResolver) DeleteRiskAssessmentScope(ctx context.Context, input types.DeleteRiskAssessmentScopeInput) (*types.DeleteRiskAssessmentScopePayload, error) {
-	if err := r.authorize(ctx, input.RiskAssessmentScopeID, probo.ActionRiskAssessmentScopeDelete); err != nil {
+	scope, err := r.authorize(ctx, input.RiskAssessmentScopeID, probo.ActionRiskAssessmentScopeDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentScopeID)
 	if err := r.riskManagement.DeleteScope(ctx, scope, input.RiskAssessmentScopeID); err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -194,11 +190,10 @@ func (r *mutationResolver) DeleteRiskAssessmentScope(ctx context.Context, input 
 
 // CreateRiskAssessmentNode is the resolver for the createRiskAssessmentNode field.
 func (r *mutationResolver) CreateRiskAssessmentNode(ctx context.Context, input types.CreateRiskAssessmentNodeInput) (*types.CreateRiskAssessmentNodePayload, error) {
-	if err := r.authorize(ctx, input.RiskAssessmentScopeID, probo.ActionRiskAssessmentNodeCreate); err != nil {
+	scope, err := r.authorize(ctx, input.RiskAssessmentScopeID, probo.ActionRiskAssessmentNodeCreate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentScopeID)
 
 	node, err := r.riskManagement.CreateNode(
 		ctx,
@@ -233,11 +228,10 @@ func (r *mutationResolver) CreateRiskAssessmentNode(ctx context.Context, input t
 
 // UpdateRiskAssessmentNode is the resolver for the updateRiskAssessmentNode field.
 func (r *mutationResolver) UpdateRiskAssessmentNode(ctx context.Context, input types.UpdateRiskAssessmentNodeInput) (*types.UpdateRiskAssessmentNodePayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionRiskAssessmentNodeUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionRiskAssessmentNodeUpdate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	node, err := r.riskManagement.UpdateNode(
 		ctx,
@@ -263,11 +257,11 @@ func (r *mutationResolver) UpdateRiskAssessmentNode(ctx context.Context, input t
 
 // DeleteRiskAssessmentNode is the resolver for the deleteRiskAssessmentNode field.
 func (r *mutationResolver) DeleteRiskAssessmentNode(ctx context.Context, input types.DeleteRiskAssessmentNodeInput) (*types.DeleteRiskAssessmentNodePayload, error) {
-	if err := r.authorize(ctx, input.RiskAssessmentNodeID, probo.ActionRiskAssessmentNodeDelete); err != nil {
+	scope, err := r.authorize(ctx, input.RiskAssessmentNodeID, probo.ActionRiskAssessmentNodeDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentNodeID)
 	if err := r.riskManagement.DeleteNode(ctx, scope, input.RiskAssessmentNodeID); err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -283,11 +277,10 @@ func (r *mutationResolver) DeleteRiskAssessmentNode(ctx context.Context, input t
 
 // CreateRiskAssessmentProcess is the resolver for the createRiskAssessmentProcess field.
 func (r *mutationResolver) CreateRiskAssessmentProcess(ctx context.Context, input types.CreateRiskAssessmentProcessInput) (*types.CreateRiskAssessmentProcessPayload, error) {
-	if err := r.authorize(ctx, input.RiskAssessmentScopeID, probo.ActionRiskAssessmentProcessCreate); err != nil {
+	scope, err := r.authorize(ctx, input.RiskAssessmentScopeID, probo.ActionRiskAssessmentProcessCreate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentScopeID)
 
 	process, err := r.riskManagement.CreateProcess(
 		ctx,
@@ -323,11 +316,10 @@ func (r *mutationResolver) CreateRiskAssessmentProcess(ctx context.Context, inpu
 
 // UpdateRiskAssessmentProcess is the resolver for the updateRiskAssessmentProcess field.
 func (r *mutationResolver) UpdateRiskAssessmentProcess(ctx context.Context, input types.UpdateRiskAssessmentProcessInput) (*types.UpdateRiskAssessmentProcessPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionRiskAssessmentProcessUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionRiskAssessmentProcessUpdate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	process, err := r.riskManagement.UpdateProcess(
 		ctx,
@@ -354,11 +346,11 @@ func (r *mutationResolver) UpdateRiskAssessmentProcess(ctx context.Context, inpu
 
 // DeleteRiskAssessmentProcess is the resolver for the deleteRiskAssessmentProcess field.
 func (r *mutationResolver) DeleteRiskAssessmentProcess(ctx context.Context, input types.DeleteRiskAssessmentProcessInput) (*types.DeleteRiskAssessmentProcessPayload, error) {
-	if err := r.authorize(ctx, input.RiskAssessmentProcessID, probo.ActionRiskAssessmentProcessDelete); err != nil {
+	scope, err := r.authorize(ctx, input.RiskAssessmentProcessID, probo.ActionRiskAssessmentProcessDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentProcessID)
 	if err := r.riskManagement.DeleteProcess(ctx, scope, input.RiskAssessmentProcessID); err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -374,11 +366,10 @@ func (r *mutationResolver) DeleteRiskAssessmentProcess(ctx context.Context, inpu
 
 // CreateRiskAssessmentThreat is the resolver for the createRiskAssessmentThreat field.
 func (r *mutationResolver) CreateRiskAssessmentThreat(ctx context.Context, input types.CreateRiskAssessmentThreatInput) (*types.CreateRiskAssessmentThreatPayload, error) {
-	if err := r.authorize(ctx, input.RiskAssessmentScopeID, probo.ActionRiskAssessmentThreatCreate); err != nil {
+	scope, err := r.authorize(ctx, input.RiskAssessmentScopeID, probo.ActionRiskAssessmentThreatCreate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentScopeID)
 
 	threat, err := r.riskManagement.CreateThreat(
 		ctx,
@@ -414,11 +405,10 @@ func (r *mutationResolver) CreateRiskAssessmentThreat(ctx context.Context, input
 
 // UpdateRiskAssessmentThreat is the resolver for the updateRiskAssessmentThreat field.
 func (r *mutationResolver) UpdateRiskAssessmentThreat(ctx context.Context, input types.UpdateRiskAssessmentThreatInput) (*types.UpdateRiskAssessmentThreatPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionRiskAssessmentThreatUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionRiskAssessmentThreatUpdate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	threat, err := r.riskManagement.UpdateThreat(
 		ctx,
@@ -445,11 +435,11 @@ func (r *mutationResolver) UpdateRiskAssessmentThreat(ctx context.Context, input
 
 // DeleteRiskAssessmentThreat is the resolver for the deleteRiskAssessmentThreat field.
 func (r *mutationResolver) DeleteRiskAssessmentThreat(ctx context.Context, input types.DeleteRiskAssessmentThreatInput) (*types.DeleteRiskAssessmentThreatPayload, error) {
-	if err := r.authorize(ctx, input.RiskAssessmentThreatID, probo.ActionRiskAssessmentThreatDelete); err != nil {
+	scope, err := r.authorize(ctx, input.RiskAssessmentThreatID, probo.ActionRiskAssessmentThreatDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentThreatID)
 	if err := r.riskManagement.DeleteThreat(ctx, scope, input.RiskAssessmentThreatID); err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -465,11 +455,10 @@ func (r *mutationResolver) DeleteRiskAssessmentThreat(ctx context.Context, input
 
 // CreateRiskAssessmentScenario is the resolver for the createRiskAssessmentScenario field.
 func (r *mutationResolver) CreateRiskAssessmentScenario(ctx context.Context, input types.CreateRiskAssessmentScenarioInput) (*types.CreateRiskAssessmentScenarioPayload, error) {
-	if err := r.authorize(ctx, input.RiskAssessmentScopeID, probo.ActionRiskAssessmentScenarioCreate); err != nil {
+	scope, err := r.authorize(ctx, input.RiskAssessmentScopeID, probo.ActionRiskAssessmentScenarioCreate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentScopeID)
 
 	scenario, err := r.riskManagement.CreateScenario(
 		ctx,
@@ -504,11 +493,10 @@ func (r *mutationResolver) CreateRiskAssessmentScenario(ctx context.Context, inp
 
 // UpdateRiskAssessmentScenario is the resolver for the updateRiskAssessmentScenario field.
 func (r *mutationResolver) UpdateRiskAssessmentScenario(ctx context.Context, input types.UpdateRiskAssessmentScenarioInput) (*types.UpdateRiskAssessmentScenarioPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionRiskAssessmentScenarioUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionRiskAssessmentScenarioUpdate)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	scenario, err := r.riskManagement.UpdateScenario(
 		ctx,
@@ -534,11 +522,11 @@ func (r *mutationResolver) UpdateRiskAssessmentScenario(ctx context.Context, inp
 
 // DeleteRiskAssessmentScenario is the resolver for the deleteRiskAssessmentScenario field.
 func (r *mutationResolver) DeleteRiskAssessmentScenario(ctx context.Context, input types.DeleteRiskAssessmentScenarioInput) (*types.DeleteRiskAssessmentScenarioPayload, error) {
-	if err := r.authorize(ctx, input.RiskAssessmentScenarioID, probo.ActionRiskAssessmentScenarioDelete); err != nil {
+	scope, err := r.authorize(ctx, input.RiskAssessmentScenarioID, probo.ActionRiskAssessmentScenarioDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentScenarioID)
 	if err := r.riskManagement.DeleteScenario(ctx, scope, input.RiskAssessmentScenarioID); err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -554,11 +542,11 @@ func (r *mutationResolver) DeleteRiskAssessmentScenario(ctx context.Context, inp
 
 // LinkRiskAssessmentScenarioThreat is the resolver for the linkRiskAssessmentScenarioThreat field.
 func (r *mutationResolver) LinkRiskAssessmentScenarioThreat(ctx context.Context, input types.LinkRiskAssessmentScenarioThreatInput) (*types.LinkRiskAssessmentScenarioThreatPayload, error) {
-	if err := r.authorize(ctx, input.RiskAssessmentScenarioID, probo.ActionRiskAssessmentScenarioThreatLink); err != nil {
+	scope, err := r.authorize(ctx, input.RiskAssessmentScenarioID, probo.ActionRiskAssessmentScenarioThreatLink)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentScenarioID)
 	if err := r.riskManagement.LinkScenarioThreat(
 		ctx,
 		scope,
@@ -591,11 +579,11 @@ func (r *mutationResolver) LinkRiskAssessmentScenarioThreat(ctx context.Context,
 
 // UnlinkRiskAssessmentScenarioThreat is the resolver for the unlinkRiskAssessmentScenarioThreat field.
 func (r *mutationResolver) UnlinkRiskAssessmentScenarioThreat(ctx context.Context, input types.UnlinkRiskAssessmentScenarioThreatInput) (*types.UnlinkRiskAssessmentScenarioThreatPayload, error) {
-	if err := r.authorize(ctx, input.RiskAssessmentScenarioID, probo.ActionRiskAssessmentScenarioThreatUnlink); err != nil {
+	scope, err := r.authorize(ctx, input.RiskAssessmentScenarioID, probo.ActionRiskAssessmentScenarioThreatUnlink)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentScenarioID)
 	if err := r.riskManagement.UnlinkScenarioThreat(
 		ctx,
 		scope,
@@ -624,11 +612,11 @@ func (r *mutationResolver) UnlinkRiskAssessmentScenarioThreat(ctx context.Contex
 
 // LinkRiskAssessmentScenarioRisk is the resolver for the linkRiskAssessmentScenarioRisk field.
 func (r *mutationResolver) LinkRiskAssessmentScenarioRisk(ctx context.Context, input types.LinkRiskAssessmentScenarioRiskInput) (*types.LinkRiskAssessmentScenarioRiskPayload, error) {
-	if err := r.authorize(ctx, input.RiskAssessmentScenarioID, probo.ActionRiskAssessmentScenarioRiskLink); err != nil {
+	scope, err := r.authorize(ctx, input.RiskAssessmentScenarioID, probo.ActionRiskAssessmentScenarioRiskLink)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentScenarioID)
 	if err := r.riskManagement.LinkScenarioRisk(
 		ctx,
 		scope,
@@ -669,11 +657,11 @@ func (r *mutationResolver) LinkRiskAssessmentScenarioRisk(ctx context.Context, i
 
 // UnlinkRiskAssessmentScenarioRisk is the resolver for the unlinkRiskAssessmentScenarioRisk field.
 func (r *mutationResolver) UnlinkRiskAssessmentScenarioRisk(ctx context.Context, input types.UnlinkRiskAssessmentScenarioRiskInput) (*types.UnlinkRiskAssessmentScenarioRiskPayload, error) {
-	if err := r.authorize(ctx, input.RiskAssessmentScenarioID, probo.ActionRiskAssessmentScenarioRiskUnlink); err != nil {
+	scope, err := r.authorize(ctx, input.RiskAssessmentScenarioID, probo.ActionRiskAssessmentScenarioRiskUnlink)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentScenarioID)
 	if err := r.riskManagement.UnlinkScenarioRisk(
 		ctx,
 		scope,
@@ -705,7 +693,7 @@ func (r *mutationResolver) UnlinkRiskAssessmentScenarioRisk(ctx context.Context,
 
 // Organization is the resolver for the organization field.
 func (r *riskAssessmentResolver) Organization(ctx context.Context, obj *types.RiskAssessment) (*types.Organization, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
 		return nil, err
 	}
 
@@ -727,11 +715,10 @@ func (r *riskAssessmentResolver) Organization(ctx context.Context, obj *types.Ri
 
 // Scopes is the resolver for the scopes field.
 func (r *riskAssessmentResolver) Scopes(ctx context.Context, obj *types.RiskAssessment, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskAssessmentScopeOrderBy) (*types.RiskAssessmentScopeConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionRiskAssessmentScopeList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionRiskAssessmentScopeList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	pageOrderBy := page.OrderBy[coredata.RiskAssessmentScopeOrderField]{
 		Field:     coredata.RiskAssessmentScopeOrderFieldCreatedAt,
@@ -759,11 +746,10 @@ func (r *riskAssessmentResolver) Permission(ctx context.Context, obj *types.Risk
 
 // TotalCount is the resolver for the totalCount field.
 func (r *riskAssessmentConnectionResolver) TotalCount(ctx context.Context, obj *types.RiskAssessmentConnection) (*int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionRiskAssessmentList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionRiskAssessmentList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 
 	count, err := r.riskManagement.CountForOrganizationID(ctx, scope, obj.ParentID)
 	if err != nil {
@@ -776,11 +762,10 @@ func (r *riskAssessmentConnectionResolver) TotalCount(ctx context.Context, obj *
 
 // TotalCount is the resolver for the totalCount field.
 func (r *riskAssessmentNodeConnectionResolver) TotalCount(ctx context.Context, obj *types.RiskAssessmentNodeConnection) (*int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionRiskAssessmentNodeList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionRiskAssessmentNodeList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 
 	count, err := r.riskManagement.CountNodesForScopeID(ctx, scope, obj.ParentID)
 	if err != nil {
@@ -793,11 +778,10 @@ func (r *riskAssessmentNodeConnectionResolver) TotalCount(ctx context.Context, o
 
 // TotalCount is the resolver for the totalCount field.
 func (r *riskAssessmentProcessConnectionResolver) TotalCount(ctx context.Context, obj *types.RiskAssessmentProcessConnection) (*int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionRiskAssessmentProcessList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionRiskAssessmentProcessList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 
 	count, err := r.riskManagement.CountProcessesForScopeID(ctx, scope, obj.ParentID)
 	if err != nil {
@@ -810,11 +794,10 @@ func (r *riskAssessmentProcessConnectionResolver) TotalCount(ctx context.Context
 
 // Scope is the resolver for the scope field.
 func (r *riskAssessmentScenarioResolver) Scope(ctx context.Context, obj *types.RiskAssessmentScenario) (*types.RiskAssessmentScope, error) {
-	if err := r.authorize(ctx, obj.RiskAssessmentScopeID, probo.ActionRiskAssessmentScopeGet); err != nil {
+	scope, err := r.authorize(ctx, obj.RiskAssessmentScopeID, probo.ActionRiskAssessmentScopeGet)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.RiskAssessmentScopeID)
 
 	raScope, err := r.riskManagement.GetScope(ctx, scope, obj.RiskAssessmentScopeID)
 	if err != nil {
@@ -827,11 +810,10 @@ func (r *riskAssessmentScenarioResolver) Scope(ctx context.Context, obj *types.R
 
 // Threats is the resolver for the threats field.
 func (r *riskAssessmentScenarioResolver) Threats(ctx context.Context, obj *types.RiskAssessmentScenario, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskAssessmentThreatOrderBy) (*types.RiskAssessmentThreatConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionRiskAssessmentThreatList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionRiskAssessmentThreatList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	pageOrderBy := page.OrderBy[coredata.RiskAssessmentThreatOrderField]{
 		Field:     coredata.RiskAssessmentThreatOrderFieldCreatedAt,
@@ -854,11 +836,10 @@ func (r *riskAssessmentScenarioResolver) Threats(ctx context.Context, obj *types
 
 // Risks is the resolver for the risks field.
 func (r *riskAssessmentScenarioResolver) Risks(ctx context.Context, obj *types.RiskAssessmentScenario, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskOrderBy) (*types.RiskConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionRiskList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionRiskList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	pageOrderBy := page.OrderBy[coredata.RiskOrderField]{
 		Field:     coredata.RiskOrderFieldCreatedAt,
@@ -881,11 +862,10 @@ func (r *riskAssessmentScenarioResolver) Risks(ctx context.Context, obj *types.R
 
 // TotalCount is the resolver for the totalCount field.
 func (r *riskAssessmentScenarioConnectionResolver) TotalCount(ctx context.Context, obj *types.RiskAssessmentScenarioConnection) (*int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionRiskAssessmentScenarioList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionRiskAssessmentScenarioList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 
 	switch obj.Resolver.(type) {
 	case *riskAssessmentScopeResolver:
@@ -917,11 +897,10 @@ func (r *riskAssessmentScenarioConnectionResolver) TotalCount(ctx context.Contex
 
 // Nodes is the resolver for the nodes field.
 func (r *riskAssessmentScopeResolver) Nodes(ctx context.Context, obj *types.RiskAssessmentScope, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskAssessmentNodeOrderBy) (*types.RiskAssessmentNodeConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionRiskAssessmentNodeList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionRiskAssessmentNodeList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	pageOrderBy := page.OrderBy[coredata.RiskAssessmentNodeOrderField]{
 		Field:     coredata.RiskAssessmentNodeOrderFieldCreatedAt,
@@ -944,11 +923,10 @@ func (r *riskAssessmentScopeResolver) Nodes(ctx context.Context, obj *types.Risk
 
 // Processes is the resolver for the processes field.
 func (r *riskAssessmentScopeResolver) Processes(ctx context.Context, obj *types.RiskAssessmentScope, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskAssessmentProcessOrderBy) (*types.RiskAssessmentProcessConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionRiskAssessmentProcessList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionRiskAssessmentProcessList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	pageOrderBy := page.OrderBy[coredata.RiskAssessmentProcessOrderField]{
 		Field:     coredata.RiskAssessmentProcessOrderFieldCreatedAt,
@@ -971,11 +949,10 @@ func (r *riskAssessmentScopeResolver) Processes(ctx context.Context, obj *types.
 
 // Threats is the resolver for the threats field.
 func (r *riskAssessmentScopeResolver) Threats(ctx context.Context, obj *types.RiskAssessmentScope, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskAssessmentThreatOrderBy) (*types.RiskAssessmentThreatConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionRiskAssessmentThreatList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionRiskAssessmentThreatList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	pageOrderBy := page.OrderBy[coredata.RiskAssessmentThreatOrderField]{
 		Field:     coredata.RiskAssessmentThreatOrderFieldCreatedAt,
@@ -998,11 +975,10 @@ func (r *riskAssessmentScopeResolver) Threats(ctx context.Context, obj *types.Ri
 
 // Scenarios is the resolver for the scenarios field.
 func (r *riskAssessmentScopeResolver) Scenarios(ctx context.Context, obj *types.RiskAssessmentScope, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskAssessmentScenarioOrderBy) (*types.RiskAssessmentScenarioConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionRiskAssessmentScenarioList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionRiskAssessmentScenarioList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	pageOrderBy := page.OrderBy[coredata.RiskAssessmentScenarioOrderField]{
 		Field:     coredata.RiskAssessmentScenarioOrderFieldCreatedAt,
@@ -1025,11 +1001,10 @@ func (r *riskAssessmentScopeResolver) Scenarios(ctx context.Context, obj *types.
 
 // MermaidChart is the resolver for the mermaidChart field.
 func (r *riskAssessmentScopeResolver) MermaidChart(ctx context.Context, obj *types.RiskAssessmentScope) (string, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionRiskAssessmentScopeGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionRiskAssessmentScopeGet)
+	if err != nil {
 		return "", err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	chart, err := r.riskManagement.BuildScopeMermaidChart(ctx, scope, obj.ID)
 	if err != nil {
@@ -1042,11 +1017,10 @@ func (r *riskAssessmentScopeResolver) MermaidChart(ctx context.Context, obj *typ
 
 // TotalCount is the resolver for the totalCount field.
 func (r *riskAssessmentScopeConnectionResolver) TotalCount(ctx context.Context, obj *types.RiskAssessmentScopeConnection) (*int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionRiskAssessmentScopeList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionRiskAssessmentScopeList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 
 	count, err := r.riskManagement.CountScopesForRiskAssessmentID(ctx, scope, obj.ParentID)
 	if err != nil {
@@ -1059,11 +1033,10 @@ func (r *riskAssessmentScopeConnectionResolver) TotalCount(ctx context.Context, 
 
 // TotalCount is the resolver for the totalCount field.
 func (r *riskAssessmentThreatConnectionResolver) TotalCount(ctx context.Context, obj *types.RiskAssessmentThreatConnection) (*int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionRiskAssessmentThreatList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionRiskAssessmentThreatList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 
 	switch obj.Resolver.(type) {
 	case *riskAssessmentScenarioResolver:

--- a/pkg/server/api/console/v1/risk_resolvers.go
+++ b/pkg/server/api/console/v1/risk_resolvers.go
@@ -29,9 +29,7 @@ func (r *mutationResolver) CreateRisk(ctx context.Context, input types.CreateRis
 		return nil, err
 	}
 
-	prb := r.probo
-
-	risk, err := prb.Risks.Create(
+	risk, err := r.probo.Risks.Create(
 		ctx, scope,
 		probo.CreateRiskRequest{
 			OrganizationID:     input.OrganizationID,
@@ -73,9 +71,7 @@ func (r *mutationResolver) UpdateRisk(ctx context.Context, input types.UpdateRis
 		return nil, err
 	}
 
-	prb := r.probo
-
-	risk, err := prb.Risks.Update(
+	risk, err := r.probo.Risks.Update(
 		ctx, scope,
 		probo.UpdateRiskRequest{
 			ID:                 input.ID,
@@ -113,9 +109,7 @@ func (r *mutationResolver) DeleteRisk(ctx context.Context, input types.DeleteRis
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.Risks.Delete(ctx, scope, input.RiskID); err != nil {
+	if err := r.probo.Risks.Delete(ctx, scope, input.RiskID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete risk", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -132,9 +126,7 @@ func (r *mutationResolver) CreateRiskMeasureMapping(ctx context.Context, input t
 		return nil, err
 	}
 
-	prb := r.probo
-
-	risk, measure, err := prb.Risks.CreateMeasureMapping(ctx, scope, input.RiskID, input.MeasureID)
+	risk, measure, err := r.probo.Risks.CreateMeasureMapping(ctx, scope, input.RiskID, input.MeasureID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot create risk measure mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -153,9 +145,7 @@ func (r *mutationResolver) DeleteRiskMeasureMapping(ctx context.Context, input t
 		return nil, err
 	}
 
-	prb := r.probo
-
-	risk, measure, err := prb.Risks.DeleteMeasureMapping(ctx, scope, input.RiskID, input.MeasureID)
+	risk, measure, err := r.probo.Risks.DeleteMeasureMapping(ctx, scope, input.RiskID, input.MeasureID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete risk measure mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -174,9 +164,7 @@ func (r *mutationResolver) CreateRiskDocumentMapping(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.probo
-
-	risk, document, err := prb.Risks.CreateDocumentMapping(ctx, scope, input.RiskID, input.DocumentID)
+	risk, document, err := r.probo.Risks.CreateDocumentMapping(ctx, scope, input.RiskID, input.DocumentID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot create risk document mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -195,9 +183,7 @@ func (r *mutationResolver) DeleteRiskDocumentMapping(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.probo
-
-	risk, document, err := prb.Risks.DeleteDocumentMapping(ctx, scope, input.RiskID, input.DocumentID)
+	risk, document, err := r.probo.Risks.DeleteDocumentMapping(ctx, scope, input.RiskID, input.DocumentID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete risk document mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -216,9 +202,7 @@ func (r *mutationResolver) CreateRiskObligationMapping(ctx context.Context, inpu
 		return nil, err
 	}
 
-	prb := r.probo
-
-	risk, obligation, err := prb.Risks.CreateObligationMapping(ctx, scope, input.RiskID, input.ObligationID)
+	risk, obligation, err := r.probo.Risks.CreateObligationMapping(ctx, scope, input.RiskID, input.ObligationID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot create risk obligation mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -237,9 +221,7 @@ func (r *mutationResolver) DeleteRiskObligationMapping(ctx context.Context, inpu
 		return nil, err
 	}
 
-	prb := r.probo
-
-	risk, obligation, err := prb.Risks.DeleteObligationMapping(ctx, scope, input.RiskID, input.ObligationID)
+	risk, obligation, err := r.probo.Risks.DeleteObligationMapping(ctx, scope, input.RiskID, input.ObligationID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete risk obligation mapping", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -258,9 +240,7 @@ func (r *mutationResolver) PublishRiskList(ctx context.Context, input types.Publ
 		return nil, err
 	}
 
-	prb := r.probo
-
-	document, documentVersion, err := prb.GeneratedDocuments.PublishRiskList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := r.probo.GeneratedDocuments.PublishRiskList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -336,8 +316,6 @@ func (r *riskResolver) Measures(ctx context.Context, obj *types.Risk, first *int
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.MeasureOrderField]{
 		Field:     coredata.MeasureOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -356,7 +334,7 @@ func (r *riskResolver) Measures(ctx context.Context, obj *types.Risk, first *int
 		measureFilter = coredata.NewMeasureFilter(filter.Query, filter.State, filter.Category)
 	}
 
-	page, err := prb.Measures.ListForRiskID(ctx, scope, obj.ID, cursor, measureFilter)
+	page, err := r.probo.Measures.ListForRiskID(ctx, scope, obj.ID, cursor, measureFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list risk measures", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -371,8 +349,6 @@ func (r *riskResolver) Documents(ctx context.Context, obj *types.Risk, first *in
 	if err != nil {
 		return nil, err
 	}
-
-	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
 		Field:     coredata.DocumentOrderFieldCreatedAt,
@@ -395,7 +371,7 @@ func (r *riskResolver) Documents(ctx context.Context, obj *types.Risk, first *in
 			WithClassifications(filter.Classifications)
 	}
 
-	page, err := prb.Documents.ListForRiskID(ctx, scope, obj.ID, cursor, documentFilter)
+	page, err := r.probo.Documents.ListForRiskID(ctx, scope, obj.ID, cursor, documentFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list risk documents", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -410,8 +386,6 @@ func (r *riskResolver) Controls(ctx context.Context, obj *types.Risk, first *int
 	if err != nil {
 		return nil, err
 	}
-
-	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ControlOrderField]{
 		Field:     coredata.ControlOrderFieldCreatedAt,
@@ -431,7 +405,7 @@ func (r *riskResolver) Controls(ctx context.Context, obj *types.Risk, first *int
 		filters = coredata.NewControlFilter(filter.Query)
 	}
 
-	page, err := prb.Controls.ListForRiskID(ctx, scope, obj.ID, cursor, filters)
+	page, err := r.probo.Controls.ListForRiskID(ctx, scope, obj.ID, cursor, filters)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list risk controls", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -447,8 +421,6 @@ func (r *riskResolver) Obligations(ctx context.Context, obj *types.Risk, first *
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.ObligationOrderField]{
 		Field:     coredata.ObligationOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -462,7 +434,7 @@ func (r *riskResolver) Obligations(ctx context.Context, obj *types.Risk, first *
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Obligations.ListForRiskID(ctx, scope, obj.ID, cursor)
+	page, err := r.probo.Obligations.ListForRiskID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list risk obligations", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -509,11 +481,9 @@ func (r *riskConnectionResolver) TotalCount(ctx context.Context, obj *types.Risk
 		return 0, err
 	}
 
-	prb := r.probo
-
 	switch obj.Resolver.(type) {
 	case *measureResolver:
-		count, err := prb.Risks.CountForMeasureID(ctx, scope, obj.ParentID, obj.Filters)
+		count, err := r.probo.Risks.CountForMeasureID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count risks", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -521,7 +491,7 @@ func (r *riskConnectionResolver) TotalCount(ctx context.Context, obj *types.Risk
 
 		return count, nil
 	case *organizationResolver:
-		count, err := prb.Risks.CountForOrganizationID(ctx, scope, obj.ParentID, obj.Filters)
+		count, err := r.probo.Risks.CountForOrganizationID(ctx, scope, obj.ParentID, obj.Filters)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count risks", log.Error(err))
 			return 0, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/risk_resolvers.go
+++ b/pkg/server/api/console/v1/risk_resolvers.go
@@ -320,6 +320,7 @@ func (r *riskResolver) Measures(ctx context.Context, obj *types.Risk, first *int
 		Field:     coredata.MeasureOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.MeasureOrderField]{
 			Field:     orderBy.Field,
@@ -354,6 +355,7 @@ func (r *riskResolver) Documents(ctx context.Context, obj *types.Risk, first *in
 		Field:     coredata.DocumentOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.DocumentOrderField]{
 			Field:     orderBy.Field,
@@ -391,6 +393,7 @@ func (r *riskResolver) Controls(ctx context.Context, obj *types.Risk, first *int
 		Field:     coredata.ControlOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ControlOrderField]{
 			Field:     orderBy.Field,
@@ -425,6 +428,7 @@ func (r *riskResolver) Obligations(ctx context.Context, obj *types.Risk, first *
 		Field:     coredata.ObligationOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ObligationOrderField]{
 			Field:     orderBy.Field,
@@ -454,6 +458,7 @@ func (r *riskResolver) Scenarios(ctx context.Context, obj *types.Risk, first *in
 		Field:     coredata.RiskAssessmentScenarioOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.RiskAssessmentScenarioOrderField]{Field: orderBy.Field, Direction: orderBy.Direction}
 	}

--- a/pkg/server/api/console/v1/risk_resolvers.go
+++ b/pkg/server/api/console/v1/risk_resolvers.go
@@ -24,11 +24,11 @@ import (
 
 // CreateRisk is the resolver for the createRisk field.
 func (r *mutationResolver) CreateRisk(ctx context.Context, input types.CreateRiskInput) (*types.CreateRiskPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionRiskCreate); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionRiskCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	risk, err := prb.Risks.Create(
@@ -68,11 +68,11 @@ func (r *mutationResolver) CreateRisk(ctx context.Context, input types.CreateRis
 
 // UpdateRisk is the resolver for the updateRisk field.
 func (r *mutationResolver) UpdateRisk(ctx context.Context, input types.UpdateRiskInput) (*types.UpdateRiskPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionRiskUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionRiskUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
 	risk, err := prb.Risks.Update(
@@ -108,15 +108,14 @@ func (r *mutationResolver) UpdateRisk(ctx context.Context, input types.UpdateRis
 
 // DeleteRisk is the resolver for the deleteRisk field.
 func (r *mutationResolver) DeleteRisk(ctx context.Context, input types.DeleteRiskInput) (*types.DeleteRiskPayload, error) {
-	if err := r.authorize(ctx, input.RiskID, probo.ActionRiskDelete); err != nil {
+	scope, err := r.authorize(ctx, input.RiskID, probo.ActionRiskDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.RiskID)
 	prb := r.probo
 
-	err := prb.Risks.Delete(ctx, scope, input.RiskID)
-	if err != nil {
+	if err := prb.Risks.Delete(ctx, scope, input.RiskID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete risk", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -128,11 +127,11 @@ func (r *mutationResolver) DeleteRisk(ctx context.Context, input types.DeleteRis
 
 // CreateRiskMeasureMapping is the resolver for the createRiskMeasureMapping field.
 func (r *mutationResolver) CreateRiskMeasureMapping(ctx context.Context, input types.CreateRiskMeasureMappingInput) (*types.CreateRiskMeasureMappingPayload, error) {
-	if err := r.authorize(ctx, input.RiskID, probo.ActionRiskMeasureMappingCreate); err != nil {
+	scope, err := r.authorize(ctx, input.RiskID, probo.ActionRiskMeasureMappingCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.RiskID)
 	prb := r.probo
 
 	risk, measure, err := prb.Risks.CreateMeasureMapping(ctx, scope, input.RiskID, input.MeasureID)
@@ -149,11 +148,11 @@ func (r *mutationResolver) CreateRiskMeasureMapping(ctx context.Context, input t
 
 // DeleteRiskMeasureMapping is the resolver for the deleteRiskMeasureMapping field.
 func (r *mutationResolver) DeleteRiskMeasureMapping(ctx context.Context, input types.DeleteRiskMeasureMappingInput) (*types.DeleteRiskMeasureMappingPayload, error) {
-	if err := r.authorize(ctx, input.RiskID, probo.ActionRiskMeasureMappingDelete); err != nil {
+	scope, err := r.authorize(ctx, input.RiskID, probo.ActionRiskMeasureMappingDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.RiskID)
 	prb := r.probo
 
 	risk, measure, err := prb.Risks.DeleteMeasureMapping(ctx, scope, input.RiskID, input.MeasureID)
@@ -170,11 +169,11 @@ func (r *mutationResolver) DeleteRiskMeasureMapping(ctx context.Context, input t
 
 // CreateRiskDocumentMapping is the resolver for the createRiskDocumentMapping field.
 func (r *mutationResolver) CreateRiskDocumentMapping(ctx context.Context, input types.CreateRiskDocumentMappingInput) (*types.CreateRiskDocumentMappingPayload, error) {
-	if err := r.authorize(ctx, input.RiskID, probo.ActionRiskDocumentMappingCreate); err != nil {
+	scope, err := r.authorize(ctx, input.RiskID, probo.ActionRiskDocumentMappingCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.RiskID)
 	prb := r.probo
 
 	risk, document, err := prb.Risks.CreateDocumentMapping(ctx, scope, input.RiskID, input.DocumentID)
@@ -191,11 +190,11 @@ func (r *mutationResolver) CreateRiskDocumentMapping(ctx context.Context, input 
 
 // DeleteRiskDocumentMapping is the resolver for the deleteRiskDocumentMapping field.
 func (r *mutationResolver) DeleteRiskDocumentMapping(ctx context.Context, input types.DeleteRiskDocumentMappingInput) (*types.DeleteRiskDocumentMappingPayload, error) {
-	if err := r.authorize(ctx, input.RiskID, probo.ActionRiskDocumentMappingDelete); err != nil {
+	scope, err := r.authorize(ctx, input.RiskID, probo.ActionRiskDocumentMappingDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.RiskID)
 	prb := r.probo
 
 	risk, document, err := prb.Risks.DeleteDocumentMapping(ctx, scope, input.RiskID, input.DocumentID)
@@ -212,11 +211,11 @@ func (r *mutationResolver) DeleteRiskDocumentMapping(ctx context.Context, input 
 
 // CreateRiskObligationMapping is the resolver for the createRiskObligationMapping field.
 func (r *mutationResolver) CreateRiskObligationMapping(ctx context.Context, input types.CreateRiskObligationMappingInput) (*types.CreateRiskObligationMappingPayload, error) {
-	if err := r.authorize(ctx, input.RiskID, probo.ActionRiskObligationMappingCreate); err != nil {
+	scope, err := r.authorize(ctx, input.RiskID, probo.ActionRiskObligationMappingCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.RiskID)
 	prb := r.probo
 
 	risk, obligation, err := prb.Risks.CreateObligationMapping(ctx, scope, input.RiskID, input.ObligationID)
@@ -233,11 +232,11 @@ func (r *mutationResolver) CreateRiskObligationMapping(ctx context.Context, inpu
 
 // DeleteRiskObligationMapping is the resolver for the deleteRiskObligationMapping field.
 func (r *mutationResolver) DeleteRiskObligationMapping(ctx context.Context, input types.DeleteRiskObligationMappingInput) (*types.DeleteRiskObligationMappingPayload, error) {
-	if err := r.authorize(ctx, input.RiskID, probo.ActionRiskObligationMappingDelete); err != nil {
+	scope, err := r.authorize(ctx, input.RiskID, probo.ActionRiskObligationMappingDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.RiskID)
 	prb := r.probo
 
 	risk, obligation, err := prb.Risks.DeleteObligationMapping(ctx, scope, input.RiskID, input.ObligationID)
@@ -254,11 +253,11 @@ func (r *mutationResolver) DeleteRiskObligationMapping(ctx context.Context, inpu
 
 // PublishRiskList is the resolver for the publishRiskList field.
 func (r *mutationResolver) PublishRiskList(ctx context.Context, input types.PublishRiskListInput) (*types.PublishRiskListPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionRiskPublish); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionRiskPublish)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	document, documentVersion, err := prb.GeneratedDocuments.PublishRiskList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
@@ -284,7 +283,7 @@ func (r *mutationResolver) PublishRiskList(ctx context.Context, input types.Publ
 
 // Owner is the resolver for the owner field.
 func (r *riskResolver) Owner(ctx context.Context, obj *types.Risk) (*types.Profile, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileGet); err != nil {
 		return nil, err
 	}
 
@@ -310,7 +309,7 @@ func (r *riskResolver) Owner(ctx context.Context, obj *types.Risk) (*types.Profi
 
 // Organization is the resolver for the organization field.
 func (r *riskResolver) Organization(ctx context.Context, obj *types.Risk) (*types.Organization, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
 		return nil, err
 	}
 
@@ -332,11 +331,11 @@ func (r *riskResolver) Organization(ctx context.Context, obj *types.Risk) (*type
 
 // Measures is the resolver for the measures field.
 func (r *riskResolver) Measures(ctx context.Context, obj *types.Risk, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.MeasureOrderBy, filter *types.MeasureFilter) (*types.MeasureConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionMeasureList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionMeasureList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.MeasureOrderField]{
@@ -368,11 +367,11 @@ func (r *riskResolver) Measures(ctx context.Context, obj *types.Risk, first *int
 
 // Documents is the resolver for the documents field.
 func (r *riskResolver) Documents(ctx context.Context, obj *types.Risk, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy, filter *types.DocumentFilter) (*types.DocumentConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDocumentList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionDocumentList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
@@ -407,11 +406,11 @@ func (r *riskResolver) Documents(ctx context.Context, obj *types.Risk, first *in
 
 // Controls is the resolver for the controls field.
 func (r *riskResolver) Controls(ctx context.Context, obj *types.Risk, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ControlOrderBy, filter *types.ControlFilter) (*types.ControlConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionControlList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionControlList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ControlOrderField]{
@@ -443,11 +442,11 @@ func (r *riskResolver) Controls(ctx context.Context, obj *types.Risk, first *int
 
 // Obligations is the resolver for the obligations field.
 func (r *riskResolver) Obligations(ctx context.Context, obj *types.Risk, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ObligationOrderBy) (*types.ObligationConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionObligationList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionObligationList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ObligationOrderField]{
@@ -474,11 +473,10 @@ func (r *riskResolver) Obligations(ctx context.Context, obj *types.Risk, first *
 
 // Scenarios is the resolver for the scenarios field.
 func (r *riskResolver) Scenarios(ctx context.Context, obj *types.Risk, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.RiskAssessmentScenarioOrderBy) (*types.RiskAssessmentScenarioConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionRiskAssessmentScenarioList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionRiskAssessmentScenarioList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	pageOrderBy := page.OrderBy[coredata.RiskAssessmentScenarioOrderField]{
 		Field:     coredata.RiskAssessmentScenarioOrderFieldCreatedAt,
@@ -506,11 +504,11 @@ func (r *riskResolver) Permission(ctx context.Context, obj *types.Risk, action s
 
 // TotalCount is the resolver for the totalCount field.
 func (r *riskConnectionResolver) TotalCount(ctx context.Context, obj *types.RiskConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionRiskList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionRiskList)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 	prb := r.probo
 
 	switch obj.Resolver.(type) {

--- a/pkg/server/api/console/v1/task_resolvers.go
+++ b/pkg/server/api/console/v1/task_resolvers.go
@@ -200,6 +200,7 @@ func (r *taskResolver) Evidences(ctx context.Context, obj *types.Task, first *in
 		Field:     coredata.EvidenceOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.EvidenceOrderField]{
 			Field:     orderBy.Field,

--- a/pkg/server/api/console/v1/task_resolvers.go
+++ b/pkg/server/api/console/v1/task_resolvers.go
@@ -29,9 +29,7 @@ func (r *mutationResolver) CreateTask(ctx context.Context, input types.CreateTas
 		return nil, err
 	}
 
-	prb := r.probo
-
-	task, err := prb.Tasks.Create(
+	task, err := r.probo.Tasks.Create(
 		ctx, scope,
 		probo.CreateTaskRequest{
 			MeasureID:      input.MeasureID,
@@ -70,9 +68,7 @@ func (r *mutationResolver) UpdateTask(ctx context.Context, input types.UpdateTas
 		return nil, err
 	}
 
-	prb := r.probo
-
-	task, err := prb.Tasks.Update(
+	task, err := r.probo.Tasks.Update(
 		ctx, scope,
 		probo.UpdateTaskRequest{
 			TaskID:       input.TaskID,
@@ -109,9 +105,7 @@ func (r *mutationResolver) DeleteTask(ctx context.Context, input types.DeleteTas
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.Tasks.Delete(ctx, scope, input.TaskID); err != nil {
+	if err := r.probo.Tasks.Delete(ctx, scope, input.TaskID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete task", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -202,8 +196,6 @@ func (r *taskResolver) Evidences(ctx context.Context, obj *types.Task, first *in
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.EvidenceOrderField]{
 		Field:     coredata.EvidenceOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -217,7 +209,7 @@ func (r *taskResolver) Evidences(ctx context.Context, obj *types.Task, first *in
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.Evidences.ListForTaskID(ctx, scope, obj.ID, cursor)
+	page, err := r.probo.Evidences.ListForTaskID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list task evidences", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -238,11 +230,9 @@ func (r *taskConnectionResolver) TotalCount(ctx context.Context, obj *types.Task
 		return 0, err
 	}
 
-	prb := r.probo
-
 	switch obj.Resolver.(type) {
 	case *measureResolver:
-		count, err := prb.Tasks.CountForMeasureID(ctx, scope, obj.ParentID)
+		count, err := r.probo.Tasks.CountForMeasureID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count tasks", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -250,7 +240,7 @@ func (r *taskConnectionResolver) TotalCount(ctx context.Context, obj *types.Task
 
 		return count, nil
 	case *organizationResolver:
-		count, err := prb.Tasks.CountForOrganizationID(ctx, scope, obj.ParentID)
+		count, err := r.probo.Tasks.CountForOrganizationID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count tasks", log.Error(err))
 			return 0, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/task_resolvers.go
+++ b/pkg/server/api/console/v1/task_resolvers.go
@@ -24,11 +24,11 @@ import (
 
 // CreateTask is the resolver for the createTask field.
 func (r *mutationResolver) CreateTask(ctx context.Context, input types.CreateTaskInput) (*types.CreateTaskPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionTaskCreate); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionTaskCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	task, err := prb.Tasks.Create(
@@ -65,11 +65,11 @@ func (r *mutationResolver) CreateTask(ctx context.Context, input types.CreateTas
 
 // UpdateTask is the resolver for the updateTask field.
 func (r *mutationResolver) UpdateTask(ctx context.Context, input types.UpdateTaskInput) (*types.UpdateTaskPayload, error) {
-	if err := r.authorize(ctx, input.TaskID, probo.ActionTaskUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.TaskID, probo.ActionTaskUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.TaskID)
 	prb := r.probo
 
 	task, err := prb.Tasks.Update(
@@ -104,15 +104,14 @@ func (r *mutationResolver) UpdateTask(ctx context.Context, input types.UpdateTas
 
 // DeleteTask is the resolver for the deleteTask field.
 func (r *mutationResolver) DeleteTask(ctx context.Context, input types.DeleteTaskInput) (*types.DeleteTaskPayload, error) {
-	if err := r.authorize(ctx, input.TaskID, probo.ActionTaskDelete); err != nil {
+	scope, err := r.authorize(ctx, input.TaskID, probo.ActionTaskDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.TaskID)
 	prb := r.probo
 
-	err := prb.Tasks.Delete(ctx, scope, input.TaskID)
-	if err != nil {
+	if err := prb.Tasks.Delete(ctx, scope, input.TaskID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete task", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -124,7 +123,7 @@ func (r *mutationResolver) DeleteTask(ctx context.Context, input types.DeleteTas
 
 // AssignedTo is the resolver for the assignedTo field.
 func (r *taskResolver) AssignedTo(ctx context.Context, obj *types.Task) (*types.Profile, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileGet); err != nil {
 		return nil, err
 	}
 
@@ -150,7 +149,7 @@ func (r *taskResolver) AssignedTo(ctx context.Context, obj *types.Task) (*types.
 
 // Organization is the resolver for the organization field.
 func (r *taskResolver) Organization(ctx context.Context, obj *types.Task) (*types.Organization, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
 		return nil, err
 	}
 
@@ -172,7 +171,7 @@ func (r *taskResolver) Organization(ctx context.Context, obj *types.Task) (*type
 
 // Measure is the resolver for the measure field.
 func (r *taskResolver) Measure(ctx context.Context, obj *types.Task) (*types.Measure, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionMeasureGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionMeasureGet); err != nil {
 		return nil, err
 	}
 
@@ -198,11 +197,11 @@ func (r *taskResolver) Measure(ctx context.Context, obj *types.Task) (*types.Mea
 
 // Evidences is the resolver for the evidences field.
 func (r *taskResolver) Evidences(ctx context.Context, obj *types.Task, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.EvidenceOrderBy) (*types.EvidenceConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionEvidenceList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionEvidenceList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.EvidenceOrderField]{
@@ -234,11 +233,11 @@ func (r *taskResolver) Permission(ctx context.Context, obj *types.Task, action s
 
 // TotalCount is the resolver for the totalCount field.
 func (r *taskConnectionResolver) TotalCount(ctx context.Context, obj *types.TaskConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionTaskList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionTaskList)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 	prb := r.probo
 
 	switch obj.Resolver.(type) {

--- a/pkg/server/api/console/v1/third_party_resolvers.go
+++ b/pkg/server/api/console/v1/third_party_resolvers.go
@@ -32,9 +32,7 @@ func (r *mutationResolver) CreateThirdParty(ctx context.Context, input types.Cre
 		return nil, err
 	}
 
-	prb := r.probo
-
-	thirdParty, err := prb.ThirdParties.Create(
+	thirdParty, err := r.probo.ThirdParties.Create(
 		ctx, scope,
 		probo.CreateThirdPartyRequest{
 			OrganizationID:                input.OrganizationID,
@@ -85,9 +83,7 @@ func (r *mutationResolver) UpdateThirdParty(ctx context.Context, input types.Upd
 		return nil, err
 	}
 
-	prb := r.probo
-
-	thirdParty, err := prb.ThirdParties.Update(
+	thirdParty, err := r.probo.ThirdParties.Update(
 		ctx, scope,
 		probo.UpdateThirdPartyRequest{
 			ID:                            input.ID,
@@ -135,9 +131,7 @@ func (r *mutationResolver) DeleteThirdParty(ctx context.Context, input types.Del
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.ThirdParties.Delete(ctx, scope, input.ThirdPartyID); err != nil {
+	if err := r.probo.ThirdParties.Delete(ctx, scope, input.ThirdPartyID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete thirdParty", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -154,8 +148,6 @@ func (r *mutationResolver) CreateThirdPartyContact(ctx context.Context, input ty
 		return nil, err
 	}
 
-	prb := r.probo
-
 	req := probo.CreateThirdPartyContactRequest{
 		ThirdPartyID: input.ThirdPartyID,
 		FullName:     input.FullName,
@@ -164,7 +156,7 @@ func (r *mutationResolver) CreateThirdPartyContact(ctx context.Context, input ty
 		Role:         input.Role,
 	}
 
-	thirdPartyContact, err := prb.ThirdPartyContacts.Create(ctx, scope, req)
+	thirdPartyContact, err := r.probo.ThirdPartyContacts.Create(ctx, scope, req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -187,8 +179,6 @@ func (r *mutationResolver) UpdateThirdPartyContact(ctx context.Context, input ty
 		return nil, err
 	}
 
-	prb := r.probo
-
 	req := probo.UpdateThirdPartyContactRequest{
 		ID:       input.ID,
 		FullName: gqlutils.UnwrapOmittable(input.FullName),
@@ -197,7 +187,7 @@ func (r *mutationResolver) UpdateThirdPartyContact(ctx context.Context, input ty
 		Role:     gqlutils.UnwrapOmittable(input.Role),
 	}
 
-	thirdPartyContact, err := prb.ThirdPartyContacts.Update(ctx, scope, req)
+	thirdPartyContact, err := r.probo.ThirdPartyContacts.Update(ctx, scope, req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -220,9 +210,7 @@ func (r *mutationResolver) DeleteThirdPartyContact(ctx context.Context, input ty
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.ThirdPartyContacts.Delete(ctx, scope, input.ThirdPartyContactID); err != nil {
+	if err := r.probo.ThirdPartyContacts.Delete(ctx, scope, input.ThirdPartyContactID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete thirdParty contact", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -239,15 +227,13 @@ func (r *mutationResolver) CreateThirdPartyService(ctx context.Context, input ty
 		return nil, err
 	}
 
-	prb := r.probo
-
 	req := probo.CreateThirdPartyServiceRequest{
 		ThirdPartyID: input.ThirdPartyID,
 		Name:         input.Name,
 		Description:  input.Description,
 	}
 
-	thirdPartyService, err := prb.ThirdPartyServices.Create(ctx, scope, req)
+	thirdPartyService, err := r.probo.ThirdPartyServices.Create(ctx, scope, req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -270,15 +256,13 @@ func (r *mutationResolver) UpdateThirdPartyService(ctx context.Context, input ty
 		return nil, err
 	}
 
-	prb := r.probo
-
 	req := probo.UpdateThirdPartyServiceRequest{
 		ID:          input.ID,
 		Name:        input.Name,
 		Description: gqlutils.UnwrapOmittable(input.Description),
 	}
 
-	thirdPartyService, err := prb.ThirdPartyServices.Update(ctx, scope, req)
+	thirdPartyService, err := r.probo.ThirdPartyServices.Update(ctx, scope, req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -301,9 +285,7 @@ func (r *mutationResolver) DeleteThirdPartyService(ctx context.Context, input ty
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.ThirdPartyServices.Delete(ctx, scope, input.ThirdPartyServiceID); err != nil {
+	if err := r.probo.ThirdPartyServices.Delete(ctx, scope, input.ThirdPartyServiceID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete thirdParty service", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -320,9 +302,7 @@ func (r *mutationResolver) UploadThirdPartyComplianceReport(ctx context.Context,
 		return nil, err
 	}
 
-	prb := r.probo
-
-	thirdPartyComplianceReport, err := prb.ThirdPartyComplianceReports.Upload(
+	thirdPartyComplianceReport, err := r.probo.ThirdPartyComplianceReports.Upload(
 		ctx, scope,
 		input.ThirdPartyID,
 		&probo.ThirdPartyComplianceReportCreateRequest{
@@ -354,9 +334,7 @@ func (r *mutationResolver) DeleteThirdPartyComplianceReport(ctx context.Context,
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.ThirdPartyComplianceReports.Delete(ctx, scope, input.ReportID); err != nil {
+	if err := r.probo.ThirdPartyComplianceReports.Delete(ctx, scope, input.ReportID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete thirdParty compliance report", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -373,9 +351,7 @@ func (r *mutationResolver) UploadThirdPartyBusinessAssociateAgreement(ctx contex
 		return nil, err
 	}
 
-	prb := r.probo
-
-	thirdPartyBusinessAssociateAgreement, file, err := prb.ThirdPartyBusinessAssociateAgreements.Upload(
+	thirdPartyBusinessAssociateAgreement, file, err := r.probo.ThirdPartyBusinessAssociateAgreements.Upload(
 		ctx, scope,
 		input.ThirdPartyID,
 		&probo.ThirdPartyBusinessAssociateAgreementCreateRequest{
@@ -407,9 +383,7 @@ func (r *mutationResolver) UpdateThirdPartyBusinessAssociateAgreement(ctx contex
 		return nil, err
 	}
 
-	prb := r.probo
-
-	thirdPartyBusinessAssociateAgreement, file, err := prb.ThirdPartyBusinessAssociateAgreements.Update(
+	thirdPartyBusinessAssociateAgreement, file, err := r.probo.ThirdPartyBusinessAssociateAgreements.Update(
 		ctx, scope,
 		input.ThirdPartyID,
 		&probo.ThirdPartyBusinessAssociateAgreementUpdateRequest{
@@ -439,9 +413,7 @@ func (r *mutationResolver) DeleteThirdPartyBusinessAssociateAgreement(ctx contex
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.ThirdPartyBusinessAssociateAgreements.DeleteByThirdPartyID(ctx, scope, input.ThirdPartyID); err != nil {
+	if err := r.probo.ThirdPartyBusinessAssociateAgreements.DeleteByThirdPartyID(ctx, scope, input.ThirdPartyID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete thirdParty business associate agreement", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -458,9 +430,7 @@ func (r *mutationResolver) UploadThirdPartyDataPrivacyAgreement(ctx context.Cont
 		return nil, err
 	}
 
-	prb := r.probo
-
-	thirdPartyDataPrivacyAgreement, file, err := prb.ThirdPartyDataPrivacyAgreements.Upload(
+	thirdPartyDataPrivacyAgreement, file, err := r.probo.ThirdPartyDataPrivacyAgreements.Upload(
 		ctx, scope,
 		input.ThirdPartyID,
 		&probo.ThirdPartyDataPrivacyAgreementCreateRequest{
@@ -492,9 +462,7 @@ func (r *mutationResolver) UpdateThirdPartyDataPrivacyAgreement(ctx context.Cont
 		return nil, err
 	}
 
-	prb := r.probo
-
-	thirdPartyDataPrivacyAgreement, file, err := prb.ThirdPartyDataPrivacyAgreements.Update(
+	thirdPartyDataPrivacyAgreement, file, err := r.probo.ThirdPartyDataPrivacyAgreements.Update(
 		ctx, scope,
 		input.ThirdPartyID,
 		&probo.ThirdPartyDataPrivacyAgreementUpdateRequest{
@@ -524,9 +492,7 @@ func (r *mutationResolver) DeleteThirdPartyDataPrivacyAgreement(ctx context.Cont
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.ThirdPartyDataPrivacyAgreements.DeleteByThirdPartyID(ctx, scope, input.ThirdPartyID); err != nil {
+	if err := r.probo.ThirdPartyDataPrivacyAgreements.DeleteByThirdPartyID(ctx, scope, input.ThirdPartyID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete thirdParty data privacy agreement", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -543,9 +509,7 @@ func (r *mutationResolver) CreateThirdPartyRiskAssessment(ctx context.Context, i
 		return nil, err
 	}
 
-	prb := r.probo
-
-	thirdPartyRiskAssessment, err := prb.ThirdParties.CreateRiskAssessment(
+	thirdPartyRiskAssessment, err := r.probo.ThirdParties.CreateRiskAssessment(
 		ctx, scope,
 		probo.CreateThirdPartyRiskAssessmentRequest{
 			ThirdPartyID:    input.ThirdPartyID,
@@ -577,9 +541,7 @@ func (r *mutationResolver) AssessThirdParty(ctx context.Context, input types.Ass
 		return nil, err
 	}
 
-	prb := r.probo
-
-	result, err := prb.ThirdParties.Assess(
+	result, err := r.probo.ThirdParties.Assess(
 		ctx, scope,
 		probo.AssessThirdPartyRequest{
 			ID:         input.ID,
@@ -611,9 +573,7 @@ func (r *mutationResolver) PublishThirdPartyList(ctx context.Context, input type
 		return nil, err
 	}
 
-	prb := r.probo
-
-	document, documentVersion, err := prb.GeneratedDocuments.PublishThirdPartyList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
+	document, documentVersion, err := r.probo.GeneratedDocuments.PublishThirdPartyList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
@@ -663,8 +623,6 @@ func (r *thirdPartyResolver) ComplianceReports(ctx context.Context, obj *types.T
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyComplianceReportOrderField]{
 		Field:     coredata.ThirdPartyComplianceReportOrderFieldReportDate,
 		Direction: page.OrderDirectionDesc,
@@ -678,7 +636,7 @@ func (r *thirdPartyResolver) ComplianceReports(ctx context.Context, obj *types.T
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.ThirdPartyComplianceReports.ListForThirdPartyID(ctx, scope, obj.ID, cursor)
+	page, err := r.probo.ThirdPartyComplianceReports.ListForThirdPartyID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list thirdParty compliance reports", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -694,9 +652,7 @@ func (r *thirdPartyResolver) BusinessAssociateAgreement(ctx context.Context, obj
 		return nil, err
 	}
 
-	prb := r.probo
-
-	thirdPartyBusinessAssociateAgreement, file, err := prb.ThirdPartyBusinessAssociateAgreements.GetByThirdPartyID(ctx, scope, obj.ID)
+	thirdPartyBusinessAssociateAgreement, file, err := r.probo.ThirdPartyBusinessAssociateAgreements.GetByThirdPartyID(ctx, scope, obj.ID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
@@ -717,9 +673,7 @@ func (r *thirdPartyResolver) DataPrivacyAgreement(ctx context.Context, obj *type
 		return nil, err
 	}
 
-	prb := r.probo
-
-	thirdPartyDataPrivacyAgreement, file, err := prb.ThirdPartyDataPrivacyAgreements.GetByThirdPartyID(ctx, scope, obj.ID)
+	thirdPartyDataPrivacyAgreement, file, err := r.probo.ThirdPartyDataPrivacyAgreements.GetByThirdPartyID(ctx, scope, obj.ID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
@@ -740,8 +694,6 @@ func (r *thirdPartyResolver) Contacts(ctx context.Context, obj *types.ThirdParty
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyContactOrderField]{
 		Field:     coredata.ThirdPartyContactOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -755,7 +707,7 @@ func (r *thirdPartyResolver) Contacts(ctx context.Context, obj *types.ThirdParty
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.ThirdPartyContacts.List(ctx, scope, obj.ID, cursor)
+	page, err := r.probo.ThirdPartyContacts.List(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list thirdParty contacts", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -771,8 +723,6 @@ func (r *thirdPartyResolver) Services(ctx context.Context, obj *types.ThirdParty
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyServiceOrderField]{
 		Field:     coredata.ThirdPartyServiceOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -786,7 +736,7 @@ func (r *thirdPartyResolver) Services(ctx context.Context, obj *types.ThirdParty
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.ThirdPartyServices.List(ctx, scope, obj.ID, cursor)
+	page, err := r.probo.ThirdPartyServices.List(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list thirdParty services", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -802,8 +752,6 @@ func (r *thirdPartyResolver) RiskAssessments(ctx context.Context, obj *types.Thi
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyRiskAssessmentOrderField]{
 		Field:     coredata.ThirdPartyRiskAssessmentOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -817,7 +765,7 @@ func (r *thirdPartyResolver) RiskAssessments(ctx context.Context, obj *types.Thi
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.ThirdParties.ListRiskAssessments(ctx, scope, obj.ID, cursor)
+	page, err := r.probo.ThirdParties.ListRiskAssessments(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list thirdParty risk assessments", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -890,9 +838,7 @@ func (r *thirdPartyBusinessAssociateAgreementResolver) ThirdParty(ctx context.Co
 		return nil, err
 	}
 
-	prb := r.probo
-
-	thirdParty, err := prb.ThirdParties.Get(ctx, scope, obj.ID)
+	thirdParty, err := r.probo.ThirdParties.Get(ctx, scope, obj.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -911,9 +857,7 @@ func (r *thirdPartyBusinessAssociateAgreementResolver) FileURL(ctx context.Conte
 		return "", err
 	}
 
-	prb := r.probo
-
-	fileURL, err := prb.ThirdPartyBusinessAssociateAgreements.GenerateFileURL(ctx, scope, obj.ID, 1*time.Hour)
+	fileURL, err := r.probo.ThirdPartyBusinessAssociateAgreements.GenerateFileURL(ctx, scope, obj.ID, 1*time.Hour)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate file URL", log.Error(err))
 		return "", gqlutils.Internal(ctx)
@@ -934,9 +878,7 @@ func (r *thirdPartyComplianceReportResolver) ThirdParty(ctx context.Context, obj
 		return nil, err
 	}
 
-	prb := r.probo
-
-	thirdParty, err := prb.ThirdParties.Get(ctx, scope, obj.ID)
+	thirdParty, err := r.probo.ThirdParties.Get(ctx, scope, obj.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -957,9 +899,7 @@ func (r *thirdPartyComplianceReportResolver) File(ctx context.Context, obj *type
 		return nil, err
 	}
 
-	prb := r.probo
-
-	evidence, err := prb.ThirdPartyComplianceReports.Get(ctx, scope, obj.ID)
+	evidence, err := r.probo.ThirdPartyComplianceReports.Get(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot load evidence", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -969,7 +909,7 @@ func (r *thirdPartyComplianceReportResolver) File(ctx context.Context, obj *type
 		return nil, nil
 	}
 
-	file, err := prb.Files.Get(ctx, scope, *evidence.ReportFileId)
+	file, err := r.probo.Files.Get(ctx, scope, *evidence.ReportFileId)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -995,11 +935,9 @@ func (r *thirdPartyConnectionResolver) TotalCount(ctx context.Context, obj *type
 		return 0, err
 	}
 
-	prb := r.probo
-
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.ThirdParties.CountForOrganizationID(ctx, scope, obj.ParentID)
+		count, err := r.probo.ThirdParties.CountForOrganizationID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count thirdParties", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -1007,7 +945,7 @@ func (r *thirdPartyConnectionResolver) TotalCount(ctx context.Context, obj *type
 
 		return count, nil
 	case *assetResolver:
-		count, err := prb.ThirdParties.CountForAssetID(ctx, scope, obj.ParentID)
+		count, err := r.probo.ThirdParties.CountForAssetID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count thirdParties", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -1015,7 +953,7 @@ func (r *thirdPartyConnectionResolver) TotalCount(ctx context.Context, obj *type
 
 		return count, nil
 	case *datumResolver:
-		count, err := prb.ThirdParties.CountForDatumID(ctx, scope, obj.ParentID)
+		count, err := r.probo.ThirdParties.CountForDatumID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count thirdParties", log.Error(err))
 			return 0, gqlutils.Internal(ctx)
@@ -1036,16 +974,14 @@ func (r *thirdPartyContactResolver) ThirdParty(ctx context.Context, obj *types.T
 		return nil, err
 	}
 
-	prb := r.probo
-
 	// Get the thirdParty contact to access the ThirdPartyID
-	thirdPartyContact, err := prb.ThirdPartyContacts.Get(ctx, scope, obj.ID)
+	thirdPartyContact, err := r.probo.ThirdPartyContacts.Get(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get thirdParty contact", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	thirdParty, err := prb.ThirdParties.Get(ctx, scope, thirdPartyContact.ThirdPartyID)
+	thirdParty, err := r.probo.ThirdParties.Get(ctx, scope, thirdPartyContact.ThirdPartyID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -1071,9 +1007,7 @@ func (r *thirdPartyDataPrivacyAgreementResolver) ThirdParty(ctx context.Context,
 		return nil, err
 	}
 
-	prb := r.probo
-
-	thirdParty, err := prb.ThirdParties.Get(ctx, scope, obj.ID)
+	thirdParty, err := r.probo.ThirdParties.Get(ctx, scope, obj.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -1094,9 +1028,7 @@ func (r *thirdPartyDataPrivacyAgreementResolver) FileURL(ctx context.Context, ob
 		return "", err
 	}
 
-	prb := r.probo
-
-	fileURL, err := prb.ThirdPartyDataPrivacyAgreements.GenerateFileURL(ctx, scope, obj.ID, 1*time.Hour)
+	fileURL, err := r.probo.ThirdPartyDataPrivacyAgreements.GenerateFileURL(ctx, scope, obj.ID, 1*time.Hour)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate file URL", log.Error(err))
 		return "", gqlutils.Internal(ctx)
@@ -1117,9 +1049,7 @@ func (r *thirdPartyRiskAssessmentResolver) ThirdParty(ctx context.Context, obj *
 		return nil, err
 	}
 
-	prb := r.probo
-
-	thirdParty, err := prb.ThirdParties.GetByRiskAssessmentID(ctx, scope, obj.ID)
+	thirdParty, err := r.probo.ThirdParties.GetByRiskAssessmentID(ctx, scope, obj.ID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)

--- a/pkg/server/api/console/v1/third_party_resolvers.go
+++ b/pkg/server/api/console/v1/third_party_resolvers.go
@@ -27,11 +27,11 @@ import (
 
 // CreateThirdParty is the resolver for the createThirdParty field.
 func (r *mutationResolver) CreateThirdParty(ctx context.Context, input types.CreateThirdPartyInput) (*types.CreateThirdPartyPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionThirdPartyCreate); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionThirdPartyCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	thirdParty, err := prb.ThirdParties.Create(
@@ -80,11 +80,11 @@ func (r *mutationResolver) CreateThirdParty(ctx context.Context, input types.Cre
 
 // UpdateThirdParty is the resolver for the updateThirdParty field.
 func (r *mutationResolver) UpdateThirdParty(ctx context.Context, input types.UpdateThirdPartyInput) (*types.UpdateThirdPartyPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionThirdPartyUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionThirdPartyUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
 	thirdParty, err := prb.ThirdParties.Update(
@@ -130,15 +130,14 @@ func (r *mutationResolver) UpdateThirdParty(ctx context.Context, input types.Upd
 
 // DeleteThirdParty is the resolver for the deleteThirdParty field.
 func (r *mutationResolver) DeleteThirdParty(ctx context.Context, input types.DeleteThirdPartyInput) (*types.DeleteThirdPartyPayload, error) {
-	if err := r.authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyDelete); err != nil {
+	scope, err := r.authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
 	prb := r.probo
 
-	err := prb.ThirdParties.Delete(ctx, scope, input.ThirdPartyID)
-	if err != nil {
+	if err := prb.ThirdParties.Delete(ctx, scope, input.ThirdPartyID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete thirdParty", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -150,11 +149,11 @@ func (r *mutationResolver) DeleteThirdParty(ctx context.Context, input types.Del
 
 // CreateThirdPartyContact is the resolver for the createThirdPartyContact field.
 func (r *mutationResolver) CreateThirdPartyContact(ctx context.Context, input types.CreateThirdPartyContactInput) (*types.CreateThirdPartyContactPayload, error) {
-	if err := r.authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyContactCreate); err != nil {
+	scope, err := r.authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyContactCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
 	prb := r.probo
 
 	req := probo.CreateThirdPartyContactRequest{
@@ -183,11 +182,11 @@ func (r *mutationResolver) CreateThirdPartyContact(ctx context.Context, input ty
 
 // UpdateThirdPartyContact is the resolver for the updateThirdPartyContact field.
 func (r *mutationResolver) UpdateThirdPartyContact(ctx context.Context, input types.UpdateThirdPartyContactInput) (*types.UpdateThirdPartyContactPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionThirdPartyContactUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionThirdPartyContactUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
 	req := probo.UpdateThirdPartyContactRequest{
@@ -216,15 +215,14 @@ func (r *mutationResolver) UpdateThirdPartyContact(ctx context.Context, input ty
 
 // DeleteThirdPartyContact is the resolver for the deleteThirdPartyContact field.
 func (r *mutationResolver) DeleteThirdPartyContact(ctx context.Context, input types.DeleteThirdPartyContactInput) (*types.DeleteThirdPartyContactPayload, error) {
-	if err := r.authorize(ctx, input.ThirdPartyContactID, probo.ActionThirdPartyContactDelete); err != nil {
+	scope, err := r.authorize(ctx, input.ThirdPartyContactID, probo.ActionThirdPartyContactDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ThirdPartyContactID)
 	prb := r.probo
 
-	err := prb.ThirdPartyContacts.Delete(ctx, scope, input.ThirdPartyContactID)
-	if err != nil {
+	if err := prb.ThirdPartyContacts.Delete(ctx, scope, input.ThirdPartyContactID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete thirdParty contact", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -236,11 +234,11 @@ func (r *mutationResolver) DeleteThirdPartyContact(ctx context.Context, input ty
 
 // CreateThirdPartyService is the resolver for the createThirdPartyService field.
 func (r *mutationResolver) CreateThirdPartyService(ctx context.Context, input types.CreateThirdPartyServiceInput) (*types.CreateThirdPartyServicePayload, error) {
-	if err := r.authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyServiceCreate); err != nil {
+	scope, err := r.authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyServiceCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
 	prb := r.probo
 
 	req := probo.CreateThirdPartyServiceRequest{
@@ -267,11 +265,11 @@ func (r *mutationResolver) CreateThirdPartyService(ctx context.Context, input ty
 
 // UpdateThirdPartyService is the resolver for the updateThirdPartyService field.
 func (r *mutationResolver) UpdateThirdPartyService(ctx context.Context, input types.UpdateThirdPartyServiceInput) (*types.UpdateThirdPartyServicePayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionThirdPartyServiceUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionThirdPartyServiceUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
 	req := probo.UpdateThirdPartyServiceRequest{
@@ -298,15 +296,14 @@ func (r *mutationResolver) UpdateThirdPartyService(ctx context.Context, input ty
 
 // DeleteThirdPartyService is the resolver for the deleteThirdPartyService field.
 func (r *mutationResolver) DeleteThirdPartyService(ctx context.Context, input types.DeleteThirdPartyServiceInput) (*types.DeleteThirdPartyServicePayload, error) {
-	if err := r.authorize(ctx, input.ThirdPartyServiceID, probo.ActionThirdPartyServiceDelete); err != nil {
+	scope, err := r.authorize(ctx, input.ThirdPartyServiceID, probo.ActionThirdPartyServiceDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ThirdPartyServiceID)
 	prb := r.probo
 
-	err := prb.ThirdPartyServices.Delete(ctx, scope, input.ThirdPartyServiceID)
-	if err != nil {
+	if err := prb.ThirdPartyServices.Delete(ctx, scope, input.ThirdPartyServiceID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete thirdParty service", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -318,11 +315,11 @@ func (r *mutationResolver) DeleteThirdPartyService(ctx context.Context, input ty
 
 // UploadThirdPartyComplianceReport is the resolver for the uploadThirdPartyComplianceReport field.
 func (r *mutationResolver) UploadThirdPartyComplianceReport(ctx context.Context, input types.UploadThirdPartyComplianceReportInput) (*types.UploadThirdPartyComplianceReportPayload, error) {
-	if err := r.authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyComplianceReportUpload); err != nil {
+	scope, err := r.authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyComplianceReportUpload)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
 	prb := r.probo
 
 	thirdPartyComplianceReport, err := prb.ThirdPartyComplianceReports.Upload(
@@ -352,15 +349,14 @@ func (r *mutationResolver) UploadThirdPartyComplianceReport(ctx context.Context,
 
 // DeleteThirdPartyComplianceReport is the resolver for the deleteThirdPartyComplianceReport field.
 func (r *mutationResolver) DeleteThirdPartyComplianceReport(ctx context.Context, input types.DeleteThirdPartyComplianceReportInput) (*types.DeleteThirdPartyComplianceReportPayload, error) {
-	if err := r.authorize(ctx, input.ReportID, probo.ActionThirdPartyComplianceReportDelete); err != nil {
+	scope, err := r.authorize(ctx, input.ReportID, probo.ActionThirdPartyComplianceReportDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ReportID)
 	prb := r.probo
 
-	err := prb.ThirdPartyComplianceReports.Delete(ctx, scope, input.ReportID)
-	if err != nil {
+	if err := prb.ThirdPartyComplianceReports.Delete(ctx, scope, input.ReportID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete thirdParty compliance report", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -372,11 +368,11 @@ func (r *mutationResolver) DeleteThirdPartyComplianceReport(ctx context.Context,
 
 // UploadThirdPartyBusinessAssociateAgreement is the resolver for the uploadThirdPartyBusinessAssociateAgreement field.
 func (r *mutationResolver) UploadThirdPartyBusinessAssociateAgreement(ctx context.Context, input types.UploadThirdPartyBusinessAssociateAgreementInput) (*types.UploadThirdPartyBusinessAssociateAgreementPayload, error) {
-	if err := r.authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyBusinessAssociateAgreementUpload); err != nil {
+	scope, err := r.authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyBusinessAssociateAgreementUpload)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
 	prb := r.probo
 
 	thirdPartyBusinessAssociateAgreement, file, err := prb.ThirdPartyBusinessAssociateAgreements.Upload(
@@ -406,11 +402,11 @@ func (r *mutationResolver) UploadThirdPartyBusinessAssociateAgreement(ctx contex
 
 // UpdateThirdPartyBusinessAssociateAgreement is the resolver for the updateThirdPartyBusinessAssociateAgreement field.
 func (r *mutationResolver) UpdateThirdPartyBusinessAssociateAgreement(ctx context.Context, input types.UpdateThirdPartyBusinessAssociateAgreementInput) (*types.UpdateThirdPartyBusinessAssociateAgreementPayload, error) {
-	if err := r.authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyBusinessAssociateAgreementUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyBusinessAssociateAgreementUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
 	prb := r.probo
 
 	thirdPartyBusinessAssociateAgreement, file, err := prb.ThirdPartyBusinessAssociateAgreements.Update(
@@ -438,15 +434,14 @@ func (r *mutationResolver) UpdateThirdPartyBusinessAssociateAgreement(ctx contex
 
 // DeleteThirdPartyBusinessAssociateAgreement is the resolver for the deleteThirdPartyBusinessAssociateAgreement field.
 func (r *mutationResolver) DeleteThirdPartyBusinessAssociateAgreement(ctx context.Context, input types.DeleteThirdPartyBusinessAssociateAgreementInput) (*types.DeleteThirdPartyBusinessAssociateAgreementPayload, error) {
-	if err := r.authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyBusinessAssociateAgreementDelete); err != nil {
+	scope, err := r.authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyBusinessAssociateAgreementDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
 	prb := r.probo
 
-	err := prb.ThirdPartyBusinessAssociateAgreements.DeleteByThirdPartyID(ctx, scope, input.ThirdPartyID)
-	if err != nil {
+	if err := prb.ThirdPartyBusinessAssociateAgreements.DeleteByThirdPartyID(ctx, scope, input.ThirdPartyID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete thirdParty business associate agreement", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -458,11 +453,11 @@ func (r *mutationResolver) DeleteThirdPartyBusinessAssociateAgreement(ctx contex
 
 // UploadThirdPartyDataPrivacyAgreement is the resolver for the uploadThirdPartyDataPrivacyAgreement field.
 func (r *mutationResolver) UploadThirdPartyDataPrivacyAgreement(ctx context.Context, input types.UploadThirdPartyDataPrivacyAgreementInput) (*types.UploadThirdPartyDataPrivacyAgreementPayload, error) {
-	if err := r.authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyDataPrivacyAgreementUpload); err != nil {
+	scope, err := r.authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyDataPrivacyAgreementUpload)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
 	prb := r.probo
 
 	thirdPartyDataPrivacyAgreement, file, err := prb.ThirdPartyDataPrivacyAgreements.Upload(
@@ -492,11 +487,11 @@ func (r *mutationResolver) UploadThirdPartyDataPrivacyAgreement(ctx context.Cont
 
 // UpdateThirdPartyDataPrivacyAgreement is the resolver for the updateThirdPartyDataPrivacyAgreement field.
 func (r *mutationResolver) UpdateThirdPartyDataPrivacyAgreement(ctx context.Context, input types.UpdateThirdPartyDataPrivacyAgreementInput) (*types.UpdateThirdPartyDataPrivacyAgreementPayload, error) {
-	if err := r.authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyDataPrivacyAgreementUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyDataPrivacyAgreementUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
 	prb := r.probo
 
 	thirdPartyDataPrivacyAgreement, file, err := prb.ThirdPartyDataPrivacyAgreements.Update(
@@ -524,15 +519,14 @@ func (r *mutationResolver) UpdateThirdPartyDataPrivacyAgreement(ctx context.Cont
 
 // DeleteThirdPartyDataPrivacyAgreement is the resolver for the deleteThirdPartyDataPrivacyAgreement field.
 func (r *mutationResolver) DeleteThirdPartyDataPrivacyAgreement(ctx context.Context, input types.DeleteThirdPartyDataPrivacyAgreementInput) (*types.DeleteThirdPartyDataPrivacyAgreementPayload, error) {
-	if err := r.authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyDataPrivacyAgreementDelete); err != nil {
+	scope, err := r.authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyDataPrivacyAgreementDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
 	prb := r.probo
 
-	err := prb.ThirdPartyDataPrivacyAgreements.DeleteByThirdPartyID(ctx, scope, input.ThirdPartyID)
-	if err != nil {
+	if err := prb.ThirdPartyDataPrivacyAgreements.DeleteByThirdPartyID(ctx, scope, input.ThirdPartyID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete thirdParty data privacy agreement", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -544,11 +538,11 @@ func (r *mutationResolver) DeleteThirdPartyDataPrivacyAgreement(ctx context.Cont
 
 // CreateThirdPartyRiskAssessment is the resolver for the createThirdPartyRiskAssessment field.
 func (r *mutationResolver) CreateThirdPartyRiskAssessment(ctx context.Context, input types.CreateThirdPartyRiskAssessmentInput) (*types.CreateThirdPartyRiskAssessmentPayload, error) {
-	if err := r.authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyRiskAssessmentCreate); err != nil {
+	scope, err := r.authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyRiskAssessmentCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
 	prb := r.probo
 
 	thirdPartyRiskAssessment, err := prb.ThirdParties.CreateRiskAssessment(
@@ -578,11 +572,11 @@ func (r *mutationResolver) CreateThirdPartyRiskAssessment(ctx context.Context, i
 
 // AssessThirdParty is the resolver for the assessThirdParty field.
 func (r *mutationResolver) AssessThirdParty(ctx context.Context, input types.AssessThirdPartyInput) (*types.AssessThirdPartyPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionThirdPartyAssess); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionThirdPartyAssess)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
 	result, err := prb.ThirdParties.Assess(
@@ -612,11 +606,11 @@ func (r *mutationResolver) AssessThirdParty(ctx context.Context, input types.Ass
 
 // PublishThirdPartyList is the resolver for the publishThirdPartyList field.
 func (r *mutationResolver) PublishThirdPartyList(ctx context.Context, input types.PublishThirdPartyListInput) (*types.PublishThirdPartyListPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionThirdPartyPublish); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionThirdPartyPublish)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	document, documentVersion, err := prb.GeneratedDocuments.PublishThirdPartyList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
@@ -642,7 +636,7 @@ func (r *mutationResolver) PublishThirdPartyList(ctx context.Context, input type
 
 // Organization is the resolver for the organization field.
 func (r *thirdPartyResolver) Organization(ctx context.Context, obj *types.ThirdParty) (*types.Organization, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
 		return nil, err
 	}
 
@@ -664,11 +658,11 @@ func (r *thirdPartyResolver) Organization(ctx context.Context, obj *types.ThirdP
 
 // ComplianceReports is the resolver for the complianceReports field.
 func (r *thirdPartyResolver) ComplianceReports(ctx context.Context, obj *types.ThirdParty, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ThirdPartyComplianceReportOrderBy) (*types.ThirdPartyComplianceReportConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyComplianceReportList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyComplianceReportList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyComplianceReportOrderField]{
@@ -695,11 +689,11 @@ func (r *thirdPartyResolver) ComplianceReports(ctx context.Context, obj *types.T
 
 // BusinessAssociateAgreement is the resolver for the businessAssociateAgreement field.
 func (r *thirdPartyResolver) BusinessAssociateAgreement(ctx context.Context, obj *types.ThirdParty) (*types.ThirdPartyBusinessAssociateAgreement, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyBusinessAssociateAgreementGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyBusinessAssociateAgreementGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	thirdPartyBusinessAssociateAgreement, file, err := prb.ThirdPartyBusinessAssociateAgreements.GetByThirdPartyID(ctx, scope, obj.ID)
@@ -718,11 +712,11 @@ func (r *thirdPartyResolver) BusinessAssociateAgreement(ctx context.Context, obj
 
 // DataPrivacyAgreement is the resolver for the dataPrivacyAgreement field.
 func (r *thirdPartyResolver) DataPrivacyAgreement(ctx context.Context, obj *types.ThirdParty) (*types.ThirdPartyDataPrivacyAgreement, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyDataPrivacyAgreementGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyDataPrivacyAgreementGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	thirdPartyDataPrivacyAgreement, file, err := prb.ThirdPartyDataPrivacyAgreements.GetByThirdPartyID(ctx, scope, obj.ID)
@@ -741,11 +735,11 @@ func (r *thirdPartyResolver) DataPrivacyAgreement(ctx context.Context, obj *type
 
 // Contacts is the resolver for the contacts field.
 func (r *thirdPartyResolver) Contacts(ctx context.Context, obj *types.ThirdParty, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ThirdPartyContactOrderBy) (*types.ThirdPartyContactConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyContactList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyContactList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyContactOrderField]{
@@ -772,11 +766,11 @@ func (r *thirdPartyResolver) Contacts(ctx context.Context, obj *types.ThirdParty
 
 // Services is the resolver for the services field.
 func (r *thirdPartyResolver) Services(ctx context.Context, obj *types.ThirdParty, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ThirdPartyServiceOrderBy) (*types.ThirdPartyServiceConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyServiceList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyServiceList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyServiceOrderField]{
@@ -803,11 +797,11 @@ func (r *thirdPartyResolver) Services(ctx context.Context, obj *types.ThirdParty
 
 // RiskAssessments is the resolver for the riskAssessments field.
 func (r *thirdPartyResolver) RiskAssessments(ctx context.Context, obj *types.ThirdParty, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ThirdPartyRiskAssessmentOrder) (*types.ThirdPartyRiskAssessmentConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyRiskAssessmentList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyRiskAssessmentList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyRiskAssessmentOrderField]{
@@ -834,7 +828,7 @@ func (r *thirdPartyResolver) RiskAssessments(ctx context.Context, obj *types.Thi
 
 // BusinessOwner is the resolver for the businessOwner field.
 func (r *thirdPartyResolver) BusinessOwner(ctx context.Context, obj *types.ThirdParty) (*types.Profile, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileGet); err != nil {
 		return nil, err
 	}
 
@@ -860,7 +854,7 @@ func (r *thirdPartyResolver) BusinessOwner(ctx context.Context, obj *types.Third
 
 // SecurityOwner is the resolver for the securityOwner field.
 func (r *thirdPartyResolver) SecurityOwner(ctx context.Context, obj *types.ThirdParty) (*types.Profile, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileGet); err != nil {
 		return nil, err
 	}
 
@@ -891,11 +885,11 @@ func (r *thirdPartyResolver) Permission(ctx context.Context, obj *types.ThirdPar
 
 // ThirdParty is the resolver for the thirdParty field.
 func (r *thirdPartyBusinessAssociateAgreementResolver) ThirdParty(ctx context.Context, obj *types.ThirdPartyBusinessAssociateAgreement) (*types.ThirdParty, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	thirdParty, err := prb.ThirdParties.Get(ctx, scope, obj.ID)
@@ -912,11 +906,11 @@ func (r *thirdPartyBusinessAssociateAgreementResolver) ThirdParty(ctx context.Co
 
 // FileURL is the resolver for the fileUrl field.
 func (r *thirdPartyBusinessAssociateAgreementResolver) FileURL(ctx context.Context, obj *types.ThirdPartyBusinessAssociateAgreement) (string, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionFileDownloadUrl); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionFileDownloadUrl)
+	if err != nil {
 		return "", err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	fileURL, err := prb.ThirdPartyBusinessAssociateAgreements.GenerateFileURL(ctx, scope, obj.ID, 1*time.Hour)
@@ -935,11 +929,11 @@ func (r *thirdPartyBusinessAssociateAgreementResolver) Permission(ctx context.Co
 
 // ThirdParty is the resolver for the thirdParty field.
 func (r *thirdPartyComplianceReportResolver) ThirdParty(ctx context.Context, obj *types.ThirdPartyComplianceReport) (*types.ThirdParty, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	thirdParty, err := prb.ThirdParties.Get(ctx, scope, obj.ID)
@@ -958,11 +952,11 @@ func (r *thirdPartyComplianceReportResolver) ThirdParty(ctx context.Context, obj
 
 // File is the resolver for the file field.
 func (r *thirdPartyComplianceReportResolver) File(ctx context.Context, obj *types.ThirdPartyComplianceReport) (*types.File, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionFileGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionFileGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	evidence, err := prb.ThirdPartyComplianceReports.Get(ctx, scope, obj.ID)
@@ -996,11 +990,11 @@ func (r *thirdPartyComplianceReportResolver) Permission(ctx context.Context, obj
 
 // TotalCount is the resolver for the totalCount field.
 func (r *thirdPartyConnectionResolver) TotalCount(ctx context.Context, obj *types.ThirdPartyConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionThirdPartyList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionThirdPartyList)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 	prb := r.probo
 
 	switch obj.Resolver.(type) {
@@ -1037,11 +1031,11 @@ func (r *thirdPartyConnectionResolver) TotalCount(ctx context.Context, obj *type
 
 // ThirdParty is the resolver for the thirdParty field.
 func (r *thirdPartyContactResolver) ThirdParty(ctx context.Context, obj *types.ThirdPartyContact) (*types.ThirdParty, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	// Get the thirdParty contact to access the ThirdPartyID
@@ -1072,11 +1066,11 @@ func (r *thirdPartyContactResolver) Permission(ctx context.Context, obj *types.T
 
 // ThirdParty is the resolver for the thirdParty field.
 func (r *thirdPartyDataPrivacyAgreementResolver) ThirdParty(ctx context.Context, obj *types.ThirdPartyDataPrivacyAgreement) (*types.ThirdParty, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	thirdParty, err := prb.ThirdParties.Get(ctx, scope, obj.ID)
@@ -1095,11 +1089,11 @@ func (r *thirdPartyDataPrivacyAgreementResolver) ThirdParty(ctx context.Context,
 
 // FileURL is the resolver for the fileUrl field.
 func (r *thirdPartyDataPrivacyAgreementResolver) FileURL(ctx context.Context, obj *types.ThirdPartyDataPrivacyAgreement) (string, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionFileDownloadUrl); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionFileDownloadUrl)
+	if err != nil {
 		return "", err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	fileURL, err := prb.ThirdPartyDataPrivacyAgreements.GenerateFileURL(ctx, scope, obj.ID, 1*time.Hour)
@@ -1118,11 +1112,11 @@ func (r *thirdPartyDataPrivacyAgreementResolver) Permission(ctx context.Context,
 
 // ThirdParty is the resolver for the thirdParty field.
 func (r *thirdPartyRiskAssessmentResolver) ThirdParty(ctx context.Context, obj *types.ThirdPartyRiskAssessment) (*types.ThirdParty, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	thirdParty, err := prb.ThirdParties.GetByRiskAssessmentID(ctx, scope, obj.ID)
@@ -1146,7 +1140,7 @@ func (r *thirdPartyRiskAssessmentResolver) Permission(ctx context.Context, obj *
 
 // ThirdParty is the resolver for the thirdParty field.
 func (r *thirdPartyServiceResolver) ThirdParty(ctx context.Context, obj *types.ThirdPartyService) (*types.ThirdParty, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyGet); err != nil {
 		return nil, err
 	}
 

--- a/pkg/server/api/console/v1/third_party_resolvers.go
+++ b/pkg/server/api/console/v1/third_party_resolvers.go
@@ -627,6 +627,7 @@ func (r *thirdPartyResolver) ComplianceReports(ctx context.Context, obj *types.T
 		Field:     coredata.ThirdPartyComplianceReportOrderFieldReportDate,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ThirdPartyComplianceReportOrderField]{
 			Field:     orderBy.Field,
@@ -698,6 +699,7 @@ func (r *thirdPartyResolver) Contacts(ctx context.Context, obj *types.ThirdParty
 		Field:     coredata.ThirdPartyContactOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ThirdPartyContactOrderField]{
 			Field:     orderBy.Field,
@@ -727,6 +729,7 @@ func (r *thirdPartyResolver) Services(ctx context.Context, obj *types.ThirdParty
 		Field:     coredata.ThirdPartyServiceOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ThirdPartyServiceOrderField]{
 			Field:     orderBy.Field,
@@ -756,6 +759,7 @@ func (r *thirdPartyResolver) RiskAssessments(ctx context.Context, obj *types.Thi
 		Field:     coredata.ThirdPartyRiskAssessmentOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ThirdPartyRiskAssessmentOrderField]{
 			Field:     orderBy.Field,

--- a/pkg/server/api/console/v1/trust_center_resolvers.go
+++ b/pkg/server/api/console/v1/trust_center_resolvers.go
@@ -63,9 +63,7 @@ func (r *mutationResolver) UpdateTrustCenter(ctx context.Context, input types.Up
 		return nil, err
 	}
 
-	prb := r.probo
-
-	trustCenter, file, err := prb.TrustCenters.Update(
+	trustCenter, file, err := r.probo.TrustCenters.Update(
 		ctx, scope,
 		&probo.UpdateTrustCenterRequest{
 			ID:                   input.TrustCenterID,
@@ -95,9 +93,7 @@ func (r *mutationResolver) UploadTrustCenterNda(ctx context.Context, input types
 		return nil, err
 	}
 
-	prb := r.probo
-
-	trustCenter, file, err := prb.TrustCenters.UploadNDA(
+	trustCenter, file, err := r.probo.TrustCenters.UploadNDA(
 		ctx, scope,
 		&probo.UploadTrustCenterNDARequest{
 			TrustCenterID: input.TrustCenterID,
@@ -127,9 +123,7 @@ func (r *mutationResolver) DeleteTrustCenterNda(ctx context.Context, input types
 		return nil, err
 	}
 
-	prb := r.probo
-
-	trustCenter, file, err := prb.TrustCenters.DeleteNDA(ctx, scope, input.TrustCenterID)
+	trustCenter, file, err := r.probo.TrustCenters.DeleteNDA(ctx, scope, input.TrustCenterID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete trust center NDA", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -146,8 +140,6 @@ func (r *mutationResolver) UpdateTrustCenterBrand(ctx context.Context, input typ
 	if err != nil {
 		return nil, err
 	}
-
-	prb := r.probo
 
 	req := &probo.UpdateTrustCenterBrandRequest{
 		TrustCenterID: input.TrustCenterID,
@@ -187,7 +179,7 @@ func (r *mutationResolver) UpdateTrustCenterBrand(ctx context.Context, input typ
 		}
 	}
 
-	trustCenter, file, err := prb.TrustCenters.UpdateTrustCenterBrand(ctx, scope, req)
+	trustCenter, file, err := r.probo.TrustCenters.UpdateTrustCenterBrand(ctx, scope, req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -209,8 +201,6 @@ func (r *mutationResolver) UpdateTrustCenterAccess(ctx context.Context, input ty
 	if err != nil {
 		return nil, err
 	}
-
-	prb := r.probo
 
 	var (
 		documentAccesses []probo.UpdateTrustCenterDocumentAccessRequest
@@ -239,7 +229,7 @@ func (r *mutationResolver) UpdateTrustCenterAccess(ctx context.Context, input ty
 		})
 	}
 
-	access, err := prb.TrustCenterAccesses.Update(
+	access, err := r.probo.TrustCenterAccesses.Update(
 		ctx, scope,
 		&probo.UpdateTrustCenterAccessRequest{
 			ID:                      input.ID,
@@ -270,9 +260,7 @@ func (r *mutationResolver) DeleteTrustCenterAccess(ctx context.Context, input ty
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.TrustCenterAccesses.Delete(ctx, scope, input.ID); err != nil {
+	if err := r.probo.TrustCenterAccesses.Delete(ctx, scope, input.ID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete trust center access", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -289,9 +277,7 @@ func (r *mutationResolver) CreateTrustCenterReference(ctx context.Context, input
 		return nil, err
 	}
 
-	prb := r.probo
-
-	reference, err := prb.TrustCenterReferences.Create(
+	reference, err := r.probo.TrustCenterReferences.Create(
 		ctx, scope,
 		&probo.CreateTrustCenterReferenceRequest{
 			TrustCenterID: input.TrustCenterID,
@@ -328,8 +314,6 @@ func (r *mutationResolver) UpdateTrustCenterReference(ctx context.Context, input
 		return nil, err
 	}
 
-	prb := r.probo
-
 	req := &probo.UpdateTrustCenterReferenceRequest{
 		ID:          input.ID,
 		Name:        input.Name,
@@ -347,7 +331,7 @@ func (r *mutationResolver) UpdateTrustCenterReference(ctx context.Context, input
 		}
 	}
 
-	reference, err := prb.TrustCenterReferences.Update(ctx, scope, req)
+	reference, err := r.probo.TrustCenterReferences.Update(ctx, scope, req)
 	if err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
@@ -370,9 +354,7 @@ func (r *mutationResolver) DeleteTrustCenterReference(ctx context.Context, input
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.TrustCenterReferences.Delete(ctx, scope, input.ID); err != nil {
+	if err := r.probo.TrustCenterReferences.Delete(ctx, scope, input.ID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete trust center reference", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -389,9 +371,7 @@ func (r *mutationResolver) CreateComplianceFramework(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.probo
-
-	cf, err := prb.ComplianceFrameworks.Create(
+	cf, err := r.probo.ComplianceFrameworks.Create(
 		ctx, scope,
 		&probo.CreateComplianceFrameworkRequest{
 			TrustCenterID: input.TrustCenterID,
@@ -420,9 +400,7 @@ func (r *mutationResolver) UpdateComplianceFramework(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.probo
-
-	cf, err := prb.ComplianceFrameworks.Update(ctx, scope, &probo.UpdateComplianceFrameworkRequest{
+	cf, err := r.probo.ComplianceFrameworks.Update(ctx, scope, &probo.UpdateComplianceFrameworkRequest{
 		ID:   input.ID,
 		Rank: input.Rank,
 	})
@@ -448,9 +426,7 @@ func (r *mutationResolver) DeleteComplianceFramework(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.ComplianceFrameworks.Delete(
+	if err := r.probo.ComplianceFrameworks.Delete(
 		ctx, scope,
 		&probo.DeleteComplianceFrameworkRequest{
 			ID: input.ID,
@@ -477,9 +453,7 @@ func (r *mutationResolver) CreateComplianceExternalURL(ctx context.Context, inpu
 		return nil, err
 	}
 
-	prb := r.probo
-
-	item, err := prb.ComplianceExternalURLs.Create(
+	item, err := r.probo.ComplianceExternalURLs.Create(
 		ctx, scope,
 		&probo.CreateComplianceExternalURLRequest{
 			TrustCenterID: input.TrustCenterID,
@@ -509,9 +483,7 @@ func (r *mutationResolver) UpdateComplianceExternalURL(ctx context.Context, inpu
 		return nil, err
 	}
 
-	prb := r.probo
-
-	item, err := prb.ComplianceExternalURLs.Update(ctx, scope, &probo.UpdateComplianceExternalURLRequest{
+	item, err := r.probo.ComplianceExternalURLs.Update(ctx, scope, &probo.UpdateComplianceExternalURLRequest{
 		ID:   input.ID,
 		Name: input.Name,
 		URL:  input.URL,
@@ -539,9 +511,7 @@ func (r *mutationResolver) DeleteComplianceExternalURL(ctx context.Context, inpu
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.ComplianceExternalURLs.Delete(ctx, scope, &probo.DeleteComplianceExternalURLRequest{ID: input.ID}); err != nil {
+	if err := r.probo.ComplianceExternalURLs.Delete(ctx, scope, &probo.DeleteComplianceExternalURLRequest{ID: input.ID}); err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
 		}
@@ -563,9 +533,7 @@ func (r *mutationResolver) CreateTrustCenterFile(ctx context.Context, input type
 		return nil, err
 	}
 
-	prb := r.probo
-
-	file, err := prb.TrustCenterFiles.Create(
+	file, err := r.probo.TrustCenterFiles.Create(
 		ctx, scope,
 		&probo.CreateTrustCenterFileRequest{
 			OrganizationID: input.OrganizationID,
@@ -602,9 +570,7 @@ func (r *mutationResolver) UpdateTrustCenterFile(ctx context.Context, input type
 		return nil, err
 	}
 
-	prb := r.probo
-
-	file, err := prb.TrustCenterFiles.Update(
+	file, err := r.probo.TrustCenterFiles.Update(
 		ctx, scope,
 		&probo.UpdateTrustCenterFileRequest{
 			ID:                    input.ID,
@@ -635,9 +601,7 @@ func (r *mutationResolver) GetTrustCenterFile(ctx context.Context, input types.G
 		return nil, err
 	}
 
-	prb := r.probo
-
-	file, err := prb.TrustCenterFiles.Get(ctx, scope, input.ID)
+	file, err := r.probo.TrustCenterFiles.Get(ctx, scope, input.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get trust center file", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -655,9 +619,7 @@ func (r *mutationResolver) DeleteTrustCenterFile(ctx context.Context, input type
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.TrustCenterFiles.Delete(ctx, scope, input.ID); err != nil {
+	if err := r.probo.TrustCenterFiles.Delete(ctx, scope, input.ID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete trust center file", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -674,9 +636,7 @@ func (r *mutationResolver) CreateCustomDomain(ctx context.Context, input types.C
 		return nil, err
 	}
 
-	prb := r.probo
-
-	domain, err := prb.CustomDomains.CreateCustomDomain(
+	domain, err := r.probo.CustomDomains.CreateCustomDomain(
 		ctx, scope,
 		probo.CreateCustomDomainRequest{
 			OrganizationID: input.OrganizationID,
@@ -705,11 +665,9 @@ func (r *mutationResolver) DeleteCustomDomain(ctx context.Context, input types.D
 		return nil, err
 	}
 
-	prb := r.probo
-
 	// TODO Drop this wierd logic
 	// Get the current custom domain ID before deleting
-	domain, err := prb.CustomDomains.GetOrganizationCustomDomain(ctx, scope, input.OrganizationID)
+	domain, err := r.probo.CustomDomains.GetOrganizationCustomDomain(ctx, scope, input.OrganizationID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get custom domain", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -721,7 +679,7 @@ func (r *mutationResolver) DeleteCustomDomain(ctx context.Context, input types.D
 
 	deletedDomainID := domain.ID
 
-	if err := prb.CustomDomains.DeleteCustomDomain(ctx, scope, input.OrganizationID); err != nil {
+	if err := r.probo.CustomDomains.DeleteCustomDomain(ctx, scope, input.OrganizationID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete custom domain", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -738,9 +696,7 @@ func (r *trustCenterResolver) LogoFileURL(ctx context.Context, obj *types.TrustC
 		return nil, err
 	}
 
-	prb := r.probo
-
-	logoURL, err := prb.TrustCenters.GenerateLogoURL(ctx, scope, obj.ID, 1*time.Hour)
+	logoURL, err := r.probo.TrustCenters.GenerateLogoURL(ctx, scope, obj.ID, 1*time.Hour)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate logo url", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -756,9 +712,7 @@ func (r *trustCenterResolver) DarkLogoFileURL(ctx context.Context, obj *types.Tr
 		return nil, err
 	}
 
-	prb := r.probo
-
-	logoURL, err := prb.TrustCenters.GenerateDarkLogoURL(ctx, scope, obj.ID, 1*time.Hour)
+	logoURL, err := r.probo.TrustCenters.GenerateDarkLogoURL(ctx, scope, obj.ID, 1*time.Hour)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate logo url", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -780,9 +734,7 @@ func (r *trustCenterResolver) NdaFileURL(ctx context.Context, obj *types.TrustCe
 	}
 
 	scope := coredata.NewScopeFromObjectID(obj.ID)
-	prb := r.probo
-
-	fileURL, err := prb.TrustCenters.GenerateNDAFileURL(ctx, scope, obj.ID, 15*time.Minute)
+	fileURL, err := r.probo.TrustCenters.GenerateNDAFileURL(ctx, scope, obj.ID, 15*time.Minute)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate NDA file URL", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -798,15 +750,13 @@ func (r *trustCenterResolver) Organization(ctx context.Context, obj *types.Trust
 		return nil, err
 	}
 
-	prb := r.probo
-
-	trustCenter, err := prb.TrustCenters.Get(ctx, scope, obj.ID)
+	trustCenter, err := r.probo.TrustCenters.Get(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get trust center", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	organization, err := prb.Organizations.Get(ctx, scope, trustCenter.OrganizationID)
+	organization, err := r.probo.Organizations.Get(ctx, scope, trustCenter.OrganizationID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -827,8 +777,6 @@ func (r *trustCenterResolver) Accesses(ctx context.Context, obj *types.TrustCent
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.TrustCenterAccessOrderField]{
 		Field:     coredata.TrustCenterAccessOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -842,7 +790,7 @@ func (r *trustCenterResolver) Accesses(ctx context.Context, obj *types.TrustCent
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	result, err := prb.TrustCenterAccesses.ListForTrustCenterID(ctx, scope, obj.ID, cursor)
+	result, err := r.probo.TrustCenterAccesses.ListForTrustCenterID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list trust center accesses", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -858,8 +806,6 @@ func (r *trustCenterResolver) References(ctx context.Context, obj *types.TrustCe
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.TrustCenterReferenceOrderField]{
 		Field:     coredata.TrustCenterReferenceOrderFieldRank,
 		Direction: page.OrderDirectionAsc,
@@ -873,7 +819,7 @@ func (r *trustCenterResolver) References(ctx context.Context, obj *types.TrustCe
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	result, err := prb.TrustCenterReferences.ListForTrustCenterID(ctx, scope, obj.ID, cursor)
+	result, err := r.probo.TrustCenterReferences.ListForTrustCenterID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list trust center references", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -889,8 +835,6 @@ func (r *trustCenterResolver) ComplianceFrameworks(ctx context.Context, obj *typ
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.ComplianceFrameworkOrderField]{
 		Field:     coredata.ComplianceFrameworkOrderFieldRank,
 		Direction: page.OrderDirectionAsc,
@@ -904,7 +848,7 @@ func (r *trustCenterResolver) ComplianceFrameworks(ctx context.Context, obj *typ
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	result, err := prb.ComplianceFrameworks.ListWithHiddenForTrustCenterID(ctx, scope, obj.ID, cursor)
+	result, err := r.probo.ComplianceFrameworks.ListWithHiddenForTrustCenterID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list compliance frameworks", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -920,8 +864,6 @@ func (r *trustCenterResolver) ExternalUrls(ctx context.Context, obj *types.Trust
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.ComplianceExternalURLOrderField]{
 		Field:     coredata.ComplianceExternalURLOrderFieldRank,
 		Direction: page.OrderDirectionAsc,
@@ -935,7 +877,7 @@ func (r *trustCenterResolver) ExternalUrls(ctx context.Context, obj *types.Trust
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	result, err := prb.ComplianceExternalURLs.List(ctx, scope, obj.ID, cursor)
+	result, err := r.probo.ComplianceExternalURLs.List(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list compliance external URLs", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -955,9 +897,7 @@ func (r *trustCenterResolver) MailingList(ctx context.Context, obj *types.TrustC
 		return obj.MailingList, nil
 	}
 
-	prb := r.probo
-
-	ml, err := prb.TrustCenters.GetMailingList(ctx, scope, obj.ID)
+	ml, err := r.probo.TrustCenters.GetMailingList(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get mailing list for trust center", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -982,9 +922,7 @@ func (r *trustCenterAccessResolver) NdaSignature(ctx context.Context, obj *types
 		return nil, err
 	}
 
-	prb := r.probo
-
-	access, err := prb.TrustCenterAccesses.Get(ctx, scope, obj.ID)
+	access, err := r.probo.TrustCenterAccesses.Get(ctx, scope, obj.ID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot load trust center access: %w", err)
 	}
@@ -1008,9 +946,7 @@ func (r *trustCenterAccessResolver) PendingRequestCount(ctx context.Context, obj
 		return 0, err
 	}
 
-	prb := r.probo
-
-	count, err := prb.TrustCenterAccesses.CountPendingRequestDocumentAccesses(ctx, scope, obj.ID)
+	count, err := r.probo.TrustCenterAccesses.CountPendingRequestDocumentAccesses(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot count pending request document accesses", log.Error(err))
 		return 0, gqlutils.Internal(ctx)
@@ -1026,9 +962,7 @@ func (r *trustCenterAccessResolver) ActiveCount(ctx context.Context, obj *types.
 		return 0, err
 	}
 
-	prb := r.probo
-
-	count, err := prb.TrustCenterAccesses.CountActiveDocumentAccesses(ctx, scope, obj.ID)
+	count, err := r.probo.TrustCenterAccesses.CountActiveDocumentAccesses(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot count active document accesses", log.Error(err))
 		return 0, gqlutils.Internal(ctx)
@@ -1064,8 +998,6 @@ func (r *trustCenterAccessResolver) AvailableDocumentAccesses(ctx context.Contex
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.TrustCenterDocumentAccessOrderField]{
 		Field:     coredata.TrustCenterDocumentAccessOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -1079,7 +1011,7 @@ func (r *trustCenterAccessResolver) AvailableDocumentAccesses(ctx context.Contex
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	result, err := prb.TrustCenterAccesses.ListAvailableDocumentAccesses(ctx, scope, obj.ID, cursor)
+	result, err := r.probo.TrustCenterAccesses.ListAvailableDocumentAccesses(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list trust center document accesses", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1104,9 +1036,7 @@ func (r *trustCenterDocumentAccessResolver) Document(ctx context.Context, obj *t
 		return nil, nil
 	}
 
-	prb := r.probo
-
-	document, err := prb.Documents.Get(ctx, scope, *obj.DocumentID)
+	document, err := r.probo.Documents.Get(ctx, scope, *obj.DocumentID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -1131,9 +1061,7 @@ func (r *trustCenterDocumentAccessResolver) Report(ctx context.Context, obj *typ
 		return nil, nil
 	}
 
-	prb := r.probo
-
-	report, err := prb.Reports.Get(ctx, scope, *obj.ReportID)
+	report, err := r.probo.Reports.Get(ctx, scope, *obj.ReportID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot load report", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1153,9 +1081,7 @@ func (r *trustCenterDocumentAccessResolver) TrustCenterFile(ctx context.Context,
 		return nil, nil
 	}
 
-	prb := r.probo
-
-	trustCenterFile, err := prb.TrustCenterFiles.Get(ctx, scope, *obj.TrustCenterFileID)
+	trustCenterFile, err := r.probo.TrustCenterFiles.Get(ctx, scope, *obj.TrustCenterFileID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot load trust center file", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -1171,9 +1097,7 @@ func (r *trustCenterDocumentAccessConnectionResolver) TotalCount(ctx context.Con
 		return 0, err
 	}
 
-	prb := r.probo
-
-	count, err := prb.TrustCenterAccesses.CountDocumentAccesses(ctx, scope, obj.ParentID)
+	count, err := r.probo.TrustCenterAccesses.CountDocumentAccesses(ctx, scope, obj.ParentID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot count trust center document accesses", log.Error(err))
 		return 0, gqlutils.Internal(ctx)
@@ -1189,9 +1113,7 @@ func (r *trustCenterFileResolver) FileURL(ctx context.Context, obj *types.TrustC
 		return "", err
 	}
 
-	prb := r.probo
-
-	fileURL, err := prb.TrustCenterFiles.GenerateFileURL(ctx, scope, obj.ID, 1*time.Hour)
+	fileURL, err := r.probo.TrustCenterFiles.GenerateFileURL(ctx, scope, obj.ID, 1*time.Hour)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate file URL", log.Error(err))
 		return "", gqlutils.Internal(ctx)
@@ -1207,15 +1129,13 @@ func (r *trustCenterFileResolver) Organization(ctx context.Context, obj *types.T
 		return nil, err
 	}
 
-	prb := r.probo
-
-	trustCenterFile, err := prb.TrustCenterFiles.Get(ctx, scope, obj.ID)
+	trustCenterFile, err := r.probo.TrustCenterFiles.Get(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get trust center file", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	organization, err := prb.Organizations.Get(ctx, scope, trustCenterFile.OrganizationID)
+	organization, err := r.probo.Organizations.Get(ctx, scope, trustCenterFile.OrganizationID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -1241,9 +1161,7 @@ func (r *trustCenterFileConnectionResolver) TotalCount(ctx context.Context, obj 
 		return 0, err
 	}
 
-	prb := r.probo
-
-	count, err := prb.TrustCenterFiles.CountForOrganizationID(ctx, scope, obj.ParentID)
+	count, err := r.probo.TrustCenterFiles.CountForOrganizationID(ctx, scope, obj.ParentID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot count trust center files", log.Error(err))
 		return 0, gqlutils.Internal(ctx)
@@ -1259,9 +1177,7 @@ func (r *trustCenterReferenceResolver) LogoURL(ctx context.Context, obj *types.T
 		return "", err
 	}
 
-	prb := r.probo
-
-	fileURL, err := prb.TrustCenterReferences.GenerateLogoURL(ctx, scope, obj.ID, 1*time.Hour)
+	fileURL, err := r.probo.TrustCenterReferences.GenerateLogoURL(ctx, scope, obj.ID, 1*time.Hour)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate logo URL", log.Error(err))
 		return "", gqlutils.Internal(ctx)
@@ -1282,9 +1198,7 @@ func (r *trustCenterReferenceConnectionResolver) TotalCount(ctx context.Context,
 		return 0, err
 	}
 
-	prb := r.probo
-
-	count, err := prb.TrustCenterReferences.CountForTrustCenterID(ctx, scope, obj.ParentID)
+	count, err := r.probo.TrustCenterReferences.CountForTrustCenterID(ctx, scope, obj.ParentID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot count trust center references", log.Error(err))
 		return 0, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/trust_center_resolvers.go
+++ b/pkg/server/api/console/v1/trust_center_resolvers.go
@@ -31,7 +31,7 @@ func (r *complianceExternalURLResolver) Permission(ctx context.Context, obj *typ
 
 // Framework is the resolver for the framework field.
 func (r *complianceFrameworkResolver) Framework(ctx context.Context, obj *types.ComplianceFramework) (*types.Framework, error) {
-	if err := r.authorize(ctx, obj.FrameworkID, probo.ActionFrameworkGet); err != nil {
+	if _, err := r.authorize(ctx, obj.FrameworkID, probo.ActionFrameworkGet); err != nil {
 		return nil, err
 	}
 
@@ -58,11 +58,11 @@ func (r *customDomainResolver) Permission(ctx context.Context, obj *types.Custom
 
 // UpdateTrustCenter is the resolver for the updateTrustCenter field.
 func (r *mutationResolver) UpdateTrustCenter(ctx context.Context, input types.UpdateTrustCenterInput) (*types.UpdateTrustCenterPayload, error) {
-	if err := r.authorize(ctx, input.TrustCenterID, probo.ActionTrustCenterUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.TrustCenterID, probo.ActionTrustCenterUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
 	prb := r.probo
 
 	trustCenter, file, err := prb.TrustCenters.Update(
@@ -90,11 +90,11 @@ func (r *mutationResolver) UpdateTrustCenter(ctx context.Context, input types.Up
 
 // UploadTrustCenterNda is the resolver for the uploadTrustCenterNDA field.
 func (r *mutationResolver) UploadTrustCenterNda(ctx context.Context, input types.UploadTrustCenterNDAInput) (*types.UploadTrustCenterNDAPayload, error) {
-	if err := r.authorize(ctx, input.TrustCenterID, probo.ActionTrustCenterNonDisclosureAgreementUpload); err != nil {
+	scope, err := r.authorize(ctx, input.TrustCenterID, probo.ActionTrustCenterNonDisclosureAgreementUpload)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
 	prb := r.probo
 
 	trustCenter, file, err := prb.TrustCenters.UploadNDA(
@@ -122,11 +122,11 @@ func (r *mutationResolver) UploadTrustCenterNda(ctx context.Context, input types
 
 // DeleteTrustCenterNda is the resolver for the deleteTrustCenterNDA field.
 func (r *mutationResolver) DeleteTrustCenterNda(ctx context.Context, input types.DeleteTrustCenterNDAInput) (*types.DeleteTrustCenterNDAPayload, error) {
-	if err := r.authorize(ctx, input.TrustCenterID, probo.ActionTrustCenterNonDisclosureAgreementDelete); err != nil {
+	scope, err := r.authorize(ctx, input.TrustCenterID, probo.ActionTrustCenterNonDisclosureAgreementDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
 	prb := r.probo
 
 	trustCenter, file, err := prb.TrustCenters.DeleteNDA(ctx, scope, input.TrustCenterID)
@@ -142,11 +142,11 @@ func (r *mutationResolver) DeleteTrustCenterNda(ctx context.Context, input types
 
 // UpdateTrustCenterBrand is the resolver for the updateTrustCenterBrand field.
 func (r *mutationResolver) UpdateTrustCenterBrand(ctx context.Context, input types.UpdateTrustCenterBrandInput) (*types.UpdateTrustCenterBrandPayload, error) {
-	if err := r.authorize(ctx, input.TrustCenterID, probo.ActionTrustCenterUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.TrustCenterID, probo.ActionTrustCenterUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
 	prb := r.probo
 
 	req := &probo.UpdateTrustCenterBrandRequest{
@@ -205,11 +205,11 @@ func (r *mutationResolver) UpdateTrustCenterBrand(ctx context.Context, input typ
 
 // UpdateTrustCenterAccess is the resolver for the updateTrustCenterAccess field.
 func (r *mutationResolver) UpdateTrustCenterAccess(ctx context.Context, input types.UpdateTrustCenterAccessInput) (*types.UpdateTrustCenterAccessPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionTrustCenterAccessUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionTrustCenterAccessUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
 	var (
@@ -265,15 +265,14 @@ func (r *mutationResolver) UpdateTrustCenterAccess(ctx context.Context, input ty
 
 // DeleteTrustCenterAccess is the resolver for the deleteTrustCenterAccess field.
 func (r *mutationResolver) DeleteTrustCenterAccess(ctx context.Context, input types.DeleteTrustCenterAccessInput) (*types.DeleteTrustCenterAccessPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionTrustCenterAccessDelete); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionTrustCenterAccessDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
-	err := prb.TrustCenterAccesses.Delete(ctx, scope, input.ID)
-	if err != nil {
+	if err := prb.TrustCenterAccesses.Delete(ctx, scope, input.ID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete trust center access", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -285,11 +284,11 @@ func (r *mutationResolver) DeleteTrustCenterAccess(ctx context.Context, input ty
 
 // CreateTrustCenterReference is the resolver for the createTrustCenterReference field.
 func (r *mutationResolver) CreateTrustCenterReference(ctx context.Context, input types.CreateTrustCenterReferenceInput) (*types.CreateTrustCenterReferencePayload, error) {
-	if err := r.authorize(ctx, input.TrustCenterID, probo.ActionTrustCenterReferenceCreate); err != nil {
+	scope, err := r.authorize(ctx, input.TrustCenterID, probo.ActionTrustCenterReferenceCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
 	prb := r.probo
 
 	reference, err := prb.TrustCenterReferences.Create(
@@ -324,11 +323,11 @@ func (r *mutationResolver) CreateTrustCenterReference(ctx context.Context, input
 
 // UpdateTrustCenterReference is the resolver for the updateTrustCenterReference field.
 func (r *mutationResolver) UpdateTrustCenterReference(ctx context.Context, input types.UpdateTrustCenterReferenceInput) (*types.UpdateTrustCenterReferencePayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionTrustCenterReferenceUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionTrustCenterReferenceUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
 	req := &probo.UpdateTrustCenterReferenceRequest{
@@ -366,15 +365,14 @@ func (r *mutationResolver) UpdateTrustCenterReference(ctx context.Context, input
 
 // DeleteTrustCenterReference is the resolver for the deleteTrustCenterReference field.
 func (r *mutationResolver) DeleteTrustCenterReference(ctx context.Context, input types.DeleteTrustCenterReferenceInput) (*types.DeleteTrustCenterReferencePayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionTrustCenterReferenceDelete); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionTrustCenterReferenceDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
-	err := prb.TrustCenterReferences.Delete(ctx, scope, input.ID)
-	if err != nil {
+	if err := prb.TrustCenterReferences.Delete(ctx, scope, input.ID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete trust center reference", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -386,11 +384,11 @@ func (r *mutationResolver) DeleteTrustCenterReference(ctx context.Context, input
 
 // CreateComplianceFramework is the resolver for the createComplianceFramework field.
 func (r *mutationResolver) CreateComplianceFramework(ctx context.Context, input types.CreateComplianceFrameworkInput) (*types.CreateComplianceFrameworkPayload, error) {
-	if err := r.authorize(ctx, input.TrustCenterID, probo.ActionComplianceFrameworkCreate); err != nil {
+	scope, err := r.authorize(ctx, input.TrustCenterID, probo.ActionComplianceFrameworkCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
 	prb := r.probo
 
 	cf, err := prb.ComplianceFrameworks.Create(
@@ -417,11 +415,11 @@ func (r *mutationResolver) CreateComplianceFramework(ctx context.Context, input 
 
 // UpdateComplianceFramework is the resolver for the updateComplianceFramework field.
 func (r *mutationResolver) UpdateComplianceFramework(ctx context.Context, input types.UpdateComplianceFrameworkInput) (*types.UpdateComplianceFrameworkPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionComplianceFrameworkUpdateRank); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionComplianceFrameworkUpdateRank)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
 	cf, err := prb.ComplianceFrameworks.Update(ctx, scope, &probo.UpdateComplianceFrameworkRequest{
@@ -445,20 +443,19 @@ func (r *mutationResolver) UpdateComplianceFramework(ctx context.Context, input 
 
 // DeleteComplianceFramework is the resolver for the deleteComplianceFramework field.
 func (r *mutationResolver) DeleteComplianceFramework(ctx context.Context, input types.DeleteComplianceFrameworkInput) (*types.DeleteComplianceFrameworkPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionComplianceFrameworkDelete); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionComplianceFrameworkDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
-	err := prb.ComplianceFrameworks.Delete(
+	if err := prb.ComplianceFrameworks.Delete(
 		ctx, scope,
 		&probo.DeleteComplianceFrameworkRequest{
 			ID: input.ID,
 		},
-	)
-	if err != nil {
+	); err != nil {
 		if validationErrors, ok := errors.AsType[validator.ValidationErrors](err); ok {
 			return nil, gqlutils.InvalidValidationErrors(ctx, validationErrors)
 		}
@@ -475,11 +472,11 @@ func (r *mutationResolver) DeleteComplianceFramework(ctx context.Context, input 
 
 // CreateComplianceExternalURL is the resolver for the createComplianceExternalURL field.
 func (r *mutationResolver) CreateComplianceExternalURL(ctx context.Context, input types.CreateComplianceExternalURLInput) (*types.CreateComplianceExternalURLPayload, error) {
-	if err := r.authorize(ctx, input.TrustCenterID, probo.ActionComplianceExternalURLCreate); err != nil {
+	scope, err := r.authorize(ctx, input.TrustCenterID, probo.ActionComplianceExternalURLCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
 	prb := r.probo
 
 	item, err := prb.ComplianceExternalURLs.Create(
@@ -507,11 +504,11 @@ func (r *mutationResolver) CreateComplianceExternalURL(ctx context.Context, inpu
 
 // UpdateComplianceExternalURL is the resolver for the updateComplianceExternalURL field.
 func (r *mutationResolver) UpdateComplianceExternalURL(ctx context.Context, input types.UpdateComplianceExternalURLInput) (*types.UpdateComplianceExternalURLPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionComplianceExternalURLUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionComplianceExternalURLUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
 	item, err := prb.ComplianceExternalURLs.Update(ctx, scope, &probo.UpdateComplianceExternalURLRequest{
@@ -537,11 +534,11 @@ func (r *mutationResolver) UpdateComplianceExternalURL(ctx context.Context, inpu
 
 // DeleteComplianceExternalURL is the resolver for the deleteComplianceExternalURL field.
 func (r *mutationResolver) DeleteComplianceExternalURL(ctx context.Context, input types.DeleteComplianceExternalURLInput) (*types.DeleteComplianceExternalURLPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionComplianceExternalURLDelete); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionComplianceExternalURLDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
 	if err := prb.ComplianceExternalURLs.Delete(ctx, scope, &probo.DeleteComplianceExternalURLRequest{ID: input.ID}); err != nil {
@@ -561,11 +558,11 @@ func (r *mutationResolver) DeleteComplianceExternalURL(ctx context.Context, inpu
 
 // CreateTrustCenterFile is the resolver for the createTrustCenterFile field.
 func (r *mutationResolver) CreateTrustCenterFile(ctx context.Context, input types.CreateTrustCenterFileInput) (*types.CreateTrustCenterFilePayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionTrustCenterFileCreate); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionTrustCenterFileCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	file, err := prb.TrustCenterFiles.Create(
@@ -600,11 +597,11 @@ func (r *mutationResolver) CreateTrustCenterFile(ctx context.Context, input type
 
 // UpdateTrustCenterFile is the resolver for the updateTrustCenterFile field.
 func (r *mutationResolver) UpdateTrustCenterFile(ctx context.Context, input types.UpdateTrustCenterFileInput) (*types.UpdateTrustCenterFilePayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionTrustCenterFileUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionTrustCenterFileUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
 	file, err := prb.TrustCenterFiles.Update(
@@ -633,11 +630,11 @@ func (r *mutationResolver) UpdateTrustCenterFile(ctx context.Context, input type
 
 // GetTrustCenterFile is the resolver for the getTrustCenterFile field.
 func (r *mutationResolver) GetTrustCenterFile(ctx context.Context, input types.GetTrustCenterFileInput) (*types.GetTrustCenterFilePayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionTrustCenterFileGet); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionTrustCenterFileGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
 	file, err := prb.TrustCenterFiles.Get(ctx, scope, input.ID)
@@ -653,15 +650,14 @@ func (r *mutationResolver) GetTrustCenterFile(ctx context.Context, input types.G
 
 // DeleteTrustCenterFile is the resolver for the deleteTrustCenterFile field.
 func (r *mutationResolver) DeleteTrustCenterFile(ctx context.Context, input types.DeleteTrustCenterFileInput) (*types.DeleteTrustCenterFilePayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionTrustCenterFileDelete); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionTrustCenterFileDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
-	err := prb.TrustCenterFiles.Delete(ctx, scope, input.ID)
-	if err != nil {
+	if err := prb.TrustCenterFiles.Delete(ctx, scope, input.ID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete trust center file", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -673,11 +669,11 @@ func (r *mutationResolver) DeleteTrustCenterFile(ctx context.Context, input type
 
 // CreateCustomDomain is the resolver for the createCustomDomain field.
 func (r *mutationResolver) CreateCustomDomain(ctx context.Context, input types.CreateCustomDomainInput) (*types.CreateCustomDomainPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionCustomDomainCreate); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionCustomDomainCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	domain, err := prb.CustomDomains.CreateCustomDomain(
@@ -704,11 +700,11 @@ func (r *mutationResolver) CreateCustomDomain(ctx context.Context, input types.C
 
 // DeleteCustomDomain is the resolver for the deleteCustomDomain field.
 func (r *mutationResolver) DeleteCustomDomain(ctx context.Context, input types.DeleteCustomDomainInput) (*types.DeleteCustomDomainPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionCustomDomainDelete); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionCustomDomainDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	// TODO Drop this wierd logic
@@ -737,11 +733,11 @@ func (r *mutationResolver) DeleteCustomDomain(ctx context.Context, input types.D
 
 // LogoFileURL is the resolver for the logoFileUrl field.
 func (r *trustCenterResolver) LogoFileURL(ctx context.Context, obj *types.TrustCenter) (*string, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionTrustCenterGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionTrustCenterGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	logoURL, err := prb.TrustCenters.GenerateLogoURL(ctx, scope, obj.ID, 1*time.Hour)
@@ -755,11 +751,11 @@ func (r *trustCenterResolver) LogoFileURL(ctx context.Context, obj *types.TrustC
 
 // DarkLogoFileURL is the resolver for the darkLogoFileUrl field.
 func (r *trustCenterResolver) DarkLogoFileURL(ctx context.Context, obj *types.TrustCenter) (*string, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionTrustCenterGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionTrustCenterGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	logoURL, err := prb.TrustCenters.GenerateDarkLogoURL(ctx, scope, obj.ID, 1*time.Hour)
@@ -797,11 +793,11 @@ func (r *trustCenterResolver) NdaFileURL(ctx context.Context, obj *types.TrustCe
 
 // Organization is the resolver for the organization field.
 func (r *trustCenterResolver) Organization(ctx context.Context, obj *types.TrustCenter) (*types.Organization, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	trustCenter, err := prb.TrustCenters.Get(ctx, scope, obj.ID)
@@ -826,11 +822,11 @@ func (r *trustCenterResolver) Organization(ctx context.Context, obj *types.Trust
 
 // Accesses is the resolver for the accesses field.
 func (r *trustCenterResolver) Accesses(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.OrderBy[coredata.TrustCenterAccessOrderField]) (*types.TrustCenterAccessConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionTrustCenterAccessList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionTrustCenterAccessList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.TrustCenterAccessOrderField]{
@@ -857,11 +853,11 @@ func (r *trustCenterResolver) Accesses(ctx context.Context, obj *types.TrustCent
 
 // References is the resolver for the references field.
 func (r *trustCenterResolver) References(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.OrderBy[coredata.TrustCenterReferenceOrderField]) (*types.TrustCenterReferenceConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionTrustCenterReferenceList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionTrustCenterReferenceList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.TrustCenterReferenceOrderField]{
@@ -888,11 +884,11 @@ func (r *trustCenterResolver) References(ctx context.Context, obj *types.TrustCe
 
 // ComplianceFrameworks is the resolver for the complianceFrameworks field.
 func (r *trustCenterResolver) ComplianceFrameworks(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.OrderBy[coredata.ComplianceFrameworkOrderField]) (*types.ComplianceFrameworkConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionComplianceFrameworkList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionComplianceFrameworkList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ComplianceFrameworkOrderField]{
@@ -919,11 +915,11 @@ func (r *trustCenterResolver) ComplianceFrameworks(ctx context.Context, obj *typ
 
 // ExternalUrls is the resolver for the externalUrls field.
 func (r *trustCenterResolver) ExternalUrls(ctx context.Context, obj *types.TrustCenter, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.OrderBy[coredata.ComplianceExternalURLOrderField]) (*types.ComplianceExternalURLConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionComplianceExternalURLList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionComplianceExternalURLList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.ComplianceExternalURLOrderField]{
@@ -950,7 +946,8 @@ func (r *trustCenterResolver) ExternalUrls(ctx context.Context, obj *types.Trust
 
 // MailingList is the resolver for the mailingList field.
 func (r *trustCenterResolver) MailingList(ctx context.Context, obj *types.TrustCenter) (*types.MailingList, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionMailingListSubscriberList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionMailingListSubscriberList)
+	if err != nil {
 		return nil, err
 	}
 
@@ -958,7 +955,6 @@ func (r *trustCenterResolver) MailingList(ctx context.Context, obj *types.TrustC
 		return obj.MailingList, nil
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	ml, err := prb.TrustCenters.GetMailingList(ctx, scope, obj.ID)
@@ -981,11 +977,11 @@ func (r *trustCenterResolver) Permission(ctx context.Context, obj *types.TrustCe
 
 // NdaSignature is the resolver for the ndaSignature field.
 func (r *trustCenterAccessResolver) NdaSignature(ctx context.Context, obj *types.TrustCenterAccess) (*types.ElectronicSignature, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionTrustCenterAccessGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionTrustCenterAccessGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	access, err := prb.TrustCenterAccesses.Get(ctx, scope, obj.ID)
@@ -1007,11 +1003,11 @@ func (r *trustCenterAccessResolver) NdaSignature(ctx context.Context, obj *types
 
 // PendingRequestCount is the resolver for the pendingRequestCount field.
 func (r *trustCenterAccessResolver) PendingRequestCount(ctx context.Context, obj *types.TrustCenterAccess) (int, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionTrustCenterAccessGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionTrustCenterAccessGet)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	count, err := prb.TrustCenterAccesses.CountPendingRequestDocumentAccesses(ctx, scope, obj.ID)
@@ -1025,11 +1021,11 @@ func (r *trustCenterAccessResolver) PendingRequestCount(ctx context.Context, obj
 
 // ActiveCount is the resolver for the activeCount field.
 func (r *trustCenterAccessResolver) ActiveCount(ctx context.Context, obj *types.TrustCenterAccess) (int, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionTrustCenterAccessGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionTrustCenterAccessGet)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	count, err := prb.TrustCenterAccesses.CountActiveDocumentAccesses(ctx, scope, obj.ID)
@@ -1043,7 +1039,7 @@ func (r *trustCenterAccessResolver) ActiveCount(ctx context.Context, obj *types.
 
 // Profile is the resolver for the profile field.
 func (r *trustCenterAccessResolver) Profile(ctx context.Context, obj *types.TrustCenterAccess) (*types.Profile, error) {
-	if err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, iam.ActionMembershipProfileGet); err != nil {
 		return nil, err
 	}
 
@@ -1063,11 +1059,11 @@ func (r *trustCenterAccessResolver) Profile(ctx context.Context, obj *types.Trus
 
 // AvailableDocumentAccesses is the resolver for the availableDocumentAccesses field.
 func (r *trustCenterAccessResolver) AvailableDocumentAccesses(ctx context.Context, obj *types.TrustCenterAccess, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.OrderBy[coredata.TrustCenterDocumentAccessOrderField]) (*types.TrustCenterDocumentAccessConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionTrustCenterAccessGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionTrustCenterAccessGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.TrustCenterDocumentAccessOrderField]{
@@ -1099,7 +1095,8 @@ func (r *trustCenterAccessResolver) Permission(ctx context.Context, obj *types.T
 
 // Document is the resolver for the document field.
 func (r *trustCenterDocumentAccessResolver) Document(ctx context.Context, obj *types.TrustCenterDocumentAccess) (*types.Document, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionDocumentGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionDocumentGet)
+	if err != nil {
 		return nil, err
 	}
 
@@ -1107,7 +1104,6 @@ func (r *trustCenterDocumentAccessResolver) Document(ctx context.Context, obj *t
 		return nil, nil
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.TrustCenterAccessID)
 	prb := r.probo
 
 	document, err := prb.Documents.Get(ctx, scope, *obj.DocumentID)
@@ -1126,7 +1122,8 @@ func (r *trustCenterDocumentAccessResolver) Document(ctx context.Context, obj *t
 
 // Report is the resolver for the report field.
 func (r *trustCenterDocumentAccessResolver) Report(ctx context.Context, obj *types.TrustCenterDocumentAccess) (*types.Report, error) {
-	if err := r.authorize(ctx, obj.TrustCenterAccessID, probo.ActionReportGet); err != nil {
+	scope, err := r.authorize(ctx, obj.TrustCenterAccessID, probo.ActionReportGet)
+	if err != nil {
 		return nil, err
 	}
 
@@ -1134,7 +1131,6 @@ func (r *trustCenterDocumentAccessResolver) Report(ctx context.Context, obj *typ
 		return nil, nil
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.TrustCenterAccessID)
 	prb := r.probo
 
 	report, err := prb.Reports.Get(ctx, scope, *obj.ReportID)
@@ -1148,7 +1144,8 @@ func (r *trustCenterDocumentAccessResolver) Report(ctx context.Context, obj *typ
 
 // TrustCenterFile is the resolver for the trustCenterFile field.
 func (r *trustCenterDocumentAccessResolver) TrustCenterFile(ctx context.Context, obj *types.TrustCenterDocumentAccess) (*types.TrustCenterFile, error) {
-	if err := r.authorize(ctx, obj.TrustCenterAccessID, probo.ActionTrustCenterFileGet); err != nil {
+	scope, err := r.authorize(ctx, obj.TrustCenterAccessID, probo.ActionTrustCenterFileGet)
+	if err != nil {
 		return nil, err
 	}
 
@@ -1156,7 +1153,6 @@ func (r *trustCenterDocumentAccessResolver) TrustCenterFile(ctx context.Context,
 		return nil, nil
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.TrustCenterAccessID)
 	prb := r.probo
 
 	trustCenterFile, err := prb.TrustCenterFiles.Get(ctx, scope, *obj.TrustCenterFileID)
@@ -1170,11 +1166,11 @@ func (r *trustCenterDocumentAccessResolver) TrustCenterFile(ctx context.Context,
 
 // TotalCount is the resolver for the totalCount field.
 func (r *trustCenterDocumentAccessConnectionResolver) TotalCount(ctx context.Context, obj *types.TrustCenterDocumentAccessConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionTrustCenterDocumentAccessList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionTrustCenterDocumentAccessList)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 	prb := r.probo
 
 	count, err := prb.TrustCenterAccesses.CountDocumentAccesses(ctx, scope, obj.ParentID)
@@ -1188,11 +1184,11 @@ func (r *trustCenterDocumentAccessConnectionResolver) TotalCount(ctx context.Con
 
 // FileURL is the resolver for the fileUrl field.
 func (r *trustCenterFileResolver) FileURL(ctx context.Context, obj *types.TrustCenterFile) (string, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionTrustCenterFileGetFileUrl); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionTrustCenterFileGetFileUrl)
+	if err != nil {
 		return "", err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	fileURL, err := prb.TrustCenterFiles.GenerateFileURL(ctx, scope, obj.ID, 1*time.Hour)
@@ -1206,11 +1202,11 @@ func (r *trustCenterFileResolver) FileURL(ctx context.Context, obj *types.TrustC
 
 // Organization is the resolver for the organization field.
 func (r *trustCenterFileResolver) Organization(ctx context.Context, obj *types.TrustCenterFile) (*types.Organization, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	trustCenterFile, err := prb.TrustCenterFiles.Get(ctx, scope, obj.ID)
@@ -1240,11 +1236,11 @@ func (r *trustCenterFileResolver) Permission(ctx context.Context, obj *types.Tru
 
 // TotalCount is the resolver for the totalCount field.
 func (r *trustCenterFileConnectionResolver) TotalCount(ctx context.Context, obj *types.TrustCenterFileConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionTrustCenterFileList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionTrustCenterFileList)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 	prb := r.probo
 
 	count, err := prb.TrustCenterFiles.CountForOrganizationID(ctx, scope, obj.ParentID)
@@ -1258,11 +1254,11 @@ func (r *trustCenterFileConnectionResolver) TotalCount(ctx context.Context, obj 
 
 // LogoURL is the resolver for the logoUrl field.
 func (r *trustCenterReferenceResolver) LogoURL(ctx context.Context, obj *types.TrustCenterReference) (string, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionTrustCenterReferenceGetLogoUrl); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionTrustCenterReferenceGetLogoUrl)
+	if err != nil {
 		return "", err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	fileURL, err := prb.TrustCenterReferences.GenerateLogoURL(ctx, scope, obj.ID, 1*time.Hour)
@@ -1281,11 +1277,11 @@ func (r *trustCenterReferenceResolver) Permission(ctx context.Context, obj *type
 
 // TotalCount is the resolver for the totalCount field.
 func (r *trustCenterReferenceConnectionResolver) TotalCount(ctx context.Context, obj *types.TrustCenterReferenceConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionTrustCenterReferenceList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionTrustCenterReferenceList)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 	prb := r.probo
 
 	count, err := prb.TrustCenterReferences.CountForTrustCenterID(ctx, scope, obj.ParentID)

--- a/pkg/server/api/console/v1/trust_center_resolvers.go
+++ b/pkg/server/api/console/v1/trust_center_resolvers.go
@@ -734,6 +734,7 @@ func (r *trustCenterResolver) NdaFileURL(ctx context.Context, obj *types.TrustCe
 	}
 
 	scope := coredata.NewScopeFromObjectID(obj.ID)
+
 	fileURL, err := r.probo.TrustCenters.GenerateNDAFileURL(ctx, scope, obj.ID, 15*time.Minute)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot generate NDA file URL", log.Error(err))
@@ -781,6 +782,7 @@ func (r *trustCenterResolver) Accesses(ctx context.Context, obj *types.TrustCent
 		Field:     coredata.TrustCenterAccessOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.TrustCenterAccessOrderField]{
 			Field:     orderBy.Field,
@@ -810,6 +812,7 @@ func (r *trustCenterResolver) References(ctx context.Context, obj *types.TrustCe
 		Field:     coredata.TrustCenterReferenceOrderFieldRank,
 		Direction: page.OrderDirectionAsc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.TrustCenterReferenceOrderField]{
 			Field:     orderBy.Field,
@@ -839,6 +842,7 @@ func (r *trustCenterResolver) ComplianceFrameworks(ctx context.Context, obj *typ
 		Field:     coredata.ComplianceFrameworkOrderFieldRank,
 		Direction: page.OrderDirectionAsc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ComplianceFrameworkOrderField]{
 			Field:     orderBy.Field,
@@ -868,6 +872,7 @@ func (r *trustCenterResolver) ExternalUrls(ctx context.Context, obj *types.Trust
 		Field:     coredata.ComplianceExternalURLOrderFieldRank,
 		Direction: page.OrderDirectionAsc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ComplianceExternalURLOrderField]{
 			Field:     orderBy.Field,
@@ -1002,6 +1007,7 @@ func (r *trustCenterAccessResolver) AvailableDocumentAccesses(ctx context.Contex
 		Field:     coredata.TrustCenterDocumentAccessOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.TrustCenterDocumentAccessOrderField]{
 			Field:     orderBy.Field,

--- a/pkg/server/api/console/v1/viewer_resolvers.go
+++ b/pkg/server/api/console/v1/viewer_resolvers.go
@@ -31,6 +31,7 @@ func (r *viewerResolver) SignableDocuments(ctx context.Context, obj *types.Viewe
 		Field:     coredata.DocumentOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.DocumentOrderField]{
 			Field:     orderBy.Field,
@@ -110,6 +111,7 @@ func (r *viewerResolver) ApprovableDocuments(ctx context.Context, obj *types.Vie
 		Field:     coredata.DocumentOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.DocumentOrderField]{
 			Field:     orderBy.Field,

--- a/pkg/server/api/console/v1/viewer_resolvers.go
+++ b/pkg/server/api/console/v1/viewer_resolvers.go
@@ -22,11 +22,11 @@ import (
 
 // SignableDocuments is the resolver for the signableDocuments field.
 func (r *viewerResolver) SignableDocuments(ctx context.Context, obj *types.Viewer, organizationID gid.GID, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy) (*types.EmployeeDocumentConnection, error) {
-	if err := r.authorize(ctx, organizationID, probo.ActionEmployeeDocumentList); err != nil {
+	scope, err := r.authorize(ctx, organizationID, probo.ActionEmployeeDocumentList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(organizationID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
@@ -71,11 +71,11 @@ func (r *viewerResolver) SignableDocuments(ctx context.Context, obj *types.Viewe
 
 // SignableDocument is the resolver for the signableDocument field.
 func (r *viewerResolver) SignableDocument(ctx context.Context, obj *types.Viewer, id gid.GID) (*types.EmployeeDocument, error) {
-	if err := r.authorize(ctx, id, probo.ActionEmployeeDocumentGet); err != nil {
+	scope, err := r.authorize(ctx, id, probo.ActionEmployeeDocumentGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(id)
 	prb := r.probo
 
 	identity := authn.IdentityFromContext(ctx)
@@ -105,11 +105,11 @@ func (r *viewerResolver) SignableDocument(ctx context.Context, obj *types.Viewer
 
 // ApprovableDocuments is the resolver for the approvableDocuments field.
 func (r *viewerResolver) ApprovableDocuments(ctx context.Context, obj *types.Viewer, organizationID gid.GID, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.DocumentOrderBy) (*types.EmployeeDocumentConnection, error) {
-	if err := r.authorize(ctx, organizationID, probo.ActionEmployeeDocumentList); err != nil {
+	scope, err := r.authorize(ctx, organizationID, probo.ActionEmployeeDocumentList)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(organizationID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
@@ -154,11 +154,11 @@ func (r *viewerResolver) ApprovableDocuments(ctx context.Context, obj *types.Vie
 
 // ApprovableDocument is the resolver for the approvableDocument field.
 func (r *viewerResolver) ApprovableDocument(ctx context.Context, obj *types.Viewer, id gid.GID) (*types.EmployeeDocument, error) {
-	if err := r.authorize(ctx, id, probo.ActionEmployeeDocumentGet); err != nil {
+	scope, err := r.authorize(ctx, id, probo.ActionEmployeeDocumentGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(id)
 	prb := r.probo
 
 	identity := authn.IdentityFromContext(ctx)

--- a/pkg/server/api/console/v1/viewer_resolvers.go
+++ b/pkg/server/api/console/v1/viewer_resolvers.go
@@ -27,8 +27,6 @@ func (r *viewerResolver) SignableDocuments(ctx context.Context, obj *types.Viewe
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
 		Field:     coredata.DocumentOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -46,7 +44,7 @@ func (r *viewerResolver) SignableDocuments(ctx context.Context, obj *types.Viewe
 
 	documentFilter := coredata.NewDocumentFilter(nil).WithEmployeeIdentityID(&identity.ID, coredata.EmployeeFilterModeSignature)
 
-	documentsPage, err := prb.Documents.ListByOrganizationID(ctx, scope, organizationID, cursor, documentFilter)
+	documentsPage, err := r.probo.Documents.ListByOrganizationID(ctx, scope, organizationID, cursor, documentFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization signable documents", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -76,13 +74,11 @@ func (r *viewerResolver) SignableDocument(ctx context.Context, obj *types.Viewer
 		return nil, err
 	}
 
-	prb := r.probo
-
 	identity := authn.IdentityFromContext(ctx)
 
 	documentFilter := coredata.NewDocumentFilter(nil).WithEmployeeIdentityID(&identity.ID, coredata.EmployeeFilterModeSignature)
 
-	document, err := prb.Documents.GetWithFilter(ctx, scope, id, documentFilter)
+	document, err := r.probo.Documents.GetWithFilter(ctx, scope, id, documentFilter)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)
@@ -110,8 +106,6 @@ func (r *viewerResolver) ApprovableDocuments(ctx context.Context, obj *types.Vie
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
 		Field:     coredata.DocumentOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -129,7 +123,7 @@ func (r *viewerResolver) ApprovableDocuments(ctx context.Context, obj *types.Vie
 
 	documentFilter := coredata.NewDocumentFilter(nil).WithEmployeeIdentityID(&identity.ID, coredata.EmployeeFilterModeApproval)
 
-	documentsPage, err := prb.Documents.ListByOrganizationID(ctx, scope, organizationID, cursor, documentFilter)
+	documentsPage, err := r.probo.Documents.ListByOrganizationID(ctx, scope, organizationID, cursor, documentFilter)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list organization approvable documents", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -159,13 +153,11 @@ func (r *viewerResolver) ApprovableDocument(ctx context.Context, obj *types.View
 		return nil, err
 	}
 
-	prb := r.probo
-
 	identity := authn.IdentityFromContext(ctx)
 
 	documentFilter := coredata.NewDocumentFilter(nil).WithEmployeeIdentityID(&identity.ID, coredata.EmployeeFilterModeApproval)
 
-	document, err := prb.Documents.GetWithFilter(ctx, scope, id, documentFilter)
+	document, err := r.probo.Documents.GetWithFilter(ctx, scope, id, documentFilter)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			return nil, gqlutils.NotFound(ctx, err)

--- a/pkg/server/api/console/v1/webhook_resolvers.go
+++ b/pkg/server/api/console/v1/webhook_resolvers.go
@@ -164,6 +164,7 @@ func (r *webhookSubscriptionResolver) Events(ctx context.Context, obj *types.Web
 		Field:     coredata.WebhookEventOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if orderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.WebhookEventOrderField]{
 			Field:     orderBy.Field,

--- a/pkg/server/api/console/v1/webhook_resolvers.go
+++ b/pkg/server/api/console/v1/webhook_resolvers.go
@@ -29,9 +29,7 @@ func (r *mutationResolver) CreateWebhookSubscription(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.probo
-
-	wc, err := prb.WebhookSubscriptions.Create(
+	wc, err := r.probo.WebhookSubscriptions.Create(
 		ctx, scope,
 		probo.CreateWebhookSubscriptionRequest{
 			OrganizationID: input.OrganizationID,
@@ -61,9 +59,7 @@ func (r *mutationResolver) UpdateWebhookSubscription(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.probo
-
-	wc, err := prb.WebhookSubscriptions.Update(
+	wc, err := r.probo.WebhookSubscriptions.Update(
 		ctx, scope,
 		probo.UpdateWebhookSubscriptionRequest{
 			WebhookSubscriptionID: input.ID,
@@ -93,9 +89,7 @@ func (r *mutationResolver) DeleteWebhookSubscription(ctx context.Context, input 
 		return nil, err
 	}
 
-	prb := r.probo
-
-	if err := prb.WebhookSubscriptions.Delete(ctx, scope, input.WebhookSubscriptionID); err != nil {
+	if err := r.probo.WebhookSubscriptions.Delete(ctx, scope, input.WebhookSubscriptionID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete webhook subscription", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -112,9 +106,7 @@ func (r *webhookEventConnectionResolver) TotalCount(ctx context.Context, obj *ty
 		return 0, err
 	}
 
-	prb := r.probo
-
-	count, err := prb.WebhookSubscriptions.CountEventsForSubscriptionID(ctx, scope, obj.ParentID)
+	count, err := r.probo.WebhookSubscriptions.CountEventsForSubscriptionID(ctx, scope, obj.ParentID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot count webhook events", log.Error(err))
 		return 0, gqlutils.Internal(ctx)
@@ -152,9 +144,7 @@ func (r *webhookSubscriptionResolver) SigningSecret(ctx context.Context, obj *ty
 		return "", err
 	}
 
-	prb := r.probo
-
-	signingSecret, err := prb.WebhookSubscriptions.GetSigningSecret(ctx, scope, obj.ID)
+	signingSecret, err := r.probo.WebhookSubscriptions.GetSigningSecret(ctx, scope, obj.ID)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot get signing secret", log.Error(err))
 		return "", gqlutils.Internal(ctx)
@@ -170,8 +160,6 @@ func (r *webhookSubscriptionResolver) Events(ctx context.Context, obj *types.Web
 		return nil, err
 	}
 
-	prb := r.probo
-
 	pageOrderBy := page.OrderBy[coredata.WebhookEventOrderField]{
 		Field:     coredata.WebhookEventOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
@@ -185,7 +173,7 @@ func (r *webhookSubscriptionResolver) Events(ctx context.Context, obj *types.Web
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 
-	page, err := prb.WebhookSubscriptions.ListEventsForSubscriptionID(ctx, scope, obj.ID, cursor)
+	page, err := r.probo.WebhookSubscriptions.ListEventsForSubscriptionID(ctx, scope, obj.ID, cursor)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot list webhook events", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
@@ -206,11 +194,9 @@ func (r *webhookSubscriptionConnectionResolver) TotalCount(ctx context.Context, 
 		return 0, err
 	}
 
-	prb := r.probo
-
 	switch obj.Resolver.(type) {
 	case *organizationResolver:
-		count, err := prb.WebhookSubscriptions.CountForOrganizationID(ctx, scope, obj.ParentID)
+		count, err := r.probo.WebhookSubscriptions.CountForOrganizationID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count webhook subscriptions", log.Error(err))
 			return 0, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/webhook_resolvers.go
+++ b/pkg/server/api/console/v1/webhook_resolvers.go
@@ -24,11 +24,11 @@ import (
 
 // CreateWebhookSubscription is the resolver for the createWebhookSubscription field.
 func (r *mutationResolver) CreateWebhookSubscription(ctx context.Context, input types.CreateWebhookSubscriptionInput) (*types.CreateWebhookSubscriptionPayload, error) {
-	if err := r.authorize(ctx, input.OrganizationID, probo.ActionWebhookSubscriptionCreate); err != nil {
+	scope, err := r.authorize(ctx, input.OrganizationID, probo.ActionWebhookSubscriptionCreate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.probo
 
 	wc, err := prb.WebhookSubscriptions.Create(
@@ -56,11 +56,11 @@ func (r *mutationResolver) CreateWebhookSubscription(ctx context.Context, input 
 
 // UpdateWebhookSubscription is the resolver for the updateWebhookSubscription field.
 func (r *mutationResolver) UpdateWebhookSubscription(ctx context.Context, input types.UpdateWebhookSubscriptionInput) (*types.UpdateWebhookSubscriptionPayload, error) {
-	if err := r.authorize(ctx, input.ID, probo.ActionWebhookSubscriptionUpdate); err != nil {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionWebhookSubscriptionUpdate)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.probo
 
 	wc, err := prb.WebhookSubscriptions.Update(
@@ -88,15 +88,14 @@ func (r *mutationResolver) UpdateWebhookSubscription(ctx context.Context, input 
 
 // DeleteWebhookSubscription is the resolver for the deleteWebhookSubscription field.
 func (r *mutationResolver) DeleteWebhookSubscription(ctx context.Context, input types.DeleteWebhookSubscriptionInput) (*types.DeleteWebhookSubscriptionPayload, error) {
-	if err := r.authorize(ctx, input.WebhookSubscriptionID, probo.ActionWebhookSubscriptionDelete); err != nil {
+	scope, err := r.authorize(ctx, input.WebhookSubscriptionID, probo.ActionWebhookSubscriptionDelete)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.WebhookSubscriptionID)
 	prb := r.probo
 
-	err := prb.WebhookSubscriptions.Delete(ctx, scope, input.WebhookSubscriptionID)
-	if err != nil {
+	if err := prb.WebhookSubscriptions.Delete(ctx, scope, input.WebhookSubscriptionID); err != nil {
 		r.logger.ErrorCtx(ctx, "cannot delete webhook subscription", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}
@@ -108,11 +107,11 @@ func (r *mutationResolver) DeleteWebhookSubscription(ctx context.Context, input 
 
 // TotalCount is the resolver for the totalCount field.
 func (r *webhookEventConnectionResolver) TotalCount(ctx context.Context, obj *types.WebhookEventConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionWebhookSubscriptionGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionWebhookSubscriptionGet)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 	prb := r.probo
 
 	count, err := prb.WebhookSubscriptions.CountEventsForSubscriptionID(ctx, scope, obj.ParentID)
@@ -126,7 +125,7 @@ func (r *webhookEventConnectionResolver) TotalCount(ctx context.Context, obj *ty
 
 // Organization is the resolver for the organization field.
 func (r *webhookSubscriptionResolver) Organization(ctx context.Context, obj *types.WebhookSubscription) (*types.Organization, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionOrganizationGet); err != nil {
 		return nil, err
 	}
 
@@ -148,11 +147,11 @@ func (r *webhookSubscriptionResolver) Organization(ctx context.Context, obj *typ
 
 // SigningSecret is the resolver for the signingSecret field.
 func (r *webhookSubscriptionResolver) SigningSecret(ctx context.Context, obj *types.WebhookSubscription) (string, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionWebhookSubscriptionUpdate); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionWebhookSubscriptionUpdate)
+	if err != nil {
 		return "", err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	signingSecret, err := prb.WebhookSubscriptions.GetSigningSecret(ctx, scope, obj.ID)
@@ -166,11 +165,11 @@ func (r *webhookSubscriptionResolver) SigningSecret(ctx context.Context, obj *ty
 
 // Events is the resolver for the events field.
 func (r *webhookSubscriptionResolver) Events(ctx context.Context, obj *types.WebhookSubscription, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.WebhookEventOrderBy) (*types.WebhookEventConnection, error) {
-	if err := r.authorize(ctx, obj.ID, probo.ActionWebhookSubscriptionGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionWebhookSubscriptionGet)
+	if err != nil {
 		return nil, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 	prb := r.probo
 
 	pageOrderBy := page.OrderBy[coredata.WebhookEventOrderField]{
@@ -202,11 +201,11 @@ func (r *webhookSubscriptionResolver) Permission(ctx context.Context, obj *types
 
 // TotalCount is the resolver for the totalCount field.
 func (r *webhookSubscriptionConnectionResolver) TotalCount(ctx context.Context, obj *types.WebhookSubscriptionConnection) (int, error) {
-	if err := r.authorize(ctx, obj.ParentID, probo.ActionWebhookSubscriptionList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, probo.ActionWebhookSubscriptionList)
+	if err != nil {
 		return 0, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(obj.ParentID)
 	prb := r.probo
 
 	switch obj.Resolver.(type) {

--- a/pkg/server/api/mcp/v1/resolver.go
+++ b/pkg/server/api/mcp/v1/resolver.go
@@ -88,3 +88,47 @@ func (r *Resolver) Authorize(ctx context.Context, entityID gid.GID, action iam.A
 
 	return nil, fmt.Errorf("internal server error")
 }
+
+func (r *Resolver) AuthorizeBatch(ctx context.Context, entityIDs []gid.GID, action iam.Action) (*coredata.Scope, error) {
+	identity := authn.IdentityFromContext(ctx)
+
+	scope, err := r.iamSvc.Authorizer.AuthorizeBatch(
+		ctx,
+		iam.AuthorizeBatchParams{
+			Principal: identity.ID,
+			Resources: entityIDs,
+			Action:    action,
+		},
+	)
+	if err == nil {
+		return scope, nil
+	}
+
+	if _, ok := errors.AsType[*iam.ErrInsufficientPermissions](err); ok {
+		return nil, fmt.Errorf("permission denied")
+	}
+
+	if _, ok := errors.AsType[*iam.ErrAssumptionRequired](err); ok {
+		return nil, fmt.Errorf("assumption required")
+	}
+
+	if _, ok := errors.AsType[*iam.ErrMixedOrganizationBatch](err); ok {
+		return nil, fmt.Errorf("mixed-organization batch")
+	}
+
+	if _, ok := errors.AsType[*iam.ErrEmptyResourceBatch](err); ok {
+		return nil, fmt.Errorf("empty resource batch")
+	}
+
+	if _, ok := errors.AsType[*iam.ErrBatchAuthorizationUnsupportedResourceType](err); ok {
+		return nil, fmt.Errorf("batch authorization unsupported for resource type")
+	}
+
+	if errors.Is(err, coredata.ErrResourceNotFound) {
+		return nil, fmt.Errorf("resource not found")
+	}
+
+	r.logger.ErrorCtx(ctx, "cannot batch authorize MCP request", log.Error(err))
+
+	return nil, fmt.Errorf("internal server error")
+}

--- a/pkg/server/api/mcp/v1/resolver.go
+++ b/pkg/server/api/mcp/v1/resolver.go
@@ -57,10 +57,10 @@ func markdownToProseMirrorJSON(markdown string) (string, error) {
 	return string(out), nil
 }
 
-func (r *Resolver) Authorize(ctx context.Context, entityID gid.GID, action iam.Action) error {
+func (r *Resolver) Authorize(ctx context.Context, entityID gid.GID, action iam.Action) (*coredata.Scope, error) {
 	identity := authn.IdentityFromContext(ctx)
 
-	err := r.iamSvc.Authorizer.Authorize(
+	scope, err := r.iamSvc.Authorizer.Authorize(
 		ctx,
 		iam.AuthorizeParams{
 			Principal: identity.ID,
@@ -69,22 +69,22 @@ func (r *Resolver) Authorize(ctx context.Context, entityID gid.GID, action iam.A
 		},
 	)
 	if err == nil {
-		return nil
+		return scope, nil
 	}
 
 	if _, ok := errors.AsType[*iam.ErrInsufficientPermissions](err); ok {
-		return fmt.Errorf("permission denied")
+		return nil, fmt.Errorf("permission denied")
 	}
 
 	if _, ok := errors.AsType[*iam.ErrAssumptionRequired](err); ok {
-		return fmt.Errorf("assumption required")
+		return nil, fmt.Errorf("assumption required")
 	}
 
 	if errors.Is(err, coredata.ErrResourceNotFound) {
-		return fmt.Errorf("resource not found")
+		return nil, fmt.Errorf("resource not found")
 	}
 
 	r.logger.ErrorCtx(ctx, "cannot authorize MCP request", log.Error(err))
 
-	return fmt.Errorf("internal server error")
+	return nil, fmt.Errorf("internal server error")
 }

--- a/pkg/server/api/mcp/v1/resolver.go
+++ b/pkg/server/api/mcp/v1/resolver.go
@@ -19,11 +19,13 @@ package mcp_v1
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/accessreview"
 	"go.probo.inc/probo/pkg/cookiebanner"
+	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/iam"
 	"go.probo.inc/probo/pkg/probo"
@@ -55,7 +57,7 @@ func markdownToProseMirrorJSON(markdown string) (string, error) {
 	return string(out), nil
 }
 
-func (r *Resolver) MustAuthorize(ctx context.Context, entityID gid.GID, action iam.Action) {
+func (r *Resolver) Authorize(ctx context.Context, entityID gid.GID, action iam.Action) error {
 	identity := authn.IdentityFromContext(ctx)
 
 	err := r.iamSvc.Authorizer.Authorize(
@@ -66,7 +68,23 @@ func (r *Resolver) MustAuthorize(ctx context.Context, entityID gid.GID, action i
 			Action:    action,
 		},
 	)
-	if err != nil {
-		panic(err)
+	if err == nil {
+		return nil
 	}
+
+	if _, ok := errors.AsType[*iam.ErrInsufficientPermissions](err); ok {
+		return fmt.Errorf("permission denied")
+	}
+
+	if _, ok := errors.AsType[*iam.ErrAssumptionRequired](err); ok {
+		return fmt.Errorf("assumption required")
+	}
+
+	if errors.Is(err, coredata.ErrResourceNotFound) {
+		return fmt.Errorf("resource not found")
+	}
+
+	r.logger.ErrorCtx(ctx, "cannot authorize MCP request", log.Error(err))
+
+	return fmt.Errorf("internal server error")
 }

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -6149,9 +6149,10 @@ func (r *Resolver) MoveTrackerResourceToCategoryTool(ctx context.Context, req *m
 }
 
 func (r *Resolver) ListRiskAssessmentsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListRiskAssessmentsInput) (*mcp.CallToolResult, types.ListRiskAssessmentsOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionRiskAssessmentList)
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionRiskAssessmentList)
+	if err != nil {
+		return nil, types.ListRiskAssessmentsOutput{}, err
+	}
 
 	pageOrderBy := page.OrderBy[coredata.RiskAssessmentOrderField]{
 		Field:     coredata.RiskAssessmentOrderFieldCreatedAt,
@@ -6175,9 +6176,10 @@ func (r *Resolver) ListRiskAssessmentsTool(ctx context.Context, req *mcp.CallToo
 }
 
 func (r *Resolver) GetRiskAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetRiskAssessmentInput) (*mcp.CallToolResult, types.GetRiskAssessmentOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionRiskAssessmentGet)
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionRiskAssessmentGet)
+	if err != nil {
+		return nil, types.GetRiskAssessmentOutput{}, err
+	}
 
 	ra, err := r.riskManagement.Get(ctx, scope, input.ID)
 	if err != nil {
@@ -6190,9 +6192,10 @@ func (r *Resolver) GetRiskAssessmentTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) AddRiskAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddRiskAssessmentInput) (*mcp.CallToolResult, types.AddRiskAssessmentOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionRiskAssessmentCreate)
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionRiskAssessmentCreate)
+	if err != nil {
+		return nil, types.AddRiskAssessmentOutput{}, err
+	}
 
 	ra, err := r.riskManagement.Create(ctx, scope, riskmanagement.CreateRiskAssessmentRequest{
 		OrganizationID: input.OrganizationID,
@@ -6209,9 +6212,10 @@ func (r *Resolver) AddRiskAssessmentTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) UpdateRiskAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateRiskAssessmentInput) (*mcp.CallToolResult, types.UpdateRiskAssessmentOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionRiskAssessmentUpdate)
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionRiskAssessmentUpdate)
+	if err != nil {
+		return nil, types.UpdateRiskAssessmentOutput{}, err
+	}
 
 	ra, err := r.riskManagement.Update(ctx, scope, riskmanagement.UpdateRiskAssessmentRequest{
 		ID:          input.ID,
@@ -6228,12 +6232,12 @@ func (r *Resolver) UpdateRiskAssessmentTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) DeleteRiskAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteRiskAssessmentInput) (*mcp.CallToolResult, types.DeleteRiskAssessmentOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionRiskAssessmentDelete)
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
-
-	err := r.riskManagement.Delete(ctx, scope, input.ID)
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionRiskAssessmentDelete)
 	if err != nil {
+		return nil, types.DeleteRiskAssessmentOutput{}, err
+	}
+
+	if err := r.riskManagement.Delete(ctx, scope, input.ID); err != nil {
 		return nil, types.DeleteRiskAssessmentOutput{}, fmt.Errorf("failed to delete risk assessment: %w", err)
 	}
 
@@ -6242,9 +6246,10 @@ func (r *Resolver) DeleteRiskAssessmentTool(ctx context.Context, req *mcp.CallTo
 	}, nil
 }
 func (r *Resolver) ListRiskAssessmentScopesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListRiskAssessmentScopesInput) (*mcp.CallToolResult, types.ListRiskAssessmentScopesOutput, error) {
-	r.MustAuthorize(ctx, input.RiskAssessmentID, probo.ActionRiskAssessmentScopeList)
-
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentID)
+	scope, err := r.Authorize(ctx, input.RiskAssessmentID, probo.ActionRiskAssessmentScopeList)
+	if err != nil {
+		return nil, types.ListRiskAssessmentScopesOutput{}, err
+	}
 
 	pageOrderBy := page.OrderBy[coredata.RiskAssessmentScopeOrderField]{
 		Field:     coredata.RiskAssessmentScopeOrderFieldCreatedAt,
@@ -6268,9 +6273,10 @@ func (r *Resolver) ListRiskAssessmentScopesTool(ctx context.Context, req *mcp.Ca
 }
 
 func (r *Resolver) GetRiskAssessmentScopeTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetRiskAssessmentScopeInput) (*mcp.CallToolResult, types.GetRiskAssessmentScopeOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionRiskAssessmentScopeGet)
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionRiskAssessmentScopeGet)
+	if err != nil {
+		return nil, types.GetRiskAssessmentScopeOutput{}, err
+	}
 
 	s, err := r.riskManagement.GetScope(ctx, scope, input.ID)
 	if err != nil {
@@ -6283,9 +6289,10 @@ func (r *Resolver) GetRiskAssessmentScopeTool(ctx context.Context, req *mcp.Call
 }
 
 func (r *Resolver) AddRiskAssessmentScopeTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddRiskAssessmentScopeInput) (*mcp.CallToolResult, types.AddRiskAssessmentScopeOutput, error) {
-	r.MustAuthorize(ctx, input.RiskAssessmentID, probo.ActionRiskAssessmentScopeCreate)
-
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentID)
+	scope, err := r.Authorize(ctx, input.RiskAssessmentID, probo.ActionRiskAssessmentScopeCreate)
+	if err != nil {
+		return nil, types.AddRiskAssessmentScopeOutput{}, err
+	}
 
 	s, err := r.riskManagement.CreateScope(ctx, scope, riskmanagement.CreateRiskAssessmentScopeRequest{
 		RiskAssessmentID: input.RiskAssessmentID,
@@ -6301,9 +6308,10 @@ func (r *Resolver) AddRiskAssessmentScopeTool(ctx context.Context, req *mcp.Call
 }
 
 func (r *Resolver) UpdateRiskAssessmentScopeTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateRiskAssessmentScopeInput) (*mcp.CallToolResult, types.UpdateRiskAssessmentScopeOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionRiskAssessmentScopeUpdate)
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionRiskAssessmentScopeUpdate)
+	if err != nil {
+		return nil, types.UpdateRiskAssessmentScopeOutput{}, err
+	}
 
 	s, err := r.riskManagement.UpdateScope(ctx, scope, riskmanagement.UpdateRiskAssessmentScopeRequest{
 		ID:   input.ID,
@@ -6319,12 +6327,12 @@ func (r *Resolver) UpdateRiskAssessmentScopeTool(ctx context.Context, req *mcp.C
 }
 
 func (r *Resolver) DeleteRiskAssessmentScopeTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteRiskAssessmentScopeInput) (*mcp.CallToolResult, types.DeleteRiskAssessmentScopeOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionRiskAssessmentScopeDelete)
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
-
-	err := r.riskManagement.DeleteScope(ctx, scope, input.ID)
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionRiskAssessmentScopeDelete)
 	if err != nil {
+		return nil, types.DeleteRiskAssessmentScopeOutput{}, err
+	}
+
+	if err := r.riskManagement.DeleteScope(ctx, scope, input.ID); err != nil {
 		return nil, types.DeleteRiskAssessmentScopeOutput{}, fmt.Errorf("failed to delete risk assessment scope: %w", err)
 	}
 
@@ -6333,9 +6341,10 @@ func (r *Resolver) DeleteRiskAssessmentScopeTool(ctx context.Context, req *mcp.C
 	}, nil
 }
 func (r *Resolver) ListRiskAssessmentNodesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListRiskAssessmentNodesInput) (*mcp.CallToolResult, types.ListRiskAssessmentNodesOutput, error) {
-	r.MustAuthorize(ctx, input.RiskAssessmentScopeID, probo.ActionRiskAssessmentNodeList)
-
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentScopeID)
+	scope, err := r.Authorize(ctx, input.RiskAssessmentScopeID, probo.ActionRiskAssessmentNodeList)
+	if err != nil {
+		return nil, types.ListRiskAssessmentNodesOutput{}, err
+	}
 
 	pageOrderBy := page.OrderBy[coredata.RiskAssessmentNodeOrderField]{
 		Field:     coredata.RiskAssessmentNodeOrderFieldCreatedAt,
@@ -6359,9 +6368,10 @@ func (r *Resolver) ListRiskAssessmentNodesTool(ctx context.Context, req *mcp.Cal
 }
 
 func (r *Resolver) GetRiskAssessmentNodeTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetRiskAssessmentNodeInput) (*mcp.CallToolResult, types.GetRiskAssessmentNodeOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionRiskAssessmentNodeGet)
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionRiskAssessmentNodeGet)
+	if err != nil {
+		return nil, types.GetRiskAssessmentNodeOutput{}, err
+	}
 
 	n, err := r.riskManagement.GetNode(ctx, scope, input.ID)
 	if err != nil {
@@ -6374,9 +6384,10 @@ func (r *Resolver) GetRiskAssessmentNodeTool(ctx context.Context, req *mcp.CallT
 }
 
 func (r *Resolver) AddRiskAssessmentNodeTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddRiskAssessmentNodeInput) (*mcp.CallToolResult, types.AddRiskAssessmentNodeOutput, error) {
-	r.MustAuthorize(ctx, input.RiskAssessmentScopeID, probo.ActionRiskAssessmentNodeCreate)
-
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentScopeID)
+	scope, err := r.Authorize(ctx, input.RiskAssessmentScopeID, probo.ActionRiskAssessmentNodeCreate)
+	if err != nil {
+		return nil, types.AddRiskAssessmentNodeOutput{}, err
+	}
 
 	n, err := r.riskManagement.CreateNode(ctx, scope, riskmanagement.CreateRiskAssessmentNodeRequest{
 		RiskAssessmentScopeID: input.RiskAssessmentScopeID,
@@ -6393,9 +6404,10 @@ func (r *Resolver) AddRiskAssessmentNodeTool(ctx context.Context, req *mcp.CallT
 }
 
 func (r *Resolver) UpdateRiskAssessmentNodeTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateRiskAssessmentNodeInput) (*mcp.CallToolResult, types.UpdateRiskAssessmentNodeOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionRiskAssessmentNodeUpdate)
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionRiskAssessmentNodeUpdate)
+	if err != nil {
+		return nil, types.UpdateRiskAssessmentNodeOutput{}, err
+	}
 
 	n, err := r.riskManagement.UpdateNode(ctx, scope, riskmanagement.UpdateRiskAssessmentNodeRequest{
 		ID:       input.ID,
@@ -6412,12 +6424,12 @@ func (r *Resolver) UpdateRiskAssessmentNodeTool(ctx context.Context, req *mcp.Ca
 }
 
 func (r *Resolver) DeleteRiskAssessmentNodeTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteRiskAssessmentNodeInput) (*mcp.CallToolResult, types.DeleteRiskAssessmentNodeOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionRiskAssessmentNodeDelete)
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
-
-	err := r.riskManagement.DeleteNode(ctx, scope, input.ID)
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionRiskAssessmentNodeDelete)
 	if err != nil {
+		return nil, types.DeleteRiskAssessmentNodeOutput{}, err
+	}
+
+	if err := r.riskManagement.DeleteNode(ctx, scope, input.ID); err != nil {
 		return nil, types.DeleteRiskAssessmentNodeOutput{}, fmt.Errorf("failed to delete risk assessment node: %w", err)
 	}
 
@@ -6426,9 +6438,10 @@ func (r *Resolver) DeleteRiskAssessmentNodeTool(ctx context.Context, req *mcp.Ca
 	}, nil
 }
 func (r *Resolver) ListRiskAssessmentProcessesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListRiskAssessmentProcessesInput) (*mcp.CallToolResult, types.ListRiskAssessmentProcessesOutput, error) {
-	r.MustAuthorize(ctx, input.RiskAssessmentScopeID, probo.ActionRiskAssessmentProcessList)
-
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentScopeID)
+	scope, err := r.Authorize(ctx, input.RiskAssessmentScopeID, probo.ActionRiskAssessmentProcessList)
+	if err != nil {
+		return nil, types.ListRiskAssessmentProcessesOutput{}, err
+	}
 
 	pageOrderBy := page.OrderBy[coredata.RiskAssessmentProcessOrderField]{
 		Field:     coredata.RiskAssessmentProcessOrderFieldCreatedAt,
@@ -6452,9 +6465,10 @@ func (r *Resolver) ListRiskAssessmentProcessesTool(ctx context.Context, req *mcp
 }
 
 func (r *Resolver) GetRiskAssessmentProcessTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetRiskAssessmentProcessInput) (*mcp.CallToolResult, types.GetRiskAssessmentProcessOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionRiskAssessmentProcessGet)
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionRiskAssessmentProcessGet)
+	if err != nil {
+		return nil, types.GetRiskAssessmentProcessOutput{}, err
+	}
 
 	p, err := r.riskManagement.GetProcess(ctx, scope, input.ID)
 	if err != nil {
@@ -6467,9 +6481,10 @@ func (r *Resolver) GetRiskAssessmentProcessTool(ctx context.Context, req *mcp.Ca
 }
 
 func (r *Resolver) AddRiskAssessmentProcessTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddRiskAssessmentProcessInput) (*mcp.CallToolResult, types.AddRiskAssessmentProcessOutput, error) {
-	r.MustAuthorize(ctx, input.RiskAssessmentScopeID, probo.ActionRiskAssessmentProcessCreate)
-
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentScopeID)
+	scope, err := r.Authorize(ctx, input.RiskAssessmentScopeID, probo.ActionRiskAssessmentProcessCreate)
+	if err != nil {
+		return nil, types.AddRiskAssessmentProcessOutput{}, err
+	}
 
 	p, err := r.riskManagement.CreateProcess(ctx, scope, riskmanagement.CreateRiskAssessmentProcessRequest{
 		RiskAssessmentScopeID: input.RiskAssessmentScopeID,
@@ -6487,9 +6502,10 @@ func (r *Resolver) AddRiskAssessmentProcessTool(ctx context.Context, req *mcp.Ca
 }
 
 func (r *Resolver) UpdateRiskAssessmentProcessTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateRiskAssessmentProcessInput) (*mcp.CallToolResult, types.UpdateRiskAssessmentProcessOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionRiskAssessmentProcessUpdate)
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionRiskAssessmentProcessUpdate)
+	if err != nil {
+		return nil, types.UpdateRiskAssessmentProcessOutput{}, err
+	}
 
 	p, err := r.riskManagement.UpdateProcess(ctx, scope, riskmanagement.UpdateRiskAssessmentProcessRequest{
 		ID:           input.ID,
@@ -6507,12 +6523,12 @@ func (r *Resolver) UpdateRiskAssessmentProcessTool(ctx context.Context, req *mcp
 }
 
 func (r *Resolver) DeleteRiskAssessmentProcessTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteRiskAssessmentProcessInput) (*mcp.CallToolResult, types.DeleteRiskAssessmentProcessOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionRiskAssessmentProcessDelete)
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
-
-	err := r.riskManagement.DeleteProcess(ctx, scope, input.ID)
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionRiskAssessmentProcessDelete)
 	if err != nil {
+		return nil, types.DeleteRiskAssessmentProcessOutput{}, err
+	}
+
+	if err := r.riskManagement.DeleteProcess(ctx, scope, input.ID); err != nil {
 		return nil, types.DeleteRiskAssessmentProcessOutput{}, fmt.Errorf("failed to delete risk assessment process: %w", err)
 	}
 
@@ -6521,9 +6537,10 @@ func (r *Resolver) DeleteRiskAssessmentProcessTool(ctx context.Context, req *mcp
 	}, nil
 }
 func (r *Resolver) ListRiskAssessmentThreatsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListRiskAssessmentThreatsInput) (*mcp.CallToolResult, types.ListRiskAssessmentThreatsOutput, error) {
-	r.MustAuthorize(ctx, input.RiskAssessmentScopeID, probo.ActionRiskAssessmentThreatList)
-
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentScopeID)
+	scope, err := r.Authorize(ctx, input.RiskAssessmentScopeID, probo.ActionRiskAssessmentThreatList)
+	if err != nil {
+		return nil, types.ListRiskAssessmentThreatsOutput{}, err
+	}
 
 	pageOrderBy := page.OrderBy[coredata.RiskAssessmentThreatOrderField]{
 		Field:     coredata.RiskAssessmentThreatOrderFieldCreatedAt,
@@ -6547,9 +6564,10 @@ func (r *Resolver) ListRiskAssessmentThreatsTool(ctx context.Context, req *mcp.C
 }
 
 func (r *Resolver) GetRiskAssessmentThreatTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetRiskAssessmentThreatInput) (*mcp.CallToolResult, types.GetRiskAssessmentThreatOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionRiskAssessmentThreatGet)
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionRiskAssessmentThreatGet)
+	if err != nil {
+		return nil, types.GetRiskAssessmentThreatOutput{}, err
+	}
 
 	t, err := r.riskManagement.GetThreat(ctx, scope, input.ID)
 	if err != nil {
@@ -6562,9 +6580,10 @@ func (r *Resolver) GetRiskAssessmentThreatTool(ctx context.Context, req *mcp.Cal
 }
 
 func (r *Resolver) AddRiskAssessmentThreatTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddRiskAssessmentThreatInput) (*mcp.CallToolResult, types.AddRiskAssessmentThreatOutput, error) {
-	r.MustAuthorize(ctx, input.RiskAssessmentScopeID, probo.ActionRiskAssessmentThreatCreate)
-
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentScopeID)
+	scope, err := r.Authorize(ctx, input.RiskAssessmentScopeID, probo.ActionRiskAssessmentThreatCreate)
+	if err != nil {
+		return nil, types.AddRiskAssessmentThreatOutput{}, err
+	}
 
 	t, err := r.riskManagement.CreateThreat(ctx, scope, riskmanagement.CreateRiskAssessmentThreatRequest{
 		RiskAssessmentScopeID: input.RiskAssessmentScopeID,
@@ -6582,9 +6601,10 @@ func (r *Resolver) AddRiskAssessmentThreatTool(ctx context.Context, req *mcp.Cal
 }
 
 func (r *Resolver) UpdateRiskAssessmentThreatTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateRiskAssessmentThreatInput) (*mcp.CallToolResult, types.UpdateRiskAssessmentThreatOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionRiskAssessmentThreatUpdate)
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionRiskAssessmentThreatUpdate)
+	if err != nil {
+		return nil, types.UpdateRiskAssessmentThreatOutput{}, err
+	}
 
 	t, err := r.riskManagement.UpdateThreat(ctx, scope, riskmanagement.UpdateRiskAssessmentThreatRequest{
 		ID:        input.ID,
@@ -6602,12 +6622,12 @@ func (r *Resolver) UpdateRiskAssessmentThreatTool(ctx context.Context, req *mcp.
 }
 
 func (r *Resolver) DeleteRiskAssessmentThreatTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteRiskAssessmentThreatInput) (*mcp.CallToolResult, types.DeleteRiskAssessmentThreatOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionRiskAssessmentThreatDelete)
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
-
-	err := r.riskManagement.DeleteThreat(ctx, scope, input.ID)
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionRiskAssessmentThreatDelete)
 	if err != nil {
+		return nil, types.DeleteRiskAssessmentThreatOutput{}, err
+	}
+
+	if err := r.riskManagement.DeleteThreat(ctx, scope, input.ID); err != nil {
 		return nil, types.DeleteRiskAssessmentThreatOutput{}, fmt.Errorf("failed to delete risk assessment threat: %w", err)
 	}
 
@@ -6616,9 +6636,10 @@ func (r *Resolver) DeleteRiskAssessmentThreatTool(ctx context.Context, req *mcp.
 	}, nil
 }
 func (r *Resolver) ListRiskAssessmentScenariosTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListRiskAssessmentScenariosInput) (*mcp.CallToolResult, types.ListRiskAssessmentScenariosOutput, error) {
-	r.MustAuthorize(ctx, input.RiskAssessmentScopeID, probo.ActionRiskAssessmentScenarioList)
-
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentScopeID)
+	scope, err := r.Authorize(ctx, input.RiskAssessmentScopeID, probo.ActionRiskAssessmentScenarioList)
+	if err != nil {
+		return nil, types.ListRiskAssessmentScenariosOutput{}, err
+	}
 
 	pageOrderBy := page.OrderBy[coredata.RiskAssessmentScenarioOrderField]{
 		Field:     coredata.RiskAssessmentScenarioOrderFieldCreatedAt,
@@ -6642,9 +6663,10 @@ func (r *Resolver) ListRiskAssessmentScenariosTool(ctx context.Context, req *mcp
 }
 
 func (r *Resolver) GetRiskAssessmentScenarioTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetRiskAssessmentScenarioInput) (*mcp.CallToolResult, types.GetRiskAssessmentScenarioOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionRiskAssessmentScenarioGet)
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionRiskAssessmentScenarioGet)
+	if err != nil {
+		return nil, types.GetRiskAssessmentScenarioOutput{}, err
+	}
 
 	s, err := r.riskManagement.GetScenario(ctx, scope, input.ID)
 	if err != nil {
@@ -6657,9 +6679,10 @@ func (r *Resolver) GetRiskAssessmentScenarioTool(ctx context.Context, req *mcp.C
 }
 
 func (r *Resolver) AddRiskAssessmentScenarioTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddRiskAssessmentScenarioInput) (*mcp.CallToolResult, types.AddRiskAssessmentScenarioOutput, error) {
-	r.MustAuthorize(ctx, input.RiskAssessmentScopeID, probo.ActionRiskAssessmentScenarioCreate)
-
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentScopeID)
+	scope, err := r.Authorize(ctx, input.RiskAssessmentScopeID, probo.ActionRiskAssessmentScenarioCreate)
+	if err != nil {
+		return nil, types.AddRiskAssessmentScenarioOutput{}, err
+	}
 
 	s, err := r.riskManagement.CreateScenario(ctx, scope, riskmanagement.CreateRiskAssessmentScenarioRequest{
 		RiskAssessmentScopeID: input.RiskAssessmentScopeID,
@@ -6676,9 +6699,10 @@ func (r *Resolver) AddRiskAssessmentScenarioTool(ctx context.Context, req *mcp.C
 }
 
 func (r *Resolver) UpdateRiskAssessmentScenarioTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateRiskAssessmentScenarioInput) (*mcp.CallToolResult, types.UpdateRiskAssessmentScenarioOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionRiskAssessmentScenarioUpdate)
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionRiskAssessmentScenarioUpdate)
+	if err != nil {
+		return nil, types.UpdateRiskAssessmentScenarioOutput{}, err
+	}
 
 	s, err := r.riskManagement.UpdateScenario(ctx, scope, riskmanagement.UpdateRiskAssessmentScenarioRequest{
 		ID:          input.ID,
@@ -6695,12 +6719,12 @@ func (r *Resolver) UpdateRiskAssessmentScenarioTool(ctx context.Context, req *mc
 }
 
 func (r *Resolver) DeleteRiskAssessmentScenarioTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteRiskAssessmentScenarioInput) (*mcp.CallToolResult, types.DeleteRiskAssessmentScenarioOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionRiskAssessmentScenarioDelete)
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
-
-	err := r.riskManagement.DeleteScenario(ctx, scope, input.ID)
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionRiskAssessmentScenarioDelete)
 	if err != nil {
+		return nil, types.DeleteRiskAssessmentScenarioOutput{}, err
+	}
+
+	if err := r.riskManagement.DeleteScenario(ctx, scope, input.ID); err != nil {
 		return nil, types.DeleteRiskAssessmentScenarioOutput{}, fmt.Errorf("failed to delete risk assessment scenario: %w", err)
 	}
 
@@ -6709,11 +6733,12 @@ func (r *Resolver) DeleteRiskAssessmentScenarioTool(ctx context.Context, req *mc
 	}, nil
 }
 func (r *Resolver) LinkRiskAssessmentScenarioThreatTool(ctx context.Context, req *mcp.CallToolRequest, input *types.LinkRiskAssessmentScenarioThreatInput) (*mcp.CallToolResult, types.LinkRiskAssessmentScenarioThreatOutput, error) {
-	r.MustAuthorize(ctx, input.RiskAssessmentScenarioID, probo.ActionRiskAssessmentScenarioThreatLink)
+	scope, err := r.Authorize(ctx, input.RiskAssessmentScenarioID, probo.ActionRiskAssessmentScenarioThreatLink)
+	if err != nil {
+		return nil, types.LinkRiskAssessmentScenarioThreatOutput{}, err
+	}
 
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentScenarioID)
-
-	err := r.riskManagement.LinkScenarioThreat(ctx, scope, riskmanagement.LinkRiskAssessmentScenarioThreatRequest{
+	err = r.riskManagement.LinkScenarioThreat(ctx, scope, riskmanagement.LinkRiskAssessmentScenarioThreatRequest{
 		RiskAssessmentScenarioID: input.RiskAssessmentScenarioID,
 		ThreatID:                 input.ThreatID,
 	})
@@ -6725,15 +6750,19 @@ func (r *Resolver) LinkRiskAssessmentScenarioThreatTool(ctx context.Context, req
 }
 
 func (r *Resolver) UnlinkRiskAssessmentScenarioThreatTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UnlinkRiskAssessmentScenarioThreatInput) (*mcp.CallToolResult, types.UnlinkRiskAssessmentScenarioThreatOutput, error) {
-	r.MustAuthorize(ctx, input.RiskAssessmentScenarioID, probo.ActionRiskAssessmentScenarioThreatUnlink)
-
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentScenarioID)
-
-	err := r.riskManagement.UnlinkScenarioThreat(ctx, scope, riskmanagement.UnlinkRiskAssessmentScenarioThreatRequest{
-		RiskAssessmentScenarioID: input.RiskAssessmentScenarioID,
-		ThreatID:                 input.ThreatID,
-	})
+	scope, err := r.Authorize(ctx, input.RiskAssessmentScenarioID, probo.ActionRiskAssessmentScenarioThreatUnlink)
 	if err != nil {
+		return nil, types.UnlinkRiskAssessmentScenarioThreatOutput{}, err
+	}
+
+	if err := r.riskManagement.UnlinkScenarioThreat(
+		ctx,
+		scope,
+		riskmanagement.UnlinkRiskAssessmentScenarioThreatRequest{
+			RiskAssessmentScenarioID: input.RiskAssessmentScenarioID,
+			ThreatID:                 input.ThreatID,
+		},
+	); err != nil {
 		return nil, types.UnlinkRiskAssessmentScenarioThreatOutput{}, fmt.Errorf("failed to unlink scenario threat: %w", err)
 	}
 
@@ -6741,15 +6770,19 @@ func (r *Resolver) UnlinkRiskAssessmentScenarioThreatTool(ctx context.Context, r
 }
 
 func (r *Resolver) LinkRiskAssessmentScenarioRiskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.LinkRiskAssessmentScenarioRiskInput) (*mcp.CallToolResult, types.LinkRiskAssessmentScenarioRiskOutput, error) {
-	r.MustAuthorize(ctx, input.RiskAssessmentScenarioID, probo.ActionRiskAssessmentScenarioRiskLink)
-
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentScenarioID)
-
-	err := r.riskManagement.LinkScenarioRisk(ctx, scope, riskmanagement.LinkRiskAssessmentScenarioRiskRequest{
-		RiskAssessmentScenarioID: input.RiskAssessmentScenarioID,
-		RiskID:                   input.RiskID,
-	})
+	scope, err := r.Authorize(ctx, input.RiskAssessmentScenarioID, probo.ActionRiskAssessmentScenarioRiskLink)
 	if err != nil {
+		return nil, types.LinkRiskAssessmentScenarioRiskOutput{}, err
+	}
+
+	if err := r.riskManagement.LinkScenarioRisk(
+		ctx,
+		scope,
+		riskmanagement.LinkRiskAssessmentScenarioRiskRequest{
+			RiskAssessmentScenarioID: input.RiskAssessmentScenarioID,
+			RiskID:                   input.RiskID,
+		},
+	); err != nil {
 		return nil, types.LinkRiskAssessmentScenarioRiskOutput{}, fmt.Errorf("failed to link scenario risk: %w", err)
 	}
 
@@ -6757,15 +6790,19 @@ func (r *Resolver) LinkRiskAssessmentScenarioRiskTool(ctx context.Context, req *
 }
 
 func (r *Resolver) UnlinkRiskAssessmentScenarioRiskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UnlinkRiskAssessmentScenarioRiskInput) (*mcp.CallToolResult, types.UnlinkRiskAssessmentScenarioRiskOutput, error) {
-	r.MustAuthorize(ctx, input.RiskAssessmentScenarioID, probo.ActionRiskAssessmentScenarioRiskUnlink)
-
-	scope := coredata.NewScopeFromObjectID(input.RiskAssessmentScenarioID)
-
-	err := r.riskManagement.UnlinkScenarioRisk(ctx, scope, riskmanagement.UnlinkRiskAssessmentScenarioRiskRequest{
-		RiskAssessmentScenarioID: input.RiskAssessmentScenarioID,
-		RiskID:                   input.RiskID,
-	})
+	scope, err := r.Authorize(ctx, input.RiskAssessmentScenarioID, probo.ActionRiskAssessmentScenarioRiskUnlink)
 	if err != nil {
+		return nil, types.UnlinkRiskAssessmentScenarioRiskOutput{}, err
+	}
+
+	if err := r.riskManagement.UnlinkScenarioRisk(
+		ctx,
+		scope,
+		riskmanagement.UnlinkRiskAssessmentScenarioRiskRequest{
+			RiskAssessmentScenarioID: input.RiskAssessmentScenarioID,
+			RiskID:                   input.RiskID,
+		},
+	); err != nil {
 		return nil, types.UnlinkRiskAssessmentScenarioRiskOutput{}, fmt.Errorf("failed to unlink scenario risk: %w", err)
 	}
 
@@ -6773,9 +6810,10 @@ func (r *Resolver) UnlinkRiskAssessmentScenarioRiskTool(ctx context.Context, req
 }
 
 func (r *Resolver) GetRiskAssessmentScopeMermaidChartTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetRiskAssessmentScopeMermaidChartInput) (*mcp.CallToolResult, types.GetRiskAssessmentScopeMermaidChartOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionRiskAssessmentScopeGet)
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionRiskAssessmentScopeGet)
+	if err != nil {
+		return nil, types.GetRiskAssessmentScopeMermaidChartOutput{}, err
+	}
 
 	chart, err := r.riskManagement.BuildScopeMermaidChart(ctx, scope, input.ID)
 	if err != nil {

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -49,11 +49,10 @@ func (r *Resolver) ListOrganizationsTool(ctx context.Context, req *mcp.CallToolR
 // ListThirdPartiesTool handles the listThirdParties tool
 // List all thirdParties for the organization
 func (r *Resolver) ListThirdPartiesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListThirdPartiesInput) (*mcp.CallToolResult, types.ListThirdPartiesOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionThirdPartyList); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionThirdPartyList)
+	if err != nil {
 		return nil, types.ListThirdPartiesOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyOrderField]{
@@ -82,11 +81,10 @@ func (r *Resolver) ListThirdPartiesTool(ctx context.Context, req *mcp.CallToolRe
 // AddThirdPartyTool handles the addThirdParty tool
 // Add a new thirdParty to the organization
 func (r *Resolver) AddThirdPartyTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddThirdPartyInput) (*mcp.CallToolResult, types.AddThirdPartyOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionThirdPartyCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionThirdPartyCreate)
+	if err != nil {
 		return nil, types.AddThirdPartyOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
 
 	var category *coredata.ThirdPartyCategory
@@ -139,11 +137,10 @@ func (r *Resolver) AddThirdPartyTool(ctx context.Context, req *mcp.CallToolReque
 // UpdateThirdPartyTool handles the updateThirdParty tool
 // Update an existing thirdParty
 func (r *Resolver) UpdateThirdPartyTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateThirdPartyInput) (*mcp.CallToolResult, types.UpdateThirdPartyOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionThirdPartyUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionThirdPartyUpdate)
+	if err != nil {
 		return nil, types.UpdateThirdPartyOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	var description **string
@@ -269,11 +266,10 @@ func (r *Resolver) UpdateThirdPartyTool(ctx context.Context, req *mcp.CallToolRe
 }
 
 func (r *Resolver) ListRisksTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListRisksInput) (*mcp.CallToolResult, types.ListRisksOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionRiskList); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionRiskList)
+	if err != nil {
 		return nil, types.ListRisksOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.RiskOrderField]{
@@ -303,11 +299,10 @@ func (r *Resolver) ListRisksTool(ctx context.Context, req *mcp.CallToolRequest, 
 }
 
 func (r *Resolver) GetRiskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetRiskInput) (*mcp.CallToolResult, types.GetRiskOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionRiskGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionRiskGet)
+	if err != nil {
 		return nil, types.GetRiskOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
 	risk, err := prb.Risks.Get(ctx, scope, input.ID)
@@ -321,11 +316,10 @@ func (r *Resolver) GetRiskTool(ctx context.Context, req *mcp.CallToolRequest, in
 }
 
 func (r *Resolver) AddRiskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddRiskInput) (*mcp.CallToolResult, types.AddRiskOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionRiskCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionRiskCreate)
+	if err != nil {
 		return nil, types.AddRiskOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
 
 	risk, err := svc.Risks.Create(
@@ -352,11 +346,10 @@ func (r *Resolver) AddRiskTool(ctx context.Context, req *mcp.CallToolRequest, in
 }
 
 func (r *Resolver) UpdateRiskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateRiskInput) (*mcp.CallToolResult, types.UpdateRiskOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionRiskUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionRiskUpdate)
+	if err != nil {
 		return nil, types.UpdateRiskOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	risk, err := svc.Risks.Update(
@@ -385,11 +378,10 @@ func (r *Resolver) UpdateRiskTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) ListMeasuresTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListMeasuresInput) (*mcp.CallToolResult, types.ListMeasuresOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionMeasureList); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionMeasureList)
+	if err != nil {
 		return nil, types.ListMeasuresOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.MeasureOrderField]{
@@ -419,11 +411,10 @@ func (r *Resolver) ListMeasuresTool(ctx context.Context, req *mcp.CallToolReques
 }
 
 func (r *Resolver) GetMeasureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetMeasureInput) (*mcp.CallToolResult, types.GetMeasureOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionMeasureGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionMeasureGet)
+	if err != nil {
 		return nil, types.GetMeasureOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
 	measure, err := prb.Measures.Get(ctx, scope, input.ID)
@@ -437,11 +428,10 @@ func (r *Resolver) GetMeasureTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) AddMeasureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddMeasureInput) (*mcp.CallToolResult, types.AddMeasureOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionMeasureCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionMeasureCreate)
+	if err != nil {
 		return nil, types.AddMeasureOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
 
 	measure, err := svc.Measures.Create(
@@ -463,11 +453,10 @@ func (r *Resolver) AddMeasureTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) UpdateMeasureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateMeasureInput) (*mcp.CallToolResult, types.UpdateMeasureOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionMeasureUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionMeasureUpdate)
+	if err != nil {
 		return nil, types.UpdateMeasureOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	measure, err := svc.Measures.Update(
@@ -490,11 +479,10 @@ func (r *Resolver) UpdateMeasureTool(ctx context.Context, req *mcp.CallToolReque
 }
 
 func (r *Resolver) ListFrameworksTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListFrameworksInput) (*mcp.CallToolResult, types.ListFrameworksOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionFrameworkList); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionFrameworkList)
+	if err != nil {
 		return nil, types.ListFrameworksOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.FrameworkOrderField]{
@@ -519,11 +507,10 @@ func (r *Resolver) ListFrameworksTool(ctx context.Context, req *mcp.CallToolRequ
 }
 
 func (r *Resolver) GetFrameworkTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetFrameworkInput) (*mcp.CallToolResult, types.GetFrameworkOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionFrameworkGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionFrameworkGet)
+	if err != nil {
 		return nil, types.GetFrameworkOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
 	framework, err := prb.Frameworks.Get(ctx, scope, input.ID)
@@ -537,11 +524,10 @@ func (r *Resolver) GetFrameworkTool(ctx context.Context, req *mcp.CallToolReques
 }
 
 func (r *Resolver) AddFrameworkTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddFrameworkInput) (*mcp.CallToolResult, types.AddFrameworkOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionFrameworkCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionFrameworkCreate)
+	if err != nil {
 		return nil, types.AddFrameworkOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
 
 	framework, err := svc.Frameworks.Create(
@@ -562,11 +548,10 @@ func (r *Resolver) AddFrameworkTool(ctx context.Context, req *mcp.CallToolReques
 }
 
 func (r *Resolver) UpdateFrameworkTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateFrameworkInput) (*mcp.CallToolResult, types.UpdateFrameworkOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionFrameworkUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionFrameworkUpdate)
+	if err != nil {
 		return nil, types.UpdateFrameworkOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	framework, err := svc.Frameworks.Update(
@@ -587,11 +572,10 @@ func (r *Resolver) UpdateFrameworkTool(ctx context.Context, req *mcp.CallToolReq
 }
 
 func (r *Resolver) ListAssetsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListAssetsInput) (*mcp.CallToolResult, types.ListAssetsOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionAssetList); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionAssetList)
+	if err != nil {
 		return nil, types.ListAssetsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.AssetOrderField]{
@@ -616,11 +600,10 @@ func (r *Resolver) ListAssetsTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) GetAssetTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetAssetInput) (*mcp.CallToolResult, types.GetAssetOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionAssetGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionAssetGet)
+	if err != nil {
 		return nil, types.GetAssetOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
 	asset, err := prb.Assets.Get(ctx, scope, input.ID)
@@ -634,11 +617,10 @@ func (r *Resolver) GetAssetTool(ctx context.Context, req *mcp.CallToolRequest, i
 }
 
 func (r *Resolver) AddAssetTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddAssetInput) (*mcp.CallToolResult, types.AddAssetOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionAssetCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionAssetCreate)
+	if err != nil {
 		return nil, types.AddAssetOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
 
 	asset, err := svc.Assets.Create(
@@ -663,11 +645,10 @@ func (r *Resolver) AddAssetTool(ctx context.Context, req *mcp.CallToolRequest, i
 }
 
 func (r *Resolver) UpdateAssetTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateAssetInput) (*mcp.CallToolResult, types.UpdateAssetOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionAssetUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionAssetUpdate)
+	if err != nil {
 		return nil, types.UpdateAssetOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	asset, err := svc.Assets.Update(
@@ -692,11 +673,10 @@ func (r *Resolver) UpdateAssetTool(ctx context.Context, req *mcp.CallToolRequest
 }
 
 func (r *Resolver) ListDataTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListDataInput) (*mcp.CallToolResult, types.ListDataOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionDatumList); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionDatumList)
+	if err != nil {
 		return nil, types.ListDataOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.DatumOrderField]{
@@ -721,11 +701,10 @@ func (r *Resolver) ListDataTool(ctx context.Context, req *mcp.CallToolRequest, i
 }
 
 func (r *Resolver) GetDatumTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetDatumInput) (*mcp.CallToolResult, types.GetDatumOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionDatumGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionDatumGet)
+	if err != nil {
 		return nil, types.GetDatumOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
 	datum, err := prb.Data.Get(ctx, scope, input.ID)
@@ -739,11 +718,10 @@ func (r *Resolver) GetDatumTool(ctx context.Context, req *mcp.CallToolRequest, i
 }
 
 func (r *Resolver) AddDatumTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddDatumInput) (*mcp.CallToolResult, types.AddDatumOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionDatumCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionDatumCreate)
+	if err != nil {
 		return nil, types.AddDatumOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
 
 	datum, err := svc.Data.Create(
@@ -766,11 +744,10 @@ func (r *Resolver) AddDatumTool(ctx context.Context, req *mcp.CallToolRequest, i
 }
 
 func (r *Resolver) UpdateDatumTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateDatumInput) (*mcp.CallToolResult, types.UpdateDatumOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionDatumUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionDatumUpdate)
+	if err != nil {
 		return nil, types.UpdateDatumOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	datum, err := svc.Data.Update(
@@ -793,11 +770,10 @@ func (r *Resolver) UpdateDatumTool(ctx context.Context, req *mcp.CallToolRequest
 }
 
 func (r *Resolver) ListFindingsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListFindingsInput) (*mcp.CallToolResult, types.ListFindingsOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionFindingList); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionFindingList)
+	if err != nil {
 		return nil, types.ListFindingsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.FindingOrderField]{
@@ -832,11 +808,10 @@ func (r *Resolver) ListFindingsTool(ctx context.Context, req *mcp.CallToolReques
 }
 
 func (r *Resolver) GetFindingTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetFindingInput) (*mcp.CallToolResult, types.GetFindingOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionFindingGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionFindingGet)
+	if err != nil {
 		return nil, types.GetFindingOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
 	finding, err := prb.Findings.Get(ctx, scope, input.ID)
@@ -850,11 +825,10 @@ func (r *Resolver) GetFindingTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) AddFindingTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddFindingInput) (*mcp.CallToolResult, types.AddFindingOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionFindingCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionFindingCreate)
+	if err != nil {
 		return nil, types.AddFindingOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
 
 	finding, err := svc.Findings.Create(
@@ -885,11 +859,10 @@ func (r *Resolver) AddFindingTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) UpdateFindingTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateFindingInput) (*mcp.CallToolResult, types.UpdateFindingOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionFindingUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionFindingUpdate)
+	if err != nil {
 		return nil, types.UpdateFindingOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	finding, err := svc.Findings.Update(
@@ -919,11 +892,10 @@ func (r *Resolver) UpdateFindingTool(ctx context.Context, req *mcp.CallToolReque
 }
 
 func (r *Resolver) ListObligationsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListObligationsInput) (*mcp.CallToolResult, types.ListObligationsOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionObligationList); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionObligationList)
+	if err != nil {
 		return nil, types.ListObligationsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ObligationOrderField]{
@@ -948,11 +920,10 @@ func (r *Resolver) ListObligationsTool(ctx context.Context, req *mcp.CallToolReq
 }
 
 func (r *Resolver) GetObligationTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetObligationInput) (*mcp.CallToolResult, types.GetObligationOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionObligationGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionObligationGet)
+	if err != nil {
 		return nil, types.GetObligationOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
 	obligation, err := prb.Obligations.Get(ctx, scope, input.ID)
@@ -966,11 +937,10 @@ func (r *Resolver) GetObligationTool(ctx context.Context, req *mcp.CallToolReque
 }
 
 func (r *Resolver) AddObligationTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddObligationInput) (*mcp.CallToolResult, types.AddObligationOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionObligationCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionObligationCreate)
+	if err != nil {
 		return nil, types.AddObligationOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
 
 	obligation, err := svc.Obligations.Create(
@@ -999,11 +969,10 @@ func (r *Resolver) AddObligationTool(ctx context.Context, req *mcp.CallToolReque
 }
 
 func (r *Resolver) UpdateObligationTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateObligationInput) (*mcp.CallToolResult, types.UpdateObligationOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionObligationUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionObligationUpdate)
+	if err != nil {
 		return nil, types.UpdateObligationOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	obligation, err := svc.Obligations.Update(
@@ -1032,11 +1001,10 @@ func (r *Resolver) UpdateObligationTool(ctx context.Context, req *mcp.CallToolRe
 }
 
 func (r *Resolver) ListProcessingActivitiesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListProcessingActivitiesInput) (*mcp.CallToolResult, types.ListProcessingActivitiesOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionProcessingActivityList); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionProcessingActivityList)
+	if err != nil {
 		return nil, types.ListProcessingActivitiesOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ProcessingActivityOrderField]{
@@ -1061,11 +1029,10 @@ func (r *Resolver) ListProcessingActivitiesTool(ctx context.Context, req *mcp.Ca
 }
 
 func (r *Resolver) GetProcessingActivityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetProcessingActivityInput) (*mcp.CallToolResult, types.GetProcessingActivityOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionProcessingActivityGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionProcessingActivityGet)
+	if err != nil {
 		return nil, types.GetProcessingActivityOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
 	processingActivity, err := prb.ProcessingActivities.Get(ctx, scope, input.ID)
@@ -1079,11 +1046,10 @@ func (r *Resolver) GetProcessingActivityTool(ctx context.Context, req *mcp.CallT
 }
 
 func (r *Resolver) AddProcessingActivityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddProcessingActivityInput) (*mcp.CallToolResult, types.AddProcessingActivityOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionProcessingActivityCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionProcessingActivityCreate)
+	if err != nil {
 		return nil, types.AddProcessingActivityOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
 
 	processingActivity, err := svc.ProcessingActivities.Create(
@@ -1122,11 +1088,10 @@ func (r *Resolver) AddProcessingActivityTool(ctx context.Context, req *mcp.CallT
 }
 
 func (r *Resolver) UpdateProcessingActivityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateProcessingActivityInput) (*mcp.CallToolResult, types.UpdateProcessingActivityOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionProcessingActivityUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionProcessingActivityUpdate)
+	if err != nil {
 		return nil, types.UpdateProcessingActivityOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	var thirdPartyIDs *[]gid.GID
@@ -1170,14 +1135,13 @@ func (r *Resolver) UpdateProcessingActivityTool(ctx context.Context, req *mcp.Ca
 }
 
 func (r *Resolver) DeleteProcessingActivityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteProcessingActivityInput) (*mcp.CallToolResult, types.DeleteProcessingActivityOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionProcessingActivityDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionProcessingActivityDelete)
+	if err != nil {
 		return nil, types.DeleteProcessingActivityOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
-	err := svc.ProcessingActivities.Delete(ctx, scope, input.ID)
+	err = svc.ProcessingActivities.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteProcessingActivityOutput{}, fmt.Errorf("failed to delete processing activity: %w", err)
 	}
@@ -1188,11 +1152,10 @@ func (r *Resolver) DeleteProcessingActivityTool(ctx context.Context, req *mcp.Ca
 }
 
 func (r *Resolver) ListDataProtectionImpactAssessmentsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListDataProtectionImpactAssessmentsInput) (*mcp.CallToolResult, types.ListDataProtectionImpactAssessmentsOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionDataProtectionImpactAssessmentList); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionDataProtectionImpactAssessmentList)
+	if err != nil {
 		return nil, types.ListDataProtectionImpactAssessmentsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.DataProtectionImpactAssessmentOrderField]{
@@ -1217,11 +1180,10 @@ func (r *Resolver) ListDataProtectionImpactAssessmentsTool(ctx context.Context, 
 }
 
 func (r *Resolver) GetDataProtectionImpactAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetDataProtectionImpactAssessmentInput) (*mcp.CallToolResult, types.GetDataProtectionImpactAssessmentOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionDataProtectionImpactAssessmentGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionDataProtectionImpactAssessmentGet)
+	if err != nil {
 		return nil, types.GetDataProtectionImpactAssessmentOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
 	dpia, err := prb.DataProtectionImpactAssessments.Get(ctx, scope, input.ID)
@@ -1235,11 +1197,10 @@ func (r *Resolver) GetDataProtectionImpactAssessmentTool(ctx context.Context, re
 }
 
 func (r *Resolver) AddDataProtectionImpactAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddDataProtectionImpactAssessmentInput) (*mcp.CallToolResult, types.AddDataProtectionImpactAssessmentOutput, error) {
-	if err := r.Authorize(ctx, input.ProcessingActivityID, probo.ActionDataProtectionImpactAssessmentCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.ProcessingActivityID, probo.ActionDataProtectionImpactAssessmentCreate)
+	if err != nil {
 		return nil, types.AddDataProtectionImpactAssessmentOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ProcessingActivityID)
 	svc := r.proboSvc
 
 	dpia, err := svc.DataProtectionImpactAssessments.Create(
@@ -1263,11 +1224,10 @@ func (r *Resolver) AddDataProtectionImpactAssessmentTool(ctx context.Context, re
 }
 
 func (r *Resolver) UpdateDataProtectionImpactAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateDataProtectionImpactAssessmentInput) (*mcp.CallToolResult, types.UpdateDataProtectionImpactAssessmentOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionDataProtectionImpactAssessmentUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionDataProtectionImpactAssessmentUpdate)
+	if err != nil {
 		return nil, types.UpdateDataProtectionImpactAssessmentOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	dpia, err := svc.DataProtectionImpactAssessments.Update(
@@ -1291,11 +1251,10 @@ func (r *Resolver) UpdateDataProtectionImpactAssessmentTool(ctx context.Context,
 }
 
 func (r *Resolver) ListTransferImpactAssessmentsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListTransferImpactAssessmentsInput) (*mcp.CallToolResult, types.ListTransferImpactAssessmentsOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionTransferImpactAssessmentList); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionTransferImpactAssessmentList)
+	if err != nil {
 		return nil, types.ListTransferImpactAssessmentsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.TransferImpactAssessmentOrderField]{
@@ -1320,11 +1279,10 @@ func (r *Resolver) ListTransferImpactAssessmentsTool(ctx context.Context, req *m
 }
 
 func (r *Resolver) GetTransferImpactAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetTransferImpactAssessmentInput) (*mcp.CallToolResult, types.GetTransferImpactAssessmentOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionTransferImpactAssessmentGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionTransferImpactAssessmentGet)
+	if err != nil {
 		return nil, types.GetTransferImpactAssessmentOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
 	tia, err := prb.TransferImpactAssessments.Get(ctx, scope, input.ID)
@@ -1338,11 +1296,10 @@ func (r *Resolver) GetTransferImpactAssessmentTool(ctx context.Context, req *mcp
 }
 
 func (r *Resolver) AddTransferImpactAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddTransferImpactAssessmentInput) (*mcp.CallToolResult, types.AddTransferImpactAssessmentOutput, error) {
-	if err := r.Authorize(ctx, input.ProcessingActivityID, probo.ActionTransferImpactAssessmentCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.ProcessingActivityID, probo.ActionTransferImpactAssessmentCreate)
+	if err != nil {
 		return nil, types.AddTransferImpactAssessmentOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ProcessingActivityID)
 	svc := r.proboSvc
 
 	tia, err := svc.TransferImpactAssessments.Create(
@@ -1366,11 +1323,10 @@ func (r *Resolver) AddTransferImpactAssessmentTool(ctx context.Context, req *mcp
 }
 
 func (r *Resolver) UpdateTransferImpactAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateTransferImpactAssessmentInput) (*mcp.CallToolResult, types.UpdateTransferImpactAssessmentOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionTransferImpactAssessmentUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionTransferImpactAssessmentUpdate)
+	if err != nil {
 		return nil, types.UpdateTransferImpactAssessmentOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	tia, err := svc.TransferImpactAssessments.Update(
@@ -1394,14 +1350,13 @@ func (r *Resolver) UpdateTransferImpactAssessmentTool(ctx context.Context, req *
 }
 
 func (r *Resolver) DeleteTransferImpactAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteTransferImpactAssessmentInput) (*mcp.CallToolResult, types.DeleteTransferImpactAssessmentOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionTransferImpactAssessmentDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionTransferImpactAssessmentDelete)
+	if err != nil {
 		return nil, types.DeleteTransferImpactAssessmentOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
-	err := svc.TransferImpactAssessments.Delete(ctx, scope, input.ID)
+	err = svc.TransferImpactAssessments.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteTransferImpactAssessmentOutput{}, fmt.Errorf("failed to delete transfer impact assessment: %w", err)
 	}
@@ -1412,11 +1367,10 @@ func (r *Resolver) DeleteTransferImpactAssessmentTool(ctx context.Context, req *
 }
 
 func (r *Resolver) ListAuditsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListAuditsInput) (*mcp.CallToolResult, types.ListAuditsOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionAuditList); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionAuditList)
+	if err != nil {
 		return nil, types.ListAuditsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.AuditOrderField]{
@@ -1441,11 +1395,10 @@ func (r *Resolver) ListAuditsTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) GetAuditTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetAuditInput) (*mcp.CallToolResult, types.GetAuditOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionAuditGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionAuditGet)
+	if err != nil {
 		return nil, types.GetAuditOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
 	audit, err := prb.Audits.Get(ctx, scope, input.ID)
@@ -1467,11 +1420,10 @@ func (r *Resolver) GetAuditTool(ctx context.Context, req *mcp.CallToolRequest, i
 }
 
 func (r *Resolver) AddAuditTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddAuditInput) (*mcp.CallToolResult, types.AddAuditOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionAuditCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionAuditCreate)
+	if err != nil {
 		return nil, types.AddAuditOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
 
 	audit, err := svc.Audits.Create(
@@ -1495,11 +1447,10 @@ func (r *Resolver) AddAuditTool(ctx context.Context, req *mcp.CallToolRequest, i
 }
 
 func (r *Resolver) UpdateAuditTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateAuditInput) (*mcp.CallToolResult, types.UpdateAuditOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionAuditUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionAuditUpdate)
+	if err != nil {
 		return nil, types.UpdateAuditOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	audit, err := svc.Audits.Update(
@@ -1531,11 +1482,10 @@ func (r *Resolver) UpdateAuditTool(ctx context.Context, req *mcp.CallToolRequest
 }
 
 func (r *Resolver) ListControlsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListControlsInput) (*mcp.CallToolResult, types.ListControlsOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionControlList); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionControlList)
+	if err != nil {
 		return nil, types.ListControlsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ControlOrderField]{
@@ -1558,7 +1508,6 @@ func (r *Resolver) ListControlsTool(ctx context.Context, req *mcp.CallToolReques
 
 	var (
 		controlPage *page.Page[*coredata.Control, coredata.ControlOrderField]
-		err         error
 	)
 
 	if input.Filter != nil && input.Filter.FrameworkID != nil {
@@ -1575,11 +1524,10 @@ func (r *Resolver) ListControlsTool(ctx context.Context, req *mcp.CallToolReques
 }
 
 func (r *Resolver) GetControlTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetControlInput) (*mcp.CallToolResult, types.GetControlOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionControlGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionControlGet)
+	if err != nil {
 		return nil, types.GetControlOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
 	control, err := prb.Controls.Get(ctx, scope, input.ID)
@@ -1593,11 +1541,10 @@ func (r *Resolver) GetControlTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) AddControlTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddControlInput) (*mcp.CallToolResult, types.AddControlOutput, error) {
-	if err := r.Authorize(ctx, input.FrameworkID, probo.ActionControlCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.FrameworkID, probo.ActionControlCreate)
+	if err != nil {
 		return nil, types.AddControlOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.FrameworkID)
 	svc := r.proboSvc
 
 	control, err := svc.Controls.Create(
@@ -1622,11 +1569,10 @@ func (r *Resolver) AddControlTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) UpdateControlTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateControlInput) (*mcp.CallToolResult, types.UpdateControlOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionControlUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionControlUpdate)
+	if err != nil {
 		return nil, types.UpdateControlOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	var maturityLevel *coredata.ControlMaturityLevel
@@ -1663,7 +1609,7 @@ func (r *Resolver) LinkControlTool(ctx context.Context, req *mcp.CallToolRequest
 
 	switch input.ResourceID.EntityType() {
 	case coredata.MeasureEntityType:
-		if err := r.Authorize(ctx, input.ControlID, probo.ActionControlMeasureMappingCreate); err != nil {
+		if _, err := r.Authorize(ctx, input.ControlID, probo.ActionControlMeasureMappingCreate); err != nil {
 			return nil, types.LinkControlOutput{}, err
 		}
 
@@ -1671,7 +1617,7 @@ func (r *Resolver) LinkControlTool(ctx context.Context, req *mcp.CallToolRequest
 			return nil, types.LinkControlOutput{}, fmt.Errorf("failed to link control to measure: %w", err)
 		}
 	case coredata.DocumentEntityType:
-		if err := r.Authorize(ctx, input.ControlID, probo.ActionControlDocumentMappingCreate); err != nil {
+		if _, err := r.Authorize(ctx, input.ControlID, probo.ActionControlDocumentMappingCreate); err != nil {
 			return nil, types.LinkControlOutput{}, err
 		}
 
@@ -1679,7 +1625,7 @@ func (r *Resolver) LinkControlTool(ctx context.Context, req *mcp.CallToolRequest
 			return nil, types.LinkControlOutput{}, fmt.Errorf("failed to link control to document: %w", err)
 		}
 	case coredata.AuditEntityType:
-		if err := r.Authorize(ctx, input.ControlID, probo.ActionControlAuditMappingCreate); err != nil {
+		if _, err := r.Authorize(ctx, input.ControlID, probo.ActionControlAuditMappingCreate); err != nil {
 			return nil, types.LinkControlOutput{}, err
 		}
 
@@ -1687,7 +1633,7 @@ func (r *Resolver) LinkControlTool(ctx context.Context, req *mcp.CallToolRequest
 			return nil, types.LinkControlOutput{}, fmt.Errorf("failed to link control to audit: %w", err)
 		}
 	case coredata.ObligationEntityType:
-		if err := r.Authorize(ctx, input.ControlID, probo.ActionControlObligationMappingCreate); err != nil {
+		if _, err := r.Authorize(ctx, input.ControlID, probo.ActionControlObligationMappingCreate); err != nil {
 			return nil, types.LinkControlOutput{}, err
 		}
 
@@ -1707,7 +1653,7 @@ func (r *Resolver) UnlinkControlTool(ctx context.Context, req *mcp.CallToolReque
 
 	switch input.ResourceID.EntityType() {
 	case coredata.MeasureEntityType:
-		if err := r.Authorize(ctx, input.ControlID, probo.ActionControlMeasureMappingDelete); err != nil {
+		if _, err := r.Authorize(ctx, input.ControlID, probo.ActionControlMeasureMappingDelete); err != nil {
 			return nil, types.UnlinkControlOutput{}, err
 		}
 
@@ -1715,7 +1661,7 @@ func (r *Resolver) UnlinkControlTool(ctx context.Context, req *mcp.CallToolReque
 			return nil, types.UnlinkControlOutput{}, fmt.Errorf("failed to unlink control from measure: %w", err)
 		}
 	case coredata.DocumentEntityType:
-		if err := r.Authorize(ctx, input.ControlID, probo.ActionControlDocumentMappingDelete); err != nil {
+		if _, err := r.Authorize(ctx, input.ControlID, probo.ActionControlDocumentMappingDelete); err != nil {
 			return nil, types.UnlinkControlOutput{}, err
 		}
 
@@ -1723,7 +1669,7 @@ func (r *Resolver) UnlinkControlTool(ctx context.Context, req *mcp.CallToolReque
 			return nil, types.UnlinkControlOutput{}, fmt.Errorf("failed to unlink control from document: %w", err)
 		}
 	case coredata.AuditEntityType:
-		if err := r.Authorize(ctx, input.ControlID, probo.ActionControlAuditMappingDelete); err != nil {
+		if _, err := r.Authorize(ctx, input.ControlID, probo.ActionControlAuditMappingDelete); err != nil {
 			return nil, types.UnlinkControlOutput{}, err
 		}
 
@@ -1731,7 +1677,7 @@ func (r *Resolver) UnlinkControlTool(ctx context.Context, req *mcp.CallToolReque
 			return nil, types.UnlinkControlOutput{}, fmt.Errorf("failed to unlink control from audit: %w", err)
 		}
 	case coredata.ObligationEntityType:
-		if err := r.Authorize(ctx, input.ControlID, probo.ActionControlObligationMappingDelete); err != nil {
+		if _, err := r.Authorize(ctx, input.ControlID, probo.ActionControlObligationMappingDelete); err != nil {
 			return nil, types.UnlinkControlOutput{}, err
 		}
 
@@ -1746,11 +1692,10 @@ func (r *Resolver) UnlinkControlTool(ctx context.Context, req *mcp.CallToolReque
 }
 
 func (r *Resolver) ListControlObligationsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListControlObligationsInput) (*mcp.CallToolResult, types.ListControlObligationsOutput, error) {
-	if err := r.Authorize(ctx, input.ControlID, probo.ActionControlGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ControlID, probo.ActionControlGet)
+	if err != nil {
 		return nil, types.ListControlObligationsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ControlID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ObligationOrderField]{
@@ -1775,11 +1720,10 @@ func (r *Resolver) ListControlObligationsTool(ctx context.Context, req *mcp.Call
 }
 
 func (r *Resolver) ListControlMeasuresTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListControlMeasuresInput) (*mcp.CallToolResult, types.ListControlMeasuresOutput, error) {
-	if err := r.Authorize(ctx, input.ControlID, probo.ActionControlGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ControlID, probo.ActionControlGet)
+	if err != nil {
 		return nil, types.ListControlMeasuresOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ControlID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.MeasureOrderField]{
@@ -1804,11 +1748,10 @@ func (r *Resolver) ListControlMeasuresTool(ctx context.Context, req *mcp.CallToo
 }
 
 func (r *Resolver) ListControlDocumentsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListControlDocumentsInput) (*mcp.CallToolResult, types.ListControlDocumentsOutput, error) {
-	if err := r.Authorize(ctx, input.ControlID, probo.ActionControlGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ControlID, probo.ActionControlGet)
+	if err != nil {
 		return nil, types.ListControlDocumentsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ControlID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
@@ -1833,11 +1776,10 @@ func (r *Resolver) ListControlDocumentsTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) ListControlAuditsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListControlAuditsInput) (*mcp.CallToolResult, types.ListControlAuditsOutput, error) {
-	if err := r.Authorize(ctx, input.ControlID, probo.ActionControlGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ControlID, probo.ActionControlGet)
+	if err != nil {
 		return nil, types.ListControlAuditsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ControlID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.AuditOrderField]{
@@ -1862,11 +1804,10 @@ func (r *Resolver) ListControlAuditsTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) ListRiskObligationsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListRiskObligationsInput) (*mcp.CallToolResult, types.ListRiskObligationsOutput, error) {
-	if err := r.Authorize(ctx, input.RiskID, probo.ActionRiskGet); err != nil {
+	scope, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskGet)
+	if err != nil {
 		return nil, types.ListRiskObligationsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.RiskID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ObligationOrderField]{
@@ -1896,7 +1837,7 @@ func (r *Resolver) LinkRiskTool(ctx context.Context, req *mcp.CallToolRequest, i
 
 	switch input.ResourceID.EntityType() {
 	case coredata.DocumentEntityType:
-		if err := r.Authorize(ctx, input.RiskID, probo.ActionRiskDocumentMappingCreate); err != nil {
+		if _, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskDocumentMappingCreate); err != nil {
 			return nil, types.LinkRiskOutput{}, err
 		}
 
@@ -1904,7 +1845,7 @@ func (r *Resolver) LinkRiskTool(ctx context.Context, req *mcp.CallToolRequest, i
 			return nil, types.LinkRiskOutput{}, fmt.Errorf("failed to link risk to document: %w", err)
 		}
 	case coredata.MeasureEntityType:
-		if err := r.Authorize(ctx, input.RiskID, probo.ActionRiskMeasureMappingCreate); err != nil {
+		if _, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskMeasureMappingCreate); err != nil {
 			return nil, types.LinkRiskOutput{}, err
 		}
 
@@ -1912,7 +1853,7 @@ func (r *Resolver) LinkRiskTool(ctx context.Context, req *mcp.CallToolRequest, i
 			return nil, types.LinkRiskOutput{}, fmt.Errorf("failed to link risk to measure: %w", err)
 		}
 	case coredata.ObligationEntityType:
-		if err := r.Authorize(ctx, input.RiskID, probo.ActionRiskObligationMappingCreate); err != nil {
+		if _, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskObligationMappingCreate); err != nil {
 			return nil, types.LinkRiskOutput{}, err
 		}
 
@@ -1932,7 +1873,7 @@ func (r *Resolver) UnlinkRiskTool(ctx context.Context, req *mcp.CallToolRequest,
 
 	switch input.ResourceID.EntityType() {
 	case coredata.DocumentEntityType:
-		if err := r.Authorize(ctx, input.RiskID, probo.ActionRiskDocumentMappingDelete); err != nil {
+		if _, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskDocumentMappingDelete); err != nil {
 			return nil, types.UnlinkRiskOutput{}, err
 		}
 
@@ -1940,7 +1881,7 @@ func (r *Resolver) UnlinkRiskTool(ctx context.Context, req *mcp.CallToolRequest,
 			return nil, types.UnlinkRiskOutput{}, fmt.Errorf("failed to unlink risk from document: %w", err)
 		}
 	case coredata.MeasureEntityType:
-		if err := r.Authorize(ctx, input.RiskID, probo.ActionRiskMeasureMappingDelete); err != nil {
+		if _, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskMeasureMappingDelete); err != nil {
 			return nil, types.UnlinkRiskOutput{}, err
 		}
 
@@ -1948,7 +1889,7 @@ func (r *Resolver) UnlinkRiskTool(ctx context.Context, req *mcp.CallToolRequest,
 			return nil, types.UnlinkRiskOutput{}, fmt.Errorf("failed to unlink risk from measure: %w", err)
 		}
 	case coredata.ObligationEntityType:
-		if err := r.Authorize(ctx, input.RiskID, probo.ActionRiskObligationMappingDelete); err != nil {
+		if _, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskObligationMappingDelete); err != nil {
 			return nil, types.UnlinkRiskOutput{}, err
 		}
 
@@ -1963,11 +1904,10 @@ func (r *Resolver) UnlinkRiskTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) ListTasksTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListTasksInput) (*mcp.CallToolResult, types.ListTasksOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionTaskList); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionTaskList)
+	if err != nil {
 		return nil, types.ListTasksOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.TaskOrderField]{
@@ -1992,11 +1932,10 @@ func (r *Resolver) ListTasksTool(ctx context.Context, req *mcp.CallToolRequest, 
 }
 
 func (r *Resolver) GetTaskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetTaskInput) (*mcp.CallToolResult, types.GetTaskOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionTaskGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionTaskGet)
+	if err != nil {
 		return nil, types.GetTaskOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
 	task, err := prb.Tasks.Get(ctx, scope, input.ID)
@@ -2010,11 +1949,10 @@ func (r *Resolver) GetTaskTool(ctx context.Context, req *mcp.CallToolRequest, in
 }
 
 func (r *Resolver) AddTaskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddTaskInput) (*mcp.CallToolResult, types.AddTaskOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionTaskCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionTaskCreate)
+	if err != nil {
 		return nil, types.AddTaskOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
 
 	priority := coredata.TaskPriorityMedium
@@ -2045,11 +1983,10 @@ func (r *Resolver) AddTaskTool(ctx context.Context, req *mcp.CallToolRequest, in
 }
 
 func (r *Resolver) UpdateTaskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateTaskInput) (*mcp.CallToolResult, types.UpdateTaskOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionTaskUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionTaskUpdate)
+	if err != nil {
 		return nil, types.UpdateTaskOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	task, err := svc.Tasks.Update(
@@ -2077,11 +2014,10 @@ func (r *Resolver) UpdateTaskTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) AssignTaskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AssignTaskInput) (*mcp.CallToolResult, types.AssignTaskOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionTaskAssign); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionTaskAssign)
+	if err != nil {
 		return nil, types.AssignTaskOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	task, err := svc.Tasks.Assign(ctx, scope, input.ID, input.AssignedToID)
@@ -2095,11 +2031,10 @@ func (r *Resolver) AssignTaskTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) UnassignTaskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UnassignTaskInput) (*mcp.CallToolResult, types.UnassignTaskOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionTaskUnassign); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionTaskUnassign)
+	if err != nil {
 		return nil, types.UnassignTaskOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	task, err := svc.Tasks.Unassign(ctx, scope, input.ID)
@@ -2113,14 +2048,13 @@ func (r *Resolver) UnassignTaskTool(ctx context.Context, req *mcp.CallToolReques
 }
 
 func (r *Resolver) DeleteTaskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteTaskInput) (*mcp.CallToolResult, types.DeleteTaskOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionTaskDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionTaskDelete)
+	if err != nil {
 		return nil, types.DeleteTaskOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
-	err := svc.Tasks.Delete(ctx, scope, input.ID)
+	err = svc.Tasks.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteTaskOutput{}, fmt.Errorf("failed to delete task: %w", err)
 	}
@@ -2131,11 +2065,10 @@ func (r *Resolver) DeleteTaskTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) ListDocumentsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListDocumentsInput) (*mcp.CallToolResult, types.ListDocumentsOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionDocumentList); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionDocumentList)
+	if err != nil {
 		return nil, types.ListDocumentsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
@@ -2180,11 +2113,10 @@ func (r *Resolver) ListDocumentsTool(ctx context.Context, req *mcp.CallToolReque
 }
 
 func (r *Resolver) GetDocumentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetDocumentInput) (*mcp.CallToolResult, types.GetDocumentOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionDocumentGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionDocumentGet)
+	if err != nil {
 		return nil, types.GetDocumentOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
 	document, err := prb.Documents.Get(ctx, scope, input.ID)
@@ -2198,11 +2130,10 @@ func (r *Resolver) GetDocumentTool(ctx context.Context, req *mcp.CallToolRequest
 }
 
 func (r *Resolver) AddDocumentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddDocumentInput) (*mcp.CallToolResult, types.AddDocumentOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionDocumentCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionDocumentCreate)
+	if err != nil {
 		return nil, types.AddDocumentOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
 
 	var trustCenterVisibility *coredata.TrustCenterVisibility
@@ -2235,11 +2166,10 @@ func (r *Resolver) AddDocumentTool(ctx context.Context, req *mcp.CallToolRequest
 }
 
 func (r *Resolver) UpdateDocumentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateDocumentInput) (*mcp.CallToolResult, types.UpdateDocumentOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionDocumentUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionDocumentUpdate)
+	if err != nil {
 		return nil, types.UpdateDocumentOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	var defaultApproverIDs *[]gid.GID
@@ -2286,7 +2216,7 @@ func (r *Resolver) UpdateDocumentTool(ctx context.Context, req *mcp.CallToolRequ
 }
 
 func (r *Resolver) ListDocumentVersionsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListDocumentVersionsInput) (*mcp.CallToolResult, types.ListDocumentVersionsOutput, error) {
-	if err := r.Authorize(ctx, input.DocumentID, probo.ActionDocumentVersionList); err != nil {
+	if _, err := r.Authorize(ctx, input.DocumentID, probo.ActionDocumentVersionList); err != nil {
 		return nil, types.ListDocumentVersionsOutput{}, err
 	}
 
@@ -2319,11 +2249,10 @@ func (r *Resolver) ListDocumentVersionsTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) GetDocumentVersionTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetDocumentVersionInput) (*mcp.CallToolResult, types.GetDocumentVersionOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionDocumentVersionGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionDocumentVersionGet)
+	if err != nil {
 		return nil, types.GetDocumentVersionOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	version, err := svc.Documents.GetVersion(ctx, scope, input.ID)
@@ -2337,11 +2266,10 @@ func (r *Resolver) GetDocumentVersionTool(ctx context.Context, req *mcp.CallTool
 }
 
 func (r *Resolver) ListDocumentVersionSignaturesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListDocumentVersionSignaturesInput) (*mcp.CallToolResult, types.ListDocumentVersionSignaturesOutput, error) {
-	if err := r.Authorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionSignatureList); err != nil {
+	scope, err := r.Authorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionSignatureList)
+	if err != nil {
 		return nil, types.ListDocumentVersionSignaturesOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.DocumentVersionID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.DocumentVersionSignatureOrderField]{
@@ -2388,11 +2316,10 @@ func (r *Resolver) ListDocumentVersionSignaturesTool(ctx context.Context, req *m
 }
 
 func (r *Resolver) GetDocumentVersionSignatureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetDocumentVersionSignatureInput) (*mcp.CallToolResult, types.GetDocumentVersionSignatureOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionDocumentVersionSignatureGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionDocumentVersionSignatureGet)
+	if err != nil {
 		return nil, types.GetDocumentVersionSignatureOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
 	signature, err := prb.Documents.GetVersionSignature(ctx, scope, input.ID)
@@ -2406,11 +2333,10 @@ func (r *Resolver) GetDocumentVersionSignatureTool(ctx context.Context, req *mcp
 }
 
 func (r *Resolver) RequestDocumentVersionSignatureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.RequestDocumentVersionSignatureInput) (*mcp.CallToolResult, types.RequestDocumentVersionSignatureOutput, error) {
-	if err := r.Authorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionSignatureRequest); err != nil {
+	scope, err := r.Authorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionSignatureRequest)
+	if err != nil {
 		return nil, types.RequestDocumentVersionSignatureOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.DocumentVersionID)
 	svc := r.proboSvc
 
 	documentVersionSignature, err := svc.Documents.RequestSignature(
@@ -2430,14 +2356,13 @@ func (r *Resolver) RequestDocumentVersionSignatureTool(ctx context.Context, req 
 }
 
 func (r *Resolver) DeleteDocumentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteDocumentInput) (*mcp.CallToolResult, types.DeleteDocumentOutput, error) {
-	if err := r.Authorize(ctx, input.DocumentID, probo.ActionDocumentDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.DocumentID, probo.ActionDocumentDelete)
+	if err != nil {
 		return nil, types.DeleteDocumentOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.DocumentID)
 	svc := r.proboSvc
 
-	err := svc.Documents.SoftDelete(ctx, scope, input.DocumentID)
+	err = svc.Documents.SoftDelete(ctx, scope, input.DocumentID)
 	if err != nil {
 		panic(fmt.Errorf("cannot soft delete document: %w", err))
 	}
@@ -2448,14 +2373,13 @@ func (r *Resolver) DeleteDocumentTool(ctx context.Context, req *mcp.CallToolRequ
 }
 
 func (r *Resolver) CancelSignatureRequestTool(ctx context.Context, req *mcp.CallToolRequest, input *types.CancelSignatureRequestInput) (*mcp.CallToolResult, types.CancelSignatureRequestOutput, error) {
-	if err := r.Authorize(ctx, input.DocumentVersionSignatureID, probo.ActionDocumentVersionCancelSignature); err != nil {
+	scope, err := r.Authorize(ctx, input.DocumentVersionSignatureID, probo.ActionDocumentVersionCancelSignature)
+	if err != nil {
 		return nil, types.CancelSignatureRequestOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.DocumentVersionSignatureID)
 	svc := r.proboSvc
 
-	err := svc.Documents.CancelSignatureRequest(ctx, scope, input.DocumentVersionSignatureID)
+	err = svc.Documents.CancelSignatureRequest(ctx, scope, input.DocumentVersionSignatureID)
 	if err != nil {
 		panic(fmt.Errorf("cannot cancel signature request: %w", err))
 	}
@@ -2466,14 +2390,13 @@ func (r *Resolver) CancelSignatureRequestTool(ctx context.Context, req *mcp.Call
 }
 
 func (r *Resolver) DeleteRiskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteRiskInput) (*mcp.CallToolResult, types.DeleteRiskOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionRiskDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionRiskDelete)
+	if err != nil {
 		return nil, types.DeleteRiskOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
-	err := svc.Risks.Delete(ctx, scope, input.ID)
+	err = svc.Risks.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteRiskOutput{}, fmt.Errorf("failed to delete risk: %w", err)
 	}
@@ -2484,14 +2407,13 @@ func (r *Resolver) DeleteRiskTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) DeleteMeasureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteMeasureInput) (*mcp.CallToolResult, types.DeleteMeasureOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionMeasureDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionMeasureDelete)
+	if err != nil {
 		return nil, types.DeleteMeasureOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
-	err := svc.Measures.Delete(ctx, scope, input.ID)
+	err = svc.Measures.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteMeasureOutput{}, fmt.Errorf("failed to delete measure: %w", err)
 	}
@@ -2502,11 +2424,10 @@ func (r *Resolver) DeleteMeasureTool(ctx context.Context, req *mcp.CallToolReque
 }
 
 func (r *Resolver) ListMeasureRisksTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListMeasureRisksInput) (*mcp.CallToolResult, types.ListMeasureRisksOutput, error) {
-	if err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureGet); err != nil {
+	scope, err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureGet)
+	if err != nil {
 		return nil, types.ListMeasureRisksOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.MeasureID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.RiskOrderField]{
@@ -2531,11 +2452,10 @@ func (r *Resolver) ListMeasureRisksTool(ctx context.Context, req *mcp.CallToolRe
 }
 
 func (r *Resolver) ListMeasureControlsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListMeasureControlsInput) (*mcp.CallToolResult, types.ListMeasureControlsOutput, error) {
-	if err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureGet); err != nil {
+	scope, err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureGet)
+	if err != nil {
 		return nil, types.ListMeasureControlsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.MeasureID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ControlOrderField]{
@@ -2560,11 +2480,10 @@ func (r *Resolver) ListMeasureControlsTool(ctx context.Context, req *mcp.CallToo
 }
 
 func (r *Resolver) ListMeasureTasksTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListMeasureTasksInput) (*mcp.CallToolResult, types.ListMeasureTasksOutput, error) {
-	if err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureGet); err != nil {
+	scope, err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureGet)
+	if err != nil {
 		return nil, types.ListMeasureTasksOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.MeasureID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.TaskOrderField]{
@@ -2589,11 +2508,10 @@ func (r *Resolver) ListMeasureTasksTool(ctx context.Context, req *mcp.CallToolRe
 }
 
 func (r *Resolver) ListMeasureEvidencesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListMeasureEvidencesInput) (*mcp.CallToolResult, types.ListMeasureEvidencesOutput, error) {
-	if err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureGet); err != nil {
+	scope, err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureGet)
+	if err != nil {
 		return nil, types.ListMeasureEvidencesOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.MeasureID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.EvidenceOrderField]{
@@ -2617,7 +2535,7 @@ func (r *Resolver) LinkMeasureTool(ctx context.Context, req *mcp.CallToolRequest
 
 	switch input.ResourceID.EntityType() {
 	case coredata.ControlEntityType:
-		if err := r.Authorize(ctx, input.MeasureID, probo.ActionControlMeasureMappingCreate); err != nil {
+		if _, err := r.Authorize(ctx, input.MeasureID, probo.ActionControlMeasureMappingCreate); err != nil {
 			return nil, types.LinkMeasureOutput{}, err
 		}
 
@@ -2625,7 +2543,7 @@ func (r *Resolver) LinkMeasureTool(ctx context.Context, req *mcp.CallToolRequest
 			return nil, types.LinkMeasureOutput{}, fmt.Errorf("failed to link measure to control: %w", err)
 		}
 	case coredata.RiskEntityType:
-		if err := r.Authorize(ctx, input.MeasureID, probo.ActionRiskMeasureMappingCreate); err != nil {
+		if _, err := r.Authorize(ctx, input.MeasureID, probo.ActionRiskMeasureMappingCreate); err != nil {
 			return nil, types.LinkMeasureOutput{}, err
 		}
 
@@ -2633,7 +2551,7 @@ func (r *Resolver) LinkMeasureTool(ctx context.Context, req *mcp.CallToolRequest
 			return nil, types.LinkMeasureOutput{}, fmt.Errorf("failed to link measure to risk: %w", err)
 		}
 	case coredata.DocumentEntityType:
-		if err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureDocumentMappingCreate); err != nil {
+		if _, err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureDocumentMappingCreate); err != nil {
 			return nil, types.LinkMeasureOutput{}, err
 		}
 
@@ -2653,7 +2571,7 @@ func (r *Resolver) UnlinkMeasureTool(ctx context.Context, req *mcp.CallToolReque
 
 	switch input.ResourceID.EntityType() {
 	case coredata.ControlEntityType:
-		if err := r.Authorize(ctx, input.MeasureID, probo.ActionControlMeasureMappingDelete); err != nil {
+		if _, err := r.Authorize(ctx, input.MeasureID, probo.ActionControlMeasureMappingDelete); err != nil {
 			return nil, types.UnlinkMeasureOutput{}, err
 		}
 
@@ -2661,7 +2579,7 @@ func (r *Resolver) UnlinkMeasureTool(ctx context.Context, req *mcp.CallToolReque
 			return nil, types.UnlinkMeasureOutput{}, fmt.Errorf("failed to unlink measure from control: %w", err)
 		}
 	case coredata.RiskEntityType:
-		if err := r.Authorize(ctx, input.MeasureID, probo.ActionRiskMeasureMappingDelete); err != nil {
+		if _, err := r.Authorize(ctx, input.MeasureID, probo.ActionRiskMeasureMappingDelete); err != nil {
 			return nil, types.UnlinkMeasureOutput{}, err
 		}
 
@@ -2669,7 +2587,7 @@ func (r *Resolver) UnlinkMeasureTool(ctx context.Context, req *mcp.CallToolReque
 			return nil, types.UnlinkMeasureOutput{}, fmt.Errorf("failed to unlink measure from risk: %w", err)
 		}
 	case coredata.DocumentEntityType:
-		if err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureDocumentMappingDelete); err != nil {
+		if _, err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureDocumentMappingDelete); err != nil {
 			return nil, types.UnlinkMeasureOutput{}, err
 		}
 
@@ -2684,7 +2602,7 @@ func (r *Resolver) UnlinkMeasureTool(ctx context.Context, req *mcp.CallToolReque
 }
 
 func (r *Resolver) ListUsersTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListUsersInput) (*mcp.CallToolResult, types.ListUsersOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, iam.ActionMembershipProfileList); err != nil {
+	if _, err := r.Authorize(ctx, input.OrganizationID, iam.ActionMembershipProfileList); err != nil {
 		return nil, types.ListUsersOutput{}, err
 	}
 
@@ -2742,7 +2660,7 @@ func (r *Resolver) GetUserTool(ctx context.Context, req *mcp.CallToolRequest, in
 		return nil, types.GetUserOutput{}, fmt.Errorf("get user: %w", err)
 	}
 
-	if err := r.Authorize(ctx, profile.OrganizationID, iam.ActionMembershipProfileGet); err != nil {
+	if _, err := r.Authorize(ctx, profile.OrganizationID, iam.ActionMembershipProfileGet); err != nil {
 		return nil, types.GetUserOutput{}, err
 	}
 
@@ -2750,7 +2668,7 @@ func (r *Resolver) GetUserTool(ctx context.Context, req *mcp.CallToolRequest, in
 }
 
 func (r *Resolver) CreateUserTool(ctx context.Context, req *mcp.CallToolRequest, input *types.CreateUserInput) (*mcp.CallToolResult, types.CreateUserOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, iam.ActionMembershipProfileCreate); err != nil {
+	if _, err := r.Authorize(ctx, input.OrganizationID, iam.ActionMembershipProfileCreate); err != nil {
 		return nil, types.CreateUserOutput{}, err
 	}
 
@@ -2786,7 +2704,7 @@ func (r *Resolver) CreateUserTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) InviteUserTool(ctx context.Context, req *mcp.CallToolRequest, input *types.InviteUserInput) (*mcp.CallToolResult, types.InviteUserOutput, error) {
-	if err := r.Authorize(ctx, input.ProfileID, iam.ActionInvitationCreate); err != nil {
+	if _, err := r.Authorize(ctx, input.ProfileID, iam.ActionInvitationCreate); err != nil {
 		return nil, types.InviteUserOutput{}, err
 	}
 
@@ -2810,7 +2728,7 @@ func (r *Resolver) InviteUserTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) UpdateUserTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateUserInput) (*mcp.CallToolResult, types.UpdateUserOutput, error) {
-	if err := r.Authorize(ctx, input.ID, iam.ActionMembershipProfileUpdate); err != nil {
+	if _, err := r.Authorize(ctx, input.ID, iam.ActionMembershipProfileUpdate); err != nil {
 		return nil, types.UpdateUserOutput{}, err
 	}
 
@@ -2850,12 +2768,12 @@ func (r *Resolver) UpdateUserTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) UpdateMembershipTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateMembershipInput) (*mcp.CallToolResult, types.UpdateMembershipOutput, error) {
-	if err := r.Authorize(ctx, input.MembershipID, iam.ActionMembershipUpdate); err != nil {
+	if _, err := r.Authorize(ctx, input.MembershipID, iam.ActionMembershipUpdate); err != nil {
 		return nil, types.UpdateMembershipOutput{}, err
 	}
 
 	if input.Role == coredata.MembershipRoleOwner {
-		if err := r.Authorize(ctx, input.MembershipID, iam.ActionMembershipRoleSetOwner); err != nil {
+		if _, err := r.Authorize(ctx, input.MembershipID, iam.ActionMembershipRoleSetOwner); err != nil {
 			return nil, types.UpdateMembershipOutput{}, err
 		}
 	}
@@ -2875,7 +2793,7 @@ func (r *Resolver) UpdateMembershipTool(ctx context.Context, req *mcp.CallToolRe
 }
 
 func (r *Resolver) RemoveUserTool(ctx context.Context, req *mcp.CallToolRequest, input *types.RemoveUserInput) (*mcp.CallToolResult, types.RemoveUserOutput, error) {
-	if err := r.Authorize(ctx, input.ProfileID, iam.ActionMembershipProfileDelete); err != nil {
+	if _, err := r.Authorize(ctx, input.ProfileID, iam.ActionMembershipProfileDelete); err != nil {
 		return nil, types.RemoveUserOutput{}, err
 	}
 
@@ -2900,14 +2818,13 @@ func (r *Resolver) RemoveUserTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) DeleteDataProtectionImpactAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteDataProtectionImpactAssessmentInput) (*mcp.CallToolResult, types.DeleteDataProtectionImpactAssessmentOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionDataProtectionImpactAssessmentDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionDataProtectionImpactAssessmentDelete)
+	if err != nil {
 		return nil, types.DeleteDataProtectionImpactAssessmentOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
-	err := svc.DataProtectionImpactAssessments.Delete(ctx, scope, input.ID)
+	err = svc.DataProtectionImpactAssessments.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteDataProtectionImpactAssessmentOutput{}, fmt.Errorf("failed to delete data protection impact assessment: %w", err)
 	}
@@ -2918,11 +2835,10 @@ func (r *Resolver) DeleteDataProtectionImpactAssessmentTool(ctx context.Context,
 }
 
 func (r *Resolver) ListStatementsOfApplicabilityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListStatementsOfApplicabilityInput) (*mcp.CallToolResult, types.ListStatementsOfApplicabilityOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionStatementOfApplicabilityList); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionStatementOfApplicabilityList)
+	if err != nil {
 		return nil, types.ListStatementsOfApplicabilityOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.StatementOfApplicabilityOrderField]{
@@ -2947,11 +2863,10 @@ func (r *Resolver) ListStatementsOfApplicabilityTool(ctx context.Context, req *m
 }
 
 func (r *Resolver) GetStatementOfApplicabilityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetStatementOfApplicabilityInput) (*mcp.CallToolResult, types.GetStatementOfApplicabilityOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionStatementOfApplicabilityGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionStatementOfApplicabilityGet)
+	if err != nil {
 		return nil, types.GetStatementOfApplicabilityOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
 	soa, err := prb.StatementsOfApplicability.Get(ctx, scope, input.ID)
@@ -2965,11 +2880,10 @@ func (r *Resolver) GetStatementOfApplicabilityTool(ctx context.Context, req *mcp
 }
 
 func (r *Resolver) AddStatementOfApplicabilityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddStatementOfApplicabilityInput) (*mcp.CallToolResult, types.AddStatementOfApplicabilityOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionStatementOfApplicabilityCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionStatementOfApplicabilityCreate)
+	if err != nil {
 		return nil, types.AddStatementOfApplicabilityOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
 
 	soa, err := svc.StatementsOfApplicability.Create(ctx, scope, probo.CreateStatementOfApplicabilityRequest{
@@ -2986,11 +2900,10 @@ func (r *Resolver) AddStatementOfApplicabilityTool(ctx context.Context, req *mcp
 }
 
 func (r *Resolver) UpdateStatementOfApplicabilityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateStatementOfApplicabilityInput) (*mcp.CallToolResult, types.UpdateStatementOfApplicabilityOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionStatementOfApplicabilityUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionStatementOfApplicabilityUpdate)
+	if err != nil {
 		return nil, types.UpdateStatementOfApplicabilityOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	soa, err := svc.StatementsOfApplicability.Update(ctx, scope, probo.UpdateStatementOfApplicabilityRequest{
@@ -3007,14 +2920,13 @@ func (r *Resolver) UpdateStatementOfApplicabilityTool(ctx context.Context, req *
 }
 
 func (r *Resolver) DeleteStatementOfApplicabilityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteStatementOfApplicabilityInput) (*mcp.CallToolResult, types.DeleteStatementOfApplicabilityOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionStatementOfApplicabilityDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionStatementOfApplicabilityDelete)
+	if err != nil {
 		return nil, types.DeleteStatementOfApplicabilityOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
-	err := svc.StatementsOfApplicability.Delete(ctx, scope, input.ID)
+	err = svc.StatementsOfApplicability.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteStatementOfApplicabilityOutput{}, fmt.Errorf("failed to delete statement of applicability: %w", err)
 	}
@@ -3025,11 +2937,10 @@ func (r *Resolver) DeleteStatementOfApplicabilityTool(ctx context.Context, req *
 }
 
 func (r *Resolver) ListApplicabilityStatementsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListApplicabilityStatementsInput) (*mcp.CallToolResult, types.ListApplicabilityStatementsOutput, error) {
-	if err := r.Authorize(ctx, input.StatementOfApplicabilityID, probo.ActionApplicabilityStatementList); err != nil {
+	scope, err := r.Authorize(ctx, input.StatementOfApplicabilityID, probo.ActionApplicabilityStatementList)
+	if err != nil {
 		return nil, types.ListApplicabilityStatementsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.StatementOfApplicabilityID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ApplicabilityStatementOrderField]{
@@ -3054,11 +2965,10 @@ func (r *Resolver) ListApplicabilityStatementsTool(ctx context.Context, req *mcp
 }
 
 func (r *Resolver) GetApplicabilityStatementTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetApplicabilityStatementInput) (*mcp.CallToolResult, types.GetApplicabilityStatementOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionApplicabilityStatementGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionApplicabilityStatementGet)
+	if err != nil {
 		return nil, types.GetApplicabilityStatementOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
 	stmt, err := prb.StatementsOfApplicability.GetApplicabilityStatement(ctx, scope, input.ID)
@@ -3072,11 +2982,10 @@ func (r *Resolver) GetApplicabilityStatementTool(ctx context.Context, req *mcp.C
 }
 
 func (r *Resolver) AddApplicabilityStatementTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddApplicabilityStatementInput) (*mcp.CallToolResult, types.AddApplicabilityStatementOutput, error) {
-	if err := r.Authorize(ctx, input.StatementOfApplicabilityID, probo.ActionApplicabilityStatementCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.StatementOfApplicabilityID, probo.ActionApplicabilityStatementCreate)
+	if err != nil {
 		return nil, types.AddApplicabilityStatementOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.StatementOfApplicabilityID)
 	svc := r.proboSvc
 
 	stmt, err := svc.StatementsOfApplicability.CreateApplicabilityStatement(
@@ -3096,11 +3005,10 @@ func (r *Resolver) AddApplicabilityStatementTool(ctx context.Context, req *mcp.C
 }
 
 func (r *Resolver) UpdateApplicabilityStatementTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateApplicabilityStatementInput) (*mcp.CallToolResult, types.UpdateApplicabilityStatementOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionApplicabilityStatementUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionApplicabilityStatementUpdate)
+	if err != nil {
 		return nil, types.UpdateApplicabilityStatementOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	stmt, err := svc.StatementsOfApplicability.UpdateApplicabilityStatement(
@@ -3119,14 +3027,13 @@ func (r *Resolver) UpdateApplicabilityStatementTool(ctx context.Context, req *mc
 }
 
 func (r *Resolver) DeleteApplicabilityStatementTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteApplicabilityStatementInput) (*mcp.CallToolResult, types.DeleteApplicabilityStatementOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionApplicabilityStatementDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionApplicabilityStatementDelete)
+	if err != nil {
 		return nil, types.DeleteApplicabilityStatementOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
-	err := svc.StatementsOfApplicability.DeleteApplicabilityStatement(ctx, scope, input.ID)
+	err = svc.StatementsOfApplicability.DeleteApplicabilityStatement(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteApplicabilityStatementOutput{}, fmt.Errorf("failed to delete applicability statement: %w", err)
 	}
@@ -3139,11 +3046,10 @@ func (r *Resolver) DeleteApplicabilityStatementTool(ctx context.Context, req *mc
 // ListThirdPartyRiskAssessmentsTool handles the listThirdPartyRiskAssessments tool
 // List all risk assessments for a thirdParty
 func (r *Resolver) ListThirdPartyRiskAssessmentsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListThirdPartyRiskAssessmentsInput) (*mcp.CallToolResult, types.ListThirdPartyRiskAssessmentsOutput, error) {
-	if err := r.Authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyRiskAssessmentList); err != nil {
+	scope, err := r.Authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyRiskAssessmentList)
+	if err != nil {
 		return nil, types.ListThirdPartyRiskAssessmentsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyRiskAssessmentOrderField]{
@@ -3170,11 +3076,10 @@ func (r *Resolver) ListThirdPartyRiskAssessmentsTool(ctx context.Context, req *m
 // AddThirdPartyRiskAssessmentTool handles the addThirdPartyRiskAssessment tool
 // Add a new risk assessment for a thirdParty
 func (r *Resolver) AddThirdPartyRiskAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddThirdPartyRiskAssessmentInput) (*mcp.CallToolResult, types.AddThirdPartyRiskAssessmentOutput, error) {
-	if err := r.Authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyRiskAssessmentCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyRiskAssessmentCreate)
+	if err != nil {
 		return nil, types.AddThirdPartyRiskAssessmentOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
 	prb := r.proboSvc
 
 	assessment, err := prb.ThirdParties.CreateRiskAssessment(
@@ -3195,14 +3100,13 @@ func (r *Resolver) AddThirdPartyRiskAssessmentTool(ctx context.Context, req *mcp
 }
 
 func (r *Resolver) DeleteThirdPartyTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteThirdPartyInput) (*mcp.CallToolResult, types.DeleteThirdPartyOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionThirdPartyDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionThirdPartyDelete)
+	if err != nil {
 		return nil, types.DeleteThirdPartyOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
-	err := svc.ThirdParties.Delete(ctx, scope, input.ID)
+	err = svc.ThirdParties.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteThirdPartyOutput{}, fmt.Errorf("failed to delete thirdParty: %w", err)
 	}
@@ -3213,14 +3117,13 @@ func (r *Resolver) DeleteThirdPartyTool(ctx context.Context, req *mcp.CallToolRe
 }
 
 func (r *Resolver) DeleteFindingTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteFindingInput) (*mcp.CallToolResult, types.DeleteFindingOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionFindingDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionFindingDelete)
+	if err != nil {
 		return nil, types.DeleteFindingOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
-	err := svc.Findings.Delete(ctx, scope, input.ID)
+	err = svc.Findings.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteFindingOutput{}, fmt.Errorf("cannot delete finding: %w", err)
 	}
@@ -3231,11 +3134,10 @@ func (r *Resolver) DeleteFindingTool(ctx context.Context, req *mcp.CallToolReque
 }
 
 func (r *Resolver) LinkFindingAuditTool(ctx context.Context, req *mcp.CallToolRequest, input *types.LinkFindingAuditInput) (*mcp.CallToolResult, types.LinkFindingAuditOutput, error) {
-	if err := r.Authorize(ctx, input.FindingID, probo.ActionFindingAuditMappingCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.FindingID, probo.ActionFindingAuditMappingCreate)
+	if err != nil {
 		return nil, types.LinkFindingAuditOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.FindingID)
 	svc := r.proboSvc
 
 	finding, audit, err := svc.Findings.CreateAuditMapping(ctx, scope, input.FindingID, input.AuditID, input.ReferenceID)
@@ -3250,11 +3152,10 @@ func (r *Resolver) LinkFindingAuditTool(ctx context.Context, req *mcp.CallToolRe
 }
 
 func (r *Resolver) UnlinkFindingAuditTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UnlinkFindingAuditInput) (*mcp.CallToolResult, types.UnlinkFindingAuditOutput, error) {
-	if err := r.Authorize(ctx, input.FindingID, probo.ActionFindingAuditMappingDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.FindingID, probo.ActionFindingAuditMappingDelete)
+	if err != nil {
 		return nil, types.UnlinkFindingAuditOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.FindingID)
 	svc := r.proboSvc
 
 	finding, audit, err := svc.Findings.DeleteAuditMapping(ctx, scope, input.FindingID, input.AuditID)
@@ -3269,11 +3170,10 @@ func (r *Resolver) UnlinkFindingAuditTool(ctx context.Context, req *mcp.CallTool
 }
 
 func (r *Resolver) ListFindingAuditsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListFindingAuditsInput) (*mcp.CallToolResult, types.ListFindingAuditsOutput, error) {
-	if err := r.Authorize(ctx, input.FindingID, probo.ActionFindingGet); err != nil {
+	scope, err := r.Authorize(ctx, input.FindingID, probo.ActionFindingGet)
+	if err != nil {
 		return nil, types.ListFindingAuditsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.FindingID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.AuditOrderField]{
@@ -3300,11 +3200,10 @@ func (r *Resolver) ListFindingAuditsTool(ctx context.Context, req *mcp.CallToolR
 // ListAccessReviewCampaignsTool handles the listAccessReviewCampaigns tool
 // List access review campaigns for an organization
 func (r *Resolver) ListAccessReviewCampaignsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListAccessReviewCampaignsInput) (*mcp.CallToolResult, types.ListAccessReviewCampaignsOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionAccessReviewCampaignList); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionAccessReviewCampaignList)
+	if err != nil {
 		return nil, types.ListAccessReviewCampaignsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 
 	pageOrderBy := page.OrderBy[coredata.AccessReviewCampaignOrderField]{
 		Field:     coredata.AccessReviewCampaignOrderFieldCreatedAt,
@@ -3330,11 +3229,10 @@ func (r *Resolver) ListAccessReviewCampaignsTool(ctx context.Context, req *mcp.C
 // ListAccessEntriesTool handles the listAccessEntries tool
 // List access entries for a campaign with optional filters
 func (r *Resolver) ListAccessEntriesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListAccessEntriesInput) (*mcp.CallToolResult, types.ListAccessEntriesOutput, error) {
-	if err := r.Authorize(ctx, input.CampaignID, probo.ActionAccessEntryList); err != nil {
+	scope, err := r.Authorize(ctx, input.CampaignID, probo.ActionAccessEntryList)
+	if err != nil {
 		return nil, types.ListAccessEntriesOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CampaignID)
 
 	pageOrderBy := page.OrderBy[coredata.AccessEntryOrderField]{
 		Field:     coredata.AccessEntryOrderFieldCreatedAt,
@@ -3390,11 +3288,10 @@ func (r *Resolver) ListAccessEntriesTool(ctx context.Context, req *mcp.CallToolR
 // GetAccessReviewCampaignStatisticsTool handles the getAccessReviewCampaignStatistics tool
 // Get statistics for an access review campaign
 func (r *Resolver) GetAccessReviewCampaignStatisticsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetAccessReviewCampaignStatisticsInput) (*mcp.CallToolResult, types.GetAccessReviewCampaignStatisticsOutput, error) {
-	if err := r.Authorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignGet); err != nil {
+	scope, err := r.Authorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignGet)
+	if err != nil {
 		return nil, types.GetAccessReviewCampaignStatisticsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CampaignID)
 
 	stats, err := r.accessReview.Entries(scope).Statistics(ctx, input.CampaignID)
 	if err != nil {
@@ -3409,11 +3306,10 @@ func (r *Resolver) GetAccessReviewCampaignStatisticsTool(ctx context.Context, re
 // RecordAccessEntryDecisionTool handles the recordAccessEntryDecision tool
 // Record a decision on an access entry
 func (r *Resolver) RecordAccessEntryDecisionTool(ctx context.Context, req *mcp.CallToolRequest, input *types.RecordAccessEntryDecisionInput) (*mcp.CallToolResult, types.RecordAccessEntryDecisionOutput, error) {
-	if err := r.Authorize(ctx, input.AccessEntryID, probo.ActionAccessEntryDecide); err != nil {
+	scope, err := r.Authorize(ctx, input.AccessEntryID, probo.ActionAccessEntryDecide)
+	if err != nil {
 		return nil, types.RecordAccessEntryDecisionOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.AccessEntryID)
 
 	identity := authn.IdentityFromContext(ctx)
 	if identity == nil {
@@ -3460,7 +3356,7 @@ func (r *Resolver) RecordAccessEntryDecisionsTool(ctx context.Context, req *mcp.
 
 	// Authorize each entry individually to prevent cross-org bypass.
 	for _, d := range input.Decisions {
-		if err := r.Authorize(ctx, d.AccessEntryID, probo.ActionAccessEntryDecide); err != nil {
+		if _, err := r.Authorize(ctx, d.AccessEntryID, probo.ActionAccessEntryDecide); err != nil {
 			return nil, types.RecordAccessEntryDecisionsOutput{}, err
 		}
 	}
@@ -3520,11 +3416,10 @@ func (r *Resolver) RecordAccessEntryDecisionsTool(ctx context.Context, req *mcp.
 // CloseAccessReviewCampaignTool handles the closeAccessReviewCampaign tool
 // Close an access review campaign
 func (r *Resolver) CloseAccessReviewCampaignTool(ctx context.Context, req *mcp.CallToolRequest, input *types.CloseAccessReviewCampaignInput) (*mcp.CallToolResult, types.CloseAccessReviewCampaignOutput, error) {
-	if err := r.Authorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignClose); err != nil {
+	scope, err := r.Authorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignClose)
+	if err != nil {
 		return nil, types.CloseAccessReviewCampaignOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CampaignID)
 
 	campaign, err := r.accessReview.Campaigns(scope).Close(ctx, input.CampaignID)
 	if err != nil {
@@ -3539,11 +3434,10 @@ func (r *Resolver) CloseAccessReviewCampaignTool(ctx context.Context, req *mcp.C
 // ListAccessSourcesTool handles the listAccessSources tool
 // List access sources for an organization
 func (r *Resolver) ListAccessSourcesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListAccessSourcesInput) (*mcp.CallToolResult, types.ListAccessSourcesOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionAccessSourceList); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionAccessSourceList)
+	if err != nil {
 		return nil, types.ListAccessSourcesOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 
 	pageOrderBy := page.OrderBy[coredata.AccessSourceOrderField]{
 		Field:     coredata.AccessSourceOrderFieldCreatedAt,
@@ -3569,11 +3463,10 @@ func (r *Resolver) ListAccessSourcesTool(ctx context.Context, req *mcp.CallToolR
 // CreateAccessSourceTool handles the createAccessSource tool
 // Create a new access source for an organization
 func (r *Resolver) CreateAccessSourceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.CreateAccessSourceInput) (*mcp.CallToolResult, types.CreateAccessSourceOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionAccessSourceCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionAccessSourceCreate)
+	if err != nil {
 		return nil, types.CreateAccessSourceOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 
 	source, err := r.accessReview.Sources(scope).Create(ctx, accessreview.CreateAccessSourceRequest{
 		OrganizationID: input.OrganizationID,
@@ -3594,11 +3487,10 @@ func (r *Resolver) CreateAccessSourceTool(ctx context.Context, req *mcp.CallTool
 // UpdateAccessSourceTool handles the updateAccessSource tool
 // Update an existing access source
 func (r *Resolver) UpdateAccessSourceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateAccessSourceInput) (*mcp.CallToolResult, types.UpdateAccessSourceOutput, error) {
-	if err := r.Authorize(ctx, input.AccessSourceID, probo.ActionAccessSourceUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.AccessSourceID, probo.ActionAccessSourceUpdate)
+	if err != nil {
 		return nil, types.UpdateAccessSourceOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.AccessSourceID)
 
 	updateReq := accessreview.UpdateAccessSourceRequest{
 		AccessSourceID: input.AccessSourceID,
@@ -3638,11 +3530,10 @@ func (r *Resolver) UpdateAccessSourceTool(ctx context.Context, req *mcp.CallTool
 // DeleteAccessSourceTool handles the deleteAccessSource tool
 // Delete an access source
 func (r *Resolver) DeleteAccessSourceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteAccessSourceInput) (*mcp.CallToolResult, types.DeleteAccessSourceOutput, error) {
-	if err := r.Authorize(ctx, input.AccessSourceID, probo.ActionAccessSourceDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.AccessSourceID, probo.ActionAccessSourceDelete)
+	if err != nil {
 		return nil, types.DeleteAccessSourceOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.AccessSourceID)
 
 	if err := r.accessReview.Sources(scope).Delete(ctx, input.AccessSourceID); err != nil {
 		return nil, types.DeleteAccessSourceOutput{}, fmt.Errorf("cannot delete access source: %w", err)
@@ -3656,11 +3547,10 @@ func (r *Resolver) DeleteAccessSourceTool(ctx context.Context, req *mcp.CallTool
 // CreateAccessReviewCampaignTool handles the createAccessReviewCampaign tool
 // Create a new access review campaign for an organization
 func (r *Resolver) CreateAccessReviewCampaignTool(ctx context.Context, req *mcp.CallToolRequest, input *types.CreateAccessReviewCampaignInput) (*mcp.CallToolResult, types.CreateAccessReviewCampaignOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionAccessReviewCampaignCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionAccessReviewCampaignCreate)
+	if err != nil {
 		return nil, types.CreateAccessReviewCampaignOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 
 	var description string
 	if input.Description != nil {
@@ -3686,11 +3576,10 @@ func (r *Resolver) CreateAccessReviewCampaignTool(ctx context.Context, req *mcp.
 // UpdateAccessReviewCampaignTool handles the updateAccessReviewCampaign tool
 // Update an existing access review campaign
 func (r *Resolver) UpdateAccessReviewCampaignTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateAccessReviewCampaignInput) (*mcp.CallToolResult, types.UpdateAccessReviewCampaignOutput, error) {
-	if err := r.Authorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignUpdate)
+	if err != nil {
 		return nil, types.UpdateAccessReviewCampaignOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CampaignID)
 
 	updateReq := accessreview.UpdateAccessReviewCampaignRequest{
 		CampaignID:  input.CampaignID,
@@ -3727,11 +3616,10 @@ func (r *Resolver) UpdateAccessReviewCampaignTool(ctx context.Context, req *mcp.
 // DeleteAccessReviewCampaignTool handles the deleteAccessReviewCampaign tool
 // Delete an access review campaign
 func (r *Resolver) DeleteAccessReviewCampaignTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteAccessReviewCampaignInput) (*mcp.CallToolResult, types.DeleteAccessReviewCampaignOutput, error) {
-	if err := r.Authorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignDelete)
+	if err != nil {
 		return nil, types.DeleteAccessReviewCampaignOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CampaignID)
 
 	if err := r.accessReview.Campaigns(scope).Delete(ctx, input.CampaignID); err != nil {
 		return nil, types.DeleteAccessReviewCampaignOutput{}, fmt.Errorf("cannot delete access review campaign: %w", err)
@@ -3745,11 +3633,10 @@ func (r *Resolver) DeleteAccessReviewCampaignTool(ctx context.Context, req *mcp.
 // StartAccessReviewCampaignTool handles the startAccessReviewCampaign tool
 // Start an access review campaign
 func (r *Resolver) StartAccessReviewCampaignTool(ctx context.Context, req *mcp.CallToolRequest, input *types.StartAccessReviewCampaignInput) (*mcp.CallToolResult, types.StartAccessReviewCampaignOutput, error) {
-	if err := r.Authorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignStart); err != nil {
+	scope, err := r.Authorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignStart)
+	if err != nil {
 		return nil, types.StartAccessReviewCampaignOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CampaignID)
 
 	campaign, err := r.accessReview.Campaigns(scope).Start(ctx, input.CampaignID)
 	if err != nil {
@@ -3764,11 +3651,10 @@ func (r *Resolver) StartAccessReviewCampaignTool(ctx context.Context, req *mcp.C
 // CancelAccessReviewCampaignTool handles the cancelAccessReviewCampaign tool
 // Cancel an in-progress access review campaign
 func (r *Resolver) CancelAccessReviewCampaignTool(ctx context.Context, req *mcp.CallToolRequest, input *types.CancelAccessReviewCampaignInput) (*mcp.CallToolResult, types.CancelAccessReviewCampaignOutput, error) {
-	if err := r.Authorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignCancel); err != nil {
+	scope, err := r.Authorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignCancel)
+	if err != nil {
 		return nil, types.CancelAccessReviewCampaignOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CampaignID)
 
 	campaign, err := r.accessReview.Campaigns(scope).Cancel(ctx, input.CampaignID)
 	if err != nil {
@@ -3783,11 +3669,10 @@ func (r *Resolver) CancelAccessReviewCampaignTool(ctx context.Context, req *mcp.
 // AddAccessReviewCampaignScopeSourceTool handles the addAccessReviewCampaignScopeSource tool
 // Add an access source to an access review campaign's scope
 func (r *Resolver) AddAccessReviewCampaignScopeSourceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddAccessReviewCampaignScopeSourceInput) (*mcp.CallToolResult, types.AddAccessReviewCampaignScopeSourceOutput, error) {
-	if err := r.Authorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignAddScopeSource); err != nil {
+	scope, err := r.Authorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignAddScopeSource)
+	if err != nil {
 		return nil, types.AddAccessReviewCampaignScopeSourceOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CampaignID)
 
 	campaign, err := r.accessReview.Campaigns(scope).AddScopeSource(ctx, accessreview.AddCampaignScopeSourceRequest{
 		CampaignID:     input.CampaignID,
@@ -3805,11 +3690,10 @@ func (r *Resolver) AddAccessReviewCampaignScopeSourceTool(ctx context.Context, r
 // RemoveAccessReviewCampaignScopeSourceTool handles the removeAccessReviewCampaignScopeSource tool
 // Remove an access source from an access review campaign's scope
 func (r *Resolver) RemoveAccessReviewCampaignScopeSourceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.RemoveAccessReviewCampaignScopeSourceInput) (*mcp.CallToolResult, types.RemoveAccessReviewCampaignScopeSourceOutput, error) {
-	if err := r.Authorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignRemoveScopeSource); err != nil {
+	scope, err := r.Authorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignRemoveScopeSource)
+	if err != nil {
 		return nil, types.RemoveAccessReviewCampaignScopeSourceOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CampaignID)
 
 	campaign, err := r.accessReview.Campaigns(scope).RemoveScopeSource(ctx, accessreview.RemoveCampaignScopeSourceRequest{
 		CampaignID:     input.CampaignID,
@@ -3827,11 +3711,10 @@ func (r *Resolver) RemoveAccessReviewCampaignScopeSourceTool(ctx context.Context
 // FlagAccessEntryTool handles the flagAccessEntry tool
 // Flag an access entry during review
 func (r *Resolver) FlagAccessEntryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.FlagAccessEntryInput) (*mcp.CallToolResult, types.FlagAccessEntryOutput, error) {
-	if err := r.Authorize(ctx, input.AccessEntryID, probo.ActionAccessEntryFlag); err != nil {
+	scope, err := r.Authorize(ctx, input.AccessEntryID, probo.ActionAccessEntryFlag)
+	if err != nil {
 		return nil, types.FlagAccessEntryOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.AccessEntryID)
 
 	entry, err := r.accessReview.Entries(scope).FlagEntry(ctx, accessreview.FlagAccessEntryRequest{
 		EntryID:     input.AccessEntryID,
@@ -3848,11 +3731,10 @@ func (r *Resolver) FlagAccessEntryTool(ctx context.Context, req *mcp.CallToolReq
 }
 
 func (r *Resolver) GetAuditReportUrlTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetAuditReportUrlInput) (*mcp.CallToolResult, types.GetAuditReportUrlOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionReportGetReportUrl); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionReportGetReportUrl)
+	if err != nil {
 		return nil, types.GetAuditReportUrlOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
 	url, err := prb.Audits.GenerateReportURL(ctx, scope, input.ID, 15*time.Minute)
@@ -3866,11 +3748,10 @@ func (r *Resolver) GetAuditReportUrlTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) ArchiveDocumentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ArchiveDocumentInput) (*mcp.CallToolResult, types.ArchiveDocumentOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionDocumentArchive); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionDocumentArchive)
+	if err != nil {
 		return nil, types.ArchiveDocumentOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	document, err := svc.Documents.Archive(ctx, scope, input.ID)
@@ -3884,11 +3765,10 @@ func (r *Resolver) ArchiveDocumentTool(ctx context.Context, req *mcp.CallToolReq
 }
 
 func (r *Resolver) UnarchiveDocumentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UnarchiveDocumentInput) (*mcp.CallToolResult, types.UnarchiveDocumentOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionDocumentUnarchive); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionDocumentUnarchive)
+	if err != nil {
 		return nil, types.UnarchiveDocumentOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	document, err := svc.Documents.Unarchive(ctx, scope, input.ID)
@@ -3902,11 +3782,10 @@ func (r *Resolver) UnarchiveDocumentTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) GetOrganizationContextTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetOrganizationContextInput) (*mcp.CallToolResult, types.GetOrganizationContextOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionOrganizationContextGet); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionOrganizationContextGet)
+	if err != nil {
 		return nil, types.GetOrganizationContextOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
 
 	orgContext, err := prb.Organizations.GetContext(ctx, scope, input.OrganizationID)
@@ -3920,11 +3799,10 @@ func (r *Resolver) GetOrganizationContextTool(ctx context.Context, req *mcp.Call
 }
 
 func (r *Resolver) UpdateOrganizationContextTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateOrganizationContextInput) (*mcp.CallToolResult, types.UpdateOrganizationContextOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionOrganizationContextUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionOrganizationContextUpdate)
+	if err != nil {
 		return nil, types.UpdateOrganizationContextOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
 
 	orgContext, err := prb.Organizations.UpdateContext(
@@ -3948,7 +3826,7 @@ func (r *Resolver) UpdateOrganizationContextTool(ctx context.Context, req *mcp.C
 }
 
 func (r *Resolver) GetAuditLogEntryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetAuditLogEntryInput) (*mcp.CallToolResult, types.GetAuditLogEntryOutput, error) {
-	if err := r.Authorize(ctx, input.ID, iam.ActionAuditLogEntryGet); err != nil {
+	if _, err := r.Authorize(ctx, input.ID, iam.ActionAuditLogEntryGet); err != nil {
 		return nil, types.GetAuditLogEntryOutput{}, err
 	}
 
@@ -3963,7 +3841,7 @@ func (r *Resolver) GetAuditLogEntryTool(ctx context.Context, req *mcp.CallToolRe
 }
 
 func (r *Resolver) ListAuditLogEntriesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListAuditLogEntriesInput) (*mcp.CallToolResult, types.ListAuditLogEntriesOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, iam.ActionAuditLogEntryList); err != nil {
+	if _, err := r.Authorize(ctx, input.OrganizationID, iam.ActionAuditLogEntryList); err != nil {
 		return nil, types.ListAuditLogEntriesOutput{}, err
 	}
 
@@ -4003,11 +3881,10 @@ func (r *Resolver) ListAuditLogEntriesTool(ctx context.Context, req *mcp.CallToo
 }
 
 func (r *Resolver) ListMeasureDocumentsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListMeasureDocumentsInput) (*mcp.CallToolResult, types.ListMeasureDocumentsOutput, error) {
-	if err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureGet); err != nil {
+	scope, err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureGet)
+	if err != nil {
 		return nil, types.ListMeasureDocumentsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.MeasureID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
@@ -4032,11 +3909,10 @@ func (r *Resolver) ListMeasureDocumentsTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) VoidDocumentVersionApprovalTool(ctx context.Context, req *mcp.CallToolRequest, input *types.VoidDocumentVersionApprovalInput) (*mcp.CallToolResult, types.VoidDocumentVersionApprovalOutput, error) {
-	if err := r.Authorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionVoidApproval); err != nil {
+	scope, err := r.Authorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionVoidApproval)
+	if err != nil {
 		return nil, types.VoidDocumentVersionApprovalOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.DocumentVersionID)
 	svc := r.proboSvc
 
 	_, documentVersion, err := svc.DocumentApprovals.VoidApproval(ctx, scope, input.DocumentVersionID)
@@ -4050,14 +3926,13 @@ func (r *Resolver) VoidDocumentVersionApprovalTool(ctx context.Context, req *mcp
 }
 
 func (r *Resolver) SendSigningNotificationsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.SendSigningNotificationsInput) (*mcp.CallToolResult, types.SendSigningNotificationsOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionDocumentSendSigningNotifications); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionDocumentSendSigningNotifications)
+	if err != nil {
 		return nil, types.SendSigningNotificationsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
 
-	err := svc.Documents.SendSigningNotifications(ctx, scope, input.OrganizationID)
+	err = svc.Documents.SendSigningNotifications(ctx, scope, input.OrganizationID)
 	if err != nil {
 		panic(fmt.Errorf("cannot send signing notifications: %w", err))
 	}
@@ -4068,11 +3943,10 @@ func (r *Resolver) SendSigningNotificationsTool(ctx context.Context, req *mcp.Ca
 }
 
 func (r *Resolver) DeleteDocumentDraftTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteDocumentDraftInput) (*mcp.CallToolResult, types.DeleteDocumentDraftOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionDocumentDeleteDraft); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionDocumentDeleteDraft)
+	if err != nil {
 		return nil, types.DeleteDocumentDraftOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	document, err := svc.Documents.DeleteDraft(ctx, scope, input.ID)
@@ -4086,11 +3960,10 @@ func (r *Resolver) DeleteDocumentDraftTool(ctx context.Context, req *mcp.CallToo
 }
 
 func (r *Resolver) PublishStatementOfApplicabilityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishStatementOfApplicabilityInput) (*mcp.CallToolResult, types.PublishStatementOfApplicabilityOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionStatementOfApplicabilityPublish); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionStatementOfApplicabilityPublish)
+	if err != nil {
 		return nil, types.PublishStatementOfApplicabilityOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	document, documentVersion, err := svc.GeneratedDocuments.PublishStatementOfApplicability(ctx, scope, input.ID, input.ApproverIds, input.Minor)
@@ -4105,11 +3978,10 @@ func (r *Resolver) PublishStatementOfApplicabilityTool(ctx context.Context, req 
 }
 
 func (r *Resolver) ListWebhookSubscriptionsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListWebhookSubscriptionsInput) (*mcp.CallToolResult, types.ListWebhookSubscriptionsOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionWebhookSubscriptionList); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionWebhookSubscriptionList)
+	if err != nil {
 		return nil, types.ListWebhookSubscriptionsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.WebhookSubscriptionOrderField]{
@@ -4134,11 +4006,10 @@ func (r *Resolver) ListWebhookSubscriptionsTool(ctx context.Context, req *mcp.Ca
 }
 
 func (r *Resolver) GetWebhookSubscriptionTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetWebhookSubscriptionInput) (*mcp.CallToolResult, types.GetWebhookSubscriptionOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionWebhookSubscriptionGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionWebhookSubscriptionGet)
+	if err != nil {
 		return nil, types.GetWebhookSubscriptionOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
 	subscription, err := prb.WebhookSubscriptions.Get(ctx, scope, input.ID)
@@ -4152,11 +4023,10 @@ func (r *Resolver) GetWebhookSubscriptionTool(ctx context.Context, req *mcp.Call
 }
 
 func (r *Resolver) CreateWebhookSubscriptionTool(ctx context.Context, req *mcp.CallToolRequest, input *types.CreateWebhookSubscriptionInput) (*mcp.CallToolResult, types.CreateWebhookSubscriptionOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionWebhookSubscriptionCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionWebhookSubscriptionCreate)
+	if err != nil {
 		return nil, types.CreateWebhookSubscriptionOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
 
 	subscription, err := prb.WebhookSubscriptions.Create(
@@ -4177,11 +4047,10 @@ func (r *Resolver) CreateWebhookSubscriptionTool(ctx context.Context, req *mcp.C
 }
 
 func (r *Resolver) UpdateWebhookSubscriptionTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateWebhookSubscriptionInput) (*mcp.CallToolResult, types.UpdateWebhookSubscriptionOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionWebhookSubscriptionUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionWebhookSubscriptionUpdate)
+	if err != nil {
 		return nil, types.UpdateWebhookSubscriptionOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
 	subscription, err := prb.WebhookSubscriptions.Update(
@@ -4202,14 +4071,13 @@ func (r *Resolver) UpdateWebhookSubscriptionTool(ctx context.Context, req *mcp.C
 }
 
 func (r *Resolver) DeleteWebhookSubscriptionTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteWebhookSubscriptionInput) (*mcp.CallToolResult, types.DeleteWebhookSubscriptionOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionWebhookSubscriptionDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionWebhookSubscriptionDelete)
+	if err != nil {
 		return nil, types.DeleteWebhookSubscriptionOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
-	err := prb.WebhookSubscriptions.Delete(ctx, scope, input.ID)
+	err = prb.WebhookSubscriptions.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteWebhookSubscriptionOutput{}, fmt.Errorf("failed to delete webhook subscription: %w", err)
 	}
@@ -4220,11 +4088,10 @@ func (r *Resolver) DeleteWebhookSubscriptionTool(ctx context.Context, req *mcp.C
 }
 
 func (r *Resolver) ListWebhookEventsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListWebhookEventsInput) (*mcp.CallToolResult, types.ListWebhookEventsOutput, error) {
-	if err := r.Authorize(ctx, input.WebhookSubscriptionID, probo.ActionWebhookSubscriptionGet); err != nil {
+	scope, err := r.Authorize(ctx, input.WebhookSubscriptionID, probo.ActionWebhookSubscriptionGet)
+	if err != nil {
 		return nil, types.ListWebhookEventsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.WebhookSubscriptionID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.WebhookEventOrderField]{
@@ -4249,11 +4116,10 @@ func (r *Resolver) ListWebhookEventsTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) ListDocumentVersionApprovalQuorumsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListDocumentVersionApprovalQuorumsInput) (*mcp.CallToolResult, types.ListDocumentVersionApprovalQuorumsOutput, error) {
-	if err := r.Authorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionApprovalList); err != nil {
+	scope, err := r.Authorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionApprovalList)
+	if err != nil {
 		return nil, types.ListDocumentVersionApprovalQuorumsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.DocumentVersionID)
 	svc := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.DocumentVersionApprovalQuorumOrderField]{
@@ -4278,11 +4144,10 @@ func (r *Resolver) ListDocumentVersionApprovalQuorumsTool(ctx context.Context, r
 }
 
 func (r *Resolver) GetDocumentVersionApprovalQuorumTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetDocumentVersionApprovalQuorumInput) (*mcp.CallToolResult, types.GetDocumentVersionApprovalQuorumOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionDocumentVersionApprovalList); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionDocumentVersionApprovalList)
+	if err != nil {
 		return nil, types.GetDocumentVersionApprovalQuorumOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	quorum, err := svc.DocumentApprovals.GetQuorum(ctx, scope, input.ID)
@@ -4296,11 +4161,10 @@ func (r *Resolver) GetDocumentVersionApprovalQuorumTool(ctx context.Context, req
 }
 
 func (r *Resolver) ListDocumentVersionApprovalDecisionsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListDocumentVersionApprovalDecisionsInput) (*mcp.CallToolResult, types.ListDocumentVersionApprovalDecisionsOutput, error) {
-	if err := r.Authorize(ctx, input.QuorumID, probo.ActionDocumentVersionApprovalList); err != nil {
+	scope, err := r.Authorize(ctx, input.QuorumID, probo.ActionDocumentVersionApprovalList)
+	if err != nil {
 		return nil, types.ListDocumentVersionApprovalDecisionsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.QuorumID)
 	svc := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.DocumentVersionApprovalDecisionOrderField]{
@@ -4332,11 +4196,10 @@ func (r *Resolver) ListDocumentVersionApprovalDecisionsTool(ctx context.Context,
 }
 
 func (r *Resolver) GetDocumentVersionApprovalDecisionTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetDocumentVersionApprovalDecisionInput) (*mcp.CallToolResult, types.GetDocumentVersionApprovalDecisionOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionDocumentVersionApprovalList); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionDocumentVersionApprovalList)
+	if err != nil {
 		return nil, types.GetDocumentVersionApprovalDecisionOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	decision, err := svc.DocumentApprovals.GetDecision(ctx, scope, input.ID)
@@ -4350,11 +4213,10 @@ func (r *Resolver) GetDocumentVersionApprovalDecisionTool(ctx context.Context, r
 }
 
 func (r *Resolver) PublishDataListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishDataListInput) (*mcp.CallToolResult, types.PublishDataListOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionDatumPublish); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionDatumPublish)
+	if err != nil {
 		return nil, types.PublishDataListOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
 
 	document, documentVersion, err := svc.GeneratedDocuments.PublishDataList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
@@ -4369,11 +4231,10 @@ func (r *Resolver) PublishDataListTool(ctx context.Context, req *mcp.CallToolReq
 }
 
 func (r *Resolver) PublishAssetListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishAssetListInput) (*mcp.CallToolResult, types.PublishAssetListOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionAssetPublish); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionAssetPublish)
+	if err != nil {
 		return nil, types.PublishAssetListOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
 
 	document, documentVersion, err := svc.GeneratedDocuments.PublishAssetList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
@@ -4390,11 +4251,10 @@ func (r *Resolver) PublishAssetListTool(ctx context.Context, req *mcp.CallToolRe
 // ListThirdPartyContactsTool handles the listThirdPartyContacts tool
 // List all contacts for a thirdParty
 func (r *Resolver) ListThirdPartyContactsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListThirdPartyContactsInput) (*mcp.CallToolResult, types.ListThirdPartyContactsOutput, error) {
-	if err := r.Authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyContactList); err != nil {
+	scope, err := r.Authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyContactList)
+	if err != nil {
 		return nil, types.ListThirdPartyContactsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyContactOrderField]{
@@ -4421,11 +4281,10 @@ func (r *Resolver) ListThirdPartyContactsTool(ctx context.Context, req *mcp.Call
 // AddThirdPartyContactTool handles the addThirdPartyContact tool
 // Add a new contact to a thirdParty
 func (r *Resolver) AddThirdPartyContactTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddThirdPartyContactInput) (*mcp.CallToolResult, types.AddThirdPartyContactOutput, error) {
-	if err := r.Authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyContactCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyContactCreate)
+	if err != nil {
 		return nil, types.AddThirdPartyContactOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
 	prb := r.proboSvc
 
 	emailAddr, err := mail.ParseAddr(input.Email)
@@ -4452,11 +4311,10 @@ func (r *Resolver) AddThirdPartyContactTool(ctx context.Context, req *mcp.CallTo
 // UpdateThirdPartyContactTool handles the updateThirdPartyContact tool
 // Update an existing thirdParty contact
 func (r *Resolver) UpdateThirdPartyContactTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateThirdPartyContactInput) (*mcp.CallToolResult, types.UpdateThirdPartyContactOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionThirdPartyContactUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionThirdPartyContactUpdate)
+	if err != nil {
 		return nil, types.UpdateThirdPartyContactOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
 	updateReq := probo.UpdateThirdPartyContactRequest{
@@ -4498,14 +4356,13 @@ func (r *Resolver) UpdateThirdPartyContactTool(ctx context.Context, req *mcp.Cal
 // DeleteThirdPartyContactTool handles the deleteThirdPartyContact tool
 // Delete a thirdParty contact
 func (r *Resolver) DeleteThirdPartyContactTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteThirdPartyContactInput) (*mcp.CallToolResult, types.DeleteThirdPartyContactOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionThirdPartyContactDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionThirdPartyContactDelete)
+	if err != nil {
 		return nil, types.DeleteThirdPartyContactOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
-	err := prb.ThirdPartyContacts.Delete(ctx, scope, input.ID)
+	err = prb.ThirdPartyContacts.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteThirdPartyContactOutput{}, fmt.Errorf("cannot delete thirdParty contact: %w", err)
 	}
@@ -4518,11 +4375,10 @@ func (r *Resolver) DeleteThirdPartyContactTool(ctx context.Context, req *mcp.Cal
 // ListThirdPartyServicesTool handles the listThirdPartyServices tool
 // List all services for a thirdParty
 func (r *Resolver) ListThirdPartyServicesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListThirdPartyServicesInput) (*mcp.CallToolResult, types.ListThirdPartyServicesOutput, error) {
-	if err := r.Authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyServiceList); err != nil {
+	scope, err := r.Authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyServiceList)
+	if err != nil {
 		return nil, types.ListThirdPartyServicesOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyServiceOrderField]{
@@ -4549,11 +4405,10 @@ func (r *Resolver) ListThirdPartyServicesTool(ctx context.Context, req *mcp.Call
 // AddThirdPartyServiceTool handles the addThirdPartyService tool
 // Add a new service to a thirdParty
 func (r *Resolver) AddThirdPartyServiceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddThirdPartyServiceInput) (*mcp.CallToolResult, types.AddThirdPartyServiceOutput, error) {
-	if err := r.Authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyServiceCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyServiceCreate)
+	if err != nil {
 		return nil, types.AddThirdPartyServiceOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
 	prb := r.proboSvc
 
 	thirdPartyService, err := prb.ThirdPartyServices.Create(ctx, scope, probo.CreateThirdPartyServiceRequest{
@@ -4573,11 +4428,10 @@ func (r *Resolver) AddThirdPartyServiceTool(ctx context.Context, req *mcp.CallTo
 // UpdateThirdPartyServiceTool handles the updateThirdPartyService tool
 // Update an existing thirdParty service
 func (r *Resolver) UpdateThirdPartyServiceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateThirdPartyServiceInput) (*mcp.CallToolResult, types.UpdateThirdPartyServiceOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionThirdPartyServiceUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionThirdPartyServiceUpdate)
+	if err != nil {
 		return nil, types.UpdateThirdPartyServiceOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
 	updateReq := probo.UpdateThirdPartyServiceRequest{
@@ -4605,14 +4459,13 @@ func (r *Resolver) UpdateThirdPartyServiceTool(ctx context.Context, req *mcp.Cal
 // DeleteThirdPartyServiceTool handles the deleteThirdPartyService tool
 // Delete a thirdParty service
 func (r *Resolver) DeleteThirdPartyServiceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteThirdPartyServiceInput) (*mcp.CallToolResult, types.DeleteThirdPartyServiceOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionThirdPartyServiceDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionThirdPartyServiceDelete)
+	if err != nil {
 		return nil, types.DeleteThirdPartyServiceOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
-	err := prb.ThirdPartyServices.Delete(ctx, scope, input.ID)
+	err = prb.ThirdPartyServices.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteThirdPartyServiceOutput{}, fmt.Errorf("cannot delete thirdParty service: %w", err)
 	}
@@ -4622,14 +4475,13 @@ func (r *Resolver) DeleteThirdPartyServiceTool(ctx context.Context, req *mcp.Cal
 	}, nil
 }
 func (r *Resolver) DeleteAssetTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteAssetInput) (*mcp.CallToolResult, types.DeleteAssetOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionAssetDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionAssetDelete)
+	if err != nil {
 		return nil, types.DeleteAssetOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
-	err := svc.Assets.Delete(ctx, scope, input.ID)
+	err = svc.Assets.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteAssetOutput{}, fmt.Errorf("failed to delete asset: %w", err)
 	}
@@ -4639,14 +4491,13 @@ func (r *Resolver) DeleteAssetTool(ctx context.Context, req *mcp.CallToolRequest
 	}, nil
 }
 func (r *Resolver) DeleteDatumTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteDatumInput) (*mcp.CallToolResult, types.DeleteDatumOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionDatumDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionDatumDelete)
+	if err != nil {
 		return nil, types.DeleteDatumOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
-	err := svc.Data.Delete(ctx, scope, input.ID)
+	err = svc.Data.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteDatumOutput{}, fmt.Errorf("failed to delete datum: %w", err)
 	}
@@ -4656,14 +4507,13 @@ func (r *Resolver) DeleteDatumTool(ctx context.Context, req *mcp.CallToolRequest
 	}, nil
 }
 func (r *Resolver) DeleteObligationTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteObligationInput) (*mcp.CallToolResult, types.DeleteObligationOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionObligationDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionObligationDelete)
+	if err != nil {
 		return nil, types.DeleteObligationOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
-	err := svc.Obligations.Delete(ctx, scope, input.ID)
+	err = svc.Obligations.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteObligationOutput{}, fmt.Errorf("failed to delete obligation: %w", err)
 	}
@@ -4673,14 +4523,13 @@ func (r *Resolver) DeleteObligationTool(ctx context.Context, req *mcp.CallToolRe
 	}, nil
 }
 func (r *Resolver) DeleteAuditTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteAuditInput) (*mcp.CallToolResult, types.DeleteAuditOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionAuditDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionAuditDelete)
+	if err != nil {
 		return nil, types.DeleteAuditOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
-	err := svc.Audits.Delete(ctx, scope, input.ID)
+	err = svc.Audits.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteAuditOutput{}, fmt.Errorf("failed to delete audit: %w", err)
 	}
@@ -4690,11 +4539,10 @@ func (r *Resolver) DeleteAuditTool(ctx context.Context, req *mcp.CallToolRequest
 	}, nil
 }
 func (r *Resolver) ListRightsRequestsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListRightsRequestsInput) (*mcp.CallToolResult, types.ListRightsRequestsOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionRightsRequestList); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionRightsRequestList)
+	if err != nil {
 		return nil, types.ListRightsRequestsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.RightsRequestOrderField]{
@@ -4718,11 +4566,10 @@ func (r *Resolver) ListRightsRequestsTool(ctx context.Context, req *mcp.CallTool
 	return nil, types.NewListRightsRequestsOutput(page), nil
 }
 func (r *Resolver) GetRightsRequestTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetRightsRequestInput) (*mcp.CallToolResult, types.GetRightsRequestOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionRightsRequestGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionRightsRequestGet)
+	if err != nil {
 		return nil, types.GetRightsRequestOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
 	rightsRequest, err := prb.RightsRequests.Get(ctx, scope, input.ID)
@@ -4735,11 +4582,10 @@ func (r *Resolver) GetRightsRequestTool(ctx context.Context, req *mcp.CallToolRe
 	}, nil
 }
 func (r *Resolver) AddRightsRequestTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddRightsRequestInput) (*mcp.CallToolResult, types.AddRightsRequestOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionRightsRequestCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionRightsRequestCreate)
+	if err != nil {
 		return nil, types.AddRightsRequestOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
 
 	rightsRequest, err := svc.RightsRequests.Create(
@@ -4764,11 +4610,10 @@ func (r *Resolver) AddRightsRequestTool(ctx context.Context, req *mcp.CallToolRe
 	}, nil
 }
 func (r *Resolver) UpdateRightsRequestTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateRightsRequestInput) (*mcp.CallToolResult, types.UpdateRightsRequestOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionRightsRequestUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionRightsRequestUpdate)
+	if err != nil {
 		return nil, types.UpdateRightsRequestOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	var dataSubject **string
@@ -4798,14 +4643,13 @@ func (r *Resolver) UpdateRightsRequestTool(ctx context.Context, req *mcp.CallToo
 	}, nil
 }
 func (r *Resolver) DeleteRightsRequestTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteRightsRequestInput) (*mcp.CallToolResult, types.DeleteRightsRequestOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionRightsRequestDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionRightsRequestDelete)
+	if err != nil {
 		return nil, types.DeleteRightsRequestOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
-	err := svc.RightsRequests.Delete(ctx, scope, input.ID)
+	err = svc.RightsRequests.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteRightsRequestOutput{}, fmt.Errorf("failed to delete rights request: %w", err)
 	}
@@ -4818,11 +4662,10 @@ func (r *Resolver) DeleteRightsRequestTool(ctx context.Context, req *mcp.CallToo
 // GetTrustCenterTool handles the getTrustCenter tool
 // Get the trust center for an organization
 func (r *Resolver) GetTrustCenterTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetTrustCenterInput) (*mcp.CallToolResult, types.GetTrustCenterOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionTrustCenterGet); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionTrustCenterGet)
+	if err != nil {
 		return nil, types.GetTrustCenterOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
 
 	trustCenter, err := prb.TrustCenters.GetByOrganizationID(ctx, scope, input.OrganizationID)
@@ -4853,11 +4696,10 @@ func (r *Resolver) GetTrustCenterTool(ctx context.Context, req *mcp.CallToolRequ
 // UpdateTrustCenterTool handles the updateTrustCenter tool
 // Update the trust center settings
 func (r *Resolver) UpdateTrustCenterTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateTrustCenterInput) (*mcp.CallToolResult, types.UpdateTrustCenterOutput, error) {
-	if err := r.Authorize(ctx, input.TrustCenterID, probo.ActionTrustCenterUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.TrustCenterID, probo.ActionTrustCenterUpdate)
+	if err != nil {
 		return nil, types.UpdateTrustCenterOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
 	prb := r.proboSvc
 
 	updateReq := &probo.UpdateTrustCenterRequest{
@@ -4882,11 +4724,10 @@ func (r *Resolver) UpdateTrustCenterTool(ctx context.Context, req *mcp.CallToolR
 // ListTrustCenterReferencesTool handles the listTrustCenterReferences tool
 // List all references for a trust center
 func (r *Resolver) ListTrustCenterReferencesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListTrustCenterReferencesInput) (*mcp.CallToolResult, types.ListTrustCenterReferencesOutput, error) {
-	if err := r.Authorize(ctx, input.TrustCenterID, probo.ActionTrustCenterReferenceList); err != nil {
+	scope, err := r.Authorize(ctx, input.TrustCenterID, probo.ActionTrustCenterReferenceList)
+	if err != nil {
 		return nil, types.ListTrustCenterReferencesOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.TrustCenterReferenceOrderField]{
@@ -4913,11 +4754,10 @@ func (r *Resolver) ListTrustCenterReferencesTool(ctx context.Context, req *mcp.C
 // AddTrustCenterReferenceTool handles the addTrustCenterReference tool
 // Add a new reference to the trust center
 func (r *Resolver) AddTrustCenterReferenceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddTrustCenterReferenceInput) (*mcp.CallToolResult, types.AddTrustCenterReferenceOutput, error) {
-	if err := r.Authorize(ctx, input.TrustCenterID, probo.ActionTrustCenterReferenceCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.TrustCenterID, probo.ActionTrustCenterReferenceCreate)
+	if err != nil {
 		return nil, types.AddTrustCenterReferenceOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
 	prb := r.proboSvc
 
 	var websiteURL string
@@ -4944,11 +4784,10 @@ func (r *Resolver) AddTrustCenterReferenceTool(ctx context.Context, req *mcp.Cal
 // UpdateTrustCenterReferenceTool handles the updateTrustCenterReference tool
 // Update a trust center reference
 func (r *Resolver) UpdateTrustCenterReferenceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateTrustCenterReferenceInput) (*mcp.CallToolResult, types.UpdateTrustCenterReferenceOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionTrustCenterReferenceUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionTrustCenterReferenceUpdate)
+	if err != nil {
 		return nil, types.UpdateTrustCenterReferenceOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
 	updateRefReq := &probo.UpdateTrustCenterReferenceRequest{
@@ -4978,14 +4817,13 @@ func (r *Resolver) UpdateTrustCenterReferenceTool(ctx context.Context, req *mcp.
 // DeleteTrustCenterReferenceTool handles the deleteTrustCenterReference tool
 // Delete a trust center reference
 func (r *Resolver) DeleteTrustCenterReferenceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteTrustCenterReferenceInput) (*mcp.CallToolResult, types.DeleteTrustCenterReferenceOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionTrustCenterReferenceDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionTrustCenterReferenceDelete)
+	if err != nil {
 		return nil, types.DeleteTrustCenterReferenceOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
-	err := prb.TrustCenterReferences.Delete(ctx, scope, input.ID)
+	err = prb.TrustCenterReferences.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteTrustCenterReferenceOutput{}, fmt.Errorf("cannot delete trust center reference: %w", err)
 	}
@@ -4996,11 +4834,10 @@ func (r *Resolver) DeleteTrustCenterReferenceTool(ctx context.Context, req *mcp.
 // ListTrustCenterFilesTool handles the listTrustCenterFiles tool
 // List all files for the trust center
 func (r *Resolver) ListTrustCenterFilesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListTrustCenterFilesInput) (*mcp.CallToolResult, types.ListTrustCenterFilesOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionTrustCenterFileList); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionTrustCenterFileList)
+	if err != nil {
 		return nil, types.ListTrustCenterFilesOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.TrustCenterFileOrderField]{
@@ -5038,14 +4875,13 @@ func (r *Resolver) ListTrustCenterFilesTool(ctx context.Context, req *mcp.CallTo
 // DeleteTrustCenterFileTool handles the deleteTrustCenterFile tool
 // Delete a trust center file
 func (r *Resolver) DeleteTrustCenterFileTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteTrustCenterFileInput) (*mcp.CallToolResult, types.DeleteTrustCenterFileOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionTrustCenterFileDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionTrustCenterFileDelete)
+	if err != nil {
 		return nil, types.DeleteTrustCenterFileOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
-	err := prb.TrustCenterFiles.Delete(ctx, scope, input.ID)
+	err = prb.TrustCenterFiles.Delete(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.DeleteTrustCenterFileOutput{}, fmt.Errorf("cannot delete trust center file: %w", err)
 	}
@@ -5056,11 +4892,10 @@ func (r *Resolver) DeleteTrustCenterFileTool(ctx context.Context, req *mcp.CallT
 // ListComplianceExternalURLsTool handles the listComplianceExternalURLs tool
 // List all external URLs for a trust center
 func (r *Resolver) ListComplianceExternalURLsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListComplianceExternalURLsInput) (*mcp.CallToolResult, types.ListComplianceExternalURLsOutput, error) {
-	if err := r.Authorize(ctx, input.TrustCenterID, probo.ActionComplianceExternalURLList); err != nil {
+	scope, err := r.Authorize(ctx, input.TrustCenterID, probo.ActionComplianceExternalURLList)
+	if err != nil {
 		return nil, types.ListComplianceExternalURLsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ComplianceExternalURLOrderField]{
@@ -5087,11 +4922,10 @@ func (r *Resolver) ListComplianceExternalURLsTool(ctx context.Context, req *mcp.
 // AddComplianceExternalURLTool handles the addComplianceExternalURL tool
 // Add a new external URL to the trust center
 func (r *Resolver) AddComplianceExternalURLTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddComplianceExternalURLInput) (*mcp.CallToolResult, types.AddComplianceExternalURLOutput, error) {
-	if err := r.Authorize(ctx, input.TrustCenterID, probo.ActionComplianceExternalURLCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.TrustCenterID, probo.ActionComplianceExternalURLCreate)
+	if err != nil {
 		return nil, types.AddComplianceExternalURLOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
 	prb := r.proboSvc
 
 	item, err := prb.ComplianceExternalURLs.Create(
@@ -5112,11 +4946,10 @@ func (r *Resolver) AddComplianceExternalURLTool(ctx context.Context, req *mcp.Ca
 // UpdateComplianceExternalURLTool handles the updateComplianceExternalURL tool
 // Update a compliance external URL
 func (r *Resolver) UpdateComplianceExternalURLTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateComplianceExternalURLInput) (*mcp.CallToolResult, types.UpdateComplianceExternalURLOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionComplianceExternalURLUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionComplianceExternalURLUpdate)
+	if err != nil {
 		return nil, types.UpdateComplianceExternalURLOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
 	updateURLReq := &probo.UpdateComplianceExternalURLRequest{
@@ -5146,14 +4979,13 @@ func (r *Resolver) UpdateComplianceExternalURLTool(ctx context.Context, req *mcp
 // DeleteComplianceExternalURLTool handles the deleteComplianceExternalURL tool
 // Delete a compliance external URL
 func (r *Resolver) DeleteComplianceExternalURLTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteComplianceExternalURLInput) (*mcp.CallToolResult, types.DeleteComplianceExternalURLOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionComplianceExternalURLDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionComplianceExternalURLDelete)
+	if err != nil {
 		return nil, types.DeleteComplianceExternalURLOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
 
-	err := prb.ComplianceExternalURLs.Delete(
+	err = prb.ComplianceExternalURLs.Delete(
 		ctx, scope,
 		&probo.DeleteComplianceExternalURLRequest{
 			ID: input.ID,
@@ -5169,11 +5001,10 @@ func (r *Resolver) DeleteComplianceExternalURLTool(ctx context.Context, req *mcp
 // CreateCustomDomainTool handles the createCustomDomain tool
 // Create a custom domain for the organization
 func (r *Resolver) CreateCustomDomainTool(ctx context.Context, req *mcp.CallToolRequest, input *types.CreateCustomDomainInput) (*mcp.CallToolResult, types.CreateCustomDomainOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionCustomDomainCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionCustomDomainCreate)
+	if err != nil {
 		return nil, types.CreateCustomDomainOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
 
 	domain, err := prb.CustomDomains.CreateCustomDomain(
@@ -5193,11 +5024,10 @@ func (r *Resolver) CreateCustomDomainTool(ctx context.Context, req *mcp.CallTool
 // DeleteCustomDomainTool handles the deleteCustomDomain tool
 // Delete the custom domain for the organization
 func (r *Resolver) DeleteCustomDomainTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteCustomDomainInput) (*mcp.CallToolResult, types.DeleteCustomDomainOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionCustomDomainDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionCustomDomainDelete)
+	if err != nil {
 		return nil, types.DeleteCustomDomainOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
 
 	domain, err := prb.CustomDomains.GetOrganizationCustomDomain(ctx, scope, input.OrganizationID)
@@ -5219,11 +5049,10 @@ func (r *Resolver) DeleteCustomDomainTool(ctx context.Context, req *mcp.CallTool
 }
 
 func (r *Resolver) AssessThirdPartyTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AssessThirdPartyInput) (*mcp.CallToolResult, types.AssessThirdPartyOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionThirdPartyAssess); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionThirdPartyAssess)
+	if err != nil {
 		return nil, types.AssessThirdPartyOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
 
 	result, err := svc.ThirdParties.Assess(
@@ -5242,11 +5071,10 @@ func (r *Resolver) AssessThirdPartyTool(ctx context.Context, req *mcp.CallToolRe
 }
 
 func (r *Resolver) PublishFindingListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishFindingListInput) (*mcp.CallToolResult, types.PublishFindingListOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionFindingPublish); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionFindingPublish)
+	if err != nil {
 		return nil, types.PublishFindingListOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
 
 	document, documentVersion, err := svc.GeneratedDocuments.PublishFindingList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
@@ -5261,11 +5089,10 @@ func (r *Resolver) PublishFindingListTool(ctx context.Context, req *mcp.CallTool
 }
 
 func (r *Resolver) PublishObligationListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishObligationListInput) (*mcp.CallToolResult, types.PublishObligationListOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionObligationPublish); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionObligationPublish)
+	if err != nil {
 		return nil, types.PublishObligationListOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
 
 	document, documentVersion, err := svc.GeneratedDocuments.PublishObligationList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
@@ -5280,11 +5107,10 @@ func (r *Resolver) PublishObligationListTool(ctx context.Context, req *mcp.CallT
 }
 
 func (r *Resolver) PublishProcessingActivityListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishProcessingActivityListInput) (*mcp.CallToolResult, types.PublishProcessingActivityListOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionProcessingActivityPublish); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionProcessingActivityPublish)
+	if err != nil {
 		return nil, types.PublishProcessingActivityListOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
 
 	document, documentVersion, err := svc.GeneratedDocuments.PublishProcessingActivityList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
@@ -5299,11 +5125,10 @@ func (r *Resolver) PublishProcessingActivityListTool(ctx context.Context, req *m
 }
 
 func (r *Resolver) PublishDataProtectionImpactAssessmentListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishDataProtectionImpactAssessmentListInput) (*mcp.CallToolResult, types.PublishDataProtectionImpactAssessmentListOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionDataProtectionImpactAssessmentPublish); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionDataProtectionImpactAssessmentPublish)
+	if err != nil {
 		return nil, types.PublishDataProtectionImpactAssessmentListOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
 
 	document, documentVersion, err := svc.GeneratedDocuments.PublishDataProtectionImpactAssessmentList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
@@ -5318,11 +5143,10 @@ func (r *Resolver) PublishDataProtectionImpactAssessmentListTool(ctx context.Con
 }
 
 func (r *Resolver) PublishTransferImpactAssessmentListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishTransferImpactAssessmentListInput) (*mcp.CallToolResult, types.PublishTransferImpactAssessmentListOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionTransferImpactAssessmentPublish); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionTransferImpactAssessmentPublish)
+	if err != nil {
 		return nil, types.PublishTransferImpactAssessmentListOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
 
 	document, documentVersion, err := svc.GeneratedDocuments.PublishTransferImpactAssessmentList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
@@ -5337,11 +5161,10 @@ func (r *Resolver) PublishTransferImpactAssessmentListTool(ctx context.Context, 
 }
 
 func (r *Resolver) PublishThirdPartyListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishThirdPartyListInput) (*mcp.CallToolResult, types.PublishThirdPartyListOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionThirdPartyPublish); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionThirdPartyPublish)
+	if err != nil {
 		return nil, types.PublishThirdPartyListOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
 
 	document, documentVersion, err := svc.GeneratedDocuments.PublishThirdPartyList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
@@ -5356,7 +5179,7 @@ func (r *Resolver) PublishThirdPartyListTool(ctx context.Context, req *mcp.CallT
 }
 
 func (r *Resolver) ListCookieBannersTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListCookieBannersInput) (*mcp.CallToolResult, types.ListCookieBannersOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionCookieBannerList); err != nil {
+	if _, err := r.Authorize(ctx, input.OrganizationID, probo.ActionCookieBannerList); err != nil {
 		return nil, types.ListCookieBannersOutput{}, err
 	}
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
@@ -5373,7 +5196,7 @@ func (r *Resolver) ListCookieBannersTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) GetCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetCookieBannerInput) (*mcp.CallToolResult, types.GetCookieBannerOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerGet); err != nil {
+	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerGet); err != nil {
 		return nil, types.GetCookieBannerOutput{}, err
 	}
 	scope := coredata.NewScopeFromObjectID(input.ID)
@@ -5387,7 +5210,7 @@ func (r *Resolver) GetCookieBannerTool(ctx context.Context, req *mcp.CallToolReq
 }
 
 func (r *Resolver) AddCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddCookieBannerInput) (*mcp.CallToolResult, types.AddCookieBannerOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionCookieBannerCreate); err != nil {
+	if _, err := r.Authorize(ctx, input.OrganizationID, probo.ActionCookieBannerCreate); err != nil {
 		return nil, types.AddCookieBannerOutput{}, err
 	}
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
@@ -5408,7 +5231,7 @@ func (r *Resolver) AddCookieBannerTool(ctx context.Context, req *mcp.CallToolReq
 }
 
 func (r *Resolver) UpdateCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateCookieBannerInput) (*mcp.CallToolResult, types.UpdateCookieBannerOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerUpdate); err != nil {
+	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerUpdate); err != nil {
 		return nil, types.UpdateCookieBannerOutput{}, err
 	}
 	scope := coredata.NewScopeFromObjectID(input.ID)
@@ -5443,11 +5266,10 @@ func (r *Resolver) UpdateCookieBannerTool(ctx context.Context, req *mcp.CallTool
 }
 
 func (r *Resolver) DeleteCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteCookieBannerInput) (*mcp.CallToolResult, types.DeleteCookieBannerOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerDelete)
+	if err != nil {
 		return nil, types.DeleteCookieBannerOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	if err := r.cookieBanner.DeleteCookieBanner(ctx, scope, input.ID); err != nil {
 		return nil, types.DeleteCookieBannerOutput{}, fmt.Errorf("cannot delete cookie banner: %w", err)
 	}
@@ -5456,7 +5278,7 @@ func (r *Resolver) DeleteCookieBannerTool(ctx context.Context, req *mcp.CallTool
 }
 
 func (r *Resolver) ActivateCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ActivateCookieBannerInput) (*mcp.CallToolResult, types.ActivateCookieBannerOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerActivate); err != nil {
+	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerActivate); err != nil {
 		return nil, types.ActivateCookieBannerOutput{}, err
 	}
 	scope := coredata.NewScopeFromObjectID(input.ID)
@@ -5470,7 +5292,7 @@ func (r *Resolver) ActivateCookieBannerTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) DeactivateCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeactivateCookieBannerInput) (*mcp.CallToolResult, types.DeactivateCookieBannerOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerDeactivate); err != nil {
+	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerDeactivate); err != nil {
 		return nil, types.DeactivateCookieBannerOutput{}, err
 	}
 	scope := coredata.NewScopeFromObjectID(input.ID)
@@ -5484,7 +5306,7 @@ func (r *Resolver) DeactivateCookieBannerTool(ctx context.Context, req *mcp.Call
 }
 
 func (r *Resolver) ListCookieCategoriesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListCookieCategoriesInput) (*mcp.CallToolResult, types.ListCookieCategoriesOutput, error) {
-	if err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieCategoryList); err != nil {
+	if _, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieCategoryList); err != nil {
 		return nil, types.ListCookieCategoriesOutput{}, err
 	}
 	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
@@ -5501,7 +5323,7 @@ func (r *Resolver) ListCookieCategoriesTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) GetCookieCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetCookieCategoryInput) (*mcp.CallToolResult, types.GetCookieCategoryOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionCookieCategoryGet); err != nil {
+	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieCategoryGet); err != nil {
 		return nil, types.GetCookieCategoryOutput{}, err
 	}
 	scope := coredata.NewScopeFromObjectID(input.ID)
@@ -5515,7 +5337,7 @@ func (r *Resolver) GetCookieCategoryTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) AddCookieCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddCookieCategoryInput) (*mcp.CallToolResult, types.AddCookieCategoryOutput, error) {
-	if err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieCategoryCreate); err != nil {
+	if _, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieCategoryCreate); err != nil {
 		return nil, types.AddCookieCategoryOutput{}, err
 	}
 	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
@@ -5535,7 +5357,7 @@ func (r *Resolver) AddCookieCategoryTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) UpdateCookieCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateCookieCategoryInput) (*mcp.CallToolResult, types.UpdateCookieCategoryOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionCookieCategoryUpdate); err != nil {
+	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieCategoryUpdate); err != nil {
 		return nil, types.UpdateCookieCategoryOutput{}, err
 	}
 	scope := coredata.NewScopeFromObjectID(input.ID)
@@ -5562,11 +5384,10 @@ func (r *Resolver) UpdateCookieCategoryTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) DeleteCookieCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteCookieCategoryInput) (*mcp.CallToolResult, types.DeleteCookieCategoryOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionCookieCategoryDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionCookieCategoryDelete)
+	if err != nil {
 		return nil, types.DeleteCookieCategoryOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	if err := r.cookieBanner.DeleteCookieCategory(ctx, scope, input.ID); err != nil {
 		return nil, types.DeleteCookieCategoryOutput{}, fmt.Errorf("cannot delete cookie category: %w", err)
 	}
@@ -5575,7 +5396,7 @@ func (r *Resolver) DeleteCookieCategoryTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) ReorderCookieCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ReorderCookieCategoryInput) (*mcp.CallToolResult, types.ReorderCookieCategoryOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionCookieCategoryUpdate); err != nil {
+	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieCategoryUpdate); err != nil {
 		return nil, types.ReorderCookieCategoryOutput{}, err
 	}
 	scope := coredata.NewScopeFromObjectID(input.ID)
@@ -5597,7 +5418,7 @@ func (r *Resolver) ReorderCookieCategoryTool(ctx context.Context, req *mcp.CallT
 }
 
 func (r *Resolver) ListTrackerPatternsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListTrackerPatternsInput) (*mcp.CallToolResult, types.ListTrackerPatternsOutput, error) {
-	if err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerPatternList); err != nil {
+	if _, err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerPatternList); err != nil {
 		return nil, types.ListTrackerPatternsOutput{}, err
 	}
 	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
@@ -5614,7 +5435,7 @@ func (r *Resolver) ListTrackerPatternsTool(ctx context.Context, req *mcp.CallToo
 }
 
 func (r *Resolver) GetTrackerPatternTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetTrackerPatternInput) (*mcp.CallToolResult, types.GetTrackerPatternOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionTrackerPatternGet); err != nil {
+	if _, err := r.Authorize(ctx, input.ID, probo.ActionTrackerPatternGet); err != nil {
 		return nil, types.GetTrackerPatternOutput{}, err
 	}
 	scope := coredata.NewScopeFromObjectID(input.ID)
@@ -5628,7 +5449,7 @@ func (r *Resolver) GetTrackerPatternTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) AddTrackerPatternTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddTrackerPatternInput) (*mcp.CallToolResult, types.AddTrackerPatternOutput, error) {
-	if err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerPatternCreate); err != nil {
+	if _, err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerPatternCreate); err != nil {
 		return nil, types.AddTrackerPatternOutput{}, err
 	}
 	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
@@ -5650,7 +5471,7 @@ func (r *Resolver) AddTrackerPatternTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) UpdateTrackerPatternTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateTrackerPatternInput) (*mcp.CallToolResult, types.UpdateTrackerPatternOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionTrackerPatternUpdate); err != nil {
+	if _, err := r.Authorize(ctx, input.ID, probo.ActionTrackerPatternUpdate); err != nil {
 		return nil, types.UpdateTrackerPatternOutput{}, err
 	}
 	scope := coredata.NewScopeFromObjectID(input.ID)
@@ -5678,11 +5499,10 @@ func (r *Resolver) UpdateTrackerPatternTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) DeleteTrackerPatternTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteTrackerPatternInput) (*mcp.CallToolResult, types.DeleteTrackerPatternOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionTrackerPatternDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionTrackerPatternDelete)
+	if err != nil {
 		return nil, types.DeleteTrackerPatternOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	if err := r.cookieBanner.DeleteTrackerPattern(ctx, scope, input.ID); err != nil {
 		return nil, types.DeleteTrackerPatternOutput{}, fmt.Errorf("cannot delete tracker pattern: %w", err)
 	}
@@ -5691,7 +5511,7 @@ func (r *Resolver) DeleteTrackerPatternTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) MoveTrackerPatternToCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.MoveTrackerPatternToCategoryInput) (*mcp.CallToolResult, types.MoveTrackerPatternToCategoryOutput, error) {
-	if err := r.Authorize(ctx, input.TrackerPatternID, probo.ActionTrackerPatternUpdate); err != nil {
+	if _, err := r.Authorize(ctx, input.TrackerPatternID, probo.ActionTrackerPatternUpdate); err != nil {
 		return nil, types.MoveTrackerPatternToCategoryOutput{}, err
 	}
 	scope := coredata.NewScopeFromObjectID(input.TrackerPatternID)
@@ -5708,7 +5528,7 @@ func (r *Resolver) MoveTrackerPatternToCategoryTool(ctx context.Context, req *mc
 }
 
 func (r *Resolver) PublishCookieBannerVersionTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishCookieBannerVersionInput) (*mcp.CallToolResult, types.PublishCookieBannerVersionOutput, error) {
-	if err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerVersionPublish); err != nil {
+	if _, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerVersionPublish); err != nil {
 		return nil, types.PublishCookieBannerVersionOutput{}, err
 	}
 	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
@@ -5722,7 +5542,7 @@ func (r *Resolver) PublishCookieBannerVersionTool(ctx context.Context, req *mcp.
 }
 
 func (r *Resolver) ListCookieBannerVersionsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListCookieBannerVersionsInput) (*mcp.CallToolResult, types.ListCookieBannerVersionsOutput, error) {
-	if err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerVersionList); err != nil {
+	if _, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerVersionList); err != nil {
 		return nil, types.ListCookieBannerVersionsOutput{}, err
 	}
 	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
@@ -5739,7 +5559,7 @@ func (r *Resolver) ListCookieBannerVersionsTool(ctx context.Context, req *mcp.Ca
 }
 
 func (r *Resolver) UpsertCookieBannerTranslationTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpsertCookieBannerTranslationInput) (*mcp.CallToolResult, types.UpsertCookieBannerTranslationOutput, error) {
-	if err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerUpdate); err != nil {
+	if _, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerUpdate); err != nil {
 		return nil, types.UpsertCookieBannerTranslationOutput{}, err
 	}
 	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
@@ -5757,7 +5577,7 @@ func (r *Resolver) UpsertCookieBannerTranslationTool(ctx context.Context, req *m
 }
 
 func (r *Resolver) ListCookieConsentRecordsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListCookieConsentRecordsInput) (*mcp.CallToolResult, types.ListCookieConsentRecordsOutput, error) {
-	if err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieConsentRecordList); err != nil {
+	if _, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieConsentRecordList); err != nil {
 		return nil, types.ListCookieConsentRecordsOutput{}, err
 	}
 	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
@@ -5783,7 +5603,7 @@ func (r *Resolver) ListCookieConsentRecordsTool(ctx context.Context, req *mcp.Ca
 }
 
 func (r *Resolver) GetCookieConsentRecordTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetCookieConsentRecordInput) (*mcp.CallToolResult, types.GetCookieConsentRecordOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionCookieConsentRecordList); err != nil {
+	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieConsentRecordList); err != nil {
 		return nil, types.GetCookieConsentRecordOutput{}, err
 	}
 	scope := coredata.NewScopeFromObjectID(input.ID)
@@ -5797,11 +5617,10 @@ func (r *Resolver) GetCookieConsentRecordTool(ctx context.Context, req *mcp.Call
 }
 
 func (r *Resolver) PublishRiskListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishRiskListInput) (*mcp.CallToolResult, types.PublishRiskListOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionRiskPublish); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionRiskPublish)
+	if err != nil {
 		return nil, types.PublishRiskListOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
 
 	document, documentVersion, err := svc.GeneratedDocuments.PublishRiskList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
@@ -5816,7 +5635,7 @@ func (r *Resolver) PublishRiskListTool(ctx context.Context, req *mcp.CallToolReq
 }
 
 func (r *Resolver) GetSCIMConfigurationTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetSCIMConfigurationInput) (*mcp.CallToolResult, types.GetSCIMConfigurationOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, iam.ActionSCIMConfigurationGet); err != nil {
+	if _, err := r.Authorize(ctx, input.OrganizationID, iam.ActionSCIMConfigurationGet); err != nil {
 		return nil, types.GetSCIMConfigurationOutput{}, err
 	}
 
@@ -5833,7 +5652,7 @@ func (r *Resolver) GetSCIMConfigurationTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) CreateSCIMConfigurationTool(ctx context.Context, req *mcp.CallToolRequest, input *types.CreateSCIMConfigurationInput) (*mcp.CallToolResult, types.CreateSCIMConfigurationOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, iam.ActionSCIMConfigurationCreate); err != nil {
+	if _, err := r.Authorize(ctx, input.OrganizationID, iam.ActionSCIMConfigurationCreate); err != nil {
 		return nil, types.CreateSCIMConfigurationOutput{}, err
 	}
 
@@ -5860,7 +5679,7 @@ func (r *Resolver) CreateSCIMConfigurationTool(ctx context.Context, req *mcp.Cal
 }
 
 func (r *Resolver) DeleteSCIMConfigurationTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteSCIMConfigurationInput) (*mcp.CallToolResult, types.DeleteSCIMConfigurationOutput, error) {
-	if err := r.Authorize(ctx, input.OrganizationID, iam.ActionSCIMConfigurationDelete); err != nil {
+	if _, err := r.Authorize(ctx, input.OrganizationID, iam.ActionSCIMConfigurationDelete); err != nil {
 		return nil, types.DeleteSCIMConfigurationOutput{}, err
 	}
 
@@ -5873,7 +5692,7 @@ func (r *Resolver) DeleteSCIMConfigurationTool(ctx context.Context, req *mcp.Cal
 }
 
 func (r *Resolver) RegenerateSCIMTokenTool(ctx context.Context, req *mcp.CallToolRequest, input *types.RegenerateSCIMTokenInput) (*mcp.CallToolResult, types.RegenerateSCIMTokenOutput, error) {
-	if err := r.Authorize(ctx, input.ScimConfigurationID, iam.ActionSCIMConfigurationUpdate); err != nil {
+	if _, err := r.Authorize(ctx, input.ScimConfigurationID, iam.ActionSCIMConfigurationUpdate); err != nil {
 		return nil, types.RegenerateSCIMTokenOutput{}, err
 	}
 
@@ -5889,7 +5708,7 @@ func (r *Resolver) RegenerateSCIMTokenTool(ctx context.Context, req *mcp.CallToo
 }
 
 func (r *Resolver) GetSCIMBridgeTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetSCIMBridgeInput) (*mcp.CallToolResult, types.GetSCIMBridgeOutput, error) {
-	if err := r.Authorize(ctx, input.ID, iam.ActionSCIMBridgeGet); err != nil {
+	if _, err := r.Authorize(ctx, input.ID, iam.ActionSCIMBridgeGet); err != nil {
 		return nil, types.GetSCIMBridgeOutput{}, err
 	}
 
@@ -5906,7 +5725,7 @@ func (r *Resolver) GetSCIMBridgeTool(ctx context.Context, req *mcp.CallToolReque
 }
 
 func (r *Resolver) UpdateSCIMBridgeTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateSCIMBridgeInput) (*mcp.CallToolResult, types.UpdateSCIMBridgeOutput, error) {
-	if err := r.Authorize(ctx, input.ScimBridgeID, iam.ActionSCIMBridgeUpdate); err != nil {
+	if _, err := r.Authorize(ctx, input.ScimBridgeID, iam.ActionSCIMBridgeUpdate); err != nil {
 		return nil, types.UpdateSCIMBridgeOutput{}, err
 	}
 
@@ -5919,7 +5738,7 @@ func (r *Resolver) UpdateSCIMBridgeTool(ctx context.Context, req *mcp.CallToolRe
 }
 
 func (r *Resolver) ListSCIMEventsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListSCIMEventsInput) (*mcp.CallToolResult, types.ListSCIMEventsOutput, error) {
-	if err := r.Authorize(ctx, input.ScimConfigurationID, iam.ActionSCIMEventList); err != nil {
+	if _, err := r.Authorize(ctx, input.ScimConfigurationID, iam.ActionSCIMEventList); err != nil {
 		return nil, types.ListSCIMEventsOutput{}, err
 	}
 
@@ -5950,11 +5769,10 @@ func (r *Resolver) PublishDocumentTool(ctx context.Context, req *mcp.CallToolReq
 		action = probo.ActionDocumentVersionRequestApproval
 	}
 
-	if err := r.Authorize(ctx, input.DocumentID, action); err != nil {
+	scope, err := r.Authorize(ctx, input.DocumentID, action)
+	if err != nil {
 		return nil, types.PublishDocumentOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.DocumentID)
 	svc := r.proboSvc
 
 	result, err := svc.Documents.PublishVersion(ctx, scope, probo.PublishDocumentRequest{
@@ -5979,7 +5797,7 @@ func (r *Resolver) PublishDocumentTool(ctx context.Context, req *mcp.CallToolReq
 }
 
 func (r *Resolver) ListTrackerResourcesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListTrackerResourcesInput) (*mcp.CallToolResult, types.ListTrackerResourcesOutput, error) {
-	if err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerResourceList); err != nil {
+	if _, err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerResourceList); err != nil {
 		return nil, types.ListTrackerResourcesOutput{}, err
 	}
 	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
@@ -5996,7 +5814,7 @@ func (r *Resolver) ListTrackerResourcesTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) GetTrackerResourceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetTrackerResourceInput) (*mcp.CallToolResult, types.GetTrackerResourceOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionTrackerResourceGet); err != nil {
+	if _, err := r.Authorize(ctx, input.ID, probo.ActionTrackerResourceGet); err != nil {
 		return nil, types.GetTrackerResourceOutput{}, err
 	}
 	scope := coredata.NewScopeFromObjectID(input.ID)
@@ -6010,7 +5828,7 @@ func (r *Resolver) GetTrackerResourceTool(ctx context.Context, req *mcp.CallTool
 }
 
 func (r *Resolver) AddTrackerResourceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddTrackerResourceInput) (*mcp.CallToolResult, types.AddTrackerResourceOutput, error) {
-	if err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerResourceCreate); err != nil {
+	if _, err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerResourceCreate); err != nil {
 		return nil, types.AddTrackerResourceOutput{}, err
 	}
 	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
@@ -6036,7 +5854,7 @@ func (r *Resolver) AddTrackerResourceTool(ctx context.Context, req *mcp.CallTool
 }
 
 func (r *Resolver) UpdateTrackerResourceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateTrackerResourceInput) (*mcp.CallToolResult, types.UpdateTrackerResourceOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionTrackerResourceUpdate); err != nil {
+	if _, err := r.Authorize(ctx, input.ID, probo.ActionTrackerResourceUpdate); err != nil {
 		return nil, types.UpdateTrackerResourceOutput{}, err
 	}
 	scope := coredata.NewScopeFromObjectID(input.ID)
@@ -6063,11 +5881,10 @@ func (r *Resolver) UpdateTrackerResourceTool(ctx context.Context, req *mcp.CallT
 }
 
 func (r *Resolver) DeleteTrackerResourceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteTrackerResourceInput) (*mcp.CallToolResult, types.DeleteTrackerResourceOutput, error) {
-	if err := r.Authorize(ctx, input.ID, probo.ActionTrackerResourceDelete); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionTrackerResourceDelete)
+	if err != nil {
 		return nil, types.DeleteTrackerResourceOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 	if err := r.cookieBanner.DeleteTrackerResource(ctx, scope, input.ID); err != nil {
 		return nil, types.DeleteTrackerResourceOutput{}, fmt.Errorf("cannot delete tracker resource: %w", err)
 	}
@@ -6076,7 +5893,7 @@ func (r *Resolver) DeleteTrackerResourceTool(ctx context.Context, req *mcp.CallT
 }
 
 func (r *Resolver) MoveTrackerResourceToCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.MoveTrackerResourceToCategoryInput) (*mcp.CallToolResult, types.MoveTrackerResourceToCategoryOutput, error) {
-	if err := r.Authorize(ctx, input.TrackerResourceID, probo.ActionTrackerResourceUpdate); err != nil {
+	if _, err := r.Authorize(ctx, input.TrackerResourceID, probo.ActionTrackerResourceUpdate); err != nil {
 		return nil, types.MoveTrackerResourceToCategoryOutput{}, err
 	}
 	scope := coredata.NewScopeFromObjectID(input.TrackerResourceID)

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -49,7 +49,9 @@ func (r *Resolver) ListOrganizationsTool(ctx context.Context, req *mcp.CallToolR
 // ListThirdPartiesTool handles the listThirdParties tool
 // List all thirdParties for the organization
 func (r *Resolver) ListThirdPartiesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListThirdPartiesInput) (*mcp.CallToolResult, types.ListThirdPartiesOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionThirdPartyList)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionThirdPartyList); err != nil {
+		return nil, types.ListThirdPartiesOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
@@ -80,7 +82,9 @@ func (r *Resolver) ListThirdPartiesTool(ctx context.Context, req *mcp.CallToolRe
 // AddThirdPartyTool handles the addThirdParty tool
 // Add a new thirdParty to the organization
 func (r *Resolver) AddThirdPartyTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddThirdPartyInput) (*mcp.CallToolResult, types.AddThirdPartyOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionThirdPartyCreate)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionThirdPartyCreate); err != nil {
+		return nil, types.AddThirdPartyOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
@@ -135,7 +139,9 @@ func (r *Resolver) AddThirdPartyTool(ctx context.Context, req *mcp.CallToolReque
 // UpdateThirdPartyTool handles the updateThirdParty tool
 // Update an existing thirdParty
 func (r *Resolver) UpdateThirdPartyTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateThirdPartyInput) (*mcp.CallToolResult, types.UpdateThirdPartyOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionThirdPartyUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionThirdPartyUpdate); err != nil {
+		return nil, types.UpdateThirdPartyOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -263,7 +269,9 @@ func (r *Resolver) UpdateThirdPartyTool(ctx context.Context, req *mcp.CallToolRe
 }
 
 func (r *Resolver) ListRisksTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListRisksInput) (*mcp.CallToolResult, types.ListRisksOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionRiskList)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionRiskList); err != nil {
+		return nil, types.ListRisksOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
@@ -295,7 +303,9 @@ func (r *Resolver) ListRisksTool(ctx context.Context, req *mcp.CallToolRequest, 
 }
 
 func (r *Resolver) GetRiskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetRiskInput) (*mcp.CallToolResult, types.GetRiskOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionRiskGet)
+	if err := r.Authorize(ctx, input.ID, probo.ActionRiskGet); err != nil {
+		return nil, types.GetRiskOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -311,7 +321,9 @@ func (r *Resolver) GetRiskTool(ctx context.Context, req *mcp.CallToolRequest, in
 }
 
 func (r *Resolver) AddRiskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddRiskInput) (*mcp.CallToolResult, types.AddRiskOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionRiskCreate)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionRiskCreate); err != nil {
+		return nil, types.AddRiskOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
@@ -340,7 +352,9 @@ func (r *Resolver) AddRiskTool(ctx context.Context, req *mcp.CallToolRequest, in
 }
 
 func (r *Resolver) UpdateRiskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateRiskInput) (*mcp.CallToolResult, types.UpdateRiskOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionRiskUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionRiskUpdate); err != nil {
+		return nil, types.UpdateRiskOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -371,7 +385,9 @@ func (r *Resolver) UpdateRiskTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) ListMeasuresTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListMeasuresInput) (*mcp.CallToolResult, types.ListMeasuresOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionMeasureList)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionMeasureList); err != nil {
+		return nil, types.ListMeasuresOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
@@ -403,7 +419,9 @@ func (r *Resolver) ListMeasuresTool(ctx context.Context, req *mcp.CallToolReques
 }
 
 func (r *Resolver) GetMeasureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetMeasureInput) (*mcp.CallToolResult, types.GetMeasureOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionMeasureGet)
+	if err := r.Authorize(ctx, input.ID, probo.ActionMeasureGet); err != nil {
+		return nil, types.GetMeasureOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -419,7 +437,9 @@ func (r *Resolver) GetMeasureTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) AddMeasureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddMeasureInput) (*mcp.CallToolResult, types.AddMeasureOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionMeasureCreate)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionMeasureCreate); err != nil {
+		return nil, types.AddMeasureOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
@@ -443,7 +463,9 @@ func (r *Resolver) AddMeasureTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) UpdateMeasureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateMeasureInput) (*mcp.CallToolResult, types.UpdateMeasureOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionMeasureUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionMeasureUpdate); err != nil {
+		return nil, types.UpdateMeasureOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -468,7 +490,9 @@ func (r *Resolver) UpdateMeasureTool(ctx context.Context, req *mcp.CallToolReque
 }
 
 func (r *Resolver) ListFrameworksTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListFrameworksInput) (*mcp.CallToolResult, types.ListFrameworksOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionFrameworkList)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionFrameworkList); err != nil {
+		return nil, types.ListFrameworksOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
@@ -495,7 +519,9 @@ func (r *Resolver) ListFrameworksTool(ctx context.Context, req *mcp.CallToolRequ
 }
 
 func (r *Resolver) GetFrameworkTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetFrameworkInput) (*mcp.CallToolResult, types.GetFrameworkOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionFrameworkGet)
+	if err := r.Authorize(ctx, input.ID, probo.ActionFrameworkGet); err != nil {
+		return nil, types.GetFrameworkOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -511,7 +537,9 @@ func (r *Resolver) GetFrameworkTool(ctx context.Context, req *mcp.CallToolReques
 }
 
 func (r *Resolver) AddFrameworkTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddFrameworkInput) (*mcp.CallToolResult, types.AddFrameworkOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionFrameworkCreate)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionFrameworkCreate); err != nil {
+		return nil, types.AddFrameworkOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
@@ -534,7 +562,9 @@ func (r *Resolver) AddFrameworkTool(ctx context.Context, req *mcp.CallToolReques
 }
 
 func (r *Resolver) UpdateFrameworkTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateFrameworkInput) (*mcp.CallToolResult, types.UpdateFrameworkOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionFrameworkUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionFrameworkUpdate); err != nil {
+		return nil, types.UpdateFrameworkOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -557,7 +587,9 @@ func (r *Resolver) UpdateFrameworkTool(ctx context.Context, req *mcp.CallToolReq
 }
 
 func (r *Resolver) ListAssetsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListAssetsInput) (*mcp.CallToolResult, types.ListAssetsOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionAssetList)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionAssetList); err != nil {
+		return nil, types.ListAssetsOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
@@ -584,7 +616,9 @@ func (r *Resolver) ListAssetsTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) GetAssetTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetAssetInput) (*mcp.CallToolResult, types.GetAssetOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionAssetGet)
+	if err := r.Authorize(ctx, input.ID, probo.ActionAssetGet); err != nil {
+		return nil, types.GetAssetOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -600,7 +634,9 @@ func (r *Resolver) GetAssetTool(ctx context.Context, req *mcp.CallToolRequest, i
 }
 
 func (r *Resolver) AddAssetTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddAssetInput) (*mcp.CallToolResult, types.AddAssetOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionAssetCreate)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionAssetCreate); err != nil {
+		return nil, types.AddAssetOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
@@ -627,7 +663,9 @@ func (r *Resolver) AddAssetTool(ctx context.Context, req *mcp.CallToolRequest, i
 }
 
 func (r *Resolver) UpdateAssetTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateAssetInput) (*mcp.CallToolResult, types.UpdateAssetOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionAssetUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionAssetUpdate); err != nil {
+		return nil, types.UpdateAssetOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -654,7 +692,9 @@ func (r *Resolver) UpdateAssetTool(ctx context.Context, req *mcp.CallToolRequest
 }
 
 func (r *Resolver) ListDataTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListDataInput) (*mcp.CallToolResult, types.ListDataOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionDatumList)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionDatumList); err != nil {
+		return nil, types.ListDataOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
@@ -681,7 +721,9 @@ func (r *Resolver) ListDataTool(ctx context.Context, req *mcp.CallToolRequest, i
 }
 
 func (r *Resolver) GetDatumTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetDatumInput) (*mcp.CallToolResult, types.GetDatumOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionDatumGet)
+	if err := r.Authorize(ctx, input.ID, probo.ActionDatumGet); err != nil {
+		return nil, types.GetDatumOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -697,7 +739,9 @@ func (r *Resolver) GetDatumTool(ctx context.Context, req *mcp.CallToolRequest, i
 }
 
 func (r *Resolver) AddDatumTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddDatumInput) (*mcp.CallToolResult, types.AddDatumOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionDatumCreate)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionDatumCreate); err != nil {
+		return nil, types.AddDatumOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
@@ -722,7 +766,9 @@ func (r *Resolver) AddDatumTool(ctx context.Context, req *mcp.CallToolRequest, i
 }
 
 func (r *Resolver) UpdateDatumTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateDatumInput) (*mcp.CallToolResult, types.UpdateDatumOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionDatumUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionDatumUpdate); err != nil {
+		return nil, types.UpdateDatumOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -747,7 +793,9 @@ func (r *Resolver) UpdateDatumTool(ctx context.Context, req *mcp.CallToolRequest
 }
 
 func (r *Resolver) ListFindingsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListFindingsInput) (*mcp.CallToolResult, types.ListFindingsOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionFindingList)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionFindingList); err != nil {
+		return nil, types.ListFindingsOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
@@ -784,7 +832,9 @@ func (r *Resolver) ListFindingsTool(ctx context.Context, req *mcp.CallToolReques
 }
 
 func (r *Resolver) GetFindingTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetFindingInput) (*mcp.CallToolResult, types.GetFindingOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionFindingGet)
+	if err := r.Authorize(ctx, input.ID, probo.ActionFindingGet); err != nil {
+		return nil, types.GetFindingOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -800,7 +850,9 @@ func (r *Resolver) GetFindingTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) AddFindingTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddFindingInput) (*mcp.CallToolResult, types.AddFindingOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionFindingCreate)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionFindingCreate); err != nil {
+		return nil, types.AddFindingOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
@@ -833,7 +885,9 @@ func (r *Resolver) AddFindingTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) UpdateFindingTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateFindingInput) (*mcp.CallToolResult, types.UpdateFindingOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionFindingUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionFindingUpdate); err != nil {
+		return nil, types.UpdateFindingOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -865,7 +919,9 @@ func (r *Resolver) UpdateFindingTool(ctx context.Context, req *mcp.CallToolReque
 }
 
 func (r *Resolver) ListObligationsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListObligationsInput) (*mcp.CallToolResult, types.ListObligationsOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionObligationList)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionObligationList); err != nil {
+		return nil, types.ListObligationsOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
@@ -892,7 +948,9 @@ func (r *Resolver) ListObligationsTool(ctx context.Context, req *mcp.CallToolReq
 }
 
 func (r *Resolver) GetObligationTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetObligationInput) (*mcp.CallToolResult, types.GetObligationOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionObligationGet)
+	if err := r.Authorize(ctx, input.ID, probo.ActionObligationGet); err != nil {
+		return nil, types.GetObligationOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -908,7 +966,9 @@ func (r *Resolver) GetObligationTool(ctx context.Context, req *mcp.CallToolReque
 }
 
 func (r *Resolver) AddObligationTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddObligationInput) (*mcp.CallToolResult, types.AddObligationOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionObligationCreate)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionObligationCreate); err != nil {
+		return nil, types.AddObligationOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
@@ -939,7 +999,9 @@ func (r *Resolver) AddObligationTool(ctx context.Context, req *mcp.CallToolReque
 }
 
 func (r *Resolver) UpdateObligationTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateObligationInput) (*mcp.CallToolResult, types.UpdateObligationOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionObligationUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionObligationUpdate); err != nil {
+		return nil, types.UpdateObligationOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -970,7 +1032,9 @@ func (r *Resolver) UpdateObligationTool(ctx context.Context, req *mcp.CallToolRe
 }
 
 func (r *Resolver) ListProcessingActivitiesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListProcessingActivitiesInput) (*mcp.CallToolResult, types.ListProcessingActivitiesOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionProcessingActivityList)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionProcessingActivityList); err != nil {
+		return nil, types.ListProcessingActivitiesOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
@@ -997,7 +1061,9 @@ func (r *Resolver) ListProcessingActivitiesTool(ctx context.Context, req *mcp.Ca
 }
 
 func (r *Resolver) GetProcessingActivityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetProcessingActivityInput) (*mcp.CallToolResult, types.GetProcessingActivityOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionProcessingActivityGet)
+	if err := r.Authorize(ctx, input.ID, probo.ActionProcessingActivityGet); err != nil {
+		return nil, types.GetProcessingActivityOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -1013,7 +1079,9 @@ func (r *Resolver) GetProcessingActivityTool(ctx context.Context, req *mcp.CallT
 }
 
 func (r *Resolver) AddProcessingActivityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddProcessingActivityInput) (*mcp.CallToolResult, types.AddProcessingActivityOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionProcessingActivityCreate)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionProcessingActivityCreate); err != nil {
+		return nil, types.AddProcessingActivityOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
@@ -1054,7 +1122,9 @@ func (r *Resolver) AddProcessingActivityTool(ctx context.Context, req *mcp.CallT
 }
 
 func (r *Resolver) UpdateProcessingActivityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateProcessingActivityInput) (*mcp.CallToolResult, types.UpdateProcessingActivityOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionProcessingActivityUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionProcessingActivityUpdate); err != nil {
+		return nil, types.UpdateProcessingActivityOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -1100,7 +1170,9 @@ func (r *Resolver) UpdateProcessingActivityTool(ctx context.Context, req *mcp.Ca
 }
 
 func (r *Resolver) DeleteProcessingActivityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteProcessingActivityInput) (*mcp.CallToolResult, types.DeleteProcessingActivityOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionProcessingActivityDelete)
+	if err := r.Authorize(ctx, input.ID, probo.ActionProcessingActivityDelete); err != nil {
+		return nil, types.DeleteProcessingActivityOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -1116,7 +1188,9 @@ func (r *Resolver) DeleteProcessingActivityTool(ctx context.Context, req *mcp.Ca
 }
 
 func (r *Resolver) ListDataProtectionImpactAssessmentsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListDataProtectionImpactAssessmentsInput) (*mcp.CallToolResult, types.ListDataProtectionImpactAssessmentsOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionDataProtectionImpactAssessmentList)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionDataProtectionImpactAssessmentList); err != nil {
+		return nil, types.ListDataProtectionImpactAssessmentsOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
@@ -1143,7 +1217,9 @@ func (r *Resolver) ListDataProtectionImpactAssessmentsTool(ctx context.Context, 
 }
 
 func (r *Resolver) GetDataProtectionImpactAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetDataProtectionImpactAssessmentInput) (*mcp.CallToolResult, types.GetDataProtectionImpactAssessmentOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionDataProtectionImpactAssessmentGet)
+	if err := r.Authorize(ctx, input.ID, probo.ActionDataProtectionImpactAssessmentGet); err != nil {
+		return nil, types.GetDataProtectionImpactAssessmentOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -1159,7 +1235,9 @@ func (r *Resolver) GetDataProtectionImpactAssessmentTool(ctx context.Context, re
 }
 
 func (r *Resolver) AddDataProtectionImpactAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddDataProtectionImpactAssessmentInput) (*mcp.CallToolResult, types.AddDataProtectionImpactAssessmentOutput, error) {
-	r.MustAuthorize(ctx, input.ProcessingActivityID, probo.ActionDataProtectionImpactAssessmentCreate)
+	if err := r.Authorize(ctx, input.ProcessingActivityID, probo.ActionDataProtectionImpactAssessmentCreate); err != nil {
+		return nil, types.AddDataProtectionImpactAssessmentOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ProcessingActivityID)
 	svc := r.proboSvc
@@ -1185,7 +1263,9 @@ func (r *Resolver) AddDataProtectionImpactAssessmentTool(ctx context.Context, re
 }
 
 func (r *Resolver) UpdateDataProtectionImpactAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateDataProtectionImpactAssessmentInput) (*mcp.CallToolResult, types.UpdateDataProtectionImpactAssessmentOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionDataProtectionImpactAssessmentUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionDataProtectionImpactAssessmentUpdate); err != nil {
+		return nil, types.UpdateDataProtectionImpactAssessmentOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -1211,7 +1291,9 @@ func (r *Resolver) UpdateDataProtectionImpactAssessmentTool(ctx context.Context,
 }
 
 func (r *Resolver) ListTransferImpactAssessmentsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListTransferImpactAssessmentsInput) (*mcp.CallToolResult, types.ListTransferImpactAssessmentsOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionTransferImpactAssessmentList)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionTransferImpactAssessmentList); err != nil {
+		return nil, types.ListTransferImpactAssessmentsOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
@@ -1238,7 +1320,9 @@ func (r *Resolver) ListTransferImpactAssessmentsTool(ctx context.Context, req *m
 }
 
 func (r *Resolver) GetTransferImpactAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetTransferImpactAssessmentInput) (*mcp.CallToolResult, types.GetTransferImpactAssessmentOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionTransferImpactAssessmentGet)
+	if err := r.Authorize(ctx, input.ID, probo.ActionTransferImpactAssessmentGet); err != nil {
+		return nil, types.GetTransferImpactAssessmentOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -1254,7 +1338,9 @@ func (r *Resolver) GetTransferImpactAssessmentTool(ctx context.Context, req *mcp
 }
 
 func (r *Resolver) AddTransferImpactAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddTransferImpactAssessmentInput) (*mcp.CallToolResult, types.AddTransferImpactAssessmentOutput, error) {
-	r.MustAuthorize(ctx, input.ProcessingActivityID, probo.ActionTransferImpactAssessmentCreate)
+	if err := r.Authorize(ctx, input.ProcessingActivityID, probo.ActionTransferImpactAssessmentCreate); err != nil {
+		return nil, types.AddTransferImpactAssessmentOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ProcessingActivityID)
 	svc := r.proboSvc
@@ -1280,7 +1366,9 @@ func (r *Resolver) AddTransferImpactAssessmentTool(ctx context.Context, req *mcp
 }
 
 func (r *Resolver) UpdateTransferImpactAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateTransferImpactAssessmentInput) (*mcp.CallToolResult, types.UpdateTransferImpactAssessmentOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionTransferImpactAssessmentUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionTransferImpactAssessmentUpdate); err != nil {
+		return nil, types.UpdateTransferImpactAssessmentOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -1306,7 +1394,9 @@ func (r *Resolver) UpdateTransferImpactAssessmentTool(ctx context.Context, req *
 }
 
 func (r *Resolver) DeleteTransferImpactAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteTransferImpactAssessmentInput) (*mcp.CallToolResult, types.DeleteTransferImpactAssessmentOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionTransferImpactAssessmentDelete)
+	if err := r.Authorize(ctx, input.ID, probo.ActionTransferImpactAssessmentDelete); err != nil {
+		return nil, types.DeleteTransferImpactAssessmentOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -1322,7 +1412,9 @@ func (r *Resolver) DeleteTransferImpactAssessmentTool(ctx context.Context, req *
 }
 
 func (r *Resolver) ListAuditsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListAuditsInput) (*mcp.CallToolResult, types.ListAuditsOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionAuditList)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionAuditList); err != nil {
+		return nil, types.ListAuditsOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
@@ -1349,7 +1441,9 @@ func (r *Resolver) ListAuditsTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) GetAuditTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetAuditInput) (*mcp.CallToolResult, types.GetAuditOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionAuditGet)
+	if err := r.Authorize(ctx, input.ID, probo.ActionAuditGet); err != nil {
+		return nil, types.GetAuditOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -1373,7 +1467,9 @@ func (r *Resolver) GetAuditTool(ctx context.Context, req *mcp.CallToolRequest, i
 }
 
 func (r *Resolver) AddAuditTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddAuditInput) (*mcp.CallToolResult, types.AddAuditOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionAuditCreate)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionAuditCreate); err != nil {
+		return nil, types.AddAuditOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
@@ -1399,7 +1495,9 @@ func (r *Resolver) AddAuditTool(ctx context.Context, req *mcp.CallToolRequest, i
 }
 
 func (r *Resolver) UpdateAuditTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateAuditInput) (*mcp.CallToolResult, types.UpdateAuditOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionAuditUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionAuditUpdate); err != nil {
+		return nil, types.UpdateAuditOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -1433,7 +1531,9 @@ func (r *Resolver) UpdateAuditTool(ctx context.Context, req *mcp.CallToolRequest
 }
 
 func (r *Resolver) ListControlsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListControlsInput) (*mcp.CallToolResult, types.ListControlsOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionControlList)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionControlList); err != nil {
+		return nil, types.ListControlsOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
@@ -1475,7 +1575,9 @@ func (r *Resolver) ListControlsTool(ctx context.Context, req *mcp.CallToolReques
 }
 
 func (r *Resolver) GetControlTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetControlInput) (*mcp.CallToolResult, types.GetControlOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionControlGet)
+	if err := r.Authorize(ctx, input.ID, probo.ActionControlGet); err != nil {
+		return nil, types.GetControlOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -1491,7 +1593,9 @@ func (r *Resolver) GetControlTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) AddControlTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddControlInput) (*mcp.CallToolResult, types.AddControlOutput, error) {
-	r.MustAuthorize(ctx, input.FrameworkID, probo.ActionControlCreate)
+	if err := r.Authorize(ctx, input.FrameworkID, probo.ActionControlCreate); err != nil {
+		return nil, types.AddControlOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.FrameworkID)
 	svc := r.proboSvc
@@ -1518,7 +1622,9 @@ func (r *Resolver) AddControlTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) UpdateControlTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateControlInput) (*mcp.CallToolResult, types.UpdateControlOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionControlUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionControlUpdate); err != nil {
+		return nil, types.UpdateControlOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -1557,25 +1663,33 @@ func (r *Resolver) LinkControlTool(ctx context.Context, req *mcp.CallToolRequest
 
 	switch input.ResourceID.EntityType() {
 	case coredata.MeasureEntityType:
-		r.MustAuthorize(ctx, input.ControlID, probo.ActionControlMeasureMappingCreate)
+		if err := r.Authorize(ctx, input.ControlID, probo.ActionControlMeasureMappingCreate); err != nil {
+			return nil, types.LinkControlOutput{}, err
+		}
 
 		if _, _, err := svc.Controls.CreateMeasureMapping(ctx, scope, input.ControlID, input.ResourceID); err != nil {
 			return nil, types.LinkControlOutput{}, fmt.Errorf("failed to link control to measure: %w", err)
 		}
 	case coredata.DocumentEntityType:
-		r.MustAuthorize(ctx, input.ControlID, probo.ActionControlDocumentMappingCreate)
+		if err := r.Authorize(ctx, input.ControlID, probo.ActionControlDocumentMappingCreate); err != nil {
+			return nil, types.LinkControlOutput{}, err
+		}
 
 		if _, _, err := svc.Controls.CreateDocumentMapping(ctx, scope, input.ControlID, input.ResourceID); err != nil {
 			return nil, types.LinkControlOutput{}, fmt.Errorf("failed to link control to document: %w", err)
 		}
 	case coredata.AuditEntityType:
-		r.MustAuthorize(ctx, input.ControlID, probo.ActionControlAuditMappingCreate)
+		if err := r.Authorize(ctx, input.ControlID, probo.ActionControlAuditMappingCreate); err != nil {
+			return nil, types.LinkControlOutput{}, err
+		}
 
 		if _, _, err := svc.Controls.CreateAuditMapping(ctx, scope, input.ControlID, input.ResourceID); err != nil {
 			return nil, types.LinkControlOutput{}, fmt.Errorf("failed to link control to audit: %w", err)
 		}
 	case coredata.ObligationEntityType:
-		r.MustAuthorize(ctx, input.ControlID, probo.ActionControlObligationMappingCreate)
+		if err := r.Authorize(ctx, input.ControlID, probo.ActionControlObligationMappingCreate); err != nil {
+			return nil, types.LinkControlOutput{}, err
+		}
 
 		if _, _, err := svc.Controls.CreateObligationMapping(ctx, scope, input.ControlID, input.ResourceID); err != nil {
 			return nil, types.LinkControlOutput{}, fmt.Errorf("failed to link control to obligation: %w", err)
@@ -1593,25 +1707,33 @@ func (r *Resolver) UnlinkControlTool(ctx context.Context, req *mcp.CallToolReque
 
 	switch input.ResourceID.EntityType() {
 	case coredata.MeasureEntityType:
-		r.MustAuthorize(ctx, input.ControlID, probo.ActionControlMeasureMappingDelete)
+		if err := r.Authorize(ctx, input.ControlID, probo.ActionControlMeasureMappingDelete); err != nil {
+			return nil, types.UnlinkControlOutput{}, err
+		}
 
 		if _, _, err := svc.Controls.DeleteMeasureMapping(ctx, scope, input.ControlID, input.ResourceID); err != nil {
 			return nil, types.UnlinkControlOutput{}, fmt.Errorf("failed to unlink control from measure: %w", err)
 		}
 	case coredata.DocumentEntityType:
-		r.MustAuthorize(ctx, input.ControlID, probo.ActionControlDocumentMappingDelete)
+		if err := r.Authorize(ctx, input.ControlID, probo.ActionControlDocumentMappingDelete); err != nil {
+			return nil, types.UnlinkControlOutput{}, err
+		}
 
 		if _, _, err := svc.Controls.DeleteDocumentMapping(ctx, scope, input.ControlID, input.ResourceID); err != nil {
 			return nil, types.UnlinkControlOutput{}, fmt.Errorf("failed to unlink control from document: %w", err)
 		}
 	case coredata.AuditEntityType:
-		r.MustAuthorize(ctx, input.ControlID, probo.ActionControlAuditMappingDelete)
+		if err := r.Authorize(ctx, input.ControlID, probo.ActionControlAuditMappingDelete); err != nil {
+			return nil, types.UnlinkControlOutput{}, err
+		}
 
 		if _, _, err := svc.Controls.DeleteAuditMapping(ctx, scope, input.ControlID, input.ResourceID); err != nil {
 			return nil, types.UnlinkControlOutput{}, fmt.Errorf("failed to unlink control from audit: %w", err)
 		}
 	case coredata.ObligationEntityType:
-		r.MustAuthorize(ctx, input.ControlID, probo.ActionControlObligationMappingDelete)
+		if err := r.Authorize(ctx, input.ControlID, probo.ActionControlObligationMappingDelete); err != nil {
+			return nil, types.UnlinkControlOutput{}, err
+		}
 
 		if _, _, err := svc.Controls.DeleteObligationMapping(ctx, scope, input.ControlID, input.ResourceID); err != nil {
 			return nil, types.UnlinkControlOutput{}, fmt.Errorf("failed to unlink control from obligation: %w", err)
@@ -1624,7 +1746,9 @@ func (r *Resolver) UnlinkControlTool(ctx context.Context, req *mcp.CallToolReque
 }
 
 func (r *Resolver) ListControlObligationsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListControlObligationsInput) (*mcp.CallToolResult, types.ListControlObligationsOutput, error) {
-	r.MustAuthorize(ctx, input.ControlID, probo.ActionControlGet)
+	if err := r.Authorize(ctx, input.ControlID, probo.ActionControlGet); err != nil {
+		return nil, types.ListControlObligationsOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ControlID)
 	prb := r.proboSvc
@@ -1651,7 +1775,9 @@ func (r *Resolver) ListControlObligationsTool(ctx context.Context, req *mcp.Call
 }
 
 func (r *Resolver) ListControlMeasuresTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListControlMeasuresInput) (*mcp.CallToolResult, types.ListControlMeasuresOutput, error) {
-	r.MustAuthorize(ctx, input.ControlID, probo.ActionControlGet)
+	if err := r.Authorize(ctx, input.ControlID, probo.ActionControlGet); err != nil {
+		return nil, types.ListControlMeasuresOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ControlID)
 	prb := r.proboSvc
@@ -1678,7 +1804,9 @@ func (r *Resolver) ListControlMeasuresTool(ctx context.Context, req *mcp.CallToo
 }
 
 func (r *Resolver) ListControlDocumentsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListControlDocumentsInput) (*mcp.CallToolResult, types.ListControlDocumentsOutput, error) {
-	r.MustAuthorize(ctx, input.ControlID, probo.ActionControlGet)
+	if err := r.Authorize(ctx, input.ControlID, probo.ActionControlGet); err != nil {
+		return nil, types.ListControlDocumentsOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ControlID)
 	prb := r.proboSvc
@@ -1705,7 +1833,9 @@ func (r *Resolver) ListControlDocumentsTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) ListControlAuditsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListControlAuditsInput) (*mcp.CallToolResult, types.ListControlAuditsOutput, error) {
-	r.MustAuthorize(ctx, input.ControlID, probo.ActionControlGet)
+	if err := r.Authorize(ctx, input.ControlID, probo.ActionControlGet); err != nil {
+		return nil, types.ListControlAuditsOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ControlID)
 	prb := r.proboSvc
@@ -1732,7 +1862,9 @@ func (r *Resolver) ListControlAuditsTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) ListRiskObligationsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListRiskObligationsInput) (*mcp.CallToolResult, types.ListRiskObligationsOutput, error) {
-	r.MustAuthorize(ctx, input.RiskID, probo.ActionRiskGet)
+	if err := r.Authorize(ctx, input.RiskID, probo.ActionRiskGet); err != nil {
+		return nil, types.ListRiskObligationsOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.RiskID)
 	prb := r.proboSvc
@@ -1764,19 +1896,25 @@ func (r *Resolver) LinkRiskTool(ctx context.Context, req *mcp.CallToolRequest, i
 
 	switch input.ResourceID.EntityType() {
 	case coredata.DocumentEntityType:
-		r.MustAuthorize(ctx, input.RiskID, probo.ActionRiskDocumentMappingCreate)
+		if err := r.Authorize(ctx, input.RiskID, probo.ActionRiskDocumentMappingCreate); err != nil {
+			return nil, types.LinkRiskOutput{}, err
+		}
 
 		if _, _, err := svc.Risks.CreateDocumentMapping(ctx, scope, input.RiskID, input.ResourceID); err != nil {
 			return nil, types.LinkRiskOutput{}, fmt.Errorf("failed to link risk to document: %w", err)
 		}
 	case coredata.MeasureEntityType:
-		r.MustAuthorize(ctx, input.RiskID, probo.ActionRiskMeasureMappingCreate)
+		if err := r.Authorize(ctx, input.RiskID, probo.ActionRiskMeasureMappingCreate); err != nil {
+			return nil, types.LinkRiskOutput{}, err
+		}
 
 		if _, _, err := svc.Risks.CreateMeasureMapping(ctx, scope, input.RiskID, input.ResourceID); err != nil {
 			return nil, types.LinkRiskOutput{}, fmt.Errorf("failed to link risk to measure: %w", err)
 		}
 	case coredata.ObligationEntityType:
-		r.MustAuthorize(ctx, input.RiskID, probo.ActionRiskObligationMappingCreate)
+		if err := r.Authorize(ctx, input.RiskID, probo.ActionRiskObligationMappingCreate); err != nil {
+			return nil, types.LinkRiskOutput{}, err
+		}
 
 		if _, _, err := svc.Risks.CreateObligationMapping(ctx, scope, input.RiskID, input.ResourceID); err != nil {
 			return nil, types.LinkRiskOutput{}, fmt.Errorf("failed to link risk to obligation: %w", err)
@@ -1794,19 +1932,25 @@ func (r *Resolver) UnlinkRiskTool(ctx context.Context, req *mcp.CallToolRequest,
 
 	switch input.ResourceID.EntityType() {
 	case coredata.DocumentEntityType:
-		r.MustAuthorize(ctx, input.RiskID, probo.ActionRiskDocumentMappingDelete)
+		if err := r.Authorize(ctx, input.RiskID, probo.ActionRiskDocumentMappingDelete); err != nil {
+			return nil, types.UnlinkRiskOutput{}, err
+		}
 
 		if _, _, err := svc.Risks.DeleteDocumentMapping(ctx, scope, input.RiskID, input.ResourceID); err != nil {
 			return nil, types.UnlinkRiskOutput{}, fmt.Errorf("failed to unlink risk from document: %w", err)
 		}
 	case coredata.MeasureEntityType:
-		r.MustAuthorize(ctx, input.RiskID, probo.ActionRiskMeasureMappingDelete)
+		if err := r.Authorize(ctx, input.RiskID, probo.ActionRiskMeasureMappingDelete); err != nil {
+			return nil, types.UnlinkRiskOutput{}, err
+		}
 
 		if _, _, err := svc.Risks.DeleteMeasureMapping(ctx, scope, input.RiskID, input.ResourceID); err != nil {
 			return nil, types.UnlinkRiskOutput{}, fmt.Errorf("failed to unlink risk from measure: %w", err)
 		}
 	case coredata.ObligationEntityType:
-		r.MustAuthorize(ctx, input.RiskID, probo.ActionRiskObligationMappingDelete)
+		if err := r.Authorize(ctx, input.RiskID, probo.ActionRiskObligationMappingDelete); err != nil {
+			return nil, types.UnlinkRiskOutput{}, err
+		}
 
 		if _, _, err := svc.Risks.DeleteObligationMapping(ctx, scope, input.RiskID, input.ResourceID); err != nil {
 			return nil, types.UnlinkRiskOutput{}, fmt.Errorf("failed to unlink risk from obligation: %w", err)
@@ -1819,7 +1963,9 @@ func (r *Resolver) UnlinkRiskTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) ListTasksTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListTasksInput) (*mcp.CallToolResult, types.ListTasksOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionTaskList)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionTaskList); err != nil {
+		return nil, types.ListTasksOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
@@ -1846,7 +1992,9 @@ func (r *Resolver) ListTasksTool(ctx context.Context, req *mcp.CallToolRequest, 
 }
 
 func (r *Resolver) GetTaskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetTaskInput) (*mcp.CallToolResult, types.GetTaskOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionTaskGet)
+	if err := r.Authorize(ctx, input.ID, probo.ActionTaskGet); err != nil {
+		return nil, types.GetTaskOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -1862,7 +2010,9 @@ func (r *Resolver) GetTaskTool(ctx context.Context, req *mcp.CallToolRequest, in
 }
 
 func (r *Resolver) AddTaskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddTaskInput) (*mcp.CallToolResult, types.AddTaskOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionTaskCreate)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionTaskCreate); err != nil {
+		return nil, types.AddTaskOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
@@ -1895,7 +2045,9 @@ func (r *Resolver) AddTaskTool(ctx context.Context, req *mcp.CallToolRequest, in
 }
 
 func (r *Resolver) UpdateTaskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateTaskInput) (*mcp.CallToolResult, types.UpdateTaskOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionTaskUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionTaskUpdate); err != nil {
+		return nil, types.UpdateTaskOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -1925,7 +2077,9 @@ func (r *Resolver) UpdateTaskTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) AssignTaskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AssignTaskInput) (*mcp.CallToolResult, types.AssignTaskOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionTaskAssign)
+	if err := r.Authorize(ctx, input.ID, probo.ActionTaskAssign); err != nil {
+		return nil, types.AssignTaskOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -1941,7 +2095,9 @@ func (r *Resolver) AssignTaskTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) UnassignTaskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UnassignTaskInput) (*mcp.CallToolResult, types.UnassignTaskOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionTaskUnassign)
+	if err := r.Authorize(ctx, input.ID, probo.ActionTaskUnassign); err != nil {
+		return nil, types.UnassignTaskOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -1957,7 +2113,9 @@ func (r *Resolver) UnassignTaskTool(ctx context.Context, req *mcp.CallToolReques
 }
 
 func (r *Resolver) DeleteTaskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteTaskInput) (*mcp.CallToolResult, types.DeleteTaskOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionTaskDelete)
+	if err := r.Authorize(ctx, input.ID, probo.ActionTaskDelete); err != nil {
+		return nil, types.DeleteTaskOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -1973,7 +2131,9 @@ func (r *Resolver) DeleteTaskTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) ListDocumentsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListDocumentsInput) (*mcp.CallToolResult, types.ListDocumentsOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionDocumentList)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionDocumentList); err != nil {
+		return nil, types.ListDocumentsOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
@@ -2020,7 +2180,9 @@ func (r *Resolver) ListDocumentsTool(ctx context.Context, req *mcp.CallToolReque
 }
 
 func (r *Resolver) GetDocumentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetDocumentInput) (*mcp.CallToolResult, types.GetDocumentOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionDocumentGet)
+	if err := r.Authorize(ctx, input.ID, probo.ActionDocumentGet); err != nil {
+		return nil, types.GetDocumentOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -2036,7 +2198,9 @@ func (r *Resolver) GetDocumentTool(ctx context.Context, req *mcp.CallToolRequest
 }
 
 func (r *Resolver) AddDocumentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddDocumentInput) (*mcp.CallToolResult, types.AddDocumentOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionDocumentCreate)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionDocumentCreate); err != nil {
+		return nil, types.AddDocumentOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
@@ -2071,7 +2235,9 @@ func (r *Resolver) AddDocumentTool(ctx context.Context, req *mcp.CallToolRequest
 }
 
 func (r *Resolver) UpdateDocumentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateDocumentInput) (*mcp.CallToolResult, types.UpdateDocumentOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionDocumentUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionDocumentUpdate); err != nil {
+		return nil, types.UpdateDocumentOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -2120,7 +2286,9 @@ func (r *Resolver) UpdateDocumentTool(ctx context.Context, req *mcp.CallToolRequ
 }
 
 func (r *Resolver) ListDocumentVersionsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListDocumentVersionsInput) (*mcp.CallToolResult, types.ListDocumentVersionsOutput, error) {
-	r.MustAuthorize(ctx, input.DocumentID, probo.ActionDocumentVersionList)
+	if err := r.Authorize(ctx, input.DocumentID, probo.ActionDocumentVersionList); err != nil {
+		return nil, types.ListDocumentVersionsOutput{}, err
+	}
 
 	pageOrderBy := page.OrderBy[coredata.DocumentVersionOrderField]{
 		Field:     coredata.DocumentVersionOrderFieldCreatedAt,
@@ -2151,7 +2319,9 @@ func (r *Resolver) ListDocumentVersionsTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) GetDocumentVersionTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetDocumentVersionInput) (*mcp.CallToolResult, types.GetDocumentVersionOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionDocumentVersionGet)
+	if err := r.Authorize(ctx, input.ID, probo.ActionDocumentVersionGet); err != nil {
+		return nil, types.GetDocumentVersionOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -2167,7 +2337,9 @@ func (r *Resolver) GetDocumentVersionTool(ctx context.Context, req *mcp.CallTool
 }
 
 func (r *Resolver) ListDocumentVersionSignaturesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListDocumentVersionSignaturesInput) (*mcp.CallToolResult, types.ListDocumentVersionSignaturesOutput, error) {
-	r.MustAuthorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionSignatureList)
+	if err := r.Authorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionSignatureList); err != nil {
+		return nil, types.ListDocumentVersionSignaturesOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.DocumentVersionID)
 	prb := r.proboSvc
@@ -2216,7 +2388,9 @@ func (r *Resolver) ListDocumentVersionSignaturesTool(ctx context.Context, req *m
 }
 
 func (r *Resolver) GetDocumentVersionSignatureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetDocumentVersionSignatureInput) (*mcp.CallToolResult, types.GetDocumentVersionSignatureOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionDocumentVersionSignatureGet)
+	if err := r.Authorize(ctx, input.ID, probo.ActionDocumentVersionSignatureGet); err != nil {
+		return nil, types.GetDocumentVersionSignatureOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -2232,7 +2406,9 @@ func (r *Resolver) GetDocumentVersionSignatureTool(ctx context.Context, req *mcp
 }
 
 func (r *Resolver) RequestDocumentVersionSignatureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.RequestDocumentVersionSignatureInput) (*mcp.CallToolResult, types.RequestDocumentVersionSignatureOutput, error) {
-	r.MustAuthorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionSignatureRequest)
+	if err := r.Authorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionSignatureRequest); err != nil {
+		return nil, types.RequestDocumentVersionSignatureOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.DocumentVersionID)
 	svc := r.proboSvc
@@ -2254,7 +2430,9 @@ func (r *Resolver) RequestDocumentVersionSignatureTool(ctx context.Context, req 
 }
 
 func (r *Resolver) DeleteDocumentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteDocumentInput) (*mcp.CallToolResult, types.DeleteDocumentOutput, error) {
-	r.MustAuthorize(ctx, input.DocumentID, probo.ActionDocumentDelete)
+	if err := r.Authorize(ctx, input.DocumentID, probo.ActionDocumentDelete); err != nil {
+		return nil, types.DeleteDocumentOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.DocumentID)
 	svc := r.proboSvc
@@ -2270,7 +2448,9 @@ func (r *Resolver) DeleteDocumentTool(ctx context.Context, req *mcp.CallToolRequ
 }
 
 func (r *Resolver) CancelSignatureRequestTool(ctx context.Context, req *mcp.CallToolRequest, input *types.CancelSignatureRequestInput) (*mcp.CallToolResult, types.CancelSignatureRequestOutput, error) {
-	r.MustAuthorize(ctx, input.DocumentVersionSignatureID, probo.ActionDocumentVersionCancelSignature)
+	if err := r.Authorize(ctx, input.DocumentVersionSignatureID, probo.ActionDocumentVersionCancelSignature); err != nil {
+		return nil, types.CancelSignatureRequestOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.DocumentVersionSignatureID)
 	svc := r.proboSvc
@@ -2286,7 +2466,9 @@ func (r *Resolver) CancelSignatureRequestTool(ctx context.Context, req *mcp.Call
 }
 
 func (r *Resolver) DeleteRiskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteRiskInput) (*mcp.CallToolResult, types.DeleteRiskOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionRiskDelete)
+	if err := r.Authorize(ctx, input.ID, probo.ActionRiskDelete); err != nil {
+		return nil, types.DeleteRiskOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -2302,7 +2484,9 @@ func (r *Resolver) DeleteRiskTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) DeleteMeasureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteMeasureInput) (*mcp.CallToolResult, types.DeleteMeasureOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionMeasureDelete)
+	if err := r.Authorize(ctx, input.ID, probo.ActionMeasureDelete); err != nil {
+		return nil, types.DeleteMeasureOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -2318,7 +2502,9 @@ func (r *Resolver) DeleteMeasureTool(ctx context.Context, req *mcp.CallToolReque
 }
 
 func (r *Resolver) ListMeasureRisksTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListMeasureRisksInput) (*mcp.CallToolResult, types.ListMeasureRisksOutput, error) {
-	r.MustAuthorize(ctx, input.MeasureID, probo.ActionMeasureGet)
+	if err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureGet); err != nil {
+		return nil, types.ListMeasureRisksOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.MeasureID)
 	prb := r.proboSvc
@@ -2345,7 +2531,9 @@ func (r *Resolver) ListMeasureRisksTool(ctx context.Context, req *mcp.CallToolRe
 }
 
 func (r *Resolver) ListMeasureControlsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListMeasureControlsInput) (*mcp.CallToolResult, types.ListMeasureControlsOutput, error) {
-	r.MustAuthorize(ctx, input.MeasureID, probo.ActionMeasureGet)
+	if err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureGet); err != nil {
+		return nil, types.ListMeasureControlsOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.MeasureID)
 	prb := r.proboSvc
@@ -2372,7 +2560,9 @@ func (r *Resolver) ListMeasureControlsTool(ctx context.Context, req *mcp.CallToo
 }
 
 func (r *Resolver) ListMeasureTasksTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListMeasureTasksInput) (*mcp.CallToolResult, types.ListMeasureTasksOutput, error) {
-	r.MustAuthorize(ctx, input.MeasureID, probo.ActionMeasureGet)
+	if err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureGet); err != nil {
+		return nil, types.ListMeasureTasksOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.MeasureID)
 	prb := r.proboSvc
@@ -2399,7 +2589,9 @@ func (r *Resolver) ListMeasureTasksTool(ctx context.Context, req *mcp.CallToolRe
 }
 
 func (r *Resolver) ListMeasureEvidencesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListMeasureEvidencesInput) (*mcp.CallToolResult, types.ListMeasureEvidencesOutput, error) {
-	r.MustAuthorize(ctx, input.MeasureID, probo.ActionMeasureGet)
+	if err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureGet); err != nil {
+		return nil, types.ListMeasureEvidencesOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.MeasureID)
 	prb := r.proboSvc
@@ -2425,19 +2617,25 @@ func (r *Resolver) LinkMeasureTool(ctx context.Context, req *mcp.CallToolRequest
 
 	switch input.ResourceID.EntityType() {
 	case coredata.ControlEntityType:
-		r.MustAuthorize(ctx, input.MeasureID, probo.ActionControlMeasureMappingCreate)
+		if err := r.Authorize(ctx, input.MeasureID, probo.ActionControlMeasureMappingCreate); err != nil {
+			return nil, types.LinkMeasureOutput{}, err
+		}
 
 		if _, _, err := svc.Controls.CreateMeasureMapping(ctx, scope, input.ResourceID, input.MeasureID); err != nil {
 			return nil, types.LinkMeasureOutput{}, fmt.Errorf("failed to link measure to control: %w", err)
 		}
 	case coredata.RiskEntityType:
-		r.MustAuthorize(ctx, input.MeasureID, probo.ActionRiskMeasureMappingCreate)
+		if err := r.Authorize(ctx, input.MeasureID, probo.ActionRiskMeasureMappingCreate); err != nil {
+			return nil, types.LinkMeasureOutput{}, err
+		}
 
 		if _, _, err := svc.Risks.CreateMeasureMapping(ctx, scope, input.ResourceID, input.MeasureID); err != nil {
 			return nil, types.LinkMeasureOutput{}, fmt.Errorf("failed to link measure to risk: %w", err)
 		}
 	case coredata.DocumentEntityType:
-		r.MustAuthorize(ctx, input.MeasureID, probo.ActionMeasureDocumentMappingCreate)
+		if err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureDocumentMappingCreate); err != nil {
+			return nil, types.LinkMeasureOutput{}, err
+		}
 
 		if _, _, err := svc.Measures.CreateDocumentMapping(ctx, scope, input.MeasureID, input.ResourceID); err != nil {
 			return nil, types.LinkMeasureOutput{}, fmt.Errorf("failed to link measure to document: %w", err)
@@ -2455,19 +2653,25 @@ func (r *Resolver) UnlinkMeasureTool(ctx context.Context, req *mcp.CallToolReque
 
 	switch input.ResourceID.EntityType() {
 	case coredata.ControlEntityType:
-		r.MustAuthorize(ctx, input.MeasureID, probo.ActionControlMeasureMappingDelete)
+		if err := r.Authorize(ctx, input.MeasureID, probo.ActionControlMeasureMappingDelete); err != nil {
+			return nil, types.UnlinkMeasureOutput{}, err
+		}
 
 		if _, _, err := svc.Controls.DeleteMeasureMapping(ctx, scope, input.ResourceID, input.MeasureID); err != nil {
 			return nil, types.UnlinkMeasureOutput{}, fmt.Errorf("failed to unlink measure from control: %w", err)
 		}
 	case coredata.RiskEntityType:
-		r.MustAuthorize(ctx, input.MeasureID, probo.ActionRiskMeasureMappingDelete)
+		if err := r.Authorize(ctx, input.MeasureID, probo.ActionRiskMeasureMappingDelete); err != nil {
+			return nil, types.UnlinkMeasureOutput{}, err
+		}
 
 		if _, _, err := svc.Risks.DeleteMeasureMapping(ctx, scope, input.ResourceID, input.MeasureID); err != nil {
 			return nil, types.UnlinkMeasureOutput{}, fmt.Errorf("failed to unlink measure from risk: %w", err)
 		}
 	case coredata.DocumentEntityType:
-		r.MustAuthorize(ctx, input.MeasureID, probo.ActionMeasureDocumentMappingDelete)
+		if err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureDocumentMappingDelete); err != nil {
+			return nil, types.UnlinkMeasureOutput{}, err
+		}
 
 		if _, _, err := svc.Measures.DeleteDocumentMapping(ctx, scope, input.MeasureID, input.ResourceID); err != nil {
 			return nil, types.UnlinkMeasureOutput{}, fmt.Errorf("failed to unlink measure from document: %w", err)
@@ -2480,7 +2684,9 @@ func (r *Resolver) UnlinkMeasureTool(ctx context.Context, req *mcp.CallToolReque
 }
 
 func (r *Resolver) ListUsersTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListUsersInput) (*mcp.CallToolResult, types.ListUsersOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, iam.ActionMembershipProfileList)
+	if err := r.Authorize(ctx, input.OrganizationID, iam.ActionMembershipProfileList); err != nil {
+		return nil, types.ListUsersOutput{}, err
+	}
 
 	pageOrderBy := page.OrderBy[coredata.MembershipProfileOrderField]{
 		Field:     coredata.MembershipProfileOrderFieldCreatedAt,
@@ -2536,13 +2742,17 @@ func (r *Resolver) GetUserTool(ctx context.Context, req *mcp.CallToolRequest, in
 		return nil, types.GetUserOutput{}, fmt.Errorf("get user: %w", err)
 	}
 
-	r.MustAuthorize(ctx, profile.OrganizationID, iam.ActionMembershipProfileGet)
+	if err := r.Authorize(ctx, profile.OrganizationID, iam.ActionMembershipProfileGet); err != nil {
+		return nil, types.GetUserOutput{}, err
+	}
 
 	return nil, types.GetUserOutput{User: types.NewProfile(profile)}, nil
 }
 
 func (r *Resolver) CreateUserTool(ctx context.Context, req *mcp.CallToolRequest, input *types.CreateUserInput) (*mcp.CallToolResult, types.CreateUserOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, iam.ActionMembershipProfileCreate)
+	if err := r.Authorize(ctx, input.OrganizationID, iam.ActionMembershipProfileCreate); err != nil {
+		return nil, types.CreateUserOutput{}, err
+	}
 
 	var contractStart, contractEnd **time.Time
 	if input.ContractStartDate != nil {
@@ -2576,7 +2786,9 @@ func (r *Resolver) CreateUserTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) InviteUserTool(ctx context.Context, req *mcp.CallToolRequest, input *types.InviteUserInput) (*mcp.CallToolResult, types.InviteUserOutput, error) {
-	r.MustAuthorize(ctx, input.ProfileID, iam.ActionInvitationCreate)
+	if err := r.Authorize(ctx, input.ProfileID, iam.ActionInvitationCreate); err != nil {
+		return nil, types.InviteUserOutput{}, err
+	}
 
 	invitation, err := r.iamSvc.OrganizationService.InviteUser(ctx, &iam.CreateInvitationRequest{
 		OrganizationID: input.OrganizationID,
@@ -2598,7 +2810,9 @@ func (r *Resolver) InviteUserTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) UpdateUserTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateUserInput) (*mcp.CallToolResult, types.UpdateUserOutput, error) {
-	r.MustAuthorize(ctx, input.ID, iam.ActionMembershipProfileUpdate)
+	if err := r.Authorize(ctx, input.ID, iam.ActionMembershipProfileUpdate); err != nil {
+		return nil, types.UpdateUserOutput{}, err
+	}
 
 	var additionalEmails []mail.Addr
 	if input.AdditionalEmailAddresses != nil {
@@ -2636,10 +2850,14 @@ func (r *Resolver) UpdateUserTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) UpdateMembershipTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateMembershipInput) (*mcp.CallToolResult, types.UpdateMembershipOutput, error) {
-	r.MustAuthorize(ctx, input.MembershipID, iam.ActionMembershipUpdate)
+	if err := r.Authorize(ctx, input.MembershipID, iam.ActionMembershipUpdate); err != nil {
+		return nil, types.UpdateMembershipOutput{}, err
+	}
 
 	if input.Role == coredata.MembershipRoleOwner {
-		r.MustAuthorize(ctx, input.MembershipID, iam.ActionMembershipRoleSetOwner)
+		if err := r.Authorize(ctx, input.MembershipID, iam.ActionMembershipRoleSetOwner); err != nil {
+			return nil, types.UpdateMembershipOutput{}, err
+		}
 	}
 
 	membership, err := r.iamSvc.OrganizationService.UpdateMembership(ctx, input.OrganizationID, input.MembershipID, input.Role)
@@ -2657,7 +2875,9 @@ func (r *Resolver) UpdateMembershipTool(ctx context.Context, req *mcp.CallToolRe
 }
 
 func (r *Resolver) RemoveUserTool(ctx context.Context, req *mcp.CallToolRequest, input *types.RemoveUserInput) (*mcp.CallToolResult, types.RemoveUserOutput, error) {
-	r.MustAuthorize(ctx, input.ProfileID, iam.ActionMembershipProfileDelete)
+	if err := r.Authorize(ctx, input.ProfileID, iam.ActionMembershipProfileDelete); err != nil {
+		return nil, types.RemoveUserOutput{}, err
+	}
 
 	err := r.iamSvc.OrganizationService.RemoveUser(ctx, input.OrganizationID, input.ProfileID)
 	if err != nil {
@@ -2680,7 +2900,9 @@ func (r *Resolver) RemoveUserTool(ctx context.Context, req *mcp.CallToolRequest,
 }
 
 func (r *Resolver) DeleteDataProtectionImpactAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteDataProtectionImpactAssessmentInput) (*mcp.CallToolResult, types.DeleteDataProtectionImpactAssessmentOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionDataProtectionImpactAssessmentDelete)
+	if err := r.Authorize(ctx, input.ID, probo.ActionDataProtectionImpactAssessmentDelete); err != nil {
+		return nil, types.DeleteDataProtectionImpactAssessmentOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -2696,7 +2918,9 @@ func (r *Resolver) DeleteDataProtectionImpactAssessmentTool(ctx context.Context,
 }
 
 func (r *Resolver) ListStatementsOfApplicabilityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListStatementsOfApplicabilityInput) (*mcp.CallToolResult, types.ListStatementsOfApplicabilityOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionStatementOfApplicabilityList)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionStatementOfApplicabilityList); err != nil {
+		return nil, types.ListStatementsOfApplicabilityOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
@@ -2723,7 +2947,9 @@ func (r *Resolver) ListStatementsOfApplicabilityTool(ctx context.Context, req *m
 }
 
 func (r *Resolver) GetStatementOfApplicabilityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetStatementOfApplicabilityInput) (*mcp.CallToolResult, types.GetStatementOfApplicabilityOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionStatementOfApplicabilityGet)
+	if err := r.Authorize(ctx, input.ID, probo.ActionStatementOfApplicabilityGet); err != nil {
+		return nil, types.GetStatementOfApplicabilityOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -2739,7 +2965,9 @@ func (r *Resolver) GetStatementOfApplicabilityTool(ctx context.Context, req *mcp
 }
 
 func (r *Resolver) AddStatementOfApplicabilityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddStatementOfApplicabilityInput) (*mcp.CallToolResult, types.AddStatementOfApplicabilityOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionStatementOfApplicabilityCreate)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionStatementOfApplicabilityCreate); err != nil {
+		return nil, types.AddStatementOfApplicabilityOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
@@ -2758,7 +2986,9 @@ func (r *Resolver) AddStatementOfApplicabilityTool(ctx context.Context, req *mcp
 }
 
 func (r *Resolver) UpdateStatementOfApplicabilityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateStatementOfApplicabilityInput) (*mcp.CallToolResult, types.UpdateStatementOfApplicabilityOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionStatementOfApplicabilityUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionStatementOfApplicabilityUpdate); err != nil {
+		return nil, types.UpdateStatementOfApplicabilityOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -2777,7 +3007,9 @@ func (r *Resolver) UpdateStatementOfApplicabilityTool(ctx context.Context, req *
 }
 
 func (r *Resolver) DeleteStatementOfApplicabilityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteStatementOfApplicabilityInput) (*mcp.CallToolResult, types.DeleteStatementOfApplicabilityOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionStatementOfApplicabilityDelete)
+	if err := r.Authorize(ctx, input.ID, probo.ActionStatementOfApplicabilityDelete); err != nil {
+		return nil, types.DeleteStatementOfApplicabilityOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -2793,7 +3025,9 @@ func (r *Resolver) DeleteStatementOfApplicabilityTool(ctx context.Context, req *
 }
 
 func (r *Resolver) ListApplicabilityStatementsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListApplicabilityStatementsInput) (*mcp.CallToolResult, types.ListApplicabilityStatementsOutput, error) {
-	r.MustAuthorize(ctx, input.StatementOfApplicabilityID, probo.ActionApplicabilityStatementList)
+	if err := r.Authorize(ctx, input.StatementOfApplicabilityID, probo.ActionApplicabilityStatementList); err != nil {
+		return nil, types.ListApplicabilityStatementsOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.StatementOfApplicabilityID)
 	prb := r.proboSvc
@@ -2820,7 +3054,9 @@ func (r *Resolver) ListApplicabilityStatementsTool(ctx context.Context, req *mcp
 }
 
 func (r *Resolver) GetApplicabilityStatementTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetApplicabilityStatementInput) (*mcp.CallToolResult, types.GetApplicabilityStatementOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionApplicabilityStatementGet)
+	if err := r.Authorize(ctx, input.ID, probo.ActionApplicabilityStatementGet); err != nil {
+		return nil, types.GetApplicabilityStatementOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -2836,7 +3072,9 @@ func (r *Resolver) GetApplicabilityStatementTool(ctx context.Context, req *mcp.C
 }
 
 func (r *Resolver) AddApplicabilityStatementTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddApplicabilityStatementInput) (*mcp.CallToolResult, types.AddApplicabilityStatementOutput, error) {
-	r.MustAuthorize(ctx, input.StatementOfApplicabilityID, probo.ActionApplicabilityStatementCreate)
+	if err := r.Authorize(ctx, input.StatementOfApplicabilityID, probo.ActionApplicabilityStatementCreate); err != nil {
+		return nil, types.AddApplicabilityStatementOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.StatementOfApplicabilityID)
 	svc := r.proboSvc
@@ -2858,7 +3096,9 @@ func (r *Resolver) AddApplicabilityStatementTool(ctx context.Context, req *mcp.C
 }
 
 func (r *Resolver) UpdateApplicabilityStatementTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateApplicabilityStatementInput) (*mcp.CallToolResult, types.UpdateApplicabilityStatementOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionApplicabilityStatementUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionApplicabilityStatementUpdate); err != nil {
+		return nil, types.UpdateApplicabilityStatementOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -2879,7 +3119,9 @@ func (r *Resolver) UpdateApplicabilityStatementTool(ctx context.Context, req *mc
 }
 
 func (r *Resolver) DeleteApplicabilityStatementTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteApplicabilityStatementInput) (*mcp.CallToolResult, types.DeleteApplicabilityStatementOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionApplicabilityStatementDelete)
+	if err := r.Authorize(ctx, input.ID, probo.ActionApplicabilityStatementDelete); err != nil {
+		return nil, types.DeleteApplicabilityStatementOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -2897,7 +3139,9 @@ func (r *Resolver) DeleteApplicabilityStatementTool(ctx context.Context, req *mc
 // ListThirdPartyRiskAssessmentsTool handles the listThirdPartyRiskAssessments tool
 // List all risk assessments for a thirdParty
 func (r *Resolver) ListThirdPartyRiskAssessmentsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListThirdPartyRiskAssessmentsInput) (*mcp.CallToolResult, types.ListThirdPartyRiskAssessmentsOutput, error) {
-	r.MustAuthorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyRiskAssessmentList)
+	if err := r.Authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyRiskAssessmentList); err != nil {
+		return nil, types.ListThirdPartyRiskAssessmentsOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
 	prb := r.proboSvc
@@ -2926,7 +3170,9 @@ func (r *Resolver) ListThirdPartyRiskAssessmentsTool(ctx context.Context, req *m
 // AddThirdPartyRiskAssessmentTool handles the addThirdPartyRiskAssessment tool
 // Add a new risk assessment for a thirdParty
 func (r *Resolver) AddThirdPartyRiskAssessmentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddThirdPartyRiskAssessmentInput) (*mcp.CallToolResult, types.AddThirdPartyRiskAssessmentOutput, error) {
-	r.MustAuthorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyRiskAssessmentCreate)
+	if err := r.Authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyRiskAssessmentCreate); err != nil {
+		return nil, types.AddThirdPartyRiskAssessmentOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
 	prb := r.proboSvc
@@ -2949,7 +3195,9 @@ func (r *Resolver) AddThirdPartyRiskAssessmentTool(ctx context.Context, req *mcp
 }
 
 func (r *Resolver) DeleteThirdPartyTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteThirdPartyInput) (*mcp.CallToolResult, types.DeleteThirdPartyOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionThirdPartyDelete)
+	if err := r.Authorize(ctx, input.ID, probo.ActionThirdPartyDelete); err != nil {
+		return nil, types.DeleteThirdPartyOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -2965,7 +3213,9 @@ func (r *Resolver) DeleteThirdPartyTool(ctx context.Context, req *mcp.CallToolRe
 }
 
 func (r *Resolver) DeleteFindingTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteFindingInput) (*mcp.CallToolResult, types.DeleteFindingOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionFindingDelete)
+	if err := r.Authorize(ctx, input.ID, probo.ActionFindingDelete); err != nil {
+		return nil, types.DeleteFindingOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -2981,7 +3231,9 @@ func (r *Resolver) DeleteFindingTool(ctx context.Context, req *mcp.CallToolReque
 }
 
 func (r *Resolver) LinkFindingAuditTool(ctx context.Context, req *mcp.CallToolRequest, input *types.LinkFindingAuditInput) (*mcp.CallToolResult, types.LinkFindingAuditOutput, error) {
-	r.MustAuthorize(ctx, input.FindingID, probo.ActionFindingAuditMappingCreate)
+	if err := r.Authorize(ctx, input.FindingID, probo.ActionFindingAuditMappingCreate); err != nil {
+		return nil, types.LinkFindingAuditOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.FindingID)
 	svc := r.proboSvc
@@ -2998,7 +3250,9 @@ func (r *Resolver) LinkFindingAuditTool(ctx context.Context, req *mcp.CallToolRe
 }
 
 func (r *Resolver) UnlinkFindingAuditTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UnlinkFindingAuditInput) (*mcp.CallToolResult, types.UnlinkFindingAuditOutput, error) {
-	r.MustAuthorize(ctx, input.FindingID, probo.ActionFindingAuditMappingDelete)
+	if err := r.Authorize(ctx, input.FindingID, probo.ActionFindingAuditMappingDelete); err != nil {
+		return nil, types.UnlinkFindingAuditOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.FindingID)
 	svc := r.proboSvc
@@ -3015,7 +3269,9 @@ func (r *Resolver) UnlinkFindingAuditTool(ctx context.Context, req *mcp.CallTool
 }
 
 func (r *Resolver) ListFindingAuditsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListFindingAuditsInput) (*mcp.CallToolResult, types.ListFindingAuditsOutput, error) {
-	r.MustAuthorize(ctx, input.FindingID, probo.ActionFindingGet)
+	if err := r.Authorize(ctx, input.FindingID, probo.ActionFindingGet); err != nil {
+		return nil, types.ListFindingAuditsOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.FindingID)
 	prb := r.proboSvc
@@ -3044,7 +3300,9 @@ func (r *Resolver) ListFindingAuditsTool(ctx context.Context, req *mcp.CallToolR
 // ListAccessReviewCampaignsTool handles the listAccessReviewCampaigns tool
 // List access review campaigns for an organization
 func (r *Resolver) ListAccessReviewCampaignsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListAccessReviewCampaignsInput) (*mcp.CallToolResult, types.ListAccessReviewCampaignsOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionAccessReviewCampaignList)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionAccessReviewCampaignList); err != nil {
+		return nil, types.ListAccessReviewCampaignsOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 
@@ -3072,7 +3330,9 @@ func (r *Resolver) ListAccessReviewCampaignsTool(ctx context.Context, req *mcp.C
 // ListAccessEntriesTool handles the listAccessEntries tool
 // List access entries for a campaign with optional filters
 func (r *Resolver) ListAccessEntriesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListAccessEntriesInput) (*mcp.CallToolResult, types.ListAccessEntriesOutput, error) {
-	r.MustAuthorize(ctx, input.CampaignID, probo.ActionAccessEntryList)
+	if err := r.Authorize(ctx, input.CampaignID, probo.ActionAccessEntryList); err != nil {
+		return nil, types.ListAccessEntriesOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.CampaignID)
 
@@ -3130,7 +3390,9 @@ func (r *Resolver) ListAccessEntriesTool(ctx context.Context, req *mcp.CallToolR
 // GetAccessReviewCampaignStatisticsTool handles the getAccessReviewCampaignStatistics tool
 // Get statistics for an access review campaign
 func (r *Resolver) GetAccessReviewCampaignStatisticsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetAccessReviewCampaignStatisticsInput) (*mcp.CallToolResult, types.GetAccessReviewCampaignStatisticsOutput, error) {
-	r.MustAuthorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignGet)
+	if err := r.Authorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignGet); err != nil {
+		return nil, types.GetAccessReviewCampaignStatisticsOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.CampaignID)
 
@@ -3147,7 +3409,9 @@ func (r *Resolver) GetAccessReviewCampaignStatisticsTool(ctx context.Context, re
 // RecordAccessEntryDecisionTool handles the recordAccessEntryDecision tool
 // Record a decision on an access entry
 func (r *Resolver) RecordAccessEntryDecisionTool(ctx context.Context, req *mcp.CallToolRequest, input *types.RecordAccessEntryDecisionInput) (*mcp.CallToolResult, types.RecordAccessEntryDecisionOutput, error) {
-	r.MustAuthorize(ctx, input.AccessEntryID, probo.ActionAccessEntryDecide)
+	if err := r.Authorize(ctx, input.AccessEntryID, probo.ActionAccessEntryDecide); err != nil {
+		return nil, types.RecordAccessEntryDecisionOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.AccessEntryID)
 
@@ -3196,7 +3460,9 @@ func (r *Resolver) RecordAccessEntryDecisionsTool(ctx context.Context, req *mcp.
 
 	// Authorize each entry individually to prevent cross-org bypass.
 	for _, d := range input.Decisions {
-		r.MustAuthorize(ctx, d.AccessEntryID, probo.ActionAccessEntryDecide)
+		if err := r.Authorize(ctx, d.AccessEntryID, probo.ActionAccessEntryDecide); err != nil {
+			return nil, types.RecordAccessEntryDecisionsOutput{}, err
+		}
 	}
 
 	scope := coredata.NewScopeFromObjectID(input.Decisions[0].AccessEntryID)
@@ -3254,7 +3520,9 @@ func (r *Resolver) RecordAccessEntryDecisionsTool(ctx context.Context, req *mcp.
 // CloseAccessReviewCampaignTool handles the closeAccessReviewCampaign tool
 // Close an access review campaign
 func (r *Resolver) CloseAccessReviewCampaignTool(ctx context.Context, req *mcp.CallToolRequest, input *types.CloseAccessReviewCampaignInput) (*mcp.CallToolResult, types.CloseAccessReviewCampaignOutput, error) {
-	r.MustAuthorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignClose)
+	if err := r.Authorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignClose); err != nil {
+		return nil, types.CloseAccessReviewCampaignOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.CampaignID)
 
@@ -3271,7 +3539,9 @@ func (r *Resolver) CloseAccessReviewCampaignTool(ctx context.Context, req *mcp.C
 // ListAccessSourcesTool handles the listAccessSources tool
 // List access sources for an organization
 func (r *Resolver) ListAccessSourcesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListAccessSourcesInput) (*mcp.CallToolResult, types.ListAccessSourcesOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionAccessSourceList)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionAccessSourceList); err != nil {
+		return nil, types.ListAccessSourcesOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 
@@ -3299,7 +3569,9 @@ func (r *Resolver) ListAccessSourcesTool(ctx context.Context, req *mcp.CallToolR
 // CreateAccessSourceTool handles the createAccessSource tool
 // Create a new access source for an organization
 func (r *Resolver) CreateAccessSourceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.CreateAccessSourceInput) (*mcp.CallToolResult, types.CreateAccessSourceOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionAccessSourceCreate)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionAccessSourceCreate); err != nil {
+		return nil, types.CreateAccessSourceOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 
@@ -3322,7 +3594,9 @@ func (r *Resolver) CreateAccessSourceTool(ctx context.Context, req *mcp.CallTool
 // UpdateAccessSourceTool handles the updateAccessSource tool
 // Update an existing access source
 func (r *Resolver) UpdateAccessSourceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateAccessSourceInput) (*mcp.CallToolResult, types.UpdateAccessSourceOutput, error) {
-	r.MustAuthorize(ctx, input.AccessSourceID, probo.ActionAccessSourceUpdate)
+	if err := r.Authorize(ctx, input.AccessSourceID, probo.ActionAccessSourceUpdate); err != nil {
+		return nil, types.UpdateAccessSourceOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.AccessSourceID)
 
@@ -3364,7 +3638,9 @@ func (r *Resolver) UpdateAccessSourceTool(ctx context.Context, req *mcp.CallTool
 // DeleteAccessSourceTool handles the deleteAccessSource tool
 // Delete an access source
 func (r *Resolver) DeleteAccessSourceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteAccessSourceInput) (*mcp.CallToolResult, types.DeleteAccessSourceOutput, error) {
-	r.MustAuthorize(ctx, input.AccessSourceID, probo.ActionAccessSourceDelete)
+	if err := r.Authorize(ctx, input.AccessSourceID, probo.ActionAccessSourceDelete); err != nil {
+		return nil, types.DeleteAccessSourceOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.AccessSourceID)
 
@@ -3380,7 +3656,9 @@ func (r *Resolver) DeleteAccessSourceTool(ctx context.Context, req *mcp.CallTool
 // CreateAccessReviewCampaignTool handles the createAccessReviewCampaign tool
 // Create a new access review campaign for an organization
 func (r *Resolver) CreateAccessReviewCampaignTool(ctx context.Context, req *mcp.CallToolRequest, input *types.CreateAccessReviewCampaignInput) (*mcp.CallToolResult, types.CreateAccessReviewCampaignOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionAccessReviewCampaignCreate)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionAccessReviewCampaignCreate); err != nil {
+		return nil, types.CreateAccessReviewCampaignOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 
@@ -3408,7 +3686,9 @@ func (r *Resolver) CreateAccessReviewCampaignTool(ctx context.Context, req *mcp.
 // UpdateAccessReviewCampaignTool handles the updateAccessReviewCampaign tool
 // Update an existing access review campaign
 func (r *Resolver) UpdateAccessReviewCampaignTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateAccessReviewCampaignInput) (*mcp.CallToolResult, types.UpdateAccessReviewCampaignOutput, error) {
-	r.MustAuthorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignUpdate)
+	if err := r.Authorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignUpdate); err != nil {
+		return nil, types.UpdateAccessReviewCampaignOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.CampaignID)
 
@@ -3447,7 +3727,9 @@ func (r *Resolver) UpdateAccessReviewCampaignTool(ctx context.Context, req *mcp.
 // DeleteAccessReviewCampaignTool handles the deleteAccessReviewCampaign tool
 // Delete an access review campaign
 func (r *Resolver) DeleteAccessReviewCampaignTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteAccessReviewCampaignInput) (*mcp.CallToolResult, types.DeleteAccessReviewCampaignOutput, error) {
-	r.MustAuthorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignDelete)
+	if err := r.Authorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignDelete); err != nil {
+		return nil, types.DeleteAccessReviewCampaignOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.CampaignID)
 
@@ -3463,7 +3745,9 @@ func (r *Resolver) DeleteAccessReviewCampaignTool(ctx context.Context, req *mcp.
 // StartAccessReviewCampaignTool handles the startAccessReviewCampaign tool
 // Start an access review campaign
 func (r *Resolver) StartAccessReviewCampaignTool(ctx context.Context, req *mcp.CallToolRequest, input *types.StartAccessReviewCampaignInput) (*mcp.CallToolResult, types.StartAccessReviewCampaignOutput, error) {
-	r.MustAuthorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignStart)
+	if err := r.Authorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignStart); err != nil {
+		return nil, types.StartAccessReviewCampaignOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.CampaignID)
 
@@ -3480,7 +3764,9 @@ func (r *Resolver) StartAccessReviewCampaignTool(ctx context.Context, req *mcp.C
 // CancelAccessReviewCampaignTool handles the cancelAccessReviewCampaign tool
 // Cancel an in-progress access review campaign
 func (r *Resolver) CancelAccessReviewCampaignTool(ctx context.Context, req *mcp.CallToolRequest, input *types.CancelAccessReviewCampaignInput) (*mcp.CallToolResult, types.CancelAccessReviewCampaignOutput, error) {
-	r.MustAuthorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignCancel)
+	if err := r.Authorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignCancel); err != nil {
+		return nil, types.CancelAccessReviewCampaignOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.CampaignID)
 
@@ -3497,7 +3783,9 @@ func (r *Resolver) CancelAccessReviewCampaignTool(ctx context.Context, req *mcp.
 // AddAccessReviewCampaignScopeSourceTool handles the addAccessReviewCampaignScopeSource tool
 // Add an access source to an access review campaign's scope
 func (r *Resolver) AddAccessReviewCampaignScopeSourceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddAccessReviewCampaignScopeSourceInput) (*mcp.CallToolResult, types.AddAccessReviewCampaignScopeSourceOutput, error) {
-	r.MustAuthorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignAddScopeSource)
+	if err := r.Authorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignAddScopeSource); err != nil {
+		return nil, types.AddAccessReviewCampaignScopeSourceOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.CampaignID)
 
@@ -3517,7 +3805,9 @@ func (r *Resolver) AddAccessReviewCampaignScopeSourceTool(ctx context.Context, r
 // RemoveAccessReviewCampaignScopeSourceTool handles the removeAccessReviewCampaignScopeSource tool
 // Remove an access source from an access review campaign's scope
 func (r *Resolver) RemoveAccessReviewCampaignScopeSourceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.RemoveAccessReviewCampaignScopeSourceInput) (*mcp.CallToolResult, types.RemoveAccessReviewCampaignScopeSourceOutput, error) {
-	r.MustAuthorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignRemoveScopeSource)
+	if err := r.Authorize(ctx, input.CampaignID, probo.ActionAccessReviewCampaignRemoveScopeSource); err != nil {
+		return nil, types.RemoveAccessReviewCampaignScopeSourceOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.CampaignID)
 
@@ -3537,7 +3827,9 @@ func (r *Resolver) RemoveAccessReviewCampaignScopeSourceTool(ctx context.Context
 // FlagAccessEntryTool handles the flagAccessEntry tool
 // Flag an access entry during review
 func (r *Resolver) FlagAccessEntryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.FlagAccessEntryInput) (*mcp.CallToolResult, types.FlagAccessEntryOutput, error) {
-	r.MustAuthorize(ctx, input.AccessEntryID, probo.ActionAccessEntryFlag)
+	if err := r.Authorize(ctx, input.AccessEntryID, probo.ActionAccessEntryFlag); err != nil {
+		return nil, types.FlagAccessEntryOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.AccessEntryID)
 
@@ -3556,7 +3848,9 @@ func (r *Resolver) FlagAccessEntryTool(ctx context.Context, req *mcp.CallToolReq
 }
 
 func (r *Resolver) GetAuditReportUrlTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetAuditReportUrlInput) (*mcp.CallToolResult, types.GetAuditReportUrlOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionReportGetReportUrl)
+	if err := r.Authorize(ctx, input.ID, probo.ActionReportGetReportUrl); err != nil {
+		return nil, types.GetAuditReportUrlOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -3572,7 +3866,9 @@ func (r *Resolver) GetAuditReportUrlTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) ArchiveDocumentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ArchiveDocumentInput) (*mcp.CallToolResult, types.ArchiveDocumentOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionDocumentArchive)
+	if err := r.Authorize(ctx, input.ID, probo.ActionDocumentArchive); err != nil {
+		return nil, types.ArchiveDocumentOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -3588,7 +3884,9 @@ func (r *Resolver) ArchiveDocumentTool(ctx context.Context, req *mcp.CallToolReq
 }
 
 func (r *Resolver) UnarchiveDocumentTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UnarchiveDocumentInput) (*mcp.CallToolResult, types.UnarchiveDocumentOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionDocumentUnarchive)
+	if err := r.Authorize(ctx, input.ID, probo.ActionDocumentUnarchive); err != nil {
+		return nil, types.UnarchiveDocumentOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -3604,7 +3902,9 @@ func (r *Resolver) UnarchiveDocumentTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) GetOrganizationContextTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetOrganizationContextInput) (*mcp.CallToolResult, types.GetOrganizationContextOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionOrganizationContextGet)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionOrganizationContextGet); err != nil {
+		return nil, types.GetOrganizationContextOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
@@ -3620,7 +3920,9 @@ func (r *Resolver) GetOrganizationContextTool(ctx context.Context, req *mcp.Call
 }
 
 func (r *Resolver) UpdateOrganizationContextTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateOrganizationContextInput) (*mcp.CallToolResult, types.UpdateOrganizationContextOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionOrganizationContextUpdate)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionOrganizationContextUpdate); err != nil {
+		return nil, types.UpdateOrganizationContextOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
@@ -3646,7 +3948,9 @@ func (r *Resolver) UpdateOrganizationContextTool(ctx context.Context, req *mcp.C
 }
 
 func (r *Resolver) GetAuditLogEntryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetAuditLogEntryInput) (*mcp.CallToolResult, types.GetAuditLogEntryOutput, error) {
-	r.MustAuthorize(ctx, input.ID, iam.ActionAuditLogEntryGet)
+	if err := r.Authorize(ctx, input.ID, iam.ActionAuditLogEntryGet); err != nil {
+		return nil, types.GetAuditLogEntryOutput{}, err
+	}
 
 	entry, err := r.iamSvc.OrganizationService.GetAuditLogEntry(ctx, input.ID)
 	if err != nil {
@@ -3659,7 +3963,9 @@ func (r *Resolver) GetAuditLogEntryTool(ctx context.Context, req *mcp.CallToolRe
 }
 
 func (r *Resolver) ListAuditLogEntriesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListAuditLogEntriesInput) (*mcp.CallToolResult, types.ListAuditLogEntriesOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, iam.ActionAuditLogEntryList)
+	if err := r.Authorize(ctx, input.OrganizationID, iam.ActionAuditLogEntryList); err != nil {
+		return nil, types.ListAuditLogEntriesOutput{}, err
+	}
 
 	pageOrderBy := page.OrderBy[coredata.AuditLogEntryOrderField]{
 		Field:     coredata.AuditLogEntryOrderFieldCreatedAt,
@@ -3697,7 +4003,9 @@ func (r *Resolver) ListAuditLogEntriesTool(ctx context.Context, req *mcp.CallToo
 }
 
 func (r *Resolver) ListMeasureDocumentsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListMeasureDocumentsInput) (*mcp.CallToolResult, types.ListMeasureDocumentsOutput, error) {
-	r.MustAuthorize(ctx, input.MeasureID, probo.ActionMeasureGet)
+	if err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureGet); err != nil {
+		return nil, types.ListMeasureDocumentsOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.MeasureID)
 	prb := r.proboSvc
@@ -3724,7 +4032,9 @@ func (r *Resolver) ListMeasureDocumentsTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) VoidDocumentVersionApprovalTool(ctx context.Context, req *mcp.CallToolRequest, input *types.VoidDocumentVersionApprovalInput) (*mcp.CallToolResult, types.VoidDocumentVersionApprovalOutput, error) {
-	r.MustAuthorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionVoidApproval)
+	if err := r.Authorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionVoidApproval); err != nil {
+		return nil, types.VoidDocumentVersionApprovalOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.DocumentVersionID)
 	svc := r.proboSvc
@@ -3740,7 +4050,9 @@ func (r *Resolver) VoidDocumentVersionApprovalTool(ctx context.Context, req *mcp
 }
 
 func (r *Resolver) SendSigningNotificationsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.SendSigningNotificationsInput) (*mcp.CallToolResult, types.SendSigningNotificationsOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionDocumentSendSigningNotifications)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionDocumentSendSigningNotifications); err != nil {
+		return nil, types.SendSigningNotificationsOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
@@ -3756,7 +4068,9 @@ func (r *Resolver) SendSigningNotificationsTool(ctx context.Context, req *mcp.Ca
 }
 
 func (r *Resolver) DeleteDocumentDraftTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteDocumentDraftInput) (*mcp.CallToolResult, types.DeleteDocumentDraftOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionDocumentDeleteDraft)
+	if err := r.Authorize(ctx, input.ID, probo.ActionDocumentDeleteDraft); err != nil {
+		return nil, types.DeleteDocumentDraftOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -3772,7 +4086,9 @@ func (r *Resolver) DeleteDocumentDraftTool(ctx context.Context, req *mcp.CallToo
 }
 
 func (r *Resolver) PublishStatementOfApplicabilityTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishStatementOfApplicabilityInput) (*mcp.CallToolResult, types.PublishStatementOfApplicabilityOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionStatementOfApplicabilityPublish)
+	if err := r.Authorize(ctx, input.ID, probo.ActionStatementOfApplicabilityPublish); err != nil {
+		return nil, types.PublishStatementOfApplicabilityOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -3789,7 +4105,9 @@ func (r *Resolver) PublishStatementOfApplicabilityTool(ctx context.Context, req 
 }
 
 func (r *Resolver) ListWebhookSubscriptionsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListWebhookSubscriptionsInput) (*mcp.CallToolResult, types.ListWebhookSubscriptionsOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionWebhookSubscriptionList)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionWebhookSubscriptionList); err != nil {
+		return nil, types.ListWebhookSubscriptionsOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
@@ -3816,7 +4134,9 @@ func (r *Resolver) ListWebhookSubscriptionsTool(ctx context.Context, req *mcp.Ca
 }
 
 func (r *Resolver) GetWebhookSubscriptionTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetWebhookSubscriptionInput) (*mcp.CallToolResult, types.GetWebhookSubscriptionOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionWebhookSubscriptionGet)
+	if err := r.Authorize(ctx, input.ID, probo.ActionWebhookSubscriptionGet); err != nil {
+		return nil, types.GetWebhookSubscriptionOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -3832,7 +4152,9 @@ func (r *Resolver) GetWebhookSubscriptionTool(ctx context.Context, req *mcp.Call
 }
 
 func (r *Resolver) CreateWebhookSubscriptionTool(ctx context.Context, req *mcp.CallToolRequest, input *types.CreateWebhookSubscriptionInput) (*mcp.CallToolResult, types.CreateWebhookSubscriptionOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionWebhookSubscriptionCreate)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionWebhookSubscriptionCreate); err != nil {
+		return nil, types.CreateWebhookSubscriptionOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
@@ -3855,7 +4177,9 @@ func (r *Resolver) CreateWebhookSubscriptionTool(ctx context.Context, req *mcp.C
 }
 
 func (r *Resolver) UpdateWebhookSubscriptionTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateWebhookSubscriptionInput) (*mcp.CallToolResult, types.UpdateWebhookSubscriptionOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionWebhookSubscriptionUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionWebhookSubscriptionUpdate); err != nil {
+		return nil, types.UpdateWebhookSubscriptionOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -3878,7 +4202,9 @@ func (r *Resolver) UpdateWebhookSubscriptionTool(ctx context.Context, req *mcp.C
 }
 
 func (r *Resolver) DeleteWebhookSubscriptionTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteWebhookSubscriptionInput) (*mcp.CallToolResult, types.DeleteWebhookSubscriptionOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionWebhookSubscriptionDelete)
+	if err := r.Authorize(ctx, input.ID, probo.ActionWebhookSubscriptionDelete); err != nil {
+		return nil, types.DeleteWebhookSubscriptionOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -3894,7 +4220,9 @@ func (r *Resolver) DeleteWebhookSubscriptionTool(ctx context.Context, req *mcp.C
 }
 
 func (r *Resolver) ListWebhookEventsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListWebhookEventsInput) (*mcp.CallToolResult, types.ListWebhookEventsOutput, error) {
-	r.MustAuthorize(ctx, input.WebhookSubscriptionID, probo.ActionWebhookSubscriptionGet)
+	if err := r.Authorize(ctx, input.WebhookSubscriptionID, probo.ActionWebhookSubscriptionGet); err != nil {
+		return nil, types.ListWebhookEventsOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.WebhookSubscriptionID)
 	prb := r.proboSvc
@@ -3921,7 +4249,9 @@ func (r *Resolver) ListWebhookEventsTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) ListDocumentVersionApprovalQuorumsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListDocumentVersionApprovalQuorumsInput) (*mcp.CallToolResult, types.ListDocumentVersionApprovalQuorumsOutput, error) {
-	r.MustAuthorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionApprovalList)
+	if err := r.Authorize(ctx, input.DocumentVersionID, probo.ActionDocumentVersionApprovalList); err != nil {
+		return nil, types.ListDocumentVersionApprovalQuorumsOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.DocumentVersionID)
 	svc := r.proboSvc
@@ -3948,7 +4278,9 @@ func (r *Resolver) ListDocumentVersionApprovalQuorumsTool(ctx context.Context, r
 }
 
 func (r *Resolver) GetDocumentVersionApprovalQuorumTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetDocumentVersionApprovalQuorumInput) (*mcp.CallToolResult, types.GetDocumentVersionApprovalQuorumOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionDocumentVersionApprovalList)
+	if err := r.Authorize(ctx, input.ID, probo.ActionDocumentVersionApprovalList); err != nil {
+		return nil, types.GetDocumentVersionApprovalQuorumOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -3964,7 +4296,9 @@ func (r *Resolver) GetDocumentVersionApprovalQuorumTool(ctx context.Context, req
 }
 
 func (r *Resolver) ListDocumentVersionApprovalDecisionsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListDocumentVersionApprovalDecisionsInput) (*mcp.CallToolResult, types.ListDocumentVersionApprovalDecisionsOutput, error) {
-	r.MustAuthorize(ctx, input.QuorumID, probo.ActionDocumentVersionApprovalList)
+	if err := r.Authorize(ctx, input.QuorumID, probo.ActionDocumentVersionApprovalList); err != nil {
+		return nil, types.ListDocumentVersionApprovalDecisionsOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.QuorumID)
 	svc := r.proboSvc
@@ -3998,7 +4332,9 @@ func (r *Resolver) ListDocumentVersionApprovalDecisionsTool(ctx context.Context,
 }
 
 func (r *Resolver) GetDocumentVersionApprovalDecisionTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetDocumentVersionApprovalDecisionInput) (*mcp.CallToolResult, types.GetDocumentVersionApprovalDecisionOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionDocumentVersionApprovalList)
+	if err := r.Authorize(ctx, input.ID, probo.ActionDocumentVersionApprovalList); err != nil {
+		return nil, types.GetDocumentVersionApprovalDecisionOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -4014,7 +4350,9 @@ func (r *Resolver) GetDocumentVersionApprovalDecisionTool(ctx context.Context, r
 }
 
 func (r *Resolver) PublishDataListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishDataListInput) (*mcp.CallToolResult, types.PublishDataListOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionDatumPublish)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionDatumPublish); err != nil {
+		return nil, types.PublishDataListOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
@@ -4031,7 +4369,9 @@ func (r *Resolver) PublishDataListTool(ctx context.Context, req *mcp.CallToolReq
 }
 
 func (r *Resolver) PublishAssetListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishAssetListInput) (*mcp.CallToolResult, types.PublishAssetListOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionAssetPublish)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionAssetPublish); err != nil {
+		return nil, types.PublishAssetListOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
@@ -4050,7 +4390,9 @@ func (r *Resolver) PublishAssetListTool(ctx context.Context, req *mcp.CallToolRe
 // ListThirdPartyContactsTool handles the listThirdPartyContacts tool
 // List all contacts for a thirdParty
 func (r *Resolver) ListThirdPartyContactsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListThirdPartyContactsInput) (*mcp.CallToolResult, types.ListThirdPartyContactsOutput, error) {
-	r.MustAuthorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyContactList)
+	if err := r.Authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyContactList); err != nil {
+		return nil, types.ListThirdPartyContactsOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
 	prb := r.proboSvc
@@ -4079,7 +4421,9 @@ func (r *Resolver) ListThirdPartyContactsTool(ctx context.Context, req *mcp.Call
 // AddThirdPartyContactTool handles the addThirdPartyContact tool
 // Add a new contact to a thirdParty
 func (r *Resolver) AddThirdPartyContactTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddThirdPartyContactInput) (*mcp.CallToolResult, types.AddThirdPartyContactOutput, error) {
-	r.MustAuthorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyContactCreate)
+	if err := r.Authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyContactCreate); err != nil {
+		return nil, types.AddThirdPartyContactOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
 	prb := r.proboSvc
@@ -4108,7 +4452,9 @@ func (r *Resolver) AddThirdPartyContactTool(ctx context.Context, req *mcp.CallTo
 // UpdateThirdPartyContactTool handles the updateThirdPartyContact tool
 // Update an existing thirdParty contact
 func (r *Resolver) UpdateThirdPartyContactTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateThirdPartyContactInput) (*mcp.CallToolResult, types.UpdateThirdPartyContactOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionThirdPartyContactUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionThirdPartyContactUpdate); err != nil {
+		return nil, types.UpdateThirdPartyContactOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -4152,7 +4498,9 @@ func (r *Resolver) UpdateThirdPartyContactTool(ctx context.Context, req *mcp.Cal
 // DeleteThirdPartyContactTool handles the deleteThirdPartyContact tool
 // Delete a thirdParty contact
 func (r *Resolver) DeleteThirdPartyContactTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteThirdPartyContactInput) (*mcp.CallToolResult, types.DeleteThirdPartyContactOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionThirdPartyContactDelete)
+	if err := r.Authorize(ctx, input.ID, probo.ActionThirdPartyContactDelete); err != nil {
+		return nil, types.DeleteThirdPartyContactOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -4170,7 +4518,9 @@ func (r *Resolver) DeleteThirdPartyContactTool(ctx context.Context, req *mcp.Cal
 // ListThirdPartyServicesTool handles the listThirdPartyServices tool
 // List all services for a thirdParty
 func (r *Resolver) ListThirdPartyServicesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListThirdPartyServicesInput) (*mcp.CallToolResult, types.ListThirdPartyServicesOutput, error) {
-	r.MustAuthorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyServiceList)
+	if err := r.Authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyServiceList); err != nil {
+		return nil, types.ListThirdPartyServicesOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
 	prb := r.proboSvc
@@ -4199,7 +4549,9 @@ func (r *Resolver) ListThirdPartyServicesTool(ctx context.Context, req *mcp.Call
 // AddThirdPartyServiceTool handles the addThirdPartyService tool
 // Add a new service to a thirdParty
 func (r *Resolver) AddThirdPartyServiceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddThirdPartyServiceInput) (*mcp.CallToolResult, types.AddThirdPartyServiceOutput, error) {
-	r.MustAuthorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyServiceCreate)
+	if err := r.Authorize(ctx, input.ThirdPartyID, probo.ActionThirdPartyServiceCreate); err != nil {
+		return nil, types.AddThirdPartyServiceOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ThirdPartyID)
 	prb := r.proboSvc
@@ -4221,7 +4573,9 @@ func (r *Resolver) AddThirdPartyServiceTool(ctx context.Context, req *mcp.CallTo
 // UpdateThirdPartyServiceTool handles the updateThirdPartyService tool
 // Update an existing thirdParty service
 func (r *Resolver) UpdateThirdPartyServiceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateThirdPartyServiceInput) (*mcp.CallToolResult, types.UpdateThirdPartyServiceOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionThirdPartyServiceUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionThirdPartyServiceUpdate); err != nil {
+		return nil, types.UpdateThirdPartyServiceOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -4251,7 +4605,9 @@ func (r *Resolver) UpdateThirdPartyServiceTool(ctx context.Context, req *mcp.Cal
 // DeleteThirdPartyServiceTool handles the deleteThirdPartyService tool
 // Delete a thirdParty service
 func (r *Resolver) DeleteThirdPartyServiceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteThirdPartyServiceInput) (*mcp.CallToolResult, types.DeleteThirdPartyServiceOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionThirdPartyServiceDelete)
+	if err := r.Authorize(ctx, input.ID, probo.ActionThirdPartyServiceDelete); err != nil {
+		return nil, types.DeleteThirdPartyServiceOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -4266,7 +4622,9 @@ func (r *Resolver) DeleteThirdPartyServiceTool(ctx context.Context, req *mcp.Cal
 	}, nil
 }
 func (r *Resolver) DeleteAssetTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteAssetInput) (*mcp.CallToolResult, types.DeleteAssetOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionAssetDelete)
+	if err := r.Authorize(ctx, input.ID, probo.ActionAssetDelete); err != nil {
+		return nil, types.DeleteAssetOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -4281,7 +4639,9 @@ func (r *Resolver) DeleteAssetTool(ctx context.Context, req *mcp.CallToolRequest
 	}, nil
 }
 func (r *Resolver) DeleteDatumTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteDatumInput) (*mcp.CallToolResult, types.DeleteDatumOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionDatumDelete)
+	if err := r.Authorize(ctx, input.ID, probo.ActionDatumDelete); err != nil {
+		return nil, types.DeleteDatumOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -4296,7 +4656,9 @@ func (r *Resolver) DeleteDatumTool(ctx context.Context, req *mcp.CallToolRequest
 	}, nil
 }
 func (r *Resolver) DeleteObligationTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteObligationInput) (*mcp.CallToolResult, types.DeleteObligationOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionObligationDelete)
+	if err := r.Authorize(ctx, input.ID, probo.ActionObligationDelete); err != nil {
+		return nil, types.DeleteObligationOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -4311,7 +4673,9 @@ func (r *Resolver) DeleteObligationTool(ctx context.Context, req *mcp.CallToolRe
 	}, nil
 }
 func (r *Resolver) DeleteAuditTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteAuditInput) (*mcp.CallToolResult, types.DeleteAuditOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionAuditDelete)
+	if err := r.Authorize(ctx, input.ID, probo.ActionAuditDelete); err != nil {
+		return nil, types.DeleteAuditOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -4326,7 +4690,9 @@ func (r *Resolver) DeleteAuditTool(ctx context.Context, req *mcp.CallToolRequest
 	}, nil
 }
 func (r *Resolver) ListRightsRequestsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListRightsRequestsInput) (*mcp.CallToolResult, types.ListRightsRequestsOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionRightsRequestList)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionRightsRequestList); err != nil {
+		return nil, types.ListRightsRequestsOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
@@ -4352,7 +4718,9 @@ func (r *Resolver) ListRightsRequestsTool(ctx context.Context, req *mcp.CallTool
 	return nil, types.NewListRightsRequestsOutput(page), nil
 }
 func (r *Resolver) GetRightsRequestTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetRightsRequestInput) (*mcp.CallToolResult, types.GetRightsRequestOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionRightsRequestGet)
+	if err := r.Authorize(ctx, input.ID, probo.ActionRightsRequestGet); err != nil {
+		return nil, types.GetRightsRequestOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -4367,7 +4735,9 @@ func (r *Resolver) GetRightsRequestTool(ctx context.Context, req *mcp.CallToolRe
 	}, nil
 }
 func (r *Resolver) AddRightsRequestTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddRightsRequestInput) (*mcp.CallToolResult, types.AddRightsRequestOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionRightsRequestCreate)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionRightsRequestCreate); err != nil {
+		return nil, types.AddRightsRequestOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
@@ -4394,7 +4764,9 @@ func (r *Resolver) AddRightsRequestTool(ctx context.Context, req *mcp.CallToolRe
 	}, nil
 }
 func (r *Resolver) UpdateRightsRequestTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateRightsRequestInput) (*mcp.CallToolResult, types.UpdateRightsRequestOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionRightsRequestUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionRightsRequestUpdate); err != nil {
+		return nil, types.UpdateRightsRequestOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -4426,7 +4798,9 @@ func (r *Resolver) UpdateRightsRequestTool(ctx context.Context, req *mcp.CallToo
 	}, nil
 }
 func (r *Resolver) DeleteRightsRequestTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteRightsRequestInput) (*mcp.CallToolResult, types.DeleteRightsRequestOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionRightsRequestDelete)
+	if err := r.Authorize(ctx, input.ID, probo.ActionRightsRequestDelete); err != nil {
+		return nil, types.DeleteRightsRequestOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -4444,7 +4818,9 @@ func (r *Resolver) DeleteRightsRequestTool(ctx context.Context, req *mcp.CallToo
 // GetTrustCenterTool handles the getTrustCenter tool
 // Get the trust center for an organization
 func (r *Resolver) GetTrustCenterTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetTrustCenterInput) (*mcp.CallToolResult, types.GetTrustCenterOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionTrustCenterGet)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionTrustCenterGet); err != nil {
+		return nil, types.GetTrustCenterOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
@@ -4477,7 +4853,9 @@ func (r *Resolver) GetTrustCenterTool(ctx context.Context, req *mcp.CallToolRequ
 // UpdateTrustCenterTool handles the updateTrustCenter tool
 // Update the trust center settings
 func (r *Resolver) UpdateTrustCenterTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateTrustCenterInput) (*mcp.CallToolResult, types.UpdateTrustCenterOutput, error) {
-	r.MustAuthorize(ctx, input.TrustCenterID, probo.ActionTrustCenterUpdate)
+	if err := r.Authorize(ctx, input.TrustCenterID, probo.ActionTrustCenterUpdate); err != nil {
+		return nil, types.UpdateTrustCenterOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
 	prb := r.proboSvc
@@ -4504,7 +4882,9 @@ func (r *Resolver) UpdateTrustCenterTool(ctx context.Context, req *mcp.CallToolR
 // ListTrustCenterReferencesTool handles the listTrustCenterReferences tool
 // List all references for a trust center
 func (r *Resolver) ListTrustCenterReferencesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListTrustCenterReferencesInput) (*mcp.CallToolResult, types.ListTrustCenterReferencesOutput, error) {
-	r.MustAuthorize(ctx, input.TrustCenterID, probo.ActionTrustCenterReferenceList)
+	if err := r.Authorize(ctx, input.TrustCenterID, probo.ActionTrustCenterReferenceList); err != nil {
+		return nil, types.ListTrustCenterReferencesOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
 	prb := r.proboSvc
@@ -4533,7 +4913,9 @@ func (r *Resolver) ListTrustCenterReferencesTool(ctx context.Context, req *mcp.C
 // AddTrustCenterReferenceTool handles the addTrustCenterReference tool
 // Add a new reference to the trust center
 func (r *Resolver) AddTrustCenterReferenceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddTrustCenterReferenceInput) (*mcp.CallToolResult, types.AddTrustCenterReferenceOutput, error) {
-	r.MustAuthorize(ctx, input.TrustCenterID, probo.ActionTrustCenterReferenceCreate)
+	if err := r.Authorize(ctx, input.TrustCenterID, probo.ActionTrustCenterReferenceCreate); err != nil {
+		return nil, types.AddTrustCenterReferenceOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
 	prb := r.proboSvc
@@ -4562,7 +4944,9 @@ func (r *Resolver) AddTrustCenterReferenceTool(ctx context.Context, req *mcp.Cal
 // UpdateTrustCenterReferenceTool handles the updateTrustCenterReference tool
 // Update a trust center reference
 func (r *Resolver) UpdateTrustCenterReferenceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateTrustCenterReferenceInput) (*mcp.CallToolResult, types.UpdateTrustCenterReferenceOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionTrustCenterReferenceUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionTrustCenterReferenceUpdate); err != nil {
+		return nil, types.UpdateTrustCenterReferenceOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -4594,7 +4978,9 @@ func (r *Resolver) UpdateTrustCenterReferenceTool(ctx context.Context, req *mcp.
 // DeleteTrustCenterReferenceTool handles the deleteTrustCenterReference tool
 // Delete a trust center reference
 func (r *Resolver) DeleteTrustCenterReferenceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteTrustCenterReferenceInput) (*mcp.CallToolResult, types.DeleteTrustCenterReferenceOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionTrustCenterReferenceDelete)
+	if err := r.Authorize(ctx, input.ID, probo.ActionTrustCenterReferenceDelete); err != nil {
+		return nil, types.DeleteTrustCenterReferenceOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -4610,7 +4996,9 @@ func (r *Resolver) DeleteTrustCenterReferenceTool(ctx context.Context, req *mcp.
 // ListTrustCenterFilesTool handles the listTrustCenterFiles tool
 // List all files for the trust center
 func (r *Resolver) ListTrustCenterFilesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListTrustCenterFilesInput) (*mcp.CallToolResult, types.ListTrustCenterFilesOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionTrustCenterFileList)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionTrustCenterFileList); err != nil {
+		return nil, types.ListTrustCenterFilesOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
@@ -4650,7 +5038,9 @@ func (r *Resolver) ListTrustCenterFilesTool(ctx context.Context, req *mcp.CallTo
 // DeleteTrustCenterFileTool handles the deleteTrustCenterFile tool
 // Delete a trust center file
 func (r *Resolver) DeleteTrustCenterFileTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteTrustCenterFileInput) (*mcp.CallToolResult, types.DeleteTrustCenterFileOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionTrustCenterFileDelete)
+	if err := r.Authorize(ctx, input.ID, probo.ActionTrustCenterFileDelete); err != nil {
+		return nil, types.DeleteTrustCenterFileOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -4666,7 +5056,9 @@ func (r *Resolver) DeleteTrustCenterFileTool(ctx context.Context, req *mcp.CallT
 // ListComplianceExternalURLsTool handles the listComplianceExternalURLs tool
 // List all external URLs for a trust center
 func (r *Resolver) ListComplianceExternalURLsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListComplianceExternalURLsInput) (*mcp.CallToolResult, types.ListComplianceExternalURLsOutput, error) {
-	r.MustAuthorize(ctx, input.TrustCenterID, probo.ActionComplianceExternalURLList)
+	if err := r.Authorize(ctx, input.TrustCenterID, probo.ActionComplianceExternalURLList); err != nil {
+		return nil, types.ListComplianceExternalURLsOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
 	prb := r.proboSvc
@@ -4695,7 +5087,9 @@ func (r *Resolver) ListComplianceExternalURLsTool(ctx context.Context, req *mcp.
 // AddComplianceExternalURLTool handles the addComplianceExternalURL tool
 // Add a new external URL to the trust center
 func (r *Resolver) AddComplianceExternalURLTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddComplianceExternalURLInput) (*mcp.CallToolResult, types.AddComplianceExternalURLOutput, error) {
-	r.MustAuthorize(ctx, input.TrustCenterID, probo.ActionComplianceExternalURLCreate)
+	if err := r.Authorize(ctx, input.TrustCenterID, probo.ActionComplianceExternalURLCreate); err != nil {
+		return nil, types.AddComplianceExternalURLOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.TrustCenterID)
 	prb := r.proboSvc
@@ -4718,7 +5112,9 @@ func (r *Resolver) AddComplianceExternalURLTool(ctx context.Context, req *mcp.Ca
 // UpdateComplianceExternalURLTool handles the updateComplianceExternalURL tool
 // Update a compliance external URL
 func (r *Resolver) UpdateComplianceExternalURLTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateComplianceExternalURLInput) (*mcp.CallToolResult, types.UpdateComplianceExternalURLOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionComplianceExternalURLUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionComplianceExternalURLUpdate); err != nil {
+		return nil, types.UpdateComplianceExternalURLOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -4750,7 +5146,9 @@ func (r *Resolver) UpdateComplianceExternalURLTool(ctx context.Context, req *mcp
 // DeleteComplianceExternalURLTool handles the deleteComplianceExternalURL tool
 // Delete a compliance external URL
 func (r *Resolver) DeleteComplianceExternalURLTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteComplianceExternalURLInput) (*mcp.CallToolResult, types.DeleteComplianceExternalURLOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionComplianceExternalURLDelete)
+	if err := r.Authorize(ctx, input.ID, probo.ActionComplianceExternalURLDelete); err != nil {
+		return nil, types.DeleteComplianceExternalURLOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	prb := r.proboSvc
@@ -4771,7 +5169,9 @@ func (r *Resolver) DeleteComplianceExternalURLTool(ctx context.Context, req *mcp
 // CreateCustomDomainTool handles the createCustomDomain tool
 // Create a custom domain for the organization
 func (r *Resolver) CreateCustomDomainTool(ctx context.Context, req *mcp.CallToolRequest, input *types.CreateCustomDomainInput) (*mcp.CallToolResult, types.CreateCustomDomainOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionCustomDomainCreate)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionCustomDomainCreate); err != nil {
+		return nil, types.CreateCustomDomainOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
@@ -4793,7 +5193,9 @@ func (r *Resolver) CreateCustomDomainTool(ctx context.Context, req *mcp.CallTool
 // DeleteCustomDomainTool handles the deleteCustomDomain tool
 // Delete the custom domain for the organization
 func (r *Resolver) DeleteCustomDomainTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteCustomDomainInput) (*mcp.CallToolResult, types.DeleteCustomDomainOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionCustomDomainDelete)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionCustomDomainDelete); err != nil {
+		return nil, types.DeleteCustomDomainOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	prb := r.proboSvc
@@ -4817,7 +5219,9 @@ func (r *Resolver) DeleteCustomDomainTool(ctx context.Context, req *mcp.CallTool
 }
 
 func (r *Resolver) AssessThirdPartyTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AssessThirdPartyInput) (*mcp.CallToolResult, types.AssessThirdPartyOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionThirdPartyAssess)
+	if err := r.Authorize(ctx, input.ID, probo.ActionThirdPartyAssess); err != nil {
+		return nil, types.AssessThirdPartyOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	svc := r.proboSvc
@@ -4838,7 +5242,9 @@ func (r *Resolver) AssessThirdPartyTool(ctx context.Context, req *mcp.CallToolRe
 }
 
 func (r *Resolver) PublishFindingListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishFindingListInput) (*mcp.CallToolResult, types.PublishFindingListOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionFindingPublish)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionFindingPublish); err != nil {
+		return nil, types.PublishFindingListOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
@@ -4855,7 +5261,9 @@ func (r *Resolver) PublishFindingListTool(ctx context.Context, req *mcp.CallTool
 }
 
 func (r *Resolver) PublishObligationListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishObligationListInput) (*mcp.CallToolResult, types.PublishObligationListOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionObligationPublish)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionObligationPublish); err != nil {
+		return nil, types.PublishObligationListOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
@@ -4872,7 +5280,9 @@ func (r *Resolver) PublishObligationListTool(ctx context.Context, req *mcp.CallT
 }
 
 func (r *Resolver) PublishProcessingActivityListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishProcessingActivityListInput) (*mcp.CallToolResult, types.PublishProcessingActivityListOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionProcessingActivityPublish)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionProcessingActivityPublish); err != nil {
+		return nil, types.PublishProcessingActivityListOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
@@ -4889,7 +5299,9 @@ func (r *Resolver) PublishProcessingActivityListTool(ctx context.Context, req *m
 }
 
 func (r *Resolver) PublishDataProtectionImpactAssessmentListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishDataProtectionImpactAssessmentListInput) (*mcp.CallToolResult, types.PublishDataProtectionImpactAssessmentListOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionDataProtectionImpactAssessmentPublish)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionDataProtectionImpactAssessmentPublish); err != nil {
+		return nil, types.PublishDataProtectionImpactAssessmentListOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
@@ -4906,7 +5318,9 @@ func (r *Resolver) PublishDataProtectionImpactAssessmentListTool(ctx context.Con
 }
 
 func (r *Resolver) PublishTransferImpactAssessmentListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishTransferImpactAssessmentListInput) (*mcp.CallToolResult, types.PublishTransferImpactAssessmentListOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionTransferImpactAssessmentPublish)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionTransferImpactAssessmentPublish); err != nil {
+		return nil, types.PublishTransferImpactAssessmentListOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
@@ -4923,7 +5337,9 @@ func (r *Resolver) PublishTransferImpactAssessmentListTool(ctx context.Context, 
 }
 
 func (r *Resolver) PublishThirdPartyListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishThirdPartyListInput) (*mcp.CallToolResult, types.PublishThirdPartyListOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionThirdPartyPublish)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionThirdPartyPublish); err != nil {
+		return nil, types.PublishThirdPartyListOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
@@ -4940,7 +5356,9 @@ func (r *Resolver) PublishThirdPartyListTool(ctx context.Context, req *mcp.CallT
 }
 
 func (r *Resolver) ListCookieBannersTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListCookieBannersInput) (*mcp.CallToolResult, types.ListCookieBannersOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionCookieBannerList)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionCookieBannerList); err != nil {
+		return nil, types.ListCookieBannersOutput{}, err
+	}
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieBannerOrderField]{Field: coredata.CookieBannerOrderFieldCreatedAt, Direction: page.OrderDirectionDesc})
 
@@ -4955,7 +5373,9 @@ func (r *Resolver) ListCookieBannersTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) GetCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetCookieBannerInput) (*mcp.CallToolResult, types.GetCookieBannerOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionCookieBannerGet)
+	if err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerGet); err != nil {
+		return nil, types.GetCookieBannerOutput{}, err
+	}
 	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	banner, err := r.cookieBanner.GetCookieBanner(ctx, scope, input.ID)
@@ -4967,7 +5387,9 @@ func (r *Resolver) GetCookieBannerTool(ctx context.Context, req *mcp.CallToolReq
 }
 
 func (r *Resolver) AddCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddCookieBannerInput) (*mcp.CallToolResult, types.AddCookieBannerOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionCookieBannerCreate)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionCookieBannerCreate); err != nil {
+		return nil, types.AddCookieBannerOutput{}, err
+	}
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 
 	banner, err := r.cookieBanner.CreateCookieBanner(ctx, scope, cookiebanner.CreateCookieBannerRequest{
@@ -4986,7 +5408,9 @@ func (r *Resolver) AddCookieBannerTool(ctx context.Context, req *mcp.CallToolReq
 }
 
 func (r *Resolver) UpdateCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateCookieBannerInput) (*mcp.CallToolResult, types.UpdateCookieBannerOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionCookieBannerUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerUpdate); err != nil {
+		return nil, types.UpdateCookieBannerOutput{}, err
+	}
 	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	updateReq := cookiebanner.UpdateCookieBannerRequest{CookieBannerID: input.ID}
@@ -5019,7 +5443,9 @@ func (r *Resolver) UpdateCookieBannerTool(ctx context.Context, req *mcp.CallTool
 }
 
 func (r *Resolver) DeleteCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteCookieBannerInput) (*mcp.CallToolResult, types.DeleteCookieBannerOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionCookieBannerDelete)
+	if err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerDelete); err != nil {
+		return nil, types.DeleteCookieBannerOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	if err := r.cookieBanner.DeleteCookieBanner(ctx, scope, input.ID); err != nil {
@@ -5030,7 +5456,9 @@ func (r *Resolver) DeleteCookieBannerTool(ctx context.Context, req *mcp.CallTool
 }
 
 func (r *Resolver) ActivateCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ActivateCookieBannerInput) (*mcp.CallToolResult, types.ActivateCookieBannerOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionCookieBannerActivate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerActivate); err != nil {
+		return nil, types.ActivateCookieBannerOutput{}, err
+	}
 	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	banner, err := r.cookieBanner.ActivateCookieBanner(ctx, scope, input.ID)
@@ -5042,7 +5470,9 @@ func (r *Resolver) ActivateCookieBannerTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) DeactivateCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeactivateCookieBannerInput) (*mcp.CallToolResult, types.DeactivateCookieBannerOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionCookieBannerDeactivate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerDeactivate); err != nil {
+		return nil, types.DeactivateCookieBannerOutput{}, err
+	}
 	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	banner, err := r.cookieBanner.DeactivateCookieBanner(ctx, scope, input.ID)
@@ -5054,7 +5484,9 @@ func (r *Resolver) DeactivateCookieBannerTool(ctx context.Context, req *mcp.Call
 }
 
 func (r *Resolver) ListCookieCategoriesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListCookieCategoriesInput) (*mcp.CallToolResult, types.ListCookieCategoriesOutput, error) {
-	r.MustAuthorize(ctx, input.CookieBannerID, probo.ActionCookieCategoryList)
+	if err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieCategoryList); err != nil {
+		return nil, types.ListCookieCategoriesOutput{}, err
+	}
 	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieCategoryOrderField]{Field: coredata.CookieCategoryOrderFieldRank, Direction: page.OrderDirectionAsc})
 
@@ -5069,7 +5501,9 @@ func (r *Resolver) ListCookieCategoriesTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) GetCookieCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetCookieCategoryInput) (*mcp.CallToolResult, types.GetCookieCategoryOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionCookieCategoryGet)
+	if err := r.Authorize(ctx, input.ID, probo.ActionCookieCategoryGet); err != nil {
+		return nil, types.GetCookieCategoryOutput{}, err
+	}
 	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	category, err := r.cookieBanner.GetCookieCategory(ctx, scope, input.ID)
@@ -5081,7 +5515,9 @@ func (r *Resolver) GetCookieCategoryTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) AddCookieCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddCookieCategoryInput) (*mcp.CallToolResult, types.AddCookieCategoryOutput, error) {
-	r.MustAuthorize(ctx, input.CookieBannerID, probo.ActionCookieCategoryCreate)
+	if err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieCategoryCreate); err != nil {
+		return nil, types.AddCookieCategoryOutput{}, err
+	}
 	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 
 	category, err := r.cookieBanner.CreateCookieCategory(ctx, scope, cookiebanner.CreateCookieCategoryRequest{
@@ -5099,7 +5535,9 @@ func (r *Resolver) AddCookieCategoryTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) UpdateCookieCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateCookieCategoryInput) (*mcp.CallToolResult, types.UpdateCookieCategoryOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionCookieCategoryUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionCookieCategoryUpdate); err != nil {
+		return nil, types.UpdateCookieCategoryOutput{}, err
+	}
 	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	updateReq := cookiebanner.UpdateCookieCategoryRequest{CookieCategoryID: input.ID}
@@ -5124,7 +5562,9 @@ func (r *Resolver) UpdateCookieCategoryTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) DeleteCookieCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteCookieCategoryInput) (*mcp.CallToolResult, types.DeleteCookieCategoryOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionCookieCategoryDelete)
+	if err := r.Authorize(ctx, input.ID, probo.ActionCookieCategoryDelete); err != nil {
+		return nil, types.DeleteCookieCategoryOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	if err := r.cookieBanner.DeleteCookieCategory(ctx, scope, input.ID); err != nil {
@@ -5135,7 +5575,9 @@ func (r *Resolver) DeleteCookieCategoryTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) ReorderCookieCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ReorderCookieCategoryInput) (*mcp.CallToolResult, types.ReorderCookieCategoryOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionCookieCategoryUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionCookieCategoryUpdate); err != nil {
+		return nil, types.ReorderCookieCategoryOutput{}, err
+	}
 	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	_, err := r.cookieBanner.ReorderCookieCategory(ctx, scope, cookiebanner.ReorderCookieCategoryRequest{
@@ -5155,7 +5597,9 @@ func (r *Resolver) ReorderCookieCategoryTool(ctx context.Context, req *mcp.CallT
 }
 
 func (r *Resolver) ListTrackerPatternsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListTrackerPatternsInput) (*mcp.CallToolResult, types.ListTrackerPatternsOutput, error) {
-	r.MustAuthorize(ctx, input.CookieCategoryID, probo.ActionTrackerPatternList)
+	if err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerPatternList); err != nil {
+		return nil, types.ListTrackerPatternsOutput{}, err
+	}
 	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.TrackerPatternOrderField]{Field: coredata.TrackerPatternOrderFieldCreatedAt, Direction: page.OrderDirectionAsc})
 
@@ -5170,7 +5614,9 @@ func (r *Resolver) ListTrackerPatternsTool(ctx context.Context, req *mcp.CallToo
 }
 
 func (r *Resolver) GetTrackerPatternTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetTrackerPatternInput) (*mcp.CallToolResult, types.GetTrackerPatternOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionTrackerPatternGet)
+	if err := r.Authorize(ctx, input.ID, probo.ActionTrackerPatternGet); err != nil {
+		return nil, types.GetTrackerPatternOutput{}, err
+	}
 	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	pattern, err := r.cookieBanner.GetTrackerPattern(ctx, scope, input.ID)
@@ -5182,7 +5628,9 @@ func (r *Resolver) GetTrackerPatternTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) AddTrackerPatternTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddTrackerPatternInput) (*mcp.CallToolResult, types.AddTrackerPatternOutput, error) {
-	r.MustAuthorize(ctx, input.CookieCategoryID, probo.ActionTrackerPatternCreate)
+	if err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerPatternCreate); err != nil {
+		return nil, types.AddTrackerPatternOutput{}, err
+	}
 	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
 
 	pattern, err := r.cookieBanner.CreateTrackerPattern(ctx, scope, cookiebanner.CreateTrackerPatternRequest{
@@ -5202,7 +5650,9 @@ func (r *Resolver) AddTrackerPatternTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) UpdateTrackerPatternTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateTrackerPatternInput) (*mcp.CallToolResult, types.UpdateTrackerPatternOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionTrackerPatternUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionTrackerPatternUpdate); err != nil {
+		return nil, types.UpdateTrackerPatternOutput{}, err
+	}
 	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	updateReq := cookiebanner.UpdateTrackerPatternRequest{TrackerPatternID: input.ID}
@@ -5228,7 +5678,9 @@ func (r *Resolver) UpdateTrackerPatternTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) DeleteTrackerPatternTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteTrackerPatternInput) (*mcp.CallToolResult, types.DeleteTrackerPatternOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionTrackerPatternDelete)
+	if err := r.Authorize(ctx, input.ID, probo.ActionTrackerPatternDelete); err != nil {
+		return nil, types.DeleteTrackerPatternOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	if err := r.cookieBanner.DeleteTrackerPattern(ctx, scope, input.ID); err != nil {
@@ -5239,7 +5691,9 @@ func (r *Resolver) DeleteTrackerPatternTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) MoveTrackerPatternToCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.MoveTrackerPatternToCategoryInput) (*mcp.CallToolResult, types.MoveTrackerPatternToCategoryOutput, error) {
-	r.MustAuthorize(ctx, input.TrackerPatternID, probo.ActionTrackerPatternUpdate)
+	if err := r.Authorize(ctx, input.TrackerPatternID, probo.ActionTrackerPatternUpdate); err != nil {
+		return nil, types.MoveTrackerPatternToCategoryOutput{}, err
+	}
 	scope := coredata.NewScopeFromObjectID(input.TrackerPatternID)
 
 	result, err := r.cookieBanner.MoveTrackerPatternToCategory(ctx, scope, cookiebanner.MoveTrackerPatternToCategoryRequest{
@@ -5254,7 +5708,9 @@ func (r *Resolver) MoveTrackerPatternToCategoryTool(ctx context.Context, req *mc
 }
 
 func (r *Resolver) PublishCookieBannerVersionTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishCookieBannerVersionInput) (*mcp.CallToolResult, types.PublishCookieBannerVersionOutput, error) {
-	r.MustAuthorize(ctx, input.CookieBannerID, probo.ActionCookieBannerVersionPublish)
+	if err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerVersionPublish); err != nil {
+		return nil, types.PublishCookieBannerVersionOutput{}, err
+	}
 	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 
 	version, err := r.cookieBanner.PublishCookieBannerVersion(ctx, scope, input.CookieBannerID)
@@ -5266,7 +5722,9 @@ func (r *Resolver) PublishCookieBannerVersionTool(ctx context.Context, req *mcp.
 }
 
 func (r *Resolver) ListCookieBannerVersionsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListCookieBannerVersionsInput) (*mcp.CallToolResult, types.ListCookieBannerVersionsOutput, error) {
-	r.MustAuthorize(ctx, input.CookieBannerID, probo.ActionCookieBannerVersionList)
+	if err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerVersionList); err != nil {
+		return nil, types.ListCookieBannerVersionsOutput{}, err
+	}
 	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieBannerVersionOrderField]{Field: coredata.CookieBannerVersionOrderFieldCreatedAt, Direction: page.OrderDirectionDesc})
 
@@ -5281,7 +5739,9 @@ func (r *Resolver) ListCookieBannerVersionsTool(ctx context.Context, req *mcp.Ca
 }
 
 func (r *Resolver) UpsertCookieBannerTranslationTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpsertCookieBannerTranslationInput) (*mcp.CallToolResult, types.UpsertCookieBannerTranslationOutput, error) {
-	r.MustAuthorize(ctx, input.CookieBannerID, probo.ActionCookieBannerUpdate)
+	if err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerUpdate); err != nil {
+		return nil, types.UpsertCookieBannerTranslationOutput{}, err
+	}
 	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 
 	translation, err := r.cookieBanner.UpsertCookieBannerTranslation(ctx, scope, cookiebanner.UpsertCookieBannerTranslationRequest{
@@ -5297,7 +5757,9 @@ func (r *Resolver) UpsertCookieBannerTranslationTool(ctx context.Context, req *m
 }
 
 func (r *Resolver) ListCookieConsentRecordsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListCookieConsentRecordsInput) (*mcp.CallToolResult, types.ListCookieConsentRecordsOutput, error) {
-	r.MustAuthorize(ctx, input.CookieBannerID, probo.ActionCookieConsentRecordList)
+	if err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieConsentRecordList); err != nil {
+		return nil, types.ListCookieConsentRecordsOutput{}, err
+	}
 	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieConsentRecordOrderField]{Field: coredata.CookieConsentRecordOrderFieldCreatedAt, Direction: page.OrderDirectionDesc})
 
@@ -5321,7 +5783,9 @@ func (r *Resolver) ListCookieConsentRecordsTool(ctx context.Context, req *mcp.Ca
 }
 
 func (r *Resolver) GetCookieConsentRecordTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetCookieConsentRecordInput) (*mcp.CallToolResult, types.GetCookieConsentRecordOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionCookieConsentRecordList)
+	if err := r.Authorize(ctx, input.ID, probo.ActionCookieConsentRecordList); err != nil {
+		return nil, types.GetCookieConsentRecordOutput{}, err
+	}
 	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	record, err := r.cookieBanner.GetCookieConsentRecord(ctx, scope, input.ID)
@@ -5333,7 +5797,9 @@ func (r *Resolver) GetCookieConsentRecordTool(ctx context.Context, req *mcp.Call
 }
 
 func (r *Resolver) PublishRiskListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishRiskListInput) (*mcp.CallToolResult, types.PublishRiskListOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, probo.ActionRiskPublish)
+	if err := r.Authorize(ctx, input.OrganizationID, probo.ActionRiskPublish); err != nil {
+		return nil, types.PublishRiskListOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	svc := r.proboSvc
@@ -5350,7 +5816,9 @@ func (r *Resolver) PublishRiskListTool(ctx context.Context, req *mcp.CallToolReq
 }
 
 func (r *Resolver) GetSCIMConfigurationTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetSCIMConfigurationInput) (*mcp.CallToolResult, types.GetSCIMConfigurationOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, iam.ActionSCIMConfigurationGet)
+	if err := r.Authorize(ctx, input.OrganizationID, iam.ActionSCIMConfigurationGet); err != nil {
+		return nil, types.GetSCIMConfigurationOutput{}, err
+	}
 
 	config, err := r.iamSvc.OrganizationService.GetSCIMConfiguration(ctx, input.OrganizationID)
 	if err != nil {
@@ -5365,7 +5833,9 @@ func (r *Resolver) GetSCIMConfigurationTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) CreateSCIMConfigurationTool(ctx context.Context, req *mcp.CallToolRequest, input *types.CreateSCIMConfigurationInput) (*mcp.CallToolResult, types.CreateSCIMConfigurationOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, iam.ActionSCIMConfigurationCreate)
+	if err := r.Authorize(ctx, input.OrganizationID, iam.ActionSCIMConfigurationCreate); err != nil {
+		return nil, types.CreateSCIMConfigurationOutput{}, err
+	}
 
 	config, token, err := r.iamSvc.OrganizationService.CreateSCIMConfiguration(ctx, input.OrganizationID)
 	if err != nil {
@@ -5390,7 +5860,9 @@ func (r *Resolver) CreateSCIMConfigurationTool(ctx context.Context, req *mcp.Cal
 }
 
 func (r *Resolver) DeleteSCIMConfigurationTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteSCIMConfigurationInput) (*mcp.CallToolResult, types.DeleteSCIMConfigurationOutput, error) {
-	r.MustAuthorize(ctx, input.OrganizationID, iam.ActionSCIMConfigurationDelete)
+	if err := r.Authorize(ctx, input.OrganizationID, iam.ActionSCIMConfigurationDelete); err != nil {
+		return nil, types.DeleteSCIMConfigurationOutput{}, err
+	}
 
 	err := r.iamSvc.OrganizationService.DeleteSCIMConfiguration(ctx, input.OrganizationID, input.ScimConfigurationID)
 	if err != nil {
@@ -5401,7 +5873,9 @@ func (r *Resolver) DeleteSCIMConfigurationTool(ctx context.Context, req *mcp.Cal
 }
 
 func (r *Resolver) RegenerateSCIMTokenTool(ctx context.Context, req *mcp.CallToolRequest, input *types.RegenerateSCIMTokenInput) (*mcp.CallToolResult, types.RegenerateSCIMTokenOutput, error) {
-	r.MustAuthorize(ctx, input.ScimConfigurationID, iam.ActionSCIMConfigurationUpdate)
+	if err := r.Authorize(ctx, input.ScimConfigurationID, iam.ActionSCIMConfigurationUpdate); err != nil {
+		return nil, types.RegenerateSCIMTokenOutput{}, err
+	}
 
 	config, token, err := r.iamSvc.OrganizationService.RegenerateSCIMToken(ctx, input.OrganizationID, input.ScimConfigurationID)
 	if err != nil {
@@ -5415,7 +5889,9 @@ func (r *Resolver) RegenerateSCIMTokenTool(ctx context.Context, req *mcp.CallToo
 }
 
 func (r *Resolver) GetSCIMBridgeTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetSCIMBridgeInput) (*mcp.CallToolResult, types.GetSCIMBridgeOutput, error) {
-	r.MustAuthorize(ctx, input.ID, iam.ActionSCIMBridgeGet)
+	if err := r.Authorize(ctx, input.ID, iam.ActionSCIMBridgeGet); err != nil {
+		return nil, types.GetSCIMBridgeOutput{}, err
+	}
 
 	bridge, err := r.iamSvc.OrganizationService.GetSCIMBridgeByID(ctx, input.ID)
 	if err != nil {
@@ -5430,7 +5906,9 @@ func (r *Resolver) GetSCIMBridgeTool(ctx context.Context, req *mcp.CallToolReque
 }
 
 func (r *Resolver) UpdateSCIMBridgeTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateSCIMBridgeInput) (*mcp.CallToolResult, types.UpdateSCIMBridgeOutput, error) {
-	r.MustAuthorize(ctx, input.ScimBridgeID, iam.ActionSCIMBridgeUpdate)
+	if err := r.Authorize(ctx, input.ScimBridgeID, iam.ActionSCIMBridgeUpdate); err != nil {
+		return nil, types.UpdateSCIMBridgeOutput{}, err
+	}
 
 	bridge, err := r.iamSvc.OrganizationService.UpdateSCIMBridge(ctx, input.OrganizationID, input.ScimBridgeID, input.ExcludedUserNames)
 	if err != nil {
@@ -5441,7 +5919,9 @@ func (r *Resolver) UpdateSCIMBridgeTool(ctx context.Context, req *mcp.CallToolRe
 }
 
 func (r *Resolver) ListSCIMEventsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListSCIMEventsInput) (*mcp.CallToolResult, types.ListSCIMEventsOutput, error) {
-	r.MustAuthorize(ctx, input.ScimConfigurationID, iam.ActionSCIMEventList)
+	if err := r.Authorize(ctx, input.ScimConfigurationID, iam.ActionSCIMEventList); err != nil {
+		return nil, types.ListSCIMEventsOutput{}, err
+	}
 
 	pageOrderBy := page.OrderBy[coredata.SCIMEventOrderField]{
 		Field:     coredata.SCIMEventOrderFieldCreatedAt,
@@ -5470,7 +5950,9 @@ func (r *Resolver) PublishDocumentTool(ctx context.Context, req *mcp.CallToolReq
 		action = probo.ActionDocumentVersionRequestApproval
 	}
 
-	r.MustAuthorize(ctx, input.DocumentID, action)
+	if err := r.Authorize(ctx, input.DocumentID, action); err != nil {
+		return nil, types.PublishDocumentOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.DocumentID)
 	svc := r.proboSvc
@@ -5497,7 +5979,9 @@ func (r *Resolver) PublishDocumentTool(ctx context.Context, req *mcp.CallToolReq
 }
 
 func (r *Resolver) ListTrackerResourcesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListTrackerResourcesInput) (*mcp.CallToolResult, types.ListTrackerResourcesOutput, error) {
-	r.MustAuthorize(ctx, input.CookieCategoryID, probo.ActionTrackerResourceList)
+	if err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerResourceList); err != nil {
+		return nil, types.ListTrackerResourcesOutput{}, err
+	}
 	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.TrackerResourceOrderField]{Field: coredata.TrackerResourceOrderFieldCreatedAt, Direction: page.OrderDirectionAsc})
 
@@ -5512,7 +5996,9 @@ func (r *Resolver) ListTrackerResourcesTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) GetTrackerResourceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetTrackerResourceInput) (*mcp.CallToolResult, types.GetTrackerResourceOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionTrackerResourceGet)
+	if err := r.Authorize(ctx, input.ID, probo.ActionTrackerResourceGet); err != nil {
+		return nil, types.GetTrackerResourceOutput{}, err
+	}
 	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	resource, err := r.cookieBanner.GetTrackerResource(ctx, scope, input.ID)
@@ -5524,7 +6010,9 @@ func (r *Resolver) GetTrackerResourceTool(ctx context.Context, req *mcp.CallTool
 }
 
 func (r *Resolver) AddTrackerResourceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddTrackerResourceInput) (*mcp.CallToolResult, types.AddTrackerResourceOutput, error) {
-	r.MustAuthorize(ctx, input.CookieCategoryID, probo.ActionTrackerResourceCreate)
+	if err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerResourceCreate); err != nil {
+		return nil, types.AddTrackerResourceOutput{}, err
+	}
 	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
 
 	description := ""
@@ -5548,7 +6036,9 @@ func (r *Resolver) AddTrackerResourceTool(ctx context.Context, req *mcp.CallTool
 }
 
 func (r *Resolver) UpdateTrackerResourceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateTrackerResourceInput) (*mcp.CallToolResult, types.UpdateTrackerResourceOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionTrackerResourceUpdate)
+	if err := r.Authorize(ctx, input.ID, probo.ActionTrackerResourceUpdate); err != nil {
+		return nil, types.UpdateTrackerResourceOutput{}, err
+	}
 	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	updateReq := cookiebanner.UpdateTrackerResourceRequest{TrackerResourceID: input.ID}
@@ -5573,7 +6063,9 @@ func (r *Resolver) UpdateTrackerResourceTool(ctx context.Context, req *mcp.CallT
 }
 
 func (r *Resolver) DeleteTrackerResourceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeleteTrackerResourceInput) (*mcp.CallToolResult, types.DeleteTrackerResourceOutput, error) {
-	r.MustAuthorize(ctx, input.ID, probo.ActionTrackerResourceDelete)
+	if err := r.Authorize(ctx, input.ID, probo.ActionTrackerResourceDelete); err != nil {
+		return nil, types.DeleteTrackerResourceOutput{}, err
+	}
 
 	scope := coredata.NewScopeFromObjectID(input.ID)
 	if err := r.cookieBanner.DeleteTrackerResource(ctx, scope, input.ID); err != nil {
@@ -5584,7 +6076,9 @@ func (r *Resolver) DeleteTrackerResourceTool(ctx context.Context, req *mcp.CallT
 }
 
 func (r *Resolver) MoveTrackerResourceToCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.MoveTrackerResourceToCategoryInput) (*mcp.CallToolResult, types.MoveTrackerResourceToCategoryOutput, error) {
-	r.MustAuthorize(ctx, input.TrackerResourceID, probo.ActionTrackerResourceUpdate)
+	if err := r.Authorize(ctx, input.TrackerResourceID, probo.ActionTrackerResourceUpdate); err != nil {
+		return nil, types.MoveTrackerResourceToCategoryOutput{}, err
+	}
 	scope := coredata.NewScopeFromObjectID(input.TrackerResourceID)
 
 	result, err := r.cookieBanner.MoveTrackerResourceToCategory(ctx, scope, cookiebanner.MoveTrackerResourceToCategoryRequest{

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -53,12 +53,14 @@ func (r *Resolver) ListThirdPartiesTool(ctx context.Context, req *mcp.CallToolRe
 	if err != nil {
 		return nil, types.ListThirdPartiesOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyOrderField]{
 		Field:     coredata.ThirdPartyOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ThirdPartyOrderField]{
 			Field:     input.OrderBy.Field,
@@ -85,6 +87,7 @@ func (r *Resolver) AddThirdPartyTool(ctx context.Context, req *mcp.CallToolReque
 	if err != nil {
 		return nil, types.AddThirdPartyOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	var category *coredata.ThirdPartyCategory
@@ -141,6 +144,7 @@ func (r *Resolver) UpdateThirdPartyTool(ctx context.Context, req *mcp.CallToolRe
 	if err != nil {
 		return nil, types.UpdateThirdPartyOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	var description **string
@@ -270,12 +274,14 @@ func (r *Resolver) ListRisksTool(ctx context.Context, req *mcp.CallToolRequest, 
 	if err != nil {
 		return nil, types.ListRisksOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.RiskOrderField]{
 		Field:     coredata.RiskOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.RiskOrderField]{
 			Field:     input.OrderBy.Field,
@@ -303,6 +309,7 @@ func (r *Resolver) GetRiskTool(ctx context.Context, req *mcp.CallToolRequest, in
 	if err != nil {
 		return nil, types.GetRiskOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	risk, err := prb.Risks.Get(ctx, scope, input.ID)
@@ -320,6 +327,7 @@ func (r *Resolver) AddRiskTool(ctx context.Context, req *mcp.CallToolRequest, in
 	if err != nil {
 		return nil, types.AddRiskOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	risk, err := svc.Risks.Create(
@@ -350,6 +358,7 @@ func (r *Resolver) UpdateRiskTool(ctx context.Context, req *mcp.CallToolRequest,
 	if err != nil {
 		return nil, types.UpdateRiskOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	risk, err := svc.Risks.Update(
@@ -382,12 +391,14 @@ func (r *Resolver) ListMeasuresTool(ctx context.Context, req *mcp.CallToolReques
 	if err != nil {
 		return nil, types.ListMeasuresOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.MeasureOrderField]{
 		Field:     coredata.MeasureOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.MeasureOrderField]{
 			Field:     input.OrderBy.Field,
@@ -415,6 +426,7 @@ func (r *Resolver) GetMeasureTool(ctx context.Context, req *mcp.CallToolRequest,
 	if err != nil {
 		return nil, types.GetMeasureOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	measure, err := prb.Measures.Get(ctx, scope, input.ID)
@@ -432,6 +444,7 @@ func (r *Resolver) AddMeasureTool(ctx context.Context, req *mcp.CallToolRequest,
 	if err != nil {
 		return nil, types.AddMeasureOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	measure, err := svc.Measures.Create(
@@ -457,6 +470,7 @@ func (r *Resolver) UpdateMeasureTool(ctx context.Context, req *mcp.CallToolReque
 	if err != nil {
 		return nil, types.UpdateMeasureOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	measure, err := svc.Measures.Update(
@@ -483,12 +497,14 @@ func (r *Resolver) ListFrameworksTool(ctx context.Context, req *mcp.CallToolRequ
 	if err != nil {
 		return nil, types.ListFrameworksOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.FrameworkOrderField]{
 		Field:     coredata.FrameworkOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.FrameworkOrderField]{
 			Field:     input.OrderBy.Field,
@@ -511,6 +527,7 @@ func (r *Resolver) GetFrameworkTool(ctx context.Context, req *mcp.CallToolReques
 	if err != nil {
 		return nil, types.GetFrameworkOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	framework, err := prb.Frameworks.Get(ctx, scope, input.ID)
@@ -528,6 +545,7 @@ func (r *Resolver) AddFrameworkTool(ctx context.Context, req *mcp.CallToolReques
 	if err != nil {
 		return nil, types.AddFrameworkOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	framework, err := svc.Frameworks.Create(
@@ -552,6 +570,7 @@ func (r *Resolver) UpdateFrameworkTool(ctx context.Context, req *mcp.CallToolReq
 	if err != nil {
 		return nil, types.UpdateFrameworkOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	framework, err := svc.Frameworks.Update(
@@ -576,12 +595,14 @@ func (r *Resolver) ListAssetsTool(ctx context.Context, req *mcp.CallToolRequest,
 	if err != nil {
 		return nil, types.ListAssetsOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.AssetOrderField]{
 		Field:     coredata.AssetOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.AssetOrderField]{
 			Field:     input.OrderBy.Field,
@@ -604,6 +625,7 @@ func (r *Resolver) GetAssetTool(ctx context.Context, req *mcp.CallToolRequest, i
 	if err != nil {
 		return nil, types.GetAssetOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	asset, err := prb.Assets.Get(ctx, scope, input.ID)
@@ -621,6 +643,7 @@ func (r *Resolver) AddAssetTool(ctx context.Context, req *mcp.CallToolRequest, i
 	if err != nil {
 		return nil, types.AddAssetOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	asset, err := svc.Assets.Create(
@@ -649,6 +672,7 @@ func (r *Resolver) UpdateAssetTool(ctx context.Context, req *mcp.CallToolRequest
 	if err != nil {
 		return nil, types.UpdateAssetOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	asset, err := svc.Assets.Update(
@@ -677,12 +701,14 @@ func (r *Resolver) ListDataTool(ctx context.Context, req *mcp.CallToolRequest, i
 	if err != nil {
 		return nil, types.ListDataOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.DatumOrderField]{
 		Field:     coredata.DatumOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.DatumOrderField]{
 			Field:     input.OrderBy.Field,
@@ -705,6 +731,7 @@ func (r *Resolver) GetDatumTool(ctx context.Context, req *mcp.CallToolRequest, i
 	if err != nil {
 		return nil, types.GetDatumOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	datum, err := prb.Data.Get(ctx, scope, input.ID)
@@ -722,6 +749,7 @@ func (r *Resolver) AddDatumTool(ctx context.Context, req *mcp.CallToolRequest, i
 	if err != nil {
 		return nil, types.AddDatumOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	datum, err := svc.Data.Create(
@@ -748,6 +776,7 @@ func (r *Resolver) UpdateDatumTool(ctx context.Context, req *mcp.CallToolRequest
 	if err != nil {
 		return nil, types.UpdateDatumOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	datum, err := svc.Data.Update(
@@ -774,12 +803,14 @@ func (r *Resolver) ListFindingsTool(ctx context.Context, req *mcp.CallToolReques
 	if err != nil {
 		return nil, types.ListFindingsOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.FindingOrderField]{
 		Field:     coredata.FindingOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.FindingOrderField]{
 			Field:     input.OrderBy.Field,
@@ -812,6 +843,7 @@ func (r *Resolver) GetFindingTool(ctx context.Context, req *mcp.CallToolRequest,
 	if err != nil {
 		return nil, types.GetFindingOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	finding, err := prb.Findings.Get(ctx, scope, input.ID)
@@ -829,6 +861,7 @@ func (r *Resolver) AddFindingTool(ctx context.Context, req *mcp.CallToolRequest,
 	if err != nil {
 		return nil, types.AddFindingOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	finding, err := svc.Findings.Create(
@@ -863,6 +896,7 @@ func (r *Resolver) UpdateFindingTool(ctx context.Context, req *mcp.CallToolReque
 	if err != nil {
 		return nil, types.UpdateFindingOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	finding, err := svc.Findings.Update(
@@ -896,12 +930,14 @@ func (r *Resolver) ListObligationsTool(ctx context.Context, req *mcp.CallToolReq
 	if err != nil {
 		return nil, types.ListObligationsOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ObligationOrderField]{
 		Field:     coredata.ObligationOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ObligationOrderField]{
 			Field:     input.OrderBy.Field,
@@ -924,6 +960,7 @@ func (r *Resolver) GetObligationTool(ctx context.Context, req *mcp.CallToolReque
 	if err != nil {
 		return nil, types.GetObligationOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	obligation, err := prb.Obligations.Get(ctx, scope, input.ID)
@@ -941,6 +978,7 @@ func (r *Resolver) AddObligationTool(ctx context.Context, req *mcp.CallToolReque
 	if err != nil {
 		return nil, types.AddObligationOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	obligation, err := svc.Obligations.Create(
@@ -973,6 +1011,7 @@ func (r *Resolver) UpdateObligationTool(ctx context.Context, req *mcp.CallToolRe
 	if err != nil {
 		return nil, types.UpdateObligationOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	obligation, err := svc.Obligations.Update(
@@ -1005,12 +1044,14 @@ func (r *Resolver) ListProcessingActivitiesTool(ctx context.Context, req *mcp.Ca
 	if err != nil {
 		return nil, types.ListProcessingActivitiesOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ProcessingActivityOrderField]{
 		Field:     coredata.ProcessingActivityOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ProcessingActivityOrderField]{
 			Field:     input.OrderBy.Field,
@@ -1033,6 +1074,7 @@ func (r *Resolver) GetProcessingActivityTool(ctx context.Context, req *mcp.CallT
 	if err != nil {
 		return nil, types.GetProcessingActivityOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	processingActivity, err := prb.ProcessingActivities.Get(ctx, scope, input.ID)
@@ -1050,6 +1092,7 @@ func (r *Resolver) AddProcessingActivityTool(ctx context.Context, req *mcp.CallT
 	if err != nil {
 		return nil, types.AddProcessingActivityOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	processingActivity, err := svc.ProcessingActivities.Create(
@@ -1092,6 +1135,7 @@ func (r *Resolver) UpdateProcessingActivityTool(ctx context.Context, req *mcp.Ca
 	if err != nil {
 		return nil, types.UpdateProcessingActivityOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	var thirdPartyIDs *[]gid.GID
@@ -1139,6 +1183,7 @@ func (r *Resolver) DeleteProcessingActivityTool(ctx context.Context, req *mcp.Ca
 	if err != nil {
 		return nil, types.DeleteProcessingActivityOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	err = svc.ProcessingActivities.Delete(ctx, scope, input.ID)
@@ -1156,12 +1201,14 @@ func (r *Resolver) ListDataProtectionImpactAssessmentsTool(ctx context.Context, 
 	if err != nil {
 		return nil, types.ListDataProtectionImpactAssessmentsOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.DataProtectionImpactAssessmentOrderField]{
 		Field:     coredata.DataProtectionImpactAssessmentOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.DataProtectionImpactAssessmentOrderField]{
 			Field:     input.OrderBy.Field,
@@ -1184,6 +1231,7 @@ func (r *Resolver) GetDataProtectionImpactAssessmentTool(ctx context.Context, re
 	if err != nil {
 		return nil, types.GetDataProtectionImpactAssessmentOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	dpia, err := prb.DataProtectionImpactAssessments.Get(ctx, scope, input.ID)
@@ -1201,6 +1249,7 @@ func (r *Resolver) AddDataProtectionImpactAssessmentTool(ctx context.Context, re
 	if err != nil {
 		return nil, types.AddDataProtectionImpactAssessmentOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	dpia, err := svc.DataProtectionImpactAssessments.Create(
@@ -1228,6 +1277,7 @@ func (r *Resolver) UpdateDataProtectionImpactAssessmentTool(ctx context.Context,
 	if err != nil {
 		return nil, types.UpdateDataProtectionImpactAssessmentOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	dpia, err := svc.DataProtectionImpactAssessments.Update(
@@ -1255,12 +1305,14 @@ func (r *Resolver) ListTransferImpactAssessmentsTool(ctx context.Context, req *m
 	if err != nil {
 		return nil, types.ListTransferImpactAssessmentsOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.TransferImpactAssessmentOrderField]{
 		Field:     coredata.TransferImpactAssessmentOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.TransferImpactAssessmentOrderField]{
 			Field:     input.OrderBy.Field,
@@ -1283,6 +1335,7 @@ func (r *Resolver) GetTransferImpactAssessmentTool(ctx context.Context, req *mcp
 	if err != nil {
 		return nil, types.GetTransferImpactAssessmentOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	tia, err := prb.TransferImpactAssessments.Get(ctx, scope, input.ID)
@@ -1300,6 +1353,7 @@ func (r *Resolver) AddTransferImpactAssessmentTool(ctx context.Context, req *mcp
 	if err != nil {
 		return nil, types.AddTransferImpactAssessmentOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	tia, err := svc.TransferImpactAssessments.Create(
@@ -1327,6 +1381,7 @@ func (r *Resolver) UpdateTransferImpactAssessmentTool(ctx context.Context, req *
 	if err != nil {
 		return nil, types.UpdateTransferImpactAssessmentOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	tia, err := svc.TransferImpactAssessments.Update(
@@ -1354,6 +1409,7 @@ func (r *Resolver) DeleteTransferImpactAssessmentTool(ctx context.Context, req *
 	if err != nil {
 		return nil, types.DeleteTransferImpactAssessmentOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	err = svc.TransferImpactAssessments.Delete(ctx, scope, input.ID)
@@ -1371,12 +1427,14 @@ func (r *Resolver) ListAuditsTool(ctx context.Context, req *mcp.CallToolRequest,
 	if err != nil {
 		return nil, types.ListAuditsOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.AuditOrderField]{
 		Field:     coredata.AuditOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.AuditOrderField]{
 			Field:     input.OrderBy.Field,
@@ -1399,6 +1457,7 @@ func (r *Resolver) GetAuditTool(ctx context.Context, req *mcp.CallToolRequest, i
 	if err != nil {
 		return nil, types.GetAuditOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	audit, err := prb.Audits.Get(ctx, scope, input.ID)
@@ -1424,6 +1483,7 @@ func (r *Resolver) AddAuditTool(ctx context.Context, req *mcp.CallToolRequest, i
 	if err != nil {
 		return nil, types.AddAuditOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	audit, err := svc.Audits.Create(
@@ -1451,6 +1511,7 @@ func (r *Resolver) UpdateAuditTool(ctx context.Context, req *mcp.CallToolRequest
 	if err != nil {
 		return nil, types.UpdateAuditOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	audit, err := svc.Audits.Update(
@@ -1486,12 +1547,14 @@ func (r *Resolver) ListControlsTool(ctx context.Context, req *mcp.CallToolReques
 	if err != nil {
 		return nil, types.ListControlsOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ControlOrderField]{
 		Field:     coredata.ControlOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ControlOrderField]{
 			Field:     input.OrderBy.Field,
@@ -1528,6 +1591,7 @@ func (r *Resolver) GetControlTool(ctx context.Context, req *mcp.CallToolRequest,
 	if err != nil {
 		return nil, types.GetControlOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	control, err := prb.Controls.Get(ctx, scope, input.ID)
@@ -1545,6 +1609,7 @@ func (r *Resolver) AddControlTool(ctx context.Context, req *mcp.CallToolRequest,
 	if err != nil {
 		return nil, types.AddControlOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	control, err := svc.Controls.Create(
@@ -1573,6 +1638,7 @@ func (r *Resolver) UpdateControlTool(ctx context.Context, req *mcp.CallToolReque
 	if err != nil {
 		return nil, types.UpdateControlOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	var maturityLevel *coredata.ControlMaturityLevel
@@ -1696,12 +1762,14 @@ func (r *Resolver) ListControlObligationsTool(ctx context.Context, req *mcp.Call
 	if err != nil {
 		return nil, types.ListControlObligationsOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ObligationOrderField]{
 		Field:     coredata.ObligationOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ObligationOrderField]{
 			Field:     input.OrderBy.Field,
@@ -1724,12 +1792,14 @@ func (r *Resolver) ListControlMeasuresTool(ctx context.Context, req *mcp.CallToo
 	if err != nil {
 		return nil, types.ListControlMeasuresOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.MeasureOrderField]{
 		Field:     coredata.MeasureOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.MeasureOrderField]{
 			Field:     input.OrderBy.Field,
@@ -1752,12 +1822,14 @@ func (r *Resolver) ListControlDocumentsTool(ctx context.Context, req *mcp.CallTo
 	if err != nil {
 		return nil, types.ListControlDocumentsOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
 		Field:     coredata.DocumentOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.DocumentOrderField]{
 			Field:     input.OrderBy.Field,
@@ -1780,12 +1852,14 @@ func (r *Resolver) ListControlAuditsTool(ctx context.Context, req *mcp.CallToolR
 	if err != nil {
 		return nil, types.ListControlAuditsOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.AuditOrderField]{
 		Field:     coredata.AuditOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.AuditOrderField]{
 			Field:     input.OrderBy.Field,
@@ -1808,12 +1882,14 @@ func (r *Resolver) ListRiskObligationsTool(ctx context.Context, req *mcp.CallToo
 	if err != nil {
 		return nil, types.ListRiskObligationsOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ObligationOrderField]{
 		Field:     coredata.ObligationOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ObligationOrderField]{
 			Field:     input.OrderBy.Field,
@@ -1908,12 +1984,14 @@ func (r *Resolver) ListTasksTool(ctx context.Context, req *mcp.CallToolRequest, 
 	if err != nil {
 		return nil, types.ListTasksOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.TaskOrderField]{
 		Field:     coredata.TaskOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.TaskOrderField]{
 			Field:     input.OrderBy.Field,
@@ -1936,6 +2014,7 @@ func (r *Resolver) GetTaskTool(ctx context.Context, req *mcp.CallToolRequest, in
 	if err != nil {
 		return nil, types.GetTaskOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	task, err := prb.Tasks.Get(ctx, scope, input.ID)
@@ -1953,6 +2032,7 @@ func (r *Resolver) AddTaskTool(ctx context.Context, req *mcp.CallToolRequest, in
 	if err != nil {
 		return nil, types.AddTaskOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	priority := coredata.TaskPriorityMedium
@@ -1987,6 +2067,7 @@ func (r *Resolver) UpdateTaskTool(ctx context.Context, req *mcp.CallToolRequest,
 	if err != nil {
 		return nil, types.UpdateTaskOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	task, err := svc.Tasks.Update(
@@ -2018,6 +2099,7 @@ func (r *Resolver) AssignTaskTool(ctx context.Context, req *mcp.CallToolRequest,
 	if err != nil {
 		return nil, types.AssignTaskOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	task, err := svc.Tasks.Assign(ctx, scope, input.ID, input.AssignedToID)
@@ -2035,6 +2117,7 @@ func (r *Resolver) UnassignTaskTool(ctx context.Context, req *mcp.CallToolReques
 	if err != nil {
 		return nil, types.UnassignTaskOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	task, err := svc.Tasks.Unassign(ctx, scope, input.ID)
@@ -2052,6 +2135,7 @@ func (r *Resolver) DeleteTaskTool(ctx context.Context, req *mcp.CallToolRequest,
 	if err != nil {
 		return nil, types.DeleteTaskOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	err = svc.Tasks.Delete(ctx, scope, input.ID)
@@ -2069,12 +2153,14 @@ func (r *Resolver) ListDocumentsTool(ctx context.Context, req *mcp.CallToolReque
 	if err != nil {
 		return nil, types.ListDocumentsOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
 		Field:     coredata.DocumentOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.DocumentOrderField]{
 			Field:     input.OrderBy.Field,
@@ -2117,6 +2203,7 @@ func (r *Resolver) GetDocumentTool(ctx context.Context, req *mcp.CallToolRequest
 	if err != nil {
 		return nil, types.GetDocumentOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	document, err := prb.Documents.Get(ctx, scope, input.ID)
@@ -2134,6 +2221,7 @@ func (r *Resolver) AddDocumentTool(ctx context.Context, req *mcp.CallToolRequest
 	if err != nil {
 		return nil, types.AddDocumentOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	var trustCenterVisibility *coredata.TrustCenterVisibility
@@ -2170,6 +2258,7 @@ func (r *Resolver) UpdateDocumentTool(ctx context.Context, req *mcp.CallToolRequ
 	if err != nil {
 		return nil, types.UpdateDocumentOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	var defaultApproverIDs *[]gid.GID
@@ -2224,6 +2313,7 @@ func (r *Resolver) ListDocumentVersionsTool(ctx context.Context, req *mcp.CallTo
 		Field:     coredata.DocumentVersionOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.DocumentVersionOrderField]{
 			Field:     input.OrderBy.Field,
@@ -2253,6 +2343,7 @@ func (r *Resolver) GetDocumentVersionTool(ctx context.Context, req *mcp.CallTool
 	if err != nil {
 		return nil, types.GetDocumentVersionOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	version, err := svc.Documents.GetVersion(ctx, scope, input.ID)
@@ -2270,12 +2361,14 @@ func (r *Resolver) ListDocumentVersionSignaturesTool(ctx context.Context, req *m
 	if err != nil {
 		return nil, types.ListDocumentVersionSignaturesOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.DocumentVersionSignatureOrderField]{
 		Field:     coredata.DocumentVersionSignatureOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.DocumentVersionSignatureOrderField]{
 			Field:     input.OrderBy.Field,
@@ -2320,6 +2413,7 @@ func (r *Resolver) GetDocumentVersionSignatureTool(ctx context.Context, req *mcp
 	if err != nil {
 		return nil, types.GetDocumentVersionSignatureOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	signature, err := prb.Documents.GetVersionSignature(ctx, scope, input.ID)
@@ -2337,6 +2431,7 @@ func (r *Resolver) RequestDocumentVersionSignatureTool(ctx context.Context, req 
 	if err != nil {
 		return nil, types.RequestDocumentVersionSignatureOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	documentVersionSignature, err := svc.Documents.RequestSignature(
@@ -2360,6 +2455,7 @@ func (r *Resolver) DeleteDocumentTool(ctx context.Context, req *mcp.CallToolRequ
 	if err != nil {
 		return nil, types.DeleteDocumentOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	err = svc.Documents.SoftDelete(ctx, scope, input.DocumentID)
@@ -2377,6 +2473,7 @@ func (r *Resolver) CancelSignatureRequestTool(ctx context.Context, req *mcp.Call
 	if err != nil {
 		return nil, types.CancelSignatureRequestOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	err = svc.Documents.CancelSignatureRequest(ctx, scope, input.DocumentVersionSignatureID)
@@ -2394,6 +2491,7 @@ func (r *Resolver) DeleteRiskTool(ctx context.Context, req *mcp.CallToolRequest,
 	if err != nil {
 		return nil, types.DeleteRiskOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	err = svc.Risks.Delete(ctx, scope, input.ID)
@@ -2411,6 +2509,7 @@ func (r *Resolver) DeleteMeasureTool(ctx context.Context, req *mcp.CallToolReque
 	if err != nil {
 		return nil, types.DeleteMeasureOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	err = svc.Measures.Delete(ctx, scope, input.ID)
@@ -2428,12 +2527,14 @@ func (r *Resolver) ListMeasureRisksTool(ctx context.Context, req *mcp.CallToolRe
 	if err != nil {
 		return nil, types.ListMeasureRisksOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.RiskOrderField]{
 		Field:     coredata.RiskOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.RiskOrderField]{
 			Field:     input.OrderBy.Field,
@@ -2456,12 +2557,14 @@ func (r *Resolver) ListMeasureControlsTool(ctx context.Context, req *mcp.CallToo
 	if err != nil {
 		return nil, types.ListMeasureControlsOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ControlOrderField]{
 		Field:     coredata.ControlOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ControlOrderField]{
 			Field:     input.OrderBy.Field,
@@ -2484,12 +2587,14 @@ func (r *Resolver) ListMeasureTasksTool(ctx context.Context, req *mcp.CallToolRe
 	if err != nil {
 		return nil, types.ListMeasureTasksOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.TaskOrderField]{
 		Field:     coredata.TaskOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.TaskOrderField]{
 			Field:     input.OrderBy.Field,
@@ -2512,6 +2617,7 @@ func (r *Resolver) ListMeasureEvidencesTool(ctx context.Context, req *mcp.CallTo
 	if err != nil {
 		return nil, types.ListMeasureEvidencesOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.EvidenceOrderField]{
@@ -2610,6 +2716,7 @@ func (r *Resolver) ListUsersTool(ctx context.Context, req *mcp.CallToolRequest, 
 		Field:     coredata.MembershipProfileOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.MembershipProfileOrderField]{
 			Field:     input.OrderBy.Field,
@@ -2822,6 +2929,7 @@ func (r *Resolver) DeleteDataProtectionImpactAssessmentTool(ctx context.Context,
 	if err != nil {
 		return nil, types.DeleteDataProtectionImpactAssessmentOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	err = svc.DataProtectionImpactAssessments.Delete(ctx, scope, input.ID)
@@ -2839,12 +2947,14 @@ func (r *Resolver) ListStatementsOfApplicabilityTool(ctx context.Context, req *m
 	if err != nil {
 		return nil, types.ListStatementsOfApplicabilityOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.StatementOfApplicabilityOrderField]{
 		Field:     coredata.StatementOfApplicabilityOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.StatementOfApplicabilityOrderField]{
 			Field:     input.OrderBy.Field,
@@ -2867,6 +2977,7 @@ func (r *Resolver) GetStatementOfApplicabilityTool(ctx context.Context, req *mcp
 	if err != nil {
 		return nil, types.GetStatementOfApplicabilityOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	soa, err := prb.StatementsOfApplicability.Get(ctx, scope, input.ID)
@@ -2884,6 +2995,7 @@ func (r *Resolver) AddStatementOfApplicabilityTool(ctx context.Context, req *mcp
 	if err != nil {
 		return nil, types.AddStatementOfApplicabilityOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	soa, err := svc.StatementsOfApplicability.Create(ctx, scope, probo.CreateStatementOfApplicabilityRequest{
@@ -2904,6 +3016,7 @@ func (r *Resolver) UpdateStatementOfApplicabilityTool(ctx context.Context, req *
 	if err != nil {
 		return nil, types.UpdateStatementOfApplicabilityOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	soa, err := svc.StatementsOfApplicability.Update(ctx, scope, probo.UpdateStatementOfApplicabilityRequest{
@@ -2924,6 +3037,7 @@ func (r *Resolver) DeleteStatementOfApplicabilityTool(ctx context.Context, req *
 	if err != nil {
 		return nil, types.DeleteStatementOfApplicabilityOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	err = svc.StatementsOfApplicability.Delete(ctx, scope, input.ID)
@@ -2941,12 +3055,14 @@ func (r *Resolver) ListApplicabilityStatementsTool(ctx context.Context, req *mcp
 	if err != nil {
 		return nil, types.ListApplicabilityStatementsOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ApplicabilityStatementOrderField]{
 		Field:     coredata.ApplicabilityStatementOrderFieldControlSectionTitle,
 		Direction: page.OrderDirectionAsc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ApplicabilityStatementOrderField]{
 			Field:     input.OrderBy.Field,
@@ -2969,6 +3085,7 @@ func (r *Resolver) GetApplicabilityStatementTool(ctx context.Context, req *mcp.C
 	if err != nil {
 		return nil, types.GetApplicabilityStatementOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	stmt, err := prb.StatementsOfApplicability.GetApplicabilityStatement(ctx, scope, input.ID)
@@ -2986,6 +3103,7 @@ func (r *Resolver) AddApplicabilityStatementTool(ctx context.Context, req *mcp.C
 	if err != nil {
 		return nil, types.AddApplicabilityStatementOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	stmt, err := svc.StatementsOfApplicability.CreateApplicabilityStatement(
@@ -3009,6 +3127,7 @@ func (r *Resolver) UpdateApplicabilityStatementTool(ctx context.Context, req *mc
 	if err != nil {
 		return nil, types.UpdateApplicabilityStatementOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	stmt, err := svc.StatementsOfApplicability.UpdateApplicabilityStatement(
@@ -3031,6 +3150,7 @@ func (r *Resolver) DeleteApplicabilityStatementTool(ctx context.Context, req *mc
 	if err != nil {
 		return nil, types.DeleteApplicabilityStatementOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	err = svc.StatementsOfApplicability.DeleteApplicabilityStatement(ctx, scope, input.ID)
@@ -3050,12 +3170,14 @@ func (r *Resolver) ListThirdPartyRiskAssessmentsTool(ctx context.Context, req *m
 	if err != nil {
 		return nil, types.ListThirdPartyRiskAssessmentsOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyRiskAssessmentOrderField]{
 		Field:     coredata.ThirdPartyRiskAssessmentOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ThirdPartyRiskAssessmentOrderField]{
 			Field:     input.OrderBy.Field,
@@ -3080,6 +3202,7 @@ func (r *Resolver) AddThirdPartyRiskAssessmentTool(ctx context.Context, req *mcp
 	if err != nil {
 		return nil, types.AddThirdPartyRiskAssessmentOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	assessment, err := prb.ThirdParties.CreateRiskAssessment(
@@ -3104,6 +3227,7 @@ func (r *Resolver) DeleteThirdPartyTool(ctx context.Context, req *mcp.CallToolRe
 	if err != nil {
 		return nil, types.DeleteThirdPartyOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	err = svc.ThirdParties.Delete(ctx, scope, input.ID)
@@ -3121,6 +3245,7 @@ func (r *Resolver) DeleteFindingTool(ctx context.Context, req *mcp.CallToolReque
 	if err != nil {
 		return nil, types.DeleteFindingOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	err = svc.Findings.Delete(ctx, scope, input.ID)
@@ -3138,6 +3263,7 @@ func (r *Resolver) LinkFindingAuditTool(ctx context.Context, req *mcp.CallToolRe
 	if err != nil {
 		return nil, types.LinkFindingAuditOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	finding, audit, err := svc.Findings.CreateAuditMapping(ctx, scope, input.FindingID, input.AuditID, input.ReferenceID)
@@ -3156,6 +3282,7 @@ func (r *Resolver) UnlinkFindingAuditTool(ctx context.Context, req *mcp.CallTool
 	if err != nil {
 		return nil, types.UnlinkFindingAuditOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	finding, audit, err := svc.Findings.DeleteAuditMapping(ctx, scope, input.FindingID, input.AuditID)
@@ -3174,12 +3301,14 @@ func (r *Resolver) ListFindingAuditsTool(ctx context.Context, req *mcp.CallToolR
 	if err != nil {
 		return nil, types.ListFindingAuditsOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.AuditOrderField]{
 		Field:     coredata.AuditOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.AuditOrderField]{
 			Field:     input.OrderBy.Field,
@@ -3209,6 +3338,7 @@ func (r *Resolver) ListAccessReviewCampaignsTool(ctx context.Context, req *mcp.C
 		Field:     coredata.AccessReviewCampaignOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.AccessReviewCampaignOrderField]{
 			Field:     input.OrderBy.Field,
@@ -3238,6 +3368,7 @@ func (r *Resolver) ListAccessEntriesTool(ctx context.Context, req *mcp.CallToolR
 		Field:     coredata.AccessEntryOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.AccessEntryOrderField]{
 			Field:     input.OrderBy.Field,
@@ -3443,6 +3574,7 @@ func (r *Resolver) ListAccessSourcesTool(ctx context.Context, req *mcp.CallToolR
 		Field:     coredata.AccessSourceOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.AccessSourceOrderField]{
 			Field:     input.OrderBy.Field,
@@ -3735,6 +3867,7 @@ func (r *Resolver) GetAuditReportUrlTool(ctx context.Context, req *mcp.CallToolR
 	if err != nil {
 		return nil, types.GetAuditReportUrlOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	url, err := prb.Audits.GenerateReportURL(ctx, scope, input.ID, 15*time.Minute)
@@ -3752,6 +3885,7 @@ func (r *Resolver) ArchiveDocumentTool(ctx context.Context, req *mcp.CallToolReq
 	if err != nil {
 		return nil, types.ArchiveDocumentOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	document, err := svc.Documents.Archive(ctx, scope, input.ID)
@@ -3769,6 +3903,7 @@ func (r *Resolver) UnarchiveDocumentTool(ctx context.Context, req *mcp.CallToolR
 	if err != nil {
 		return nil, types.UnarchiveDocumentOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	document, err := svc.Documents.Unarchive(ctx, scope, input.ID)
@@ -3786,6 +3921,7 @@ func (r *Resolver) GetOrganizationContextTool(ctx context.Context, req *mcp.Call
 	if err != nil {
 		return nil, types.GetOrganizationContextOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	orgContext, err := prb.Organizations.GetContext(ctx, scope, input.OrganizationID)
@@ -3803,6 +3939,7 @@ func (r *Resolver) UpdateOrganizationContextTool(ctx context.Context, req *mcp.C
 	if err != nil {
 		return nil, types.UpdateOrganizationContextOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	orgContext, err := prb.Organizations.UpdateContext(
@@ -3885,12 +4022,14 @@ func (r *Resolver) ListMeasureDocumentsTool(ctx context.Context, req *mcp.CallTo
 	if err != nil {
 		return nil, types.ListMeasureDocumentsOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.DocumentOrderField]{
 		Field:     coredata.DocumentOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.DocumentOrderField]{
 			Field:     input.OrderBy.Field,
@@ -3913,6 +4052,7 @@ func (r *Resolver) VoidDocumentVersionApprovalTool(ctx context.Context, req *mcp
 	if err != nil {
 		return nil, types.VoidDocumentVersionApprovalOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	_, documentVersion, err := svc.DocumentApprovals.VoidApproval(ctx, scope, input.DocumentVersionID)
@@ -3930,6 +4070,7 @@ func (r *Resolver) SendSigningNotificationsTool(ctx context.Context, req *mcp.Ca
 	if err != nil {
 		return nil, types.SendSigningNotificationsOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	err = svc.Documents.SendSigningNotifications(ctx, scope, input.OrganizationID)
@@ -3947,6 +4088,7 @@ func (r *Resolver) DeleteDocumentDraftTool(ctx context.Context, req *mcp.CallToo
 	if err != nil {
 		return nil, types.DeleteDocumentDraftOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	document, err := svc.Documents.DeleteDraft(ctx, scope, input.ID)
@@ -3964,6 +4106,7 @@ func (r *Resolver) PublishStatementOfApplicabilityTool(ctx context.Context, req 
 	if err != nil {
 		return nil, types.PublishStatementOfApplicabilityOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	document, documentVersion, err := svc.GeneratedDocuments.PublishStatementOfApplicability(ctx, scope, input.ID, input.ApproverIds, input.Minor)
@@ -3982,12 +4125,14 @@ func (r *Resolver) ListWebhookSubscriptionsTool(ctx context.Context, req *mcp.Ca
 	if err != nil {
 		return nil, types.ListWebhookSubscriptionsOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.WebhookSubscriptionOrderField]{
 		Field:     coredata.WebhookSubscriptionOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.WebhookSubscriptionOrderField]{
 			Field:     input.OrderBy.Field,
@@ -4010,6 +4155,7 @@ func (r *Resolver) GetWebhookSubscriptionTool(ctx context.Context, req *mcp.Call
 	if err != nil {
 		return nil, types.GetWebhookSubscriptionOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	subscription, err := prb.WebhookSubscriptions.Get(ctx, scope, input.ID)
@@ -4027,6 +4173,7 @@ func (r *Resolver) CreateWebhookSubscriptionTool(ctx context.Context, req *mcp.C
 	if err != nil {
 		return nil, types.CreateWebhookSubscriptionOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	subscription, err := prb.WebhookSubscriptions.Create(
@@ -4051,6 +4198,7 @@ func (r *Resolver) UpdateWebhookSubscriptionTool(ctx context.Context, req *mcp.C
 	if err != nil {
 		return nil, types.UpdateWebhookSubscriptionOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	subscription, err := prb.WebhookSubscriptions.Update(
@@ -4075,6 +4223,7 @@ func (r *Resolver) DeleteWebhookSubscriptionTool(ctx context.Context, req *mcp.C
 	if err != nil {
 		return nil, types.DeleteWebhookSubscriptionOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	err = prb.WebhookSubscriptions.Delete(ctx, scope, input.ID)
@@ -4092,12 +4241,14 @@ func (r *Resolver) ListWebhookEventsTool(ctx context.Context, req *mcp.CallToolR
 	if err != nil {
 		return nil, types.ListWebhookEventsOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.WebhookEventOrderField]{
 		Field:     coredata.WebhookEventOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.WebhookEventOrderField]{
 			Field:     input.OrderBy.Field,
@@ -4120,12 +4271,14 @@ func (r *Resolver) ListDocumentVersionApprovalQuorumsTool(ctx context.Context, r
 	if err != nil {
 		return nil, types.ListDocumentVersionApprovalQuorumsOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.DocumentVersionApprovalQuorumOrderField]{
 		Field:     coredata.DocumentVersionApprovalQuorumOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.DocumentVersionApprovalQuorumOrderField]{
 			Field:     input.OrderBy.Field,
@@ -4148,6 +4301,7 @@ func (r *Resolver) GetDocumentVersionApprovalQuorumTool(ctx context.Context, req
 	if err != nil {
 		return nil, types.GetDocumentVersionApprovalQuorumOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	quorum, err := svc.DocumentApprovals.GetQuorum(ctx, scope, input.ID)
@@ -4165,12 +4319,14 @@ func (r *Resolver) ListDocumentVersionApprovalDecisionsTool(ctx context.Context,
 	if err != nil {
 		return nil, types.ListDocumentVersionApprovalDecisionsOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.DocumentVersionApprovalDecisionOrderField]{
 		Field:     coredata.DocumentVersionApprovalDecisionOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.DocumentVersionApprovalDecisionOrderField]{
 			Field:     input.OrderBy.Field,
@@ -4200,6 +4356,7 @@ func (r *Resolver) GetDocumentVersionApprovalDecisionTool(ctx context.Context, r
 	if err != nil {
 		return nil, types.GetDocumentVersionApprovalDecisionOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	decision, err := svc.DocumentApprovals.GetDecision(ctx, scope, input.ID)
@@ -4217,6 +4374,7 @@ func (r *Resolver) PublishDataListTool(ctx context.Context, req *mcp.CallToolReq
 	if err != nil {
 		return nil, types.PublishDataListOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	document, documentVersion, err := svc.GeneratedDocuments.PublishDataList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
@@ -4235,6 +4393,7 @@ func (r *Resolver) PublishAssetListTool(ctx context.Context, req *mcp.CallToolRe
 	if err != nil {
 		return nil, types.PublishAssetListOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	document, documentVersion, err := svc.GeneratedDocuments.PublishAssetList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
@@ -4255,12 +4414,14 @@ func (r *Resolver) ListThirdPartyContactsTool(ctx context.Context, req *mcp.Call
 	if err != nil {
 		return nil, types.ListThirdPartyContactsOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyContactOrderField]{
 		Field:     coredata.ThirdPartyContactOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ThirdPartyContactOrderField]{
 			Field:     input.OrderBy.Field,
@@ -4285,6 +4446,7 @@ func (r *Resolver) AddThirdPartyContactTool(ctx context.Context, req *mcp.CallTo
 	if err != nil {
 		return nil, types.AddThirdPartyContactOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	emailAddr, err := mail.ParseAddr(input.Email)
@@ -4315,6 +4477,7 @@ func (r *Resolver) UpdateThirdPartyContactTool(ctx context.Context, req *mcp.Cal
 	if err != nil {
 		return nil, types.UpdateThirdPartyContactOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	updateReq := probo.UpdateThirdPartyContactRequest{
@@ -4360,6 +4523,7 @@ func (r *Resolver) DeleteThirdPartyContactTool(ctx context.Context, req *mcp.Cal
 	if err != nil {
 		return nil, types.DeleteThirdPartyContactOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	err = prb.ThirdPartyContacts.Delete(ctx, scope, input.ID)
@@ -4379,12 +4543,14 @@ func (r *Resolver) ListThirdPartyServicesTool(ctx context.Context, req *mcp.Call
 	if err != nil {
 		return nil, types.ListThirdPartyServicesOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ThirdPartyServiceOrderField]{
 		Field:     coredata.ThirdPartyServiceOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ThirdPartyServiceOrderField]{
 			Field:     input.OrderBy.Field,
@@ -4409,6 +4575,7 @@ func (r *Resolver) AddThirdPartyServiceTool(ctx context.Context, req *mcp.CallTo
 	if err != nil {
 		return nil, types.AddThirdPartyServiceOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	thirdPartyService, err := prb.ThirdPartyServices.Create(ctx, scope, probo.CreateThirdPartyServiceRequest{
@@ -4432,6 +4599,7 @@ func (r *Resolver) UpdateThirdPartyServiceTool(ctx context.Context, req *mcp.Cal
 	if err != nil {
 		return nil, types.UpdateThirdPartyServiceOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	updateReq := probo.UpdateThirdPartyServiceRequest{
@@ -4463,6 +4631,7 @@ func (r *Resolver) DeleteThirdPartyServiceTool(ctx context.Context, req *mcp.Cal
 	if err != nil {
 		return nil, types.DeleteThirdPartyServiceOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	err = prb.ThirdPartyServices.Delete(ctx, scope, input.ID)
@@ -4479,6 +4648,7 @@ func (r *Resolver) DeleteAssetTool(ctx context.Context, req *mcp.CallToolRequest
 	if err != nil {
 		return nil, types.DeleteAssetOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	err = svc.Assets.Delete(ctx, scope, input.ID)
@@ -4495,6 +4665,7 @@ func (r *Resolver) DeleteDatumTool(ctx context.Context, req *mcp.CallToolRequest
 	if err != nil {
 		return nil, types.DeleteDatumOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	err = svc.Data.Delete(ctx, scope, input.ID)
@@ -4511,6 +4682,7 @@ func (r *Resolver) DeleteObligationTool(ctx context.Context, req *mcp.CallToolRe
 	if err != nil {
 		return nil, types.DeleteObligationOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	err = svc.Obligations.Delete(ctx, scope, input.ID)
@@ -4527,6 +4699,7 @@ func (r *Resolver) DeleteAuditTool(ctx context.Context, req *mcp.CallToolRequest
 	if err != nil {
 		return nil, types.DeleteAuditOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	err = svc.Audits.Delete(ctx, scope, input.ID)
@@ -4543,12 +4716,14 @@ func (r *Resolver) ListRightsRequestsTool(ctx context.Context, req *mcp.CallTool
 	if err != nil {
 		return nil, types.ListRightsRequestsOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.RightsRequestOrderField]{
 		Field:     coredata.RightsRequestOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.RightsRequestOrderField]{
 			Field:     input.OrderBy.Field,
@@ -4570,6 +4745,7 @@ func (r *Resolver) GetRightsRequestTool(ctx context.Context, req *mcp.CallToolRe
 	if err != nil {
 		return nil, types.GetRightsRequestOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	rightsRequest, err := prb.RightsRequests.Get(ctx, scope, input.ID)
@@ -4586,6 +4762,7 @@ func (r *Resolver) AddRightsRequestTool(ctx context.Context, req *mcp.CallToolRe
 	if err != nil {
 		return nil, types.AddRightsRequestOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	rightsRequest, err := svc.RightsRequests.Create(
@@ -4614,6 +4791,7 @@ func (r *Resolver) UpdateRightsRequestTool(ctx context.Context, req *mcp.CallToo
 	if err != nil {
 		return nil, types.UpdateRightsRequestOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	var dataSubject **string
@@ -4647,6 +4825,7 @@ func (r *Resolver) DeleteRightsRequestTool(ctx context.Context, req *mcp.CallToo
 	if err != nil {
 		return nil, types.DeleteRightsRequestOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	err = svc.RightsRequests.Delete(ctx, scope, input.ID)
@@ -4666,6 +4845,7 @@ func (r *Resolver) GetTrustCenterTool(ctx context.Context, req *mcp.CallToolRequ
 	if err != nil {
 		return nil, types.GetTrustCenterOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	trustCenter, err := prb.TrustCenters.GetByOrganizationID(ctx, scope, input.OrganizationID)
@@ -4700,11 +4880,13 @@ func (r *Resolver) UpdateTrustCenterTool(ctx context.Context, req *mcp.CallToolR
 	if err != nil {
 		return nil, types.UpdateTrustCenterOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	updateReq := &probo.UpdateTrustCenterRequest{
 		ID: input.TrustCenterID,
 	}
+
 	if active := UnwrapOmittable(input.Active); active != nil {
 		updateReq.Active = *active
 	}
@@ -4728,12 +4910,14 @@ func (r *Resolver) ListTrustCenterReferencesTool(ctx context.Context, req *mcp.C
 	if err != nil {
 		return nil, types.ListTrustCenterReferencesOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.TrustCenterReferenceOrderField]{
 		Field:     coredata.TrustCenterReferenceOrderFieldRank,
 		Direction: page.OrderDirectionAsc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.TrustCenterReferenceOrderField]{
 			Field:     input.OrderBy.Field,
@@ -4758,6 +4942,7 @@ func (r *Resolver) AddTrustCenterReferenceTool(ctx context.Context, req *mcp.Cal
 	if err != nil {
 		return nil, types.AddTrustCenterReferenceOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	var websiteURL string
@@ -4788,12 +4973,14 @@ func (r *Resolver) UpdateTrustCenterReferenceTool(ctx context.Context, req *mcp.
 	if err != nil {
 		return nil, types.UpdateTrustCenterReferenceOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	updateRefReq := &probo.UpdateTrustCenterReferenceRequest{
 		ID:          input.ID,
 		Description: UnwrapOmittable(input.Description),
 	}
+
 	if name := UnwrapOmittable(input.Name); name != nil {
 		updateRefReq.Name = *name
 	}
@@ -4821,6 +5008,7 @@ func (r *Resolver) DeleteTrustCenterReferenceTool(ctx context.Context, req *mcp.
 	if err != nil {
 		return nil, types.DeleteTrustCenterReferenceOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	err = prb.TrustCenterReferences.Delete(ctx, scope, input.ID)
@@ -4838,12 +5026,14 @@ func (r *Resolver) ListTrustCenterFilesTool(ctx context.Context, req *mcp.CallTo
 	if err != nil {
 		return nil, types.ListTrustCenterFilesOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.TrustCenterFileOrderField]{
 		Field:     coredata.TrustCenterFileOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.TrustCenterFileOrderField]{
 			Field:     input.OrderBy.Field,
@@ -4879,6 +5069,7 @@ func (r *Resolver) DeleteTrustCenterFileTool(ctx context.Context, req *mcp.CallT
 	if err != nil {
 		return nil, types.DeleteTrustCenterFileOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	err = prb.TrustCenterFiles.Delete(ctx, scope, input.ID)
@@ -4896,12 +5087,14 @@ func (r *Resolver) ListComplianceExternalURLsTool(ctx context.Context, req *mcp.
 	if err != nil {
 		return nil, types.ListComplianceExternalURLsOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	pageOrderBy := page.OrderBy[coredata.ComplianceExternalURLOrderField]{
 		Field:     coredata.ComplianceExternalURLOrderFieldRank,
 		Direction: page.OrderDirectionAsc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.ComplianceExternalURLOrderField]{
 			Field:     input.OrderBy.Field,
@@ -4926,6 +5119,7 @@ func (r *Resolver) AddComplianceExternalURLTool(ctx context.Context, req *mcp.Ca
 	if err != nil {
 		return nil, types.AddComplianceExternalURLOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	item, err := prb.ComplianceExternalURLs.Create(
@@ -4950,6 +5144,7 @@ func (r *Resolver) UpdateComplianceExternalURLTool(ctx context.Context, req *mcp
 	if err != nil {
 		return nil, types.UpdateComplianceExternalURLOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	updateURLReq := &probo.UpdateComplianceExternalURLRequest{
@@ -4983,6 +5178,7 @@ func (r *Resolver) DeleteComplianceExternalURLTool(ctx context.Context, req *mcp
 	if err != nil {
 		return nil, types.DeleteComplianceExternalURLOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	err = prb.ComplianceExternalURLs.Delete(
@@ -5005,6 +5201,7 @@ func (r *Resolver) CreateCustomDomainTool(ctx context.Context, req *mcp.CallTool
 	if err != nil {
 		return nil, types.CreateCustomDomainOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	domain, err := prb.CustomDomains.CreateCustomDomain(
@@ -5028,6 +5225,7 @@ func (r *Resolver) DeleteCustomDomainTool(ctx context.Context, req *mcp.CallTool
 	if err != nil {
 		return nil, types.DeleteCustomDomainOutput{}, err
 	}
+
 	prb := r.proboSvc
 
 	domain, err := prb.CustomDomains.GetOrganizationCustomDomain(ctx, scope, input.OrganizationID)
@@ -5053,6 +5251,7 @@ func (r *Resolver) AssessThirdPartyTool(ctx context.Context, req *mcp.CallToolRe
 	if err != nil {
 		return nil, types.AssessThirdPartyOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	result, err := svc.ThirdParties.Assess(
@@ -5075,6 +5274,7 @@ func (r *Resolver) PublishFindingListTool(ctx context.Context, req *mcp.CallTool
 	if err != nil {
 		return nil, types.PublishFindingListOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	document, documentVersion, err := svc.GeneratedDocuments.PublishFindingList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
@@ -5093,6 +5293,7 @@ func (r *Resolver) PublishObligationListTool(ctx context.Context, req *mcp.CallT
 	if err != nil {
 		return nil, types.PublishObligationListOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	document, documentVersion, err := svc.GeneratedDocuments.PublishObligationList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
@@ -5111,6 +5312,7 @@ func (r *Resolver) PublishProcessingActivityListTool(ctx context.Context, req *m
 	if err != nil {
 		return nil, types.PublishProcessingActivityListOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	document, documentVersion, err := svc.GeneratedDocuments.PublishProcessingActivityList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
@@ -5129,6 +5331,7 @@ func (r *Resolver) PublishDataProtectionImpactAssessmentListTool(ctx context.Con
 	if err != nil {
 		return nil, types.PublishDataProtectionImpactAssessmentListOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	document, documentVersion, err := svc.GeneratedDocuments.PublishDataProtectionImpactAssessmentList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
@@ -5147,6 +5350,7 @@ func (r *Resolver) PublishTransferImpactAssessmentListTool(ctx context.Context, 
 	if err != nil {
 		return nil, types.PublishTransferImpactAssessmentListOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	document, documentVersion, err := svc.GeneratedDocuments.PublishTransferImpactAssessmentList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
@@ -5165,6 +5369,7 @@ func (r *Resolver) PublishThirdPartyListTool(ctx context.Context, req *mcp.CallT
 	if err != nil {
 		return nil, types.PublishThirdPartyListOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	document, documentVersion, err := svc.GeneratedDocuments.PublishThirdPartyList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
@@ -5182,6 +5387,7 @@ func (r *Resolver) ListCookieBannersTool(ctx context.Context, req *mcp.CallToolR
 	if _, err := r.Authorize(ctx, input.OrganizationID, probo.ActionCookieBannerList); err != nil {
 		return nil, types.ListCookieBannersOutput{}, err
 	}
+
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieBannerOrderField]{Field: coredata.CookieBannerOrderFieldCreatedAt, Direction: page.OrderDirectionDesc})
 
@@ -5199,6 +5405,7 @@ func (r *Resolver) GetCookieBannerTool(ctx context.Context, req *mcp.CallToolReq
 	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerGet); err != nil {
 		return nil, types.GetCookieBannerOutput{}, err
 	}
+
 	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	banner, err := r.cookieBanner.GetCookieBanner(ctx, scope, input.ID)
@@ -5213,6 +5420,7 @@ func (r *Resolver) AddCookieBannerTool(ctx context.Context, req *mcp.CallToolReq
 	if _, err := r.Authorize(ctx, input.OrganizationID, probo.ActionCookieBannerCreate); err != nil {
 		return nil, types.AddCookieBannerOutput{}, err
 	}
+
 	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 
 	banner, err := r.cookieBanner.CreateCookieBanner(ctx, scope, cookiebanner.CreateCookieBannerRequest{
@@ -5234,6 +5442,7 @@ func (r *Resolver) UpdateCookieBannerTool(ctx context.Context, req *mcp.CallTool
 	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerUpdate); err != nil {
 		return nil, types.UpdateCookieBannerOutput{}, err
 	}
+
 	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	updateReq := cookiebanner.UpdateCookieBannerRequest{CookieBannerID: input.ID}
@@ -5270,6 +5479,7 @@ func (r *Resolver) DeleteCookieBannerTool(ctx context.Context, req *mcp.CallTool
 	if err != nil {
 		return nil, types.DeleteCookieBannerOutput{}, err
 	}
+
 	if err := r.cookieBanner.DeleteCookieBanner(ctx, scope, input.ID); err != nil {
 		return nil, types.DeleteCookieBannerOutput{}, fmt.Errorf("cannot delete cookie banner: %w", err)
 	}
@@ -5281,6 +5491,7 @@ func (r *Resolver) ActivateCookieBannerTool(ctx context.Context, req *mcp.CallTo
 	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerActivate); err != nil {
 		return nil, types.ActivateCookieBannerOutput{}, err
 	}
+
 	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	banner, err := r.cookieBanner.ActivateCookieBanner(ctx, scope, input.ID)
@@ -5295,6 +5506,7 @@ func (r *Resolver) DeactivateCookieBannerTool(ctx context.Context, req *mcp.Call
 	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerDeactivate); err != nil {
 		return nil, types.DeactivateCookieBannerOutput{}, err
 	}
+
 	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	banner, err := r.cookieBanner.DeactivateCookieBanner(ctx, scope, input.ID)
@@ -5309,6 +5521,7 @@ func (r *Resolver) ListCookieCategoriesTool(ctx context.Context, req *mcp.CallTo
 	if _, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieCategoryList); err != nil {
 		return nil, types.ListCookieCategoriesOutput{}, err
 	}
+
 	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieCategoryOrderField]{Field: coredata.CookieCategoryOrderFieldRank, Direction: page.OrderDirectionAsc})
 
@@ -5326,6 +5539,7 @@ func (r *Resolver) GetCookieCategoryTool(ctx context.Context, req *mcp.CallToolR
 	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieCategoryGet); err != nil {
 		return nil, types.GetCookieCategoryOutput{}, err
 	}
+
 	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	category, err := r.cookieBanner.GetCookieCategory(ctx, scope, input.ID)
@@ -5340,6 +5554,7 @@ func (r *Resolver) AddCookieCategoryTool(ctx context.Context, req *mcp.CallToolR
 	if _, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieCategoryCreate); err != nil {
 		return nil, types.AddCookieCategoryOutput{}, err
 	}
+
 	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 
 	category, err := r.cookieBanner.CreateCookieCategory(ctx, scope, cookiebanner.CreateCookieCategoryRequest{
@@ -5360,6 +5575,7 @@ func (r *Resolver) UpdateCookieCategoryTool(ctx context.Context, req *mcp.CallTo
 	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieCategoryUpdate); err != nil {
 		return nil, types.UpdateCookieCategoryOutput{}, err
 	}
+
 	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	updateReq := cookiebanner.UpdateCookieCategoryRequest{CookieCategoryID: input.ID}
@@ -5388,6 +5604,7 @@ func (r *Resolver) DeleteCookieCategoryTool(ctx context.Context, req *mcp.CallTo
 	if err != nil {
 		return nil, types.DeleteCookieCategoryOutput{}, err
 	}
+
 	if err := r.cookieBanner.DeleteCookieCategory(ctx, scope, input.ID); err != nil {
 		return nil, types.DeleteCookieCategoryOutput{}, fmt.Errorf("cannot delete cookie category: %w", err)
 	}
@@ -5399,6 +5616,7 @@ func (r *Resolver) ReorderCookieCategoryTool(ctx context.Context, req *mcp.CallT
 	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieCategoryUpdate); err != nil {
 		return nil, types.ReorderCookieCategoryOutput{}, err
 	}
+
 	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	_, err := r.cookieBanner.ReorderCookieCategory(ctx, scope, cookiebanner.ReorderCookieCategoryRequest{
@@ -5421,6 +5639,7 @@ func (r *Resolver) ListTrackerPatternsTool(ctx context.Context, req *mcp.CallToo
 	if _, err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerPatternList); err != nil {
 		return nil, types.ListTrackerPatternsOutput{}, err
 	}
+
 	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.TrackerPatternOrderField]{Field: coredata.TrackerPatternOrderFieldCreatedAt, Direction: page.OrderDirectionAsc})
 
@@ -5438,6 +5657,7 @@ func (r *Resolver) GetTrackerPatternTool(ctx context.Context, req *mcp.CallToolR
 	if _, err := r.Authorize(ctx, input.ID, probo.ActionTrackerPatternGet); err != nil {
 		return nil, types.GetTrackerPatternOutput{}, err
 	}
+
 	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	pattern, err := r.cookieBanner.GetTrackerPattern(ctx, scope, input.ID)
@@ -5452,6 +5672,7 @@ func (r *Resolver) AddTrackerPatternTool(ctx context.Context, req *mcp.CallToolR
 	if _, err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerPatternCreate); err != nil {
 		return nil, types.AddTrackerPatternOutput{}, err
 	}
+
 	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
 
 	pattern, err := r.cookieBanner.CreateTrackerPattern(ctx, scope, cookiebanner.CreateTrackerPatternRequest{
@@ -5474,6 +5695,7 @@ func (r *Resolver) UpdateTrackerPatternTool(ctx context.Context, req *mcp.CallTo
 	if _, err := r.Authorize(ctx, input.ID, probo.ActionTrackerPatternUpdate); err != nil {
 		return nil, types.UpdateTrackerPatternOutput{}, err
 	}
+
 	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	updateReq := cookiebanner.UpdateTrackerPatternRequest{TrackerPatternID: input.ID}
@@ -5503,6 +5725,7 @@ func (r *Resolver) DeleteTrackerPatternTool(ctx context.Context, req *mcp.CallTo
 	if err != nil {
 		return nil, types.DeleteTrackerPatternOutput{}, err
 	}
+
 	if err := r.cookieBanner.DeleteTrackerPattern(ctx, scope, input.ID); err != nil {
 		return nil, types.DeleteTrackerPatternOutput{}, fmt.Errorf("cannot delete tracker pattern: %w", err)
 	}
@@ -5514,6 +5737,7 @@ func (r *Resolver) MoveTrackerPatternToCategoryTool(ctx context.Context, req *mc
 	if _, err := r.Authorize(ctx, input.TrackerPatternID, probo.ActionTrackerPatternUpdate); err != nil {
 		return nil, types.MoveTrackerPatternToCategoryOutput{}, err
 	}
+
 	scope := coredata.NewScopeFromObjectID(input.TrackerPatternID)
 
 	result, err := r.cookieBanner.MoveTrackerPatternToCategory(ctx, scope, cookiebanner.MoveTrackerPatternToCategoryRequest{
@@ -5531,6 +5755,7 @@ func (r *Resolver) PublishCookieBannerVersionTool(ctx context.Context, req *mcp.
 	if _, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerVersionPublish); err != nil {
 		return nil, types.PublishCookieBannerVersionOutput{}, err
 	}
+
 	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 
 	version, err := r.cookieBanner.PublishCookieBannerVersion(ctx, scope, input.CookieBannerID)
@@ -5545,6 +5770,7 @@ func (r *Resolver) ListCookieBannerVersionsTool(ctx context.Context, req *mcp.Ca
 	if _, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerVersionList); err != nil {
 		return nil, types.ListCookieBannerVersionsOutput{}, err
 	}
+
 	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieBannerVersionOrderField]{Field: coredata.CookieBannerVersionOrderFieldCreatedAt, Direction: page.OrderDirectionDesc})
 
@@ -5562,6 +5788,7 @@ func (r *Resolver) UpsertCookieBannerTranslationTool(ctx context.Context, req *m
 	if _, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerUpdate); err != nil {
 		return nil, types.UpsertCookieBannerTranslationOutput{}, err
 	}
+
 	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 
 	translation, err := r.cookieBanner.UpsertCookieBannerTranslation(ctx, scope, cookiebanner.UpsertCookieBannerTranslationRequest{
@@ -5580,6 +5807,7 @@ func (r *Resolver) ListCookieConsentRecordsTool(ctx context.Context, req *mcp.Ca
 	if _, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieConsentRecordList); err != nil {
 		return nil, types.ListCookieConsentRecordsOutput{}, err
 	}
+
 	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieConsentRecordOrderField]{Field: coredata.CookieConsentRecordOrderFieldCreatedAt, Direction: page.OrderDirectionDesc})
 
@@ -5606,6 +5834,7 @@ func (r *Resolver) GetCookieConsentRecordTool(ctx context.Context, req *mcp.Call
 	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieConsentRecordList); err != nil {
 		return nil, types.GetCookieConsentRecordOutput{}, err
 	}
+
 	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	record, err := r.cookieBanner.GetCookieConsentRecord(ctx, scope, input.ID)
@@ -5621,6 +5850,7 @@ func (r *Resolver) PublishRiskListTool(ctx context.Context, req *mcp.CallToolReq
 	if err != nil {
 		return nil, types.PublishRiskListOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	document, documentVersion, err := svc.GeneratedDocuments.PublishRiskList(ctx, scope, input.OrganizationID, input.ApproverIds, input.Minor)
@@ -5746,6 +5976,7 @@ func (r *Resolver) ListSCIMEventsTool(ctx context.Context, req *mcp.CallToolRequ
 		Field:     coredata.SCIMEventOrderFieldCreatedAt,
 		Direction: page.OrderDirectionDesc,
 	}
+
 	if input.OrderBy != nil {
 		pageOrderBy = page.OrderBy[coredata.SCIMEventOrderField]{
 			Field:     input.OrderBy.Field,
@@ -5773,6 +6004,7 @@ func (r *Resolver) PublishDocumentTool(ctx context.Context, req *mcp.CallToolReq
 	if err != nil {
 		return nil, types.PublishDocumentOutput{}, err
 	}
+
 	svc := r.proboSvc
 
 	result, err := svc.Documents.PublishVersion(ctx, scope, probo.PublishDocumentRequest{
@@ -5789,6 +6021,7 @@ func (r *Resolver) PublishDocumentTool(ctx context.Context, req *mcp.CallToolReq
 		Document:        types.NewDocument(result.Document),
 		DocumentVersion: types.NewDocumentVersion(result.Version),
 	}
+
 	if result.Quorum != nil {
 		output.ApprovalQuorum = types.NewDocumentVersionApprovalQuorum(result.Quorum)
 	}
@@ -5800,6 +6033,7 @@ func (r *Resolver) ListTrackerResourcesTool(ctx context.Context, req *mcp.CallTo
 	if _, err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerResourceList); err != nil {
 		return nil, types.ListTrackerResourcesOutput{}, err
 	}
+
 	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.TrackerResourceOrderField]{Field: coredata.TrackerResourceOrderFieldCreatedAt, Direction: page.OrderDirectionAsc})
 
@@ -5817,6 +6051,7 @@ func (r *Resolver) GetTrackerResourceTool(ctx context.Context, req *mcp.CallTool
 	if _, err := r.Authorize(ctx, input.ID, probo.ActionTrackerResourceGet); err != nil {
 		return nil, types.GetTrackerResourceOutput{}, err
 	}
+
 	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	resource, err := r.cookieBanner.GetTrackerResource(ctx, scope, input.ID)
@@ -5831,6 +6066,7 @@ func (r *Resolver) AddTrackerResourceTool(ctx context.Context, req *mcp.CallTool
 	if _, err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerResourceCreate); err != nil {
 		return nil, types.AddTrackerResourceOutput{}, err
 	}
+
 	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
 
 	description := ""
@@ -5857,6 +6093,7 @@ func (r *Resolver) UpdateTrackerResourceTool(ctx context.Context, req *mcp.CallT
 	if _, err := r.Authorize(ctx, input.ID, probo.ActionTrackerResourceUpdate); err != nil {
 		return nil, types.UpdateTrackerResourceOutput{}, err
 	}
+
 	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	updateReq := cookiebanner.UpdateTrackerResourceRequest{TrackerResourceID: input.ID}
@@ -5885,6 +6122,7 @@ func (r *Resolver) DeleteTrackerResourceTool(ctx context.Context, req *mcp.CallT
 	if err != nil {
 		return nil, types.DeleteTrackerResourceOutput{}, err
 	}
+
 	if err := r.cookieBanner.DeleteTrackerResource(ctx, scope, input.ID); err != nil {
 		return nil, types.DeleteTrackerResourceOutput{}, fmt.Errorf("cannot delete tracker resource: %w", err)
 	}
@@ -5896,6 +6134,7 @@ func (r *Resolver) MoveTrackerResourceToCategoryTool(ctx context.Context, req *m
 	if _, err := r.Authorize(ctx, input.TrackerResourceID, probo.ActionTrackerResourceUpdate); err != nil {
 		return nil, types.MoveTrackerResourceToCategoryOutput{}, err
 	}
+
 	scope := coredata.NewScopeFromObjectID(input.TrackerResourceID)
 
 	result, err := r.cookieBanner.MoveTrackerResourceToCategory(ctx, scope, cookiebanner.MoveTrackerResourceToCategoryRequest{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Return an authorization scope from IAM and add all‑or‑nothing batch authorization across GraphQL, MCP, and Console. Also add a tracker pattern detail page, unify cookie category queries, align document signature counts, tailor certificate email subjects, and expose a full risk assessment system in the CLI and `@probo/n8n-nodes-probo`.

- **New Features**
  - IAM: added `iam.Authorizer.AuthorizeBatch` and `AuthorizeMulti`; single `Authorize` returns a `*coredata.Scope`; structured batch errors; `AuthorizationAttributer` now loads attributes in batch; wired via `pkg/server/api/authz.NewBatchAuthorizeFunc` with options; Console adds an authorize dataloader; Connect Node resolver uses the returned scope. Replaced `MustAuthorize` with `Authorize`. Added actions `ActionCommonThirdPartyGet/List` and `ActionElectronicSignatureGet`; implemented `AuthorizationAttributes` on `CommonThirdParty` (global) and `ElectronicSignature`. Fix: treat empty string attributes as “no attributes”.
  - Console: new tracker pattern detail page; cookie banner field renamed to `categories` with `filter: { excludeKind: UNCATEGORISED }`; tightened IAM on all data-bearing resolvers and total counts.
  - Documents/Emails: signature counts and lists use `{ activeContract: true, state: ACTIVE }`; n8n get-all-signatures supports `state`; certificate emails read a per-signature subject and use a neutral intro.
  - Integrations: added `prb risk-assessment` CLI group and full `riskAssessment` CRUD/linking to `@probo/n8n-nodes-probo`.

- **Migration**
  - Update all `AuthorizationAttributes` implementations and call sites to the batched signature; replace `MustAuthorize` with `Authorize`/`AuthorizeBatch`; handle new batch errors (`ErrMixedOrganizationBatch`, `ErrMixedEntityTypeBatch`, `ErrEmptyResourceBatch`, `ErrBatchAuthorizationUnsupportedResourceType`) as invalid input in GraphQL/MCP. Adopt the updated `authz.AuthorizeFunc` that returns a `*coredata.Scope` and pass it through where needed (e.g., Connect Node resolver).
  - Update GraphQL/Console references from `consentCategories` to `categories` and add `filter: { excludeKind: UNCATEGORISED }`; for signature queries, use `{ activeContract: true, state: ACTIVE }` to keep counts in sync.

<sup>Written for commit bd04f1812a1300edbb43adf7ea95adcd9a22e8c0. Summary will update on new commits. <a href="https://cubic.dev/pr/getprobo/probo/pull/1211?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

