### PR TITLE
Grant SCIM bridge get/manage in IAM policies

### DIFF
--- a/pkg/iam/iam_policies.go
+++ b/pkg/iam/iam_policies.go
@@ -216,9 +216,9 @@ var IAMOwnerPolicy = policy.NewPolicy(
 		WithSID("full-scim-event-access").
 		When(policy.Equals("principal.organization_id", "resource.organization_id")),
 
-	// Allow updating SCIM bridge settings (scoped to own organization)
-	policy.Allow(ActionSCIMBridgeUpdate).
-		WithSID("scim-bridge-update-access").
+	// Full access to SCIM bridge management (scoped to own organization)
+	policy.Allow("iam:scim-bridge:*").
+		WithSID("full-scim-bridge-access").
 		When(policy.Equals("principal.organization_id", "resource.organization_id")),
 
 	// Full access to audit log entries (scoped to own organization)
@@ -310,20 +310,24 @@ var IAMAdminPolicy = policy.NewPolicy(
 	).
 		WithSID("deny-saml-management"),
 
-	// Can view SCIM configuration and events (scoped to own organization)
+	// Can view SCIM configuration, bridge, and events (scoped to own organization)
 	policy.Allow(
 		ActionSCIMConfigurationGet,
+		ActionSCIMBridgeGet,
 		ActionSCIMEventList,
 		ActionSCIMEventGet,
 	).
 		WithSID("scim-admin-view-access").
 		When(policy.Equals("principal.organization_id", "resource.organization_id")),
 
-	// Cannot manage SCIM configurations (only owner can)
+	// Cannot manage SCIM configurations or bridges (only owner can)
 	policy.Deny(
 		ActionSCIMConfigurationCreate,
 		ActionSCIMConfigurationUpdate,
 		ActionSCIMConfigurationDelete,
+		ActionSCIMBridgeCreate,
+		ActionSCIMBridgeUpdate,
+		ActionSCIMBridgeDelete,
 	).
 		WithSID("deny-scim-management"),
 


### PR DESCRIPTION
The MCP getSCIMBridge tool authorized on iam:scim-bridge:get, but no role policy allowed that action, so every call denied — including for owners and admins.

Owners now get the full iam:scim-bridge:* wildcard (matching the scim-configuration and scim-event treatment in the same policy). Admins get read-only access and are explicitly denied create/update/ delete, mirroring how scim-configuration is handled.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix SCIM Bridge IAM policies so MCP `getSCIMBridge` calls are allowed and role access mirrors SCIM configuration/event rules. Owners get full `iam:scim-bridge:*`; admins have read-only (`iam:scim-bridge:get`) and are explicitly denied create/update/delete.

<sup>Written for commit 29051e1f80f66bf2bf092ed0498d73f4ca1d7a9e. Summary will update on new commits. <a href="https://cubic.dev/pr/getprobo/probo/pull/1238?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

