### PR TITLE
Migrate MCP behind the OAuth2 server

### DIFF
--- a/pkg/iam/oauth2server/bearer_method.go
+++ b/pkg/iam/oauth2server/bearer_method.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package oauth2server
+
+import (
+	"encoding"
+	"fmt"
+)
+
+type (
+	// BearerMethod is an RFC 6750 bearer token presentation method named in
+	// RFC 9728 bearer_methods_supported.
+	BearerMethod string
+
+	// BearerMethods is a list of bearer token presentation methods.
+	BearerMethods []BearerMethod
+)
+
+const (
+	BearerMethodHeader BearerMethod = "header"
+	BearerMethodBody   BearerMethod = "body"
+	BearerMethodQuery  BearerMethod = "query"
+)
+
+var (
+	_ encoding.TextMarshaler   = BearerMethod("")
+	_ encoding.TextUnmarshaler = (*BearerMethod)(nil)
+)
+
+func (m BearerMethod) IsValid() bool {
+	switch m {
+	case BearerMethodHeader, BearerMethodBody, BearerMethodQuery:
+		return true
+	}
+
+	return false
+}
+
+func (m BearerMethod) String() string {
+	return string(m)
+}
+
+func (m BearerMethod) MarshalText() ([]byte, error) {
+	return []byte(m.String()), nil
+}
+
+func (m *BearerMethod) UnmarshalText(text []byte) error {
+	val := BearerMethod(text)
+	if !val.IsValid() {
+		return fmt.Errorf("invalid BearerMethod value: %q", string(text))
+	}
+
+	*m = val
+
+	return nil
+}

--- a/pkg/iam/oauth2server/bearer_method_test.go
+++ b/pkg/iam/oauth2server/bearer_method_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package oauth2server_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/iam/oauth2server"
+)
+
+func TestBearerMethod(t *testing.T) {
+	t.Parallel()
+
+	t.Run(
+		"valid RFC values",
+		func(t *testing.T) {
+			t.Parallel()
+
+			assert.True(t, oauth2server.BearerMethodHeader.IsValid())
+			assert.True(t, oauth2server.BearerMethodBody.IsValid())
+			assert.True(t, oauth2server.BearerMethodQuery.IsValid())
+			assert.False(t, oauth2server.BearerMethod("cookie").IsValid())
+		},
+	)
+
+	t.Run(
+		"JSON marshals as string array",
+		func(t *testing.T) {
+			t.Parallel()
+
+			methods := oauth2server.BearerMethods{oauth2server.BearerMethodHeader}
+			data, err := json.Marshal(methods)
+			require.NoError(t, err)
+
+			assert.JSONEq(t, `["header"]`, string(data))
+		},
+	)
+}

--- a/pkg/iam/oauth2server/protected_resource.go
+++ b/pkg/iam/oauth2server/protected_resource.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package oauth2server
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/uri"
+)
+
+const (
+	// WellKnownProtectedResourcePrefix is the default RFC 9728 path inserted
+	// between the host and the resource path.
+	WellKnownProtectedResourcePrefix = "/.well-known/oauth-protected-resource"
+)
+
+type (
+	// ProtectedResourceMetadata is the RFC 9728 metadata document for an
+	// OAuth 2.0 protected resource.
+	ProtectedResourceMetadata struct {
+		Resource               uri.URI                `json:"resource"`
+		AuthorizationServers   []uri.URI              `json:"authorization_servers"`
+		ScopesSupported        []coredata.OAuth2Scope `json:"scopes_supported,omitempty"`
+		BearerMethodsSupported BearerMethods          `json:"bearer_methods_supported,omitempty"`
+	}
+
+	// ProtectedResourceConfig describes a protected resource served by Probo.
+	ProtectedResourceConfig struct {
+		Resource               uri.URI
+		AuthorizationServers   []uri.URI
+		ScopesSupported        coredata.OAuth2Scopes
+		BearerMethodsSupported BearerMethods
+	}
+)
+
+func WellKnownPath(resourcePath string) (string, error) {
+	if resourcePath == "" {
+		resourcePath = "/"
+	}
+
+	escapedPath, err := url.JoinPath(WellKnownProtectedResourcePrefix, resourcePath)
+	if err != nil {
+		return "", err
+	}
+
+	return url.PathUnescape(escapedPath)
+}
+
+func ProtectedResourceMetadataURL(resource uri.URI) (uri.URI, error) {
+	u, err := url.Parse(resource.String())
+
+	if err != nil {
+		return "", fmt.Errorf("cannot parse resource URI: %w", err)
+	}
+
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("resource URI must be absolute: %q", resource)
+	}
+
+	wellKnownPath, err := WellKnownPath(u.Path)
+	if err != nil {
+		return "", fmt.Errorf("cannot build well-known path: %w", err)
+	}
+
+	meta := &url.URL{
+		Scheme: u.Scheme,
+		Host:   u.Host,
+		Path:   wellKnownPath,
+	}
+
+	return uri.Parse(meta.String())
+}
+
+func WWWAuthenticateHeader(resource uri.URI) (string, error) {
+	metadataURL, err := ProtectedResourceMetadataURL(resource)
+	if err != nil {
+		return "", fmt.Errorf("cannot build protected resource metadata URL: %w", err)
+	}
+
+	return "Bearer resource_metadata=" + strconv.Quote(metadataURL.String()), nil
+}
+
+func NewProtectedResourceMetadata(cfg ProtectedResourceConfig) *ProtectedResourceMetadata {
+	return &ProtectedResourceMetadata{
+		Resource:               cfg.Resource,
+		AuthorizationServers:   cfg.AuthorizationServers,
+		ScopesSupported:        cfg.ScopesSupported,
+		BearerMethodsSupported: cfg.BearerMethodsSupported,
+	}
+}

