### PR TITLE
Allow initial document minor publishing

### DIFF
--- a/e2e/console/document_version_test.go
+++ b/e2e/console/document_version_test.go
@@ -222,6 +222,109 @@ func TestDocumentVersion_PublishVersion(t *testing.T) {
 	assert.Equal(t, 0, result.Node.Versions.Edges[0].Node.Minor)
 }
 
+func TestDocumentVersion_PublishInitialMinorVersion(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+
+	docID, _ := createTestDocument(t, owner)
+
+	publishMutation := `
+		mutation($input: PublishDocumentInput!) {
+			publishDocument(input: $input) {
+				document {
+					currentPublishedMajor
+					currentPublishedMinor
+				}
+				documentVersion {
+					status
+					major
+					minor
+				}
+			}
+		}
+	`
+
+	var publishResult struct {
+		PublishDocument struct {
+			Document struct {
+				CurrentPublishedMajor *int `json:"currentPublishedMajor"`
+				CurrentPublishedMinor *int `json:"currentPublishedMinor"`
+			} `json:"document"`
+			DocumentVersion struct {
+				Status string `json:"status"`
+				Major  int    `json:"major"`
+				Minor  int    `json:"minor"`
+			} `json:"documentVersion"`
+		} `json:"publishDocument"`
+	}
+
+	err := owner.Execute(publishMutation, map[string]any{
+		"input": map[string]any{
+			"minor":      true,
+			"documentId": docID,
+			"changelog":  "Initial minor release",
+		},
+	}, &publishResult)
+	require.NoError(t, err)
+
+	require.NotNil(t, publishResult.PublishDocument.Document.CurrentPublishedMajor)
+	require.NotNil(t, publishResult.PublishDocument.Document.CurrentPublishedMinor)
+	assert.Equal(t, 0, *publishResult.PublishDocument.Document.CurrentPublishedMajor)
+	assert.Equal(t, 1, *publishResult.PublishDocument.Document.CurrentPublishedMinor)
+	assert.Equal(t, "PUBLISHED", publishResult.PublishDocument.DocumentVersion.Status)
+	assert.Equal(t, 0, publishResult.PublishDocument.DocumentVersion.Major)
+	assert.Equal(t, 1, publishResult.PublishDocument.DocumentVersion.Minor)
+
+	var updateResult struct {
+		UpdateDocument struct {
+			DocumentVersion *struct {
+				Status string `json:"status"`
+				Major  int    `json:"major"`
+				Minor  int    `json:"minor"`
+			} `json:"documentVersion"`
+		} `json:"updateDocument"`
+	}
+
+	err = owner.Execute(`
+		mutation($input: UpdateDocumentInput!) {
+			updateDocument(input: $input) {
+				documentVersion {
+					status
+					major
+					minor
+				}
+			}
+		}
+	`, map[string]any{
+		"input": map[string]any{
+			"id":      docID,
+			"content": testutil.ProseMirrorTextDoc("Updated content for 0.2"),
+		},
+	}, &updateResult)
+	require.NoError(t, err)
+	require.NotNil(t, updateResult.UpdateDocument.DocumentVersion)
+	assert.Equal(t, "DRAFT", updateResult.UpdateDocument.DocumentVersion.Status)
+	assert.Equal(t, 0, updateResult.UpdateDocument.DocumentVersion.Major)
+	assert.Equal(t, 2, updateResult.UpdateDocument.DocumentVersion.Minor)
+
+	err = owner.Execute(publishMutation, map[string]any{
+		"input": map[string]any{
+			"minor":      true,
+			"documentId": docID,
+			"changelog":  "Second minor release",
+		},
+	}, &publishResult)
+	require.NoError(t, err)
+
+	require.NotNil(t, publishResult.PublishDocument.Document.CurrentPublishedMajor)
+	require.NotNil(t, publishResult.PublishDocument.Document.CurrentPublishedMinor)
+	assert.Equal(t, 0, *publishResult.PublishDocument.Document.CurrentPublishedMajor)
+	assert.Equal(t, 2, *publishResult.PublishDocument.Document.CurrentPublishedMinor)
+	assert.Equal(t, "PUBLISHED", publishResult.PublishDocument.DocumentVersion.Status)
+	assert.Equal(t, 0, publishResult.PublishDocument.DocumentVersion.Major)
+	assert.Equal(t, 2, publishResult.PublishDocument.DocumentVersion.Minor)
+}
+
 func TestDocumentVersion_AutoCreateDraft(t *testing.T) {
 	t.Parallel()
 	owner := testutil.NewClient(t, testutil.RoleOwner)

--- a/packages/n8n-node/nodes/Probo/actions/document/publish.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/document/publish.operation.ts
@@ -41,7 +41,7 @@ export const description: INodeProperties[] = [
 			},
 		},
 		default: false,
