### PR TITLE
Cookie banner third parties creation on move

### DIFF
--- a/.cursor/rules/go-authorize-scope.mdc
+++ b/.cursor/rules/go-authorize-scope.mdc
@@ -1,0 +1,59 @@
+---
+description: Go authorize — always take scope from authorize, never reconstruct it
+globs: "pkg/server/api/**/*.go"
+alwaysApply: false
+---
+
+# Authorize returns the scope — use it
+
+`r.authorize` (GraphQL) and `r.Authorize` (MCP) return a `*coredata.Scope`
+resolved from the resource's `organization_id` attribute. **Always** pass that
+scope to the downstream service or coredata call. **Never** discard it and
+rebuild a scope with `coredata.NewScopeFromObjectID(...)`.
+
+The two are not identical: `NewScopeFromObjectID(id)` only reads the tenant
+encoded in the GID, while the authorizer derives the scope from the loaded
+resource attributes. Reconstructing the scope from the GID silently drifts
+when the resource lookup changes.
+
+```go
+// GOOD — scope comes from authorize, fed straight to the service
+scope, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyList)
+if err != nil {
+	return nil, err
+}
+
+thirdPartyIDs, err := r.cookieBanner.LoadDistinctThirdPartyIDsByCookieBannerID(ctx, scope, obj.ID)
+
+// BAD — authorize discards scope, then we rebuild it from the same GID
+if _, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyList); err != nil {
+	return nil, err
+}
+
+scope := coredata.NewScopeFromObjectID(obj.ID)
+thirdPartyIDs, err := r.cookieBanner.LoadDistinctThirdPartyIDsByCookieBannerID(ctx, scope, obj.ID)
+```
+
+## When discarding `scope` with `_` is acceptable
+
+Only when **no downstream call needs a scope** — typically authorize calls
+against the caller's `identity.ID` for global / cross-tenant catalogs (e.g.
+`ActionCommonThirdPartyList`, `ActionCommonThirdPartyGet`) whose service
+methods are unscoped. The returned scope would be derived from the identity
+(a nil-tenant principal) and is useless to the caller:
+
+```go
+// GOOD — global catalog, downstream is unscoped
+identity := authn.IdentityFromContext(ctx)
+if _, err := r.authorize(ctx, identity.ID, probo.ActionCommonThirdPartyList); err != nil {
+	return nil, err
+}
+
+parties, err := r.thirdParty.Search(ctx, name) // no scope argument
+```
+
+The same rule applies to `r.batchAuthorize` (GraphQL) and `r.AuthorizeBatch`
+(MCP).
+
+See [`contrib/claude/authorization.md`](../../contrib/claude/authorization.md)
+for the full authorization guide.

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/CookieBannerTrackersPage.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/CookieBannerTrackersPage.tsx
@@ -87,7 +87,6 @@ const trackersFragment = graphql`
       ... on CommonThirdParty {
         id
         name
-        logoUrl
       }
     }
     trackerPatterns(
@@ -219,6 +218,15 @@ export default function CookieBannerTrackersPage({
           className="w-72"
         />
         <Select
+          value={thirdPartyFilter ?? "ALL"}
+          onValueChange={handleThirdPartyFilterChange}
+        >
+          <Option value="ALL">{__("All third parties")}</Option>
+          {linkedThirdParties.map(party => (
+            <Option key={party.id} value={party.id}>{party.name}</Option>
+          ))}
+        </Select>
+        <Select
           value={trackerTypeFilter ?? "ALL"}
           onValueChange={handleTrackerTypeFilterChange}
         >
@@ -245,15 +253,6 @@ export default function CookieBannerTrackersPage({
           <Option value="ALL">{__("All categories")}</Option>
           {categories.map(category => (
             <Option key={category.id} value={category.id}>{category.name}</Option>
-          ))}
-        </Select>
-        <Select
-          value={thirdPartyFilter ?? "ALL"}
-          onValueChange={handleThirdPartyFilterChange}
-        >
-          <Option value="ALL">{__("All third parties")}</Option>
-          {linkedThirdParties.map(party => (
-            <Option key={party.id} value={party.id}>{party.name}</Option>
           ))}
         </Select>
       </div>

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/CookieBannerTrackersPage.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/CookieBannerTrackersPage.tsx
@@ -76,14 +76,27 @@ const trackersFragment = graphql`
     source: { type: "CookieSource", defaultValue: null }
     trackerType: { type: "TrackerType", defaultValue: null }
     cookieCategoryId: { type: "ID", defaultValue: null }
