### PR TITLE
Deactivate users after contract end

### DIFF
--- a/pkg/coredata/membership_profile.go
+++ b/pkg/coredata/membership_profile.go
@@ -217,6 +217,83 @@ LIMIT 1;
 	return nil
 }
 
+func (p *MembershipProfile) LoadByIDForUpdate(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	profileID gid.GID,
+) error {
+	q := `
+SELECT
+    p.id,
+    p.identity_id,
+    p.organization_id,
+    i.email_address,
+    p.source,
+    p.state,
+    p.full_name,
+    p.kind,
+    p.additional_email_addresses,
+    p.position,
+    p.contract_start_date,
+    p.contract_end_date,
+    '' AS organization_name,
+    p.user_name,
+    p.external_id,
+    p.nickname,
+    p.locale,
+    p.timezone,
+    p.profile_url,
+    p.preferred_language,
+    p.given_name,
+    p.family_name,
+    p.formatted_name,
+    p.middle_name,
+    p.honorific_prefix,
+    p.honorific_suffix,
+    p.employee_number,
+    p.department,
+    p.cost_center,
+    p.enterprise_organization,
+    p.division,
+    p.manager_value,
+    p.created_at,
+    p.updated_at
+FROM
+    iam_membership_profiles p
+INNER JOIN identities i
+    ON i.id = p.identity_id
+WHERE
+    p.%s
+    AND p.id = @profile_id
+LIMIT 1
+FOR UPDATE;
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"profile_id": profileID}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query profile: %w", err)
+	}
+
+	profile, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[MembershipProfile])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrResourceNotFound
+		}
+
+		return fmt.Errorf("cannot collect profile: %w", err)
+	}
+
+	*p = profile
+
+	return nil
+}
+
 func (p *MembershipProfile) LoadByIdentityIDAndOrganizationID(
 	ctx context.Context,
 	conn pg.Querier,
@@ -1093,6 +1170,83 @@ WHERE
 	}
 
 	return count, nil
+}
+
+func (p *MembershipProfiles) LoadContractEndedActive(
+	ctx context.Context,
+	conn pg.Querier,
+	limit int,
+	currentDate time.Time,
+) error {
+	q := `
+SELECT
+    p.id,
+    p.identity_id,
+    p.organization_id,
+    i.email_address,
+    p.source,
+    p.state,
+    p.full_name,
+    p.kind,
+    p.additional_email_addresses,
+    p.position,
+    p.contract_start_date,
+    p.contract_end_date,
+    '' AS organization_name,
+    p.user_name,
+    p.external_id,
+    p.nickname,
+    p.locale,
+    p.timezone,
+    p.profile_url,
+    p.preferred_language,
+    p.given_name,
+    p.family_name,
+    p.formatted_name,
+    p.middle_name,
+    p.honorific_prefix,
+    p.honorific_suffix,
+    p.employee_number,
+    p.department,
+    p.cost_center,
+    p.enterprise_organization,
+    p.division,
+    p.manager_value,
+    p.created_at,
+    p.updated_at
+FROM
+    iam_membership_profiles p
+INNER JOIN identities i
+    ON i.id = p.identity_id
+WHERE
+    p.state = @state
+    AND p.contract_end_date IS NOT NULL
+    AND p.contract_end_date < @current_date::date
+ORDER BY
+    p.contract_end_date ASC,
+    p.id ASC
+LIMIT @limit;
+`
+
+	args := pgx.StrictNamedArgs{
+		"state":        ProfileStateActive,
+		"current_date": currentDate,
+		"limit":        limit,
+	}
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query profiles: %w", err)
+	}
+
+	profiles, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[MembershipProfile])
+	if err != nil {
+		return fmt.Errorf("cannot collect profiles: %w", err)
+	}
+
+	*p = profiles
+
+	return nil
 }
 
 func (p *MembershipProfiles) CountActiveOwnerByOrganizationID(

--- a/pkg/coredata/session.go
+++ b/pkg/coredata/session.go
@@ -445,6 +445,51 @@ WHERE
 	return result.RowsAffected(), nil
 }
 
+func (s *Sessions) ExpireRootAndMembershipSessionsForIdentity(
+	ctx context.Context,
+	conn pg.Querier,
+	identityID gid.GID,
+	membershipID *gid.GID,
+) (int64, error) {
+	var membershipArg any
+	if membershipID != nil {
+		membershipArg = *membershipID
+	}
+
+	q := `
+UPDATE iam_sessions
+SET
+    expired_at = @now,
+    updated_at = @now,
+    expire_reason = @expire_reason
+WHERE
+    identity_id = @identity_id
+    AND expire_reason IS NULL
+    AND expired_at > @now
+    AND (
+        parent_session_id IS NULL
+        OR (
+            @membership_id::text IS NOT NULL
+            AND membership_id = @membership_id
+        )
+    )
+`
+
+	args := pgx.StrictNamedArgs{
+		"identity_id":   identityID,
+		"membership_id": membershipArg,
+		"expire_reason": ExpireReasonRevoked,
+		"now":           time.Now(),
+	}
+
+	result, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return 0, fmt.Errorf("cannot expire sessions: %w", err)
+	}
+
+	return result.RowsAffected(), nil
+}
+
 func (s *Session) LoadByRootSessionIDAndMembershipID(
 	ctx context.Context,
 	conn pg.Querier,

--- a/pkg/iam/contract_end.go
+++ b/pkg/iam/contract_end.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package iam
+
+import "time"
+
+func currentDate(now time.Time) time.Time {
+	year, month, day := now.UTC().Date()
+	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+}
+
+func contractEndDateHasPassed(contractEndDate *time.Time, now time.Time) bool {
+	if contractEndDate == nil {
+		return false
+	}
+
+	return currentDate(*contractEndDate).Before(currentDate(now))
+}

--- a/pkg/iam/contract_end_test.go
+++ b/pkg/iam/contract_end_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package iam
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContractEndDateHasPassed(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.May, 25, 17, 30, 0, 0, time.UTC)
+
+	t.Run(
+		"nil end date",
+		func(t *testing.T) {
+			t.Parallel()
+
+			assert.False(t, contractEndDateHasPassed(nil, now))
+		},
+	)
+
+	t.Run(
+		"past date",
+		func(t *testing.T) {
+			t.Parallel()
+
+			endDate := time.Date(2026, time.May, 24, 0, 0, 0, 0, time.UTC)
+
+			assert.True(t, contractEndDateHasPassed(&endDate, now))
+		},
+	)
+
+	t.Run(
+		"same date",
+		func(t *testing.T) {
+			t.Parallel()
+
+			endDate := time.Date(2026, time.May, 25, 0, 0, 0, 0, time.UTC)
+
+			assert.False(t, contractEndDateHasPassed(&endDate, now))
+		},
+	)
+
+	t.Run(
+		"future date",
+		func(t *testing.T) {
+			t.Parallel()
+
+			endDate := time.Date(2026, time.May, 26, 0, 0, 0, 0, time.UTC)
+
+			assert.False(t, contractEndDateHasPassed(&endDate, now))
+		},
+	)
+}

--- a/pkg/iam/contract_ended_user_worker.go
+++ b/pkg/iam/contract_ended_user_worker.go
@@ -84,8 +84,7 @@ func (h *contractEndedUserHandler) Claim(_ context.Context) (struct{}, error) {
 }
 
 func (h *contractEndedUserHandler) Process(ctx context.Context, _ struct{}) error {
-	now := time.Now()
-	total, err := h.deactivateContractEndedUsers(ctx, now)
+	total, err := h.deactivateContractEndedUsers(ctx, time.Now())
 	if err != nil {
 		return err
 	}

--- a/pkg/iam/contract_ended_user_worker.go
+++ b/pkg/iam/contract_ended_user_worker.go
@@ -86,7 +86,6 @@ func (h *contractEndedUserHandler) Claim(_ context.Context) (struct{}, error) {
 func (h *contractEndedUserHandler) Process(ctx context.Context, _ struct{}) error {
 	now := time.Now()
 	total, err := h.deactivateContractEndedUsers(ctx, now)
-
 	if err != nil {
 		return err
 	}

--- a/pkg/iam/contract_ended_user_worker.go
+++ b/pkg/iam/contract_ended_user_worker.go
@@ -86,6 +86,7 @@ func (h *contractEndedUserHandler) Claim(_ context.Context) (struct{}, error) {
 func (h *contractEndedUserHandler) Process(ctx context.Context, _ struct{}) error {
 	now := time.Now()
 	total, err := h.deactivateContractEndedUsers(ctx, now)
+
 	if err != nil {
 		return err
 	}

--- a/pkg/iam/contract_ended_user_worker.go
+++ b/pkg/iam/contract_ended_user_worker.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package iam
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"go.gearno.de/kit/log"
+	"go.gearno.de/kit/pg"
+	"go.gearno.de/kit/worker"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+type ContractEndedUserWorker = worker.Worker[struct{}]
+
+type contractEndedUserHandler struct {
+	pg        *pg.Client
+	service   *OrganizationService
+	logger    *log.Logger
+	batchSize int
+	lastRunAt atomic.Int64
+}
+
+const (
+	DefaultContractEndedUserWorkerInterval  = time.Hour
+	DefaultContractEndedUserWorkerBatchSize = 100
+)
+
+func NewContractEndedUserWorker(
+	pgClient *pg.Client,
+	service *OrganizationService,
+	logger *log.Logger,
+	opts ...worker.Option,
+) *ContractEndedUserWorker {
+	h := &contractEndedUserHandler{
+		pg:        pgClient,
+		service:   service,
+		logger:    logger.Named("contract-ended-user-worker"),
+		batchSize: DefaultContractEndedUserWorkerBatchSize,
+	}
+
+	return worker.New(
+		"contract-ended-user-worker",
+		h,
+		logger,
+		append(
+			[]worker.Option{
+				worker.WithInterval(DefaultContractEndedUserWorkerInterval),
+				worker.WithMaxConcurrency(1),
+			},
+			opts...,
+		)...,
+	)
+}
+
+func (h *contractEndedUserHandler) Claim(_ context.Context) (struct{}, error) {
+	now := time.Now().UnixNano()
+	last := h.lastRunAt.Load()
+
+	if last > 0 && now-last < int64(DefaultContractEndedUserWorkerInterval) {
+		return struct{}{}, worker.ErrNoTask
+	}
+
+	if !h.lastRunAt.CompareAndSwap(last, now) {
+		return struct{}{}, worker.ErrNoTask
+	}
+
+	return struct{}{}, nil
+}
+
+func (h *contractEndedUserHandler) Process(ctx context.Context, _ struct{}) error {
+	now := time.Now()
+	total, err := h.deactivateContractEndedUsers(ctx, now)
+	if err != nil {
+		return err
+	}
+
+	h.logger.InfoCtx(
+		ctx,
+		"contract-ended user worker completed",
+		log.Int("users_deactivated", total),
+	)
+
+	return nil
+}
+
+func (h *contractEndedUserHandler) deactivateContractEndedUsers(ctx context.Context, now time.Time) (int, error) {
+	total := 0
+
+	for {
+		profiles, err := h.loadContractEndedActiveProfiles(ctx, currentDate(now))
+		if err != nil {
+			return 0, fmt.Errorf("cannot load contract-ended active profiles: %w", err)
+		}
+
+		if len(profiles) == 0 {
+			return total, nil
+		}
+
+		for _, profile := range profiles {
+			deactivated, err := h.service.DeactivateUserForContractEnd(ctx, profile.ID, now)
+			if err != nil {
+				return total, fmt.Errorf("cannot deactivate contract-ended user: %w", err)
+			}
+
+			if deactivated {
+				total++
+			}
+		}
+
+		if len(profiles) < h.batchSize {
+			return total, nil
+		}
+	}
+}
+
+func (h *contractEndedUserHandler) loadContractEndedActiveProfiles(
+	ctx context.Context,
+	currentDate time.Time,
+) (coredata.MembershipProfiles, error) {
+	var profiles coredata.MembershipProfiles
+
+	err := h.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			return profiles.LoadContractEndedActive(ctx, conn, h.batchSize, currentDate)
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return profiles, nil
+}

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -1087,6 +1087,85 @@ func (s *OrganizationService) UpdateUserState(
 	return profile, nil
 }
 
+func (s *OrganizationService) DeactivateUserForContractEnd(
+	ctx context.Context,
+	userID gid.GID,
+	now time.Time,
+) (bool, error) {
+	var (
+		scope       = coredata.NewScopeFromObjectID(userID)
+		deactivated bool
+	)
+
+	err := s.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			profile := &coredata.MembershipProfile{}
+			if err := profile.LoadByIDForUpdate(ctx, tx, scope, userID); err != nil {
+				return fmt.Errorf("cannot load profile: %w", err)
+			}
+
+			if profile.State != coredata.ProfileStateActive || !contractEndDateHasPassed(profile.ContractEndDate, now) {
+				return nil
+			}
+
+			profile.State = coredata.ProfileStateInactive
+			profile.UpdatedAt = time.Now()
+
+			if err := profile.Update(ctx, tx, scope); err != nil {
+				return fmt.Errorf("cannot update profile: %w", err)
+			}
+
+			invitations := &coredata.Invitations{}
+			onlyPending := coredata.NewInvitationFilter([]coredata.InvitationStatus{coredata.InvitationStatusPending})
+			if err := invitations.ExpireByUserID(ctx, tx, scope, profile.ID, onlyPending); err != nil {
+				return fmt.Errorf("cannot expire pending invitations: %w", err)
+			}
+
+			var webhookPayload *webhooktypes.User
+
+			membership := &coredata.Membership{}
+			if err := membership.LoadByIdentityIDAndOrganizationID(ctx, tx, scope, profile.IdentityID, profile.OrganizationID); err != nil {
+				if !errors.Is(err, coredata.ErrResourceNotFound) {
+					return fmt.Errorf("cannot load membership: %w", err)
+				}
+
+				if _, err := s.SessionService.revokeRootAndMembershipSessions(ctx, tx, profile.IdentityID, nil); err != nil {
+					return fmt.Errorf("cannot revoke sessions: %w", err)
+				}
+
+				webhookPayload = webhooktypes.NewUser(profile, nil)
+			} else {
+				if _, err := s.SessionService.revokeRootAndMembershipSessions(ctx, tx, profile.IdentityID, &membership.ID); err != nil {
+					return fmt.Errorf("cannot revoke sessions: %w", err)
+				}
+
+				webhookPayload = webhooktypes.NewUser(profile, membership)
+			}
+
+			if err := webhook.InsertData(
+				ctx,
+				tx,
+				scope,
+				profile.OrganizationID,
+				coredata.WebhookEventTypeUserUpdated,
+				webhookPayload,
+			); err != nil {
+				return fmt.Errorf("cannot insert webhook event: %w", err)
+			}
+
+			deactivated = true
+
+			return nil
+		},
+	)
+	if err != nil {
+		return false, err
+	}
+
+	return deactivated, nil
+}
+
 func (s *OrganizationService) GetProfile(ctx context.Context, profileID gid.GID) (*coredata.MembershipProfile, error) {
 	profile := &coredata.MembershipProfile{}
 

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -1118,6 +1118,7 @@ func (s *OrganizationService) DeactivateUserForContractEnd(
 
 			invitations := &coredata.Invitations{}
 			onlyPending := coredata.NewInvitationFilter([]coredata.InvitationStatus{coredata.InvitationStatusPending})
+
 			if err := invitations.ExpireByUserID(ctx, tx, scope, profile.ID, onlyPending); err != nil {
 				return fmt.Errorf("cannot expire pending invitations: %w", err)
 			}

--- a/pkg/iam/service.go
+++ b/pkg/iam/service.go
@@ -69,7 +69,8 @@ type (
 		OAuth2ServerService   *oauth2server.Service
 		Authorizer            *Authorizer
 
-		samlDomainVerifier *SAMLDomainVerifier
+		samlDomainVerifier      *SAMLDomainVerifier
+		contractEndedUserWorker *ContractEndedUserWorker
 	}
 
 	Config struct {
@@ -199,6 +200,12 @@ func NewService(
 		cfg.DomainVerificationResolverAddr,
 	)
 
+	svc.contractEndedUserWorker = NewContractEndedUserWorker(
+		pgClient,
+		svc.OrganizationService,
+		cfg.Logger,
+	)
+
 	return svc, nil
 }
 
@@ -262,6 +269,16 @@ func (s *Service) Run(ctx context.Context) error {
 		},
 	)
 
+	contractEndedUserCtx, stopContractEndedUser := context.WithCancel(context.WithoutCancel(ctx))
+
+	wg.Go(
+		func() {
+			if err := s.contractEndedUserWorker.Run(contractEndedUserCtx); err != nil {
+				cancel(fmt.Errorf("contract-ended user worker crashed: %w", err))
+			}
+		},
+	)
+
 	<-ctx.Done()
 
 	stopSAML()
@@ -269,6 +286,7 @@ func (s *Service) Run(ctx context.Context) error {
 	stopDomainVerifier()
 	stopSCIM()
 	stopOAuth2Server()
+	stopContractEndedUser()
 
 	wg.Wait()
 

--- a/pkg/iam/session_service.go
+++ b/pkg/iam/session_service.go
@@ -195,6 +195,44 @@ func (s SessionService) RevokeAllSessions(ctx context.Context, currentSessionID 
 	return count, err
 }
 
+func (s SessionService) RevokeRootAndMembershipSessions(
+	ctx context.Context,
+	identityID gid.GID,
+	membershipID *gid.GID,
+) (int64, error) {
+	var count int64
+
+	err := s.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			var err error
+			count, err = s.revokeRootAndMembershipSessions(ctx, tx, identityID, membershipID)
+			return err
+		},
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+func (s SessionService) revokeRootAndMembershipSessions(
+	ctx context.Context,
+	conn pg.Querier,
+	identityID gid.GID,
+	membershipID *gid.GID,
+) (int64, error) {
+	sessions := coredata.Sessions{}
+
+	count, err := sessions.ExpireRootAndMembershipSessionsForIdentity(ctx, conn, identityID, membershipID)
+	if err != nil {
+		return 0, fmt.Errorf("cannot expire root and membership sessions: %w", err)
+	}
+
+	return count, nil
+}
+
 func (s SessionService) UpdateSessionInfo(ctx context.Context, sessionID gid.GID, userAgent string, ipAddress net.IP) error {
 	return s.pg.WithTx(
 		ctx,

--- a/pkg/iam/session_service.go
+++ b/pkg/iam/session_service.go
@@ -206,7 +206,9 @@ func (s SessionService) RevokeRootAndMembershipSessions(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			var err error
+
 			count, err = s.revokeRootAndMembershipSessions(ctx, tx, identityID, membershipID)
+
 			return err
 		},
 	)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add an hourly IAM worker that scans active profiles whose contract end date has passed.
- Add organization-service deactivation that re-locks the profile, marks it inactive, expires pending invitations, revokes root/membership sessions through SessionService, and enqueues the existing `user:updated` webhook when subscribed.
- Add coredata helpers for contract-ended profile loading, row-locking profiles, and root/membership session expiry.
- Fix Go linter whitespace around the contract-end worker changes.

## Tests
- `go test ./pkg/iam ./pkg/coredata`
- `git diff --check`

## Notes
- `go test ./pkg/probod` is blocked in this environment by missing embedded frontend `dist` assets for `apps/trust` and `apps/console`.
- `make go-lint` could not complete locally because `golangci-lint` is not installed in this environment; the reported `wsl_v5` spacing issues were fixed directly.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-357](https://linear.app/probo/issue/ENG-357/deactivate-users-whose-contract-end-date-has-passed)

<div><a href="https://cursor.com/agents/bc-bc48a300-7221-4769-9122-c0d24b57420e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc48a300-7221-4769-9122-c0d24b57420e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically deactivate users whose contract end date has passed. Fulfills ENG-357 with an hourly worker that inactivates profiles, revokes sessions, expires pending invites, and emits the `user:updated` webhook.

- **New Features**
  - Added `ContractEndedUserWorker` (hourly, batch size 100, single concurrency) to scan active profiles with past `contract_end_date` using UTC day-based checks via `contractEndDateHasPassed`.
  - Added `OrganizationService.DeactivateUserForContractEnd` to lock and inactivate the profile, expire pending invitations, revoke root/membership sessions via `SessionService`, and enqueue the webhook.
  - Added `coredata` helpers: `MembershipProfiles.LoadContractEndedActive`, `MembershipProfile.LoadByIDForUpdate`, `Sessions.ExpireRootAndMembershipSessionsForIdentity`; added `SessionService.RevokeRootAndMembershipSessions` and wired the worker into `Service.Run`. Added tests for contract-end date logic.

- **Refactors**
  - Simplified worker error handling.

<sup>Written for commit 4751af976bfa9561b33503c232d63fead7b2d6fd. Summary will update on new commits. <a href="https://cubic.dev/pr/getprobo/probo/pull/1220?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