-		description: 'Whether to publish as a minor version. Approvers are ignored when set. The document must already have a published major version.',
+		description: 'Whether to publish as a minor version. Approvers are ignored when set.',
 	},
 	{
 		displayName: 'Approver IDs',

--- a/pkg/cmd/document/publish/publish.go
+++ b/pkg/cmd/document/publish/publish.go
@@ -70,7 +70,7 @@ func NewCmdPublish(f *cmdutil.Factory) *cobra.Command {
 		Long: `Publish the latest draft of a document.
 
 By default, the draft is published as a new major version. Pass --minor to
-publish as a minor version (the document must already have a major version).
+publish as a minor version.
 When --approver is set (one or more profile IDs), an approval is requested
 instead of publishing immediately. Approvers are ignored with --minor.`,
 		Args: cobra.ExactArgs(1),

--- a/pkg/probo/document_service.go
+++ b/pkg/probo/document_service.go
@@ -541,10 +541,8 @@ func (s DocumentService) generateChangelog(
 
 // PublishVersion is the single entry point for publishing a document
 // version. The behaviour depends on req.Minor and req.ApproverIDs:
-//   - Minor=true: publish the existing draft as a minor bump (currentMajor.
-//     currentMinor+1). ApproverIDs are ignored. Errors with
-//     ErrCannotPublishMinorWithoutMajor when the document has never been
-//     published.
+//   - Minor=true: publish the existing draft as a minor version. ApproverIDs
+//     are ignored.
 //   - Minor=false with ApproverIDs: open an approval quorum on the draft as
 //     a pending major bump (currentMajor+1.0). Result.Quorum is set.
 //   - Minor=false without ApproverIDs: publish the draft immediately as a
@@ -2824,10 +2822,6 @@ func (s *DocumentService) publishMinorVersionInTx(
 
 	if ignoreExisting && documentVersion.Status == coredata.DocumentVersionStatusPublished {
 		return document, documentVersion, nil
-	}
-
-	if document.CurrentPublishedMajor == nil || document.CurrentPublishedMinor == nil {
-		return nil, nil, &ErrCannotPublishMinorWithoutMajor{}
 	}
 
 	document.CurrentPublishedMajor = &documentVersion.Major

--- a/pkg/probo/document_service.go
+++ b/pkg/probo/document_service.go
@@ -75,9 +75,6 @@ type (
 	ErrDocumentArchived struct {
 	}
 
-	ErrCannotPublishMinorWithoutMajor struct {
-	}
-
 	ErrDocumentDraftNotDeletable struct {
 	}
 
@@ -250,10 +247,6 @@ func (e ErrDocumentVersionPendingApproval) Error() string {
 
 func (e ErrDocumentArchived) Error() string {
 	return "cannot modify an archived document"
-}
-
-func (e ErrCannotPublishMinorWithoutMajor) Error() string {
-	return "cannot publish a minor version before a major version exists"
 }
 
 func (e ErrDocumentDraftNotDeletable) Error() string {

--- a/pkg/probo/generated_document_service.go
+++ b/pkg/probo/generated_document_service.go
@@ -3028,10 +3028,9 @@ func formatRiskTreatment(t coredata.RiskTreatment) string {
 // version. The version's Major, Minor, Status and PublishedAt fields are
 // computed here based on the document's current published state, the minor
 // flag, and whether approvers were provided. When minor is true the version
-// is always published at currentMajor.(currentMinor+1) and approvers are
-// ignored. When minor is false a non-empty approverIDs triggers an approval
-// request at (currentMajor+1).0; otherwise the version is published at
-// (currentMajor+1).0.
+// is always published as a minor version and approvers are ignored. When
+// minor is false a non-empty approverIDs triggers an approval request at
+// (currentMajor+1).0; otherwise the version is published at (currentMajor+1).0.
 func (s *GeneratedDocumentService) publishOrRequestApproval(
 	ctx context.Context, scope coredata.Scoper,
 	tx pg.Tx,
@@ -3057,12 +3056,14 @@ func (s *GeneratedDocumentService) publishOrRequestApproval(
 	}
 
 	if minor {
-		if document.CurrentPublishedMajor == nil || document.CurrentPublishedMinor == nil {
-			return &ErrCannotPublishMinorWithoutMajor{}
+		if document.CurrentPublishedMajor != nil && document.CurrentPublishedMinor != nil {
+			version.Major = *document.CurrentPublishedMajor
+			version.Minor = *document.CurrentPublishedMinor + 1
+		} else {
+			version.Major = 0
+			version.Minor = 1
 		}
 
-		version.Major = *document.CurrentPublishedMajor
-		version.Minor = *document.CurrentPublishedMinor + 1
 		version.Status = coredata.DocumentVersionStatusPublished
 		version.PublishedAt = &now
 		approverIDs = nil

--- a/pkg/server/api/console/v1/asset_resolvers.go
+++ b/pkg/server/api/console/v1/asset_resolvers.go
@@ -409,10 +409,6 @@ func (r *mutationResolver) PublishDataList(ctx context.Context, input types.Publ
 			return nil, gqlutils.Conflict(ctx, err)
 		}
 
-		if errMinor, ok := errors.AsType[*probo.ErrCannotPublishMinorWithoutMajor](err); ok {
-			return nil, gqlutils.Invalid(ctx, errMinor)
-		}
-
 		r.logger.ErrorCtx(ctx, "cannot publish data list", log.Error(err))
 
 		return nil, gqlutils.Internal(ctx)
@@ -435,10 +431,6 @@ func (r *mutationResolver) PublishAssetList(ctx context.Context, input types.Pub
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
-		}
-
-		if errMinor, ok := errors.AsType[*probo.ErrCannotPublishMinorWithoutMajor](err); ok {
-			return nil, gqlutils.Invalid(ctx, errMinor)
 		}
 
 		r.logger.ErrorCtx(ctx, "cannot publish asset list", log.Error(err))

--- a/pkg/server/api/console/v1/audit_resolvers.go
+++ b/pkg/server/api/console/v1/audit_resolvers.go
@@ -693,10 +693,6 @@ func (r *mutationResolver) PublishFindingList(ctx context.Context, input types.P
 			return nil, gqlutils.Conflict(ctx, err)
 		}
 
-		if errMinor, ok := errors.AsType[*probo.ErrCannotPublishMinorWithoutMajor](err); ok {
-			return nil, gqlutils.Invalid(ctx, errMinor)
-		}
-
 		r.logger.ErrorCtx(ctx, "cannot publish finding list", log.Error(err))
 
 		return nil, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/control_resolvers.go
+++ b/pkg/server/api/console/v1/control_resolvers.go
@@ -785,10 +785,6 @@ func (r *mutationResolver) PublishStatementOfApplicability(ctx context.Context, 
 			return nil, gqlutils.Conflict(ctx, err)
 		}
 
-		if errMinor, ok := errors.AsType[*probo.ErrCannotPublishMinorWithoutMajor](err); ok {
-			return nil, gqlutils.Invalid(ctx, errMinor)
-		}
-
 		r.logger.ErrorCtx(ctx, "cannot publish statement of applicability", log.Error(err))
 
 		return nil, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/data_protection_impact_assessment_resolvers.go
+++ b/pkg/server/api/console/v1/data_protection_impact_assessment_resolvers.go
@@ -280,10 +280,6 @@ func (r *mutationResolver) PublishDataProtectionImpactAssessmentList(ctx context
 			return nil, gqlutils.Conflict(ctx, err)
 		}
 
-		if errMinor, ok := errors.AsType[*probo.ErrCannotPublishMinorWithoutMajor](err); ok {
-			return nil, gqlutils.Invalid(ctx, errMinor)
-		}
-
 		r.logger.ErrorCtx(ctx, "cannot publish data protection impact assessment list", log.Error(err))
 
 		return nil, gqlutils.Internal(ctx)
@@ -306,10 +302,6 @@ func (r *mutationResolver) PublishTransferImpactAssessmentList(ctx context.Conte
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceAlreadyExists) {
 			return nil, gqlutils.Conflict(ctx, err)
-		}
-
-		if errMinor, ok := errors.AsType[*probo.ErrCannotPublishMinorWithoutMajor](err); ok {
-			return nil, gqlutils.Invalid(ctx, errMinor)
 		}
 
 		r.logger.ErrorCtx(ctx, "cannot publish transfer impact assessment list", log.Error(err))

--- a/pkg/server/api/console/v1/document_resolvers.go
+++ b/pkg/server/api/console/v1/document_resolvers.go
@@ -1045,10 +1045,6 @@ func (r *mutationResolver) PublishDocument(ctx context.Context, input types.Publ
 			return nil, gqlutils.Conflict(ctx, errPending)
 		}
 
-		if errMinor, ok := errors.AsType[*probo.ErrCannotPublishMinorWithoutMajor](err); ok {
-			return nil, gqlutils.Invalid(ctx, errMinor)
-		}
-
 		if errContractEnded, ok := errors.AsType[*probo.ErrProfileContractEnded](err); ok {
 			return nil, gqlutils.Conflict(ctx, errContractEnded)
 		}

--- a/pkg/server/api/console/v1/obligation_resolvers.go
+++ b/pkg/server/api/console/v1/obligation_resolvers.go
@@ -125,10 +125,6 @@ func (r *mutationResolver) PublishObligationList(ctx context.Context, input type
 			return nil, gqlutils.Conflict(ctx, err)
 		}
 
-		if errMinor, ok := errors.AsType[*probo.ErrCannotPublishMinorWithoutMajor](err); ok {
-			return nil, gqlutils.Invalid(ctx, errMinor)
-		}
-
 		r.logger.ErrorCtx(ctx, "cannot publish obligation list", log.Error(err))
 
 		return nil, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/processing_activity_resolvers.go
+++ b/pkg/server/api/console/v1/processing_activity_resolvers.go
@@ -133,10 +133,6 @@ func (r *mutationResolver) PublishProcessingActivityList(ctx context.Context, in
 			return nil, gqlutils.Conflict(ctx, err)
 		}
 
-		if errMinor, ok := errors.AsType[*probo.ErrCannotPublishMinorWithoutMajor](err); ok {
-			return nil, gqlutils.Invalid(ctx, errMinor)
-		}
-
 		r.logger.ErrorCtx(ctx, "cannot publish processing activity list", log.Error(err))
 
 		return nil, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/risk_resolvers.go
+++ b/pkg/server/api/console/v1/risk_resolvers.go
@@ -246,10 +246,6 @@ func (r *mutationResolver) PublishRiskList(ctx context.Context, input types.Publ
 			return nil, gqlutils.Conflict(ctx, err)
 		}
 
-		if errMinor, ok := errors.AsType[*probo.ErrCannotPublishMinorWithoutMajor](err); ok {
-			return nil, gqlutils.Invalid(ctx, errMinor)
-		}
-
 		r.logger.ErrorCtx(ctx, "cannot publish risk list", log.Error(err))
 
 		return nil, gqlutils.Internal(ctx)

--- a/pkg/server/api/console/v1/third_party_resolvers.go
+++ b/pkg/server/api/console/v1/third_party_resolvers.go
@@ -581,10 +581,6 @@ func (r *mutationResolver) PublishThirdPartyList(ctx context.Context, input type
 			return nil, gqlutils.Conflict(ctx, err)
 		}
 
-		if errMinor, ok := errors.AsType[*probo.ErrCannotPublishMinorWithoutMajor](err); ok {
-			return nil, gqlutils.Invalid(ctx, errMinor)
-		}
-
 		r.logger.ErrorCtx(ctx, "cannot publish thirdParty list", log.Error(err))
 
 		return nil, gqlutils.Internal(ctx)

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -6321,7 +6321,7 @@ components:
           description: Document ID
         minor:
           type: boolean
-          description: When true, publish the draft as a minor version (currentMajor.currentMinor+1) and ignore approver_ids; the document must already have a published major version. When false, publish as a new major version; if approver_ids are provided, an approval is requested instead.
+          description: When true, publish the draft as a minor version and ignore approver_ids. When false, publish as a new major version; if approver_ids are provided, an approval is requested instead.
         approver_ids:
           type: array
           items:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Allow authored document drafts to be published as initial 0.x minor versions
- Allow generated document/list publishers to initialize minor publishing at 0.1 instead of returning the removed minor-before-major error
- Remove the obsolete `ErrCannotPublishMinorWithoutMajor` type and stale GraphQL resolver mappings
- Add e2e coverage for publishing 0.1, creating 0.2, and publishing 0.2
- Update document publish wording in CLI, n8n metadata, and MCP schema

## Testing
- `make go-fmt`
- `go generate ./pkg/server/api/mcp/v1`
- `npm --workspace @probo/emails run build`
- `npm --workspace @probo/n8n-nodes-probo run build`
- `go test ./pkg/probo ./pkg/cmd/document/publish ./packages/n8n-node/...`
  - Note: `./packages/n8n-node/...` has no Go packages
- `go test ./pkg/probo ./pkg/cmd/document/publish ./pkg/server/api/console/v1 ./packages/n8n-node/...`
  - Note: `./packages/n8n-node/...` has no Go packages
- `make bin/probod`
- `PROBO_E2E_BINARY=/workspace/bin/probod go test ./e2e/console -run TestDocumentVersion_PublishInitialMinorVersion -count=1` (blocked: local PostgreSQL for `probod_test` is not running; Docker is not installed in this cloud machine to start the compose service)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-421](https://linear.app/probo/issue/ENG-421/allow-publishing-minor-document-versions-before-10)

<div><a href="https://cursor.com/agents/bc-f31a9b57-5902-4674-8a75-988782c118ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f31a9b57-5902-4674-8a75-988782c118ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow publishing an initial 0.x minor directly from a draft; no prior major required (ENG-421).

- **New Features**
  - Allow minor publishes as the first release (0.1); approvers are ignored.
  - Update CLI help, `n8n` node description, and MCP schema to match behavior.
  - Add e2e coverage: publish 0.1, create 0.2 draft, publish 0.2.

- **Refactors**
  - Remove obsolete “minor-before-major” error and related GraphQL resolver handling.

<sup>Written for commit 600aa6b8a864cf0eec6d7945323882be81888e96. Summary will update on new commits. <a href="https://cubic.dev/pr/getprobo/probo/pull/1221?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