+    thirdPartyId: { type: "ID", defaultValue: null }
   ) {
+    linkedThirdParties {
+      __typename
+      ... on ThirdParty {
+        id
+        name
+      }
+      ... on CommonThirdParty {
+        id
+        name
+        logoUrl
+      }
+    }
     trackerPatterns(
       first: $first
       after: $after
       last: $last
       before: $before
       orderBy: $order
-      filter: { query: $query, source: $source, trackerType: $trackerType, cookieCategoryId: $cookieCategoryId }
+      filter: { query: $query, source: $source, trackerType: $trackerType, cookieCategoryId: $cookieCategoryId, thirdPartyId: $thirdPartyId }
     )
       @connection(
         key: "CookieBannerTrackersPage_trackerPatterns"
@@ -120,6 +133,7 @@ export default function CookieBannerTrackersPage({
   const [sourceFilter, setSourceFilter] = useState<CookieSource | null>(null);
   const [trackerTypeFilter, setTrackerTypeFilter] = useState<TrackerType | null>(null);
   const [categoryFilter, setCategoryFilter] = useState<string | null>(null);
+  const [thirdPartyFilter, setThirdPartyFilter] = useState<string | null>(null);
 
   const { data: fragmentData, ...pagination } = usePaginationFragment<
     CookieBannerTrackersPageRefetchQuery,
@@ -128,6 +142,11 @@ export default function CookieBannerTrackersPage({
 
   const connectionId = fragmentData.trackerPatterns.__id;
   const patterns = fragmentData.trackerPatterns.edges.map(edge => edge.node) ?? [];
+  const linkedThirdParties = (fragmentData.linkedThirdParties ?? []).filter(
+    (party): party is Extract<typeof party, { id: string; name: string }> =>
+      party.__typename === "ThirdParty"
+      || party.__typename === "CommonThirdParty",
+  );
 
   const categories = data.node.__typename === "CookieBanner"
     ? data.node.categories.edges.map(edge => edge.node)
@@ -141,6 +160,7 @@ export default function CookieBannerTrackersPage({
           source: sourceFilter,
           trackerType: trackerTypeFilter,
           cookieCategoryId: categoryFilter,
+          thirdPartyId: thirdPartyFilter,
           ...overrides,
         },
         { fetchPolicy: "network-only" },
@@ -170,6 +190,12 @@ export default function CookieBannerTrackersPage({
     refetchFilters({ cookieCategoryId: newCategory });
   };
 
+  const handleThirdPartyFilterChange = (value: string) => {
+    const newThirdParty = value === "ALL" ? null : value;
+    setThirdPartyFilter(newThirdParty);
+    refetchFilters({ thirdPartyId: newThirdParty });
+  };
+
   const refetchWithFilters: ComponentProps<typeof SortableTable>["refetch"] = ({ order }) => {
     pagination.refetch({
       order: { direction: order.direction, field: order.field as TrackerPatternOrderField },
@@ -177,6 +203,7 @@ export default function CookieBannerTrackersPage({
       source: sourceFilter,
       trackerType: trackerTypeFilter,
       cookieCategoryId: categoryFilter,
+      thirdPartyId: thirdPartyFilter,
     });
   };
 
@@ -220,6 +247,15 @@ export default function CookieBannerTrackersPage({
             <Option key={category.id} value={category.id}>{category.name}</Option>
           ))}
         </Select>
+        <Select
+          value={thirdPartyFilter ?? "ALL"}
+          onValueChange={handleThirdPartyFilterChange}
+        >
+          <Option value="ALL">{__("All third parties")}</Option>
+          {linkedThirdParties.map(party => (
+            <Option key={party.id} value={party.id}>{party.name}</Option>
+          ))}
+        </Select>
       </div>
 
       <div className={isPending ? "opacity-50 pointer-events-none transition-opacity" : ""}>
@@ -234,6 +270,7 @@ export default function CookieBannerTrackersPage({
                   <Tr>
                     <Th>{__("Type")}</Th>
                     <SortableTh field="NAME">{__("Name")}</SortableTh>
+                    <Th>{__("Third party")}</Th>
                     <SortableTh field="SOURCE">{__("Source")}</SortableTh>
                     <Th>{__("Category")}</Th>
                     <SortableTh field="LAST_MATCHED_AT">{__("Last Matched")}</SortableTh>

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternPropertiesSection.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternPropertiesSection.tsx
@@ -34,13 +34,10 @@ const trackerPatternPropertiesSectionFragment = graphql`
       name
     }
     thirdParty {
-      id
       name
     }
     commonThirdParty {
-      id
       name
-      logoUrl
     }
   }
 `;

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternPropertiesSection.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternPropertiesSection.tsx
@@ -14,7 +14,7 @@
 
 import { humanizeSeconds } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
-import { Badge, Card, PropertyRow } from "@probo/ui";
+import { Avatar, Badge, Card, PropertyRow } from "@probo/ui";
 import { graphql, useFragment } from "react-relay";
 
 import type { TrackerPatternPropertiesSection_trackerPattern$key } from "#/__generated__/core/TrackerPatternPropertiesSection_trackerPattern.graphql";
@@ -32,6 +32,15 @@ const trackerPatternPropertiesSectionFragment = graphql`
     lastMatchedAt
     cookieCategory {
       name
+    }
+    thirdParty {
+      id
+      name
+    }
+    commonThirdParty {
+      id
+      name
+      logoUrl
     }
   }
 `;
@@ -92,6 +101,26 @@ export function TrackerPatternPropertiesSection({
         <span className="text-sm">
           {pattern.cookieCategory?.name ?? "-"}
         </span>
+      </PropertyRow>
+      <PropertyRow label={__("Third party")}>
+        {pattern.thirdParty
+          ? (
+              <div className="flex items-center gap-2">
+                <Avatar name={pattern.thirdParty.name} />
+                <span className="text-sm">{pattern.thirdParty.name}</span>
+              </div>
+            )
+          : pattern.commonThirdParty
+            ? (
+                <div className="flex items-center gap-2">
+                  <Avatar
+                    name={pattern.commonThirdParty.name}
+                    src={pattern.commonThirdParty.logoUrl}
+                  />
+                  <span className="text-sm">{pattern.commonThirdParty.name}</span>
+                </div>
+              )
+            : <span className="text-txt-tertiary text-sm">-</span>}
       </PropertyRow>
       <PropertyRow label={__("Max Age")}>
         <span className="text-sm">

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternPropertiesSection.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternPropertiesSection.tsx
@@ -14,7 +14,7 @@
 
 import { humanizeSeconds } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
-import { Avatar, Badge, Card, PropertyRow } from "@probo/ui";
+import { Badge, Card, PropertyRow } from "@probo/ui";
 import { graphql, useFragment } from "react-relay";
 
 import type { TrackerPatternPropertiesSection_trackerPattern$key } from "#/__generated__/core/TrackerPatternPropertiesSection_trackerPattern.graphql";
@@ -106,17 +106,12 @@ export function TrackerPatternPropertiesSection({
         {pattern.thirdParty
           ? (
               <div className="flex items-center gap-2">
-                <Avatar name={pattern.thirdParty.name} />
                 <span className="text-sm">{pattern.thirdParty.name}</span>
               </div>
             )
           : pattern.commonThirdParty
             ? (
                 <div className="flex items-center gap-2">
-                  <Avatar
-                    name={pattern.commonThirdParty.name}
-                    src={pattern.commonThirdParty.logoUrl}
-                  />
                   <span className="text-sm">{pattern.commonThirdParty.name}</span>
                 </div>
               )

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternRow.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternRow.tsx
@@ -16,7 +16,6 @@ import { EyeIcon, EyeSlashIcon } from "@phosphor-icons/react";
 import { formatError, type GraphQLError } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
 import {
-  Avatar,
   Badge,
   Dropdown,
   IconArrowBoxLeft,
@@ -64,7 +63,6 @@ const trackerPatternFragment = graphql`
     commonThirdParty {
       id
       name
-      logoUrl
     }
   }
 `;
@@ -328,17 +326,12 @@ export function TrackerPatternRow({ patternKey, connectionId }: TrackerPatternRo
         {pattern.thirdParty
           ? (
               <div className="flex items-center gap-2 min-w-0">
-                <Avatar name={pattern.thirdParty.name} />
                 <span className="truncate">{pattern.thirdParty.name}</span>
               </div>
             )
           : pattern.commonThirdParty
             ? (
                 <div className="flex items-center gap-2 min-w-0">
-                  <Avatar
-                    name={pattern.commonThirdParty.name}
-                    src={pattern.commonThirdParty.logoUrl}
-                  />
                   <span className="truncate">{pattern.commonThirdParty.name}</span>
                 </div>
               )

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternRow.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternRow.tsx
@@ -16,6 +16,7 @@ import { EyeIcon, EyeSlashIcon } from "@phosphor-icons/react";
 import { formatError, type GraphQLError } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
 import {
+  Avatar,
   Badge,
   Dropdown,
   IconArrowBoxLeft,
@@ -55,6 +56,15 @@ const trackerPatternFragment = graphql`
     lastMatchedAt
     cookieCategory {
       name
+    }
+    thirdParty {
+      id
+      name
+    }
+    commonThirdParty {
+      id
+      name
+      logoUrl
     }
   }
 `;
@@ -313,6 +323,26 @@ export function TrackerPatternRow({ patternKey, connectionId }: TrackerPatternRo
             </span>
           )}
         </div>
+      </Td>
+      <Td>
+        {pattern.thirdParty
+          ? (
+              <div className="flex items-center gap-2 min-w-0">
+                <Avatar name={pattern.thirdParty.name} />
+                <span className="truncate">{pattern.thirdParty.name}</span>
+              </div>
+            )
+          : pattern.commonThirdParty
+            ? (
+                <div className="flex items-center gap-2 min-w-0">
+                  <Avatar
+                    name={pattern.commonThirdParty.name}
+                    src={pattern.commonThirdParty.logoUrl}
+                  />
+                  <span className="truncate">{pattern.commonThirdParty.name}</span>
+                </div>
+              )
+            : <span className="text-txt-tertiary">-</span>}
       </Td>
       <Td>
         {srcBadge

--- a/contrib/claude/authorization.md
+++ b/contrib/claude/authorization.md
@@ -178,7 +178,7 @@ var (
 
 **GraphQL resolvers** use `AuthorizeFunc` from `pkg/server/api/authz/`:
 ```go
-scope, err := authorize(ctx, thirdPartyID, probo.ActionThirdPartyGet)
+scope, err := r.authorize(ctx, thirdPartyID, probo.ActionThirdPartyGet)
 if err != nil {
 	return nil, err
 }
@@ -191,6 +191,58 @@ if err != nil {
 	return nil, types.GetThirdPartyOutput{}, err
 }
 ```
+
+### Always take `scope` from `authorize` — never reconstruct it
+
+`authorize` (and `Authorize` in MCP) returns a `*coredata.Scope` that has been
+resolved from the resource's `organization_id` attribute. Pass that scope
+straight to the service/coredata layer instead of building a new one with
+`coredata.NewScopeFromObjectID(...)` after the authorize call.
+
+The two are not strictly identical: `NewScopeFromObjectID(id)` only reads the
+tenant component of the GID, while the authorizer derives the scope from the
+loaded resource attributes (and may be extended to compute it differently in
+the future). Reconstructing the scope from the GID bypasses that and silently
+drifts when the resource lookup changes.
+
+```go
+// GOOD — scope comes from authorize, fed straight to the service
+scope, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyList)
+if err != nil {
+	return nil, err
+}
+
+thirdPartyIDs, err := r.cookieBanner.LoadDistinctThirdPartyIDsByCookieBannerID(ctx, scope, obj.ID)
+
+// BAD — authorize discards scope, then we rebuild it from the same GID
+if _, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyList); err != nil {
+	return nil, err
+}
+
+scope := coredata.NewScopeFromObjectID(obj.ID)
+thirdPartyIDs, err := r.cookieBanner.LoadDistinctThirdPartyIDsByCookieBannerID(ctx, scope, obj.ID)
+```
+
+The only time it is acceptable to write `if _, err := r.authorize(...)` is when
+**no downstream call needs a scope** — typically authorize calls against the
+caller's `identity.ID` for global / cross-tenant catalogs (e.g.
+`ActionCommonThirdPartyList`, `ActionCommonThirdPartyGet`) whose service
+methods are unscoped. In that case the returned scope would be derived from
+the identity (a nil-tenant principal) and is useless to the caller, so
+discarding it with `_` is correct:
+
+```go
+// GOOD — global catalog, downstream is unscoped
+identity := authn.IdentityFromContext(ctx)
+if _, err := r.authorize(ctx, identity.ID, probo.ActionCommonThirdPartyList); err != nil {
+	return nil, err
+}
+
+parties, err := r.thirdParty.Search(ctx, name) // no scope argument
+```
+
+For batch authorization, the same rule applies to `r.batchAuthorize` (GraphQL)
+and `r.AuthorizeBatch` (MCP) — keep the returned scope and pass it down.
 
 ## File locations
 

--- a/contrib/claude/file-naming.md
+++ b/contrib/claude/file-naming.md
@@ -42,16 +42,47 @@ pkg/cookiebanner/pattern_analysis_worker.go
 
 ## Agent files
 
-When a package has a worker that uses an agent, the agent construction logic
-goes in `<worker_prefix>_agent.go` alongside `<worker_prefix>_worker.go`. The
-worker file stays focused on `Claim`/`Process` and handler methods; the agent
-file owns agent construction, prompt building, constants, config, and the
-`//go:embed` directive for prompt templates.
+A file whose **sole purpose** is to construct and operate an agent uses the
+`<name>_agent.go` suffix. The agent file owns agent construction, prompt
+building, the `//go:embed` directive for prompt templates, the typed result,
+the agent-specific config, and any agent-only constants (timeout, confidence
+threshold). Callers (workers, services) hold a `*agent.Agent` field and import
+the file's `Build…Agent` constructor.
+
+This applies in two shapes:
+
+1. **Paired with a worker** (most common). The worker file
+   `<worker_prefix>_worker.go` stays focused on `Claim`/`Process`, and the
+   agent it uses lives in `<worker_prefix>_agent.go` next to it.
+
+   ```
+   pkg/cookiebanner/tracker_mapping_worker.go   -- worker handler
+   pkg/cookiebanner/tracker_mapping_agent.go    -- agent construction + prompts
+   ```
+
+2. **Standalone, called from elsewhere.** When the agent is consumed by a
+   different package (or by multiple packages — e.g. an agent that operates on
+   a domain entity, used by several feature workers), it lives in the package
+   that owns the domain, named `<purpose>_agent.go`.
+
+   ```
+   pkg/thirdparty/disambiguation_agent.go   -- catalog→org ThirdParty matcher
+   pkg/vetting/sub_agent.go                  -- generic vetting sub-agent
+   ```
+
+A file is NOT renamed to `_agent.go` when the agent is incidental to a service
+that does substantially more than agent orchestration (e.g. CRUD, caching,
+auth). In that case the file keeps its service name and the agent is built
+inline:
 
 ```
-pkg/cookiebanner/tracker_mapping_worker.go   -- worker handler
-pkg/cookiebanner/tracker_mapping_agent.go    -- agent construction + prompts
+pkg/evidencedescriber/evidencedescriber.go   -- single-file describer service
+pkg/vetting/assessment.go                     -- third-party assessment service
 ```
+
+If the agent construction grows past a few dozen lines or sprouts its own
+prompt embed / typed result / config struct, extract it into a sibling
+`<purpose>_agent.go`.
 
 ## Tool files
 

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -2709,6 +2709,128 @@ func (s *Service) CountTrackerPatternsForBanner(
 	return count, nil
 }
 
+func (s *Service) GetCommonTrackerPatternsByIDs(
+	ctx context.Context,
+	ids ...gid.GID,
+) (coredata.CommonTrackerPatterns, error) {
+	var patterns coredata.CommonTrackerPatterns
+
+	err := s.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			if err := patterns.LoadByIDs(ctx, conn, ids); err != nil {
+				return fmt.Errorf("cannot load common tracker patterns by ids: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return patterns, nil
+}
+
+// LoadCommonTrackerPatternIDsByCommonThirdPartyID returns the IDs of
+// every common tracker pattern referencing the given common third party.
+// Used by the trackers list filter to translate a CommonThirdParty GID
+// into a `common_tracker_pattern_id = ANY(...)` constraint without
+// JOINing across entity tables in coredata.
+func (s *Service) LoadCommonTrackerPatternIDsByCommonThirdPartyID(
+	ctx context.Context,
+	commonThirdPartyID gid.GID,
+) ([]gid.GID, error) {
+	var ids []gid.GID
+
+	err := s.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			var (
+				patterns coredata.CommonTrackerPatterns
+				err      error
+			)
+
+			ids, err = patterns.LoadIDsByCommonThirdPartyID(ctx, conn, commonThirdPartyID)
+			if err != nil {
+				return fmt.Errorf("cannot load common tracker pattern ids: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return ids, nil
+}
+
+// LoadDistinctThirdPartyIDsByCookieBannerID returns the distinct
+// org-scoped third-party IDs referenced by tracker patterns of the
+// banner. The companion
+// LoadDistinctCommonTrackerPatternIDsByCookieBannerID covers the
+// indirect mapping through common_tracker_patterns.
+func (s *Service) LoadDistinctThirdPartyIDsByCookieBannerID(
+	ctx context.Context,
+	scope coredata.Scoper,
+	cookieBannerID gid.GID,
+) ([]gid.GID, error) {
+	var ids []gid.GID
+
+	err := s.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			var (
+				patterns coredata.TrackerPatterns
+				err      error
+			)
+
+			ids, err = patterns.LoadDistinctThirdPartyIDsByCookieBannerID(ctx, conn, scope, cookieBannerID)
+			if err != nil {
+				return fmt.Errorf("cannot load distinct third party ids: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return ids, nil
+}
+
+func (s *Service) LoadDistinctCommonTrackerPatternIDsByCookieBannerID(
+	ctx context.Context,
+	scope coredata.Scoper,
+	cookieBannerID gid.GID,
+) ([]gid.GID, error) {
+	var ids []gid.GID
+
+	err := s.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			var (
+				patterns coredata.TrackerPatterns
+				err      error
+			)
+
+			ids, err = patterns.LoadDistinctCommonTrackerPatternIDsByCookieBannerID(ctx, conn, scope, cookieBannerID)
+			if err != nil {
+				return fmt.Errorf("cannot load distinct common tracker pattern ids: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return ids, nil
+}
+
 func (s *Service) CountDetectedTrackersByPatternID(
 	ctx context.Context,
 	scope coredata.Scoper,

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -2628,6 +2628,20 @@ func (s *Service) MoveTrackerPatternToCategory(
 				return fmt.Errorf("cannot update tracker pattern: %w", err)
 			}
 
+			// A manual move is the user's signal that this is a
+			// real tracker. Enqueue the tracker-mapping worker so
+			// it can promote the pattern to an org ThirdParty (or
+			// link an existing one) — never EXTENSION-sourced
+			// patterns, and never patterns we already promoted.
+			// SetMappingRequested is idempotent: it short-circuits
+			// when mapping_requested_at is already non-NULL.
+			if pattern.ThirdPartyID == nil &&
+				(pattern.Source == nil || *pattern.Source != coredata.CookieSourceExtension) {
+				if err := pattern.SetMappingRequested(ctx, tx); err != nil {
+					return fmt.Errorf("cannot enqueue tracker mapping after move: %w", err)
+				}
+			}
+
 			var banner coredata.CookieBanner
 			if err := banner.LoadByID(ctx, tx, scope, pattern.CookieBannerID); err != nil {
 				return fmt.Errorf("cannot load cookie banner: %w", err)

--- a/pkg/cookiebanner/tracker_mapping_agent.go
+++ b/pkg/cookiebanner/tracker_mapping_agent.go
@@ -48,6 +48,9 @@ type TrackerMappingAgentResult struct {
 	Confidence     float64                     `json:"confidence" jsonschema:"Confidence level from 0.0 to 1.0. Set below 0.5 if unsure."`
 }
 
+// TrackerMappingConfig configures the tracker-mapping agent (catalog
+// identification). The agent uses DB-backed search tools and may also
+// use Firecrawl for web search when an API key is supplied.
 type TrackerMappingConfig struct {
 	LLMClient       *llm.Client
 	Model           string

--- a/pkg/cookiebanner/tracker_mapping_worker.go
+++ b/pkg/cookiebanner/tracker_mapping_worker.go
@@ -90,11 +90,13 @@ func (h *trackerMappingHandler) Claim(ctx context.Context) (coredata.TrackerPatt
 }
 
 // Process resolves the catalog mapping (when missing) and then promotes
-// the pattern to an org ThirdParty (when eligible). When a pattern is
-// re-triggered by a manual move (it already carries a
-// common_tracker_pattern_id), we MUST NOT re-resolve the catalog: the
-// existing link is preserved and we jump straight to third-party
-// promotion.
+// the pattern to an org ThirdParty (when eligible). Promotion is
+// skipped for patterns still in the uncategorised category — the user
+// must categorize a tracker before it creates or links an org
+// ThirdParty. When a pattern is re-triggered by a manual move (it
+// already carries a common_tracker_pattern_id), we MUST NOT re-resolve
+// the catalog: the existing link is preserved and we jump straight to
+// third-party promotion.
 func (h *trackerMappingHandler) Process(ctx context.Context, tp coredata.TrackerPattern) error {
 	return h.pg.WithTx(
 		ctx,
@@ -139,12 +141,21 @@ func (h *trackerMappingHandler) Process(ctx context.Context, tp coredata.Tracker
 			if thirdPartyID == nil &&
 				commonPatternID != nil &&
 				(tp.Source == nil || *tp.Source != coredata.CookieSourceExtension) {
-				promoted, err := h.promoteThirdParty(ctx, tx, tp, *commonPatternID)
-				if err != nil {
-					return fmt.Errorf("cannot promote third party: %w", err)
+				scope := coredata.NewScopeFromObjectID(tp.ID)
+
+				var category coredata.CookieCategory
+				if err := category.LoadByID(ctx, tx, scope, tp.CookieCategoryID); err != nil {
+					return fmt.Errorf("cannot load cookie category: %w", err)
 				}
 
-				thirdPartyID = promoted
+				if category.Kind != coredata.CookieCategoryKindUncategorised {
+					promoted, err := h.promoteThirdParty(ctx, tx, tp, *commonPatternID)
+					if err != nil {
+						return fmt.Errorf("cannot promote third party: %w", err)
+					}
+
+					thirdPartyID = promoted
+				}
 			}
 
 			if commonPatternID != nil || thirdPartyID != nil {

--- a/pkg/cookiebanner/tracker_mapping_worker.go
+++ b/pkg/cookiebanner/tracker_mapping_worker.go
@@ -28,18 +28,21 @@ import (
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/llm"
 	"go.probo.inc/probo/pkg/slug"
+	"go.probo.inc/probo/pkg/thirdparty"
 )
 
 type trackerMappingHandler struct {
-	pg     *pg.Client
-	logger *log.Logger
-	agent  *agent.Agent
+	pg                  *pg.Client
+	logger              *log.Logger
+	mappingAgent        *agent.Agent
+	disambiguationAgent *agent.Agent
 }
 
 func NewTrackerMappingWorker(
 	pgClient *pg.Client,
 	logger *log.Logger,
-	cfg TrackerMappingConfig,
+	mappingCfg TrackerMappingConfig,
+	disambiguationCfg thirdparty.DisambiguationConfig,
 	opts ...worker.Option,
 ) *worker.Worker[coredata.TrackerPattern] {
 	h := &trackerMappingHandler{
@@ -47,8 +50,12 @@ func NewTrackerMappingWorker(
 		logger: logger,
 	}
 
-	if cfg.LLMClient != nil {
-		h.agent = buildTrackerMappingAgent(cfg, pgClient, logger)
+	if mappingCfg.LLMClient != nil {
+		h.mappingAgent = buildTrackerMappingAgent(mappingCfg, pgClient, logger)
+	}
+
+	if disambiguationCfg.LLMClient != nil {
+		h.disambiguationAgent = thirdparty.BuildDisambiguationAgent(disambiguationCfg, logger)
 	}
 
 	return worker.New(
@@ -82,40 +89,62 @@ func (h *trackerMappingHandler) Claim(ctx context.Context) (coredata.TrackerPatt
 	return tp, nil
 }
 
+// Process resolves the catalog mapping (when missing) and then promotes
+// the pattern to an org ThirdParty (when eligible). When a pattern is
+// re-triggered by a manual move (it already carries a
+// common_tracker_pattern_id), we MUST NOT re-resolve the catalog: the
+// existing link is preserved and we jump straight to third-party
+// promotion.
 func (h *trackerMappingHandler) Process(ctx context.Context, tp coredata.TrackerPattern) error {
 	return h.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			var (
 				commonPatternID *gid.GID
-				thirdPartyID    *gid.GID
 				err             error
 			)
 
-			commonPatternID, thirdPartyID, err = h.matchByPattern(ctx, tx, tp)
-			if err != nil {
-				return fmt.Errorf("cannot match by pattern: %w", err)
-			}
-
-			if commonPatternID == nil {
-				commonPatternID, thirdPartyID, err = h.matchByDomain(ctx, tx, tp)
+			if tp.CommonTrackerPatternID != nil {
+				commonPatternID = tp.CommonTrackerPatternID
+			} else {
+				commonPatternID, err = h.matchByPattern(ctx, tx, tp)
 				if err != nil {
-					return fmt.Errorf("cannot match by domain: %w", err)
+					return fmt.Errorf("cannot match by pattern: %w", err)
+				}
+
+				if commonPatternID == nil {
+					commonPatternID, err = h.matchByDomain(ctx, tx, tp)
+					if err != nil {
+						return fmt.Errorf("cannot match by domain: %w", err)
+					}
+				}
+
+				if commonPatternID == nil && h.mappingAgent != nil {
+					commonPatternID, err = h.identifyWithAgent(ctx, tx, tp)
+					if err != nil {
+						return fmt.Errorf("cannot identify with agent: %w", err)
+					}
+				}
+
+				if commonPatternID == nil {
+					commonPatternID, err = h.createUnmatchedPattern(ctx, tx, tp)
+					if err != nil {
+						return fmt.Errorf("cannot create unmatched pattern: %w", err)
+					}
 				}
 			}
 
-			if commonPatternID == nil && h.agent != nil {
-				commonPatternID, thirdPartyID, err = h.identifyWithAgent(ctx, tx, tp)
-				if err != nil {
-					return fmt.Errorf("cannot identify with agent: %w", err)
-				}
-			}
+			thirdPartyID := tp.ThirdPartyID
 
-			if commonPatternID == nil {
-				commonPatternID, err = h.createUnmatchedPattern(ctx, tx, tp)
+			if thirdPartyID == nil &&
+				commonPatternID != nil &&
+				(tp.Source == nil || *tp.Source != coredata.CookieSourceExtension) {
+				promoted, err := h.promoteThirdParty(ctx, tx, tp, *commonPatternID)
 				if err != nil {
-					return fmt.Errorf("cannot create unmatched pattern: %w", err)
+					return fmt.Errorf("cannot promote third party: %w", err)
 				}
+
+				thirdPartyID = promoted
 			}
 
 			if commonPatternID != nil || thirdPartyID != nil {
@@ -136,59 +165,55 @@ func (h *trackerMappingHandler) Process(ctx context.Context, tp coredata.Tracker
 	)
 }
 
+// matchByPattern looks for a catalog row with the same pattern. It now
+// only returns the catalog ID; third-party resolution happens later in
+// promoteThirdParty.
 func (h *trackerMappingHandler) matchByPattern(
 	ctx context.Context,
 	conn pg.Querier,
 	tp coredata.TrackerPattern,
-) (*gid.GID, *gid.GID, error) {
+) (*gid.GID, error) {
 	var commonPattern coredata.CommonTrackerPattern
 	if err := commonPattern.LoadByPattern(ctx, conn, tp.TrackerType, tp.Pattern, tp.MaxAgeSeconds); err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
-			return nil, nil, nil
+			return nil, nil
 		}
 
-		return nil, nil, fmt.Errorf("cannot load common tracker pattern: %w", err)
+		return nil, fmt.Errorf("cannot load common tracker pattern: %w", err)
 	}
 
-	var thirdPartyID *gid.GID
-
-	if commonPattern.CommonThirdPartyID != nil {
-		var err error
-
-		thirdPartyID, err = h.resolveThirdParty(ctx, conn, tp, &commonPattern)
-		if err != nil {
-			return nil, nil, fmt.Errorf("cannot resolve third party from pattern match: %w", err)
-		}
-	}
-
-	return &commonPattern.ID, thirdPartyID, nil
+	return &commonPattern.ID, nil
 }
 
+// matchByDomain finds a CommonThirdParty whose registered domains
+// overlap the pattern's observed initiator domains, and upserts a
+// CommonTrackerPattern linking the two. As with matchByPattern,
+// third-party resolution is deferred to promoteThirdParty.
 func (h *trackerMappingHandler) matchByDomain(
 	ctx context.Context,
 	tx pg.Tx,
 	tp coredata.TrackerPattern,
-) (*gid.GID, *gid.GID, error) {
+) (*gid.GID, error) {
 	var trackers coredata.DetectedTrackers
 
 	domains, err := trackers.LoadInitiatorDomainsByTrackerPatternID(ctx, tx, tp.ID, 10)
 	if err != nil {
-		return nil, nil, fmt.Errorf("cannot load initiator domains: %w", err)
+		return nil, fmt.Errorf("cannot load initiator domains: %w", err)
 	}
 
 	if len(domains) == 0 {
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	filter := coredata.NewCommonThirdPartyDomainFilter(domains)
 
 	var matchedDomains coredata.CommonThirdPartyDomains
 	if err := matchedDomains.Load(ctx, tx, 1, filter); err != nil {
-		return nil, nil, fmt.Errorf("cannot load common third party domain by domain match: %w", err)
+		return nil, fmt.Errorf("cannot load common third party domain by domain match: %w", err)
 	}
 
 	if len(matchedDomains) == 0 {
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	commonThirdPartyID := matchedDomains[0].CommonThirdPartyID
@@ -208,22 +233,17 @@ func (h *trackerMappingHandler) matchByDomain(
 	}
 
 	if _, err := commonPattern.Upsert(ctx, tx); err != nil {
-		return nil, nil, fmt.Errorf("cannot upsert common tracker pattern from domain match: %w", err)
+		return nil, fmt.Errorf("cannot upsert common tracker pattern from domain match: %w", err)
 	}
 
-	thirdPartyID, err := h.resolveThirdParty(ctx, tx, tp, &commonPattern)
-	if err != nil {
-		return nil, nil, fmt.Errorf("cannot resolve third party from domain match: %w", err)
-	}
-
-	return &commonPattern.ID, thirdPartyID, nil
+	return &commonPattern.ID, nil
 }
 
 func (h *trackerMappingHandler) identifyWithAgent(
 	ctx context.Context,
 	tx pg.Tx,
 	tp coredata.TrackerPattern,
-) (*gid.GID, *gid.GID, error) {
+) (*gid.GID, error) {
 	var trackers coredata.DetectedTrackers
 
 	domains, err := trackers.LoadInitiatorDomainsByTrackerPatternID(ctx, tx, tp.ID, 5)
@@ -238,7 +258,7 @@ func (h *trackerMappingHandler) identifyWithAgent(
 
 	result, err := agent.RunTyped[TrackerMappingAgentResult](
 		agentCtx,
-		h.agent,
+		h.mappingAgent,
 		[]llm.Message{
 			{
 				Role:  llm.RoleUser,
@@ -254,7 +274,7 @@ func (h *trackerMappingHandler) identifyWithAgent(
 			log.String("pattern", tp.Pattern),
 		)
 
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	identification := result.Output
@@ -267,7 +287,7 @@ func (h *trackerMappingHandler) identifyWithAgent(
 			log.Float64("confidence", identification.Confidence),
 		)
 
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	confidence := float32(identification.Confidence)
@@ -284,7 +304,7 @@ func (h *trackerMappingHandler) identifyWithAgent(
 			domains,
 		)
 		if err != nil {
-			return nil, nil, fmt.Errorf("cannot resolve or create common third party: %w", err)
+			return nil, fmt.Errorf("cannot resolve or create common third party: %w", err)
 		}
 	}
 
@@ -303,12 +323,7 @@ func (h *trackerMappingHandler) identifyWithAgent(
 	}
 
 	if _, err := commonPattern.Upsert(ctx, tx); err != nil {
-		return nil, nil, fmt.Errorf("cannot upsert common tracker pattern from agent: %w", err)
-	}
-
-	thirdPartyID, err := h.resolveThirdParty(ctx, tx, tp, &commonPattern)
-	if err != nil {
-		return nil, nil, fmt.Errorf("cannot resolve third party from agent match: %w", err)
+		return nil, fmt.Errorf("cannot upsert common tracker pattern from agent: %w", err)
 	}
 
 	h.logger.InfoCtx(
@@ -319,7 +334,7 @@ func (h *trackerMappingHandler) identifyWithAgent(
 		log.Float64("confidence", identification.Confidence),
 	)
 
-	return &commonPattern.ID, thirdPartyID, nil
+	return &commonPattern.ID, nil
 }
 
 func (h *trackerMappingHandler) resolveOrCreateCommonThirdParty(
@@ -408,32 +423,163 @@ func (h *trackerMappingHandler) createUnmatchedPattern(
 	return &commonPattern.ID, nil
 }
 
-func (h *trackerMappingHandler) resolveThirdParty(
+// promoteThirdParty resolves an org ThirdParty for the given pattern
+// once the catalog mapping is known. The resolution order is:
+//
+//  1. Exact link by common_third_party_id (O(1)).
+//  2. Heuristic match against the org's existing ThirdParty rows
+//     (lowercased name, suffix-stripped name, slug, website host,
+//     CommonThirdPartyDomain overlap).
+//  3. Agent disambiguation when the heuristic is ambiguous.
+//  4. Fallback create from CommonThirdParty.
+//
+// A confident heuristic/agent match is auto-tagged with
+// common_third_party_id so subsequent promotions hit the exact-link
+// path in O(1). Returns (nil, nil) when the catalog row has no
+// CommonThirdPartyID — there is nothing to promote to.
+func (h *trackerMappingHandler) promoteThirdParty(
 	ctx context.Context,
-	conn pg.Querier,
+	tx pg.Tx,
 	tp coredata.TrackerPattern,
-	commonPattern *coredata.CommonTrackerPattern,
+	commonPatternID gid.GID,
 ) (*gid.GID, error) {
+	var commonPattern coredata.CommonTrackerPattern
+	if err := commonPattern.LoadByID(ctx, tx, commonPatternID); err != nil {
+		return nil, fmt.Errorf("cannot load common tracker pattern: %w", err)
+	}
+
 	if commonPattern.CommonThirdPartyID == nil {
 		return nil, nil
 	}
 
+	commonThirdPartyID := *commonPattern.CommonThirdPartyID
 	scope := coredata.NewScopeFromObjectID(tp.ID)
 
-	var t coredata.ThirdParty
-	if err := t.LoadByOrganizationIDAndCommonThirdPartyID(
+	var existing coredata.ThirdParty
+
+	err := existing.LoadByOrganizationIDAndCommonThirdPartyID(
 		ctx,
-		conn,
+		tx,
 		scope,
 		tp.OrganizationID,
-		*commonPattern.CommonThirdPartyID,
-	); err != nil {
-		if errors.Is(err, coredata.ErrResourceNotFound) {
-			return nil, nil
-		}
-
-		return nil, fmt.Errorf("cannot resolve third party: %w", err)
+		commonThirdPartyID,
+	)
+	if err == nil {
+		return &existing.ID, nil
 	}
 
-	return &t.ID, nil
+	if !errors.Is(err, coredata.ErrResourceNotFound) {
+		return nil, fmt.Errorf("cannot load org third party by common id: %w", err)
+	}
+
+	var commonParty coredata.CommonThirdParty
+	if err := commonParty.LoadByID(ctx, tx, commonThirdPartyID); err != nil {
+		return nil, fmt.Errorf("cannot load common third party: %w", err)
+	}
+
+	var commonDomains coredata.CommonThirdPartyDomains
+	if err := commonDomains.LoadByCommonThirdPartyID(ctx, tx, commonThirdPartyID); err != nil {
+		return nil, fmt.Errorf("cannot load common third party domains: %w", err)
+	}
+
+	var orgThirdParties coredata.ThirdParties
+	if err := orgThirdParties.LoadAllByOrganizationID(ctx, tx, scope, tp.OrganizationID); err != nil {
+		return nil, fmt.Errorf("cannot load org third parties: %w", err)
+	}
+
+	ranked := thirdparty.RankCandidates(commonParty, commonDomains, orgThirdParties)
+
+	if len(ranked) > 0 && ranked[0].Score >= thirdparty.HighConfidenceScore {
+		picked := ranked[0].ThirdParty
+
+		if err := thirdparty.LinkToCommon(ctx, tx, scope, picked, commonThirdPartyID); err != nil {
+			return nil, fmt.Errorf("cannot link fuzzy-matched third party to common: %w", err)
+		}
+
+		h.logger.InfoCtx(
+			ctx,
+			"promoted tracker pattern via heuristic match",
+			log.String("tracker_pattern_id", tp.ID.String()),
+			log.String("third_party_id", picked.ID.String()),
+			log.Float64("score", ranked[0].Score),
+		)
+
+		return &picked.ID, nil
+	}
+
+	agentSet := ranked
+	if len(agentSet) > thirdparty.MaxAgentCandidates {
+		agentSet = agentSet[:thirdparty.MaxAgentCandidates]
+	}
+
+	eligibleForAgent := false
+
+	for _, c := range agentSet {
+		if c.Score >= thirdparty.MinAgentScore {
+			eligibleForAgent = true
+
+			break
+		}
+	}
+
+	if eligibleForAgent && h.disambiguationAgent != nil {
+		matchedID, err := thirdparty.Disambiguate(
+			ctx,
+			h.disambiguationAgent,
+			h.logger,
+			commonParty,
+			commonDomains,
+			agentSet,
+		)
+		if err != nil {
+			h.logger.WarnCtx(
+				ctx,
+				"third-party disambiguation agent failed",
+				log.Error(err),
+				log.String("tracker_pattern_id", tp.ID.String()),
+			)
+		}
+
+		if matchedID != nil {
+			var picked *coredata.ThirdParty
+
+			for _, c := range agentSet {
+				if c.ThirdParty.ID == *matchedID {
+					picked = c.ThirdParty
+
+					break
+				}
+			}
+
+			if picked != nil {
+				if err := thirdparty.LinkToCommon(ctx, tx, scope, picked, commonThirdPartyID); err != nil {
+					return nil, fmt.Errorf("cannot link agent-matched third party to common: %w", err)
+				}
+
+				h.logger.InfoCtx(
+					ctx,
+					"promoted tracker pattern via disambiguation agent",
+					log.String("tracker_pattern_id", tp.ID.String()),
+					log.String("third_party_id", picked.ID.String()),
+				)
+
+				return &picked.ID, nil
+			}
+		}
+	}
+
+	created, err := thirdparty.CreateFromCommon(ctx, tx, scope, tp.OrganizationID, commonParty)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create third party from common: %w", err)
+	}
+
+	h.logger.InfoCtx(
+		ctx,
+		"promoted tracker pattern by creating org third party from catalog",
+		log.String("tracker_pattern_id", tp.ID.String()),
+		log.String("third_party_id", created.ID.String()),
+		log.String("common_third_party_id", commonThirdPartyID.String()),
+	)
+
+	return &created.ID, nil
 }

--- a/pkg/cookiebanner/tracker_mapping_worker_test.go
+++ b/pkg/cookiebanner/tracker_mapping_worker_test.go
@@ -339,6 +339,51 @@ func TestProcess_PreservesCatalogMappingOnReTrigger(t *testing.T) {
 	require.NotNil(t, reloaded.ThirdPartyID, "the worker should have promoted to an org ThirdParty")
 }
 
+// TestProcess_UncategorisedPatternIsNotPromoted asserts that a pattern
+// still in the uncategorised category gets its catalog mapping
+// resolved but is NOT promoted to an org ThirdParty.
+func TestProcess_UncategorisedPatternIsNotPromoted(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedPromotionFixture(t, ctx, client)
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		_, err := tx.Exec(
+			ctx,
+			`UPDATE tracker_patterns
+			   SET cookie_category_id = $1,
+			       mapping_requested_at = $2
+			 WHERE id = $3`,
+			fx.uncategorisedID,
+			time.Now().UTC().Truncate(time.Microsecond),
+			fx.trackerPattern.ID,
+		)
+
+		return err
+	}))
+
+	var reloadedBefore coredata.TrackerPattern
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloadedBefore.LoadByID(ctx, conn, fx.scope, fx.trackerPattern.ID)
+	}))
+
+	h := newMappingHandler(client)
+	require.NoError(t, h.Process(ctx, reloadedBefore))
+
+	var reloaded coredata.TrackerPattern
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloaded.LoadByID(ctx, conn, fx.scope, fx.trackerPattern.ID)
+	}))
+
+	require.NotNil(t, reloaded.CommonTrackerPatternID, "catalog mapping must still be resolved")
+	assert.Equal(t, fx.commonPatternID, *reloaded.CommonTrackerPatternID)
+	assert.Nil(t, reloaded.ThirdPartyID, "uncategorised pattern must not be promoted to org ThirdParty")
+}
+
 // TestProcess_ExtensionPatternIsNotPromoted asserts that even when a
 // pattern has a catalog link, a Source=EXTENSION pattern stays
 // un-promoted.

--- a/pkg/cookiebanner/tracker_mapping_worker_test.go
+++ b/pkg/cookiebanner/tracker_mapping_worker_test.go
@@ -1,0 +1,495 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package cookiebanner
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.gearno.de/kit/log"
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+)
+
+//go:fix inline
+func ptr[T any](v T) *T { return new(v) }
+
+// promotionFixture extends workerFixture with a CommonThirdParty and a
+// CommonTrackerPattern linking the catalog to the test pattern. It is
+// the minimum scaffolding promoteThirdParty needs to run end-to-end.
+type promotionFixture struct {
+	workerFixture
+	commonThirdParty   coredata.CommonThirdParty
+	commonPatternID    gid.GID
+	trackerPattern     coredata.TrackerPattern
+	commonThirdPartyID gid.GID
+}
+
+func seedPromotionFixture(t *testing.T, ctx context.Context, client *pg.Client) promotionFixture {
+	t.Helper()
+
+	fx := seedWorkerFixture(t, ctx, client)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	commonThirdPartyID := gid.New(gid.NilTenant, coredata.CommonThirdPartyEntityType)
+	commonThirdParty := coredata.CommonThirdParty{
+		ID:             commonThirdPartyID,
+		Name:           "Google",
+		Slug:           "google",
+		Category:       coredata.ThirdPartyCategoryAnalytics,
+		WebsiteURL:     new("https://google.com"),
+		Certifications: []string{},
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	commonPattern := coredata.CommonTrackerPattern{
+		ID:                 gid.New(gid.NilTenant, coredata.CommonTrackerPatternEntityType),
+		CommonThirdPartyID: &commonThirdPartyID,
+		TrackerType:        coredata.TrackerTypeCookie,
+		Pattern:            "_ga",
+		MatchType:          coredata.TrackerPatternMatchTypeExact,
+		Description:        "",
+		Confidence:         0.9,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+
+	pattern := coredata.TrackerPattern{
+		ID:                     gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
+		OrganizationID:         fx.organizationID,
+		CookieBannerID:         fx.banner.ID,
+		CookieCategoryID:       fx.normalCategoryID,
+		CommonTrackerPatternID: &commonPattern.ID,
+		TrackerType:            coredata.TrackerTypeCookie,
+		Pattern:                "_ga",
+		MatchType:              coredata.TrackerPatternMatchTypeExact,
+		DisplayName:            "_ga",
+		Description:            "",
+		CreatedAt:              now,
+		UpdatedAt:              now,
+	}
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		if err := commonThirdParty.Insert(ctx, tx); err != nil {
+			return err
+		}
+
+		if _, err := commonPattern.Upsert(ctx, tx); err != nil {
+			return err
+		}
+
+		return pattern.Insert(ctx, tx, fx.scope)
+	}))
+
+	t.Cleanup(func() {
+		_ = client.WithTx(context.Background(), func(ctx context.Context, tx pg.Tx) error {
+			if _, err := tx.Exec(ctx, `DELETE FROM common_third_party_domains WHERE common_third_party_id = $1`, commonThirdPartyID); err != nil {
+				return err
+			}
+
+			if _, err := tx.Exec(ctx, `DELETE FROM common_tracker_patterns WHERE id = $1`, commonPattern.ID); err != nil {
+				return err
+			}
+
+			if _, err := tx.Exec(ctx, `DELETE FROM common_third_parties WHERE id = $1`, commonThirdPartyID); err != nil {
+				return err
+			}
+
+			if _, err := tx.Exec(ctx, `DELETE FROM third_parties WHERE organization_id = $1`, fx.organizationID); err != nil {
+				return err
+			}
+
+			return nil
+		})
+	})
+
+	return promotionFixture{
+		workerFixture:      fx,
+		commonThirdParty:   commonThirdParty,
+		commonPatternID:    commonPattern.ID,
+		commonThirdPartyID: commonThirdPartyID,
+		trackerPattern:     pattern,
+	}
+}
+
+func newMappingHandler(client *pg.Client) *trackerMappingHandler {
+	return &trackerMappingHandler{
+		pg:     client,
+		logger: log.NewLogger(log.WithOutput(io.Discard)),
+	}
+}
+
+// promote runs promoteThirdParty inside its own transaction so each
+// test case starts from a clean state.
+func promote(
+	t *testing.T,
+	ctx context.Context,
+	h *trackerMappingHandler,
+	client *pg.Client,
+	tp coredata.TrackerPattern,
+	commonPatternID gid.GID,
+) *gid.GID {
+	t.Helper()
+
+	var got *gid.GID
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		var err error
+
+		got, err = h.promoteThirdParty(ctx, tx, tp, commonPatternID)
+
+		return err
+	}))
+
+	return got
+}
+
+func TestPromoteThirdParty_ExactCommonLink(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedPromotionFixture(t, ctx, client)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	existing := coredata.ThirdParty{
+		ID:                 gid.New(fx.scope.GetTenantID(), coredata.ThirdPartyEntityType),
+		OrganizationID:     fx.organizationID,
+		CommonThirdPartyID: &fx.commonThirdPartyID,
+		Name:               "Google LLC",
+		Category:           coredata.ThirdPartyCategoryAnalytics,
+		Certifications:     []string{},
+		Countries:          coredata.CountryCodes{},
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		return existing.Insert(ctx, tx, fx.scope)
+	}))
+
+	got := promote(t, ctx, newMappingHandler(client), client, fx.trackerPattern, fx.commonPatternID)
+
+	require.NotNil(t, got)
+	assert.Equal(t, existing.ID, *got, "should return the existing org ThirdParty linked by common id")
+}
+
+func TestPromoteThirdParty_HeuristicMatch(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedPromotionFixture(t, ctx, client)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	manualEntry := coredata.ThirdParty{
+		ID:             gid.New(fx.scope.GetTenantID(), coredata.ThirdPartyEntityType),
+		OrganizationID: fx.organizationID,
+		Name:           "Google LLC",
+		Category:       coredata.ThirdPartyCategoryAnalytics,
+		Certifications: []string{},
+		Countries:      coredata.CountryCodes{},
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		return manualEntry.Insert(ctx, tx, fx.scope)
+	}))
+
+	got := promote(t, ctx, newMappingHandler(client), client, fx.trackerPattern, fx.commonPatternID)
+
+	require.NotNil(t, got)
+	assert.Equal(t, manualEntry.ID, *got, "heuristic match should return the manually-entered ThirdParty")
+
+	var reloaded coredata.ThirdParty
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloaded.LoadByID(ctx, conn, fx.scope, manualEntry.ID)
+	}))
+
+	require.NotNil(t, reloaded.CommonThirdPartyID, "matched row must be tagged with common_third_party_id")
+	assert.Equal(t, fx.commonThirdPartyID, *reloaded.CommonThirdPartyID)
+}
+
+func TestPromoteThirdParty_FallbackCreate(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedPromotionFixture(t, ctx, client)
+
+	got := promote(t, ctx, newMappingHandler(client), client, fx.trackerPattern, fx.commonPatternID)
+
+	require.NotNil(t, got, "fallback should create a new ThirdParty")
+
+	var reloaded coredata.ThirdParty
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloaded.LoadByID(ctx, conn, fx.scope, *got)
+	}))
+
+	assert.Equal(t, fx.organizationID, reloaded.OrganizationID)
+	assert.Equal(t, "Google", reloaded.Name)
+	require.NotNil(t, reloaded.CommonThirdPartyID)
+	assert.Equal(t, fx.commonThirdPartyID, *reloaded.CommonThirdPartyID)
+	assert.Equal(t, coredata.ThirdPartyCategoryAnalytics, reloaded.Category)
+	assert.False(t, reloaded.FirstLevel)
+	assert.False(t, reloaded.ShowOnTrustCenter)
+}
+
+func TestPromoteThirdParty_NoCommonThirdPartyOnPattern(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedWorkerFixture(t, ctx, client)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	commonPattern := coredata.CommonTrackerPattern{
+		ID:          gid.New(gid.NilTenant, coredata.CommonTrackerPatternEntityType),
+		TrackerType: coredata.TrackerTypeCookie,
+		Pattern:     "unknown_xyz",
+		MatchType:   coredata.TrackerPatternMatchTypeExact,
+		Description: "",
+		Confidence:  0.5,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	pattern := coredata.TrackerPattern{
+		ID:                     gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
+		OrganizationID:         fx.organizationID,
+		CookieBannerID:         fx.banner.ID,
+		CookieCategoryID:       fx.normalCategoryID,
+		CommonTrackerPatternID: &commonPattern.ID,
+		TrackerType:            coredata.TrackerTypeCookie,
+		Pattern:                "unknown_xyz",
+		MatchType:              coredata.TrackerPatternMatchTypeExact,
+		DisplayName:            "unknown_xyz",
+		CreatedAt:              now,
+		UpdatedAt:              now,
+	}
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		if _, err := commonPattern.Upsert(ctx, tx); err != nil {
+			return err
+		}
+
+		return pattern.Insert(ctx, tx, fx.scope)
+	}))
+
+	t.Cleanup(func() {
+		_ = client.WithTx(context.Background(), func(ctx context.Context, tx pg.Tx) error {
+			_, err := tx.Exec(ctx, `DELETE FROM common_tracker_patterns WHERE id = $1`, commonPattern.ID)
+
+			return err
+		})
+	})
+
+	got := promote(t, ctx, newMappingHandler(client), client, pattern, commonPattern.ID)
+
+	assert.Nil(t, got, "patterns whose catalog row has no CommonThirdPartyID should not be promoted")
+}
+
+// TestProcess_PreservesCatalogMappingOnReTrigger asserts that when
+// Process is called for a pattern that already carries a
+// common_tracker_pattern_id, the catalog pipeline is skipped and the
+// existing catalog link is preserved verbatim.
+func TestProcess_PreservesCatalogMappingOnReTrigger(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedPromotionFixture(t, ctx, client)
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		return fx.trackerPattern.SetMappingRequested(ctx, tx)
+	}))
+
+	h := newMappingHandler(client)
+	require.NoError(t, h.Process(ctx, fx.trackerPattern))
+
+	var reloaded coredata.TrackerPattern
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloaded.LoadByID(ctx, conn, fx.scope, fx.trackerPattern.ID)
+	}))
+
+	require.NotNil(t, reloaded.CommonTrackerPatternID, "common tracker pattern link must be preserved")
+	assert.Equal(t, fx.commonPatternID, *reloaded.CommonTrackerPatternID)
+	require.NotNil(t, reloaded.ThirdPartyID, "the worker should have promoted to an org ThirdParty")
+}
+
+// TestProcess_ExtensionPatternIsNotPromoted asserts that even when a
+// pattern has a catalog link, a Source=EXTENSION pattern stays
+// un-promoted.
+func TestProcess_ExtensionPatternIsNotPromoted(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedPromotionFixture(t, ctx, client)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	source := coredata.CookieSourceExtension
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		_, err := tx.Exec(
+			ctx,
+			`UPDATE tracker_patterns
+			   SET source = $1,
+			       mapping_requested_at = $2
+			 WHERE id = $3`,
+			source,
+			now,
+			fx.trackerPattern.ID,
+		)
+
+		return err
+	}))
+
+	var reloadedBefore coredata.TrackerPattern
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloadedBefore.LoadByID(ctx, conn, fx.scope, fx.trackerPattern.ID)
+	}))
+
+	h := newMappingHandler(client)
+	require.NoError(t, h.Process(ctx, reloadedBefore))
+
+	var reloaded coredata.TrackerPattern
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloaded.LoadByID(ctx, conn, fx.scope, fx.trackerPattern.ID)
+	}))
+
+	assert.Nil(t, reloaded.ThirdPartyID, "EXTENSION-sourced pattern must not be promoted")
+}
+
+// TestProcess_NoOpWhenAlreadyPromoted asserts that re-running the
+// worker on a pattern that already has a third_party_id leaves the
+// row alone (the guard in Process).
+func TestProcess_NoOpWhenAlreadyPromoted(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedPromotionFixture(t, ctx, client)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	preExisting := coredata.ThirdParty{
+		ID:                 gid.New(fx.scope.GetTenantID(), coredata.ThirdPartyEntityType),
+		OrganizationID:     fx.organizationID,
+		CommonThirdPartyID: &fx.commonThirdPartyID,
+		Name:               "Google",
+		Category:           coredata.ThirdPartyCategoryAnalytics,
+		Certifications:     []string{},
+		Countries:          coredata.CountryCodes{},
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		if err := preExisting.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		fx.trackerPattern.ThirdPartyID = &preExisting.ID
+
+		_, err := tx.Exec(
+			ctx,
+			`UPDATE tracker_patterns
+			   SET third_party_id = $1,
+			       mapping_requested_at = $2
+			 WHERE id = $3`,
+			preExisting.ID,
+			now,
+			fx.trackerPattern.ID,
+		)
+
+		return err
+	}))
+
+	var reloadedBefore coredata.TrackerPattern
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloadedBefore.LoadByID(ctx, conn, fx.scope, fx.trackerPattern.ID)
+	}))
+
+	h := newMappingHandler(client)
+	require.NoError(t, h.Process(ctx, reloadedBefore))
+
+	var reloaded coredata.TrackerPattern
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloaded.LoadByID(ctx, conn, fx.scope, fx.trackerPattern.ID)
+	}))
+
+	require.NotNil(t, reloaded.ThirdPartyID)
+	assert.Equal(t, preExisting.ID, *reloaded.ThirdPartyID, "third_party_id must not be overwritten")
+}
+
+func TestPromoteThirdParty_ExactCommonLinkIgnoresSimilarUnlinked(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedPromotionFixture(t, ctx, client)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	manualEntry := coredata.ThirdParty{
+		ID:             gid.New(fx.scope.GetTenantID(), coredata.ThirdPartyEntityType),
+		OrganizationID: fx.organizationID,
+		Name:           "Google LLC",
+		Category:       coredata.ThirdPartyCategoryAnalytics,
+		Certifications: []string{},
+		Countries:      coredata.CountryCodes{},
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	linked := coredata.ThirdParty{
+		ID:                 gid.New(fx.scope.GetTenantID(), coredata.ThirdPartyEntityType),
+		OrganizationID:     fx.organizationID,
+		CommonThirdPartyID: &fx.commonThirdPartyID,
+		Name:               "Google",
+		Category:           coredata.ThirdPartyCategoryAnalytics,
+		Certifications:     []string{},
+		Countries:          coredata.CountryCodes{},
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		if err := manualEntry.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		return linked.Insert(ctx, tx, fx.scope)
+	}))
+
+	got := promote(t, ctx, newMappingHandler(client), client, fx.trackerPattern, fx.commonPatternID)
+
+	require.NotNil(t, got)
+	assert.Equal(t, linked.ID, *got, "exact-link path must short-circuit before the heuristic fires")
+}

