### PR TITLE
Fix signature count mismatch with signatures tab on documents

### DIFF
--- a/apps/console/src/pages/organizations/documents/DocumentLayout.tsx
+++ b/apps/console/src/pages/organizations/documents/DocumentLayout.tsx
@@ -40,10 +40,10 @@ export const documentLayoutQuery = graphql`
         ...DocumentTitleFormFragment
         ...DocumentActionsDropdown_versionFragment
         ...DocumentDetailsCard_versionFragment
-        signatures(first: 0 filter: { activeContract: true }) {
+        signatures(first: 0 filter: { activeContract: true, state: ACTIVE }) {
           totalCount
         }
-        signedSignatures: signatures(first: 0 filter: { states: [SIGNED], activeContract: true }) {
+        signedSignatures: signatures(first: 0 filter: { states: [SIGNED], activeContract: true, state: ACTIVE }) {
           totalCount
         }
         approvalQuorums(first: 1, orderBy: { field: CREATED_AT, direction: DESC }) {
@@ -85,10 +85,10 @@ export const documentLayoutQuery = graphql`
               ...DocumentTitleFormFragment
               ...DocumentActionsDropdown_versionFragment
               ...DocumentDetailsCard_versionFragment
-              signatures(first: 0 filter: { activeContract: true }) {
+              signatures(first: 0 filter: { activeContract: true, state: ACTIVE }) {
                 totalCount
               }
-              signedSignatures: signatures(first: 0 filter: { states: [SIGNED], activeContract: true }) {
+              signedSignatures: signatures(first: 0 filter: { states: [SIGNED], activeContract: true, state: ACTIVE }) {
                 totalCount
               }
               approvalQuorums(first: 1, orderBy: { field: CREATED_AT, direction: DESC }) {

--- a/apps/console/src/pages/organizations/documents/_components/DocumentListItem.tsx
+++ b/apps/console/src/pages/organizations/documents/_components/DocumentListItem.tsx
@@ -54,10 +54,10 @@ const fragment = graphql`
               }
             }
           }
-          signatures(first: 0 filter: { activeContract: true }) {
+          signatures(first: 0 filter: { activeContract: true, state: ACTIVE }) {
             totalCount
           }
-          signedSignatures: signatures(first: 0 filter: { states: [SIGNED], activeContract: true }) {
+          signedSignatures: signatures(first: 0 filter: { states: [SIGNED], activeContract: true, state: ACTIVE }) {
             totalCount
           }
         }

--- a/apps/console/src/pages/organizations/documents/signatures/_components/DocumentSignatureList.tsx
+++ b/apps/console/src/pages/organizations/documents/signatures/_components/DocumentSignatureList.tsx
@@ -29,7 +29,7 @@ const versionFragment = graphql`
   @argumentDefinitions(
     count: { type: "Int", defaultValue: 1000 }
     cursor: { type: "CursorKey" }
-    signatureFilter: { type: "DocumentVersionSignatureFilter" }
+    signatureFilter: { type: "DocumentVersionSignatureFilter", defaultValue: { activeContract: true, state: ACTIVE } }
   ) {
     ...DocumentSignaturePlaceholder_versionFragment
     signatures(first: $count, after: $cursor, filter: $signatureFilter)
@@ -102,8 +102,11 @@ export function DocumentSignatureList(props: {
       return;
     }
 
-    const filter
-      = selectedStates.length > 0 ? { states: selectedStates } : null;
+    const filter = {
+      activeContract: true,
+      state: "ACTIVE" as const,
+      ...(selectedStates.length > 0 ? { states: selectedStates } : {}),
+    };
 
     refetch({ signatureFilter: filter });
   }, [selectedStates, refetch]);

--- a/packages/n8n-node/nodes/Probo/actions/document/getAllSignatures.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/document/getAllSignatures.operation.ts
@@ -91,6 +91,18 @@ export const description: INodeProperties[] = [
 				default: false,
 				description: 'Whether to filter by active contract status',
 			},
+			{
+				displayName: 'Profile State',
+				name: 'state',
+				type: 'options',
+				default: '',
+				description: 'Filter by signatory profile state',
+				options: [
+					{ name: 'Any', value: '' },
+					{ name: 'Active', value: 'ACTIVE' },
+					{ name: 'Inactive', value: 'INACTIVE' },
+				],
+			},
 		],
 	},
 ];
