### PR TITLE
Expose profile source in MCP users

### DIFF
--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -187,6 +187,14 @@ components:
         - INACTIVE
       go.probo.inc/mcpgen/type: go.probo.inc/probo/pkg/coredata.ProfileState
 
+    ProfileSource:
+      type: string
+      enum:
+        - MANUAL
+        - SCIM
+        - SAML
+      go.probo.inc/mcpgen/type: go.probo.inc/probo/pkg/coredata.ProfileSource
+
     Regulation:
       type: string
       enum:
@@ -470,6 +478,7 @@ components:
         - email_address
         - additional_email_addresses
         - kind
+        - source
         - state
         - created_at
         - updated_at
@@ -496,6 +505,9 @@ components:
             - string
             - "null"
           description: Profile kind
+        source:
+          $ref: "#/components/schemas/ProfileSource"
+          description: Profile source (MANUAL, SCIM, or SAML)
         state:
           $ref: "#/components/schemas/ProfileState"
           description: Profile state (ACTIVE or INACTIVE)

--- a/pkg/server/api/mcp/v1/types/profile.go
+++ b/pkg/server/api/mcp/v1/types/profile.go
@@ -24,6 +24,7 @@ func NewProfile(p *coredata.MembershipProfile) *Profile {
 		EmailAddress:             p.EmailAddress,
 		AdditionalEmailAddresses: p.AdditionalEmailAddresses,
 		Kind:                     p.Kind,
+		Source:                   p.Source,
 		State:                    p.State,
 		Position:                 p.Position,
 		ContractStartDate:        p.ContractStartDate,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a `ProfileSource` schema to MCP v1 with `MANUAL`, `SCIM`, and `SAML`
- expose `source` on the MCP `Profile` schema and mark it required
- map `MembershipProfile.Source` into MCP responses in `types.NewProfile`

## Validation
- `go generate ./pkg/server/api/mcp/v1`
- `go test ./pkg/server/api/mcp/v1/...` *(fails in this environment: `packages/emails/emails.go:37:12: pattern dist: no matching files found`)*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fff9ffa-c89c-41d1-90f9-7688728c63ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fff9ffa-c89c-41d1-90f9-7688728c63ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose profile source in MCP users so clients can tell if a profile is manual or managed by SCIM/SAML. Adds a `ProfileSource` enum and returns `source` in all `Profile` responses.

- **New Features**
  - Added `ProfileSource` enum: `MANUAL`, `SCIM`, `SAML` in `pkg/server/api/mcp/v1/specification.yaml`.
  - Exposed required `source` field on `Profile` and wired it in `types.NewProfile` so list/get/create responses include the persisted source.

- **Migration**
  - Regenerate `MCP v1` clients.
  - Update any mocks/fixtures and handle `profile.source` as required.

<sup>Written for commit 4d4f4fa526eef6fb48e6b3ec8978171981461b3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1242?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

