### PR TITLE
Show bridge errors in connector cards

### DIFF
--- a/apps/console/src/pages/iam/organizations/settings/_components/GoogleWorkspaceConnector.tsx
+++ b/apps/console/src/pages/iam/organizations/settings/_components/GoogleWorkspaceConnector.tsx
@@ -23,6 +23,7 @@ import {
   DialogFooter,
   Google,
   IconSettingsGear2,
+  IconWarning,
   Input,
   useDialogRef,
   useToast,
@@ -38,9 +39,18 @@ import { useOrganizationId } from "#/hooks/useOrganizationId";
 const googleWorkspaceConnectorFragment = graphql`
   fragment GoogleWorkspaceConnectorFragment on SCIMConfiguration {
     id
+    events(first: 1) {
+      edges {
+        node {
+          id
+          errorMessage
+        }
+      }
+    }
     bridge {
       id
       type
+      state
       excludedUserNames
       connector {
         id
@@ -83,9 +93,26 @@ export function GoogleWorkspaceConnector(props: {
   const connector = bridge?.connector;
   const scimConfigurationId = data?.id;
   const bridgeId = bridge?.id;
-
   const organizationId = useOrganizationId();
   const { __, dateTimeFormat } = useTranslate();
+  const bridgeState = bridge?.state ?? null;
+  const latestBridgeError = data?.events?.edges?.[0]?.node?.errorMessage ?? null;
+  const isBridgeFailed = bridgeState === "FAILED";
+  const isBridgePending = bridgeState === "PENDING";
+  const bridgeStatusBadgeVariant = isBridgeFailed
+    ? "danger"
+    : isBridgePending
+      ? "warning"
+      : "success";
+  const bridgeStatusLabel = isBridgeFailed
+    ? __("Error")
+    : isBridgePending
+      ? __("Syncing")
+      : __("Connected");
+  const bridgeErrorMessage = latestBridgeError
+    ?? __(
+      "The bridge is currently failing to sync. Check the provisioning event history for more details.",
+    );
   const { toast } = useToast();
   const dialogRef = useDialogRef();
   const excludedUserNamesDialogRef = useDialogRef();
@@ -225,118 +252,134 @@ export function GoogleWorkspaceConnector(props: {
 
   // Connected state
   return (
-    <Card padded className="flex items-center gap-3">
-      <div className="w-10 h-10 flex items-center justify-center bg-subtle rounded">
-        <Google className="w-6 h-6" />
-      </div>
-      <div className="mr-auto">
-        <h3 className="font-medium">{__("Google Workspace / Cloud Identity")}</h3>
-        <p className="text-sm text-txt-secondary">
-          {sprintf(__("Connected on %s"), dateTimeFormat(connector.createdAt))}
-        </p>
-      </div>
-      <Badge variant="success" size="md">
-        {__("Connected")}
-      </Badge>
-      <Dialog
-        ref={excludedUserNamesDialogRef}
-        trigger={(
-          <Button variant="secondary">
-            <IconSettingsGear2 size={16} />
-            {__("Settings")}
-          </Button>
-        )}
-        title={__("Google Workspace / Cloud Identity Settings")}
-        className="max-w-lg"
-      >
-        <DialogContent padded className="space-y-6">
-          <div className="space-y-4">
-            <div>
-              <h4 className="text-sm font-medium">{__("Excluded user names")}</h4>
-              <p className="text-sm text-txt-secondary mt-1">
-                {__("Users with these user names will not be synced from Google Workspace / Cloud Identity.")}
-              </p>
-            </div>
-            <div className="flex gap-2">
-              <Input
-                type="text"
-                value={newUser}
-                onChange={e => setNewUser(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    if (isUpdating) return;
-                    handleAddUser();
-                  }
-                }}
-                placeholder="user@example.com"
-                className="flex-1"
-              />
-              <Button onClick={handleAddUser} variant="secondary" disabled={isUpdating}>
-                {__("Add")}
-              </Button>
-            </div>
-
-            {currentExcludedUserNames.length > 0 && (
-              <div className="space-y-2">
-                {currentExcludedUserNames.map((user: string) => (
-                  <div
-                    key={user}
-                    className="flex items-center justify-between p-2 bg-subtle rounded"
-                  >
-                    <span className="text-sm">{user}</span>
-                    <Button
-                      variant="quaternary"
-                      onClick={() => handleRemoveUser(user)}
-                      disabled={isUpdating}
-                    >
-                      {__("Remove")}
-                    </Button>
-                  </div>
-                ))}
+    <Card padded className="space-y-3">
+      <div className="flex items-center gap-3">
+        <div className="w-10 h-10 flex items-center justify-center bg-subtle rounded">
+          <Google className="w-6 h-6" />
+        </div>
+        <div className="mr-auto">
+          <h3 className="font-medium">{__("Google Workspace / Cloud Identity")}</h3>
+          <p className="text-sm text-txt-secondary">
+            {sprintf(__("Connected on %s"), dateTimeFormat(connector.createdAt))}
+          </p>
+        </div>
+        <Badge variant={bridgeStatusBadgeVariant} size="md">
+          {bridgeStatusLabel}
+        </Badge>
+        <Dialog
+          ref={excludedUserNamesDialogRef}
+          trigger={(
+            <Button variant="secondary">
+              <IconSettingsGear2 size={16} />
+              {__("Settings")}
+            </Button>
+          )}
+          title={__("Google Workspace / Cloud Identity Settings")}
+          className="max-w-lg"
+        >
+          <DialogContent padded className="space-y-6">
+            <div className="space-y-4">
+              <div>
+                <h4 className="text-sm font-medium">{__("Excluded user names")}</h4>
+                <p className="text-sm text-txt-secondary mt-1">
+                  {__("Users with these user names will not be synced from Google Workspace / Cloud Identity.")}
+                </p>
               </div>
-            )}
+              <div className="flex gap-2">
+                <Input
+                  type="text"
+                  value={newUser}
+                  onChange={e => setNewUser(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      if (isUpdating) return;
+                      handleAddUser();
+                    }
+                  }}
+                  placeholder="user@example.com"
+                  className="flex-1"
+                />
+                <Button onClick={handleAddUser} variant="secondary" disabled={isUpdating}>
+                  {__("Add")}
+                </Button>
+              </div>
 
-            {currentExcludedUserNames.length === 0 && (
-              <p className="text-sm text-txt-secondary text-center py-4">
-                {__("No excluded user names. All Google Workspace / Cloud Identity users will be synced.")}
-              </p>
-            )}
+              {currentExcludedUserNames.length > 0 && (
+                <div className="space-y-2">
+                  {currentExcludedUserNames.map((user: string) => (
+                    <div
+                      key={user}
+                      className="flex items-center justify-between p-2 bg-subtle rounded"
+                    >
+                      <span className="text-sm">{user}</span>
+                      <Button
+                        variant="quaternary"
+                        onClick={() => handleRemoveUser(user)}
+                        disabled={isUpdating}
+                      >
+                        {__("Remove")}
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {currentExcludedUserNames.length === 0 && (
+                <p className="text-sm text-txt-secondary text-center py-4">
+                  {__("No excluded user names. All Google Workspace / Cloud Identity users will be synced.")}
+                </p>
+              )}
+            </div>
+          </DialogContent>
+        </Dialog>
+        <Dialog
+          ref={dialogRef}
+          trigger={(
+            <Button variant="danger">
+              {__("Disconnect")}
+            </Button>
+          )}
+          title={__("Disconnect Google Workspace / Cloud Identity")}
+          className="max-w-lg"
+        >
+          <DialogContent padded className="space-y-4">
+            <p className="text-txt-secondary text-sm">
+              {__(
+                "This will disconnect your Google Workspace / Cloud Identity integration. Users will no longer be automatically synced via SCIM.",
+              )}
+            </p>
+            <p className="text-red-600 text-sm font-medium">
+              {__("This action cannot be undone.")}
+            </p>
+          </DialogContent>
+          <DialogFooter>
+            <Button
+              variant="danger"
+              onClick={handleDisconnect}
+              disabled={isDeleting}
+            >
+              {isDeleting
+                ? __("Disconnecting...")
+                : __("Disconnect")}
+            </Button>
+          </DialogFooter>
+        </Dialog>
+      </div>
+
+      {isBridgeFailed && (
+        <div className="flex items-start gap-2 rounded-lg bg-bg-warning/10 border border-border-warning p-3">
+          <IconWarning size={16} className="text-txt-danger shrink-0 mt-0.5" />
+          <div className="space-y-1">
+            <p className="text-sm font-medium text-txt-danger">
+              {__("Bridge is in an error state")}
+            </p>
+            <p className="text-sm text-txt-secondary whitespace-pre-wrap break-all">
+              {bridgeErrorMessage}
+            </p>
           </div>
-        </DialogContent>
-      </Dialog>
-      <Dialog
-        ref={dialogRef}
-        trigger={(
-          <Button variant="danger">
-            {__("Disconnect")}
-          </Button>
-        )}
-        title={__("Disconnect Google Workspace / Cloud Identity")}
-        className="max-w-lg"
-      >
-        <DialogContent padded className="space-y-4">
-          <p className="text-txt-secondary text-sm">
-            {__(
-              "This will disconnect your Google Workspace / Cloud Identity integration. Users will no longer be automatically synced via SCIM.",
-            )}
-          </p>
-          <p className="text-red-600 text-sm font-medium">
-            {__("This action cannot be undone.")}
-          </p>
-        </DialogContent>
-        <DialogFooter>
-          <Button
-            variant="danger"
-            onClick={handleDisconnect}
-            disabled={isDeleting}
-          >
-            {isDeleting
-              ? __("Disconnecting...")
-              : __("Disconnect")}
-          </Button>
-        </DialogFooter>
-      </Dialog>
+        </div>
+      )}
     </Card>
   );
 }

--- a/apps/console/src/pages/iam/organizations/settings/_components/GoogleWorkspaceConnector.tsx
+++ b/apps/console/src/pages/iam/organizations/settings/_components/GoogleWorkspaceConnector.tsx
@@ -39,18 +39,11 @@ import { useOrganizationId } from "#/hooks/useOrganizationId";
 const googleWorkspaceConnectorFragment = graphql`
   fragment GoogleWorkspaceConnectorFragment on SCIMConfiguration {
     id
-    eventsLatest: events(first: 1) {
-      edges {
-        node {
-          id
-          errorMessage
-        }
-      }
-    }
     bridge {
       id
       type
       state
+      syncError
       excludedUserNames
       connector {
         id
@@ -96,7 +89,7 @@ export function GoogleWorkspaceConnector(props: {
   const organizationId = useOrganizationId();
   const { __, dateTimeFormat } = useTranslate();
   const bridgeState = bridge?.state ?? null;
-  const latestBridgeError = data?.eventsLatest?.edges?.[0]?.node?.errorMessage ?? null;
+  const latestBridgeError = bridge?.syncError ?? null;
   const isBridgeFailed = bridgeState === "FAILED";
   const isBridgePending = bridgeState === "PENDING";
   const bridgeStatusBadgeVariant = isBridgeFailed

--- a/apps/console/src/pages/iam/organizations/settings/_components/GoogleWorkspaceConnector.tsx
+++ b/apps/console/src/pages/iam/organizations/settings/_components/GoogleWorkspaceConnector.tsx
@@ -39,7 +39,7 @@ import { useOrganizationId } from "#/hooks/useOrganizationId";
 const googleWorkspaceConnectorFragment = graphql`
   fragment GoogleWorkspaceConnectorFragment on SCIMConfiguration {
     id
-    events(first: 1) {
+    eventsLatest: events(first: 1) {
       edges {
         node {
           id
@@ -96,7 +96,7 @@ export function GoogleWorkspaceConnector(props: {
   const organizationId = useOrganizationId();
   const { __, dateTimeFormat } = useTranslate();
   const bridgeState = bridge?.state ?? null;
-  const latestBridgeError = data?.events?.edges?.[0]?.node?.errorMessage ?? null;
+  const latestBridgeError = data?.eventsLatest?.edges?.[0]?.node?.errorMessage ?? null;
   const isBridgeFailed = bridgeState === "FAILED";
   const isBridgePending = bridgeState === "PENDING";
   const bridgeStatusBadgeVariant = isBridgeFailed

--- a/apps/console/src/pages/iam/organizations/settings/_components/Microsoft365Connector.tsx
+++ b/apps/console/src/pages/iam/organizations/settings/_components/Microsoft365Connector.tsx
@@ -39,7 +39,7 @@ import { useOrganizationId } from "#/hooks/useOrganizationId";
 const microsoft365ConnectorFragment = graphql`
   fragment Microsoft365ConnectorFragment on SCIMConfiguration {
     id
-    events(first: 1) {
+    eventsLatest: events(first: 1) {
       edges {
         node {
           id
@@ -96,7 +96,7 @@ export function Microsoft365Connector(props: {
   const organizationId = useOrganizationId();
   const { __, dateTimeFormat } = useTranslate();
   const bridgeState = bridge?.state ?? null;
-  const latestBridgeError = data?.events?.edges?.[0]?.node?.errorMessage ?? null;
+  const latestBridgeError = data?.eventsLatest?.edges?.[0]?.node?.errorMessage ?? null;
   const isBridgeFailed = bridgeState === "FAILED";
   const isBridgePending = bridgeState === "PENDING";
   const bridgeStatusBadgeVariant = isBridgeFailed

--- a/apps/console/src/pages/iam/organizations/settings/_components/Microsoft365Connector.tsx
+++ b/apps/console/src/pages/iam/organizations/settings/_components/Microsoft365Connector.tsx
@@ -39,18 +39,11 @@ import { useOrganizationId } from "#/hooks/useOrganizationId";
 const microsoft365ConnectorFragment = graphql`
   fragment Microsoft365ConnectorFragment on SCIMConfiguration {
     id
-    eventsLatest: events(first: 1) {
-      edges {
-        node {
-          id
-          errorMessage
-        }
-      }
-    }
     bridge {
       id
       type
       state
+      syncError
       excludedUserNames
       connector {
         id
@@ -96,7 +89,7 @@ export function Microsoft365Connector(props: {
   const organizationId = useOrganizationId();
   const { __, dateTimeFormat } = useTranslate();
   const bridgeState = bridge?.state ?? null;
-  const latestBridgeError = data?.eventsLatest?.edges?.[0]?.node?.errorMessage ?? null;
+  const latestBridgeError = bridge?.syncError ?? null;
   const isBridgeFailed = bridgeState === "FAILED";
   const isBridgePending = bridgeState === "PENDING";
   const bridgeStatusBadgeVariant = isBridgeFailed

--- a/apps/console/src/pages/iam/organizations/settings/_components/Microsoft365Connector.tsx
+++ b/apps/console/src/pages/iam/organizations/settings/_components/Microsoft365Connector.tsx
@@ -22,6 +22,7 @@ import {
   DialogContent,
   DialogFooter,
   IconSettingsGear2,
+  IconWarning,
   Input,
   Microsoft,
   useDialogRef,
@@ -38,9 +39,18 @@ import { useOrganizationId } from "#/hooks/useOrganizationId";
 const microsoft365ConnectorFragment = graphql`
   fragment Microsoft365ConnectorFragment on SCIMConfiguration {
     id
+    events(first: 1) {
+      edges {
+        node {
+          id
+          errorMessage
+        }
+      }
+    }
     bridge {
       id
       type
+      state
       excludedUserNames
       connector {
         id
@@ -83,9 +93,26 @@ export function Microsoft365Connector(props: {
   const connector = bridge?.connector;
   const scimConfigurationId = data?.id;
   const bridgeId = bridge?.id;
-
   const organizationId = useOrganizationId();
   const { __, dateTimeFormat } = useTranslate();
+  const bridgeState = bridge?.state ?? null;
+  const latestBridgeError = data?.events?.edges?.[0]?.node?.errorMessage ?? null;
+  const isBridgeFailed = bridgeState === "FAILED";
+  const isBridgePending = bridgeState === "PENDING";
+  const bridgeStatusBadgeVariant = isBridgeFailed
+    ? "danger"
+    : isBridgePending
+      ? "warning"
+      : "success";
+  const bridgeStatusLabel = isBridgeFailed
+    ? __("Error")
+    : isBridgePending
+      ? __("Syncing")
+      : __("Connected");
+  const bridgeErrorMessage = latestBridgeError
+    ?? __(
+      "The bridge is currently failing to sync. Check the provisioning event history for more details.",
+    );
   const { toast } = useToast();
   const dialogRef = useDialogRef();
   const excludedUserNamesDialogRef = useDialogRef();
@@ -223,118 +250,134 @@ export function Microsoft365Connector(props: {
   }
 
   return (
-    <Card padded className="flex items-center gap-3">
-      <div className="w-10 h-10 flex items-center justify-center bg-subtle rounded">
-        <Microsoft className="w-6 h-6" />
-      </div>
-      <div className="mr-auto">
-        <h3 className="font-medium">{__("Microsoft 365")}</h3>
-        <p className="text-sm text-txt-secondary">
-          {sprintf(__("Connected on %s"), dateTimeFormat(connector.createdAt))}
-        </p>
-      </div>
-      <Badge variant="success" size="md">
-        {__("Connected")}
-      </Badge>
-      <Dialog
-        ref={excludedUserNamesDialogRef}
-        trigger={(
-          <Button variant="secondary">
-            <IconSettingsGear2 size={16} />
-            {__("Settings")}
-          </Button>
-        )}
-        title={__("Microsoft 365 Settings")}
-        className="max-w-lg"
-      >
-        <DialogContent padded className="space-y-6">
-          <div className="space-y-4">
-            <div>
-              <h4 className="text-sm font-medium">{__("Excluded user names")}</h4>
-              <p className="text-sm text-txt-secondary mt-1">
-                {__("Users with these user names will not be synced from Microsoft 365.")}
-              </p>
-            </div>
-            <div className="flex gap-2">
-              <Input
-                type="text"
-                value={newUser}
-                onChange={e => setNewUser(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    if (isUpdating) return;
-                    handleAddUser();
-                  }
-                }}
-                placeholder="user@example.com"
-                className="flex-1"
-              />
-              <Button onClick={handleAddUser} variant="secondary" disabled={isUpdating}>
-                {__("Add")}
-              </Button>
-            </div>
-
-            {currentExcludedUserNames.length > 0 && (
-              <div className="space-y-2">
-                {currentExcludedUserNames.map((user: string) => (
-                  <div
-                    key={user}
-                    className="flex items-center justify-between p-2 bg-subtle rounded"
-                  >
-                    <span className="text-sm">{user}</span>
-                    <Button
-                      variant="quaternary"
-                      onClick={() => handleRemoveUser(user)}
-                      disabled={isUpdating}
-                    >
-                      {__("Remove")}
-                    </Button>
-                  </div>
-                ))}
+    <Card padded className="space-y-3">
+      <div className="flex items-center gap-3">
+        <div className="w-10 h-10 flex items-center justify-center bg-subtle rounded">
+          <Microsoft className="w-6 h-6" />
+        </div>
+        <div className="mr-auto">
+          <h3 className="font-medium">{__("Microsoft 365")}</h3>
+          <p className="text-sm text-txt-secondary">
+            {sprintf(__("Connected on %s"), dateTimeFormat(connector.createdAt))}
+          </p>
+        </div>
+        <Badge variant={bridgeStatusBadgeVariant} size="md">
+          {bridgeStatusLabel}
+        </Badge>
+        <Dialog
+          ref={excludedUserNamesDialogRef}
+          trigger={(
+            <Button variant="secondary">
+              <IconSettingsGear2 size={16} />
+              {__("Settings")}
+            </Button>
+          )}
+          title={__("Microsoft 365 Settings")}
+          className="max-w-lg"
+        >
+          <DialogContent padded className="space-y-6">
+            <div className="space-y-4">
+              <div>
+                <h4 className="text-sm font-medium">{__("Excluded user names")}</h4>
+                <p className="text-sm text-txt-secondary mt-1">
+                  {__("Users with these user names will not be synced from Microsoft 365.")}
+                </p>
               </div>
-            )}
+              <div className="flex gap-2">
+                <Input
+                  type="text"
+                  value={newUser}
+                  onChange={e => setNewUser(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      if (isUpdating) return;
+                      handleAddUser();
+                    }
+                  }}
+                  placeholder="user@example.com"
+                  className="flex-1"
+                />
+                <Button onClick={handleAddUser} variant="secondary" disabled={isUpdating}>
+                  {__("Add")}
+                </Button>
+              </div>
 
-            {currentExcludedUserNames.length === 0 && (
-              <p className="text-sm text-txt-secondary text-center py-4">
-                {__("No excluded user names. All Microsoft 365 users will be synced.")}
-              </p>
-            )}
+              {currentExcludedUserNames.length > 0 && (
+                <div className="space-y-2">
+                  {currentExcludedUserNames.map((user: string) => (
+                    <div
+                      key={user}
+                      className="flex items-center justify-between p-2 bg-subtle rounded"
+                    >
+                      <span className="text-sm">{user}</span>
+                      <Button
+                        variant="quaternary"
+                        onClick={() => handleRemoveUser(user)}
+                        disabled={isUpdating}
+                      >
+                        {__("Remove")}
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {currentExcludedUserNames.length === 0 && (
+                <p className="text-sm text-txt-secondary text-center py-4">
+                  {__("No excluded user names. All Microsoft 365 users will be synced.")}
+                </p>
+              )}
+            </div>
+          </DialogContent>
+        </Dialog>
+        <Dialog
+          ref={dialogRef}
+          trigger={(
+            <Button variant="danger">
+              {__("Disconnect")}
+            </Button>
+          )}
+          title={__("Disconnect Microsoft 365")}
+          className="max-w-lg"
+        >
+          <DialogContent padded className="space-y-4">
+            <p className="text-txt-secondary text-sm">
+              {__(
+                "This will disconnect your Microsoft 365 integration. Users will no longer be automatically synced via SCIM.",
+              )}
+            </p>
+            <p className="text-red-600 text-sm font-medium">
+              {__("This action cannot be undone.")}
+            </p>
+          </DialogContent>
+          <DialogFooter>
+            <Button
+              variant="danger"
+              onClick={handleDisconnect}
+              disabled={isDeleting}
+            >
+              {isDeleting
+                ? __("Disconnecting...")
+                : __("Disconnect")}
+            </Button>
+          </DialogFooter>
+        </Dialog>
+      </div>
+
+      {isBridgeFailed && (
+        <div className="flex items-start gap-2 rounded-lg bg-bg-warning/10 border border-border-warning p-3">
+          <IconWarning size={16} className="text-txt-danger shrink-0 mt-0.5" />
+          <div className="space-y-1">
+            <p className="text-sm font-medium text-txt-danger">
+              {__("Bridge is in an error state")}
+            </p>
+            <p className="text-sm text-txt-secondary whitespace-pre-wrap break-all">
+              {bridgeErrorMessage}
+            </p>
           </div>
-        </DialogContent>
-      </Dialog>
-      <Dialog
-        ref={dialogRef}
-        trigger={(
-          <Button variant="danger">
-            {__("Disconnect")}
-          </Button>
-        )}
-        title={__("Disconnect Microsoft 365")}
-        className="max-w-lg"
-      >
-        <DialogContent padded className="space-y-4">
-          <p className="text-txt-secondary text-sm">
-            {__(
-              "This will disconnect your Microsoft 365 integration. Users will no longer be automatically synced via SCIM.",
-            )}
-          </p>
-          <p className="text-red-600 text-sm font-medium">
-            {__("This action cannot be undone.")}
-          </p>
-        </DialogContent>
-        <DialogFooter>
-          <Button
-            variant="danger"
-            onClick={handleDisconnect}
-            disabled={isDeleting}
-          >
-            {isDeleting
-              ? __("Disconnecting...")
-              : __("Disconnect")}
-          </Button>
-        </DialogFooter>
-      </Dialog>
+        </div>
+      )}
     </Card>
   );
 }

--- a/pkg/server/api/connect/v1/graphql/scim.graphql
+++ b/pkg/server/api/connect/v1/graphql/scim.graphql
@@ -23,6 +23,7 @@ type SCIMConfiguration implements Node {
 type SCIMBridge implements Node {
   id: ID!
   state: SCIMBridgeState!
+  syncError: String
   scimConfiguration: SCIMConfiguration @goField(forceResolver: true)
   connector: Connector @goField(forceResolver: true)
   type: SCIMBridgeType!

--- a/pkg/server/api/connect/v1/types/bridge.go
+++ b/pkg/server/api/connect/v1/types/bridge.go
@@ -25,8 +25,9 @@ func NewSCIMBridge(bridge *coredata.SCIMBridge) *SCIMBridge {
 	}
 
 	return &SCIMBridge{
-		ID:    bridge.ID,
-		State: bridge.State,
+		ID:        bridge.ID,
+		State:     bridge.State,
+		SyncError: bridge.SyncError,
 		ScimConfiguration: &SCIMConfiguration{
 			ID: bridge.ScimConfigurationID,
 		},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- surface SCIM bridge runtime state on the Google Workspace and Microsoft 365 connector cards
- map bridge states to explicit status badges (Connected, Syncing, Error)
- display an inline error callout when a bridge is failed and show the latest provisioning event error message
- alias connector event selection to `eventsLatest` to avoid Relay field-argument conflicts with `SCIMEventList`

## Validation
- `make go-fmt`
- `git -c gpg.ssh.allowedSignersFile=/tmp/cursor_allowed_signers log -1 --show-signature`
- CI `lint-js` failure root cause confirmed from logs and addressed (Relay compile conflict on `events` arguments)
- new CI run started for commit `089596acc718abc99f2d5c1f3d7f4b3749e7739c`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16fb0b3d-9dcb-4a33-9408-4c86f99fc5fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16fb0b3d-9dcb-4a33-9408-4c86f99fc5fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show SCIM bridge state and the latest sync error on the Google Workspace and Microsoft 365 connector cards so admins can spot failures fast. Adds status badges and an inline error callout when the bridge is failed.

- **New Features**
  - Read `bridge.state` and `bridge.syncError`; map badges: Connected (success), Syncing (warning), Error (danger).
  - On failure, show an inline callout with `IconWarning` and the latest error message.

- **Bug Fixes**
  - Add `SCIMBridge.syncError` to the GraphQL API and use it in the cards, removing the events query and resolving the prior Relay fragment conflict.

<sup>Written for commit 6f4ac54a277728483e0460df7c40cd4f281197cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1241?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