--- a/pkg/coredata/common_third_party.go
+++ b/pkg/coredata/common_third_party.go
@@ -507,6 +507,57 @@ func (t CommonThirdParty) Delete(
 	return nil
 }
 
+func (t *CommonThirdParties) LoadByIDs(
+	ctx context.Context,
+	conn pg.Querier,
+	ids []gid.GID,
+) error {
+	q := `
+SELECT
+    id,
+    name,
+    slug,
+    category,
+    headquarter_address,
+    legal_name,
+    website_url,
+    privacy_policy_url,
+    service_level_agreement_url,
+    service_software_agreement_url,
+    data_processing_agreement_url,
+    business_associate_agreement_url,
+    subprocessors_list_url,
+    certifications,
+    status_page_url,
+    terms_of_service_url,
+    security_page_url,
+    trust_page_url,
+    logo_file_id,
+    created_at,
+    updated_at
+FROM
+    common_third_parties
+WHERE
+    id = ANY(@ids)
+`
+
+	args := pgx.StrictNamedArgs{"ids": ids}
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query common third parties: %w", err)
+	}
+
+	parties, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[CommonThirdParty])
+	if err != nil {
+		return fmt.Errorf("cannot collect common third parties: %w", err)
+	}
+
+	*t = parties
+
+	return nil
+}
+
 func (t *CommonThirdParties) LoadAll(
 	ctx context.Context,
 	conn pg.Querier,

--- a/pkg/coredata/common_tracker_pattern.go
+++ b/pkg/coredata/common_tracker_pattern.go
@@ -443,3 +443,76 @@ ORDER BY pattern ASC;
 
 	return nil
 }
+
+func (ps *CommonTrackerPatterns) LoadByIDs(
+	ctx context.Context,
+	conn pg.Querier,
+	ids []gid.GID,
+) error {
+	q := `
+SELECT
+    id,
+    common_third_party_id,
+    tracker_type,
+    pattern,
+    match_type,
+    description,
+    max_age_seconds,
+    confidence,
+    created_at,
+    updated_at
+FROM
+    common_tracker_patterns
+WHERE
+    id = ANY(@ids)
+`
+
+	args := pgx.StrictNamedArgs{"ids": ids}
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query common tracker patterns: %w", err)
+	}
+
+	patterns, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[CommonTrackerPattern])
+	if err != nil {
+		return fmt.Errorf("cannot collect common tracker patterns: %w", err)
+	}
+
+	*ps = patterns
+
+	return nil
+}
+
+// LoadIDsByCommonThirdPartyID returns just the IDs of the common tracker
+// patterns linked to the given common third party. Callers use it to feed
+// a `common_tracker_pattern_id = ANY(...)` filter on tracker_patterns
+// without crossing the entity boundary.
+func (ps *CommonTrackerPatterns) LoadIDsByCommonThirdPartyID(
+	ctx context.Context,
+	conn pg.Querier,
+	commonThirdPartyID gid.GID,
+) ([]gid.GID, error) {
+	q := `
+SELECT
+    id
+FROM
+    common_tracker_patterns
+WHERE
+    common_third_party_id = @common_third_party_id
+`
+
+	args := pgx.StrictNamedArgs{"common_third_party_id": commonThirdPartyID}
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query common tracker pattern ids: %w", err)
+	}
+
+	ids, err := pgx.CollectRows(rows, pgx.RowTo[gid.GID])
+	if err != nil {
+		return nil, fmt.Errorf("cannot collect common tracker pattern ids: %w", err)
+	}
+
+	return ids, nil
+}