--- a/pkg/iam/oauth2server/protected_resource_test.go
+++ b/pkg/iam/oauth2server/protected_resource_test.go
@@ -1,0 +1,161 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package oauth2server_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/iam/oauth2server"
+	"go.probo.inc/probo/pkg/uri"
+)
+
+func TestProtectedResource(t *testing.T) {
+	t.Parallel()
+
+	const (
+		origin       = "https://console.example.com"
+		resourcePath = "/api/example/v1"
+	)
+
+	resource, err := uri.Parse(origin + resourcePath)
+	require.NoError(t, err)
+
+	issuer := uri.URI(origin)
+	cfg := oauth2server.ProtectedResourceConfig{
+		Resource:               resource,
+		AuthorizationServers:   []uri.URI{issuer},
+		BearerMethodsSupported: oauth2server.BearerMethods{oauth2server.BearerMethodHeader},
+	}
+
+	metadata := oauth2server.NewProtectedResourceMetadata(cfg)
+	require.NotNil(t, metadata)
+
+	t.Run(
+		"resource identifier",
+		func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(
+				t,
+				uri.URI("https://console.example.com/api/example/v1"),
+				resource,
+			)
+		},
+	)
+
+	t.Run(
+		"authorization servers",
+		func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, []uri.URI{issuer}, metadata.AuthorizationServers)
+		},
+	)
+
+	t.Run(
+		"bearer methods supported",
+		func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(
+				t,
+				oauth2server.BearerMethods{oauth2server.BearerMethodHeader},
+				metadata.BearerMethodsSupported,
+			)
+		},
+	)
+
+	t.Run(
+		"well-known path",
+		func(t *testing.T) {
+			t.Parallel()
+
+			wellKnownPath, err := oauth2server.WellKnownPath(resourcePath)
+			require.NoError(t, err)
+
+			assert.Equal(
+				t,
+				"/.well-known/oauth-protected-resource/api/example/v1",
+				wellKnownPath,
+			)
+		},
+	)
+
+	t.Run(
+		"metadata URL",
+		func(t *testing.T) {
+			t.Parallel()
+
+			metadataURL, err := oauth2server.ProtectedResourceMetadataURL(resource)
+			require.NoError(t, err)
+
+			assert.Equal(
+				t,
+				uri.URI("https://console.example.com/.well-known/oauth-protected-resource/api/example/v1"),
+				metadataURL,
+			)
+		},
+	)
+}
+
+func TestWWWAuthenticateHeader(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		resource   uri.URI
+		wantHeader string
+		wantErr    bool
+	}{
+		{
+			name:     "quotes metadata URL for a valid resource",
+			resource: uri.URI("https://console.example.com/api/example/v1"),
+			wantHeader: `Bearer resource_metadata="https://console.example.com/.well-known/oauth-protected-resource/api/example/v1"`,
+		},
+		{
+			name:     "percent-encodes quotes in the metadata URL path",
+			resource: uri.URI(`https://console.example.com/api/foo"bar/v1`),
+			wantHeader: `Bearer resource_metadata="https://console.example.com/.well-known/oauth-protected-resource/api/foo%22bar/v1"`,
+		},
+		{
+			name:     "rejects a relative resource identifier",
+			resource: uri.URI("/api/example/v1"),
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				header, err := oauth2server.WWWAuthenticateHeader(tt.resource)
+				if tt.wantErr {
+					require.Error(t, err)
+					assert.Empty(t, header)
+
+					return
+				}
+
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantHeader, header)
+			},
+		)
+	}
+}
+