@@ -107,6 +119,7 @@ export async function execute(
 	const filter: IDataObject = {};
 	if ((filters.states as string[])?.length) filter.states = filters.states;
 	if (filters.activeContract !== undefined) filter.activeContract = filters.activeContract;
+	if (filters.state) filter.state = filters.state;
 
 	const hasFilter = Object.keys(filter).length > 0;
 

--- a/pkg/coredata/document_version_signature_filter.go
+++ b/pkg/coredata/document_version_signature_filter.go
@@ -22,13 +22,15 @@ type (
 	DocumentVersionSignatureFilter struct {
 		states         DocumentVersionSignatureStates
 		activeContract *bool
+		state          *ProfileState
 	}
 )
 
-func NewDocumentVersionSignatureFilter(states []DocumentVersionSignatureState, activeContract *bool) *DocumentVersionSignatureFilter {
+func NewDocumentVersionSignatureFilter(states []DocumentVersionSignatureState, activeContract *bool, state *ProfileState) *DocumentVersionSignatureFilter {
 	return &DocumentVersionSignatureFilter{
 		states:         DocumentVersionSignatureStates(states),
 		activeContract: activeContract,
+		state:          state,
 	}
 }
 
@@ -36,6 +38,7 @@ func (f *DocumentVersionSignatureFilter) SQLArguments() pgx.StrictNamedArgs {
 	return pgx.StrictNamedArgs{
 		"states":          f.states,
 		"active_contract": f.activeContract,
+		"profile_state":   f.state,
 	}
 }
 
@@ -68,6 +71,17 @@ func (f *DocumentVersionSignatureFilter) SQLFragment() string {
                 )
             )
         )
+    )
+    END
+    AND
+    CASE
+    WHEN @profile_state::text IS NULL
+        THEN TRUE
+    ELSE EXISTS (
+        SELECT 1
+        FROM iam_membership_profiles p
+        WHERE p.id = signed_by_profile_id
+        AND p.state = @profile_state::membership_state
     )
     END
 )`

--- a/pkg/server/api/console/v1/document_resolvers.go
+++ b/pkg/server/api/console/v1/document_resolvers.go
@@ -279,6 +279,7 @@ func (r *documentVersionResolver) Signatures(ctx context.Context, obj *types.Doc
 	var (
 		signatureStates []coredata.DocumentVersionSignatureState
 		activeContract  *bool
+		profileState    *coredata.ProfileState
 	)
 
 	if filter != nil {
@@ -289,9 +290,13 @@ func (r *documentVersionResolver) Signatures(ctx context.Context, obj *types.Doc
 		if filter.ActiveContract != nil {
 			activeContract = filter.ActiveContract
 		}
+
+		if filter.State != nil {
+			profileState = filter.State
+		}
 	}
 
-	signatureFilter := coredata.NewDocumentVersionSignatureFilter(signatureStates, activeContract)
+	signatureFilter := coredata.NewDocumentVersionSignatureFilter(signatureStates, activeContract, profileState)
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
 

--- a/pkg/server/api/console/v1/graphql/document.graphql
+++ b/pkg/server/api/console/v1/graphql/document.graphql
@@ -247,6 +247,7 @@ input DocumentVersionSignatureOrder {
 input DocumentVersionSignatureFilter {
     states: [DocumentVersionSignatureState!]
     activeContract: Boolean
+    state: ProfileState
 }
 
 input DocumentVersionApprovalQuorumOrder {

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -2188,6 +2188,7 @@ func (r *Resolver) ListDocumentVersionSignaturesTool(ctx context.Context, req *m
 	var (
 		signatureStates []coredata.DocumentVersionSignatureState
 		activeContract  *bool
+		profileState    *coredata.ProfileState
 	)
 
 	if input.Filter != nil {
@@ -2198,9 +2199,13 @@ func (r *Resolver) ListDocumentVersionSignaturesTool(ctx context.Context, req *m
 		if input.Filter.ActiveContract != nil {
 			activeContract = input.Filter.ActiveContract
 		}
+
+		if input.Filter.State != nil {
+			profileState = input.Filter.State
+		}
 	}
 
-	signatureFilter := coredata.NewDocumentVersionSignatureFilter(signatureStates, activeContract)
+	signatureFilter := coredata.NewDocumentVersionSignatureFilter(signatureStates, activeContract, profileState)
 
 	page, err := prb.Documents.ListSignatures(ctx, scope, input.DocumentVersionID, cursor, signatureFilter)
 	if err != nil {

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -6322,6 +6322,9 @@ components:
             active_contract:
               type: boolean
               description: Signatory contract status
+            state:
+              $ref: "#/components/schemas/ProfileState"
+              description: Signatory profile state
 
     ListDocumentVersionSignaturesOutput:
       type: object


### PR DESCRIPTION
The badge on a document version showed signatures(activeContract: true) totals, but the signatures tab fetched signatures with no activeContract filter. So when a signer's contract had ended, the badge excluded them while the tab still listed them — the two numbers disagreed.

Pass activeContract: true on the tab's signatures query as well, both as the fragment's default value and when refetching after the user toggles the state filter. Both views now apply the same backend filter.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the document version badge, list, and signatures tab use the same signatures filter `{ activeContract: true, state: ACTIVE }` for counts and lists. Fixes mismatches when contracts ended or profiles were inactive.

- **Bug Fixes**
  - Defaulted `signatureFilter` to `{ activeContract: true, state: ACTIVE }` and applied it on refetch and signed counts.
  - Added `state: ProfileState` to the backend filter and threaded it through GraphQL/MCP; exposed “Profile State” in the `n8n` getAllSignatures operation.

<sup>Written for commit 83445c6e340551e80cc301cb5f5967214671f2b8. Summary will update on new commits. <a href="https://cubic.dev/pr/getprobo/probo/pull/1213?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