--- a/pkg/coredata/third_party.go
+++ b/pkg/coredata/third_party.go
@@ -645,6 +645,7 @@ func (v *ThirdParty) Update(
 	q := `
 UPDATE third_parties
 SET
+	common_third_party_id = @common_third_party_id,
 	name = @name,
 	description = @description,
 	category = @category,
@@ -675,6 +676,7 @@ WHERE %s
 	args := pgx.StrictNamedArgs{
 		"third_party_id":                   v.ID,
 		"updated_at":                       time.Now(),
+		"common_third_party_id":            v.CommonThirdPartyID,
 		"name":                             v.Name,
 		"description":                      v.Description,
 		"category":                         v.Category,

--- a/pkg/coredata/tracker_pattern.go
+++ b/pkg/coredata/tracker_pattern.go
@@ -864,6 +864,82 @@ WHERE
 	return count, nil
 }
 
+// LoadDistinctThirdPartyIDsByCookieBannerID returns the distinct non-null
+// `third_party_id` values referenced by tracker patterns of the given
+// banner. Callers feed it to ThirdParty.GetByIDs to power per-banner
+// pickers without crossing the entity boundary.
+func (tps *TrackerPatterns) LoadDistinctThirdPartyIDsByCookieBannerID(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	cookieBannerID gid.GID,
+) ([]gid.GID, error) {
+	q := `
+SELECT DISTINCT third_party_id
+FROM tracker_patterns
+WHERE
+	%s
+	AND cookie_banner_id = @cookie_banner_id
+	AND third_party_id IS NOT NULL
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"cookie_banner_id": cookieBannerID}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query distinct third party ids: %w", err)
+	}
+
+	ids, err := pgx.CollectRows(rows, pgx.RowTo[gid.GID])
+	if err != nil {
+		return nil, fmt.Errorf("cannot collect distinct third party ids: %w", err)
+	}
+
+	return ids, nil
+}
+
+// LoadDistinctCommonTrackerPatternIDsByCookieBannerID returns the
+// distinct non-null `common_tracker_pattern_id` values referenced by
+// tracker patterns of the given banner. Callers chain this with
+// CommonTrackerPatterns.LoadByIDs and CommonThirdParties.LoadByIDs to
+// resolve the linked common third parties without JOINs.
+func (tps *TrackerPatterns) LoadDistinctCommonTrackerPatternIDsByCookieBannerID(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	cookieBannerID gid.GID,
+) ([]gid.GID, error) {
+	q := `
+SELECT DISTINCT common_tracker_pattern_id
+FROM tracker_patterns
+WHERE
+	%s
+	AND cookie_banner_id = @cookie_banner_id
+	AND common_tracker_pattern_id IS NOT NULL
+	AND third_party_id IS NULL
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"cookie_banner_id": cookieBannerID}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query distinct common tracker pattern ids: %w", err)
+	}
+
+	ids, err := pgx.CollectRows(rows, pgx.RowTo[gid.GID])
+	if err != nil {
+		return nil, fmt.Errorf("cannot collect distinct common tracker pattern ids: %w", err)
+	}
+
+	return ids, nil
+}
+
 func (tps *TrackerPatterns) UpdateLastMatchedAt(
 	ctx context.Context,
 	tx pg.Tx,

--- a/pkg/coredata/tracker_pattern_filter.go
+++ b/pkg/coredata/tracker_pattern_filter.go
@@ -20,12 +20,14 @@ import (
 )
 
 type TrackerPatternFilter struct {
-	matchType        *TrackerPatternMatchType
-	cookieCategoryID *gid.GID
-	excluded         *bool
-	query            *string
-	source           *CookieSource
-	trackerType      *TrackerType
+	matchType               *TrackerPatternMatchType
+	cookieCategoryID        *gid.GID
+	excluded                *bool
+	query                   *string
+	source                  *CookieSource
+	trackerType             *TrackerType
+	thirdPartyID            *gid.GID
+	commonTrackerPatternIDs []gid.GID
 }
 
 func NewTrackerPatternFilter(
@@ -52,6 +54,22 @@ func (f *TrackerPatternFilter) WithSource(source *CookieSource) *TrackerPatternF
 
 func (f *TrackerPatternFilter) WithTrackerType(trackerType *TrackerType) *TrackerPatternFilter {
 	f.trackerType = trackerType
+	return f
+}
+
+func (f *TrackerPatternFilter) WithThirdPartyID(thirdPartyID *gid.GID) *TrackerPatternFilter {
+	f.thirdPartyID = thirdPartyID
+	return f
+}
+
+// WithCommonTrackerPatternIDs constrains the result to tracker patterns
+// whose `common_tracker_pattern_id` is in the given set. Callers
+// pre-resolve this list (typically via
+// CommonTrackerPatterns.LoadIDsByCommonThirdPartyID) so the filter stays
+// inside the tracker_patterns table. Passing an empty (non-nil) slice
+// yields no rows.
+func (f *TrackerPatternFilter) WithCommonTrackerPatternIDs(ids []gid.GID) *TrackerPatternFilter {
+	f.commonTrackerPatternIDs = ids
 	return f
 }
 
@@ -103,6 +121,20 @@ func (f *TrackerPatternFilter) SQLFragment() string {
 			tracker_type = @filter_tracker_type::tracker_type
 		ELSE TRUE
 	END
+	AND
+	CASE
+		WHEN @has_third_party_id_filter::boolean = false THEN TRUE
+		WHEN @has_third_party_id_filter::boolean = true THEN
+			third_party_id = @filter_third_party_id::text
+		ELSE TRUE
+	END
+	AND
+	CASE
+		WHEN @has_common_tracker_pattern_ids_filter::boolean = false THEN TRUE
+		WHEN @has_common_tracker_pattern_ids_filter::boolean = true THEN
+			common_tracker_pattern_id = ANY(@filter_common_tracker_pattern_ids::text[])
+		ELSE TRUE
+	END
 )`
 }
 
@@ -112,17 +144,21 @@ func (f *TrackerPatternFilter) SQLArguments() pgx.StrictNamedArgs {
 	}
 
 	args := pgx.StrictNamedArgs{
-		"has_match_type_filter":         false,
-		"filter_match_type":             nil,
-		"has_cookie_category_id_filter": false,
-		"filter_cookie_category_id":     nil,
-		"has_excluded_filter":           false,
-		"filter_excluded":               nil,
-		"filter_query":                  nil,
-		"has_source_filter":             false,
-		"filter_source":                 nil,
-		"has_tracker_type_filter":       false,
-		"filter_tracker_type":           nil,
+		"has_match_type_filter":                 false,
+		"filter_match_type":                     nil,
+		"has_cookie_category_id_filter":         false,
+		"filter_cookie_category_id":             nil,
+		"has_excluded_filter":                   false,
+		"filter_excluded":                       nil,
+		"filter_query":                          nil,
+		"has_source_filter":                     false,
+		"filter_source":                         nil,
+		"has_tracker_type_filter":               false,
+		"filter_tracker_type":                   nil,
+		"has_third_party_id_filter":             false,
+		"filter_third_party_id":                 nil,
+		"has_common_tracker_pattern_ids_filter": false,
+		"filter_common_tracker_pattern_ids":     []gid.GID{},
 	}
 
 	if f.matchType != nil {
@@ -152,6 +188,16 @@ func (f *TrackerPatternFilter) SQLArguments() pgx.StrictNamedArgs {
 	if f.trackerType != nil {
 		args["has_tracker_type_filter"] = true
 		args["filter_tracker_type"] = string(*f.trackerType)
+	}
+
+	if f.thirdPartyID != nil {
+		args["has_third_party_id_filter"] = true
+		args["filter_third_party_id"] = *f.thirdPartyID
+	}
+
+	if f.commonTrackerPatternIDs != nil {
+		args["has_common_tracker_pattern_ids_filter"] = true
+		args["filter_common_tracker_pattern_ids"] = f.commonTrackerPatternIDs
 	}
 
 	return args

--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -313,7 +313,7 @@ func (impl *Implm) Run(
 		return err
 	}
 
-	trackerMappingCfg, err := impl.buildTrackerMappingConfig(l, tp, r)
+	trackerMappingCfg, thirdPartyDisambiguationCfg, err := impl.buildTrackerMappingConfig(l, tp, r)
 	if err != nil {
 		return err
 	}
@@ -725,7 +725,7 @@ func (impl *Implm) Run(
 		},
 	)
 
-	trackerMappingWorker := cookiebanner.NewTrackerMappingWorker(pgClient, l, trackerMappingCfg)
+	trackerMappingWorker := cookiebanner.NewTrackerMappingWorker(pgClient, l, trackerMappingCfg, thirdPartyDisambiguationCfg)
 	trackerMappingWorkerCtx, stopTrackerMappingWorker := context.WithCancel(context.Background())
 
 	wg.Go(

--- a/pkg/probod/tracker_mapping.go
+++ b/pkg/probod/tracker_mapping.go
@@ -21,18 +21,28 @@ import (
 	"go.gearno.de/kit/log"
 	"go.opentelemetry.io/otel/trace"
 	"go.probo.inc/probo/pkg/cookiebanner"
+	"go.probo.inc/probo/pkg/thirdparty"
 )
 
-// buildTrackerMappingConfig wires the tracker-mapping agent. It is opt-in:
-// deployments that do not set `llm.tracker-mapping.provider` get a zero
-// config (nil LLM client) so the worker runs without agent fallback.
+// buildTrackerMappingConfig wires the tracker-mapping agent (catalog
+// identification) and the third-party disambiguation agent that the
+// tracker-mapping worker uses to promote patterns to org ThirdParties.
+// Both are opt-in: deployments that do not set
+// `llm.tracker-mapping.provider` get zero configs (nil LLM client) so
+// the worker runs without agent fallback.
+//
+// Both agents are sourced from the same `tracker-mapping` config slot
+// because they share the LLM client, model, and lifecycle. The
+// disambiguation agent has no Firecrawl/DB tools, so its config
+// surface is narrower and it lives in the cross-domain pkg/thirdparty
+// package.
 func (impl *Implm) buildTrackerMappingConfig(
 	l *log.Logger,
 	tp trace.TracerProvider,
 	r prometheus.Registerer,
-) (cookiebanner.TrackerMappingConfig, error) {
+) (cookiebanner.TrackerMappingConfig, thirdparty.DisambiguationConfig, error) {
 	if impl.cfg.Agents.TrackerMapping.Provider == "" {
-		return cookiebanner.TrackerMappingConfig{}, nil
+		return cookiebanner.TrackerMappingConfig{}, thirdparty.DisambiguationConfig{}, nil
 	}
 
 	agentCfg, llmClient, err := impl.resolveAgentClient(
@@ -43,12 +53,19 @@ func (impl *Implm) buildTrackerMappingConfig(
 		r,
 	)
 	if err != nil {
-		return cookiebanner.TrackerMappingConfig{}, fmt.Errorf("cannot resolve tracker mapping agent client: %w", err)
+		return cookiebanner.TrackerMappingConfig{}, thirdparty.DisambiguationConfig{}, fmt.Errorf("cannot resolve tracker mapping agent client: %w", err)
 	}
 
-	return cookiebanner.TrackerMappingConfig{
+	mappingCfg := cookiebanner.TrackerMappingConfig{
 		LLMClient:       llmClient,
 		Model:           agentCfg.ModelName,
 		FirecrawlAPIKey: impl.cfg.Agents.Tools.FirecrawlAPIKey,
-	}, nil
+	}
+
+	disambiguationCfg := thirdparty.DisambiguationConfig{
+		LLMClient: llmClient,
+		Model:     agentCfg.ModelName,
+	}
+
+	return mappingCfg, disambiguationCfg, nil
 }

--- a/pkg/server/api/console/v1/cookie_banner_resolvers.go
+++ b/pkg/server/api/console/v1/cookie_banner_resolvers.go
@@ -16,6 +16,7 @@ import (
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/page"
 	"go.probo.inc/probo/pkg/probo"
+	"go.probo.inc/probo/pkg/server/api/authn"
 	"go.probo.inc/probo/pkg/server/api/console/v1/dataloader"
 	"go.probo.inc/probo/pkg/server/api/console/v1/schema"
 	"go.probo.inc/probo/pkg/server/api/console/v1/types"
@@ -1271,6 +1272,78 @@ func (r *trackerPatternResolver) DetectedCount(ctx context.Context, obj *types.T
 	}
 
 	return count, nil
+}
+
+// ThirdParty is the resolver for the thirdParty field.
+func (r *trackerPatternResolver) ThirdParty(ctx context.Context, obj *types.TrackerPattern) (*types.ThirdParty, error) {
+	if obj.ThirdPartyID == nil {
+		return nil, nil
+	}
+
+	if _, err := r.authorize(ctx, *obj.ThirdPartyID, probo.ActionThirdPartyGet); err != nil {
+		return nil, err
+	}
+
+	loaders := dataloader.FromContext(ctx)
+
+	tp, err := loaders.ThirdParty.Load(ctx, *obj.ThirdPartyID)
+	if err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) || errors.Is(err, dataloadgen.ErrNotFound) {
+			return nil, nil
+		}
+
+		r.logger.ErrorCtx(ctx, "cannot get tracker pattern third party", log.Error(err))
+
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	return types.NewThirdParty(tp), nil
+}
+
+// CommonThirdParty is the resolver for the commonThirdParty field.
+//
+// The org-scoped thirdParty takes priority: when ThirdPartyID is set we
+// short-circuit to nil so the chained common-tracker-pattern lookup is
+// never paid for.
+func (r *trackerPatternResolver) CommonThirdParty(ctx context.Context, obj *types.TrackerPattern) (*types.CommonThirdParty, error) {
+	if obj.ThirdPartyID != nil || obj.CommonTrackerPatternID == nil {
+		return nil, nil
+	}
+
+	identity := authn.IdentityFromContext(ctx)
+	if _, err := r.authorize(ctx, identity.ID, probo.ActionCommonThirdPartyGet); err != nil {
+		return nil, err
+	}
+
+	loaders := dataloader.FromContext(ctx)
+
+	pattern, err := loaders.CommonTrackerPattern.Load(ctx, *obj.CommonTrackerPatternID)
+	if err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) || errors.Is(err, dataloadgen.ErrNotFound) {
+			return nil, nil
+		}
+
+		r.logger.ErrorCtx(ctx, "cannot get common tracker pattern", log.Error(err))
+
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	if pattern.CommonThirdPartyID == nil {
+		return nil, nil
+	}
+
+	party, err := loaders.CommonThirdParty.Load(ctx, *pattern.CommonThirdPartyID)
+	if err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) || errors.Is(err, dataloadgen.ErrNotFound) {
+			return nil, nil
+		}
+
+		r.logger.ErrorCtx(ctx, "cannot get common third party", log.Error(err))
+
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	return types.NewCommonThirdParty(party), nil
 }
 
 // DetectedTrackers is the resolver for the detectedTrackers field.

