### PR TITLE
Fix github access-source worker loop on empty org

### DIFF
--- a/pkg/accessreview/drivers/name_resolver.go
+++ b/pkg/accessreview/drivers/name_resolver.go
@@ -552,6 +552,10 @@ func NewGitHubNameResolver(httpClient *http.Client, org string) NameResolver {
 }
 
 func (r *githubNameResolver) ResolveInstanceName(ctx context.Context) (string, error) {
+	if r.org == "" {
+		return "", nil
+	}
+
 	endpoint, err := url.JoinPath("https://api.github.com", "orgs", url.PathEscape(r.org))
 	if err != nil {
 		return "", fmt.Errorf("cannot build github organization URL: %w", err)

--- a/pkg/accessreview/drivers/name_resolver_test.go
+++ b/pkg/accessreview/drivers/name_resolver_test.go
@@ -337,8 +337,10 @@ func TestGitHubNameResolver(t *testing.T) {
 			t.Parallel()
 
 			var called bool
+
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				called = true
+
 				assert.Equal(t, http.MethodGet, r.Method)
 				assert.Equal(t, "/orgs/"+tc.org, r.URL.Path)
 				assert.Equal(t, "application/vnd.github+json", r.Header.Get("Accept"))

--- a/pkg/accessreview/drivers/name_resolver_test.go
+++ b/pkg/accessreview/drivers/name_resolver_test.go
@@ -284,6 +284,90 @@ func TestHerokuNameResolver(t *testing.T) {
 	})
 }
 
+func TestGitHubNameResolver(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		org       string
+		status    int
+		body      string
+		want      string
+		wantErr   bool
+		wantNoReq bool
+	}{
+		{
+			name:      "empty org returns empty name without HTTP call",
+			org:       "",
+			wantNoReq: true,
+			want:      "",
+		},
+		{
+			name:   "200 with name",
+			org:    "acme",
+			status: http.StatusOK,
+			body:   `{"name":"Acme Inc"}`,
+			want:   "Acme Inc",
+		},
+		{
+			name:   "200 with empty name falls back to org slug",
+			org:    "acme",
+			status: http.StatusOK,
+			body:   `{"name":""}`,
+			want:   "acme",
+		},
+		{
+			name:    "404 errors",
+			org:     "missing",
+			status:  http.StatusNotFound,
+			body:    `{"message":"Not Found"}`,
+			wantErr: true,
+		},
+		{
+			name:    "500 errors",
+			org:     "acme",
+			status:  http.StatusInternalServerError,
+			body:    `{"message":"boom"}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var called bool
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				called = true
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "/orgs/"+tc.org, r.URL.Path)
+				assert.Equal(t, "application/vnd.github+json", r.Header.Get("Accept"))
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			client := &http.Client{Transport: &hostRewriter{target: srv.URL}}
+
+			got, err := NewGitHubNameResolver(client, tc.org).ResolveInstanceName(context.Background())
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+
+			if tc.wantNoReq {
+				assert.False(t, called, "expected no HTTP call when org is empty")
+			} else {
+				assert.True(t, called, "expected HTTP call when org is non-empty")
+			}
+		})
+	}
+}
+
 // roundTripperFunc adapts a function into an http.RoundTripper, useful for
 // asserting that a resolver short-circuits before making any HTTP call.
 type roundTripperFunc func(*http.Request) (*http.Response, error)

--- a/pkg/accessreview/source_name_worker.go
+++ b/pkg/accessreview/source_name_worker.go
@@ -166,7 +166,7 @@ func (h *sourceNameHandler) Process(ctx context.Context, source coredata.AccessS
 
 	instanceName, err := resolver.ResolveInstanceName(resolveCtx)
 	if err != nil {
-		h.logger.ErrorCtx(
+		h.logger.WarnCtx(
 			ctx,
 			"cannot resolve instance name",
 			log.String("source_id", source.ID.String()),


### PR DESCRIPTION
## Summary

- Guard the GitHub name resolver against empty `GitHubConnectorSettings.Organization` (aligns it with sentry/gitlab/bitbucket/heroku/asana/netlify/clickup/vercel which already short-circuit to `("", nil)`). When a connector is OAuth'd but the org picker is abandoned, the source-name worker hit `https://api.github.com/orgs/` → 404 every 10 s and re-claimed the row forever because `LoadNextUnsyncedNameForUpdateSkipLocked` only filters on `name_synced_at IS NULL`. After the guard the worker takes its existing "empty instance name → mark synced with generic name" branch.
- Downgrade Probo's `cannot resolve instance name` log from `ErrorCtx` to `WarnCtx`. Provider 4xx on this lookup is almost always a configuration state, not a paging-worthy system error. The `kit/worker` `task processing failed` Error entry still fires until the deferred retry-limit work lands.
- Adds `TestGitHubNameResolver` covering the empty-org case (no HTTP call), 200 with name, 200 with empty name (falls back to org slug), 404, 500.

Context: production flood reported in #access-review (Émile, Sacha) starting 2026-05-19. The offending source `v-myYNfhAAEARwAAAZ4_ljWFme89Tl5Q` was deleted manually in EU prod.

Explicitly out of scope (tracked separately):

- Worker retry limit / attempt counter (Sacha's ask) — requires schema changes (`name_sync_attempts`, `name_sync_last_error_at`).
- Gating `CreateAccessSource` so a connector without configured settings cannot be referenced — would make the orphan-row state unrepresentable.

## Test plan

- [x] `go test -race -count=1 ./pkg/accessreview/...` passes.
- [x] `go vet ./pkg/accessreview/...` clean, `gofmt` clean.
- [ ] Manual reproducer in dev: `UPDATE access_sources SET name_synced_at = NULL WHERE id = '<github source with empty settings>';` → expect a single `instance name is empty, keeping generic name` Info log, then silence (vs. repeating Error every 10 s pre-fix).
- [ ] Post-deploy: no new `cannot fetch github organization: unexpected status 404` in Loki for 24 h.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the GitHub source-name worker from looping when a connector has no org set by short-circuiting the resolver, and reduces log noise by logging failed lookups as warnings. Adds tests for empty org, success, fallback, and error cases.

### Service **`+5`** **`-1`**
Short-circuit the GitHub resolver when `org` is empty so no HTTP call is made and the worker keeps the generic name, marking the source as synced. Downgrade "cannot resolve instance name" to `Warn` in `pkg/accessreview/source_name_worker.go` to avoid noisy errors on provider 4xx.

### Tests **`+86`** **`-0`**
Add `TestGitHubNameResolver` covering: empty org (no request), 200 with name, 200 with empty name falling back to the org slug, and 404/500 errors. Asserts GET `/orgs/{org}` and the `application/vnd.github+json` Accept header.

<sup>Written for commit e55569848e032b6bc969f640bd6a1b7acaaebc8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