--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -216,6 +216,7 @@ func NewServer(cfg Config) (*Server, error) {
 			cfg.AccessReview,
 			cfg.CookieBanner,
 			cfg.RiskManagement,
+			cfg.BaseURL,
 			cfg.TokenSecret,
 		),
 		slackHandler: slack_v1.NewMux(

--- a/pkg/server/api/mcp/v1/middleware.go
+++ b/pkg/server/api/mcp/v1/middleware.go
@@ -16,17 +16,24 @@ package mcp_v1
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"go.gearno.de/kit/httpserver"
 	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/iam/oauth2server"
 	"go.probo.inc/probo/pkg/server/api/authn"
 )
 
-func RequireAPIKeyHandler(
+func RequireIdentityHandler(
 	logger *log.Logger,
+	protectedResource oauth2server.ProtectedResourceConfig,
 	next http.Handler,
 ) http.Handler {
+	wwwAuthenticate, err := oauth2server.WWWAuthenticateHeader(protectedResource.Resource)
+	if err != nil {
+		panic(fmt.Errorf("cannot build MCP WWW-Authenticate header: %w", err))
+	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
@@ -42,23 +49,30 @@ func RequireAPIKeyHandler(
 			log.String("path", r.URL.Path),
 		)
 
-		apiKey := authn.APIKeyFromContext(ctx)
-
 		identity := authn.IdentityFromContext(ctx)
 		if identity == nil {
-			w.Header().Set("WWW-Authenticate", "Bearer")
+			w.Header().Set("WWW-Authenticate", wwwAuthenticate)
 			httpserver.RenderError(w, http.StatusUnauthorized, errors.New("authentication required"))
 
 			return
 		}
 
-		logger.InfoCtx(
-			ctx,
-			"MCP authentication successful",
-			log.String("correlation_id", correlationID),
-			log.String("identity_id", identity.ID.String()),
-			log.String("api_key_id", apiKey.ID.String()),
-		)
+		if apiKey := authn.APIKeyFromContext(ctx); apiKey != nil {
+			logger.InfoCtx(
+				ctx,
+				"MCP authentication successful",
+				log.String("correlation_id", correlationID),
+				log.String("identity_id", identity.ID.String()),
+				log.String("api_key_id", apiKey.ID.String()),
+			)
+		} else {
+			logger.InfoCtx(
+				ctx,
+				"MCP authentication successful",
+				log.String("correlation_id", correlationID),
+				log.String("identity_id", identity.ID.String()),
+			)
+		}
 
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})

--- a/pkg/server/api/mcp/v1/protected_resource.go
+++ b/pkg/server/api/mcp/v1/protected_resource.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package mcp_v1
+
+import (
+	"fmt"
+
+	"go.probo.inc/probo/pkg/baseurl"
+	"go.probo.inc/probo/pkg/iam/oauth2server"
+	"go.probo.inc/probo/pkg/uri"
+)
+
+const (
+	// ResourcePath is the MCP protected resource path from the deployment origin.
+	ResourcePath = "/api/mcp/v1"
+)
+
+// ProtectedResourceConfig returns the RFC 9728 configuration for the MCP API.
+func ProtectedResourceConfig(baseURL *baseurl.BaseURL) (oauth2server.ProtectedResourceConfig, error) {
+	resourceStr, err := baseURL.WithPath(ResourcePath).String()
+	if err != nil {
+		return oauth2server.ProtectedResourceConfig{}, fmt.Errorf("cannot build MCP resource identifier: %w", err)
+	}
+
+	resource, err := uri.Parse(resourceStr)
+	if err != nil {
+		return oauth2server.ProtectedResourceConfig{}, fmt.Errorf("cannot parse MCP resource identifier: %w", err)
+	}
+
+	issuer, err := uri.Parse(baseURL.String())
+	if err != nil {
+		return oauth2server.ProtectedResourceConfig{}, fmt.Errorf("cannot parse MCP issuer: %w", err)
+	}
+
+	return oauth2server.ProtectedResourceConfig{
+		Resource:               resource,
+		AuthorizationServers:   []uri.URI{issuer},
+		BearerMethodsSupported: oauth2server.BearerMethods{oauth2server.BearerMethodHeader},
+	}, nil
+}
+
+// ProtectedResourceWellKnownPath returns the HTTP path where MCP protected
+// resource metadata is served.
+func ProtectedResourceWellKnownPath() (string, error) {
+	return oauth2server.WellKnownPath(ResourcePath)
+}

--- a/pkg/server/api/mcp/v1/protected_resource_test.go
+++ b/pkg/server/api/mcp/v1/protected_resource_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package mcp_v1_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/baseurl"
+	mcp_v1 "go.probo.inc/probo/pkg/server/api/mcp/v1"
+)
+
+func TestMCPProtectedResourceConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := mcp_v1.ProtectedResourceConfig(baseurl.MustParse("https://console.example.com"))
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		"https://console.example.com/api/mcp/v1",
+		cfg.Resource.String(),
+	)
+	wellKnownPath, err := mcp_v1.ProtectedResourceWellKnownPath()
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		"/.well-known/oauth-protected-resource/api/mcp/v1",
+		wellKnownPath,
+	)
+}
+
+func TestMCPProtectedResourceConfig_ignores_base_path(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := mcp_v1.ProtectedResourceConfig(baseurl.MustParse("https://console.example.com/sub"))
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		"https://console.example.com/api/mcp/v1",
+		cfg.Resource.String(),
+	)
+}