--- a/pkg/server/api/console/v1/cookie_banner_resolvers.go
+++ b/pkg/server/api/console/v1/cookie_banner_resolvers.go
@@ -14,6 +14,7 @@ import (
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/cookiebanner"
 	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/page"
 	"go.probo.inc/probo/pkg/probo"
 	"go.probo.inc/probo/pkg/server/api/authn"
@@ -210,6 +211,25 @@ func (r *cookieBannerResolver) TrackerPatterns(ctx context.Context, obj *types.C
 	if filter != nil {
 		coredataFilter = coredata.NewTrackerPatternFilter(nil, filter.CookieCategoryID, nil)
 		coredataFilter = coredataFilter.WithQuery(filter.Query).WithSource(filter.Source).WithTrackerType(filter.TrackerType)
+
+		if filter.ThirdPartyID != nil {
+			switch filter.ThirdPartyID.EntityType() {
+			case coredata.ThirdPartyEntityType:
+				coredataFilter = coredataFilter.WithThirdPartyID(filter.ThirdPartyID)
+			case coredata.CommonThirdPartyEntityType:
+				ids, err := r.cookieBanner.LoadCommonTrackerPatternIDsByCommonThirdPartyID(ctx, *filter.ThirdPartyID)
+				if err != nil {
+					r.logger.ErrorCtx(ctx, "cannot resolve common third party tracker patterns", log.Error(err))
+					return nil, gqlutils.Internal(ctx)
+				}
+				if ids == nil {
+					ids = []gid.GID{}
+				}
+				coredataFilter = coredataFilter.WithCommonTrackerPatternIDs(ids)
+			default:
+				return nil, gqlutils.Invalidf(ctx, "thirdPartyId must reference a ThirdParty or CommonThirdParty")
+			}
+		}
 	}
 
 	patterns, err := r.cookieBanner.ListTrackerPatternsForBanner(ctx, scope, obj.ID, cursor, coredataFilter)
@@ -221,6 +241,101 @@ func (r *cookieBannerResolver) TrackerPatterns(ctx context.Context, obj *types.C
 	p := page.NewPage(patterns, cursor)
 
 	return types.NewTrackerPatternConnectionWithFilter(p, r, obj.ID, filter), nil
+}
+
+// LinkedThirdParties is the resolver for the linkedThirdParties field.
+//
+// Aggregates the deduped union of third parties linked to the banner's
+// tracker patterns: the org-scoped ThirdParty values reached through
+// the direct foreign key, plus the global CommonThirdParty values
+// reached indirectly through CommonTrackerPattern. The two sources are
+// independent, so a tracker pattern that has both ThirdPartyID and
+// CommonTrackerPatternID contributes the org-scoped link only — the
+// commonThirdParty resolver follows the same priority and we want the
+// banner-level filter to mirror it.
+func (r *cookieBannerResolver) LinkedThirdParties(ctx context.Context, obj *types.CookieBanner) ([]types.TrackerPatternThirdPartyLink, error) {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionTrackerPatternList); err != nil {
+		return nil, err
+	}
+
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+
+	thirdPartyIDs, err := r.cookieBanner.LoadDistinctThirdPartyIDsByCookieBannerID(ctx, scope, obj.ID)
+	if err != nil {
+		r.logger.ErrorCtx(ctx, "cannot list banner third party links", log.Error(err))
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	commonPatternIDs, err := r.cookieBanner.LoadDistinctCommonTrackerPatternIDsByCookieBannerID(ctx, scope, obj.ID)
+	if err != nil {
+		r.logger.ErrorCtx(ctx, "cannot list banner common tracker pattern links", log.Error(err))
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	out := make([]types.TrackerPatternThirdPartyLink, 0, len(thirdPartyIDs)+len(commonPatternIDs))
+	loaders := dataloader.FromContext(ctx)
+
+	if len(thirdPartyIDs) > 0 {
+		if _, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyGet); err != nil {
+			return nil, err
+		}
+
+		tps, loadErr := loaders.ThirdParty.LoadAll(ctx, thirdPartyIDs)
+		var loadErrs dataloadgen.ErrorSlice
+		if loadErr != nil && !errors.As(loadErr, &loadErrs) {
+			r.logger.ErrorCtx(ctx, "cannot get third parties", log.Error(loadErr))
+			return nil, gqlutils.Internal(ctx)
+		}
+		for i, tp := range tps {
+			if loadErrs != nil && loadErrs[i] != nil {
+				if errors.Is(loadErrs[i], coredata.ErrResourceNotFound) || errors.Is(loadErrs[i], dataloadgen.ErrNotFound) {
+					continue
+				}
+				r.logger.ErrorCtx(ctx, "cannot get third party", log.Error(loadErrs[i]))
+				return nil, gqlutils.Internal(ctx)
+			}
+			out = append(out, types.NewThirdParty(tp))
+		}
+	}
+
+	if len(commonPatternIDs) > 0 {
+		identity := authn.IdentityFromContext(ctx)
+		if _, err := r.authorize(ctx, identity.ID, probo.ActionCommonThirdPartyGet); err != nil {
+			return nil, err
+		}
+
+		patterns, err := r.cookieBanner.GetCommonTrackerPatternsByIDs(ctx, commonPatternIDs...)
+		if err != nil {
+			r.logger.ErrorCtx(ctx, "cannot get common tracker patterns", log.Error(err))
+			return nil, gqlutils.Internal(ctx)
+		}
+
+		seen := make(map[gid.GID]struct{}, len(patterns))
+		commonThirdPartyIDs := make([]gid.GID, 0, len(patterns))
+		for _, p := range patterns {
+			if p.CommonThirdPartyID == nil {
+				continue
+			}
+			if _, ok := seen[*p.CommonThirdPartyID]; ok {
+				continue
+			}
+			seen[*p.CommonThirdPartyID] = struct{}{}
+			commonThirdPartyIDs = append(commonThirdPartyIDs, *p.CommonThirdPartyID)
+		}
+
+		if len(commonThirdPartyIDs) > 0 {
+			parties, err := r.thirdParty.GetCommonThirdPartiesByIDs(ctx, commonThirdPartyIDs...)
+			if err != nil {
+				r.logger.ErrorCtx(ctx, "cannot get common third parties", log.Error(err))
+				return nil, gqlutils.Internal(ctx)
+			}
+			for _, p := range parties {
+				out = append(out, types.NewCommonThirdParty(p))
+			}
+		}
+	}
+
+	return out, nil
 }
 
 // UncategorisedTrackerResources is the resolver for the uncategorisedTrackerResources field.

--- a/pkg/server/api/console/v1/cookie_banner_resolvers.go
+++ b/pkg/server/api/console/v1/cookie_banner_resolvers.go
@@ -49,7 +49,8 @@ func (r *cookieBannerResolver) Organization(ctx context.Context, obj *types.Cook
 
 // Categories is the resolver for the categories field.
 func (r *cookieBannerResolver) Categories(ctx context.Context, obj *types.CookieBanner, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.CookieCategoryOrderBy, filter *types.CookieCategoryFilter) (*types.CookieCategoryConnection, error) {
-	if _, err := r.authorize(ctx, obj.ID, probo.ActionCookieCategoryList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionCookieCategoryList)
+	if err != nil {
 		return nil, err
 	}
 
@@ -65,7 +66,6 @@ func (r *cookieBannerResolver) Categories(ctx context.Context, obj *types.Cookie
 	}
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	var excludeKind *coredata.CookieCategoryKind
 	if filter != nil {
@@ -189,7 +189,8 @@ func (r *cookieBannerResolver) ConsentRecords(ctx context.Context, obj *types.Co
 
 // TrackerPatterns is the resolver for the trackerPatterns field.
 func (r *cookieBannerResolver) TrackerPatterns(ctx context.Context, obj *types.CookieBanner, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TrackerPatternOrderBy, filter *types.TrackerPatternFilter) (*types.TrackerPatternConnection, error) {
-	if _, err := r.authorize(ctx, obj.ID, probo.ActionTrackerPatternList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionTrackerPatternList)
+	if err != nil {
 		return nil, err
 	}
 
@@ -205,7 +206,6 @@ func (r *cookieBannerResolver) TrackerPatterns(ctx context.Context, obj *types.C
 	}
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	coredataFilter := coredata.NewTrackerPatternFilter(nil, nil, nil)
 	if filter != nil {
@@ -254,11 +254,10 @@ func (r *cookieBannerResolver) TrackerPatterns(ctx context.Context, obj *types.C
 // commonThirdParty resolver follows the same priority and we want the
 // banner-level filter to mirror it.
 func (r *cookieBannerResolver) LinkedThirdParties(ctx context.Context, obj *types.CookieBanner) ([]types.TrackerPatternThirdPartyLink, error) {
-	if _, err := r.authorize(ctx, obj.ID, probo.ActionTrackerPatternList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	thirdPartyIDs, err := r.cookieBanner.LoadDistinctThirdPartyIDsByCookieBannerID(ctx, scope, obj.ID)
 	if err != nil {
@@ -276,10 +275,6 @@ func (r *cookieBannerResolver) LinkedThirdParties(ctx context.Context, obj *type
 	loaders := dataloader.FromContext(ctx)
 
 	if len(thirdPartyIDs) > 0 {
-		if _, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyGet); err != nil {
-			return nil, err
-		}
-
 		tps, loadErr := loaders.ThirdParty.LoadAll(ctx, thirdPartyIDs)
 		var loadErrs dataloadgen.ErrorSlice
 		if loadErr != nil && !errors.As(loadErr, &loadErrs) {
@@ -300,7 +295,7 @@ func (r *cookieBannerResolver) LinkedThirdParties(ctx context.Context, obj *type
 
 	if len(commonPatternIDs) > 0 {
 		identity := authn.IdentityFromContext(ctx)
-		if _, err := r.authorize(ctx, identity.ID, probo.ActionCommonThirdPartyGet); err != nil {
+		if _, err := r.authorize(ctx, identity.ID, probo.ActionCommonThirdPartyList); err != nil {
 			return nil, err
 		}
 
@@ -340,7 +335,8 @@ func (r *cookieBannerResolver) LinkedThirdParties(ctx context.Context, obj *type
 
 // UncategorisedTrackerResources is the resolver for the uncategorisedTrackerResources field.
 func (r *cookieBannerResolver) UncategorisedTrackerResources(ctx context.Context, obj *types.CookieBanner, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TrackerResourceOrderBy, filter *types.TrackerResourceFilter) (*types.TrackerResourceConnection, error) {
-	if _, err := r.authorize(ctx, obj.ID, probo.ActionTrackerResourceList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionTrackerResourceList)
+	if err != nil {
 		return nil, err
 	}
 
@@ -356,7 +352,6 @@ func (r *cookieBannerResolver) UncategorisedTrackerResources(ctx context.Context
 	}
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	coredataFilter := coredata.NewTrackerResourceFilter(nil, nil)
 	if filter != nil {
@@ -465,7 +460,8 @@ func (r *cookieCategoryResolver) CookieBanner(ctx context.Context, obj *types.Co
 
 // TrackerPatterns is the resolver for the trackerPatterns field.
 func (r *cookieCategoryResolver) TrackerPatterns(ctx context.Context, obj *types.CookieCategory, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TrackerPatternOrderBy) (*types.TrackerPatternConnection, error) {
-	if _, err := r.authorize(ctx, obj.ID, probo.ActionTrackerPatternList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionTrackerPatternList)
+	if err != nil {
 		return nil, err
 	}
 
@@ -481,7 +477,6 @@ func (r *cookieCategoryResolver) TrackerPatterns(ctx context.Context, obj *types
 	}
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	patterns, err := r.cookieBanner.ListTrackerPatternsForCategory(ctx, scope, obj.ID, cursor)
 	if err != nil {
@@ -496,7 +491,8 @@ func (r *cookieCategoryResolver) TrackerPatterns(ctx context.Context, obj *types
 
 // TrackerResources is the resolver for the trackerResources field.
 func (r *cookieCategoryResolver) TrackerResources(ctx context.Context, obj *types.CookieCategory, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TrackerResourceOrderBy) (*types.TrackerResourceConnection, error) {
-	if _, err := r.authorize(ctx, obj.ID, probo.ActionTrackerResourceList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionTrackerResourceList)
+	if err != nil {
 		return nil, err
 	}
 
@@ -512,7 +508,6 @@ func (r *cookieCategoryResolver) TrackerResources(ctx context.Context, obj *type
 	}
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	resources, err := r.cookieBanner.ListTrackerResourcesForCategory(ctx, scope, obj.ID, cursor)
 	if err != nil {

--- a/pkg/server/api/console/v1/cookie_banner_resolvers.go
+++ b/pkg/server/api/console/v1/cookie_banner_resolvers.go
@@ -222,9 +222,11 @@ func (r *cookieBannerResolver) TrackerPatterns(ctx context.Context, obj *types.C
 					r.logger.ErrorCtx(ctx, "cannot resolve common third party tracker patterns", log.Error(err))
 					return nil, gqlutils.Internal(ctx)
 				}
+
 				if ids == nil {
 					ids = []gid.GID{}
 				}
+
 				coredataFilter = coredataFilter.WithCommonTrackerPatternIDs(ids)
 			default:
 				return nil, gqlutils.Invalidf(ctx, "thirdPartyId must reference a ThirdParty or CommonThirdParty")
@@ -276,19 +278,24 @@ func (r *cookieBannerResolver) LinkedThirdParties(ctx context.Context, obj *type
 
 	if len(thirdPartyIDs) > 0 {
 		tps, loadErr := loaders.ThirdParty.LoadAll(ctx, thirdPartyIDs)
+
 		var loadErrs dataloadgen.ErrorSlice
 		if loadErr != nil && !errors.As(loadErr, &loadErrs) {
 			r.logger.ErrorCtx(ctx, "cannot get third parties", log.Error(loadErr))
 			return nil, gqlutils.Internal(ctx)
 		}
+
 		for i, tp := range tps {
 			if loadErrs != nil && loadErrs[i] != nil {
 				if errors.Is(loadErrs[i], coredata.ErrResourceNotFound) || errors.Is(loadErrs[i], dataloadgen.ErrNotFound) {
 					continue
 				}
+
 				r.logger.ErrorCtx(ctx, "cannot get third party", log.Error(loadErrs[i]))
+
 				return nil, gqlutils.Internal(ctx)
 			}
+
 			out = append(out, types.NewThirdParty(tp))
 		}
 	}
@@ -306,14 +313,17 @@ func (r *cookieBannerResolver) LinkedThirdParties(ctx context.Context, obj *type
 		}
 
 		seen := make(map[gid.GID]struct{}, len(patterns))
+
 		commonThirdPartyIDs := make([]gid.GID, 0, len(patterns))
 		for _, p := range patterns {
 			if p.CommonThirdPartyID == nil {
 				continue
 			}
+
 			if _, ok := seen[*p.CommonThirdPartyID]; ok {
 				continue
 			}
+
 			seen[*p.CommonThirdPartyID] = struct{}{}
 			commonThirdPartyIDs = append(commonThirdPartyIDs, *p.CommonThirdPartyID)
 		}
@@ -324,6 +334,7 @@ func (r *cookieBannerResolver) LinkedThirdParties(ctx context.Context, obj *type
 				r.logger.ErrorCtx(ctx, "cannot get common third parties", log.Error(err))
 				return nil, gqlutils.Internal(ctx)
 			}
+
 			for _, p := range parties {
 				out = append(out, types.NewCommonThirdParty(p))
 			}

--- a/pkg/server/api/console/v1/dataloader/dataloader.go
+++ b/pkg/server/api/console/v1/dataloader/dataloader.go
@@ -29,6 +29,7 @@ import (
 	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/probo"
 	"go.probo.inc/probo/pkg/server/api/authn"
+	"go.probo.inc/probo/pkg/thirdparty"
 )
 
 type (
@@ -51,26 +52,29 @@ type (
 	}
 
 	Loaders struct {
-		Organization   *dataloadgen.Loader[gid.GID, *coredata.Organization]
-		Framework      *dataloadgen.Loader[gid.GID, *coredata.Framework]
-		Control        *dataloadgen.Loader[gid.GID, *coredata.Control]
-		ThirdParty     *dataloadgen.Loader[gid.GID, *coredata.ThirdParty]
-		Document       *dataloadgen.Loader[gid.GID, *coredata.Document]
-		Profile        *dataloadgen.Loader[gid.GID, *coredata.MembershipProfile]
-		Risk           *dataloadgen.Loader[gid.GID, *coredata.Risk]
-		Measure        *dataloadgen.Loader[gid.GID, *coredata.Measure]
-		Task           *dataloadgen.Loader[gid.GID, *coredata.Task]
-		File           *dataloadgen.Loader[gid.GID, *coredata.File]
-		Report         *dataloadgen.Loader[gid.GID, *coredata.Report]
-		CookieBanner   *dataloadgen.Loader[gid.GID, *coredata.CookieBanner]
-		CookieCategory *dataloadgen.Loader[gid.GID, *coredata.CookieCategory]
-		Authorize      *dataloadgen.Loader[AuthorizeKey, AuthorizeResult]
+		Organization         *dataloadgen.Loader[gid.GID, *coredata.Organization]
+		Framework            *dataloadgen.Loader[gid.GID, *coredata.Framework]
+		Control              *dataloadgen.Loader[gid.GID, *coredata.Control]
+		ThirdParty           *dataloadgen.Loader[gid.GID, *coredata.ThirdParty]
+		Document             *dataloadgen.Loader[gid.GID, *coredata.Document]
+		Profile              *dataloadgen.Loader[gid.GID, *coredata.MembershipProfile]
+		Risk                 *dataloadgen.Loader[gid.GID, *coredata.Risk]
+		Measure              *dataloadgen.Loader[gid.GID, *coredata.Measure]
+		Task                 *dataloadgen.Loader[gid.GID, *coredata.Task]
+		File                 *dataloadgen.Loader[gid.GID, *coredata.File]
+		Report               *dataloadgen.Loader[gid.GID, *coredata.Report]
+		CookieBanner         *dataloadgen.Loader[gid.GID, *coredata.CookieBanner]
+		CookieCategory       *dataloadgen.Loader[gid.GID, *coredata.CookieCategory]
+		CommonTrackerPattern *dataloadgen.Loader[gid.GID, *coredata.CommonTrackerPattern]
+		CommonThirdParty     *dataloadgen.Loader[gid.GID, *coredata.CommonThirdParty]
+		Authorize            *dataloadgen.Loader[AuthorizeKey, AuthorizeResult]
 	}
 
 	batchFetcher struct {
 		probo        *probo.Service
 		iam          *iam.Service
 		cookieBanner *cookiebanner.Service
+		thirdParty   *thirdparty.Service
 	}
 )
 
@@ -80,11 +84,16 @@ func FromContext(ctx context.Context) *Loaders {
 	return ctx.Value(loadersKey).(*Loaders)
 }
 
-func NewMiddleware(proboSvc *probo.Service, iamSvc *iam.Service, cookieBannerSvc *cookiebanner.Service) func(http.Handler) http.Handler {
+func NewMiddleware(proboSvc *probo.Service, iamSvc *iam.Service, cookieBannerSvc *cookiebanner.Service, thirdPartySvc *thirdparty.Service) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
-				f := &batchFetcher{probo: proboSvc, iam: iamSvc, cookieBanner: cookieBannerSvc}
+				f := &batchFetcher{
+					probo:        proboSvc,
+					iam:          iamSvc,
+					cookieBanner: cookieBannerSvc,
+					thirdParty:   thirdPartySvc,
+				}
 				loaders := f.newLoaders()
 				ctx := context.WithValue(r.Context(), loadersKey, loaders)
 				next.ServeHTTP(w, r.WithContext(ctx))
@@ -95,19 +104,21 @@ func NewMiddleware(proboSvc *probo.Service, iamSvc *iam.Service, cookieBannerSvc
 
 func (f *batchFetcher) newLoaders() *Loaders {
 	return &Loaders{
-		Organization:   dataloadgen.NewMappedLoader(f.fetchOrganizations),
-		Framework:      dataloadgen.NewMappedLoader(f.fetchFrameworks),
-		Control:        dataloadgen.NewMappedLoader(f.fetchControls),
-		ThirdParty:     dataloadgen.NewMappedLoader(f.fetchThirdParties),
-		Document:       dataloadgen.NewMappedLoader(f.fetchDocuments),
-		Profile:        dataloadgen.NewMappedLoader(f.fetchProfiles),
-		Risk:           dataloadgen.NewMappedLoader(f.fetchRisks),
-		Measure:        dataloadgen.NewMappedLoader(f.fetchMeasures),
-		Task:           dataloadgen.NewMappedLoader(f.fetchTasks),
-		File:           dataloadgen.NewMappedLoader(f.fetchFiles),
-		Report:         dataloadgen.NewMappedLoader(f.fetchReports),
-		CookieBanner:   dataloadgen.NewMappedLoader(f.fetchCookieBanners),
-		CookieCategory: dataloadgen.NewMappedLoader(f.fetchCookieCategories),
+		Organization:         dataloadgen.NewMappedLoader(f.fetchOrganizations),
+		Framework:            dataloadgen.NewMappedLoader(f.fetchFrameworks),
+		Control:              dataloadgen.NewMappedLoader(f.fetchControls),
+		ThirdParty:           dataloadgen.NewMappedLoader(f.fetchThirdParties),
+		Document:             dataloadgen.NewMappedLoader(f.fetchDocuments),
+		Profile:              dataloadgen.NewMappedLoader(f.fetchProfiles),
+		Risk:                 dataloadgen.NewMappedLoader(f.fetchRisks),
+		Measure:              dataloadgen.NewMappedLoader(f.fetchMeasures),
+		Task:                 dataloadgen.NewMappedLoader(f.fetchTasks),
+		File:                 dataloadgen.NewMappedLoader(f.fetchFiles),
+		Report:               dataloadgen.NewMappedLoader(f.fetchReports),
+		CookieBanner:         dataloadgen.NewMappedLoader(f.fetchCookieBanners),
+		CookieCategory:       dataloadgen.NewMappedLoader(f.fetchCookieCategories),
+		CommonTrackerPattern: dataloadgen.NewMappedLoader(f.fetchCommonTrackerPatterns),
+		CommonThirdParty:     dataloadgen.NewMappedLoader(f.fetchCommonThirdParties),
 		Authorize: dataloadgen.NewMappedLoader(
 			f.fetchAuthorizes,
 			dataloadgen.WithoutCache(),
@@ -317,6 +328,34 @@ func (f *batchFetcher) fetchCookieCategories(ctx context.Context, keys []gid.GID
 
 	result := make(map[gid.GID]*coredata.CookieCategory, len(categories))
 	for _, v := range categories {
+		result[v.ID] = v
+	}
+
+	return result, nil
+}
+
+func (f *batchFetcher) fetchCommonTrackerPatterns(ctx context.Context, keys []gid.GID) (map[gid.GID]*coredata.CommonTrackerPattern, error) {
+	patterns, err := f.cookieBanner.GetCommonTrackerPatternsByIDs(ctx, keys...)
+	if err != nil {
+		return nil, fmt.Errorf("cannot batch load common tracker patterns: %w", err)
+	}
+
+	result := make(map[gid.GID]*coredata.CommonTrackerPattern, len(patterns))
+	for _, v := range patterns {
+		result[v.ID] = v
+	}
+
+	return result, nil
+}
+
+func (f *batchFetcher) fetchCommonThirdParties(ctx context.Context, keys []gid.GID) (map[gid.GID]*coredata.CommonThirdParty, error) {
+	parties, err := f.thirdParty.GetCommonThirdPartiesByIDs(ctx, keys...)
+	if err != nil {
+		return nil, fmt.Errorf("cannot batch load common third parties: %w", err)
+	}
+
+	result := make(map[gid.GID]*coredata.CommonThirdParty, len(parties))
+	for _, v := range parties {
 		result[v.ID] = v
 	}
 

--- a/pkg/server/api/console/v1/document_resolvers.go
+++ b/pkg/server/api/console/v1/document_resolvers.go
@@ -683,13 +683,12 @@ func (r *employeeDocumentResolver) Signed(ctx context.Context, obj *types.Employ
 
 // ApprovalState is the resolver for the approvalState field.
 func (r *employeeDocumentResolver) ApprovalState(ctx context.Context, obj *types.EmployeeDocument) (*coredata.DocumentVersionApprovalDecisionState, error) {
-	if _, err := r.authorize(ctx, obj.ID, probo.ActionEmployeeDocumentGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionEmployeeDocumentGet)
+	if err != nil {
 		return nil, err
 	}
 
 	identity := authn.IdentityFromContext(ctx)
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	state, err := r.probo.Documents.GetViewerApprovalState(ctx, scope, obj.ID, identity.ID)
 	if err != nil {
@@ -791,12 +790,12 @@ func (r *employeeDocumentVersionResolver) Signed(ctx context.Context, obj *types
 
 // ApprovalDecision is the resolver for the approvalDecision field.
 func (r *employeeDocumentVersionResolver) ApprovalDecision(ctx context.Context, obj *types.EmployeeDocumentVersion) (*types.DocumentVersionApprovalDecision, error) {
-	if _, err := r.authorize(ctx, obj.DocumentID, probo.ActionEmployeeDocumentGet); err != nil {
+	scope, err := r.authorize(ctx, obj.DocumentID, probo.ActionEmployeeDocumentGet)
+	if err != nil {
 		return nil, err
 	}
 
 	identity := authn.IdentityFromContext(ctx)
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	decision, err := r.probo.DocumentApprovals.GetViewerDecision(ctx, scope, obj.ID, identity.ID)
 	if err != nil {

--- a/pkg/server/api/console/v1/graphql/cookie_banner.graphql
+++ b/pkg/server/api/console/v1/graphql/cookie_banner.graphql
@@ -167,6 +167,15 @@ type CookieBanner implements Node {
         filter: TrackerPatternFilter
     ): TrackerPatternConnection @goField(forceResolver: true)
 
+    """
+    The deduped union of third parties referenced by the banner's
+    tracker patterns, both org-scoped (ThirdParty) and global
+    (CommonThirdParty). Powers the third-party filter combobox on the
+    trackers list page.
+    """
+    linkedThirdParties: [TrackerPatternThirdPartyLink!]!
+        @goField(forceResolver: true)
+
     uncategorisedTrackerResources(
         first: Int
         after: CursorKey
@@ -318,6 +327,14 @@ type TrackerPatternConnection
     pageInfo: PageInfo!
 }
 
+"""
+A third party associated with a banner's tracker patterns. Either the
+tenant-managed ThirdParty (when a pattern was promoted to the org
+catalog) or the global CommonThirdParty linked through a common
+tracker pattern.
+"""
+union TrackerPatternThirdPartyLink = ThirdParty | CommonThirdParty
+
 type TrackerPatternEdge {
     cursor: CursorKey!
     node: TrackerPattern!
@@ -339,6 +356,14 @@ input TrackerPatternFilter
     source: CookieSource
     trackerType: TrackerType
     cookieCategoryId: ID
+    """
+    Filter to tracker patterns linked to a single third party. Accepts
+    either an org-scoped ThirdParty GID (matched against third_party_id)
+    or a global CommonThirdParty GID (matched against the indirect link
+    through common_tracker_patterns). The dispatch happens at the
+    resolver based on the GID entity-type prefix.
+    """
+    thirdPartyId: ID
 }
 
 type DetectedTracker implements Node {

--- a/pkg/server/api/console/v1/graphql/cookie_banner.graphql
+++ b/pkg/server/api/console/v1/graphql/cookie_banner.graphql
@@ -263,7 +263,10 @@ enum TrackerPatternOrderField
         )
 }
 
-type TrackerPattern implements Node {
+type TrackerPattern implements Node
+    @goModel(
+        model: "go.probo.inc/probo/pkg/server/api/console/v1/types.TrackerPattern"
+    ) {
     id: ID!
     cookieCategory: CookieCategory @goField(forceResolver: true)
     trackerType: TrackerType!
@@ -278,6 +281,22 @@ type TrackerPattern implements Node {
     lastMatchedAt: Datetime
     createdAt: Datetime!
     updatedAt: Datetime!
+
+    """
+    The org-scoped third party this pattern is mapped to, if any. Set
+    when the mapping worker promoted the pattern to a tenant-managed
+    ThirdParty record. When this field is non-null, commonThirdParty is
+    always null.
+    """
+    thirdParty: ThirdParty @goField(forceResolver: true)
+
+    """
+    The global third party this pattern is mapped to via the common
+    tracker-pattern catalog. Null when the pattern has its own
+    org-scoped thirdParty, when it has not been mapped, or when the
+    matched common pattern has no common third party.
+    """
+    commonThirdParty: CommonThirdParty @goField(forceResolver: true)
 
     detectedTrackers(
         first: Int

--- a/pkg/server/api/console/v1/organization_resolvers.go
+++ b/pkg/server/api/console/v1/organization_resolvers.go
@@ -1394,7 +1394,8 @@ func (r *profileResolver) Permission(ctx context.Context, obj *types.Profile, ac
 
 // TotalCount is the resolver for the totalCount field.
 func (r *profileConnectionResolver) TotalCount(ctx context.Context, obj *types.ProfileConnection) (int, error) {
-	if _, err := r.authorize(ctx, obj.ParentID, iam.ActionMembershipProfileList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, iam.ActionMembershipProfileList)
+	if err != nil {
 		return 0, err
 	}
 
@@ -1408,8 +1409,6 @@ func (r *profileConnectionResolver) TotalCount(ctx context.Context, obj *types.P
 
 		return count, nil
 	case *documentVersionResolver:
-		scope := coredata.NewScopeFromObjectID(obj.ParentID)
-
 		count, err := r.probo.Documents.CountVersionApprovers(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count document version approvers", log.Error(err))

--- a/pkg/server/api/console/v1/resolver.go
+++ b/pkg/server/api/console/v1/resolver.go
@@ -107,7 +107,7 @@ func NewMux(
 		r.Use(authn.NewAPIKeyMiddleware(iamSvc, tokenSecret))
 		r.Use(authn.NewOAuth2AccessTokenMiddleware(iamSvc))
 		r.Use(authn.NewIdentityPresenceMiddleware())
-		r.Use(dataloader.NewMiddleware(proboSvc, iamSvc, cookieBannerSvc))
+		r.Use(dataloader.NewMiddleware(proboSvc, iamSvc, cookieBannerSvc, thirdPartySvc))
 
 		r.Handle("/graphql", graphqlHandler)
 

--- a/pkg/server/api/console/v1/risk_resolvers.go
+++ b/pkg/server/api/console/v1/risk_resolvers.go
@@ -500,8 +500,6 @@ func (r *riskConnectionResolver) TotalCount(ctx context.Context, obj *types.Risk
 
 		return count, nil
 	case *riskAssessmentScenarioResolver:
-		scope := coredata.NewScopeFromObjectID(obj.ParentID)
-
 		count, err := r.riskManagement.CountRisksForScenarioID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count scenario risks", log.Error(err))

--- a/pkg/server/api/console/v1/types/common_third_party.go
+++ b/pkg/server/api/console/v1/types/common_third_party.go
@@ -37,6 +37,8 @@ type CommonThirdParty struct {
 	LogoFileID                 *gid.GID                    `json:"logoFileId,omitempty"`
 }
 
+func (CommonThirdParty) IsTrackerPatternThirdPartyLink() {}
+
 func NewCommonThirdParty(c *coredata.CommonThirdParty) *CommonThirdParty {
 	return &CommonThirdParty{
 		ID:                         c.ID,

--- a/pkg/server/api/console/v1/types/tracker_pattern.go
+++ b/pkg/server/api/console/v1/types/tracker_pattern.go
@@ -15,6 +15,8 @@
 package types
 
 import (
+	"time"
+
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/page"
@@ -22,6 +24,39 @@ import (
 
 type (
 	TrackerPatternOrderBy OrderBy[coredata.TrackerPatternOrderField]
+
+	// TrackerPattern is the Go model bound to the GraphQL TrackerPattern
+	// type via @goModel. The first block contains the fields gqlgen
+	// fulfills directly from the model; resolver-only fields
+	// (cookieCategory, detectedTrackers, thirdParty, commonThirdParty,
+	// detectedCount, permission) are populated by the resolver.
+	//
+	// ThirdPartyID and CommonTrackerPatternID are not exposed in
+	// GraphQL — they are foreign-key handles the resolver uses to load
+	// the linked third party (org-scoped or via the common catalog)
+	// without re-querying coredata.
+	TrackerPattern struct {
+		ID            gid.GID                          `json:"id"`
+		TrackerType   coredata.TrackerType             `json:"trackerType"`
+		Pattern       string                           `json:"pattern"`
+		MatchType     coredata.TrackerPatternMatchType `json:"matchType"`
+		DisplayName   string                           `json:"displayName"`
+		MaxAgeSeconds *int                             `json:"maxAgeSeconds,omitempty"`
+		Description   string                           `json:"description"`
+		Source        *coredata.CookieSource           `json:"source,omitempty"`
+		Excluded      bool                             `json:"excluded"`
+		LastMatchedAt *time.Time                       `json:"lastMatchedAt,omitempty"`
+		CreatedAt     time.Time                        `json:"createdAt"`
+		UpdatedAt     time.Time                        `json:"updatedAt"`
+
+		CookieCategory   *CookieCategory            `json:"cookieCategory,omitempty"`
+		DetectedTrackers *DetectedTrackerConnection `json:"detectedTrackers,omitempty"`
+		DetectedCount    int                        `json:"detectedCount"`
+		Permission       bool                       `json:"permission"`
+
+		ThirdPartyID           *gid.GID `json:"-"`
+		CommonTrackerPatternID *gid.GID `json:"-"`
+	}
 
 	TrackerPatternConnection struct {
 		TotalCount int
@@ -40,6 +75,9 @@ type (
 		CookieCategoryID *gid.GID
 	}
 )
+
+func (TrackerPattern) IsNode()          {}
+func (t TrackerPattern) GetID() gid.GID { return t.ID }
 
 func NewTrackerPatternConnection(
 	p *page.Page[*coredata.TrackerPattern, coredata.TrackerPatternOrderField],
@@ -89,16 +127,18 @@ func NewTrackerPatternNode(tp *coredata.TrackerPattern) *TrackerPattern {
 				ID: tp.CookieBannerID,
 			},
 		},
-		TrackerType:   tp.TrackerType,
-		Pattern:       tp.Pattern,
-		MatchType:     tp.MatchType,
-		DisplayName:   tp.DisplayName,
-		MaxAgeSeconds: tp.MaxAgeSeconds,
-		Description:   tp.Description,
-		Source:        tp.Source,
-		Excluded:      tp.Excluded,
-		LastMatchedAt: tp.LastMatchedAt,
-		CreatedAt:     tp.CreatedAt,
-		UpdatedAt:     tp.UpdatedAt,
+		TrackerType:            tp.TrackerType,
+		Pattern:                tp.Pattern,
+		MatchType:              tp.MatchType,
+		DisplayName:            tp.DisplayName,
+		MaxAgeSeconds:          tp.MaxAgeSeconds,
+		Description:            tp.Description,
+		Source:                 tp.Source,
+		Excluded:               tp.Excluded,
+		LastMatchedAt:          tp.LastMatchedAt,
+		CreatedAt:              tp.CreatedAt,
+		UpdatedAt:              tp.UpdatedAt,
+		ThirdPartyID:           tp.ThirdPartyID,
+		CommonTrackerPatternID: tp.CommonTrackerPatternID,
 	}
 }

--- a/pkg/server/api/console/v1/types/tracker_pattern.go
+++ b/pkg/server/api/console/v1/types/tracker_pattern.go
@@ -73,6 +73,7 @@ type (
 		Source           *coredata.CookieSource
 		TrackerType      *coredata.TrackerType
 		CookieCategoryID *gid.GID
+		ThirdPartyID     *gid.GID
 	}
 )
 

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -1670,12 +1670,12 @@ func (r *Resolver) UpdateControlTool(ctx context.Context, req *mcp.CallToolReque
 }
 
 func (r *Resolver) LinkControlTool(ctx context.Context, req *mcp.CallToolRequest, input *types.LinkControlInput) (*mcp.CallToolResult, types.LinkControlOutput, error) {
-	scope := coredata.NewScopeFromObjectID(input.ControlID)
 	svc := r.proboSvc
 
 	switch input.ResourceID.EntityType() {
 	case coredata.MeasureEntityType:
-		if _, err := r.Authorize(ctx, input.ControlID, probo.ActionControlMeasureMappingCreate); err != nil {
+		scope, err := r.Authorize(ctx, input.ControlID, probo.ActionControlMeasureMappingCreate)
+		if err != nil {
 			return nil, types.LinkControlOutput{}, err
 		}
 
@@ -1683,7 +1683,8 @@ func (r *Resolver) LinkControlTool(ctx context.Context, req *mcp.CallToolRequest
 			return nil, types.LinkControlOutput{}, fmt.Errorf("failed to link control to measure: %w", err)
 		}
 	case coredata.DocumentEntityType:
-		if _, err := r.Authorize(ctx, input.ControlID, probo.ActionControlDocumentMappingCreate); err != nil {
+		scope, err := r.Authorize(ctx, input.ControlID, probo.ActionControlDocumentMappingCreate)
+		if err != nil {
 			return nil, types.LinkControlOutput{}, err
 		}
 
@@ -1691,7 +1692,8 @@ func (r *Resolver) LinkControlTool(ctx context.Context, req *mcp.CallToolRequest
 			return nil, types.LinkControlOutput{}, fmt.Errorf("failed to link control to document: %w", err)
 		}
 	case coredata.AuditEntityType:
-		if _, err := r.Authorize(ctx, input.ControlID, probo.ActionControlAuditMappingCreate); err != nil {
+		scope, err := r.Authorize(ctx, input.ControlID, probo.ActionControlAuditMappingCreate)
+		if err != nil {
 			return nil, types.LinkControlOutput{}, err
 		}
 
@@ -1699,7 +1701,8 @@ func (r *Resolver) LinkControlTool(ctx context.Context, req *mcp.CallToolRequest
 			return nil, types.LinkControlOutput{}, fmt.Errorf("failed to link control to audit: %w", err)
 		}
 	case coredata.ObligationEntityType:
-		if _, err := r.Authorize(ctx, input.ControlID, probo.ActionControlObligationMappingCreate); err != nil {
+		scope, err := r.Authorize(ctx, input.ControlID, probo.ActionControlObligationMappingCreate)
+		if err != nil {
 			return nil, types.LinkControlOutput{}, err
 		}
 
@@ -1714,12 +1717,12 @@ func (r *Resolver) LinkControlTool(ctx context.Context, req *mcp.CallToolRequest
 }
 
 func (r *Resolver) UnlinkControlTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UnlinkControlInput) (*mcp.CallToolResult, types.UnlinkControlOutput, error) {
-	scope := coredata.NewScopeFromObjectID(input.ControlID)
 	svc := r.proboSvc
 
 	switch input.ResourceID.EntityType() {
 	case coredata.MeasureEntityType:
-		if _, err := r.Authorize(ctx, input.ControlID, probo.ActionControlMeasureMappingDelete); err != nil {
+		scope, err := r.Authorize(ctx, input.ControlID, probo.ActionControlMeasureMappingDelete)
+		if err != nil {
 			return nil, types.UnlinkControlOutput{}, err
 		}
 
@@ -1727,7 +1730,8 @@ func (r *Resolver) UnlinkControlTool(ctx context.Context, req *mcp.CallToolReque
 			return nil, types.UnlinkControlOutput{}, fmt.Errorf("failed to unlink control from measure: %w", err)
 		}
 	case coredata.DocumentEntityType:
-		if _, err := r.Authorize(ctx, input.ControlID, probo.ActionControlDocumentMappingDelete); err != nil {
+		scope, err := r.Authorize(ctx, input.ControlID, probo.ActionControlDocumentMappingDelete)
+		if err != nil {
 			return nil, types.UnlinkControlOutput{}, err
 		}
 
@@ -1735,7 +1739,8 @@ func (r *Resolver) UnlinkControlTool(ctx context.Context, req *mcp.CallToolReque
 			return nil, types.UnlinkControlOutput{}, fmt.Errorf("failed to unlink control from document: %w", err)
 		}
 	case coredata.AuditEntityType:
-		if _, err := r.Authorize(ctx, input.ControlID, probo.ActionControlAuditMappingDelete); err != nil {
+		scope, err := r.Authorize(ctx, input.ControlID, probo.ActionControlAuditMappingDelete)
+		if err != nil {
 			return nil, types.UnlinkControlOutput{}, err
 		}
 
@@ -1743,7 +1748,8 @@ func (r *Resolver) UnlinkControlTool(ctx context.Context, req *mcp.CallToolReque
 			return nil, types.UnlinkControlOutput{}, fmt.Errorf("failed to unlink control from audit: %w", err)
 		}
 	case coredata.ObligationEntityType:
-		if _, err := r.Authorize(ctx, input.ControlID, probo.ActionControlObligationMappingDelete); err != nil {
+		scope, err := r.Authorize(ctx, input.ControlID, probo.ActionControlObligationMappingDelete)
+		if err != nil {
 			return nil, types.UnlinkControlOutput{}, err
 		}
 
@@ -1908,12 +1914,12 @@ func (r *Resolver) ListRiskObligationsTool(ctx context.Context, req *mcp.CallToo
 }
 
 func (r *Resolver) LinkRiskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.LinkRiskInput) (*mcp.CallToolResult, types.LinkRiskOutput, error) {
-	scope := coredata.NewScopeFromObjectID(input.RiskID)
 	svc := r.proboSvc
 
 	switch input.ResourceID.EntityType() {
 	case coredata.DocumentEntityType:
-		if _, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskDocumentMappingCreate); err != nil {
+		scope, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskDocumentMappingCreate)
+		if err != nil {
 			return nil, types.LinkRiskOutput{}, err
 		}
 
@@ -1921,7 +1927,8 @@ func (r *Resolver) LinkRiskTool(ctx context.Context, req *mcp.CallToolRequest, i
 			return nil, types.LinkRiskOutput{}, fmt.Errorf("failed to link risk to document: %w", err)
 		}
 	case coredata.MeasureEntityType:
-		if _, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskMeasureMappingCreate); err != nil {
+		scope, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskMeasureMappingCreate)
+		if err != nil {
 			return nil, types.LinkRiskOutput{}, err
 		}
 
@@ -1929,7 +1936,8 @@ func (r *Resolver) LinkRiskTool(ctx context.Context, req *mcp.CallToolRequest, i
 			return nil, types.LinkRiskOutput{}, fmt.Errorf("failed to link risk to measure: %w", err)
 		}
 	case coredata.ObligationEntityType:
-		if _, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskObligationMappingCreate); err != nil {
+		scope, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskObligationMappingCreate)
+		if err != nil {
 			return nil, types.LinkRiskOutput{}, err
 		}
 
@@ -1944,12 +1952,12 @@ func (r *Resolver) LinkRiskTool(ctx context.Context, req *mcp.CallToolRequest, i
 }
 
 func (r *Resolver) UnlinkRiskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UnlinkRiskInput) (*mcp.CallToolResult, types.UnlinkRiskOutput, error) {
-	scope := coredata.NewScopeFromObjectID(input.RiskID)
 	svc := r.proboSvc
 
 	switch input.ResourceID.EntityType() {
 	case coredata.DocumentEntityType:
-		if _, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskDocumentMappingDelete); err != nil {
+		scope, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskDocumentMappingDelete)
+		if err != nil {
 			return nil, types.UnlinkRiskOutput{}, err
 		}
 
@@ -1957,7 +1965,8 @@ func (r *Resolver) UnlinkRiskTool(ctx context.Context, req *mcp.CallToolRequest,
 			return nil, types.UnlinkRiskOutput{}, fmt.Errorf("failed to unlink risk from document: %w", err)
 		}
 	case coredata.MeasureEntityType:
-		if _, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskMeasureMappingDelete); err != nil {
+		scope, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskMeasureMappingDelete)
+		if err != nil {
 			return nil, types.UnlinkRiskOutput{}, err
 		}
 
@@ -1965,7 +1974,8 @@ func (r *Resolver) UnlinkRiskTool(ctx context.Context, req *mcp.CallToolRequest,
 			return nil, types.UnlinkRiskOutput{}, fmt.Errorf("failed to unlink risk from measure: %w", err)
 		}
 	case coredata.ObligationEntityType:
-		if _, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskObligationMappingDelete); err != nil {
+		scope, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskObligationMappingDelete)
+		if err != nil {
 			return nil, types.UnlinkRiskOutput{}, err
 		}
 
@@ -2305,7 +2315,8 @@ func (r *Resolver) UpdateDocumentTool(ctx context.Context, req *mcp.CallToolRequ
 }
 
 func (r *Resolver) ListDocumentVersionsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListDocumentVersionsInput) (*mcp.CallToolResult, types.ListDocumentVersionsOutput, error) {
-	if _, err := r.Authorize(ctx, input.DocumentID, probo.ActionDocumentVersionList); err != nil {
+	scope, err := r.Authorize(ctx, input.DocumentID, probo.ActionDocumentVersionList)
+	if err != nil {
 		return nil, types.ListDocumentVersionsOutput{}, err
 	}
 
@@ -2322,7 +2333,6 @@ func (r *Resolver) ListDocumentVersionsTool(ctx context.Context, req *mcp.CallTo
 	}
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
-	scope := coredata.NewScopeFromObjectID(input.DocumentID)
 	svc := r.proboSvc
 
 	versionFilter := coredata.NewDocumentVersionFilter()
@@ -2636,12 +2646,12 @@ func (r *Resolver) ListMeasureEvidencesTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) LinkMeasureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.LinkMeasureInput) (*mcp.CallToolResult, types.LinkMeasureOutput, error) {
-	scope := coredata.NewScopeFromObjectID(input.MeasureID)
 	svc := r.proboSvc
 
 	switch input.ResourceID.EntityType() {
 	case coredata.ControlEntityType:
-		if _, err := r.Authorize(ctx, input.MeasureID, probo.ActionControlMeasureMappingCreate); err != nil {
+		scope, err := r.Authorize(ctx, input.MeasureID, probo.ActionControlMeasureMappingCreate)
+		if err != nil {
 			return nil, types.LinkMeasureOutput{}, err
 		}
 
@@ -2649,7 +2659,8 @@ func (r *Resolver) LinkMeasureTool(ctx context.Context, req *mcp.CallToolRequest
 			return nil, types.LinkMeasureOutput{}, fmt.Errorf("failed to link measure to control: %w", err)
 		}
 	case coredata.RiskEntityType:
-		if _, err := r.Authorize(ctx, input.MeasureID, probo.ActionRiskMeasureMappingCreate); err != nil {
+		scope, err := r.Authorize(ctx, input.MeasureID, probo.ActionRiskMeasureMappingCreate)
+		if err != nil {
 			return nil, types.LinkMeasureOutput{}, err
 		}
 
@@ -2657,7 +2668,8 @@ func (r *Resolver) LinkMeasureTool(ctx context.Context, req *mcp.CallToolRequest
 			return nil, types.LinkMeasureOutput{}, fmt.Errorf("failed to link measure to risk: %w", err)
 		}
 	case coredata.DocumentEntityType:
-		if _, err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureDocumentMappingCreate); err != nil {
+		scope, err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureDocumentMappingCreate)
+		if err != nil {
 			return nil, types.LinkMeasureOutput{}, err
 		}
 
@@ -2665,7 +2677,8 @@ func (r *Resolver) LinkMeasureTool(ctx context.Context, req *mcp.CallToolRequest
 			return nil, types.LinkMeasureOutput{}, fmt.Errorf("failed to link measure to document: %w", err)
 		}
 	case coredata.ThirdPartyEntityType:
-		if _, err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureThirdPartyMappingCreate); err != nil {
+		scope, err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureThirdPartyMappingCreate)
+		if err != nil {
 			return nil, types.LinkMeasureOutput{}, err
 		}
 
@@ -2680,12 +2693,12 @@ func (r *Resolver) LinkMeasureTool(ctx context.Context, req *mcp.CallToolRequest
 }
 
 func (r *Resolver) UnlinkMeasureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UnlinkMeasureInput) (*mcp.CallToolResult, types.UnlinkMeasureOutput, error) {
-	scope := coredata.NewScopeFromObjectID(input.MeasureID)
 	svc := r.proboSvc
 
 	switch input.ResourceID.EntityType() {
 	case coredata.ControlEntityType:
-		if _, err := r.Authorize(ctx, input.MeasureID, probo.ActionControlMeasureMappingDelete); err != nil {
+		scope, err := r.Authorize(ctx, input.MeasureID, probo.ActionControlMeasureMappingDelete)
+		if err != nil {
 			return nil, types.UnlinkMeasureOutput{}, err
 		}
 
@@ -2693,7 +2706,8 @@ func (r *Resolver) UnlinkMeasureTool(ctx context.Context, req *mcp.CallToolReque
 			return nil, types.UnlinkMeasureOutput{}, fmt.Errorf("failed to unlink measure from control: %w", err)
 		}
 	case coredata.RiskEntityType:
-		if _, err := r.Authorize(ctx, input.MeasureID, probo.ActionRiskMeasureMappingDelete); err != nil {
+		scope, err := r.Authorize(ctx, input.MeasureID, probo.ActionRiskMeasureMappingDelete)
+		if err != nil {
 			return nil, types.UnlinkMeasureOutput{}, err
 		}
 
@@ -2701,7 +2715,8 @@ func (r *Resolver) UnlinkMeasureTool(ctx context.Context, req *mcp.CallToolReque
 			return nil, types.UnlinkMeasureOutput{}, fmt.Errorf("failed to unlink measure from risk: %w", err)
 		}
 	case coredata.DocumentEntityType:
-		if _, err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureDocumentMappingDelete); err != nil {
+		scope, err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureDocumentMappingDelete)
+		if err != nil {
 			return nil, types.UnlinkMeasureOutput{}, err
 		}
 
@@ -2709,7 +2724,8 @@ func (r *Resolver) UnlinkMeasureTool(ctx context.Context, req *mcp.CallToolReque
 			return nil, types.UnlinkMeasureOutput{}, fmt.Errorf("failed to unlink measure from document: %w", err)
 		}
 	case coredata.ThirdPartyEntityType:
-		if _, err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureThirdPartyMappingDelete); err != nil {
+		scope, err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureThirdPartyMappingDelete)
+		if err != nil {
 			return nil, types.UnlinkMeasureOutput{}, err
 		}
 
@@ -5418,11 +5434,11 @@ func (r *Resolver) PublishThirdPartyListTool(ctx context.Context, req *mcp.CallT
 }
 
 func (r *Resolver) ListCookieBannersTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListCookieBannersInput) (*mcp.CallToolResult, types.ListCookieBannersOutput, error) {
-	if _, err := r.Authorize(ctx, input.OrganizationID, probo.ActionCookieBannerList); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionCookieBannerList)
+	if err != nil {
 		return nil, types.ListCookieBannersOutput{}, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieBannerOrderField]{Field: coredata.CookieBannerOrderFieldCreatedAt, Direction: page.OrderDirectionDesc})
 
 	banners, err := r.cookieBanner.ListCookieBannersForOrganization(ctx, scope, input.OrganizationID, cursor, coredata.NewCookieBannerFilter(nil))
@@ -5436,11 +5452,10 @@ func (r *Resolver) ListCookieBannersTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) GetCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetCookieBannerInput) (*mcp.CallToolResult, types.GetCookieBannerOutput, error) {
-	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerGet)
+	if err != nil {
 		return nil, types.GetCookieBannerOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	banner, err := r.cookieBanner.GetCookieBanner(ctx, scope, input.ID)
 	if err != nil {
@@ -5451,11 +5466,10 @@ func (r *Resolver) GetCookieBannerTool(ctx context.Context, req *mcp.CallToolReq
 }
 
 func (r *Resolver) AddCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddCookieBannerInput) (*mcp.CallToolResult, types.AddCookieBannerOutput, error) {
-	if _, err := r.Authorize(ctx, input.OrganizationID, probo.ActionCookieBannerCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionCookieBannerCreate)
+	if err != nil {
 		return nil, types.AddCookieBannerOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 
 	banner, err := r.cookieBanner.CreateCookieBanner(ctx, scope, cookiebanner.CreateCookieBannerRequest{
 		OrganizationID:    input.OrganizationID,
@@ -5473,11 +5487,10 @@ func (r *Resolver) AddCookieBannerTool(ctx context.Context, req *mcp.CallToolReq
 }
 
 func (r *Resolver) UpdateCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateCookieBannerInput) (*mcp.CallToolResult, types.UpdateCookieBannerOutput, error) {
-	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerUpdate)
+	if err != nil {
 		return nil, types.UpdateCookieBannerOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	updateReq := cookiebanner.UpdateCookieBannerRequest{CookieBannerID: input.ID}
 	if v := UnwrapOmittable(input.Name); v != nil && *v != nil {
@@ -5522,11 +5535,10 @@ func (r *Resolver) DeleteCookieBannerTool(ctx context.Context, req *mcp.CallTool
 }
 
 func (r *Resolver) ActivateCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ActivateCookieBannerInput) (*mcp.CallToolResult, types.ActivateCookieBannerOutput, error) {
-	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerActivate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerActivate)
+	if err != nil {
 		return nil, types.ActivateCookieBannerOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	banner, err := r.cookieBanner.ActivateCookieBanner(ctx, scope, input.ID)
 	if err != nil {
@@ -5537,11 +5549,10 @@ func (r *Resolver) ActivateCookieBannerTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) DeactivateCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeactivateCookieBannerInput) (*mcp.CallToolResult, types.DeactivateCookieBannerOutput, error) {
-	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerDeactivate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerDeactivate)
+	if err != nil {
 		return nil, types.DeactivateCookieBannerOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	banner, err := r.cookieBanner.DeactivateCookieBanner(ctx, scope, input.ID)
 	if err != nil {
@@ -5552,11 +5563,10 @@ func (r *Resolver) DeactivateCookieBannerTool(ctx context.Context, req *mcp.Call
 }
 
 func (r *Resolver) ListCookieCategoriesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListCookieCategoriesInput) (*mcp.CallToolResult, types.ListCookieCategoriesOutput, error) {
-	if _, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieCategoryList); err != nil {
+	scope, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieCategoryList)
+	if err != nil {
 		return nil, types.ListCookieCategoriesOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieCategoryOrderField]{Field: coredata.CookieCategoryOrderFieldRank, Direction: page.OrderDirectionAsc})
 
 	categories, err := r.cookieBanner.ListCategoriesForBanner(ctx, scope, input.CookieBannerID, cursor, coredata.NewCookieCategoryFilter(new(coredata.CookieCategoryKindUncategorised)))
@@ -5570,11 +5580,10 @@ func (r *Resolver) ListCookieCategoriesTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) GetCookieCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetCookieCategoryInput) (*mcp.CallToolResult, types.GetCookieCategoryOutput, error) {
-	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieCategoryGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionCookieCategoryGet)
+	if err != nil {
 		return nil, types.GetCookieCategoryOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	category, err := r.cookieBanner.GetCookieCategory(ctx, scope, input.ID)
 	if err != nil {
@@ -5585,11 +5594,10 @@ func (r *Resolver) GetCookieCategoryTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) AddCookieCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddCookieCategoryInput) (*mcp.CallToolResult, types.AddCookieCategoryOutput, error) {
-	if _, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieCategoryCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieCategoryCreate)
+	if err != nil {
 		return nil, types.AddCookieCategoryOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 
 	category, err := r.cookieBanner.CreateCookieCategory(ctx, scope, cookiebanner.CreateCookieCategoryRequest{
 		CookieBannerID: input.CookieBannerID,
@@ -5606,11 +5614,10 @@ func (r *Resolver) AddCookieCategoryTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) UpdateCookieCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateCookieCategoryInput) (*mcp.CallToolResult, types.UpdateCookieCategoryOutput, error) {
-	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieCategoryUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionCookieCategoryUpdate)
+	if err != nil {
 		return nil, types.UpdateCookieCategoryOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	updateReq := cookiebanner.UpdateCookieCategoryRequest{CookieCategoryID: input.ID}
 	if v := UnwrapOmittable(input.Name); v != nil && *v != nil {
@@ -5647,13 +5654,12 @@ func (r *Resolver) DeleteCookieCategoryTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) ReorderCookieCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ReorderCookieCategoryInput) (*mcp.CallToolResult, types.ReorderCookieCategoryOutput, error) {
-	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieCategoryUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionCookieCategoryUpdate)
+	if err != nil {
 		return nil, types.ReorderCookieCategoryOutput{}, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
-
-	_, err := r.cookieBanner.ReorderCookieCategory(ctx, scope, cookiebanner.ReorderCookieCategoryRequest{
+	_, err = r.cookieBanner.ReorderCookieCategory(ctx, scope, cookiebanner.ReorderCookieCategoryRequest{
 		CookieCategoryID: input.ID,
 		Rank:             input.Rank,
 	})
@@ -5670,11 +5676,10 @@ func (r *Resolver) ReorderCookieCategoryTool(ctx context.Context, req *mcp.CallT
 }
 
 func (r *Resolver) ListTrackerPatternsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListTrackerPatternsInput) (*mcp.CallToolResult, types.ListTrackerPatternsOutput, error) {
-	if _, err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerPatternList); err != nil {
+	scope, err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerPatternList)
+	if err != nil {
 		return nil, types.ListTrackerPatternsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.TrackerPatternOrderField]{Field: coredata.TrackerPatternOrderFieldCreatedAt, Direction: page.OrderDirectionAsc})
 
 	patterns, err := r.cookieBanner.ListTrackerPatternsForCategory(ctx, scope, input.CookieCategoryID, cursor)
@@ -5688,11 +5693,10 @@ func (r *Resolver) ListTrackerPatternsTool(ctx context.Context, req *mcp.CallToo
 }
 
 func (r *Resolver) GetTrackerPatternTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetTrackerPatternInput) (*mcp.CallToolResult, types.GetTrackerPatternOutput, error) {
-	if _, err := r.Authorize(ctx, input.ID, probo.ActionTrackerPatternGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionTrackerPatternGet)
+	if err != nil {
 		return nil, types.GetTrackerPatternOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	pattern, err := r.cookieBanner.GetTrackerPattern(ctx, scope, input.ID)
 	if err != nil {
@@ -5703,11 +5707,10 @@ func (r *Resolver) GetTrackerPatternTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) AddTrackerPatternTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddTrackerPatternInput) (*mcp.CallToolResult, types.AddTrackerPatternOutput, error) {
-	if _, err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerPatternCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerPatternCreate)
+	if err != nil {
 		return nil, types.AddTrackerPatternOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
 
 	pattern, err := r.cookieBanner.CreateTrackerPattern(ctx, scope, cookiebanner.CreateTrackerPatternRequest{
 		CookieCategoryID: input.CookieCategoryID,
@@ -5726,11 +5729,10 @@ func (r *Resolver) AddTrackerPatternTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) UpdateTrackerPatternTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateTrackerPatternInput) (*mcp.CallToolResult, types.UpdateTrackerPatternOutput, error) {
-	if _, err := r.Authorize(ctx, input.ID, probo.ActionTrackerPatternUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionTrackerPatternUpdate)
+	if err != nil {
 		return nil, types.UpdateTrackerPatternOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	updateReq := cookiebanner.UpdateTrackerPatternRequest{TrackerPatternID: input.ID}
 	if input.MaxAgeSeconds.IsSet() {
@@ -5768,11 +5770,10 @@ func (r *Resolver) DeleteTrackerPatternTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) MoveTrackerPatternToCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.MoveTrackerPatternToCategoryInput) (*mcp.CallToolResult, types.MoveTrackerPatternToCategoryOutput, error) {
-	if _, err := r.Authorize(ctx, input.TrackerPatternID, probo.ActionTrackerPatternUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.TrackerPatternID, probo.ActionTrackerPatternUpdate)
+	if err != nil {
 		return nil, types.MoveTrackerPatternToCategoryOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.TrackerPatternID)
 
 	result, err := r.cookieBanner.MoveTrackerPatternToCategory(ctx, scope, cookiebanner.MoveTrackerPatternToCategoryRequest{
 		TrackerPatternID:       input.TrackerPatternID,
@@ -5786,11 +5787,10 @@ func (r *Resolver) MoveTrackerPatternToCategoryTool(ctx context.Context, req *mc
 }
 
 func (r *Resolver) PublishCookieBannerVersionTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishCookieBannerVersionInput) (*mcp.CallToolResult, types.PublishCookieBannerVersionOutput, error) {
-	if _, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerVersionPublish); err != nil {
+	scope, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerVersionPublish)
+	if err != nil {
 		return nil, types.PublishCookieBannerVersionOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 
 	version, err := r.cookieBanner.PublishCookieBannerVersion(ctx, scope, input.CookieBannerID)
 	if err != nil {
@@ -5801,11 +5801,10 @@ func (r *Resolver) PublishCookieBannerVersionTool(ctx context.Context, req *mcp.
 }
 
 func (r *Resolver) ListCookieBannerVersionsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListCookieBannerVersionsInput) (*mcp.CallToolResult, types.ListCookieBannerVersionsOutput, error) {
-	if _, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerVersionList); err != nil {
+	scope, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerVersionList)
+	if err != nil {
 		return nil, types.ListCookieBannerVersionsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieBannerVersionOrderField]{Field: coredata.CookieBannerVersionOrderFieldCreatedAt, Direction: page.OrderDirectionDesc})
 
 	versions, err := r.cookieBanner.ListCookieBannerVersionsForBanner(ctx, scope, input.CookieBannerID, cursor)
@@ -5819,11 +5818,10 @@ func (r *Resolver) ListCookieBannerVersionsTool(ctx context.Context, req *mcp.Ca
 }
 
 func (r *Resolver) UpsertCookieBannerTranslationTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpsertCookieBannerTranslationInput) (*mcp.CallToolResult, types.UpsertCookieBannerTranslationOutput, error) {
-	if _, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerUpdate)
+	if err != nil {
 		return nil, types.UpsertCookieBannerTranslationOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 
 	translation, err := r.cookieBanner.UpsertCookieBannerTranslation(ctx, scope, cookiebanner.UpsertCookieBannerTranslationRequest{
 		CookieBannerID: input.CookieBannerID,
@@ -5838,11 +5836,10 @@ func (r *Resolver) UpsertCookieBannerTranslationTool(ctx context.Context, req *m
 }
 
 func (r *Resolver) ListCookieConsentRecordsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListCookieConsentRecordsInput) (*mcp.CallToolResult, types.ListCookieConsentRecordsOutput, error) {
-	if _, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieConsentRecordList); err != nil {
+	scope, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieConsentRecordList)
+	if err != nil {
 		return nil, types.ListCookieConsentRecordsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieConsentRecordOrderField]{Field: coredata.CookieConsentRecordOrderFieldCreatedAt, Direction: page.OrderDirectionDesc})
 
 	var action *coredata.CookieConsentAction
@@ -5865,11 +5862,10 @@ func (r *Resolver) ListCookieConsentRecordsTool(ctx context.Context, req *mcp.Ca
 }
 
 func (r *Resolver) GetCookieConsentRecordTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetCookieConsentRecordInput) (*mcp.CallToolResult, types.GetCookieConsentRecordOutput, error) {
-	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieConsentRecordList); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionCookieConsentRecordList)
+	if err != nil {
 		return nil, types.GetCookieConsentRecordOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	record, err := r.cookieBanner.GetCookieConsentRecord(ctx, scope, input.ID)
 	if err != nil {
@@ -6064,11 +6060,10 @@ func (r *Resolver) PublishDocumentTool(ctx context.Context, req *mcp.CallToolReq
 }
 
 func (r *Resolver) ListTrackerResourcesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListTrackerResourcesInput) (*mcp.CallToolResult, types.ListTrackerResourcesOutput, error) {
-	if _, err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerResourceList); err != nil {
+	scope, err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerResourceList)
+	if err != nil {
 		return nil, types.ListTrackerResourcesOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.TrackerResourceOrderField]{Field: coredata.TrackerResourceOrderFieldCreatedAt, Direction: page.OrderDirectionAsc})
 
 	resources, err := r.cookieBanner.ListTrackerResourcesForCategory(ctx, scope, input.CookieCategoryID, cursor)
@@ -6082,11 +6077,10 @@ func (r *Resolver) ListTrackerResourcesTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) GetTrackerResourceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetTrackerResourceInput) (*mcp.CallToolResult, types.GetTrackerResourceOutput, error) {
-	if _, err := r.Authorize(ctx, input.ID, probo.ActionTrackerResourceGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionTrackerResourceGet)
+	if err != nil {
 		return nil, types.GetTrackerResourceOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	resource, err := r.cookieBanner.GetTrackerResource(ctx, scope, input.ID)
 	if err != nil {
@@ -6097,11 +6091,10 @@ func (r *Resolver) GetTrackerResourceTool(ctx context.Context, req *mcp.CallTool
 }
 
 func (r *Resolver) AddTrackerResourceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddTrackerResourceInput) (*mcp.CallToolResult, types.AddTrackerResourceOutput, error) {
-	if _, err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerResourceCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerResourceCreate)
+	if err != nil {
 		return nil, types.AddTrackerResourceOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
 
 	description := ""
 	if input.Description != nil {
@@ -6124,11 +6117,10 @@ func (r *Resolver) AddTrackerResourceTool(ctx context.Context, req *mcp.CallTool
 }
 
 func (r *Resolver) UpdateTrackerResourceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateTrackerResourceInput) (*mcp.CallToolResult, types.UpdateTrackerResourceOutput, error) {
-	if _, err := r.Authorize(ctx, input.ID, probo.ActionTrackerResourceUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionTrackerResourceUpdate)
+	if err != nil {
 		return nil, types.UpdateTrackerResourceOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	updateReq := cookiebanner.UpdateTrackerResourceRequest{TrackerResourceID: input.ID}
 	if v := UnwrapOmittable(input.DisplayName); v != nil && *v != nil {
@@ -6165,11 +6157,10 @@ func (r *Resolver) DeleteTrackerResourceTool(ctx context.Context, req *mcp.CallT
 }
 
 func (r *Resolver) MoveTrackerResourceToCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.MoveTrackerResourceToCategoryInput) (*mcp.CallToolResult, types.MoveTrackerResourceToCategoryOutput, error) {
-	if _, err := r.Authorize(ctx, input.TrackerResourceID, probo.ActionTrackerResourceUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.TrackerResourceID, probo.ActionTrackerResourceUpdate)
+	if err != nil {
 		return nil, types.MoveTrackerResourceToCategoryOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.TrackerResourceID)
 
 	result, err := r.cookieBanner.MoveTrackerResourceToCategory(ctx, scope, cookiebanner.MoveTrackerResourceToCategoryRequest{
 		TrackerResourceID:      input.TrackerResourceID,

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -5567,6 +5567,7 @@ func (r *Resolver) ListCookieCategoriesTool(ctx context.Context, req *mcp.CallTo
 	if err != nil {
 		return nil, types.ListCookieCategoriesOutput{}, err
 	}
+
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieCategoryOrderField]{Field: coredata.CookieCategoryOrderFieldRank, Direction: page.OrderDirectionAsc})
 
 	categories, err := r.cookieBanner.ListCategoriesForBanner(ctx, scope, input.CookieBannerID, cursor, coredata.NewCookieCategoryFilter(new(coredata.CookieCategoryKindUncategorised)))
@@ -5680,6 +5681,7 @@ func (r *Resolver) ListTrackerPatternsTool(ctx context.Context, req *mcp.CallToo
 	if err != nil {
 		return nil, types.ListTrackerPatternsOutput{}, err
 	}
+
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.TrackerPatternOrderField]{Field: coredata.TrackerPatternOrderFieldCreatedAt, Direction: page.OrderDirectionAsc})
 
 	patterns, err := r.cookieBanner.ListTrackerPatternsForCategory(ctx, scope, input.CookieCategoryID, cursor)
@@ -5805,6 +5807,7 @@ func (r *Resolver) ListCookieBannerVersionsTool(ctx context.Context, req *mcp.Ca
 	if err != nil {
 		return nil, types.ListCookieBannerVersionsOutput{}, err
 	}
+
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieBannerVersionOrderField]{Field: coredata.CookieBannerVersionOrderFieldCreatedAt, Direction: page.OrderDirectionDesc})
 
 	versions, err := r.cookieBanner.ListCookieBannerVersionsForBanner(ctx, scope, input.CookieBannerID, cursor)
@@ -5840,6 +5843,7 @@ func (r *Resolver) ListCookieConsentRecordsTool(ctx context.Context, req *mcp.Ca
 	if err != nil {
 		return nil, types.ListCookieConsentRecordsOutput{}, err
 	}
+
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieConsentRecordOrderField]{Field: coredata.CookieConsentRecordOrderFieldCreatedAt, Direction: page.OrderDirectionDesc})
 
 	var action *coredata.CookieConsentAction
@@ -6064,6 +6068,7 @@ func (r *Resolver) ListTrackerResourcesTool(ctx context.Context, req *mcp.CallTo
 	if err != nil {
 		return nil, types.ListTrackerResourcesOutput{}, err
 	}
+
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.TrackerResourceOrderField]{Field: coredata.TrackerResourceOrderFieldCreatedAt, Direction: page.OrderDirectionAsc})
 
 	resources, err := r.cookieBanner.ListTrackerResourcesForCategory(ctx, scope, input.CookieCategoryID, cursor)

--- a/pkg/thirdparty/disambiguation_agent.go
+++ b/pkg/thirdparty/disambiguation_agent.go
@@ -1,0 +1,209 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package thirdparty
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/agent"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/llm"
+)
+
+//go:embed prompts/disambiguation.txt.tmpl
+var disambiguationPrompt string
+
+const (
+	// disambiguationConfidenceThreshold is the floor below which we
+	// treat the agent's pick as "no confident match" even when it
+	// returned a non-nil matched_id. Mirrors the conservative bias
+	// described in the prompt.
+	disambiguationConfidenceThreshold = 0.6
+
+	// disambiguationTimeout caps a single disambiguation run. The
+	// agent has no tools and a single turn, so this is mostly a
+	// guard against a hung LLM provider, not a real budget.
+	disambiguationTimeout = 60 * time.Second
+)
+
+// DisambiguationConfig configures the third-party disambiguation
+// agent. The agent has no DB tools and no web-search tools: the
+// candidate list is supplied entirely in the prompt and the agent
+// only picks among it.
+type DisambiguationConfig struct {
+	LLMClient *llm.Client
+	Model     string
+}
+
+// DisambiguationResult is the structured output the disambiguation
+// agent returns when picking the best existing org ThirdParty for a
+// catalog entry.
+type DisambiguationResult struct {
+	MatchedID  *string `json:"matched_id"  jsonschema:"GID of the org third party that best matches, or null if none of the candidates is a confident match."`
+	Confidence float64 `json:"confidence"  jsonschema:"Confidence level from 0.0 to 1.0. Below 0.6 means 'no confident match' and matched_id MUST be null."`
+	Reasoning  string  `json:"reasoning"   jsonschema:"One short sentence describing the rationale."`
+}
+
+// BuildDisambiguationAgent wires the agent that picks the best
+// existing org ThirdParty for a catalog entry. It deliberately has
+// no tools: the candidate list is supplied in the prompt and the
+// agent must only choose among it.
+func BuildDisambiguationAgent(
+	cfg DisambiguationConfig,
+	logger *log.Logger,
+) *agent.Agent {
+	outputType, err := agent.NewOutputType[DisambiguationResult]("third_party_disambiguation")
+	if err != nil {
+		panic(fmt.Sprintf("thirdparty: cannot build disambiguation output type: %s", err))
+	}
+
+	return agent.New(
+		"third-party-disambiguation",
+		cfg.LLMClient,
+		agent.WithInstructions(disambiguationPrompt),
+		agent.WithModel(cfg.Model),
+		agent.WithOutputType(outputType),
+		agent.WithMaxTurns(1),
+		agent.WithLogger(logger),
+	)
+}
+
+// Disambiguate runs the agent against the given catalog third party
+// and candidate list, and returns the matched candidate's ID — or
+// nil when the agent picks "none", returns a confidence below the
+// threshold, or fails. Errors from the agent itself are returned;
+// "no confident match" is not an error.
+//
+// The matched candidate is identified by string equality against the
+// IDs supplied in `candidates`; we never invent IDs from the agent's
+// output, so a model that hallucinates an ID is treated as "none".
+func Disambiguate(
+	ctx context.Context,
+	a *agent.Agent,
+	logger *log.Logger,
+	commonParty coredata.CommonThirdParty,
+	commonDomains coredata.CommonThirdPartyDomains,
+	candidates []ScoredCandidate,
+) (*gid.GID, error) {
+	if a == nil || len(candidates) == 0 {
+		return nil, nil
+	}
+
+	prompt := buildDisambiguationPrompt(commonParty, commonDomains, candidates)
+
+	agentCtx, cancel := context.WithTimeout(ctx, disambiguationTimeout)
+	defer cancel()
+
+	result, err := agent.RunTyped[DisambiguationResult](
+		agentCtx,
+		a,
+		[]llm.Message{
+			{
+				Role:  llm.RoleUser,
+				Parts: []llm.Part{llm.TextPart{Text: prompt}},
+			},
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot run disambiguation agent: %w", err)
+	}
+
+	out := result.Output
+
+	if out.MatchedID == nil || *out.MatchedID == "" {
+		return nil, nil
+	}
+
+	if out.Confidence < disambiguationConfidenceThreshold {
+		logger.InfoCtx(
+			ctx,
+			"disambiguation agent below confidence threshold",
+			log.String("matched_id", *out.MatchedID),
+			log.Float64("confidence", out.Confidence),
+		)
+
+		return nil, nil
+	}
+
+	for _, c := range candidates {
+		if c.ThirdParty.ID.String() == *out.MatchedID {
+			id := c.ThirdParty.ID
+
+			return &id, nil
+		}
+	}
+
+	logger.WarnCtx(
+		ctx,
+		"disambiguation agent returned id not in candidate list",
+		log.String("matched_id", *out.MatchedID),
+	)
+
+	return nil, nil
+}
+
+// buildDisambiguationPrompt formats the catalog third party and the
+// heuristic-ranked candidate list into the user message for the
+// disambiguation agent. The prompt is intentionally compact: the
+// agent only needs ids, names, websites, and the heuristic score to
+// decide.
+func buildDisambiguationPrompt(
+	commonParty coredata.CommonThirdParty,
+	commonDomains coredata.CommonThirdPartyDomains,
+	candidates []ScoredCandidate,
+) string {
+	var b strings.Builder
+
+	b.WriteString("Catalog third party:\n")
+	fmt.Fprintf(&b, "  name: %s\n", commonParty.Name)
+
+	if commonParty.WebsiteURL != nil && *commonParty.WebsiteURL != "" {
+		fmt.Fprintf(&b, "  website: %s\n", *commonParty.WebsiteURL)
+	}
+
+	if len(commonDomains) > 0 {
+		domains := make([]string, len(commonDomains))
+		for i, d := range commonDomains {
+			domains[i] = d.Domain
+		}
+
+		fmt.Fprintf(&b, "  domains: %s\n", strings.Join(domains, ", "))
+	}
+
+	b.WriteString("\nCandidate organisation third parties (heuristic-ranked):\n")
+
+	for i, c := range candidates {
+		fmt.Fprintf(&b, "- id: %s\n", c.ThirdParty.ID.String())
+		fmt.Fprintf(&b, "  name: %s\n", c.ThirdParty.Name)
+
+		if c.ThirdParty.WebsiteURL != nil && *c.ThirdParty.WebsiteURL != "" {
+			fmt.Fprintf(&b, "  website: %s\n", *c.ThirdParty.WebsiteURL)
+		}
+
+		fmt.Fprintf(&b, "  heuristic_score: %.2f\n", c.Score)
+
+		if i < len(candidates)-1 {
+			b.WriteString("\n")
+		}
+	}
+
+	return b.String()
+}

--- a/pkg/thirdparty/match.go
+++ b/pkg/thirdparty/match.go
@@ -1,0 +1,274 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package thirdparty
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/slug"
+	"go.probo.inc/probo/pkg/uri"
+)
+
+// Heuristic thresholds for matching a CommonThirdParty to an existing
+// org ThirdParty. Exported so callers can short-circuit explicitly
+// (skip the agent, fall back to creating, etc.) instead of duplicating
+// magic numbers.
+const (
+	// HighConfidenceScore is the floor at which a heuristic match
+	// is treated as obvious (exact name, suffix-stripped name, slug
+	// equality). Callers typically link without consulting the
+	// agent at this score.
+	HighConfidenceScore = 0.85
+
+	// MinAgentScore is the floor below which a candidate is
+	// statistical noise and should not be shown to the
+	// disambiguation agent. Below this, callers typically prefer
+	// to create a fresh row over asking the model to pick among
+	// weak candidates.
+	MinAgentScore = 0.6
+
+	// MaxAgentCandidates caps the candidate list shown to the
+	// disambiguation agent. The list is heuristic-ranked, so the
+	// top few are the only ones worth the agent's tokens.
+	MaxAgentCandidates = 5
+)
+
+// ScoredCandidate is a scored heuristic-match candidate. It is the
+// unified currency between the heuristic ranker (RankCandidates) and
+// the disambiguation agent (Disambiguate): the agent renders the
+// `ThirdParty` fields plus the score directly into its prompt, with
+// no intermediate DTO.
+type ScoredCandidate struct {
+	ThirdParty *coredata.ThirdParty
+	Score      float64
+}
+
+// corporateSuffixes are the legal-form noise words stripped when
+// comparing third-party names heuristically. The list is intentionally
+// short and conservative: matching "Foo Inc" to "Foo" is safe, but
+// stripping "Group" or "Services" would over-match unrelated entries.
+//
+// Order matters: stripCorporateSuffixes returns on the first match,
+// so longer / comma-prefixed forms must come before their shorter
+// siblings (", inc." before " inc.", which itself comes before " inc").
+var corporateSuffixes = []string{
+	" incorporated",
+	" corporation",
+	", inc.",
+	", inc",
+	" l.l.c.",
+	" s.a.s.",
+	" inc.",
+	" inc",
+	" llc",
+	" ltd.",
+	" ltd",
+	" limited",
+	" gmbh",
+	" s.a.",
+	" sas",
+	" sa",
+	" ag",
+	" plc",
+	" corp.",
+	" corp",
+	" co.",
+	" co",
+	" b.v.",
+	" bv",
+}
+
+// RankCandidates ranks org ThirdParty rows by how likely each is to
+// represent the given CommonThirdParty. Returned slice is sorted by
+// descending score; only candidates with score > 0 are kept. Pure
+// function: no I/O, deterministic on its inputs.
+//
+// Scoring (highest match wins; website-host overlap can lift a name
+// miss to 0.8):
+//
+//   - exact lowercase name                                      = 1.0
+//   - lowercase name with corporate suffix stripped, equal      = 0.9
+//   - slug equality (slug.Make on the org's name)               = 0.85
+//   - website host (eTLD+1) overlap with the catalog domain set = 0.8
+func RankCandidates(
+	commonParty coredata.CommonThirdParty,
+	commonDomains coredata.CommonThirdPartyDomains,
+	candidates coredata.ThirdParties,
+) []ScoredCandidate {
+	commonName := strings.ToLower(strings.TrimSpace(commonParty.Name))
+	commonStripped := stripCorporateSuffixes(commonName)
+	commonSlug := commonParty.Slug
+
+	commonHost := ""
+	if commonParty.WebsiteURL != nil {
+		commonHost = uri.ExtractDomain(*commonParty.WebsiteURL)
+	}
+
+	commonDomainSet := make(map[string]struct{}, len(commonDomains))
+	for _, d := range commonDomains {
+		commonDomainSet[strings.ToLower(d.Domain)] = struct{}{}
+	}
+
+	if commonHost != "" {
+		commonDomainSet[commonHost] = struct{}{}
+	}
+
+	scored := make([]ScoredCandidate, 0, len(candidates))
+
+	for _, tp := range candidates {
+		score := 0.0
+
+		orgName := strings.ToLower(strings.TrimSpace(tp.Name))
+		orgStripped := stripCorporateSuffixes(orgName)
+
+		switch {
+		case orgName != "" && orgName == commonName:
+			score = 1.0
+		case orgStripped != "" && orgStripped == commonStripped:
+			score = 0.9
+		case commonSlug != "" && slug.Make(tp.Name) == commonSlug:
+			score = 0.85
+		}
+
+		if tp.WebsiteURL != nil {
+			orgHost := uri.ExtractDomain(*tp.WebsiteURL)
+			if orgHost != "" {
+				if _, hit := commonDomainSet[orgHost]; hit {
+					if score < 0.8 {
+						score = 0.8
+					}
+				}
+			}
+		}
+
+		if score == 0 {
+			continue
+		}
+
+		scored = append(scored, ScoredCandidate{
+			ThirdParty: tp,
+			Score:      score,
+		})
+	}
+
+	sort.SliceStable(scored, func(i, j int) bool {
+		return scored[i].Score > scored[j].Score
+	})
+
+	return scored
+}
+
+// stripCorporateSuffixes removes a single trailing legal-form suffix
+// from a lowercased name. Only one suffix is stripped to avoid
+// mangling names that happen to end in two stop-words (e.g. "Foo Inc
+// LLC" → "Foo Inc", not "Foo").
+func stripCorporateSuffixes(lowerName string) string {
+	for _, s := range corporateSuffixes {
+		if before, ok := strings.CutSuffix(lowerName, s); ok {
+			return strings.TrimSpace(before)
+		}
+	}
+
+	return lowerName
+}
+
+// LinkToCommon writes common_third_party_id onto an org ThirdParty so
+// future matches against the same CommonThirdParty can short-circuit
+// to the exact-link path in O(1). No-op when the field is already set
+// to commonID; otherwise writes the field via ThirdParty.Update and
+// updates the receiver in place.
+func LinkToCommon(
+	ctx context.Context,
+	tx pg.Tx,
+	scope coredata.Scoper,
+	orgThirdParty *coredata.ThirdParty,
+	commonID gid.GID,
+) error {
+	if orgThirdParty.CommonThirdPartyID != nil && *orgThirdParty.CommonThirdPartyID == commonID {
+		return nil
+	}
+
+	orgThirdParty.CommonThirdPartyID = &commonID
+
+	if err := orgThirdParty.Update(ctx, tx, scope); err != nil {
+		return fmt.Errorf("cannot update third party with common id: %w", err)
+	}
+
+	return nil
+}
+
+// CreateFromCommon inserts a new org ThirdParty seeded from the catalog
+// row (name, category, addresses, URLs, certifications, …). The new row
+// has common_third_party_id pointed at commonParty, an empty Countries
+// list, and ShowOnTrustCenter / FirstLevel both false — mirroring the
+// front-end CreateThirdPartyDialog's "pick from catalog" seeding shape
+// so the result is indistinguishable from a manual creation.
+//
+// Deliberately bypasses any service-level webhook emission: callers
+// that need a webhook for the implicit creation should emit it
+// themselves.
+func CreateFromCommon(
+	ctx context.Context,
+	tx pg.Tx,
+	scope coredata.Scoper,
+	organizationID gid.GID,
+	commonParty coredata.CommonThirdParty,
+) (*coredata.ThirdParty, error) {
+	commonID := commonParty.ID
+	now := time.Now()
+
+	tp := &coredata.ThirdParty{
+		ID:                            gid.New(scope.GetTenantID(), coredata.ThirdPartyEntityType),
+		OrganizationID:                organizationID,
+		CommonThirdPartyID:            &commonID,
+		Name:                          commonParty.Name,
+		Category:                      commonParty.Category,
+		HeadquarterAddress:            commonParty.HeadquarterAddress,
+		LegalName:                     commonParty.LegalName,
+		WebsiteURL:                    commonParty.WebsiteURL,
+		PrivacyPolicyURL:              commonParty.PrivacyPolicyURL,
+		ServiceLevelAgreementURL:      commonParty.ServiceLevelAgreementURL,
+		DataProcessingAgreementURL:    commonParty.DataProcessingAgreementURL,
+		BusinessAssociateAgreementURL: commonParty.BusinessAssociateAgreementURL,
+		SubprocessorsListURL:          commonParty.SubprocessorsListURL,
+		Certifications:                commonParty.Certifications,
+		Countries:                     coredata.CountryCodes{},
+		StatusPageURL:                 commonParty.StatusPageURL,
+		TermsOfServiceURL:             commonParty.TermsOfServiceURL,
+		SecurityPageURL:               commonParty.SecurityPageURL,
+		TrustPageURL:                  commonParty.TrustPageURL,
+		ShowOnTrustCenter:             false,
+		FirstLevel:                    false,
+		CreatedAt:                     now,
+		UpdatedAt:                     now,
+	}
+
+	if tp.Certifications == nil {
+		tp.Certifications = []string{}
+	}
+
+	if err := tp.Insert(ctx, tx, scope); err != nil {
+		return nil, fmt.Errorf("cannot insert org third party: %w", err)
+	}
+
+	return tp, nil
+}

--- a/pkg/thirdparty/match_test.go
+++ b/pkg/thirdparty/match_test.go
@@ -1,0 +1,181 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package thirdparty
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+)
+
+//go:fix inline
+func ptr[T any](v T) *T { return new(v) }
+
+func TestStripCorporateSuffixes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "llc suffix", in: "google llc", want: "google"},
+		{name: "comma inc", in: "stripe, inc", want: "stripe"},
+		{name: "inc dot", in: "meta inc.", want: "meta"},
+		{name: "ltd", in: "deepmind ltd", want: "deepmind"},
+		{name: "gmbh", in: "n8n gmbh", want: "n8n"},
+		{name: "no suffix", in: "cloudflare", want: "cloudflare"},
+		{name: "trailing space", in: "github  inc", want: "github"},
+		{name: "only one suffix stripped", in: "foo inc llc", want: "foo inc"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, stripCorporateSuffixes(tt.in))
+		})
+	}
+}
+
+func TestRankCandidates(t *testing.T) {
+	t.Parallel()
+
+	tenantID := gid.NewTenantID()
+
+	mkTP := func(name, website string) *coredata.ThirdParty {
+		tp := &coredata.ThirdParty{
+			ID:   gid.New(tenantID, coredata.ThirdPartyEntityType),
+			Name: name,
+		}
+
+		if website != "" {
+			tp.WebsiteURL = new(website)
+		}
+
+		return tp
+	}
+
+	t.Run("exact name match scores 1.0", func(t *testing.T) {
+		t.Parallel()
+
+		common := coredata.CommonThirdParty{Name: "Google", Slug: "google"}
+		got := RankCandidates(common, nil, coredata.ThirdParties{
+			mkTP("Google", ""),
+			mkTP("Stripe", ""),
+		})
+
+		require.Len(t, got, 1)
+		assert.Equal(t, 1.0, got[0].Score)
+		assert.Equal(t, "Google", got[0].ThirdParty.Name)
+	})
+
+	t.Run("suffix-stripped name scores 0.9", func(t *testing.T) {
+		t.Parallel()
+
+		common := coredata.CommonThirdParty{Name: "Google", Slug: "google"}
+		got := RankCandidates(common, nil, coredata.ThirdParties{
+			mkTP("Google LLC", ""),
+		})
+
+		require.Len(t, got, 1)
+		assert.Equal(t, 0.9, got[0].Score)
+	})
+
+	t.Run("slug equality scores 0.85", func(t *testing.T) {
+		t.Parallel()
+
+		common := coredata.CommonThirdParty{Name: "Google", Slug: "google"}
+		got := RankCandidates(common, nil, coredata.ThirdParties{
+			mkTP("google!", ""),
+		})
+
+		require.Len(t, got, 1)
+		assert.Equal(t, 0.85, got[0].Score)
+	})
+
+	t.Run("website host overlap scores 0.8 when name does not match", func(t *testing.T) {
+		t.Parallel()
+
+		common := coredata.CommonThirdParty{
+			Name:       "Google Analytics",
+			Slug:       "google-analytics",
+			WebsiteURL: new("https://google.com"),
+		}
+
+		got := RankCandidates(common, nil, coredata.ThirdParties{
+			mkTP("Sundar's Search Co", "https://www.google.com/about"),
+		})
+
+		require.Len(t, got, 1)
+		assert.Equal(t, 0.8, got[0].Score)
+	})
+
+	t.Run("domain set overlap scores 0.8", func(t *testing.T) {
+		t.Parallel()
+
+		common := coredata.CommonThirdParty{Name: "Stripe", Slug: "stripe"}
+		domains := coredata.CommonThirdPartyDomains{
+			{Domain: "stripe.com"},
+			{Domain: "stripe.network"},
+		}
+
+		got := RankCandidates(common, domains, coredata.ThirdParties{
+			mkTP("Payment Processor", "https://api.stripe.com/v1"),
+		})
+
+		require.Len(t, got, 1)
+		assert.Equal(t, 0.8, got[0].Score)
+	})
+
+	t.Run("no match returns empty", func(t *testing.T) {
+		t.Parallel()
+
+		common := coredata.CommonThirdParty{Name: "Stripe", Slug: "stripe"}
+		got := RankCandidates(common, nil, coredata.ThirdParties{
+			mkTP("Acme", "https://acme.example"),
+			mkTP("Widgets Inc", "https://widgets.example"),
+		})
+
+		assert.Empty(t, got)
+	})
+
+	t.Run("ranks descending by score", func(t *testing.T) {
+		t.Parallel()
+
+		common := coredata.CommonThirdParty{
+			Name:       "Google",
+			Slug:       "google",
+			WebsiteURL: new("https://google.com"),
+		}
+
+		got := RankCandidates(common, nil, coredata.ThirdParties{
+			mkTP("Random", "https://google.com"),
+			mkTP("Google", ""),
+			mkTP("Google LLC", ""),
+		})
+
+		require.Len(t, got, 3)
+		assert.Equal(t, "Google", got[0].ThirdParty.Name)
+		assert.Equal(t, 1.0, got[0].Score)
+		assert.Equal(t, "Google LLC", got[1].ThirdParty.Name)
+		assert.Equal(t, 0.9, got[1].Score)
+		assert.Equal(t, "Random", got[2].ThirdParty.Name)
+		assert.Equal(t, 0.8, got[2].Score)
+	})
+}

--- a/pkg/thirdparty/prompts/disambiguation.txt.tmpl
+++ b/pkg/thirdparty/prompts/disambiguation.txt.tmpl
@@ -1,0 +1,25 @@
+<role>
+You are a third-party catalog matcher. The product groups web trackers under a global catalog of "common" third parties (Google Analytics, Stripe, Meta Pixel, …). Each customer organisation also maintains its own list of "third parties" — sometimes seeded from the catalog, sometimes typed manually. Your only job is to decide whether one of the organisation's existing third parties already represents a given catalog entry, so we don't create a duplicate.
+</role>
+
+<task>
+You are given:
+- A catalog third party: name, website, and known domains.
+- A small list of candidate organisation third parties: each with a stable id, a name, and (optionally) a website.
+
+Pick the candidate that best represents the catalog third party, or none.
+
+Return a structured JSON response with:
+- matched_id: the candidate id, or null if none of them is a confident match.
+- confidence: 0.0 to 1.0; below 0.6 means "no confident match" (set matched_id to null in that case).
+- reasoning: one short sentence describing the rationale.
+</task>
+
+<instructions>
+1. The candidates have already been ranked by a heuristic; the list is small (usually a handful). Use that as a hint, but do not trust it blindly.
+2. Treat corporate suffixes (LLC, Inc, Ltd, GmbH, SA, …) as noise. "Google" and "Google LLC" are the same company.
+3. Treat brand/product names as the same when the parent company is obvious: "Google Analytics" maps to "Google" if the org only has the parent. Only do this when the catalog domains plainly match the parent's domains.
+4. Website hostnames and known domains are the strongest signal. If the catalog domain (or its eTLD+1) matches a candidate's website host, they are almost certainly the same.
+5. Be conservative. If two candidates look plausible and you cannot rule one out, return matched_id=null with confidence < 0.6 — we will create a fresh org third party from the catalog rather than risk a wrong link.
+6. Do not invent ids. Return only ids that appear verbatim in the candidate list.
+</instructions>

--- a/pkg/thirdparty/service.go
+++ b/pkg/thirdparty/service.go
@@ -50,6 +50,29 @@ func (s *Service) GenerateLogoURL(
 	return &url, nil
 }
 
+func (s *Service) GetCommonThirdPartiesByIDs(
+	ctx context.Context,
+	ids ...gid.GID,
+) (coredata.CommonThirdParties, error) {
+	var parties coredata.CommonThirdParties
+
+	err := s.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			if err := parties.LoadByIDs(ctx, conn, ids); err != nil {
+				return fmt.Errorf("cannot load common third parties by ids: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return parties, nil
+}
+
 func (s *Service) Search(ctx context.Context, name string) ([]*coredata.CommonThirdParty, error) {
 	var parties coredata.CommonThirdParties
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
<details>
<summary>Coredata (+265 -17)</summary>

- Added batch loaders: `CommonThirdParties.LoadByIDs`, `CommonTrackerPatterns.LoadByIDs`, and distinct ID queries on `TrackerPatterns` for per-banner third-party lookups.
- Extended `TrackerPatternFilter` with `thirdPartyId` and `commonTrackerPatternIds` to filter by org or catalog third party without cross-entity JOINs.
- Allowed updating `ThirdParty.common_third_party_id` to tag org entries with their catalog source.

</details>

<details>
<summary>Service (+1650 -85)</summary>

- On manual move to a category, non-extension tracker patterns without a `third_party_id` now enqueue mapping (`SetMappingRequested`) to create/link a third party.
- Tracker-mapping worker: exact link via `common_tracker_pattern_id`, heuristic ranking, agent disambiguation, then link-or-create from catalog; skips uncategorised patterns.
- New `pkg/thirdparty` helpers: candidate ranking, link/create from catalog, disambiguation agent (+ prompt), and `GetCommonThirdPartiesByIDs`.
- Wired both mapping and disambiguation agents via `probod` and passed into the worker.
- Added comprehensive worker tests.

</details>

<details>
<summary>GraphQL API (+324 -51)</summary>

- Added `CookieBanner.linkedThirdParties` (union of `ThirdParty` and `CommonThirdParty`) to power the trackers-page filter.
- Exposed `TrackerPattern.thirdParty` and `TrackerPattern.commonThirdParty`; priority goes to org `ThirdParty` when present.
- Enabled filtering tracker patterns by `thirdPartyId` (dispatches to org or catalog IDs).
- Introduced request-scoped loaders for `CommonTrackerPattern` and `CommonThirdParty`; mux wires the `thirdparty` service.
- Resolvers now pass the `scope` returned from `authorize` to services (no GID-based reconstruction).

</details>

<details>
<summary>App: console (+81 -1)</summary>

- Trackers page: new “Third party” column and a filter Select backed by `linkedThirdParties`.
- Pattern row and properties: show linked org third party or catalog third party name.

</details>

<details>
<summary>Docs (+91 -8)</summary>

- Documented the “use `authorize` scope, don’t reconstruct” rule and added a Cursor rule to enforce it.
- Clarified agent file naming and responsibilities.

</details>

<details>
<summary>MCP (+99 -103)</summary>

- Tools now use the `scope` returned from `Authorize` per-operation; removed GID-based scope reconstruction.

</details>

<details>
<summary>Other (+59 -0)</summary>

- Added `.cursor` rule `go-authorize-scope.mdc` to ensure resolvers pass the `authorize`-returned scope downstream.

</details>

<sup>Written for commit 3916313ba694c6c73230f0eeab5b1f8ad244a4b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1246?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

