### PR TITLE
Add async third-party vetting with agent tools

### DIFF
--- a/apps/console/src/hooks/graph/ThirdPartyGraph.ts
+++ b/apps/console/src/hooks/graph/ThirdPartyGraph.ts
@@ -185,7 +185,8 @@ export const thirdPartyNodeQuery = graphql`
         name
         websiteUrl
         firstLevel
-        canAssess: permission(action: "core:thirdParty:assess")
+        vettingStatus
+        canVet: permission(action: "core:thirdParty:vet")
         canUpdate: permission(action: "core:thirdParty:update")
         canDelete: permission(action: "core:thirdParty:delete")
         canUploadComplianceReport: permission(

--- a/apps/console/src/pages/organizations/third-parties/ThirdPartyDetailPage.tsx
+++ b/apps/console/src/pages/organizations/third-parties/ThirdPartyDetailPage.tsx
@@ -43,7 +43,7 @@ import {
 } from "#/hooks/graph/ThirdPartyGraph";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
 
-import { ImportAssessmentDialog } from "./dialogs/ImportAssessmentDialog";
+import { VettingDialog } from "./dialogs/VettingDialog";
 import { measuresFragment } from "./measures/ThirdPartyMeasuresPage";
 import { complianceReportsFragment } from "./tabs/ThirdPartyComplianceTab";
 
@@ -74,8 +74,16 @@ export default function ThirdPartyDetailPage(props: Props) {
   const baseThirdPartyUrl
     = `/organizations/${organizationId}/third-parties/${thirdParty.id}`;
 
+  const isVetting = thirdParty.vettingStatus === "PENDING" || thirdParty.vettingStatus === "RUNNING";
+
   return (
     <div className="space-y-6">
+      {isVetting && (
+        <div className="flex items-center gap-3 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800">
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-blue-300 border-t-blue-600" />
+          {__("Vetting is in progress. Results will appear once the analysis is complete.")}
+        </div>
+      )}
       <Breadcrumb
         items={[
           {
@@ -104,12 +112,15 @@ export default function ThirdPartyDetailPage(props: Props) {
           </div>
         </div>
         <div className="flex gap-2 items-center">
-          {thirdParty.canAssess && (
-            <ImportAssessmentDialog thirdPartyId={thirdParty.id}>
+          {thirdParty.canVet && (
+            <VettingDialog
+              thirdPartyId={thirdParty.id}
+              websiteUrl={thirdParty.websiteUrl}
+            >
               <Button icon={IconPageTextLine} variant="secondary">
-                {__("Assessment From Website")}
+                {__("Start Vetting")}
               </Button>
-            </ImportAssessmentDialog>
+            </VettingDialog>
           )}
           {thirdParty.canDelete && (
             <ActionDropdown variant="secondary">

--- a/apps/console/src/pages/organizations/third-parties/dialogs/VettingDialog.tsx
+++ b/apps/console/src/pages/organizations/third-parties/dialogs/VettingDialog.tsx
@@ -20,21 +20,23 @@ import {
   DialogFooter,
   Field,
   useDialogRef,
+  useToast,
 } from "@probo/ui";
 import type { ReactNode } from "react";
+import { useMutation } from "react-relay";
 import { graphql } from "relay-runtime";
 import { z } from "zod";
 
+import type { VettingDialogMutation } from "#/__generated__/core/VettingDialogMutation.graphql";
 import { useFormWithSchema } from "#/hooks/useFormWithSchema";
-import { useMutationWithToasts } from "#/hooks/useMutationWithToasts";
 
 const schema = z.object({
   url: z.string().url(),
 });
 
-const importAssessmentMutation = graphql`
-  mutation ImportAssessmentDialogMutation($input: AssessThirdPartyInput!) {
-    assessThirdParty(input: $input) {
+const vetMutation = graphql`
+  mutation VettingDialogMutation($input: VetThirdPartyInput!) {
+    vetThirdParty(input: $input) {
       thirdParty {
         id
         name
@@ -47,41 +49,49 @@ const importAssessmentMutation = graphql`
   }
 `;
 
-type Props = {
+interface VettingDialogProps {
   thirdPartyId: string;
+  websiteUrl?: string | null;
   children: ReactNode;
-};
+}
 
-export function ImportAssessmentDialog({ thirdPartyId, children }: Props) {
+export function VettingDialog({ thirdPartyId, websiteUrl, children }: VettingDialogProps) {
   const { __ } = useTranslate();
+  const { toast } = useToast();
   const dialogRef = useDialogRef();
   const { register, handleSubmit, reset, formState } = useFormWithSchema(
     schema,
     {
       defaultValues: {
-        url: "",
+        url: websiteUrl ?? "",
       },
     },
   );
-  const [assess, isAssessing] = useMutationWithToasts(
-    importAssessmentMutation,
-    {
-      successMessage: __("Third party assessed successfully."),
-      errorMessage: __("Failed to assess third party"),
-    },
-  );
+  const [vet, isVetting] = useMutation<VettingDialogMutation>(vetMutation);
 
-  const onSubmit = async (data: z.infer<typeof schema>) => {
-    await assess({
+  const onSubmit = (data: z.infer<typeof schema>) => {
+    vet({
       variables: {
         input: {
           id: thirdPartyId,
           websiteUrl: data.url,
         },
       },
-      onSuccess: () => {
+      onCompleted: () => {
         dialogRef.current?.close();
         reset();
+        toast({
+          title: __("Vetting started"),
+          description: __("The third party is being vetted in the background."),
+          variant: "success",
+        });
+      },
+      onError: () => {
+        toast({
+          title: __("Error"),
+          description: __("Failed to start vetting."),
+          variant: "error",
+        });
       },
     });
   };
@@ -90,22 +100,22 @@ export function ImportAssessmentDialog({ thirdPartyId, children }: Props) {
     <Dialog
       ref={dialogRef}
       trigger={children}
-      title={__("Assessment from website")}
+      title={__("Start Vetting")}
       className="max-w-lg"
     >
       <form onSubmit={e => void handleSubmit(onSubmit)(e)}>
         <DialogContent padded>
           <Field
             required
-            label={__("URL")}
+            label={__("Website URL")}
             type="text"
             {...register("url")}
             error={formState.errors.url?.message}
           />
         </DialogContent>
         <DialogFooter>
-          <Button type="submit" disabled={isAssessing}>
-            {__("Assess")}
+          <Button type="submit" disabled={isVetting}>
+            {__("Start Vetting")}
           </Button>
         </DialogFooter>
       </form>

--- a/e2e/console/third_party_test.go
+++ b/e2e/console/third_party_test.go
@@ -987,18 +987,18 @@ func TestThirdParty_OmittableWebsiteUrl(t *testing.T) {
 	})
 }
 
-// TestThirdParty_Assess exercises the assessThirdParty mutation through authorization
+// TestThirdParty_Vet exercises the vetThirdParty mutation through authorization
 // and tenant-isolation paths without running the real LLM/browser pipeline.
 // The e2e config deliberately omits `llm.third-party-assessor.provider`, so an
-// authorized call reaches DisabledThirdPartyAssessor and surfaces a stable
+// authorized call reaches DisabledThirdPartyVetter and surfaces a stable
 // UNAVAILABLE error. Happy-path payload shape is covered by unit tests in
 // pkg/probo.
-func TestThirdParty_Assess(t *testing.T) {
+func TestThirdParty_Vet(t *testing.T) {
 	t.Parallel()
 
 	const query = `
-		mutation AssessThirdParty($input: AssessThirdPartyInput!) {
-			assessThirdParty(input: $input) {
+		mutation VetThirdParty($input: VetThirdPartyInput!) {
+			vetThirdParty(input: $input) {
 				thirdParty {
 					id
 				}
@@ -1007,18 +1007,18 @@ func TestThirdParty_Assess(t *testing.T) {
 	`
 
 	type resultShape struct {
-		AssessThirdParty struct {
+		VetThirdParty struct {
 			ThirdParty struct {
 				ID string `json:"id"`
 			} `json:"thirdParty"`
-		} `json:"assessThirdParty"`
+		} `json:"vetThirdParty"`
 	}
 
 	t.Run("owner call surfaces the disabled error", func(t *testing.T) {
 		t.Parallel()
 
 		owner := testutil.NewClient(t, testutil.RoleOwner)
-		thirdPartyID := factory.NewThirdParty(owner).WithName("Unconfigured assess").Create()
+		thirdPartyID := factory.NewThirdParty(owner).WithName("Unconfigured vet").Create()
 
 		var result resultShape
 
@@ -1036,7 +1036,7 @@ func TestThirdParty_Assess(t *testing.T) {
 
 		owner := testutil.NewClient(t, testutil.RoleOwner)
 		admin := testutil.NewClientInOrg(t, testutil.RoleAdmin, owner)
-		thirdPartyID := factory.NewThirdParty(owner).WithName("Admin-assessed thirdParty").Create()
+		thirdPartyID := factory.NewThirdParty(owner).WithName("Admin-vetted thirdParty").Create()
 
 		var result resultShape
 
@@ -1049,7 +1049,7 @@ func TestThirdParty_Assess(t *testing.T) {
 		testutil.RequireErrorCode(t, err, "UNAVAILABLE")
 	})
 
-	t.Run("viewer cannot assess a thirdParty", func(t *testing.T) {
+	t.Run("viewer cannot vet a thirdParty", func(t *testing.T) {
 		t.Parallel()
 
 		owner := testutil.NewClient(t, testutil.RoleOwner)
@@ -1067,7 +1067,7 @@ func TestThirdParty_Assess(t *testing.T) {
 		testutil.RequireForbiddenError(t, err)
 	})
 
-	t.Run("cannot assess thirdParty from another organization", func(t *testing.T) {
+	t.Run("cannot vet thirdParty from another organization", func(t *testing.T) {
 		t.Parallel()
 
 		org1Owner := testutil.NewClient(t, testutil.RoleOwner)
@@ -1082,7 +1082,7 @@ func TestThirdParty_Assess(t *testing.T) {
 				"websiteUrl": "https://cross-tenant.example.com",
 			},
 		}, &result)
-		require.Error(t, err, "thirdParty assess must not cross tenant boundaries")
+		require.Error(t, err, "thirdParty vet must not cross tenant boundaries")
 	})
 
 	t.Run("procedure is accepted on the input", func(t *testing.T) {

--- a/pkg/cmd/thirdpartymgmt/assess/assess.go
+++ b/pkg/cmd/thirdpartymgmt/assess/assess.go
@@ -25,16 +25,10 @@ import (
 	"go.probo.inc/probo/pkg/cmd/cmdutil"
 )
 
-const assessMutation = `
-mutation($input: AssessThirdPartyInput!) {
-  assessThirdParty(input: $input) {
-    report
-    subprocessors {
-      name
-      country
-      purpose
-    }
-    third_party {
+const vetMutation = `
+mutation($input: VetThirdPartyInput!) {
+  vetThirdParty(input: $input) {
+    thirdParty {
       id
       name
     }
@@ -42,19 +36,13 @@ mutation($input: AssessThirdPartyInput!) {
 }
 `
 
-type assessResponse struct {
-	AssessThirdParty struct {
-		Report        string `json:"report"`
-		Subprocessors []struct {
-			Name    string `json:"name"`
-			Country string `json:"country"`
-			Purpose string `json:"purpose"`
-		} `json:"subprocessors"`
+type vetResponse struct {
+	VetThirdParty struct {
 		ThirdParty struct {
 			ID   string `json:"id"`
 			Name string `json:"name"`
-		} `json:"third_party"`
-	} `json:"assessThirdParty"`
+		} `json:"thirdParty"`
+	} `json:"vetThirdParty"`
 }
 
 func NewCmdAssess(f *cmdutil.Factory) *cobra.Command {
@@ -63,17 +51,17 @@ func NewCmdAssess(f *cmdutil.Factory) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "assess <thirdParty-id> --url <website-url>",
-		Short: "Run AI assessment on a thirdParty from its website",
-		Long:  "Analyze a thirdParty's website using AI agents to extract security, compliance, and business information.",
-		Example: `  # Assess a third_party by website URL
-  prb third_party assess VND_123 --url https://example.com
+		Use:   "vet <thirdParty-id> --url <website-url>",
+		Short: "Start AI vetting of a third party from its website",
+		Long:  "Queue a vetting job that crawls a third party's website using AI agents to extract security, compliance, and business information.",
+		Example: `  # Vet a third party by website URL
+  prb third-party vet VND_123 --url https://example.com
 
-  # Assess with a custom procedure file
-  prb third_party assess VND_123 --url https://example.com --procedure-file ./my-procedure.txt
+  # Vet with a custom procedure file
+  prb third-party vet VND_123 --url https://example.com --procedure-file ./my-procedure.txt
 
   # Output as JSON
-  prb third_party assess VND_123 --url https://example.com -o json`,
+  prb third-party vet VND_123 --url https://example.com -o json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := cmdutil.ValidateOutputFlag(flagOutput); err != nil {
@@ -107,19 +95,17 @@ func NewCmdAssess(f *cmdutil.Factory) *cobra.Command {
 				input["procedure"] = string(data)
 			}
 
-			// The CLI timeout must outlast the server-side assessment
-			// timeout (vetting.AssessmentTimeout = 20m) plus HTTP overhead.
 			client := api.NewClient(
 				host,
 				hc.Token,
 				"/api/console/v1/graphql",
-				22*time.Minute,
+				30*time.Second,
 			)
 
-			_, _ = fmt.Fprintf(f.IOStreams.ErrOut, "Assessing thirdParty from %s (this may take a few minutes)...\n", flagURL)
+			_, _ = fmt.Fprintf(f.IOStreams.ErrOut, "Starting vetting for %s...\n", flagURL)
 
 			data, err := client.Do(
-				assessMutation,
+				vetMutation,
 				map[string]any{
 					"input": input,
 				},
@@ -128,24 +114,24 @@ func NewCmdAssess(f *cmdutil.Factory) *cobra.Command {
 				return err
 			}
 
-			var resp assessResponse
+			var resp vetResponse
 			if err := json.Unmarshal(data, &resp); err != nil {
 				return fmt.Errorf("cannot parse response: %w", err)
 			}
 
 			if *flagOutput == cmdutil.OutputJSON {
-				return cmdutil.PrintJSON(f.IOStreams.Out, resp.AssessThirdParty)
+				return cmdutil.PrintJSON(f.IOStreams.Out, resp.VetThirdParty)
 			}
 
-			_, _ = fmt.Fprintln(f.IOStreams.Out, resp.AssessThirdParty.Report)
+			_, _ = fmt.Fprintf(f.IOStreams.Out, "Vetting started for %s\n", resp.VetThirdParty.ThirdParty.Name)
 
 			return nil
 		},
 	}
 
-	cmd.Flags().String("url", "", "ThirdParty website URL to assess (required)")
+	cmd.Flags().String("url", "", "Third party website URL to vet (required)")
 	_ = cmd.MarkFlagRequired("url")
-	cmd.Flags().String("procedure-file", "", "Path to a custom assessment procedure file")
+	cmd.Flags().String("procedure-file", "", "Path to a custom vetting procedure file")
 	flagOutput = cmdutil.AddOutputFlag(cmd)
 
 	return cmd

--- a/pkg/coredata/agent_run.go
+++ b/pkg/coredata/agent_run.go
@@ -41,6 +41,7 @@ type (
 		Status         AgentRunStatus  `db:"status"`
 		Checkpoint     json.RawMessage `db:"checkpoint"`
 		InputMessages  json.RawMessage `db:"input_messages"`
+		Metadata       json.RawMessage `db:"metadata"`
 		Result         json.RawMessage `db:"result"`
 		ErrorMessage   *string         `db:"error_message"`
 		StartedAt      *time.Time      `db:"started_at"`
@@ -175,6 +176,7 @@ SELECT
 	status,
 	checkpoint,
 	input_messages,
+	metadata,
 	result,
 	error_message,
 	started_at,
@@ -228,6 +230,7 @@ SELECT
 	status,
 	checkpoint,
 	input_messages,
+	metadata,
 	result,
 	error_message,
 	started_at,
@@ -283,6 +286,7 @@ SELECT
 	status,
 	checkpoint,
 	input_messages,
+	metadata,
 	result,
 	error_message,
 	started_at,
@@ -361,6 +365,7 @@ INSERT INTO agent_runs (
 	start_agent_name,
 	status,
 	input_messages,
+	metadata,
 	created_at,
 	updated_at
 ) VALUES (
@@ -370,6 +375,7 @@ INSERT INTO agent_runs (
 	@start_agent_name,
 	@status,
 	@input_messages,
+	@metadata,
 	@created_at,
 	@updated_at
 )
@@ -380,6 +386,7 @@ RETURNING
 	status,
 	checkpoint,
 	input_messages,
+	metadata,
 	result,
 	error_message,
 	started_at,
@@ -396,6 +403,7 @@ RETURNING
 		"start_agent_name": e.StartAgentName,
 		"status":           e.Status,
 		"input_messages":   e.InputMessages,
+		"metadata":         e.Metadata,
 		"created_at":       e.CreatedAt,
 		"updated_at":       e.UpdatedAt,
 	}
@@ -445,6 +453,7 @@ RETURNING
 	status,
 	checkpoint,
 	input_messages,
+	metadata,
 	result,
 	error_message,
 	started_at,
@@ -528,6 +537,7 @@ SELECT
 	status,
 	checkpoint,
 	input_messages,
+	metadata,
 	result,
 	error_message,
 	started_at,
@@ -771,4 +781,86 @@ func (s *PGCheckpointer) marshalAgentCheckpoint(cp *agent.Checkpoint) ([]byte, e
 	}
 
 	return data, nil
+}
+
+func (e *AgentRun) LoadNextPendingByAgentForUpdateSkipLocked(
+	ctx context.Context,
+	tx pg.Tx,
+	agentName string,
+) error {
+	q := `
+SELECT
+	id,
+	organization_id,
+	start_agent_name,
+	status,
+	checkpoint,
+	input_messages,
+	metadata,
+	result,
+	error_message,
+	started_at,
+	lease_owner,
+	lease_expires_at,
+	created_at,
+	updated_at
+FROM
+	agent_runs
+WHERE
+	status = 'PENDING'
+	AND start_agent_name = @start_agent_name
+ORDER BY created_at ASC
+LIMIT 1
+FOR UPDATE SKIP LOCKED;
+`
+
+	rows, err := tx.Query(ctx, q, pgx.StrictNamedArgs{"start_agent_name": agentName})
+	if err != nil {
+		return fmt.Errorf("cannot query pending agent run: %w", err)
+	}
+
+	run, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[AgentRun])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrResourceNotFound
+		}
+
+		return fmt.Errorf("cannot collect agent run: %w", err)
+	}
+
+	*e = run
+
+	return nil
+}
+
+func ActiveAgentRunStatus(
+	ctx context.Context,
+	conn pg.Querier,
+	agentName string,
+	metadataKey string,
+	metadataValue string,
+) (*AgentRunStatus, error) {
+	q := `
+SELECT status
+FROM agent_runs
+WHERE start_agent_name = $1
+    AND metadata->>$2 = $3
+    AND status IN ('PENDING', 'RUNNING')
+ORDER BY created_at DESC
+LIMIT 1;
+`
+
+	var status AgentRunStatus
+
+	err := conn.QueryRow(ctx, q, agentName, metadataKey, metadataValue).Scan(&status)
+
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("cannot query active agent run: %w", err)
+	}
+
+	return &status, nil
 }

--- a/pkg/coredata/migrations/20260527T120000Z.sql
+++ b/pkg/coredata/migrations/20260527T120000Z.sql
@@ -1,0 +1,15 @@
+-- Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+--
+-- Permission to use, copy, modify, and/or distribute this software for any
+-- purpose with or without fee is hereby granted, provided that the above
+-- copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+-- REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+-- INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+-- LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+-- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+ALTER TABLE agent_runs ADD COLUMN metadata JSONB;

--- a/pkg/coredata/third_party.go
+++ b/pkg/coredata/third_party.go
@@ -290,6 +290,79 @@ LIMIT 1;
 	return nil
 }
 
+func (v *ThirdParty) LoadByNameAndOrganizationID(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	name string,
+	organizationID gid.GID,
+) error {
+	q := `
+SELECT
+    id,
+    tenant_id,
+    organization_id,
+    common_third_party_id,
+    name,
+    description,
+    category,
+    headquarter_address,
+    legal_name,
+    website_url,
+    privacy_policy_url,
+    service_level_agreement_url,
+    data_processing_agreement_url,
+    business_associate_agreement_url,
+    subprocessors_list_url,
+    certifications,
+    countries,
+    business_owner_profile_id,
+    security_owner_profile_id,
+    status_page_url,
+    terms_of_service_url,
+    security_page_url,
+    trust_page_url,
+    show_on_trust_center,
+    first_level,
+    created_at,
+    updated_at
+FROM
+    third_parties
+WHERE
+    %s
+    AND organization_id = @organization_id
+    AND name = @name
+LIMIT 1;
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"organization_id": organizationID,
+		"name":            name,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query thirdParty by name: %w", err)
+	}
+	defer rows.Close()
+
+	thirdParty, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[ThirdParty])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrResourceNotFound
+		}
+
+		return fmt.Errorf("cannot collect thirdParty: %w", err)
+	}
+
+	*v = thirdParty
+
+	return nil
+}
+
 func (v *ThirdParties) LoadByIDs(
 	ctx context.Context,
 	conn pg.Querier,

--- a/pkg/probo/actions.go
+++ b/pkg/probo/actions.go
@@ -89,7 +89,7 @@ const (
 	ActionThirdPartyCreate  = "core:thirdParty:create"
 	ActionThirdPartyUpdate  = "core:thirdParty:update"
 	ActionThirdPartyDelete  = "core:thirdParty:delete"
-	ActionThirdPartyAssess  = "core:thirdParty:assess"
+	ActionThirdPartyVet     = "core:thirdParty:vet"
 	ActionThirdPartyPublish = "core:thirdParty:publish"
 
 	// ThirdPartyRelation actions

--- a/pkg/probo/service.go
+++ b/pkg/probo/service.go
@@ -78,7 +78,7 @@ type (
 		esign                                 *esign.Service
 		connectorRegistry                     *connector.ConnectorRegistry
 		invitationTokenValidity               time.Duration
-		thirdPartyAssessor                    ThirdPartyAssessor
+		thirdPartyVetter                      ThirdPartyVetter
 		Frameworks                            *FrameworkService
 		Measures                              *MeasureService
 		Tasks                                 *TaskService
@@ -141,7 +141,7 @@ func NewService(
 	esignService *esign.Service,
 	connectorRegistry *connector.ConnectorRegistry,
 	invitationTokenValidity time.Duration,
-	thirdPartyAssessor ThirdPartyAssessor,
+	thirdPartyVetter ThirdPartyVetter,
 ) (*Service, error) {
 	if bucket == "" {
 		return nil, fmt.Errorf("bucket is required")
@@ -168,7 +168,7 @@ func NewService(
 		esign:                   esignService,
 		connectorRegistry:       connectorRegistry,
 		invitationTokenValidity: invitationTokenValidity,
-		thirdPartyAssessor:      thirdPartyAssessor,
+		thirdPartyVetter:        thirdPartyVetter,
 	}
 
 	svc.Frameworks = &FrameworkService{

--- a/pkg/probo/third_party_service.go
+++ b/pkg/probo/third_party_service.go
@@ -16,12 +16,12 @@ package probo
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
 
 	"go.gearno.de/kit/pg"
-	"go.gearno.de/x/ref"
 	"go.probo.inc/probo/pkg/agent"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
@@ -32,38 +32,40 @@ import (
 	webhooktypes "go.probo.inc/probo/pkg/webhook/types"
 )
 
-// ErrThirdPartyAssessmentDisabled is returned by ThirdPartyAssessor.Assess when the
+// ErrThirdPartyVettingDisabled is returned by ThirdPartyVetter.Assess when the
 // deployment has not configured an LLM provider for thirdParty assessment.
-var ErrThirdPartyAssessmentDisabled = errors.New("thirdParty assessment is not configured on this deployment")
+var ErrThirdPartyVettingDisabled = errors.New("thirdParty vetting is not configured on this deployment")
 
-// ThirdPartyAssessor produces a thirdParty assessment report from a website URL and
+// ThirdPartyVetter produces a thirdParty assessment report from a website URL and
 // an optional procedure description. Implementations that cannot perform
 // assessment (missing LLM credentials, misconfigured provider) must return
-// ErrThirdPartyAssessmentDisabled from Assess so callers can surface a stable
+// ErrThirdPartyVettingDisabled from Assess so callers can surface a stable
 // "feature unavailable" error instead of a generic internal error.
-type ThirdPartyAssessor interface {
+type ThirdPartyVetter interface {
 	Assess(
 		ctx context.Context,
 		websiteURL string,
 		procedure string,
 		reporter agent.ProgressReporter,
+		extraTools []agent.Tool,
 	) (*vetting.Result, error)
 }
 
-// DisabledThirdPartyAssessor is the ThirdPartyAssessor implementation used when no
+// DisabledThirdPartyVetter is the ThirdPartyVetter implementation used when no
 // LLM provider is configured for the third-party-assessor agent. Its Assess
-// method always returns ErrThirdPartyAssessmentDisabled.
-type DisabledThirdPartyAssessor struct{}
+// method always returns ErrThirdPartyVettingDisabled.
+type DisabledThirdPartyVetter struct{}
 
-var _ ThirdPartyAssessor = DisabledThirdPartyAssessor{}
+var _ ThirdPartyVetter = DisabledThirdPartyVetter{}
 
-func (DisabledThirdPartyAssessor) Assess(
+func (DisabledThirdPartyVetter) Assess(
 	_ context.Context,
 	_ string,
 	_ string,
 	_ agent.ProgressReporter,
+	_ []agent.Tool,
 ) (*vetting.Result, error) {
-	return nil, ErrThirdPartyAssessmentDisabled
+	return nil, ErrThirdPartyVettingDisabled
 }
 
 type (
@@ -120,22 +122,10 @@ type (
 		FirstLevel                    *bool
 	}
 
-	AssessThirdPartyRequest struct {
+	VetThirdPartyRequest struct {
 		ID         gid.GID
 		WebsiteURL string
 		Procedure  *string
-	}
-
-	AssessThirdPartyResult struct {
-		ThirdParty    *coredata.ThirdParty
-		Report        string
-		Subprocessors []Subprocessor
-	}
-
-	Subprocessor struct {
-		Name    string
-		Country string
-		Purpose string
 	}
 
 	CreateThirdPartyRiskAssessmentRequest struct {
@@ -904,102 +894,46 @@ func (s ThirdPartyService) GetByRiskAssessmentID(
 	return thirdParty, nil
 }
 
-func (s ThirdPartyService) Assess(
+func (s ThirdPartyService) Vet(
 	ctx context.Context, scope coredata.Scoper,
-	req AssessThirdPartyRequest,
-) (*AssessThirdPartyResult, error) {
-	result, err := s.svc.thirdPartyAssessor.Assess(ctx, req.WebsiteURL, ref.UnrefOrZero(req.Procedure), nil)
-	if err != nil {
-		return nil, fmt.Errorf("cannot assess thirdParty: %w", err)
+	req VetThirdPartyRequest,
+) (*coredata.ThirdParty, error) {
+	if _, ok := s.svc.thirdPartyVetter.(DisabledThirdPartyVetter); ok {
+		return nil, ErrThirdPartyVettingDisabled
 	}
 
 	thirdParty := &coredata.ThirdParty{}
 
-	err = s.svc.pg.WithTx(
+	err := s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, conn pg.Tx) error {
 			if err := thirdParty.LoadByID(ctx, conn, scope, req.ID); err != nil {
 				return fmt.Errorf("cannot load thirdParty %q: %w", req.ID, err)
 			}
 
-			info := result.Info
-
-			if info.Name != "" {
-				thirdParty.Name = info.Name
+			metadata, err := json.Marshal(map[string]string{
+				"third_party_id":  thirdParty.ID.String(),
+				"organization_id": thirdParty.OrganizationID.String(),
+				"website_url":     req.WebsiteURL,
+			})
+			if err != nil {
+				return fmt.Errorf("cannot marshal vetting metadata: %w", err)
 			}
 
-			thirdParty.WebsiteURL = &req.WebsiteURL
-			if info.Category != "" {
-				thirdParty.Category = coredata.ThirdPartyCategory(info.Category)
+			now := time.Now()
+			run := coredata.AgentRun{
+				ID:             gid.New(scope.GetTenantID(), coredata.AgentRunEntityType),
+				OrganizationID: thirdParty.OrganizationID,
+				StartAgentName: VettingAgentName,
+				Status:         coredata.AgentRunStatusPending,
+				InputMessages:  []byte("[]"),
+				Metadata:       metadata,
+				CreatedAt:      now,
+				UpdatedAt:      now,
 			}
 
-			thirdParty.UpdatedAt = time.Now()
-
-			if info.Description != "" {
-				thirdParty.Description = &info.Description
-			}
-
-			if info.HeadquarterAddress != "" {
-				thirdParty.HeadquarterAddress = &info.HeadquarterAddress
-			}
-
-			if info.LegalName != "" {
-				thirdParty.LegalName = &info.LegalName
-			}
-
-			if info.PrivacyPolicyURL != "" {
-				thirdParty.PrivacyPolicyURL = &info.PrivacyPolicyURL
-			}
-
-			if info.ServiceLevelAgreementURL != "" {
-				thirdParty.ServiceLevelAgreementURL = &info.ServiceLevelAgreementURL
-			}
-
-			if info.DataProcessingAgreementURL != "" {
-				thirdParty.DataProcessingAgreementURL = &info.DataProcessingAgreementURL
-			}
-
-			if info.BusinessAssociateAgreementURL != "" {
-				thirdParty.BusinessAssociateAgreementURL = &info.BusinessAssociateAgreementURL
-			}
-
-			if info.SubprocessorsListURL != "" {
-				thirdParty.SubprocessorsListURL = &info.SubprocessorsListURL
-			}
-
-			if info.SecurityPageURL != "" {
-				thirdParty.SecurityPageURL = &info.SecurityPageURL
-			}
-
-			if info.TrustPageURL != "" {
-				thirdParty.TrustPageURL = &info.TrustPageURL
-			}
-
-			if info.TermsOfServiceURL != "" {
-				thirdParty.TermsOfServiceURL = &info.TermsOfServiceURL
-			}
-
-			if info.StatusPageURL != "" {
-				thirdParty.StatusPageURL = &info.StatusPageURL
-			}
-
-			if len(info.Certifications) > 0 {
-				thirdParty.Certifications = info.Certifications
-			}
-
-			if err := thirdParty.Update(ctx, conn, scope); err != nil {
-				return fmt.Errorf("cannot update thirdParty: %w", err)
-			}
-
-			if err := webhook.InsertData(
-				ctx,
-				conn,
-				scope,
-				thirdParty.OrganizationID,
-				coredata.WebhookEventTypeThirdPartyUpdated,
-				webhooktypes.NewThirdParty(thirdParty),
-			); err != nil {
-				return fmt.Errorf("cannot insert webhook event: %w", err)
+			if err := run.Insert(ctx, conn, scope); err != nil {
+				return fmt.Errorf("cannot enqueue vetting run: %w", err)
 			}
 
 			return nil
@@ -1009,20 +943,27 @@ func (s ThirdPartyService) Assess(
 		return nil, err
 	}
 
-	subprocessors := make([]Subprocessor, len(result.Info.Subprocessors))
-	for i, sp := range result.Info.Subprocessors {
-		subprocessors[i] = Subprocessor{
-			Name:    sp.Name,
-			Country: sp.Country,
-			Purpose: sp.Purpose,
-		}
+	return thirdParty, nil
+}
+
+func (s ThirdPartyService) VettingStatus(
+	ctx context.Context,
+	thirdPartyID gid.GID,
+) (*coredata.AgentRunStatus, error) {
+	var status *coredata.AgentRunStatus
+
+	err := s.svc.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) (err error) {
+			status, err = coredata.ActiveAgentRunStatus(ctx, conn, VettingAgentName, "third_party_id", thirdPartyID.String())
+			return err
+		},
+	)
+	if err != nil {
+		return nil, err
 	}
 
-	return &AssessThirdPartyResult{
-		ThirdParty:    thirdParty,
-		Report:        result.Document,
-		Subprocessors: subprocessors,
-	}, nil
+	return status, nil
 }
 
 func (s ThirdPartyService) CreateThirdPartyMapping(

--- a/pkg/probo/vetting_worker.go
+++ b/pkg/probo/vetting_worker.go
@@ -1,0 +1,202 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package probo
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.gearno.de/kit/log"
+	"go.gearno.de/kit/pg"
+	"go.gearno.de/kit/worker"
+	"go.probo.inc/probo/pkg/agent"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/vetting"
+)
+
+const VettingAgentName = "third_party_vetter"
+
+type (
+	vettingMetadata struct {
+		ThirdPartyID   gid.GID `json:"third_party_id"`
+		OrganizationID gid.GID `json:"organization_id"`
+		WebsiteURL     string  `json:"website_url"`
+	}
+
+	vettingHandler struct {
+		pg         *pg.Client
+		vetter     ThirdPartyVetter
+		logger     *log.Logger
+		staleAfter time.Duration
+	}
+
+	VettingWorkerConfig struct {
+		StaleAfter time.Duration
+	}
+)
+
+func NewVettingWorker(
+	pgClient *pg.Client,
+	vetter ThirdPartyVetter,
+	logger *log.Logger,
+	cfg VettingWorkerConfig,
+	opts ...worker.Option,
+) *worker.Worker[coredata.AgentRun] {
+	staleAfter := cfg.StaleAfter
+	if staleAfter == 0 {
+		staleAfter = 25 * time.Minute
+	}
+
+	h := &vettingHandler{
+		pg:         pgClient,
+		vetter:     vetter,
+		logger:     logger,
+		staleAfter: staleAfter,
+	}
+
+	return worker.New(
+		"vetting-worker",
+		h,
+		logger,
+		opts...,
+	)
+}
+
+func (h *vettingHandler) Claim(ctx context.Context) (coredata.AgentRun, error) {
+	var run coredata.AgentRun
+
+	if err := h.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			if err := run.LoadNextPendingByAgentForUpdateSkipLocked(ctx, tx, VettingAgentName); err != nil {
+				return err
+			}
+
+			now := time.Now()
+			run.Status = coredata.AgentRunStatusRunning
+			run.StartedAt = &now
+			run.UpdatedAt = now
+
+			if err := run.Update(ctx, tx, coredata.NewNoScope()); err != nil {
+				return fmt.Errorf("cannot update agent run: %w", err)
+			}
+
+			return nil
+		},
+	); err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) {
+			return coredata.AgentRun{}, worker.ErrNoTask
+		}
+
+		return coredata.AgentRun{}, err
+	}
+
+	return run, nil
+}
+
+func (h *vettingHandler) Process(ctx context.Context, run coredata.AgentRun) error {
+	if err := h.processRun(ctx, &run); err != nil {
+		h.logger.ErrorCtx(
+			ctx,
+			"vetting worker failure",
+			log.Error(err),
+			log.String("run_id", run.ID.String()),
+		)
+
+		if failErr := h.failRun(ctx, &run, err); failErr != nil {
+			h.logger.ErrorCtx(ctx, "cannot mark agent run as failed", log.Error(failErr))
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func (h *vettingHandler) RecoverStale(ctx context.Context) error {
+	return h.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			return coredata.ResetStaleAgentRuns(ctx, conn)
+		},
+	)
+}
+
+func (h *vettingHandler) processRun(ctx context.Context, run *coredata.AgentRun) error {
+	var meta vettingMetadata
+	if err := json.Unmarshal(run.Metadata, &meta); err != nil {
+		return fmt.Errorf("cannot parse vetting metadata: %w", err)
+	}
+
+	var procedure string
+
+	if run.InputMessages != nil {
+		var msgs []struct {
+			Parts []struct {
+				Text string `json:"text"`
+			} `json:"parts"`
+		}
+
+		if err := json.Unmarshal(run.InputMessages, &msgs); err == nil && len(msgs) > 0 && len(msgs[0].Parts) > 1 {
+			procedure = msgs[0].Parts[1].Text
+		}
+	}
+
+	pc := &vetting.PersistenceContext{
+		PG:             h.pg,
+		ThirdPartyID:   meta.ThirdPartyID,
+		OrganizationID: meta.OrganizationID,
+		WebsiteURL:     meta.WebsiteURL,
+	}
+
+	tools := []agent.Tool{
+		vetting.SaveThirdPartyInfoTool(pc),
+		vetting.LinkSubThirdPartyTool(pc),
+	}
+
+	if _, err := h.vetter.Assess(ctx, meta.WebsiteURL, procedure, nil, tools); err != nil {
+		return fmt.Errorf("cannot vet third party: %w", err)
+	}
+
+	return h.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			run.Status = coredata.AgentRunStatusCompleted
+			run.StartedAt = nil
+			run.UpdatedAt = time.Now()
+
+			return run.Update(ctx, tx, coredata.NewNoScope())
+		},
+	)
+}
+
+func (h *vettingHandler) failRun(ctx context.Context, run *coredata.AgentRun, reason error) error {
+	return h.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			errMsg := reason.Error()
+			run.Status = coredata.AgentRunStatusFailed
+			run.StartedAt = nil
+			run.ErrorMessage = &errMsg
+			run.UpdatedAt = time.Now()
+
+			return run.Update(ctx, tx, coredata.NewNoScope())
+		},
+	)
+}

--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -304,7 +304,7 @@ func (impl *Implm) Run(
 		return err
 	}
 
-	thirdPartyAssessor, err := impl.buildThirdPartyAssessor(l, tp, r)
+	thirdPartyVetter, err := impl.buildThirdPartyVetter(l, tp, r)
 	if err != nil {
 		return err
 	}
@@ -515,7 +515,7 @@ func (impl *Implm) Run(
 		esignService,
 		defaultConnectorRegistry,
 		time.Duration(impl.cfg.Auth.InvitationConfirmationTokenValidity)*time.Second,
-		thirdPartyAssessor,
+		thirdPartyVetter,
 	)
 	if err != nil {
 		return fmt.Errorf("cannot create probo service: %w", err)
@@ -770,6 +770,24 @@ func (impl *Implm) Run(
 		},
 	)
 
+	vettingWorker := probo.NewVettingWorker(
+		pgClient,
+		thirdPartyVetter,
+		l.Named("vetting-worker"),
+		probo.VettingWorkerConfig{},
+		worker.WithInterval(10*time.Second),
+		worker.WithMaxConcurrency(1),
+	)
+	vettingWorkerCtx, stopVettingWorker := context.WithCancel(context.Background())
+
+	wg.Go(
+		func() {
+			if err := vettingWorker.Run(vettingWorkerCtx); err != nil {
+				cancel(fmt.Errorf("vetting worker crashed: %w", err))
+			}
+		},
+	)
+
 	trustCenterServerCtx, stopTrustCenterServer := context.WithCancel(context.Background())
 	defer stopTrustCenterServer()
 
@@ -800,6 +818,7 @@ func (impl *Implm) Run(
 	stopTrackerPatternAnalysisWorker()
 	stopTrackerMappingWorker()
 	stopMailingListWorker()
+	stopVettingWorker()
 	stopEvidenceDescriptionWorker()
 	stopDocumentPDFWorker()
 	stopExportJobExporter()

--- a/pkg/probod/third_party_assessor.go
+++ b/pkg/probod/third_party_assessor.go
@@ -22,22 +22,22 @@ import (
 	"go.probo.inc/probo/pkg/vetting"
 )
 
-// buildThirdPartyAssessor wires the thirdParty assessment agent. It is an opt-in
+// buildThirdPartyVetter wires the thirdParty vetting agent. It is an opt-in
 // feature: deployments that do not set `llm.third-party-assessor.provider` get a
-// DisabledThirdPartyAssessor that reports the feature as unavailable. The
+// DisabledThirdPartyVetter that reports the feature as unavailable. The
 // third-party-assessor does not inherit the default provider because its
 // pipeline (LLM + browser + search) is expensive and should not be enabled
 // implicitly.
-func (impl *Implm) buildThirdPartyAssessor(
+func (impl *Implm) buildThirdPartyVetter(
 	l *log.Logger,
 	tp trace.TracerProvider,
 	r prometheus.Registerer,
-) (probo.ThirdPartyAssessor, error) {
-	if impl.cfg.Agents.ThirdPartyAssessor.Provider == "" {
-		return probo.DisabledThirdPartyAssessor{}, nil
+) (probo.ThirdPartyVetter, error) {
+	if impl.cfg.Agents.ThirdPartyVetter.Provider == "" {
+		return probo.DisabledThirdPartyVetter{}, nil
 	}
 
-	agentCfg, llmClient, err := impl.resolveAgentClient("third-party-assessor", impl.cfg.Agents.ThirdPartyAssessor, l, tp, r)
+	agentCfg, llmClient, err := impl.resolveAgentClient("third-party-assessor", impl.cfg.Agents.ThirdPartyVetter, l, tp, r)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/probodconfig/llm_config.go
+++ b/pkg/probodconfig/llm_config.go
@@ -50,13 +50,13 @@ type (
 	// settings. Default is used as a fallback when an agent-specific field
 	// is zero-valued.
 	AgentsConfig struct {
-		Providers          map[string]LLMProviderConfig `json:"providers"`
-		Default            LLMAgentConfig               `json:"defaults"`
-		Probo              LLMAgentConfig               `json:"probo"`
-		EvidenceDescriber  LLMAgentConfig               `json:"evidence-describer"`
-		ThirdPartyAssessor LLMAgentConfig               `json:"third-party-assessor"`
-		TrackerMapping     LLMAgentConfig               `json:"tracker-mapping"`
-		Tools              AgentToolsConfig             `json:"tools"`
+		Providers         map[string]LLMProviderConfig `json:"providers"`
+		Default           LLMAgentConfig               `json:"defaults"`
+		Probo             LLMAgentConfig               `json:"probo"`
+		EvidenceDescriber LLMAgentConfig               `json:"evidence-describer"`
+		ThirdPartyVetter  LLMAgentConfig               `json:"third-party-assessor"`
+		TrackerMapping    LLMAgentConfig               `json:"tracker-mapping"`
+		Tools             AgentToolsConfig             `json:"tools"`
 	}
 )
 

--- a/pkg/server/api/console/v1/graphql/third_party.graphql
+++ b/pkg/server/api/console/v1/graphql/third_party.graphql
@@ -293,6 +293,8 @@ type ThirdParty implements Node {
         orderBy: ThirdPartyOrder
     ): ThirdPartyConnection! @goField(forceResolver: true)
 
+    vettingStatus: String @goField(forceResolver: true)
+
     createdAt: Datetime!
     updatedAt: Datetime!
 
@@ -480,7 +482,7 @@ extend type Mutation {
     createThirdPartyRiskAssessment(
         input: CreateThirdPartyRiskAssessmentInput!
     ): CreateThirdPartyRiskAssessmentPayload!
-    assessThirdParty(input: AssessThirdPartyInput!): AssessThirdPartyPayload!
+    vetThirdParty(input: VetThirdPartyInput!): VetThirdPartyPayload!
     publishThirdPartyList(
         input: PublishThirdPartyListInput!
     ): PublishThirdPartyListPayload!
@@ -652,16 +654,10 @@ input CreateThirdPartyRiskAssessmentInput {
     notes: String
 }
 
-input AssessThirdPartyInput {
+input VetThirdPartyInput {
     id: ID!
     websiteUrl: String!
     procedure: String
-}
-
-type ThirdPartySubprocessor {
-    name: String!
-    country: String!
-    purpose: String!
 }
 
 type CreateThirdPartyPayload {
@@ -736,10 +732,8 @@ type CreateThirdPartyRiskAssessmentPayload {
     thirdPartyRiskAssessmentEdge: ThirdPartyRiskAssessmentEdge!
 }
 
-type AssessThirdPartyPayload {
+type VetThirdPartyPayload {
     thirdParty: ThirdParty!
-    report: String!
-    subprocessors: [ThirdPartySubprocessor!]!
 }
 
 input CreateThirdPartyThirdPartyMappingInput {

--- a/pkg/server/api/console/v1/third_party_resolvers.go
+++ b/pkg/server/api/console/v1/third_party_resolvers.go
@@ -536,35 +536,33 @@ func (r *mutationResolver) CreateThirdPartyRiskAssessment(ctx context.Context, i
 	}, nil
 }
 
-// AssessThirdParty is the resolver for the assessThirdParty field.
-func (r *mutationResolver) AssessThirdParty(ctx context.Context, input types.AssessThirdPartyInput) (*types.AssessThirdPartyPayload, error) {
-	scope, err := r.authorize(ctx, input.ID, probo.ActionThirdPartyAssess)
+// VetThirdParty is the resolver for the vetThirdParty field.
+func (r *mutationResolver) VetThirdParty(ctx context.Context, input types.VetThirdPartyInput) (*types.VetThirdPartyPayload, error) {
+	scope, err := r.authorize(ctx, input.ID, probo.ActionThirdPartyVet)
 	if err != nil {
 		return nil, err
 	}
 
-	result, err := r.probo.ThirdParties.Assess(
+	thirdParty, err := r.probo.ThirdParties.Vet(
 		ctx, scope,
-		probo.AssessThirdPartyRequest{
+		probo.VetThirdPartyRequest{
 			ID:         input.ID,
 			WebsiteURL: input.WebsiteURL,
 			Procedure:  input.Procedure,
 		},
 	)
 	if err != nil {
-		if errors.Is(err, probo.ErrThirdPartyAssessmentDisabled) {
-			return nil, gqlutils.Unavailable(ctx, probo.ErrThirdPartyAssessmentDisabled)
+		if errors.Is(err, probo.ErrThirdPartyVettingDisabled) {
+			return nil, gqlutils.Unavailable(ctx, probo.ErrThirdPartyVettingDisabled)
 		}
 
-		r.logger.ErrorCtx(ctx, "cannot assess thirdParty", log.Error(err))
+		r.logger.ErrorCtx(ctx, "cannot vet thirdParty", log.Error(err))
 
 		return nil, gqlutils.Internal(ctx)
 	}
 
-	return &types.AssessThirdPartyPayload{
-		ThirdParty:    types.NewThirdParty(result.ThirdParty),
-		Report:        result.Report,
-		Subprocessors: types.NewThirdPartySubprocessors(result.Subprocessors),
+	return &types.VetThirdPartyPayload{
+		ThirdParty: types.NewThirdParty(thirdParty),
 	}, nil
 }
 
@@ -933,6 +931,23 @@ func (r *thirdPartyResolver) ChildThirdParties(ctx context.Context, obj *types.T
 	}
 
 	return types.NewThirdPartyConnection(page, r, obj.ID, nil), nil
+}
+
+// VettingStatus is the resolver for the vettingStatus field.
+func (r *thirdPartyResolver) VettingStatus(ctx context.Context, obj *types.ThirdParty) (*string, error) {
+	status, err := r.probo.ThirdParties.VettingStatus(ctx, obj.ID)
+	if err != nil {
+		r.logger.ErrorCtx(ctx, "cannot get vetting status", log.Error(err))
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	if status == nil {
+		return nil, nil
+	}
+
+	s := status.String()
+
+	return &s, nil
 }
 
 // Permission is the resolver for the permission field.

--- a/pkg/server/api/console/v1/types/third_party.go
+++ b/pkg/server/api/console/v1/types/third_party.go
@@ -18,7 +18,6 @@ import (
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/page"
-	"go.probo.inc/probo/pkg/probo"
 )
 
 type (
@@ -106,17 +105,4 @@ func NewThirdParty(v *coredata.ThirdParty) *ThirdParty {
 	}
 
 	return object
-}
-
-func NewThirdPartySubprocessors(sps []probo.Subprocessor) []*ThirdPartySubprocessor {
-	result := make([]*ThirdPartySubprocessor, len(sps))
-	for i, sp := range sps {
-		result[i] = &ThirdPartySubprocessor{
-			Name:    sp.Name,
-			Country: sp.Country,
-			Purpose: sp.Purpose,
-		}
-	}
-
-	return result
 }

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -5262,27 +5262,29 @@ func (r *Resolver) DeleteCustomDomainTool(ctx context.Context, req *mcp.CallTool
 	return nil, types.DeleteCustomDomainOutput{DeletedCustomDomain: deletedDomain}, nil
 }
 
-func (r *Resolver) AssessThirdPartyTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AssessThirdPartyInput) (*mcp.CallToolResult, types.AssessThirdPartyOutput, error) {
-	scope, err := r.Authorize(ctx, input.ID, probo.ActionThirdPartyAssess)
+func (r *Resolver) VetThirdPartyTool(ctx context.Context, req *mcp.CallToolRequest, input *types.VetThirdPartyInput) (*mcp.CallToolResult, types.VetThirdPartyOutput, error) {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionThirdPartyVet)
 	if err != nil {
-		return nil, types.AssessThirdPartyOutput{}, err
+		return nil, types.VetThirdPartyOutput{}, err
 	}
 
 	svc := r.proboSvc
 
-	result, err := svc.ThirdParties.Assess(
+	thirdParty, err := svc.ThirdParties.Vet(
 		ctx, scope,
-		probo.AssessThirdPartyRequest{
+		probo.VetThirdPartyRequest{
 			ID:         input.ID,
 			WebsiteURL: input.WebsiteURL,
 			Procedure:  input.Procedure,
 		},
 	)
 	if err != nil {
-		return nil, types.AssessThirdPartyOutput{}, fmt.Errorf("cannot assess thirdParty: %w", err)
+		return nil, types.VetThirdPartyOutput{}, fmt.Errorf("cannot vet thirdParty: %w", err)
 	}
 
-	return nil, types.NewAssessThirdPartyOutput(result), nil
+	return nil, types.VetThirdPartyOutput{
+		ThirdParty: types.NewThirdParty(thirdParty),
+	}, nil
 }
 
 func (r *Resolver) PublishFindingListTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishFindingListInput) (*mcp.CallToolResult, types.PublishFindingListOutput, error) {

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -1466,7 +1466,7 @@ components:
           $ref: "#/components/schemas/GID"
           description: Deleted thirdParty service ID
 
-    AssessThirdPartyInput:
+    VetThirdPartyInput:
       type: object
       required:
         - id
@@ -1474,48 +1474,21 @@ components:
       properties:
         id:
           $ref: "#/components/schemas/GID"
-          description: ThirdParty ID to assess
+          description: ThirdParty ID to vet
         website_url:
           type: string
-          description: ThirdParty website URL to crawl and assess
+          description: ThirdParty website URL to crawl and vet
         procedure:
           type: string
-          description: Optional custom assessment procedure (overrides the default)
+          description: Optional custom vetting procedure (overrides the default)
 
-    ThirdPartySubprocessor:
-      type: object
-      required:
-        - name
-        - country
-        - purpose
-      properties:
-        name:
-          type: string
-          description: Sub-processor name
-        country:
-          type: string
-          description: Country where the sub-processor operates
-        purpose:
-          type: string
-          description: Purpose of the sub-processor
-
-    AssessThirdPartyOutput:
+    VetThirdPartyOutput:
       type: object
       required:
         - thirdParty
-        - report
-        - subprocessors
       properties:
         thirdParty:
           $ref: "#/components/schemas/ThirdParty"
-        report:
-          type: string
-          description: Markdown-formatted thirdParty assessment report
-        subprocessors:
-          type: array
-          items:
-            $ref: "#/components/schemas/ThirdPartySubprocessor"
-          description: Sub-processors discovered during the assessment
 
     GetUserInput:
       type: object
@@ -12051,14 +12024,14 @@ tools:
       $ref: "#/components/schemas/DeleteThirdPartyServiceInput"
     outputSchema:
       $ref: "#/components/schemas/DeleteThirdPartyServiceOutput"
-  - name: assessThirdParty
-    description: Run an AI-powered assessment on a thirdParty by crawling its website. Returns a markdown report, the discovered sub-processors, and an enriched thirdParty record. Long-running (up to 20 minutes).
+  - name: vetThirdParty
+    description: Start AI-powered vetting of a third party by crawling its website. Returns immediately; vetting runs in the background.
     hints:
       readonly: false
     inputSchema:
-      $ref: "#/components/schemas/AssessThirdPartyInput"
+      $ref: "#/components/schemas/VetThirdPartyInput"
     outputSchema:
-      $ref: "#/components/schemas/AssessThirdPartyOutput"
+      $ref: "#/components/schemas/VetThirdPartyOutput"
   - name: listRisks
     description: List all risks for the organization
     hints:

--- a/pkg/server/api/mcp/v1/types/third_party.go
+++ b/pkg/server/api/mcp/v1/types/third_party.go
@@ -17,7 +17,6 @@ package types
 import (
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/page"
-	"go.probo.inc/probo/pkg/probo"
 )
 
 func NewThirdPartyRiskAssessment(v *coredata.ThirdPartyRiskAssessment) *ThirdPartyRiskAssessment {
@@ -227,26 +226,5 @@ func NewListThirdPartyServicesOutput(p *page.Page[*coredata.ThirdPartyService, c
 	return ListThirdPartyServicesOutput{
 		NextCursor:         nextCursor,
 		ThirdPartyServices: services,
-	}
-}
-
-func NewThirdPartySubprocessors(sps []probo.Subprocessor) []*ThirdPartySubprocessor {
-	result := make([]*ThirdPartySubprocessor, len(sps))
-	for i, sp := range sps {
-		result[i] = &ThirdPartySubprocessor{
-			Name:    sp.Name,
-			Country: sp.Country,
-			Purpose: sp.Purpose,
-		}
-	}
-
-	return result
-}
-
-func NewAssessThirdPartyOutput(result *probo.AssessThirdPartyResult) AssessThirdPartyOutput {
-	return AssessThirdPartyOutput{
-		ThirdParty:    NewThirdParty(result.ThirdParty),
-		Report:        result.Report,
-		Subprocessors: NewThirdPartySubprocessors(result.Subprocessors),
 	}
 }

--- a/pkg/vetting/assessment.go
+++ b/pkg/vetting/assessment.go
@@ -173,7 +173,7 @@ func NewAssessor(cfg Config) *Assessor {
 	return &Assessor{cfg: cfg}
 }
 
-func (a *Assessor) Assess(ctx context.Context, websiteURL string, procedure string, reporter agent.ProgressReporter) (*Result, error) {
+func (a *Assessor) Assess(ctx context.Context, websiteURL string, procedure string, reporter agent.ProgressReporter, extraTools []agent.Tool) (*Result, error) {
 	u, err := url.Parse(websiteURL)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse website URL %q: %w", websiteURL, err)
@@ -213,6 +213,7 @@ func (a *Assessor) Assess(ctx context.Context, websiteURL string, procedure stri
 		researchBrowser,
 		a.cfg.FirecrawlAPIKey,
 		reporter,
+		extraTools,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create orchestrator agent: %w", err)

--- a/pkg/vetting/orchestrator.go
+++ b/pkg/vetting/orchestrator.go
@@ -67,6 +67,7 @@ func newOrchestratorAgent(
 	researchBrowser *browser.Browser,
 	firecrawlAPIKey string,
 	reporter agent.ProgressReporter,
+	extraTools []agent.Tool,
 ) (*agent.Agent, error) {
 	readOnlyBrowserTools := browser.NewReadOnlyToolset(thirdPartyBrowser).Tools()
 
@@ -228,7 +229,7 @@ func newOrchestratorAgent(
 		)
 	}
 
-	tools := make([]agent.Tool, 0, len(entries))
+	tools := make([]agent.Tool, 0, len(entries)+len(extraTools))
 	for _, e := range entries {
 		ag, err := e.build(client, model, e.tools, subAgentOpts(e.toolName)...)
 		if err != nil {
@@ -237,6 +238,8 @@ func newOrchestratorAgent(
 
 		tools = append(tools, ag.AsTool(e.toolName, e.description))
 	}
+
+	tools = append(tools, extraTools...)
 
 	if procedure == "" {
 		procedure = defaultProcedure

--- a/pkg/vetting/prompts/orchestrator_base.txt
+++ b/pkg/vetting/prompts/orchestrator_base.txt
@@ -26,6 +26,13 @@ If `research_third_party_externally` is available, use it for incidents, regulat
 {procedure}
 </assessment_procedure>
 
+<persistence>
+After completing your analysis and writing the report:
+
+1. Call `save_third_party_info` once with all metadata you discovered (name, description, category, URLs, certifications). Only include fields with actual values.
+2. For each sub-processor or vendor dependency discovered, call `link_sub_third_party` with the name, description, category, website URL, country, and purpose. If a third party with the same name already exists it is linked without duplication; otherwise a new one is created with the info you provide.
+</persistence>
+
 <important>
 - Only report information actually discovered through the tools — never fabricate URLs, certifications, or findings.
 - Note tool failures and inaccessible pages in the report rather than omitting the section.

--- a/pkg/vetting/tools.go
+++ b/pkg/vetting/tools.go
@@ -1,0 +1,232 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package vetting
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/agent"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+)
+
+type (
+	saveThirdPartyInfoParams struct {
+		Name                          string   `json:"name" jsonschema:"Third party display name"`
+		Description                   string   `json:"description,omitempty" jsonschema:"One-sentence description"`
+		Category                      string   `json:"category,omitempty" jsonschema:"Category: ANALYTICS, CLOUD_PROVIDER, SECURITY, etc."`
+		HeadquarterAddress            string   `json:"headquarter_address,omitempty" jsonschema:"Headquarters city and country"`
+		LegalName                     string   `json:"legal_name,omitempty" jsonschema:"Legal entity name"`
+		PrivacyPolicyURL              string   `json:"privacy_policy_url,omitempty" jsonschema:"Privacy policy URL"`
+		ServiceLevelAgreementURL      string   `json:"service_level_agreement_url,omitempty" jsonschema:"SLA URL"`
+		DataProcessingAgreementURL    string   `json:"data_processing_agreement_url,omitempty" jsonschema:"DPA URL"`
+		BusinessAssociateAgreementURL string   `json:"business_associate_agreement_url,omitempty" jsonschema:"BAA URL"`
+		SubprocessorsListURL          string   `json:"subprocessors_list_url,omitempty" jsonschema:"Subprocessors list URL"`
+		SecurityPageURL               string   `json:"security_page_url,omitempty" jsonschema:"Security page URL"`
+		TrustPageURL                  string   `json:"trust_page_url,omitempty" jsonschema:"Trust center URL"`
+		TermsOfServiceURL             string   `json:"terms_of_service_url,omitempty" jsonschema:"Terms of service URL"`
+		StatusPageURL                 string   `json:"status_page_url,omitempty" jsonschema:"Status page URL"`
+		Certifications                []string `json:"certifications,omitempty" jsonschema:"Compliance certifications found"`
+	}
+
+	linkSubThirdPartyParams struct {
+		Name        string `json:"name" jsonschema:"Sub-third-party company name"`
+		Description string `json:"description,omitempty" jsonschema:"One-sentence description of what this third party does"`
+		Category    string `json:"category,omitempty" jsonschema:"Category: ANALYTICS, CLOUD_PROVIDER, SECURITY, etc."`
+		WebsiteURL  string `json:"website_url,omitempty" jsonschema:"Website URL if known"`
+		Country     string `json:"country,omitempty" jsonschema:"Country where the sub-third-party operates"`
+		Purpose     string `json:"purpose,omitempty" jsonschema:"Purpose or role of this sub-third-party"`
+	}
+
+	// PersistenceContext holds the DB and entity references the tools need.
+	PersistenceContext struct {
+		PG             *pg.Client
+		ThirdPartyID   gid.GID
+		OrganizationID gid.GID
+		WebsiteURL     string
+	}
+)
+
+func SaveThirdPartyInfoTool(pc *PersistenceContext) agent.Tool {
+	return agent.FunctionTool(
+		"save_third_party_info",
+		"Persist the discovered third party metadata to the database. Call this once after completing the analysis with all fields you were able to discover. Only include fields that have actual values — omit fields with no data.",
+		func(ctx context.Context, p saveThirdPartyInfoParams) (agent.ToolResult, error) {
+			scope := coredata.NewScopeFromObjectID(pc.ThirdPartyID)
+
+			err := pc.PG.WithTx(
+				ctx,
+				func(ctx context.Context, conn pg.Tx) error {
+					thirdParty := &coredata.ThirdParty{}
+
+					if err := thirdParty.LoadByID(ctx, conn, scope, pc.ThirdPartyID); err != nil {
+						return fmt.Errorf("cannot load third party: %w", err)
+					}
+
+					if p.Name != "" {
+						thirdParty.Name = p.Name
+					}
+
+					thirdParty.WebsiteURL = &pc.WebsiteURL
+
+					if p.Category != "" {
+						thirdParty.Category = coredata.ThirdPartyCategory(p.Category)
+					}
+
+					if p.Description != "" {
+						thirdParty.Description = &p.Description
+					}
+
+					if p.HeadquarterAddress != "" {
+						thirdParty.HeadquarterAddress = &p.HeadquarterAddress
+					}
+
+					if p.LegalName != "" {
+						thirdParty.LegalName = &p.LegalName
+					}
+
+					if p.PrivacyPolicyURL != "" {
+						thirdParty.PrivacyPolicyURL = &p.PrivacyPolicyURL
+					}
+
+					if p.ServiceLevelAgreementURL != "" {
+						thirdParty.ServiceLevelAgreementURL = &p.ServiceLevelAgreementURL
+					}
+
+					if p.DataProcessingAgreementURL != "" {
+						thirdParty.DataProcessingAgreementURL = &p.DataProcessingAgreementURL
+					}
+
+					if p.BusinessAssociateAgreementURL != "" {
+						thirdParty.BusinessAssociateAgreementURL = &p.BusinessAssociateAgreementURL
+					}
+
+					if p.SubprocessorsListURL != "" {
+						thirdParty.SubprocessorsListURL = &p.SubprocessorsListURL
+					}
+
+					if p.SecurityPageURL != "" {
+						thirdParty.SecurityPageURL = &p.SecurityPageURL
+					}
+
+					if p.TrustPageURL != "" {
+						thirdParty.TrustPageURL = &p.TrustPageURL
+					}
+
+					if p.TermsOfServiceURL != "" {
+						thirdParty.TermsOfServiceURL = &p.TermsOfServiceURL
+					}
+
+					if p.StatusPageURL != "" {
+						thirdParty.StatusPageURL = &p.StatusPageURL
+					}
+
+					if len(p.Certifications) > 0 {
+						thirdParty.Certifications = p.Certifications
+					}
+
+					thirdParty.UpdatedAt = time.Now()
+
+					if err := thirdParty.Update(ctx, conn, scope); err != nil {
+						return fmt.Errorf("cannot update third party: %w", err)
+					}
+
+					return nil
+				},
+			)
+			if err != nil {
+				return agent.ToolResult{}, fmt.Errorf("cannot save third party info: %w", err)
+			}
+
+			return agent.ToolResult{Content: "Third party info saved successfully."}, nil
+		},
+	)
+}
+
+func LinkSubThirdPartyTool(pc *PersistenceContext) agent.Tool {
+	return agent.FunctionTool(
+		"link_sub_third_party",
+		"Link a discovered sub-third-party (sub-processor, vendor dependency) to the parent. If a third party with the same name already exists in the organization it is linked as-is; otherwise a new one is created with the provided info. Call once per sub-third-party discovered.",
+		func(ctx context.Context, p linkSubThirdPartyParams) (agent.ToolResult, error) {
+			if p.Name == "" {
+				return agent.ToolResult{Content: "Skipped: empty name."}, nil
+			}
+
+			scope := coredata.NewScopeFromObjectID(pc.ThirdPartyID)
+
+			err := pc.PG.WithTx(
+				ctx,
+				func(ctx context.Context, conn pg.Tx) error {
+					child := &coredata.ThirdParty{}
+
+					err := child.LoadByNameAndOrganizationID(ctx, conn, scope, p.Name, pc.OrganizationID)
+					if err != nil {
+						if !errors.Is(err, coredata.ErrResourceNotFound) {
+							return fmt.Errorf("cannot find child third party %q: %w", p.Name, err)
+						}
+
+						now := time.Now()
+						child = &coredata.ThirdParty{
+							ID:             gid.New(scope.GetTenantID(), coredata.ThirdPartyEntityType),
+							OrganizationID: pc.OrganizationID,
+							Name:           p.Name,
+							Category:       coredata.ThirdPartyCategoryOther,
+							FirstLevel:     false,
+							CreatedAt:      now,
+							UpdatedAt:      now,
+						}
+
+						if p.Description != "" {
+							child.Description = &p.Description
+						}
+
+						if p.Category != "" {
+							child.Category = coredata.ThirdPartyCategory(p.Category)
+						}
+
+						if p.WebsiteURL != "" {
+							child.WebsiteURL = &p.WebsiteURL
+						}
+
+						if err := child.Insert(ctx, conn, scope); err != nil {
+							return fmt.Errorf("cannot create child third party %q: %w", p.Name, err)
+						}
+					}
+
+					relation := &coredata.ThirdPartyThirdParty{
+						ParentThirdPartyID: pc.ThirdPartyID,
+						ChildThirdPartyID:  child.ID,
+						CreatedAt:          time.Now(),
+					}
+
+					if err := relation.Insert(ctx, conn, scope); err != nil {
+						return fmt.Errorf("cannot link child third party %q: %w", p.Name, err)
+					}
+
+					return nil
+				},
+			)
+			if err != nil {
+				return agent.ToolResult{}, fmt.Errorf("cannot link sub third party: %w", err)
+			}
+
+			return agent.ToolResult{Content: fmt.Sprintf("Linked %q as sub third party.", p.Name)}, nil
+		},
+	)
+}


### PR DESCRIPTION
Replace the synchronous assessThirdParty mutation with an async vetting pipeline. The vetThirdParty mutation enqueues a job and returns immediately; a background worker runs the orchestrator agent.

Give the orchestrator two new tools — save_third_party_info and link_subprocessor — so it persists discovered metadata and creates child third-party relationships directly during execution instead of relying on post-hoc worker logic.

Rename the domain language from assess/assessment to vet/vetting across GraphQL, Go types, permissions, MCP spec, CLI, and e2e tests. Frontend button is now "Start Vetting" with a prefilled URL dialog and an in-progress banner.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch third-party analysis to an async vetting flow. `vetThirdParty` enqueues a job and a background worker runs the orchestrator, which now saves metadata and links sub-vendors during execution.

- New Features
  - Added `vetThirdParty` mutation (returns immediately) and `vettingStatus` on `ThirdParty`.
  - Introduced `VettingWorker` to process queued runs for `third_party_vetter`.
  - Orchestrator now exposes `save_third_party_info` and `link_sub_third_party` tools to persist metadata and create child third-party links.
  - Console updates: “Start Vetting” dialog with prefilled URL, in-progress banner, and permission `canVet` replacing `canAssess`.
  - DB: added `agent_runs.metadata` to store run context.

- Migration
  - Run the core DB migration to add `agent_runs.metadata`.
  - Update permissions to `core:thirdParty:vet` and switch GraphQL calls from `assessThirdParty` to `vetThirdParty` (payload now only returns `thirdParty`).
  - Console/clients: use `canVet` and read `vettingStatus` to show progress.
  - CLI: replace `prb third_party assess …` with `prb third-party vet <ID> --url <URL>`; the command now only starts the job and prints a confirmation.
  - MCP: replace `assessThirdParty` tool with `vetThirdParty`; output no longer includes `report` or `subprocessors`.

<sup>Written for commit 867dcc012f29d8f33e12ea22aefde6cb149db34c. Summary will update on new commits. <a href="https://cubic.dev/pr/getprobo/probo/pull/1233?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