--- a/pkg/server/api/mcp/v1/v1_handler.go
+++ b/pkg/server/api/mcp/v1/v1_handler.go
@@ -15,6 +15,7 @@
 package mcp_v1
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -22,6 +23,7 @@ import (
 	"go.gearno.de/kit/log"
 	mcpgenmcp "go.probo.inc/mcpgen/mcp"
 	"go.probo.inc/probo/pkg/accessreview"
+	"go.probo.inc/probo/pkg/baseurl"
 	"go.probo.inc/probo/pkg/cookiebanner"
 	"go.probo.inc/probo/pkg/iam"
 	"go.probo.inc/probo/pkg/probo"
@@ -31,7 +33,16 @@ import (
 	"go.probo.inc/probo/pkg/server/api/mcp/v1/server"
 )
 
-func NewMux(logger *log.Logger, proboSvc *probo.Service, iamSvc *iam.Service, accessReviewSvc *accessreview.Service, cookieBannerSvc *cookiebanner.Service, riskManagementSvc *riskmanagement.Service, tokenSecret string) *chi.Mux {
+func NewMux(
+	logger *log.Logger,
+	proboSvc *probo.Service,
+	iamSvc *iam.Service,
+	accessReviewSvc *accessreview.Service,
+	cookieBannerSvc *cookiebanner.Service,
+	riskManagementSvc *riskmanagement.Service,
+	baseURL *baseurl.BaseURL,
+	tokenSecret string,
+) *chi.Mux {
 	logger = logger.Named("mcp.v1")
 
 	logger.Info("initializing MCP server")
@@ -63,9 +74,15 @@ func NewMux(logger *log.Logger, proboSvc *probo.Service, iamSvc *iam.Service, ac
 	)
 	protectedHandler := http.NewCrossOriginProtection().Handler(handler)
 
+	protectedResource, err := ProtectedResourceConfig(baseURL)
+	if err != nil {
+		panic(fmt.Errorf("cannot configure MCP protected resource: %w", err))
+	}
+
 	r := chi.NewMux()
 	r.Use(authn.NewAPIKeyMiddleware(iamSvc, tokenSecret))
-	r.Handle("/", RequireAPIKeyHandler(logger, protectedHandler))
+	r.Use(authn.NewOAuth2AccessTokenMiddleware(iamSvc))
+	r.Handle("/", RequireIdentityHandler(logger, protectedResource, protectedHandler))
 
 	logger.Info("MCP server initialized successfully")
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"path"
 	"strings"
@@ -40,6 +41,7 @@ import (
 	"go.probo.inc/probo/pkg/securecookie"
 	"go.probo.inc/probo/pkg/server/api"
 	"go.probo.inc/probo/pkg/server/api/compliancepage"
+	mcp_v1 "go.probo.inc/probo/pkg/server/api/mcp/v1"
 	"go.probo.inc/probo/pkg/server/mailactions"
 	trust_web "go.probo.inc/probo/pkg/server/trust"
 	console_web "go.probo.inc/probo/pkg/server/web"
@@ -80,7 +82,7 @@ type Server struct {
 	trustWebServer     *trust_web.Server
 	router             *chi.Mux
 	extraHeaderFields  map[string]string
-	baseURL            string
+	baseURL            *baseurl.BaseURL
 	proboService       *probo.Service
 	iamService         *iam.Service
 	trustService       *trust.Service
@@ -135,23 +137,34 @@ func NewServer(cfg Config) (*Server, error) {
 		trustWebServer:     trustWebServer,
 		router:             router,
 		extraHeaderFields:  cfg.ExtraHeaderFields,
-		baseURL:            cfg.BaseURL.String(),
+		baseURL:            cfg.BaseURL,
 		proboService:       cfg.Probo,
 		iamService:         cfg.IAM,
 		trustService:       cfg.Trust,
 		logger:             cfg.Logger,
 	}
 
-	server.setupRoutes(cfg.BaseURL.String())
+	if err := server.setupRoutes(cfg.BaseURL.String()); err != nil {
+		return nil, err
+	}
 
 	return server, nil
 }
 
-func (s *Server) setupRoutes(baseURL string) {
+func (s *Server) setupRoutes(baseURL string) error {
 	// OIDC Discovery 1.0 §4 and RFC 8414 §3 both require the metadata
 	// document at the issuer root under well-known paths.
 	s.router.Get("/.well-known/openid-configuration", s.oidcDiscoveryHandler)
 	s.router.Get("/.well-known/oauth-authorization-server", s.oidcDiscoveryHandler)
+	protectedResourceWellKnownPath, err := mcp_v1.ProtectedResourceWellKnownPath()
+	if err != nil {
+		return fmt.Errorf("cannot build MCP protected resource well-known path: %w", err)
+	}
+
+	s.router.Get(
+		protectedResourceWellKnownPath,
+		s.protectedResourceMetadataHandler(mcp_v1.ProtectedResourceConfig),
+	)
 
 	s.router.Mount("/api", http.StripPrefix("/api", s.apiServer))
 	s.router.Mount("/mail-actions", http.StripPrefix("/mail-actions", s.mailActionsHandler))
@@ -163,6 +176,8 @@ func (s *Server) setupRoutes(baseURL string) {
 	})
 
 	s.router.Mount("/", s.consoleWebServer)
+
+	return nil
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -177,7 +192,7 @@ func (s *Server) setExtraHeaders(w http.ResponseWriter) {
 }
 
 func (s *Server) oidcDiscoveryHandler(w http.ResponseWriter, r *http.Request) {
-	api := s.baseURL + "/api/connect/v1"
+	api := s.baseURL.String() + "/api/connect/v1"
 
 	endpoints := oauth2server.Endpoints{
 		Authorization:       uri.URI(api + "/oauth2/authorize"),
@@ -194,6 +209,22 @@ func (s *Server) oidcDiscoveryHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Cache-Control", "public, max-age=3600")
 	httpserver.RenderJSON(w, http.StatusOK, metadata)
+}
+
+func (s *Server) protectedResourceMetadataHandler(
+	configFn func(baseURL *baseurl.BaseURL) (oauth2server.ProtectedResourceConfig, error),
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		cfg, err := configFn(s.baseURL)
+		if err != nil {
+			panic(fmt.Errorf("cannot load protected resource config: %w", err))
+		}
+
+		metadata := oauth2server.NewProtectedResourceMetadata(cfg)
+
+		w.Header().Set("Cache-Control", "public, max-age=3600")
+		httpserver.RenderJSON(w, http.StatusOK, metadata)
+	}
 }
 
 func (s *Server) handleCustomDomain404(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Move the MCP API behind the OAuth2 server and add RFC 9728 protected resource metadata. MCP now supports OAuth 2.0 Bearer tokens and still accepts API keys.

- **New Features**
  - Serve MCP protected resource metadata at the well-known path with `authorization_servers` and `bearer_methods_supported`.
  - Add OAuth2 access token middleware to `pkg/server/api/mcp/v1` and return `WWW-Authenticate: Bearer resource_metadata="..."` on 401.
  - Introduce `pkg/iam/oauth2server` helpers: `BearerMethod`, `WellKnownPath`, `ProtectedResourceMetadataURL`, `WWWAuthenticateHeader`, and metadata types.

- **Refactors**
  - `pkg/server/api/mcp/v1.NewMux` now requires `baseURL`; server stores `baseURL` as `*baseurl.BaseURL` and mounts the MCP well-known route.
  - Replace `RequireAPIKeyHandler` with `RequireIdentityHandler` to allow API key or OAuth2 token.
  - Add tests for bearer methods, protected resource metadata, and MCP protected resource config.

<sup>Written for commit 68115805f1dd780e241fcfcd22f0dbbd77843049. Summary will update on new commits. <a href="https://cubic.dev/pr/getprobo/probo/pull/1240?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

