### PR TITLE
Trackers - improve third party mapping, catalog backfilling, third party creation on categorised trackers

### DIFF
--- a/.cursor/rules/go-authorize-scope.mdc
+++ b/.cursor/rules/go-authorize-scope.mdc
@@ -1,0 +1,59 @@
+---
+description: Go authorize — always take scope from authorize, never reconstruct it
+globs: "pkg/server/api/**/*.go"
+alwaysApply: false
+---
+
+# Authorize returns the scope — use it
+
+`r.authorize` (GraphQL) and `r.Authorize` (MCP) return a `*coredata.Scope`
+resolved from the resource's `organization_id` attribute. **Always** pass that
+scope to the downstream service or coredata call. **Never** discard it and
+rebuild a scope with `coredata.NewScopeFromObjectID(...)`.
+
+The two are not identical: `NewScopeFromObjectID(id)` only reads the tenant
+encoded in the GID, while the authorizer derives the scope from the loaded
+resource attributes. Reconstructing the scope from the GID silently drifts
+when the resource lookup changes.
+
+```go
+// GOOD — scope comes from authorize, fed straight to the service
+scope, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyList)
+if err != nil {
+	return nil, err
+}
+
+thirdPartyIDs, err := r.cookieBanner.LoadDistinctThirdPartyIDsByCookieBannerID(ctx, scope, obj.ID)
+
+// BAD — authorize discards scope, then we rebuild it from the same GID
+if _, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyList); err != nil {
+	return nil, err
+}
+
+scope := coredata.NewScopeFromObjectID(obj.ID)
+thirdPartyIDs, err := r.cookieBanner.LoadDistinctThirdPartyIDsByCookieBannerID(ctx, scope, obj.ID)
+```
+
+## When discarding `scope` with `_` is acceptable
+
+Only when **no downstream call needs a scope** — typically authorize calls
+against the caller's `identity.ID` for global / cross-tenant catalogs (e.g.
+`ActionCommonThirdPartyList`, `ActionCommonThirdPartyGet`) whose service
+methods are unscoped. The returned scope would be derived from the identity
+(a nil-tenant principal) and is useless to the caller:
+
+```go
+// GOOD — global catalog, downstream is unscoped
+identity := authn.IdentityFromContext(ctx)
+if _, err := r.authorize(ctx, identity.ID, probo.ActionCommonThirdPartyList); err != nil {
+	return nil, err
+}
+
+parties, err := r.thirdParty.Search(ctx, name) // no scope argument
+```
+
+The same rule applies to `r.batchAuthorize` (GraphQL) and `r.AuthorizeBatch`
+(MCP).
+
+See [`contrib/claude/authorization.md`](../../contrib/claude/authorization.md)
+for the full authorization guide.

--- a/.cursor/rules/go-coredata-load-naming.mdc
+++ b/.cursor/rules/go-coredata-load-naming.mdc
@@ -58,15 +58,20 @@ func (ds *Things) LoadByParentID(
 ) error {
 ```
 
-# No cross-entity JOINs
+# Cross-entity table references
 
-Each entity file in `pkg/coredata` queries only its own table. When data from multiple entities is needed, the caller orchestrates separate calls.
+Each entity file in `pkg/coredata` queries its own table. Never JOIN two
+entity tables to **return columns from both** — the caller orchestrates
+separate calls instead.
 
-- Never JOIN two entity tables inside an entity method.
-- Never return a raw ID belonging to a different entity — return the full entity and let the caller read the foreign key field.
+**Subqueries for filtering are OK.** When the only purpose of the other
+table is to narrow a `WHERE` clause (e.g. `IN (SELECT id FROM ...)`),
+keep it in the query rather than materializing IDs in Go and passing
+them as an `ANY(@ids)` parameter. A subquery keeps the filtering in the
+database and eliminates an extra round trip.
 
 ```go
-// BAD — cross-entity JOIN inside DetectedTrackers
+// BAD — cross-entity JOIN that returns columns from both tables
 q := `
 SELECT ctpd.common_third_party_id
 FROM detected_trackers dt
@@ -80,4 +85,14 @@ filter := coredata.NewCommonThirdPartyDomainFilter(domains)
 var matched coredata.CommonThirdPartyDomains
 err = matched.Load(ctx, conn, 1, filter)
 thirdPartyID := matched[0].CommonThirdPartyID
+
+// GOOD — subquery only used for filtering, no columns returned from it
+q := `
+SELECT id, pattern, tracker_type, ...
+FROM tracker_patterns
+WHERE common_tracker_pattern_id IN (
+    SELECT id FROM common_tracker_patterns
+    WHERE common_third_party_id = @filter_common_third_party_id
+)
+`
 ```

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/resources/CookieBannerResourcesPage.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/resources/CookieBannerResourcesPage.tsx
@@ -187,8 +187,9 @@ export default function CookieBannerResourcesPage({
                     <Th>{__("Type")}</Th>
                     <SortableTh field="ORIGIN">{__("Origin")}</SortableTh>
                     <Th>{__("Path")}</Th>
+                    <Th>{__("Category")}</Th>
                     <SortableTh field="LAST_DETECTED_AT">{__("Last Detected")}</SortableTh>
-                    <Th className="w-28" />
+                    <Th className="w-px" />
                   </Tr>
                 </Thead>
                 <Tbody>

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/resources/_components/TrackerResourceRow.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/resources/_components/TrackerResourceRow.tsx
@@ -16,9 +16,9 @@ import { EyeIcon, EyeSlashIcon } from "@phosphor-icons/react";
 import { formatError, type GraphQLError } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
 import {
+  ActionDropdown,
   Badge,
-  Dropdown,
-  IconArrowBoxLeft,
+  DropdownItem,
   IconPencil,
   IconTrashCan,
   Td,
@@ -26,21 +26,16 @@ import {
   useConfirm,
   useToast,
 } from "@probo/ui";
-import { Suspense, useCallback, useState } from "react";
-import { graphql, useFragment, useMutation, useQueryLoader } from "react-relay";
-import { useParams } from "react-router";
+import { useState } from "react";
+import { graphql, useFragment, useMutation } from "react-relay";
 import { ConnectionHandler } from "relay-runtime";
 
-import type { MoveToCategoryDropdownQuery } from "#/__generated__/core/MoveToCategoryDropdownQuery.graphql";
 import type { TrackerResourceRowDeleteMutation } from "#/__generated__/core/TrackerResourceRowDeleteMutation.graphql";
 import type { TrackerResourceRowFragment$key } from "#/__generated__/core/TrackerResourceRowFragment.graphql";
 import type { TrackerResourceRowMoveMutation } from "#/__generated__/core/TrackerResourceRowMoveMutation.graphql";
 import type { TrackerResourceRowUpdateMutation } from "#/__generated__/core/TrackerResourceRowUpdateMutation.graphql";
 
-import {
-  MoveToCategoryDropdown,
-  moveToCategoryDropdownQuery,
-} from "../../trackers/_components/MoveToCategoryDropdown";
+import { MoveToCategorySelect } from "../../trackers/_components/MoveToCategorySelect";
 
 import { TrackerResourceRowEdit } from "./TrackerResourceRowEdit";
 
@@ -54,6 +49,10 @@ const trackerResourceFragment = graphql`
     description
     excluded
     lastDetectedAt
+    cookieCategory {
+      id
+      name
+    }
   }
 `;
 
@@ -147,22 +146,10 @@ export function TrackerResourceRow({ resourceKey, connectionId }: TrackerResourc
   const { __ } = useTranslate();
   const { toast } = useToast();
   const confirm = useConfirm();
-  const { cookieBannerId } = useParams<{ cookieBannerId: string }>();
   const resource = useFragment(trackerResourceFragment, resourceKey);
   const typeBadge = resourceTypeBadge(resource.type, __);
 
   const [isEditing, setIsEditing] = useState(false);
-  const [categoryQueryRef, loadCategoryQuery]
-    = useQueryLoader<MoveToCategoryDropdownQuery>(moveToCategoryDropdownQuery);
-
-  const handleCategoryDropdownOpen = useCallback(
-    (open: boolean) => {
-      if (open && cookieBannerId) {
-        loadCategoryQuery({ cookieBannerId });
-      }
-    },
-    [loadCategoryQuery, cookieBannerId],
-  );
 
   const [deleteResource]
     = useMutation<TrackerResourceRowDeleteMutation>(deleteResourceMutation);
@@ -310,6 +297,13 @@ export function TrackerResourceRow({ resourceKey, connectionId }: TrackerResourc
         <span className="font-mono text-xs break-all max-w-xs inline-block">{resource.path}</span>
       </Td>
       <Td>
+        <MoveToCategorySelect
+          currentCategoryId={resource.cookieCategory?.id}
+          currentCategoryName={resource.cookieCategory?.name}
+          onSelect={handleMove}
+        />
+      </Td>
+      <Td>
         {resource.lastDetectedAt
           ? (
               <time dateTime={resource.lastDetectedAt}>
@@ -318,7 +312,7 @@ export function TrackerResourceRow({ resourceKey, connectionId }: TrackerResourc
             )
           : <span className="text-txt-tertiary">-</span>}
       </Td>
-      <Td>
+      <Td className="w-px whitespace-nowrap">
         <div className="flex items-center gap-1">
           <button
             type="button"
@@ -328,40 +322,21 @@ export function TrackerResourceRow({ resourceKey, connectionId }: TrackerResourc
           >
             <IconPencil size={14} />
           </button>
-          <Dropdown
-            onOpenChange={handleCategoryDropdownOpen}
-            toggle={(
-              <button
-                type="button"
-                className="p-1 rounded cursor-pointer"
-                title={__("Move to category")}
-              >
-                <IconArrowBoxLeft size={14} />
-              </button>
-            )}
-          >
-            {categoryQueryRef && (
-              <Suspense>
-                <MoveToCategoryDropdown queryRef={categoryQueryRef} onMove={handleMove} />
-              </Suspense>
-            )}
-          </Dropdown>
-          <button
-            type="button"
-            onClick={handleToggleExcluded}
-            className="p-1 rounded cursor-pointer"
-            title={resource.excluded ? __("Include") : __("Exclude")}
-          >
-            {resource.excluded ? <EyeIcon size={14} /> : <EyeSlashIcon size={14} />}
-          </button>
-          <button
-            type="button"
-            onClick={handleDelete}
-            className="p-1 rounded cursor-pointer text-danger-dark"
-            title={__("Delete")}
-          >
-            <IconTrashCan size={14} />
-          </button>
+          <ActionDropdown>
+            <DropdownItem
+              icon={resource.excluded ? EyeIcon : EyeSlashIcon}
+              onSelect={handleToggleExcluded}
+            >
+              {resource.excluded ? __("Include") : __("Exclude")}
+            </DropdownItem>
+            <DropdownItem
+              variant="danger"
+              icon={IconTrashCan}
+              onSelect={handleDelete}
+            >
+              {__("Delete")}
+            </DropdownItem>
+          </ActionDropdown>
         </div>
       </Td>
     </Tr>

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/resources/_components/TrackerResourceRowEdit.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/resources/_components/TrackerResourceRowEdit.tsx
@@ -61,7 +61,7 @@ export function TrackerResourceRowEdit({
           placeholder={__("Display name")}
         />
       </Td>
-      <Td className="pr-3" colSpan={3}>
+      <Td className="pr-3" colSpan={4}>
         <div className="flex items-center gap-2">
           <Input
             {...register("description")}

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/CookieBannerTrackersPage.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/CookieBannerTrackersPage.tsx
@@ -87,7 +87,6 @@ const trackersFragment = graphql`
       ... on CommonThirdParty {
         id
         name
-        logoUrl
       }
     }
     trackerPatterns(
@@ -219,6 +218,15 @@ export default function CookieBannerTrackersPage({
           className="w-72"
         />
         <Select
+          value={thirdPartyFilter ?? "ALL"}
+          onValueChange={handleThirdPartyFilterChange}
+        >
+          <Option value="ALL">{__("All third parties")}</Option>
+          {linkedThirdParties.map(party => (
+            <Option key={party.id} value={party.id}>{party.name}</Option>
+          ))}
+        </Select>
+        <Select
           value={trackerTypeFilter ?? "ALL"}
           onValueChange={handleTrackerTypeFilterChange}
         >
@@ -245,15 +253,6 @@ export default function CookieBannerTrackersPage({
           <Option value="ALL">{__("All categories")}</Option>
           {categories.map(category => (
             <Option key={category.id} value={category.id}>{category.name}</Option>
-          ))}
-        </Select>
-        <Select
-          value={thirdPartyFilter ?? "ALL"}
-          onValueChange={handleThirdPartyFilterChange}
-        >
-          <Option value="ALL">{__("All third parties")}</Option>
-          {linkedThirdParties.map(party => (
-            <Option key={party.id} value={party.id}>{party.name}</Option>
           ))}
         </Select>
       </div>

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/CookieBannerTrackersPage.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/CookieBannerTrackersPage.tsx
@@ -76,14 +76,27 @@ const trackersFragment = graphql`
     source: { type: "CookieSource", defaultValue: null }
     trackerType: { type: "TrackerType", defaultValue: null }
     cookieCategoryId: { type: "ID", defaultValue: null }
+    thirdPartyId: { type: "ID", defaultValue: null }
   ) {
+    linkedThirdParties {
+      __typename
+      ... on ThirdParty {
+        id
+        name
+      }
+      ... on CommonThirdParty {
+        id
+        name
+        logoUrl
+      }
+    }
     trackerPatterns(
       first: $first
       after: $after
       last: $last
       before: $before
       orderBy: $order
-      filter: { query: $query, source: $source, trackerType: $trackerType, cookieCategoryId: $cookieCategoryId }
+      filter: { query: $query, source: $source, trackerType: $trackerType, cookieCategoryId: $cookieCategoryId, thirdPartyId: $thirdPartyId }
     )
       @connection(
         key: "CookieBannerTrackersPage_trackerPatterns"
@@ -120,6 +133,7 @@ export default function CookieBannerTrackersPage({
   const [sourceFilter, setSourceFilter] = useState<CookieSource | null>(null);
   const [trackerTypeFilter, setTrackerTypeFilter] = useState<TrackerType | null>(null);
   const [categoryFilter, setCategoryFilter] = useState<string | null>(null);
+  const [thirdPartyFilter, setThirdPartyFilter] = useState<string | null>(null);
 
   const { data: fragmentData, ...pagination } = usePaginationFragment<
     CookieBannerTrackersPageRefetchQuery,
@@ -128,6 +142,11 @@ export default function CookieBannerTrackersPage({
 
   const connectionId = fragmentData.trackerPatterns.__id;
   const patterns = fragmentData.trackerPatterns.edges.map(edge => edge.node) ?? [];
+  const linkedThirdParties = (fragmentData.linkedThirdParties ?? []).filter(
+    (party): party is Extract<typeof party, { id: string; name: string }> =>
+      party.__typename === "ThirdParty"
+      || party.__typename === "CommonThirdParty",
+  );
 
   const categories = data.node.__typename === "CookieBanner"
     ? data.node.categories.edges.map(edge => edge.node)
@@ -141,6 +160,7 @@ export default function CookieBannerTrackersPage({
           source: sourceFilter,
           trackerType: trackerTypeFilter,
           cookieCategoryId: categoryFilter,
+          thirdPartyId: thirdPartyFilter,
           ...overrides,
         },
         { fetchPolicy: "network-only" },
@@ -170,6 +190,12 @@ export default function CookieBannerTrackersPage({
     refetchFilters({ cookieCategoryId: newCategory });
   };
 
+  const handleThirdPartyFilterChange = (value: string) => {
+    const newThirdParty = value === "ALL" ? null : value;
+    setThirdPartyFilter(newThirdParty);
+    refetchFilters({ thirdPartyId: newThirdParty });
+  };
+
   const refetchWithFilters: ComponentProps<typeof SortableTable>["refetch"] = ({ order }) => {
     pagination.refetch({
       order: { direction: order.direction, field: order.field as TrackerPatternOrderField },
@@ -177,6 +203,7 @@ export default function CookieBannerTrackersPage({
       source: sourceFilter,
       trackerType: trackerTypeFilter,
       cookieCategoryId: categoryFilter,
+      thirdPartyId: thirdPartyFilter,
     });
   };
 
@@ -220,6 +247,15 @@ export default function CookieBannerTrackersPage({
             <Option key={category.id} value={category.id}>{category.name}</Option>
           ))}
         </Select>
+        <Select
+          value={thirdPartyFilter ?? "ALL"}
+          onValueChange={handleThirdPartyFilterChange}
+        >
+          <Option value="ALL">{__("All third parties")}</Option>
+          {linkedThirdParties.map(party => (
+            <Option key={party.id} value={party.id}>{party.name}</Option>
+          ))}
+        </Select>
       </div>
 
       <div className={isPending ? "opacity-50 pointer-events-none transition-opacity" : ""}>
@@ -234,6 +270,7 @@ export default function CookieBannerTrackersPage({
                   <Tr>
                     <Th>{__("Type")}</Th>
                     <SortableTh field="NAME">{__("Name")}</SortableTh>
+                    <Th>{__("Third party")}</Th>
                     <SortableTh field="SOURCE">{__("Source")}</SortableTh>
                     <Th>{__("Category")}</Th>
                     <SortableTh field="LAST_MATCHED_AT">{__("Last Matched")}</SortableTh>

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/CookieBannerTrackersPage.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/CookieBannerTrackersPage.tsx
@@ -272,8 +272,9 @@ export default function CookieBannerTrackersPage({
                     <Th>{__("Third party")}</Th>
                     <SortableTh field="SOURCE">{__("Source")}</SortableTh>
                     <Th>{__("Category")}</Th>
+                    <Th>{__("Max Age")}</Th>
                     <SortableTh field="LAST_MATCHED_AT">{__("Last Matched")}</SortableTh>
-                    <Th className="w-28" />
+                    <Th className="w-px" />
                   </Tr>
                 </Thead>
                 <Tbody>

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/DetectedTrackerRow.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/DetectedTrackerRow.tsx
@@ -12,6 +12,7 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
+import { getTrackerSourceBadge } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
 import { Badge, Td, Tr } from "@probo/ui";
 import { graphql, useFragment } from "react-relay";
@@ -28,14 +29,6 @@ const detectedTrackerFragment = graphql`
     lastDetectedAt
   }
 `;
-
-function sourceBadge(source: string, __: (s: string) => string) {
-  switch (source) {
-    case "SCRIPT": return { label: __("Script"), variant: "info" as const };
-    case "PRE_EXISTING": return { label: __("Pre-existing"), variant: "outline" as const };
-    default: return { label: source, variant: "neutral" as const };
-  }
-}
 
 interface DetectedTrackerRowProps {
   detectedTrackerKey: DetectedTrackerRow_detectedTracker$key;
@@ -63,8 +56,8 @@ export function DetectedTrackerRow({ detectedTrackerKey }: DetectedTrackerRowPro
       <Td>
         {tracker.source
           ? (
-              <Badge variant={sourceBadge(tracker.source, __).variant}>
-                {sourceBadge(tracker.source, __).label}
+              <Badge variant={getTrackerSourceBadge(tracker.source, __).variant}>
+                {getTrackerSourceBadge(tracker.source, __).label}
               </Badge>
             )
           : <span className="text-txt-tertiary">-</span>}

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/MoveToCategorySelect.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/MoveToCategorySelect.tsx
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { useTranslate } from "@probo/i18n";
+import { Option, Select } from "@probo/ui";
+import { Suspense, useCallback } from "react";
+import { type PreloadedQuery, usePreloadedQuery, useQueryLoader } from "react-relay";
+import { useParams } from "react-router";
+
+import type { MoveToCategoryDropdownQuery } from "#/__generated__/core/MoveToCategoryDropdownQuery.graphql";
+
+import { moveToCategoryDropdownQuery } from "./MoveToCategoryDropdown";
+
+interface MoveToCategorySelectProps {
+  currentCategoryId?: string;
+  currentCategoryName?: string;
+  onSelect: (categoryId: string) => void;
+}
+
+export function MoveToCategorySelect({
+  currentCategoryId,
+  currentCategoryName,
+  onSelect,
+}: MoveToCategorySelectProps) {
+  const { cookieBannerId } = useParams<{ cookieBannerId: string }>();
+  const [categoryQueryRef, loadCategoryQuery]
+    = useQueryLoader<MoveToCategoryDropdownQuery>(moveToCategoryDropdownQuery);
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (open && cookieBannerId) {
+        loadCategoryQuery({ cookieBannerId });
+      }
+    },
+    [loadCategoryQuery, cookieBannerId],
+  );
+
+  const handleValueChange = useCallback(
+    (categoryId: string) => {
+      if (categoryId !== currentCategoryId) {
+        onSelect(categoryId);
+      }
+    },
+    [currentCategoryId, onSelect],
+  );
+
+  return (
+    <Select
+      variant="ghost"
+      placeholder={currentCategoryName ?? <span className="text-txt-tertiary">-</span>}
+      onValueChange={handleValueChange}
+      onOpenChange={handleOpenChange}
+    >
+      {categoryQueryRef && (
+        <Suspense>
+          <MoveToCategoryOptions queryRef={categoryQueryRef} />
+        </Suspense>
+      )}
+    </Select>
+  );
+}
+
+interface MoveToCategoryOptionsProps {
+  queryRef: PreloadedQuery<MoveToCategoryDropdownQuery>;
+}
+
+function MoveToCategoryOptions({ queryRef }: MoveToCategoryOptionsProps) {
+  const { __ } = useTranslate();
+  const data = usePreloadedQuery(moveToCategoryDropdownQuery, queryRef);
+
+  if (data.node.__typename !== "CookieBanner") {
+    return null;
+  }
+
+  const categories = data.node.categories.edges.map(e => e.node);
+
+  if (categories.length === 0) {
+    return (
+      <Option value="" disabled className="text-txt-tertiary">
+        {__("No categories")}
+      </Option>
+    );
+  }
+
+  return (
+    <>
+      {categories.map(cat => (
+        <Option key={cat.id} value={cat.id}>
+          {cat.name}
+        </Option>
+      ))}
+    </>
+  );
+}

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternPropertiesSection.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternPropertiesSection.tsx
@@ -34,13 +34,10 @@ const trackerPatternPropertiesSectionFragment = graphql`
       name
     }
     thirdParty {
-      id
       name
     }
     commonThirdParty {
-      id
       name
-      logoUrl
     }
   }
 `;

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternPropertiesSection.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternPropertiesSection.tsx
@@ -12,7 +12,7 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import { humanizeSeconds } from "@probo/helpers";
+import { getTrackerSourceBadge, getTrackerTypeBadge, humanizeSeconds } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
 import { Badge, Card, PropertyRow } from "@probo/ui";
 import { graphql, useFragment } from "react-relay";
@@ -42,25 +42,6 @@ const trackerPatternPropertiesSectionFragment = graphql`
   }
 `;
 
-function trackerTypeBadge(type: string, __: (s: string) => string) {
-  switch (type) {
-    case "COOKIE": return { label: __("Cookie"), variant: "warning" as const };
-    case "LOCAL_STORAGE": return { label: __("localStorage"), variant: "info" as const };
-    case "SESSION_STORAGE": return { label: __("sessionStorage"), variant: "highlight" as const };
-    case "INDEXED_DB": return { label: __("IndexedDB"), variant: "success" as const };
-    case "CACHE_STORAGE": return { label: __("Cache Storage"), variant: "outline" as const };
-    default: return { label: type, variant: "neutral" as const };
-  }
-}
-
-function sourceBadge(source: string, __: (s: string) => string) {
-  switch (source) {
-    case "SCRIPT": return { label: __("Script"), variant: "info" as const };
-    case "PRE_EXISTING": return { label: __("Pre-existing"), variant: "outline" as const };
-    default: return { label: source, variant: "neutral" as const };
-  }
-}
-
 interface TrackerPatternPropertiesSectionProps {
   trackerPatternKey: TrackerPatternPropertiesSection_trackerPattern$key;
 }
@@ -74,7 +55,7 @@ export function TrackerPatternPropertiesSection({
     trackerPatternKey,
   );
 
-  const typeBadge = trackerTypeBadge(pattern.trackerType, __);
+  const typeBadge = getTrackerTypeBadge(pattern.trackerType, __);
 
   return (
     <Card padded>
@@ -89,8 +70,8 @@ export function TrackerPatternPropertiesSection({
       </PropertyRow>
       {pattern.source && (
         <PropertyRow label={__("Source")}>
-          <Badge variant={sourceBadge(pattern.source, __).variant}>
-            {sourceBadge(pattern.source, __).label}
+          <Badge variant={getTrackerSourceBadge(pattern.source, __).variant}>
+            {getTrackerSourceBadge(pattern.source, __).label}
           </Badge>
         </PropertyRow>
       )}

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternPropertiesSection.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternPropertiesSection.tsx
@@ -14,7 +14,7 @@
 
 import { humanizeSeconds } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
-import { Badge, Card, PropertyRow } from "@probo/ui";
+import { Avatar, Badge, Card, PropertyRow } from "@probo/ui";
 import { graphql, useFragment } from "react-relay";
 
 import type { TrackerPatternPropertiesSection_trackerPattern$key } from "#/__generated__/core/TrackerPatternPropertiesSection_trackerPattern.graphql";
@@ -32,6 +32,15 @@ const trackerPatternPropertiesSectionFragment = graphql`
     lastMatchedAt
     cookieCategory {
       name
+    }
+    thirdParty {
+      id
+      name
+    }
+    commonThirdParty {
+      id
+      name
+      logoUrl
     }
   }
 `;
@@ -92,6 +101,26 @@ export function TrackerPatternPropertiesSection({
         <span className="text-sm">
           {pattern.cookieCategory?.name ?? "-"}
         </span>
+      </PropertyRow>
+      <PropertyRow label={__("Third party")}>
+        {pattern.thirdParty
+          ? (
+              <div className="flex items-center gap-2">
+                <Avatar name={pattern.thirdParty.name} />
+                <span className="text-sm">{pattern.thirdParty.name}</span>
+              </div>
+            )
+          : pattern.commonThirdParty
+            ? (
+                <div className="flex items-center gap-2">
+                  <Avatar
+                    name={pattern.commonThirdParty.name}
+                    src={pattern.commonThirdParty.logoUrl}
+                  />
+                  <span className="text-sm">{pattern.commonThirdParty.name}</span>
+                </div>
+              )
+            : <span className="text-txt-tertiary text-sm">-</span>}
       </PropertyRow>
       <PropertyRow label={__("Max Age")}>
         <span className="text-sm">

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternPropertiesSection.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternPropertiesSection.tsx
@@ -14,7 +14,7 @@
 
 import { humanizeSeconds } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
-import { Avatar, Badge, Card, PropertyRow } from "@probo/ui";
+import { Badge, Card, PropertyRow } from "@probo/ui";
 import { graphql, useFragment } from "react-relay";
 
 import type { TrackerPatternPropertiesSection_trackerPattern$key } from "#/__generated__/core/TrackerPatternPropertiesSection_trackerPattern.graphql";
@@ -106,17 +106,12 @@ export function TrackerPatternPropertiesSection({
         {pattern.thirdParty
           ? (
               <div className="flex items-center gap-2">
-                <Avatar name={pattern.thirdParty.name} />
                 <span className="text-sm">{pattern.thirdParty.name}</span>
               </div>
             )
           : pattern.commonThirdParty
             ? (
                 <div className="flex items-center gap-2">
-                  <Avatar
-                    name={pattern.commonThirdParty.name}
-                    src={pattern.commonThirdParty.logoUrl}
-                  />
                   <span className="text-sm">{pattern.commonThirdParty.name}</span>
                 </div>
               )

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternRow.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternRow.tsx
@@ -13,7 +13,7 @@
 // PERFORMANCE OF THIS SOFTWARE.
 
 import { EyeIcon, EyeSlashIcon } from "@phosphor-icons/react";
-import { formatError, type GraphQLError } from "@probo/helpers";
+import { formatError, getTrackerSourceBadge, getTrackerTypeBadge, type GraphQLError } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
 import {
   Badge,
@@ -133,25 +133,6 @@ const updatePatternMutation = graphql`
     }
   }
 `;
-
-function trackerTypeBadge(type: string, __: (s: string) => string) {
-  switch (type) {
-    case "COOKIE": return { label: __("Cookie"), variant: "warning" as const };
-    case "LOCAL_STORAGE": return { label: __("localStorage"), variant: "info" as const };
-    case "SESSION_STORAGE": return { label: __("sessionStorage"), variant: "highlight" as const };
-    case "INDEXED_DB": return { label: __("IndexedDB"), variant: "success" as const };
-    case "CACHE_STORAGE": return { label: __("Cache Storage"), variant: "outline" as const };
-    default: return { label: type, variant: "neutral" as const };
-  }
-}
-
-function sourceBadge(source: string, __: (s: string) => string) {
-  switch (source) {
-    case "SCRIPT": return { label: __("Script"), variant: "info" as const };
-    case "PRE_EXISTING": return { label: __("Pre-existing"), variant: "outline" as const };
-    default: return { label: source, variant: "neutral" as const };
-  }
-}
 
 interface TrackerPatternRowProps {
   patternKey: TrackerPatternRowFragment$key;
@@ -304,8 +285,8 @@ export function TrackerPatternRow({ patternKey, connectionId }: TrackerPatternRo
     );
   }
 
-  const typeBadge = trackerTypeBadge(pattern.trackerType, __);
-  const srcBadge = pattern.source ? sourceBadge(pattern.source, __) : null;
+  const typeBadge = getTrackerTypeBadge(pattern.trackerType, __);
+  const srcBadge = pattern.source ? getTrackerSourceBadge(pattern.source, __) : null;
 
   return (
     <Tr to={pattern.id} className={pattern.excluded ? "bg-txt-quaternary opacity-80  line-through" : undefined}>

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternRow.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternRow.tsx
@@ -16,7 +16,6 @@ import { EyeIcon, EyeSlashIcon } from "@phosphor-icons/react";
 import { formatError, type GraphQLError } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
 import {
-  Avatar,
   Badge,
   Dropdown,
   IconArrowBoxLeft,
@@ -64,7 +63,6 @@ const trackerPatternFragment = graphql`
     commonThirdParty {
       id
       name
-      logoUrl
     }
   }
 `;
@@ -328,17 +326,12 @@ export function TrackerPatternRow({ patternKey, connectionId }: TrackerPatternRo
         {pattern.thirdParty
           ? (
               <div className="flex items-center gap-2 min-w-0">
-                <Avatar name={pattern.thirdParty.name} />
                 <span className="truncate">{pattern.thirdParty.name}</span>
               </div>
             )
           : pattern.commonThirdParty
             ? (
                 <div className="flex items-center gap-2 min-w-0">
-                  <Avatar
-                    name={pattern.commonThirdParty.name}
-                    src={pattern.commonThirdParty.logoUrl}
-                  />
                   <span className="truncate">{pattern.commonThirdParty.name}</span>
                 </div>
               )

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternRow.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternRow.tsx
@@ -16,6 +16,7 @@ import { EyeIcon, EyeSlashIcon } from "@phosphor-icons/react";
 import { formatError, type GraphQLError } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
 import {
+  Avatar,
   Badge,
   Dropdown,
   IconArrowBoxLeft,
@@ -55,6 +56,15 @@ const trackerPatternFragment = graphql`
     lastMatchedAt
     cookieCategory {
       name
+    }
+    thirdParty {
+      id
+      name
+    }
+    commonThirdParty {
+      id
+      name
+      logoUrl
     }
   }
 `;
@@ -313,6 +323,26 @@ export function TrackerPatternRow({ patternKey, connectionId }: TrackerPatternRo
             </span>
           )}
         </div>
+      </Td>
+      <Td>
+        {pattern.thirdParty
+          ? (
+              <div className="flex items-center gap-2 min-w-0">
+                <Avatar name={pattern.thirdParty.name} />
+                <span className="truncate">{pattern.thirdParty.name}</span>
+              </div>
+            )
+          : pattern.commonThirdParty
+            ? (
+                <div className="flex items-center gap-2 min-w-0">
+                  <Avatar
+                    name={pattern.commonThirdParty.name}
+                    src={pattern.commonThirdParty.logoUrl}
+                  />
+                  <span className="truncate">{pattern.commonThirdParty.name}</span>
+                </div>
+              )
+            : <span className="text-txt-tertiary">-</span>}
       </Td>
       <Td>
         {srcBadge

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternRow.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternRow.tsx
@@ -13,12 +13,12 @@
 // PERFORMANCE OF THIS SOFTWARE.
 
 import { EyeIcon, EyeSlashIcon } from "@phosphor-icons/react";
-import { formatError, getTrackerSourceBadge, getTrackerTypeBadge, type GraphQLError } from "@probo/helpers";
+import { formatError, getTrackerSourceBadge, getTrackerTypeBadge, type GraphQLError, humanizeSeconds } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
 import {
+  ActionDropdown,
   Badge,
-  Dropdown,
-  IconArrowBoxLeft,
+  DropdownItem,
   IconPencil,
   IconTrashCan,
   Td,
@@ -26,21 +26,16 @@ import {
   useConfirm,
   useToast,
 } from "@probo/ui";
-import { Suspense, useCallback, useState } from "react";
-import { graphql, useFragment, useMutation, useQueryLoader } from "react-relay";
-import { useParams } from "react-router";
+import { useState } from "react";
+import { graphql, useFragment, useMutation } from "react-relay";
 import { ConnectionHandler } from "relay-runtime";
 
-import type { MoveToCategoryDropdownQuery } from "#/__generated__/core/MoveToCategoryDropdownQuery.graphql";
 import type { TrackerPatternRowDeleteMutation } from "#/__generated__/core/TrackerPatternRowDeleteMutation.graphql";
 import type { TrackerPatternRowFragment$key } from "#/__generated__/core/TrackerPatternRowFragment.graphql";
 import type { TrackerPatternRowMoveMutation } from "#/__generated__/core/TrackerPatternRowMoveMutation.graphql";
 import type { TrackerPatternRowUpdateMutation } from "#/__generated__/core/TrackerPatternRowUpdateMutation.graphql";
 
-import {
-  MoveToCategoryDropdown,
-  moveToCategoryDropdownQuery,
-} from "./MoveToCategoryDropdown";
+import { MoveToCategorySelect } from "./MoveToCategorySelect";
 import { TrackerPatternRowEdit } from "./TrackerPatternRowEdit";
 
 const trackerPatternFragment = graphql`
@@ -54,6 +49,7 @@ const trackerPatternFragment = graphql`
     excluded
     lastMatchedAt
     cookieCategory {
+      id
       name
     }
     thirdParty {
@@ -143,21 +139,9 @@ export function TrackerPatternRow({ patternKey, connectionId }: TrackerPatternRo
   const { __ } = useTranslate();
   const { toast } = useToast();
   const confirm = useConfirm();
-  const { cookieBannerId } = useParams<{ cookieBannerId: string }>();
   const pattern = useFragment(trackerPatternFragment, patternKey);
 
   const [isEditing, setIsEditing] = useState(false);
-  const [categoryQueryRef, loadCategoryQuery]
-    = useQueryLoader<MoveToCategoryDropdownQuery>(moveToCategoryDropdownQuery);
-
-  const handleCategoryDropdownOpen = useCallback(
-    (open: boolean) => {
-      if (open && cookieBannerId) {
-        loadCategoryQuery({ cookieBannerId });
-      }
-    },
-    [loadCategoryQuery, cookieBannerId],
-  );
 
   const [deletePattern]
     = useMutation<TrackerPatternRowDeleteMutation>(deletePatternMutation);
@@ -227,6 +211,22 @@ export function TrackerPatternRow({ patternKey, connectionId }: TrackerPatternRo
         toast({ title: __("Error"), description: formatError(__("Failed to move cookie"), error as GraphQLError), variant: "error" });
       },
     });
+  };
+
+  const handleMoveWithConfirm = (targetCategoryId: string) => {
+    if (targetCategoryId === pattern.cookieCategory?.id) {
+      return;
+    }
+    confirm(
+      () => {
+        handleMove(targetCategoryId);
+      },
+      {
+        message: __("Moving this tracker to a category will create a third party for it (or link an existing one) if it doesn't have one yet. Continue?"),
+        variant: "primary",
+        label: __("Move"),
+      },
+    );
   };
 
   const handleToggleExcluded = () => {
@@ -323,10 +323,15 @@ export function TrackerPatternRow({ patternKey, connectionId }: TrackerPatternRo
           ? <Badge variant={srcBadge.variant}>{srcBadge.label}</Badge>
           : <span className="text-txt-tertiary">-</span>}
       </Td>
+      <Td noLink>
+        <MoveToCategorySelect
+          currentCategoryId={pattern.cookieCategory?.id}
+          currentCategoryName={pattern.cookieCategory?.name}
+          onSelect={handleMoveWithConfirm}
+        />
+      </Td>
       <Td>
-        {pattern.cookieCategory
-          ? <span>{pattern.cookieCategory.name}</span>
-          : <span className="text-txt-tertiary">-</span>}
+        <span>{humanizeSeconds(pattern.maxAgeSeconds ?? null)}</span>
       </Td>
       <Td>
         {pattern.lastMatchedAt
@@ -337,7 +342,7 @@ export function TrackerPatternRow({ patternKey, connectionId }: TrackerPatternRo
             )
           : <span className="text-txt-tertiary">-</span>}
       </Td>
-      <Td>
+      <Td noLink className="w-px whitespace-nowrap">
         <div className="flex items-center gap-1">
           <button
             type="button"
@@ -347,40 +352,21 @@ export function TrackerPatternRow({ patternKey, connectionId }: TrackerPatternRo
           >
             <IconPencil size={14} />
           </button>
-          <Dropdown
-            onOpenChange={handleCategoryDropdownOpen}
-            toggle={(
-              <button
-                type="button"
-                className="p-1 rounded cursor-pointer"
-                title={__("Move to category")}
-              >
-                <IconArrowBoxLeft size={14} />
-              </button>
-            )}
-          >
-            {categoryQueryRef && (
-              <Suspense>
-                <MoveToCategoryDropdown queryRef={categoryQueryRef} onMove={handleMove} />
-              </Suspense>
-            )}
-          </Dropdown>
-          <button
-            type="button"
-            onClick={handleToggleExcluded}
-            className="p-1 rounded cursor-pointer"
-            title={pattern.excluded ? __("Include") : __("Exclude")}
-          >
-            {pattern.excluded ? <EyeIcon size={14} /> : <EyeSlashIcon size={14} />}
-          </button>
-          <button
-            type="button"
-            onClick={handleDelete}
-            className="p-1 rounded cursor-pointer text-danger-dark"
-            title={__("Delete")}
-          >
-            <IconTrashCan size={14} />
-          </button>
+          <ActionDropdown>
+            <DropdownItem
+              icon={pattern.excluded ? EyeIcon : EyeSlashIcon}
+              onSelect={handleToggleExcluded}
+            >
+              {pattern.excluded ? __("Include") : __("Exclude")}
+            </DropdownItem>
+            <DropdownItem
+              variant="danger"
+              icon={IconTrashCan}
+              onSelect={handleDelete}
+            >
+              {__("Delete")}
+            </DropdownItem>
+          </ActionDropdown>
         </div>
       </Td>
     </Tr>

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternRowEdit.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/trackers/_components/TrackerPatternRowEdit.tsx
@@ -58,44 +58,45 @@ export function TrackerPatternRowEdit({
 
   return (
     <Tr>
-      <Td className="pr-3">
-        <span className="font-medium">{pattern}</span>
-      </Td>
-      <Td />
-      <Td />
-      <Td className="pr-3">
-        <Controller
-          name="duration"
-          control={control}
-          render={({ field }) => (
-            <DurationInput
-              value={field.value.value}
-              unit={field.value.unit}
-              onValueChange={v => field.onChange({ ...field.value, value: v })}
-              onUnitChange={u => field.onChange({ ...field.value, unit: u })}
-            />
-          )}
-        />
-      </Td>
-      <Td className="pr-3" colSpan={2}>
-        <div className="flex items-center gap-2">
-          <Input
-            {...register("description")}
-            placeholder={__("Description")}
-            className="flex-1"
-          />
-          <Button
-            onClick={() => void handleSubmit(onSubmit)()}
-            disabled={isUpdating}
-          >
-            {__("Save")}
-          </Button>
-          <Button
-            variant="secondary"
-            onClick={onCancel}
-          >
-            {__("Cancel")}
-          </Button>
+      <Td colSpan={8}>
+        <div className="flex flex-col gap-3">
+          <span className="font-medium wrap-break-word">{pattern}</span>
+          <div className="flex items-end gap-2">
+            <div className="flex flex-col gap-1 flex-1">
+              <label className="text-xs text-txt-tertiary">{__("Description")}</label>
+              <Input
+                {...register("description")}
+                placeholder={__("Description")}
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-xs text-txt-tertiary">{__("Max Age")}</label>
+              <Controller
+                name="duration"
+                control={control}
+                render={({ field }) => (
+                  <DurationInput
+                    value={field.value.value}
+                    unit={field.value.unit}
+                    onValueChange={v => field.onChange({ ...field.value, value: v })}
+                    onUnitChange={u => field.onChange({ ...field.value, unit: u })}
+                  />
+                )}
+              />
+            </div>
+            <Button
+              onClick={() => void handleSubmit(onSubmit)()}
+              disabled={isUpdating}
+            >
+              {__("Save")}
+            </Button>
+            <Button
+              variant="secondary"
+              onClick={onCancel}
+            >
+              {__("Cancel")}
+            </Button>
+          </div>
         </div>
       </Td>
     </Tr>

--- a/contrib/claude/authorization.md
+++ b/contrib/claude/authorization.md
@@ -178,7 +178,7 @@ var (
 
 **GraphQL resolvers** use `AuthorizeFunc` from `pkg/server/api/authz/`:
 ```go
-scope, err := authorize(ctx, thirdPartyID, probo.ActionThirdPartyGet)
+scope, err := r.authorize(ctx, thirdPartyID, probo.ActionThirdPartyGet)
 if err != nil {
 	return nil, err
 }
@@ -191,6 +191,58 @@ if err != nil {
 	return nil, types.GetThirdPartyOutput{}, err
 }
 ```
+
+### Always take `scope` from `authorize` — never reconstruct it
+
+`authorize` (and `Authorize` in MCP) returns a `*coredata.Scope` that has been
+resolved from the resource's `organization_id` attribute. Pass that scope
+straight to the service/coredata layer instead of building a new one with
+`coredata.NewScopeFromObjectID(...)` after the authorize call.
+
+The two are not strictly identical: `NewScopeFromObjectID(id)` only reads the
+tenant component of the GID, while the authorizer derives the scope from the
+loaded resource attributes (and may be extended to compute it differently in
+the future). Reconstructing the scope from the GID bypasses that and silently
+drifts when the resource lookup changes.
+
+```go
+// GOOD — scope comes from authorize, fed straight to the service
+scope, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyList)
+if err != nil {
+	return nil, err
+}
+
+thirdPartyIDs, err := r.cookieBanner.LoadDistinctThirdPartyIDsByCookieBannerID(ctx, scope, obj.ID)
+
+// BAD — authorize discards scope, then we rebuild it from the same GID
+if _, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyList); err != nil {
+	return nil, err
+}
+
+scope := coredata.NewScopeFromObjectID(obj.ID)
+thirdPartyIDs, err := r.cookieBanner.LoadDistinctThirdPartyIDsByCookieBannerID(ctx, scope, obj.ID)
+```
+
+The only time it is acceptable to write `if _, err := r.authorize(...)` is when
+**no downstream call needs a scope** — typically authorize calls against the
+caller's `identity.ID` for global / cross-tenant catalogs (e.g.
+`ActionCommonThirdPartyList`, `ActionCommonThirdPartyGet`) whose service
+methods are unscoped. In that case the returned scope would be derived from
+the identity (a nil-tenant principal) and is useless to the caller, so
+discarding it with `_` is correct:
+
+```go
+// GOOD — global catalog, downstream is unscoped
+identity := authn.IdentityFromContext(ctx)
+if _, err := r.authorize(ctx, identity.ID, probo.ActionCommonThirdPartyList); err != nil {
+	return nil, err
+}
+
+parties, err := r.thirdParty.Search(ctx, name) // no scope argument
+```
+
+For batch authorization, the same rule applies to `r.batchAuthorize` (GraphQL)
+and `r.AuthorizeBatch` (MCP) — keep the returned scope and pass it down.
 
 ## File locations
 

--- a/contrib/claude/file-naming.md
+++ b/contrib/claude/file-naming.md
@@ -42,16 +42,47 @@ pkg/cookiebanner/pattern_analysis_worker.go
 
 ## Agent files
 
-When a package has a worker that uses an agent, the agent construction logic
-goes in `<worker_prefix>_agent.go` alongside `<worker_prefix>_worker.go`. The
-worker file stays focused on `Claim`/`Process` and handler methods; the agent
-file owns agent construction, prompt building, constants, config, and the
-`//go:embed` directive for prompt templates.
+A file whose **sole purpose** is to construct and operate an agent uses the
+`<name>_agent.go` suffix. The agent file owns agent construction, prompt
+building, the `//go:embed` directive for prompt templates, the typed result,
+the agent-specific config, and any agent-only constants (timeout, confidence
+threshold). Callers (workers, services) hold a `*agent.Agent` field and import
+the file's `Build…Agent` constructor.
+
+This applies in two shapes:
+
+1. **Paired with a worker** (most common). The worker file
+   `<worker_prefix>_worker.go` stays focused on `Claim`/`Process`, and the
+   agent it uses lives in `<worker_prefix>_agent.go` next to it.
+
+   ```
+   pkg/cookiebanner/tracker_mapping_worker.go   -- worker handler
+   pkg/cookiebanner/tracker_mapping_agent.go    -- agent construction + prompts
+   ```
+
+2. **Standalone, called from elsewhere.** When the agent is consumed by a
+   different package (or by multiple packages — e.g. an agent that operates on
+   a domain entity, used by several feature workers), it lives in the package
+   that owns the domain, named `<purpose>_agent.go`.
+
+   ```
+   pkg/thirdparty/disambiguation_agent.go   -- catalog→org ThirdParty matcher
+   pkg/vetting/sub_agent.go                  -- generic vetting sub-agent
+   ```
+
+A file is NOT renamed to `_agent.go` when the agent is incidental to a service
+that does substantially more than agent orchestration (e.g. CRUD, caching,
+auth). In that case the file keeps its service name and the agent is built
+inline:
 
 ```
-pkg/cookiebanner/tracker_mapping_worker.go   -- worker handler
-pkg/cookiebanner/tracker_mapping_agent.go    -- agent construction + prompts
+pkg/evidencedescriber/evidencedescriber.go   -- single-file describer service
+pkg/vetting/assessment.go                     -- third-party assessment service
 ```
+
+If the agent construction grows past a few dozen lines or sprouts its own
+prompt embed / typed result / config struct, extract it into a sibling
+`<purpose>_agent.go`.
 
 ## Tool files
 

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -109,6 +109,7 @@ export {
   toMaxAgeSeconds,
   fromMaxAgeSeconds,
 } from "./duration";
+export { getTrackerTypeBadge, getTrackerSourceBadge } from "./tracker";
 export { getTrustCenterUrl } from "./trustCenter";
 export { detectSocialName } from "./socialUrl";
 export { formatError, type GraphQLError } from "./error";

--- a/packages/helpers/src/tracker.ts
+++ b/packages/helpers/src/tracker.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2025-2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+type Translator = (s: string) => string;
+
+type BadgeVariant
+  = | "warning"
+    | "info"
+    | "highlight"
+    | "success"
+    | "outline"
+    | "neutral";
+
+type Badge = {
+  label: string;
+  variant: BadgeVariant;
+};
+
+export function getTrackerTypeBadge(type: string, __: Translator): Badge {
+  switch (type) {
+    case "COOKIE": return { label: __("Cookie"), variant: "warning" };
+    case "LOCAL_STORAGE": return { label: __("localStorage"), variant: "info" };
+    case "SESSION_STORAGE": return { label: __("sessionStorage"), variant: "highlight" };
+    case "INDEXED_DB": return { label: __("IndexedDB"), variant: "success" };
+    case "CACHE_STORAGE": return { label: __("Cache Storage"), variant: "outline" };
+    default: return { label: type, variant: "neutral" };
+  }
+}
+
+export function getTrackerSourceBadge(source: string, __: Translator): Badge {
+  switch (source) {
+    case "SCRIPT": return { label: __("Script"), variant: "info" };
+    case "PRE_EXISTING": return { label: __("Pre-existing"), variant: "outline" };
+    case "HTTP": return { label: __("HTTP"), variant: "neutral" };
+    default: return { label: source, variant: "neutral" };
+  }
+}

--- a/pkg/cookiebanner/common_pattern_enrichment_agent.go
+++ b/pkg/cookiebanner/common_pattern_enrichment_agent.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package cookiebanner
+
+import (
+	_ "embed"
+	"fmt"
+	"strings"
+
+	"go.gearno.de/kit/log"
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/agent"
+	"go.probo.inc/probo/pkg/agent/tools/search"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+//go:embed prompts/tracker_enrichment.txt.tmpl
+var trackerEnrichmentPrompt string
+
+// CommonPatternEnrichmentResult is the structured output the
+// common-pattern enrichment agent returns.
+type CommonPatternEnrichmentResult struct {
+	Description string `json:"description" jsonschema:"A concise, factual, compliance-grade description of what this tracker stores or does and its purpose. One or two sentences. Name the operating company when known."`
+}
+
+func buildCommonPatternEnrichmentAgent(
+	cfg TrackerAgentsConfig,
+	pgClient *pg.Client,
+	logger *log.Logger,
+) *agent.Agent {
+	tools := []agent.Tool{
+		searchThirdPartiesTool(pgClient),
+	}
+
+	if cfg.FirecrawlAPIKey != "" {
+		tools = append(tools, search.FirecrawlSearchTool(cfg.FirecrawlAPIKey))
+	}
+
+	outputType, err := agent.NewOutputType[CommonPatternEnrichmentResult]("tracker_enrichment")
+	if err != nil {
+		panic(fmt.Sprintf("cookiebanner: cannot build tracker enrichment output type: %s", err))
+	}
+
+	return agent.New(
+		"common-pattern-enrichment",
+		cfg.LLMClient,
+		agent.WithInstructions(trackerEnrichmentPrompt),
+		agent.WithModel(cfg.Model),
+		agent.WithTools(tools...),
+		agent.WithOutputType(outputType),
+		agent.WithMaxTurns(agentMaxTurns),
+		agent.WithLogger(logger),
+	)
+}
+
+func buildEnrichmentPrompt(cp coredata.CommonTrackerPattern, thirdPartyName string) string {
+	maxAge := "session"
+	if cp.MaxAgeSeconds != nil {
+		maxAge = fmt.Sprintf("%d seconds", *cp.MaxAgeSeconds)
+	}
+
+	prompt := fmt.Sprintf(
+		"Describe the following tracker:\n\n"+
+			"<pattern> %s </pattern>\n"+
+			"<type> %s </type>\n"+
+			"<match_type> %s </match_type>\n"+
+			"<max_age> %s </max_age>\n",
+		cp.Pattern,
+		cp.TrackerType,
+		cp.MatchType,
+		maxAge,
+	)
+
+	if name := strings.TrimSpace(thirdPartyName); name != "" {
+		prompt += fmt.Sprintf("<third_party> %s </third_party>\n", name)
+	}
+
+	return prompt
+}

--- a/pkg/cookiebanner/common_pattern_enrichment_worker.go
+++ b/pkg/cookiebanner/common_pattern_enrichment_worker.go
@@ -1,0 +1,208 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package cookiebanner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.gearno.de/kit/log"
+	"go.gearno.de/kit/pg"
+	"go.gearno.de/kit/worker"
+	"go.probo.inc/probo/pkg/agent"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/llm"
+)
+
+const enrichmentStaleAfter = 10 * time.Minute
+
+type commonPatternEnrichmentHandler struct {
+	pg              *pg.Client
+	logger          *log.Logger
+	enrichmentAgent *agent.Agent
+	staleAfter      time.Duration
+}
+
+// NewCommonPatternEnrichmentWorker builds the worker that fills
+// descriptions on common_tracker_patterns using an agent with web
+// search, then fans the result out to every linked tracker pattern. It is
+// a global system worker: common_tracker_patterns is not tenant-scoped,
+// so a single enrichment benefits all tenants. The worker no-ops when no
+// LLM client is configured; callers should gate registration on config
+// presence.
+func NewCommonPatternEnrichmentWorker(
+	pgClient *pg.Client,
+	logger *log.Logger,
+	cfg TrackerAgentsConfig,
+	opts ...worker.Option,
+) *worker.Worker[coredata.CommonTrackerPattern] {
+	h := &commonPatternEnrichmentHandler{
+		pg:         pgClient,
+		logger:     logger,
+		staleAfter: enrichmentStaleAfter,
+	}
+
+	if cfg.LLMClient != nil {
+		h.enrichmentAgent = buildCommonPatternEnrichmentAgent(cfg, pgClient, logger)
+	}
+
+	return worker.New(
+		"common-pattern-enrichment-worker",
+		h,
+		logger,
+		opts...,
+	)
+}
+
+func (h *commonPatternEnrichmentHandler) Claim(ctx context.Context) (coredata.CommonTrackerPattern, error) {
+	var cp coredata.CommonTrackerPattern
+
+	if err := h.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			if err := cp.LoadNextForEnrichmentForUpdateSkipLocked(ctx, tx); err != nil {
+				return err
+			}
+
+			return cp.ClearEnrichmentRequestedAt(ctx, tx)
+		},
+	); err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) {
+			return coredata.CommonTrackerPattern{}, worker.ErrNoTask
+		}
+
+		return coredata.CommonTrackerPattern{}, fmt.Errorf("cannot claim common tracker pattern enrichment task: %w", err)
+	}
+
+	return cp, nil
+}
+
+func (h *commonPatternEnrichmentHandler) Process(ctx context.Context, cp coredata.CommonTrackerPattern) error {
+	if h.enrichmentAgent == nil {
+		return nil
+	}
+
+	thirdPartyName, err := h.loadThirdPartyName(ctx, cp)
+	if err != nil {
+		return err
+	}
+
+	description, err := h.research(ctx, cp, thirdPartyName)
+	if err != nil {
+		return fmt.Errorf("cannot research tracker description: %w", err)
+	}
+
+	if description == "" {
+		return fmt.Errorf("enrichment produced empty description for pattern %q", cp.Pattern)
+	}
+
+	return h.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			if err := cp.SetEnriched(ctx, tx, description); err != nil {
+				return fmt.Errorf("cannot set common tracker pattern enriched: %w", err)
+			}
+
+			var patterns coredata.TrackerPatterns
+
+			count, err := patterns.BackfillDescriptionByCommonTrackerPatternID(ctx, tx, cp.ID, description)
+			if err != nil {
+				return err
+			}
+
+			h.logger.InfoCtx(
+				ctx,
+				"enriched common tracker pattern",
+				log.String("common_tracker_pattern_id", cp.ID.String()),
+				log.String("pattern", cp.Pattern),
+				log.Int64("backfilled_tracker_patterns", count),
+			)
+
+			return nil
+		},
+	)
+}
+
+func (h *commonPatternEnrichmentHandler) RecoverStale(ctx context.Context) error {
+	return h.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			if err := coredata.ResetStaleEnrichments(ctx, conn, h.staleAfter); err != nil {
+				return fmt.Errorf("cannot reset stale common tracker pattern enrichments: %w", err)
+			}
+
+			return nil
+		},
+	)
+}
+
+func (h *commonPatternEnrichmentHandler) loadThirdPartyName(
+	ctx context.Context,
+	cp coredata.CommonTrackerPattern,
+) (string, error) {
+	if cp.CommonThirdPartyID == nil {
+		return "", nil
+	}
+
+	var name string
+
+	if err := h.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			var party coredata.CommonThirdParty
+			if err := party.LoadByID(ctx, conn, *cp.CommonThirdPartyID); err != nil {
+				return err
+			}
+
+			name = party.Name
+
+			return nil
+		},
+	); err != nil {
+		return "", fmt.Errorf("cannot load common third party for enrichment: %w", err)
+	}
+
+	return name, nil
+}
+
+func (h *commonPatternEnrichmentHandler) research(
+	ctx context.Context,
+	cp coredata.CommonTrackerPattern,
+	thirdPartyName string,
+) (string, error) {
+	prompt := buildEnrichmentPrompt(cp, thirdPartyName)
+
+	agentCtx, cancel := context.WithTimeout(ctx, agentTimeout)
+	defer cancel()
+
+	result, err := agent.RunTyped[CommonPatternEnrichmentResult](
+		agentCtx,
+		h.enrichmentAgent,
+		[]llm.Message{
+			{
+				Role:  llm.RoleUser,
+				Parts: []llm.Part{llm.TextPart{Text: prompt}},
+			},
+		},
+	)
+	if err != nil {
+		return "", fmt.Errorf("enrichment agent run failed: %w", err)
+	}
+
+	return strings.TrimSpace(result.Output.Description), nil
+}

--- a/pkg/cookiebanner/pattern_analysis_worker.go
+++ b/pkg/cookiebanner/pattern_analysis_worker.go
@@ -208,6 +208,13 @@ func (h *patternAnalysisHandler) Process(ctx context.Context, banner coredata.Co
 						if err := globPattern.Update(ctx, tx, scope); err != nil {
 							return fmt.Errorf("cannot promote source on glob pattern %q: %w", key.template, err)
 						}
+
+						// A stronger source can unblock mapping (e.g.
+						// EXTENSION->SCRIPT lifts the creationAllowed
+						// gate), so re-arm mapping on the existing glob.
+						if err := globPattern.SetMappingRequested(ctx, tx); err != nil {
+							return fmt.Errorf("cannot request mapping after source promotion on glob pattern %q: %w", key.template, err)
+						}
 					}
 				}
 
@@ -797,6 +804,13 @@ func (h *patternAnalysisHandler) adoptUncategorisedPatterns(
 
 			if err := match.Update(ctx, tx, scope); err != nil {
 				return false, fmt.Errorf("cannot promote source on glob pattern %q: %w", match.Pattern, err)
+			}
+
+			// A stronger source can unblock mapping (e.g.
+			// EXTENSION->SCRIPT lifts the creationAllowed gate), so
+			// re-arm mapping on the adopted glob.
+			if err := match.SetMappingRequested(ctx, tx); err != nil {
+				return false, fmt.Errorf("cannot request mapping after source promotion on glob pattern %q: %w", match.Pattern, err)
 			}
 		}
 

--- a/pkg/cookiebanner/prompts/tracker_enrichment.txt.tmpl
+++ b/pkg/cookiebanner/prompts/tracker_enrichment.txt.tmpl
@@ -1,0 +1,27 @@
+<role>
+You are a privacy and web-tracking compliance expert. Your job is to write an accurate, source-grounded description of what a given cookie or web tracker does, for use in a privacy/compliance register.
+</role>
+
+<task>
+Given a tracker pattern (cookie name, local storage key, etc.), its type, max-age, and the third party that operates it when known, produce a concise factual description of the tracker's purpose.
+
+Return a structured JSON response with:
+- description: one or two sentences describing what this tracker stores or does and the purpose it serves (e.g. analytics, advertising, session management, security). When the operating company is known, name it.
+</task>
+
+<instructions>
+1. Use the search_third_parties tool to confirm details about the operating company when one is associated with this tracker.
+
+2. Use web_search to find authoritative information about the tracker's purpose. Try up to 3 targeted queries, adapting to the available signals:
+   - With a recognizable prefix or name: "[name] cookie purpose" (e.g. "_ga cookie purpose").
+   - For localStorage keys: "[name] localStorage purpose tracking".
+   - Broaden if needed: "[name] cookie what is it used for".
+   - Stop once you have a confident, well-sourced answer; do not exhaust all queries if the first succeeds.
+   - Verify that any result discusses a tracker whose name shares a meaningful prefix with the pattern being described. Discard results about a differently-named tracker.
+
+3. Be factual and conservative. Describe only what the evidence supports. Do not speculate about data flows or purposes you cannot substantiate.
+
+4. Keep the description concise (one to two sentences) and free of marketing language. It should read as a neutral, compliance-grade statement of purpose.
+
+5. If you genuinely cannot determine the tracker's purpose, write a minimal factual description based on its type and name (e.g. "Cookie set by an unidentified third party; purpose could not be determined.") rather than inventing details.
+</instructions>

--- a/pkg/cookiebanner/prompts/tracker_identification.txt.tmpl
+++ b/pkg/cookiebanner/prompts/tracker_identification.txt.tmpl
@@ -8,7 +8,7 @@ Given a tracker pattern (cookie name, local storage key, etc.), its type, max-ag
 Return a structured JSON response with:
 - third_party_name: the canonical company/service name (e.g. "Google Analytics", not "google" or "GA")
 - category: the business category of the third party
-- confidence: how confident you are in the identification (0.0 to 1.0)
+- third_party_confidence: how confident you are about WHICH company or service set this tracker (0.0 to 1.0). This is the confidence in the attribution alone — not a judgment of whether the artifact is a "real" web tracker. A browser-extension artifact whose name names its vendor can still warrant high confidence here.
 </task>
 
 <instructions>
@@ -37,15 +37,17 @@ Return a structured JSON response with:
 
 5. The observed domains are useful signals but not conclusive on their own. Many sites load third-party tracker scripts through a first-party reverse proxy (e.g. t.example.com proxying PostHog). When a domain matches the scanned site, it reveals nothing about which third party set the tracker — rely on the naming convention or a database/web search instead. First-party proxy domains are filtered before they reach you, but if you still see the scanned site's own domain, ignore it as evidence. Well-known third-party tracking domains (e.g. doubleclick.net, facebook.com, analytics.google.com) remain strong evidence.
 
-6. Be conservative with confidence:
-   - 0.9-1.0: exact pattern match found in database or unmistakable naming convention + matching domain
+6. Be conservative with third_party_confidence. It measures certainty about the attribution (who set the tracker), nothing else:
+   - 0.9-1.0: exact pattern match found in database, or unmistakable naming convention + matching domain, or a name that embeds the vendor (e.g. "__darkreader__*" -> Dark Reader)
    - 0.7-0.8: strong signal from naming convention or domain, but not a database match
    - 0.5-0.6: reasonable guess based on partial naming patterns
    - Below 0.5: uncertain, speculative
 
-7. If you truly cannot identify the tracker, set third_party_name to an empty string and confidence below 0.3.
+   Do not lower third_party_confidence just because the artifact is a browser-extension key, localStorage entry, or otherwise not a classic web tracker. The goal is to attribute the vendor, not to judge how "tracker-worthy" the artifact is — if the name unambiguously names its source, attribute it with high confidence.
 
-8. Only attribute a tracker to a company or service when you have concrete evidence: a database match, an unmistakable naming convention, or a clear web search result. Never guess or invent attributions based on vague similarity or general knowledge. If no evidence supports a match, return an empty third_party_name with confidence below 0.3.
+7. If you truly cannot identify who set the tracker, set third_party_name to an empty string and third_party_confidence below 0.3.
+
+8. Only attribute a tracker to a company or service when you have concrete evidence: a database match, an unmistakable naming convention (including a vendor name embedded in the key), or a clear web search result. Never guess or invent attributions based on vague similarity or general knowledge. If no evidence supports a match, return an empty third_party_name with third_party_confidence below 0.3.
 
 9. For the category field, use one of: {{.Categories}}.
    Most cookies fall under ANALYTICS or MARKETING.

--- a/pkg/cookiebanner/prompts/tracker_identification.txt.tmpl
+++ b/pkg/cookiebanner/prompts/tracker_identification.txt.tmpl
@@ -8,7 +8,6 @@ Given a tracker pattern (cookie name, local storage key, etc.), its type, max-ag
 Return a structured JSON response with:
 - third_party_name: the canonical company/service name (e.g. "Google Analytics", not "google" or "GA")
 - category: the business category of the third party
-- description: a one-sentence description of what this tracker does
 - confidence: how confident you are in the identification (0.0 to 1.0)
 </task>
 

--- a/pkg/cookiebanner/prompts/tracker_identification.txt.tmpl
+++ b/pkg/cookiebanner/prompts/tracker_identification.txt.tmpl
@@ -23,6 +23,7 @@ Return a structured JSON response with:
    - For localStorage keys, include the type: "[name] localStorage tracking script".
    - If the first query returns nothing useful, broaden: "[name] web tracker" or "site:[domain] cookie documentation".
    - Stop searching once you get a confident match; do not exhaust all query slots if the first one succeeds.
+   - When evaluating web search results, verify that the tracker name discussed in the result shares a meaningful prefix with the pattern you are identifying. Trackers with different prefixes are distinct — for example, _hjCookieTest (Hotjar's _hj prefix) must not be confused with a pattern named cookietest (no _hj prefix). If the search result discusses a tracker whose prefix does not match, discard it and continue searching or lower your confidence.
 
 4. Common cookie naming conventions to recognize:
    - _ga*, _gid, _gat*: Google Analytics
@@ -35,7 +36,7 @@ Return a structured JSON response with:
    - hubspot*: HubSpot
    - _cls_*: Clarity (Microsoft)
 
-5. The observed domains are strong signals. If the cookie comes from a well-known tracking domain (e.g. doubleclick.net, facebook.com, analytics.google.com), that is strong evidence of the third party.
+5. The observed domains are useful signals but not conclusive on their own. Many sites load third-party tracker scripts through a first-party reverse proxy (e.g. t.example.com proxying PostHog). When a domain matches the scanned site, it reveals nothing about which third party set the tracker — rely on the naming convention or a database/web search instead. First-party proxy domains are filtered before they reach you, but if you still see the scanned site's own domain, ignore it as evidence. Well-known third-party tracking domains (e.g. doubleclick.net, facebook.com, analytics.google.com) remain strong evidence.
 
 6. Be conservative with confidence:
    - 0.9-1.0: exact pattern match found in database or unmistakable naming convention + matching domain
@@ -45,6 +46,8 @@ Return a structured JSON response with:
 
 7. If you truly cannot identify the tracker, set third_party_name to an empty string and confidence below 0.3.
 
-8. For the category field, use one of: {{.Categories}}.
+8. Only attribute a tracker to a company or service when you have concrete evidence: a database match, an unmistakable naming convention, or a clear web search result. Never guess or invent attributions based on vague similarity or general knowledge. If no evidence supports a match, return an empty third_party_name with confidence below 0.3.
+
+9. For the category field, use one of: {{.Categories}}.
    Most cookies fall under ANALYTICS or MARKETING.
 </instructions>

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -2746,40 +2746,6 @@ func (s *Service) GetCommonTrackerPatternsByIDs(
 	return patterns, nil
 }
 
-// LoadCommonTrackerPatternIDsByCommonThirdPartyID returns the IDs of
-// every common tracker pattern referencing the given common third party.
-// Used by the trackers list filter to translate a CommonThirdParty GID
-// into a `common_tracker_pattern_id = ANY(...)` constraint without
-// JOINing across entity tables in coredata.
-func (s *Service) LoadCommonTrackerPatternIDsByCommonThirdPartyID(
-	ctx context.Context,
-	commonThirdPartyID gid.GID,
-) ([]gid.GID, error) {
-	var ids []gid.GID
-
-	err := s.pg.WithConn(
-		ctx,
-		func(ctx context.Context, conn pg.Querier) error {
-			var (
-				patterns coredata.CommonTrackerPatterns
-				err      error
-			)
-
-			ids, err = patterns.LoadIDsByCommonThirdPartyID(ctx, conn, commonThirdPartyID)
-			if err != nil {
-				return fmt.Errorf("cannot load common tracker pattern ids: %w", err)
-			}
-
-			return nil
-		},
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return ids, nil
-}
-
 // LoadDistinctThirdPartyIDsByCookieBannerID returns the distinct
 // org-scoped third-party IDs referenced by tracker patterns of the
 // banner. The companion

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -2709,6 +2709,128 @@ func (s *Service) CountTrackerPatternsForBanner(
 	return count, nil
 }
 
+func (s *Service) GetCommonTrackerPatternsByIDs(
+	ctx context.Context,
+	ids ...gid.GID,
+) (coredata.CommonTrackerPatterns, error) {
+	var patterns coredata.CommonTrackerPatterns
+
+	err := s.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			if err := patterns.LoadByIDs(ctx, conn, ids); err != nil {
+				return fmt.Errorf("cannot load common tracker patterns by ids: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return patterns, nil
+}
+
+// LoadCommonTrackerPatternIDsByCommonThirdPartyID returns the IDs of
+// every common tracker pattern referencing the given common third party.
+// Used by the trackers list filter to translate a CommonThirdParty GID
+// into a `common_tracker_pattern_id = ANY(...)` constraint without
+// JOINing across entity tables in coredata.
+func (s *Service) LoadCommonTrackerPatternIDsByCommonThirdPartyID(
+	ctx context.Context,
+	commonThirdPartyID gid.GID,
+) ([]gid.GID, error) {
+	var ids []gid.GID
+
+	err := s.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			var (
+				patterns coredata.CommonTrackerPatterns
+				err      error
+			)
+
+			ids, err = patterns.LoadIDsByCommonThirdPartyID(ctx, conn, commonThirdPartyID)
+			if err != nil {
+				return fmt.Errorf("cannot load common tracker pattern ids: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return ids, nil
+}
+
+// LoadDistinctThirdPartyIDsByCookieBannerID returns the distinct
+// org-scoped third-party IDs referenced by tracker patterns of the
+// banner. The companion
+// LoadDistinctCommonTrackerPatternIDsByCookieBannerID covers the
+// indirect mapping through common_tracker_patterns.
+func (s *Service) LoadDistinctThirdPartyIDsByCookieBannerID(
+	ctx context.Context,
+	scope coredata.Scoper,
+	cookieBannerID gid.GID,
+) ([]gid.GID, error) {
+	var ids []gid.GID
+
+	err := s.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			var (
+				patterns coredata.TrackerPatterns
+				err      error
+			)
+
+			ids, err = patterns.LoadDistinctThirdPartyIDsByCookieBannerID(ctx, conn, scope, cookieBannerID)
+			if err != nil {
+				return fmt.Errorf("cannot load distinct third party ids: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return ids, nil
+}
+
+func (s *Service) LoadDistinctCommonTrackerPatternIDsByCookieBannerID(
+	ctx context.Context,
+	scope coredata.Scoper,
+	cookieBannerID gid.GID,
+) ([]gid.GID, error) {
+	var ids []gid.GID
+
+	err := s.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			var (
+				patterns coredata.TrackerPatterns
+				err      error
+			)
+
+			ids, err = patterns.LoadDistinctCommonTrackerPatternIDsByCookieBannerID(ctx, conn, scope, cookieBannerID)
+			if err != nil {
+				return fmt.Errorf("cannot load distinct common tracker pattern ids: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return ids, nil
+}
+
 func (s *Service) CountDetectedTrackersByPatternID(
 	ctx context.Context,
 	scope coredata.Scoper,

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -2628,6 +2628,20 @@ func (s *Service) MoveTrackerPatternToCategory(
 				return fmt.Errorf("cannot update tracker pattern: %w", err)
 			}
 
+			// A manual move is the user's signal that this is a
+			// real tracker. Enqueue the tracker-mapping worker so
+			// it can promote the pattern to an org ThirdParty (or
+			// link an existing one) — never EXTENSION-sourced
+			// patterns, and never patterns we already promoted.
+			// SetMappingRequested is idempotent: it short-circuits
+			// when mapping_requested_at is already non-NULL.
+			if pattern.ThirdPartyID == nil &&
+				(pattern.Source == nil || *pattern.Source != coredata.CookieSourceExtension) {
+				if err := pattern.SetMappingRequested(ctx, tx); err != nil {
+					return fmt.Errorf("cannot enqueue tracker mapping after move: %w", err)
+				}
+			}
+
 			var banner coredata.CookieBanner
 			if err := banner.LoadByID(ctx, tx, scope, pattern.CookieBannerID); err != nil {
 				return fmt.Errorf("cannot load cookie banner: %w", err)

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -2229,6 +2229,15 @@ func (s *Service) reportDetectedTracker(
 			if err := matchedPattern.Update(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot promote source on matched tracker pattern %q: %w", matchedPattern.Pattern, err)
 			}
+
+			// A stronger source can unblock mapping: the detection
+			// upserted below carries a fresh initiator domain that
+			// matchByDomain/matchBySiblingOrigin can now use, and an
+			// EXTENSION->SCRIPT promotion lifts the creationAllowed
+			// gate. Re-arm mapping so the worker revisits the pattern.
+			if err := matchedPattern.SetMappingRequested(ctx, tx); err != nil {
+				return fmt.Errorf("cannot request mapping after source promotion on tracker pattern %q: %w", matchedPattern.Pattern, err)
+			}
 		}
 	} else {
 		newPattern := &coredata.TrackerPattern{

--- a/pkg/cookiebanner/tracker_agents_config.go
+++ b/pkg/cookiebanner/tracker_agents_config.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package cookiebanner
+
+import "go.probo.inc/probo/pkg/llm"
+
+// TrackerAgentsConfig configures the tracker agents that share one LLM
+// client, model, and tool surface: the tracker-mapping agent (catalog
+// identification) and the common-pattern enrichment agent (description
+// research). Both use DB-backed search tools and may also use Firecrawl
+// for web search when an API key is supplied.
+type TrackerAgentsConfig struct {
+	LLMClient       *llm.Client
+	Model           string
+	FirecrawlAPIKey string
+}

--- a/pkg/cookiebanner/tracker_mapping_agent.go
+++ b/pkg/cookiebanner/tracker_mapping_agent.go
@@ -26,7 +26,6 @@ import (
 	"go.probo.inc/probo/pkg/agent"
 	"go.probo.inc/probo/pkg/agent/tools/search"
 	"go.probo.inc/probo/pkg/coredata"
-	"go.probo.inc/probo/pkg/llm"
 )
 
 const (
@@ -44,21 +43,11 @@ var trackerIdentificationPrompt string
 type TrackerMappingAgentResult struct {
 	ThirdPartyName string                      `json:"third_party_name" jsonschema:"Name of the company or service that sets this tracker (e.g. 'Google Analytics', 'Meta Pixel'). Empty string if truly unknown."`
 	Category       coredata.ThirdPartyCategory `json:"category" jsonschema:"Third party category"`
-	Description    string                      `json:"description" jsonschema:"What this tracker does in one sentence"`
 	Confidence     float64                     `json:"confidence" jsonschema:"Confidence level from 0.0 to 1.0. Set below 0.5 if unsure."`
 }
 
-// TrackerMappingConfig configures the tracker-mapping agent (catalog
-// identification). The agent uses DB-backed search tools and may also
-// use Firecrawl for web search when an API key is supplied.
-type TrackerMappingConfig struct {
-	LLMClient       *llm.Client
-	Model           string
-	FirecrawlAPIKey string
-}
-
 func buildTrackerMappingAgent(
-	cfg TrackerMappingConfig,
+	cfg TrackerAgentsConfig,
 	pgClient *pg.Client,
 	logger *log.Logger,
 ) *agent.Agent {

--- a/pkg/cookiebanner/tracker_mapping_agent.go
+++ b/pkg/cookiebanner/tracker_mapping_agent.go
@@ -48,6 +48,9 @@ type TrackerMappingAgentResult struct {
 	Confidence     float64                     `json:"confidence" jsonschema:"Confidence level from 0.0 to 1.0. Set below 0.5 if unsure."`
 }
 
+// TrackerMappingConfig configures the tracker-mapping agent (catalog
+// identification). The agent uses DB-backed search tools and may also
+// use Firecrawl for web search when an API key is supplied.
 type TrackerMappingConfig struct {
 	LLMClient       *llm.Client
 	Model           string

--- a/pkg/cookiebanner/tracker_mapping_agent.go
+++ b/pkg/cookiebanner/tracker_mapping_agent.go
@@ -29,10 +29,15 @@ import (
 )
 
 const (
-	agentTimeout              = 60 * time.Second
-	agentMaxTurns             = 5
-	agentConfidenceThreshold  = 0.6
-	agentMaxPatternConfidence = 0.8
+	agentTimeout                       = 60 * time.Second
+	agentMaxTurns                      = 5
+	agentThirdPartyConfidenceThreshold = 0.6
+	// agentSourceConfidence is the fixed confidence stored on catalog
+	// rows the agent attributes to a third party. The agent's own
+	// confidence now gauges the attribution (see ThirdPartyConfidence)
+	// rather than the pattern, so the stored row confidence is a
+	// constant like the other heuristic signals (domain, sibling).
+	agentSourceConfidence = 0.8
 )
 
 //go:embed prompts/tracker_identification.txt.tmpl
@@ -41,9 +46,9 @@ var trackerIdentificationPrompt string
 // TrackerMappingAgentResult is the structured output the tracker-mapping
 // agent returns.
 type TrackerMappingAgentResult struct {
-	ThirdPartyName string                      `json:"third_party_name" jsonschema:"Name of the company or service that sets this tracker (e.g. 'Google Analytics', 'Meta Pixel'). Empty string if truly unknown."`
-	Category       coredata.ThirdPartyCategory `json:"category" jsonschema:"Third party category"`
-	Confidence     float64                     `json:"confidence" jsonschema:"Confidence level from 0.0 to 1.0. Set below 0.5 if unsure."`
+	ThirdPartyName       string                      `json:"third_party_name" jsonschema:"Name of the company or service that sets this tracker (e.g. 'Google Analytics', 'Meta Pixel'). Empty string if truly unknown."`
+	Category             coredata.ThirdPartyCategory `json:"category" jsonschema:"Third party category"`
+	ThirdPartyConfidence float64                     `json:"third_party_confidence" jsonschema:"Confidence (0.0 to 1.0) in which company or service set this tracker, independent of whether the artifact is a classic web tracker. Set below 0.5 if unsure who set it."`
 }
 
 func buildTrackerMappingAgent(

--- a/pkg/cookiebanner/tracker_mapping_worker.go
+++ b/pkg/cookiebanner/tracker_mapping_worker.go
@@ -90,11 +90,13 @@ func (h *trackerMappingHandler) Claim(ctx context.Context) (coredata.TrackerPatt
 }
 
 // Process resolves the catalog mapping (when missing) and then promotes
-// the pattern to an org ThirdParty (when eligible). When a pattern is
-// re-triggered by a manual move (it already carries a
-// common_tracker_pattern_id), we MUST NOT re-resolve the catalog: the
-// existing link is preserved and we jump straight to third-party
-// promotion.
+// the pattern to an org ThirdParty (when eligible). Promotion is
+// skipped for patterns still in the uncategorised category — the user
+// must categorize a tracker before it creates or links an org
+// ThirdParty. When a pattern is re-triggered by a manual move (it
+// already carries a common_tracker_pattern_id), we MUST NOT re-resolve
+// the catalog: the existing link is preserved and we jump straight to
+// third-party promotion.
 func (h *trackerMappingHandler) Process(ctx context.Context, tp coredata.TrackerPattern) error {
 	return h.pg.WithTx(
 		ctx,
@@ -139,12 +141,21 @@ func (h *trackerMappingHandler) Process(ctx context.Context, tp coredata.Tracker
 			if thirdPartyID == nil &&
 				commonPatternID != nil &&
 				(tp.Source == nil || *tp.Source != coredata.CookieSourceExtension) {
-				promoted, err := h.promoteThirdParty(ctx, tx, tp, *commonPatternID)
-				if err != nil {
-					return fmt.Errorf("cannot promote third party: %w", err)
+				scope := coredata.NewScopeFromObjectID(tp.ID)
+
+				var category coredata.CookieCategory
+				if err := category.LoadByID(ctx, tx, scope, tp.CookieCategoryID); err != nil {
+					return fmt.Errorf("cannot load cookie category: %w", err)
 				}
 
-				thirdPartyID = promoted
+				if category.Kind != coredata.CookieCategoryKindUncategorised {
+					promoted, err := h.promoteThirdParty(ctx, tx, tp, *commonPatternID)
+					if err != nil {
+						return fmt.Errorf("cannot promote third party: %w", err)
+					}
+
+					thirdPartyID = promoted
+				}
 			}
 
 			if commonPatternID != nil || thirdPartyID != nil {

--- a/pkg/cookiebanner/tracker_mapping_worker.go
+++ b/pkg/cookiebanner/tracker_mapping_worker.go
@@ -29,6 +29,7 @@ import (
 	"go.probo.inc/probo/pkg/llm"
 	"go.probo.inc/probo/pkg/slug"
 	"go.probo.inc/probo/pkg/thirdparty"
+	"go.probo.inc/probo/pkg/uri"
 )
 
 type trackerMappingHandler struct {
@@ -109,20 +110,27 @@ func (h *trackerMappingHandler) Process(ctx context.Context, tp coredata.Tracker
 			if tp.CommonTrackerPatternID != nil {
 				commonPatternID = tp.CommonTrackerPatternID
 			} else {
+				scope := coredata.NewScopeFromObjectID(tp.ID)
+
+				var banner coredata.CookieBanner
+				if err := banner.LoadByID(ctx, tx, scope, tp.CookieBannerID); err != nil {
+					return fmt.Errorf("cannot load cookie banner for domain filtering: %w", err)
+				}
+
 				commonPatternID, err = h.matchByPattern(ctx, tx, tp)
 				if err != nil {
 					return fmt.Errorf("cannot match by pattern: %w", err)
 				}
 
 				if commonPatternID == nil {
-					commonPatternID, err = h.matchByDomain(ctx, tx, tp)
+					commonPatternID, err = h.matchByDomain(ctx, tx, tp, banner.Origin)
 					if err != nil {
 						return fmt.Errorf("cannot match by domain: %w", err)
 					}
 				}
 
 				if commonPatternID == nil && h.mappingAgent != nil {
-					commonPatternID, err = h.identifyWithAgent(ctx, tx, tp)
+					commonPatternID, err = h.identifyWithAgent(ctx, tx, tp, banner.Origin)
 					if err != nil {
 						return fmt.Errorf("cannot identify with agent: %w", err)
 					}
@@ -212,10 +220,16 @@ func (h *trackerMappingHandler) matchByPattern(
 // overlap the pattern's observed initiator domains, and upserts a
 // CommonTrackerPattern linking the two. As with matchByPattern,
 // third-party resolution is deferred to promoteThirdParty.
+//
+// Domains that share the scanned site's eTLD+1 are filtered out before
+// querying. Tracker scripts loaded through a first-party proxy (e.g.
+// t.probo.com proxying PostHog on a probo.com site) would otherwise
+// match the site owner's own CommonThirdParty entry.
 func (h *trackerMappingHandler) matchByDomain(
 	ctx context.Context,
 	tx pg.Tx,
 	tp coredata.TrackerPattern,
+	siteOrigin string,
 ) (*gid.GID, error) {
 	var trackers coredata.DetectedTrackers
 
@@ -223,6 +237,8 @@ func (h *trackerMappingHandler) matchByDomain(
 	if err != nil {
 		return nil, fmt.Errorf("cannot load initiator domains: %w", err)
 	}
+
+	domains = uri.FilterFirstPartyDomains(domains, siteOrigin)
 
 	if len(domains) == 0 {
 		return nil, nil
@@ -266,6 +282,7 @@ func (h *trackerMappingHandler) identifyWithAgent(
 	ctx context.Context,
 	tx pg.Tx,
 	tp coredata.TrackerPattern,
+	siteOrigin string,
 ) (*gid.GID, error) {
 	var trackers coredata.DetectedTrackers
 
@@ -273,6 +290,8 @@ func (h *trackerMappingHandler) identifyWithAgent(
 	if err != nil {
 		h.logger.WarnCtx(ctx, "cannot load initiator domains for agent", log.Error(err))
 	}
+
+	domains = uri.FilterFirstPartyDomains(domains, siteOrigin)
 
 	prompt := buildAgentPrompt(tp, domains)
 

--- a/pkg/cookiebanner/tracker_mapping_worker.go
+++ b/pkg/cookiebanner/tracker_mapping_worker.go
@@ -117,13 +117,33 @@ func (h *trackerMappingHandler) Process(ctx context.Context, tp coredata.Tracker
 					return fmt.Errorf("cannot load cookie banner for domain filtering: %w", err)
 				}
 
+				banner.Origin = "https://t.probo.com"
+
 				commonPatternID, err = h.matchByPattern(ctx, tx, tp)
 				if err != nil {
 					return fmt.Errorf("cannot match by pattern: %w", err)
 				}
 
+				var domains []string
+
 				if commonPatternID == nil {
-					commonPatternID, err = h.matchByDomain(ctx, tx, tp, banner.Origin)
+					var trackers coredata.DetectedTrackers
+
+					domains, err = trackers.LoadInitiatorDomainsByTrackerPatternID(ctx, tx, tp.ID, 10)
+					if err != nil {
+						return fmt.Errorf("cannot load initiator domains: %w", err)
+					}
+
+					domains = uri.FilterFirstPartyDomains(domains, banner.Origin)
+
+					commonPatternID, err = h.matchBySiblingOrigin(ctx, tx, tp, domains)
+					if err != nil {
+						return fmt.Errorf("cannot match by sibling origin: %w", err)
+					}
+				}
+
+				if commonPatternID == nil {
+					commonPatternID, err = h.matchByDomain(ctx, tx, tp, domains)
 					if err != nil {
 						return fmt.Errorf("cannot match by domain: %w", err)
 					}
@@ -221,25 +241,17 @@ func (h *trackerMappingHandler) matchByPattern(
 // CommonTrackerPattern linking the two. As with matchByPattern,
 // third-party resolution is deferred to promoteThirdParty.
 //
-// Domains that share the scanned site's eTLD+1 are filtered out before
-// querying. Tracker scripts loaded through a first-party proxy (e.g.
-// t.probo.com proxying PostHog on a probo.com site) would otherwise
-// match the site owner's own CommonThirdParty entry.
+// The caller is responsible for loading and filtering the domains
+// (removing first-party domains). Tracker scripts loaded through a
+// first-party proxy (e.g. t.probo.com proxying PostHog on a probo.com
+// site) would otherwise match the site owner's own CommonThirdParty
+// entry.
 func (h *trackerMappingHandler) matchByDomain(
 	ctx context.Context,
 	tx pg.Tx,
 	tp coredata.TrackerPattern,
-	siteOrigin string,
+	domains []string,
 ) (*gid.GID, error) {
-	var trackers coredata.DetectedTrackers
-
-	domains, err := trackers.LoadInitiatorDomainsByTrackerPatternID(ctx, tx, tp.ID, 10)
-	if err != nil {
-		return nil, fmt.Errorf("cannot load initiator domains: %w", err)
-	}
-
-	domains = uri.FilterFirstPartyDomains(domains, siteOrigin)
-
 	if len(domains) == 0 {
 		return nil, nil
 	}
@@ -438,6 +450,151 @@ func (h *trackerMappingHandler) resolveOrCreateCommonThirdParty(
 	)
 
 	return &party.ID, nil
+}
+
+// matchBySiblingOrigin finds other tracker patterns on the same banner
+// that share initiator domains with the current pattern and are already
+// mapped to a common third party. Sharing an origin across multiple
+// detected patterns is a strong indicator of the same third party.
+func (h *trackerMappingHandler) matchBySiblingOrigin(
+	ctx context.Context,
+	tx pg.Tx,
+	tp coredata.TrackerPattern,
+	domains []string,
+) (*gid.GID, error) {
+	if len(domains) == 0 {
+		return nil, nil
+	}
+
+	var trackers coredata.DetectedTrackers
+
+	siblingIDs, err := trackers.LoadSiblingPatternIDsByInitiatorDomains(
+		ctx,
+		tx,
+		tp.CookieBannerID,
+		domains,
+		tp.ID,
+		20,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load sibling pattern ids: %w", err)
+	}
+
+	if len(siblingIDs) == 0 {
+		return nil, nil
+	}
+
+	scope := coredata.NewScopeFromObjectID(tp.ID)
+
+	commonThirdPartyID, err := h.resolveCommonThirdPartyFromSiblings(ctx, tx, scope, siblingIDs)
+	if err != nil {
+		return nil, fmt.Errorf("cannot resolve common third party from siblings: %w", err)
+	}
+
+	if commonThirdPartyID == nil {
+		return nil, nil
+	}
+
+	now := time.Now()
+	commonPattern := coredata.CommonTrackerPattern{
+		ID:                 gid.New(gid.NilTenant, coredata.CommonTrackerPatternEntityType),
+		CommonThirdPartyID: commonThirdPartyID,
+		TrackerType:        tp.TrackerType,
+		Pattern:            tp.Pattern,
+		MatchType:          tp.MatchType,
+		Description:        tp.Description,
+		MaxAgeSeconds:      tp.MaxAgeSeconds,
+		Confidence:         0.7,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+
+	if _, err := commonPattern.Upsert(ctx, tx); err != nil {
+		return nil, fmt.Errorf("cannot upsert common tracker pattern from sibling origin: %w", err)
+	}
+
+	h.logger.InfoCtx(
+		ctx,
+		"matched tracker pattern via sibling origin",
+		log.String("pattern", tp.Pattern),
+		log.String("tracker_pattern_id", tp.ID.String()),
+		log.String("common_third_party_id", commonThirdPartyID.String()),
+	)
+
+	return &commonPattern.ID, nil
+}
+
+// resolveCommonThirdPartyFromSiblings extracts a single unambiguous
+// CommonThirdPartyID from sibling patterns. It first checks siblings
+// with a third_party_id (fully promoted), then falls back to siblings
+// with only a common_tracker_pattern_id.
+func (h *trackerMappingHandler) resolveCommonThirdPartyFromSiblings(
+	ctx context.Context,
+	conn pg.Querier,
+	scope coredata.Scoper,
+	siblingIDs []gid.GID,
+) (*gid.GID, error) {
+	var patterns coredata.TrackerPatterns
+
+	thirdPartyIDs, err := patterns.LoadDistinctThirdPartyIDsByIDs(ctx, conn, scope, siblingIDs)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load distinct third party ids from siblings: %w", err)
+	}
+
+	if len(thirdPartyIDs) > 0 {
+		commonIDs := make(map[gid.GID]struct{})
+
+		for _, tpID := range thirdPartyIDs {
+			var tp coredata.ThirdParty
+			if err := tp.LoadByID(ctx, conn, scope, tpID); err != nil {
+				continue
+			}
+
+			if tp.CommonThirdPartyID != nil {
+				commonIDs[*tp.CommonThirdPartyID] = struct{}{}
+			}
+		}
+
+		if len(commonIDs) == 1 {
+			for id := range commonIDs {
+				return &id, nil
+			}
+		}
+
+		if len(commonIDs) > 1 {
+			return nil, nil
+		}
+	}
+
+	commonPatternIDs, err := patterns.LoadDistinctCommonTrackerPatternIDsByIDs(ctx, conn, scope, siblingIDs)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load distinct common tracker pattern ids from siblings: %w", err)
+	}
+
+	if len(commonPatternIDs) == 0 {
+		return nil, nil
+	}
+
+	commonIDs := make(map[gid.GID]struct{})
+
+	for _, cpID := range commonPatternIDs {
+		var cp coredata.CommonTrackerPattern
+		if err := cp.LoadByID(ctx, conn, cpID); err != nil {
+			continue
+		}
+
+		if cp.CommonThirdPartyID != nil {
+			commonIDs[*cp.CommonThirdPartyID] = struct{}{}
+		}
+	}
+
+	if len(commonIDs) == 1 {
+		for id := range commonIDs {
+			return &id, nil
+		}
+	}
+
+	return nil, nil
 }
 
 func (h *trackerMappingHandler) createUnmatchedPattern(

--- a/pkg/cookiebanner/tracker_mapping_worker.go
+++ b/pkg/cookiebanner/tracker_mapping_worker.go
@@ -42,7 +42,7 @@ type trackerMappingHandler struct {
 func NewTrackerMappingWorker(
 	pgClient *pg.Client,
 	logger *log.Logger,
-	mappingCfg TrackerMappingConfig,
+	mappingCfg TrackerAgentsConfig,
 	disambiguationCfg thirdparty.DisambiguationConfig,
 	opts ...worker.Option,
 ) *worker.Worker[coredata.TrackerPattern] {
@@ -260,6 +260,11 @@ func (h *trackerMappingHandler) Process(ctx context.Context, tp coredata.Tracker
 				tp.ThirdPartyID = thirdPartyID
 				tp.UpdatedAt = time.Now()
 
+				// Descriptions are owned by the common-pattern enrichment
+				// worker. Here we only propagate: if the linked catalog row
+				// is already enriched, copy its description onto this
+				// pattern. A pattern linked before enrichment is filled
+				// later by the enrichment worker's fan-out instead.
 				if tp.Description == "" && commonPatternID != nil {
 					var commonPattern coredata.CommonTrackerPattern
 					if err := commonPattern.LoadByID(ctx, tx, *commonPatternID); err == nil && commonPattern.Description != "" {
@@ -451,7 +456,6 @@ func (h *trackerMappingHandler) matchByDomain(
 		TrackerType:        tp.TrackerType,
 		Pattern:            tp.Pattern,
 		MatchType:          tp.MatchType,
-		Description:        tp.Description,
 		MaxAgeSeconds:      tp.MaxAgeSeconds,
 		Confidence:         0.7,
 		CreatedAt:          now,
@@ -547,7 +551,6 @@ func (h *trackerMappingHandler) identifyWithAgent(
 		TrackerType:        tp.TrackerType,
 		Pattern:            tp.Pattern,
 		MatchType:          tp.MatchType,
-		Description:        identification.Description,
 		MaxAgeSeconds:      tp.MaxAgeSeconds,
 		Confidence:         confidence,
 		CreatedAt:          now,
@@ -693,7 +696,6 @@ func (h *trackerMappingHandler) matchBySiblingOrigin(
 		TrackerType:        tp.TrackerType,
 		Pattern:            tp.Pattern,
 		MatchType:          tp.MatchType,
-		Description:        tp.Description,
 		MaxAgeSeconds:      tp.MaxAgeSeconds,
 		Confidence:         0.7,
 		CreatedAt:          now,
@@ -822,7 +824,6 @@ func (h *trackerMappingHandler) createUnmatchedPattern(
 		TrackerType:   tp.TrackerType,
 		Pattern:       tp.Pattern,
 		MatchType:     tp.MatchType,
-		Description:   tp.Description,
 		MaxAgeSeconds: tp.MaxAgeSeconds,
 		Confidence:    0.5,
 		CreatedAt:     now,

--- a/pkg/cookiebanner/tracker_mapping_worker.go
+++ b/pkg/cookiebanner/tracker_mapping_worker.go
@@ -131,9 +131,6 @@ func (h *trackerMappingHandler) Process(ctx context.Context, tp coredata.Tracker
 				return fmt.Errorf("cannot load cookie banner for domain filtering: %w", err)
 			}
 
-			// FIXME: remove
-			banner.Origin = "https://t.probo.com"
-
 			var (
 				commonPatternID    *gid.GID
 				commonThirdPartyID *gid.GID

--- a/pkg/cookiebanner/tracker_mapping_worker.go
+++ b/pkg/cookiebanner/tracker_mapping_worker.go
@@ -515,33 +515,29 @@ func (h *trackerMappingHandler) identifyWithAgent(
 
 	identification := result.Output
 
-	if identification.Confidence < agentConfidenceThreshold {
+	// The agent's confidence gauges the attribution (who set the
+	// tracker), not whether the artifact is a meaningful tracker. Without
+	// a confident vendor there is nothing to catalog here; the unmatched
+	// fallback records the pattern with no third party instead.
+	if identification.ThirdPartyName == "" || identification.ThirdPartyConfidence < agentThirdPartyConfidenceThreshold {
 		h.logger.InfoCtx(
 			ctx,
-			"agent identification below confidence threshold",
+			"agent third-party attribution below confidence threshold",
 			log.String("pattern", tp.Pattern),
-			log.Float64("confidence", identification.Confidence),
+			log.Float64("third_party_confidence", identification.ThirdPartyConfidence),
 		)
 
 		return nil, nil
 	}
 
-	confidence := float32(identification.Confidence)
-	if confidence > agentMaxPatternConfidence {
-		confidence = agentMaxPatternConfidence
-	}
-
-	var commonThirdPartyID *gid.GID
-	if identification.ThirdPartyName != "" {
-		commonThirdPartyID, err = h.resolveOrCreateCommonThirdParty(
-			ctx,
-			tx,
-			identification,
-			domains,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("cannot resolve or create common third party: %w", err)
-		}
+	commonThirdPartyID, err := h.resolveOrCreateCommonThirdParty(
+		ctx,
+		tx,
+		identification,
+		domains,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot resolve or create common third party: %w", err)
 	}
 
 	now := time.Now()
@@ -552,7 +548,7 @@ func (h *trackerMappingHandler) identifyWithAgent(
 		Pattern:            tp.Pattern,
 		MatchType:          tp.MatchType,
 		MaxAgeSeconds:      tp.MaxAgeSeconds,
-		Confidence:         confidence,
+		Confidence:         agentSourceConfidence,
 		CreatedAt:          now,
 		UpdatedAt:          now,
 	}
@@ -566,7 +562,7 @@ func (h *trackerMappingHandler) identifyWithAgent(
 		"agent identified tracker pattern",
 		log.String("pattern", tp.Pattern),
 		log.String("third_party", identification.ThirdPartyName),
-		log.Float64("confidence", identification.Confidence),
+		log.Float64("third_party_confidence", identification.ThirdPartyConfidence),
 	)
 
 	return &catalogMatch{

--- a/pkg/cookiebanner/tracker_mapping_worker.go
+++ b/pkg/cookiebanner/tracker_mapping_worker.go
@@ -28,18 +28,21 @@ import (
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/llm"
 	"go.probo.inc/probo/pkg/slug"
+	"go.probo.inc/probo/pkg/thirdparty"
 )
 
 type trackerMappingHandler struct {
-	pg     *pg.Client
-	logger *log.Logger
-	agent  *agent.Agent
+	pg                  *pg.Client
+	logger              *log.Logger
+	mappingAgent        *agent.Agent
+	disambiguationAgent *agent.Agent
 }
 
 func NewTrackerMappingWorker(
 	pgClient *pg.Client,
 	logger *log.Logger,
-	cfg TrackerMappingConfig,
+	mappingCfg TrackerMappingConfig,
+	disambiguationCfg thirdparty.DisambiguationConfig,
 	opts ...worker.Option,
 ) *worker.Worker[coredata.TrackerPattern] {
 	h := &trackerMappingHandler{
@@ -47,8 +50,12 @@ func NewTrackerMappingWorker(
 		logger: logger,
 	}
 
-	if cfg.LLMClient != nil {
-		h.agent = buildTrackerMappingAgent(cfg, pgClient, logger)
+	if mappingCfg.LLMClient != nil {
+		h.mappingAgent = buildTrackerMappingAgent(mappingCfg, pgClient, logger)
+	}
+
+	if disambiguationCfg.LLMClient != nil {
+		h.disambiguationAgent = thirdparty.BuildDisambiguationAgent(disambiguationCfg, logger)
 	}
 
 	return worker.New(
@@ -82,40 +89,62 @@ func (h *trackerMappingHandler) Claim(ctx context.Context) (coredata.TrackerPatt
 	return tp, nil
 }
 
+// Process resolves the catalog mapping (when missing) and then promotes
+// the pattern to an org ThirdParty (when eligible). When a pattern is
+// re-triggered by a manual move (it already carries a
+// common_tracker_pattern_id), we MUST NOT re-resolve the catalog: the
+// existing link is preserved and we jump straight to third-party
+// promotion.
 func (h *trackerMappingHandler) Process(ctx context.Context, tp coredata.TrackerPattern) error {
 	return h.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			var (
 				commonPatternID *gid.GID
-				thirdPartyID    *gid.GID
 				err             error
 			)
 
-			commonPatternID, thirdPartyID, err = h.matchByPattern(ctx, tx, tp)
-			if err != nil {
-				return fmt.Errorf("cannot match by pattern: %w", err)
-			}
-
-			if commonPatternID == nil {
-				commonPatternID, thirdPartyID, err = h.matchByDomain(ctx, tx, tp)
+			if tp.CommonTrackerPatternID != nil {
+				commonPatternID = tp.CommonTrackerPatternID
+			} else {
+				commonPatternID, err = h.matchByPattern(ctx, tx, tp)
 				if err != nil {
-					return fmt.Errorf("cannot match by domain: %w", err)
+					return fmt.Errorf("cannot match by pattern: %w", err)
+				}
+
+				if commonPatternID == nil {
+					commonPatternID, err = h.matchByDomain(ctx, tx, tp)
+					if err != nil {
+						return fmt.Errorf("cannot match by domain: %w", err)
+					}
+				}
+
+				if commonPatternID == nil && h.mappingAgent != nil {
+					commonPatternID, err = h.identifyWithAgent(ctx, tx, tp)
+					if err != nil {
+						return fmt.Errorf("cannot identify with agent: %w", err)
+					}
+				}
+
+				if commonPatternID == nil {
+					commonPatternID, err = h.createUnmatchedPattern(ctx, tx, tp)
+					if err != nil {
+						return fmt.Errorf("cannot create unmatched pattern: %w", err)
+					}
 				}
 			}
 
-			if commonPatternID == nil && h.agent != nil {
-				commonPatternID, thirdPartyID, err = h.identifyWithAgent(ctx, tx, tp)
-				if err != nil {
-					return fmt.Errorf("cannot identify with agent: %w", err)
-				}
-			}
+			thirdPartyID := tp.ThirdPartyID
 
-			if commonPatternID == nil {
-				commonPatternID, err = h.createUnmatchedPattern(ctx, tx, tp)
+			if thirdPartyID == nil &&
+				commonPatternID != nil &&
+				(tp.Source == nil || *tp.Source != coredata.CookieSourceExtension) {
+				promoted, err := h.promoteThirdParty(ctx, tx, tp, *commonPatternID)
 				if err != nil {
-					return fmt.Errorf("cannot create unmatched pattern: %w", err)
+					return fmt.Errorf("cannot promote third party: %w", err)
 				}
+
+				thirdPartyID = promoted
 			}
 
 			if commonPatternID != nil || thirdPartyID != nil {
@@ -136,59 +165,55 @@ func (h *trackerMappingHandler) Process(ctx context.Context, tp coredata.Tracker
 	)
 }
 
+// matchByPattern looks for a catalog row with the same pattern. It now
+// only returns the catalog ID; third-party resolution happens later in
+// promoteThirdParty.
 func (h *trackerMappingHandler) matchByPattern(
 	ctx context.Context,
 	conn pg.Querier,
 	tp coredata.TrackerPattern,
-) (*gid.GID, *gid.GID, error) {
+) (*gid.GID, error) {
 	var commonPattern coredata.CommonTrackerPattern
 	if err := commonPattern.LoadByPattern(ctx, conn, tp.TrackerType, tp.Pattern, tp.MaxAgeSeconds); err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
-			return nil, nil, nil
+			return nil, nil
 		}
 
-		return nil, nil, fmt.Errorf("cannot load common tracker pattern: %w", err)
+		return nil, fmt.Errorf("cannot load common tracker pattern: %w", err)
 	}
 
-	var thirdPartyID *gid.GID
-
-	if commonPattern.CommonThirdPartyID != nil {
-		var err error
-
-		thirdPartyID, err = h.resolveThirdParty(ctx, conn, tp, &commonPattern)
-		if err != nil {
-			return nil, nil, fmt.Errorf("cannot resolve third party from pattern match: %w", err)
-		}
-	}
-
-	return &commonPattern.ID, thirdPartyID, nil
+	return &commonPattern.ID, nil
 }
 
+// matchByDomain finds a CommonThirdParty whose registered domains
+// overlap the pattern's observed initiator domains, and upserts a
+// CommonTrackerPattern linking the two. As with matchByPattern,
+// third-party resolution is deferred to promoteThirdParty.
 func (h *trackerMappingHandler) matchByDomain(
 	ctx context.Context,
 	tx pg.Tx,
 	tp coredata.TrackerPattern,
-) (*gid.GID, *gid.GID, error) {
+) (*gid.GID, error) {
 	var trackers coredata.DetectedTrackers
 
 	domains, err := trackers.LoadInitiatorDomainsByTrackerPatternID(ctx, tx, tp.ID, 10)
 	if err != nil {
-		return nil, nil, fmt.Errorf("cannot load initiator domains: %w", err)
+		return nil, fmt.Errorf("cannot load initiator domains: %w", err)
 	}
 
 	if len(domains) == 0 {
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	filter := coredata.NewCommonThirdPartyDomainFilter(domains)
 
 	var matchedDomains coredata.CommonThirdPartyDomains
 	if err := matchedDomains.Load(ctx, tx, 1, filter); err != nil {
-		return nil, nil, fmt.Errorf("cannot load common third party domain by domain match: %w", err)
+		return nil, fmt.Errorf("cannot load common third party domain by domain match: %w", err)
 	}
 
 	if len(matchedDomains) == 0 {
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	commonThirdPartyID := matchedDomains[0].CommonThirdPartyID
@@ -208,22 +233,17 @@ func (h *trackerMappingHandler) matchByDomain(
 	}
 
 	if _, err := commonPattern.Upsert(ctx, tx); err != nil {
-		return nil, nil, fmt.Errorf("cannot upsert common tracker pattern from domain match: %w", err)
+		return nil, fmt.Errorf("cannot upsert common tracker pattern from domain match: %w", err)
 	}
 
-	thirdPartyID, err := h.resolveThirdParty(ctx, tx, tp, &commonPattern)
-	if err != nil {
-		return nil, nil, fmt.Errorf("cannot resolve third party from domain match: %w", err)
-	}
-
-	return &commonPattern.ID, thirdPartyID, nil
+	return &commonPattern.ID, nil
 }
 
 func (h *trackerMappingHandler) identifyWithAgent(
 	ctx context.Context,
 	tx pg.Tx,
 	tp coredata.TrackerPattern,
-) (*gid.GID, *gid.GID, error) {
+) (*gid.GID, error) {
 	var trackers coredata.DetectedTrackers
 
 	domains, err := trackers.LoadInitiatorDomainsByTrackerPatternID(ctx, tx, tp.ID, 5)
@@ -238,7 +258,7 @@ func (h *trackerMappingHandler) identifyWithAgent(
 
 	result, err := agent.RunTyped[TrackerMappingAgentResult](
 		agentCtx,
-		h.agent,
+		h.mappingAgent,
 		[]llm.Message{
 			{
 				Role:  llm.RoleUser,
@@ -254,7 +274,7 @@ func (h *trackerMappingHandler) identifyWithAgent(
 			log.String("pattern", tp.Pattern),
 		)
 
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	identification := result.Output
@@ -267,7 +287,7 @@ func (h *trackerMappingHandler) identifyWithAgent(
 			log.Float64("confidence", identification.Confidence),
 		)
 
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	confidence := float32(identification.Confidence)
@@ -284,7 +304,7 @@ func (h *trackerMappingHandler) identifyWithAgent(
 			domains,
 		)
 		if err != nil {
-			return nil, nil, fmt.Errorf("cannot resolve or create common third party: %w", err)
+			return nil, fmt.Errorf("cannot resolve or create common third party: %w", err)
 		}
 	}
 
@@ -303,12 +323,7 @@ func (h *trackerMappingHandler) identifyWithAgent(
 	}
 
 	if _, err := commonPattern.Upsert(ctx, tx); err != nil {
-		return nil, nil, fmt.Errorf("cannot upsert common tracker pattern from agent: %w", err)
-	}
-
-	thirdPartyID, err := h.resolveThirdParty(ctx, tx, tp, &commonPattern)
-	if err != nil {
-		return nil, nil, fmt.Errorf("cannot resolve third party from agent match: %w", err)
+		return nil, fmt.Errorf("cannot upsert common tracker pattern from agent: %w", err)
 	}
 
 	h.logger.InfoCtx(
@@ -319,7 +334,7 @@ func (h *trackerMappingHandler) identifyWithAgent(
 		log.Float64("confidence", identification.Confidence),
 	)
 
-	return &commonPattern.ID, thirdPartyID, nil
+	return &commonPattern.ID, nil
 }
 
 func (h *trackerMappingHandler) resolveOrCreateCommonThirdParty(
@@ -408,32 +423,163 @@ func (h *trackerMappingHandler) createUnmatchedPattern(
 	return &commonPattern.ID, nil
 }
 
-func (h *trackerMappingHandler) resolveThirdParty(
+// promoteThirdParty resolves an org ThirdParty for the given pattern
+// once the catalog mapping is known. The resolution order is:
+//
+//  1. Exact link by common_third_party_id (O(1)).
+//  2. Heuristic match against the org's existing ThirdParty rows
+//     (lowercased name, suffix-stripped name, slug, website host,
+//     CommonThirdPartyDomain overlap).
+//  3. Agent disambiguation when the heuristic is ambiguous.
+//  4. Fallback create from CommonThirdParty.
+//
+// A confident heuristic/agent match is auto-tagged with
+// common_third_party_id so subsequent promotions hit the exact-link
+// path in O(1). Returns (nil, nil) when the catalog row has no
+// CommonThirdPartyID — there is nothing to promote to.
+func (h *trackerMappingHandler) promoteThirdParty(
 	ctx context.Context,
-	conn pg.Querier,
+	tx pg.Tx,
 	tp coredata.TrackerPattern,
-	commonPattern *coredata.CommonTrackerPattern,
+	commonPatternID gid.GID,
 ) (*gid.GID, error) {
+	var commonPattern coredata.CommonTrackerPattern
+	if err := commonPattern.LoadByID(ctx, tx, commonPatternID); err != nil {
+		return nil, fmt.Errorf("cannot load common tracker pattern: %w", err)
+	}
+
 	if commonPattern.CommonThirdPartyID == nil {
 		return nil, nil
 	}
 
+	commonThirdPartyID := *commonPattern.CommonThirdPartyID
 	scope := coredata.NewScopeFromObjectID(tp.ID)
 
-	var t coredata.ThirdParty
-	if err := t.LoadByOrganizationIDAndCommonThirdPartyID(
+	var existing coredata.ThirdParty
+
+	err := existing.LoadByOrganizationIDAndCommonThirdPartyID(
 		ctx,
-		conn,
+		tx,
 		scope,
 		tp.OrganizationID,
-		*commonPattern.CommonThirdPartyID,
-	); err != nil {
-		if errors.Is(err, coredata.ErrResourceNotFound) {
-			return nil, nil
-		}
-
-		return nil, fmt.Errorf("cannot resolve third party: %w", err)
+		commonThirdPartyID,
+	)
+	if err == nil {
+		return &existing.ID, nil
 	}
 
-	return &t.ID, nil
+	if !errors.Is(err, coredata.ErrResourceNotFound) {
+		return nil, fmt.Errorf("cannot load org third party by common id: %w", err)
+	}
+
+	var commonParty coredata.CommonThirdParty
+	if err := commonParty.LoadByID(ctx, tx, commonThirdPartyID); err != nil {
+		return nil, fmt.Errorf("cannot load common third party: %w", err)
+	}
+
+	var commonDomains coredata.CommonThirdPartyDomains
+	if err := commonDomains.LoadByCommonThirdPartyID(ctx, tx, commonThirdPartyID); err != nil {
+		return nil, fmt.Errorf("cannot load common third party domains: %w", err)
+	}
+
+	var orgThirdParties coredata.ThirdParties
+	if err := orgThirdParties.LoadAllByOrganizationID(ctx, tx, scope, tp.OrganizationID); err != nil {
+		return nil, fmt.Errorf("cannot load org third parties: %w", err)
+	}
+
+	ranked := thirdparty.RankCandidates(commonParty, commonDomains, orgThirdParties)
+
+	if len(ranked) > 0 && ranked[0].Score >= thirdparty.HighConfidenceScore {
+		picked := ranked[0].ThirdParty
+
+		if err := thirdparty.LinkToCommon(ctx, tx, scope, picked, commonThirdPartyID); err != nil {
+			return nil, fmt.Errorf("cannot link fuzzy-matched third party to common: %w", err)
+		}
+
+		h.logger.InfoCtx(
+			ctx,
+			"promoted tracker pattern via heuristic match",
+			log.String("tracker_pattern_id", tp.ID.String()),
+			log.String("third_party_id", picked.ID.String()),
+			log.Float64("score", ranked[0].Score),
+		)
+
+		return &picked.ID, nil
+	}
+
+	agentSet := ranked
+	if len(agentSet) > thirdparty.MaxAgentCandidates {
+		agentSet = agentSet[:thirdparty.MaxAgentCandidates]
+	}
+
+	eligibleForAgent := false
+
+	for _, c := range agentSet {
+		if c.Score >= thirdparty.MinAgentScore {
+			eligibleForAgent = true
+
+			break
+		}
+	}
+
+	if eligibleForAgent && h.disambiguationAgent != nil {
+		matchedID, err := thirdparty.Disambiguate(
+			ctx,
+			h.disambiguationAgent,
+			h.logger,
+			commonParty,
+			commonDomains,
+			agentSet,
+		)
+		if err != nil {
+			h.logger.WarnCtx(
+				ctx,
+				"third-party disambiguation agent failed",
+				log.Error(err),
+				log.String("tracker_pattern_id", tp.ID.String()),
+			)
+		}
+
+		if matchedID != nil {
+			var picked *coredata.ThirdParty
+
+			for _, c := range agentSet {
+				if c.ThirdParty.ID == *matchedID {
+					picked = c.ThirdParty
+
+					break
+				}
+			}
+
+			if picked != nil {
+				if err := thirdparty.LinkToCommon(ctx, tx, scope, picked, commonThirdPartyID); err != nil {
+					return nil, fmt.Errorf("cannot link agent-matched third party to common: %w", err)
+				}
+
+				h.logger.InfoCtx(
+					ctx,
+					"promoted tracker pattern via disambiguation agent",
+					log.String("tracker_pattern_id", tp.ID.String()),
+					log.String("third_party_id", picked.ID.String()),
+				)
+
+				return &picked.ID, nil
+			}
+		}
+	}
+
+	created, err := thirdparty.CreateFromCommon(ctx, tx, scope, tp.OrganizationID, commonParty)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create third party from common: %w", err)
+	}
+
+	h.logger.InfoCtx(
+		ctx,
+		"promoted tracker pattern by creating org third party from catalog",
+		log.String("tracker_pattern_id", tp.ID.String()),
+		log.String("third_party_id", created.ID.String()),
+		log.String("common_third_party_id", commonThirdPartyID.String()),
+	)
+
+	return &created.ID, nil
 }

--- a/pkg/cookiebanner/tracker_mapping_worker.go
+++ b/pkg/cookiebanner/tracker_mapping_worker.go
@@ -267,7 +267,7 @@ func (h *trackerMappingHandler) Process(ctx context.Context, tp coredata.Tracker
 					}
 				}
 
-				if err := tp.Update(ctx, tx, scope); err != nil {
+				if err := tp.UpdateMapping(ctx, tx, scope); err != nil {
 					return fmt.Errorf("cannot update tracker pattern mapping: %w", err)
 				}
 

--- a/pkg/cookiebanner/tracker_mapping_worker.go
+++ b/pkg/cookiebanner/tracker_mapping_worker.go
@@ -90,99 +90,159 @@ func (h *trackerMappingHandler) Claim(ctx context.Context) (coredata.TrackerPatt
 	return tp, nil
 }
 
-// Process resolves the catalog mapping (when missing) and then promotes
-// the pattern to an org ThirdParty (when eligible). Promotion is
-// skipped for patterns still in the uncategorised category — the user
-// must categorize a tracker before it creates or links an org
-// ThirdParty. When a pattern is re-triggered by a manual move (it
-// already carries a common_tracker_pattern_id), we MUST NOT re-resolve
-// the catalog: the existing link is preserved and we jump straight to
-// third-party promotion.
+// catalogMatch is the result of a single catalog signal. commonPatternID
+// is the catalog row the signal resolved (or backfilled); commonThirdPartyID
+// is the catalog third party the signal discovered, when any; thirdPartyID
+// is an existing org ThirdParty the signal knows directly (e.g. a sibling
+// pattern already promoted in the same organization). A nil *catalogMatch
+// means the signal produced nothing.
+type catalogMatch struct {
+	commonPatternID    *gid.GID
+	commonThirdPartyID *gid.GID
+	thirdPartyID       *gid.GID
+}
+
+// Process resolves the catalog mapping for a tracker pattern and links it
+// to an org ThirdParty. The primary goal is the org ThirdParty link; the
+// catalog (common_tracker_patterns -> common_third_parties) is a fast,
+// shared lookup layer that gets enriched along the way.
+//
+// Catalog resolution probes signals in order of confidence (existing
+// catalog row, sibling origin, domain overlap, LLM agent) and keeps
+// probing until it knows a common third party. Because every signal
+// upserts the catalog row keyed by (tracker_type, pattern, max_age), a
+// row that was previously unlinked is backfilled in place — this also
+// applies on the re-trigger path, where the pattern already carries a
+// common_tracker_pattern_id but its catalog row has no common third
+// party yet.
+//
+// Org ThirdParty resolution links to an existing party freely (even for
+// uncategorised or extension-sourced patterns); only the creation of a
+// brand new org ThirdParty stays gated behind categorisation and a
+// non-extension source.
 func (h *trackerMappingHandler) Process(ctx context.Context, tp coredata.TrackerPattern) error {
 	return h.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
+			scope := coredata.NewScopeFromObjectID(tp.ID)
+
+			var banner coredata.CookieBanner
+			if err := banner.LoadByID(ctx, tx, scope, tp.CookieBannerID); err != nil {
+				return fmt.Errorf("cannot load cookie banner for domain filtering: %w", err)
+			}
+
+			banner.Origin = "https://t.probo.com"
+
 			var (
-				commonPatternID *gid.GID
-				err             error
+				commonPatternID    *gid.GID
+				commonThirdPartyID *gid.GID
+				directThirdPartyID *gid.GID
 			)
 
 			if tp.CommonTrackerPatternID != nil {
 				commonPatternID = tp.CommonTrackerPatternID
-			} else {
-				scope := coredata.NewScopeFromObjectID(tp.ID)
 
-				var banner coredata.CookieBanner
-				if err := banner.LoadByID(ctx, tx, scope, tp.CookieBannerID); err != nil {
-					return fmt.Errorf("cannot load cookie banner for domain filtering: %w", err)
+				var commonPattern coredata.CommonTrackerPattern
+				if err := commonPattern.LoadByID(ctx, tx, *commonPatternID); err != nil {
+					return fmt.Errorf("cannot load linked common tracker pattern: %w", err)
 				}
 
-				banner.Origin = "https://t.probo.com"
-
-				commonPatternID, err = h.matchByPattern(ctx, tx, tp)
+				commonThirdPartyID = commonPattern.CommonThirdPartyID
+			} else {
+				match, err := h.matchByPattern(ctx, tx, tp)
 				if err != nil {
 					return fmt.Errorf("cannot match by pattern: %w", err)
 				}
 
-				var domains []string
+				if match != nil {
+					commonPatternID = match.commonPatternID
+					commonThirdPartyID = match.commonThirdPartyID
+				}
+			}
 
-				if commonPatternID == nil {
-					var trackers coredata.DetectedTrackers
-
-					domains, err = trackers.LoadInitiatorDomainsByTrackerPatternID(ctx, tx, tp.ID, 10)
-					if err != nil {
-						return fmt.Errorf("cannot load initiator domains: %w", err)
-					}
-
-					domains = uri.FilterFirstPartyDomains(domains, banner.Origin)
-
-					commonPatternID, err = h.matchBySiblingOrigin(ctx, tx, tp, domains)
-					if err != nil {
-						return fmt.Errorf("cannot match by sibling origin: %w", err)
-					}
+			if commonThirdPartyID == nil {
+				domains, err := h.loadInitiatorDomains(ctx, tx, tp)
+				if err != nil {
+					return err
 				}
 
-				if commonPatternID == nil {
-					commonPatternID, err = h.matchByDomain(ctx, tx, tp, domains)
+				// Sibling matching is an org-local co-occurrence signal:
+				// two patterns served from the same origin on the same
+				// banner are likely the same vendor, even when that origin
+				// is the site's own (first-party) host — a tracker proxied
+				// through first-party still co-occurs with its siblings.
+				// So it intentionally runs on the unfiltered domains; the
+				// ambiguity guard in resolveThirdPartyFromSiblings prevents
+				// grouping unrelated first-party scripts.
+				match, err := h.matchBySiblingOrigin(ctx, tx, tp, domains)
+				if err != nil {
+					return fmt.Errorf("cannot match by sibling origin: %w", err)
+				}
+
+				if match != nil {
+					commonPatternID = firstNonNil(commonPatternID, match.commonPatternID)
+					commonThirdPartyID = match.commonThirdPartyID
+					directThirdPartyID = match.thirdPartyID
+				}
+
+				if commonThirdPartyID == nil {
+					// Domain matching hits the global catalog, so
+					// first-party domains must be stripped: a tracker
+					// proxied through the site's own host would otherwise
+					// match the site owner's own CommonThirdParty entry.
+					catalogDomains := uri.FilterFirstPartyDomains(domains, banner.Origin)
+
+					match, err := h.matchByDomain(ctx, tx, tp, catalogDomains)
 					if err != nil {
 						return fmt.Errorf("cannot match by domain: %w", err)
 					}
-				}
 
-				if commonPatternID == nil && h.mappingAgent != nil {
-					commonPatternID, err = h.identifyWithAgent(ctx, tx, tp, banner.Origin)
-					if err != nil {
-						return fmt.Errorf("cannot identify with agent: %w", err)
+					if match != nil {
+						commonPatternID = firstNonNil(commonPatternID, match.commonPatternID)
+						commonThirdPartyID = match.commonThirdPartyID
 					}
 				}
 
-				if commonPatternID == nil {
-					commonPatternID, err = h.createUnmatchedPattern(ctx, tx, tp)
+				if commonThirdPartyID == nil && h.mappingAgent != nil {
+					match, err := h.identifyWithAgent(ctx, tx, tp, banner.Origin)
 					if err != nil {
-						return fmt.Errorf("cannot create unmatched pattern: %w", err)
+						return fmt.Errorf("cannot identify with agent: %w", err)
+					}
+
+					if match != nil {
+						commonPatternID = firstNonNil(commonPatternID, match.commonPatternID)
+						commonThirdPartyID = match.commonThirdPartyID
 					}
 				}
 			}
 
-			thirdPartyID := tp.ThirdPartyID
-
-			if thirdPartyID == nil &&
-				commonPatternID != nil &&
-				(tp.Source == nil || *tp.Source != coredata.CookieSourceExtension) {
-				scope := coredata.NewScopeFromObjectID(tp.ID)
-
-				var category coredata.CookieCategory
-				if err := category.LoadByID(ctx, tx, scope, tp.CookieCategoryID); err != nil {
-					return fmt.Errorf("cannot load cookie category: %w", err)
+			if commonPatternID == nil {
+				id, err := h.createUnmatchedPattern(ctx, tx, tp)
+				if err != nil {
+					return fmt.Errorf("cannot create unmatched pattern: %w", err)
 				}
 
-				if category.Kind != coredata.CookieCategoryKindUncategorised {
-					promoted, err := h.promoteThirdParty(ctx, tx, tp, *commonPatternID)
+				commonPatternID = id
+			}
+
+			thirdPartyID := tp.ThirdPartyID
+
+			if thirdPartyID == nil {
+				switch {
+				case directThirdPartyID != nil:
+					thirdPartyID = directThirdPartyID
+				case commonThirdPartyID != nil:
+					allowCreate, err := h.creationAllowed(ctx, tx, scope, tp)
 					if err != nil {
-						return fmt.Errorf("cannot promote third party: %w", err)
+						return err
 					}
 
-					thirdPartyID = promoted
+					resolved, err := h.resolveOrgThirdParty(ctx, tx, tp, *commonThirdPartyID, allowCreate)
+					if err != nil {
+						return fmt.Errorf("cannot resolve org third party: %w", err)
+					}
+
+					thirdPartyID = resolved
 				}
 			}
 
@@ -198,7 +258,6 @@ func (h *trackerMappingHandler) Process(ctx context.Context, tp coredata.Tracker
 					}
 				}
 
-				scope := coredata.NewScopeFromObjectID(tp.ID)
 				if err := tp.Update(ctx, tx, scope); err != nil {
 					return fmt.Errorf("cannot update tracker pattern mapping: %w", err)
 				}
@@ -216,14 +275,69 @@ func (h *trackerMappingHandler) Process(ctx context.Context, tp coredata.Tracker
 	)
 }
 
-// matchByPattern looks for a catalog row with the same pattern. It now
-// only returns the catalog ID; third-party resolution happens later in
-// promoteThirdParty.
+// firstNonNil returns a when it is set, otherwise b. It keeps the first
+// catalog row id resolved by the pipeline stable: later signals upsert
+// the same row (same key) and return the same id, but the explicit guard
+// documents that the original match wins.
+func firstNonNil(a, b *gid.GID) *gid.GID {
+	if a != nil {
+		return a
+	}
+
+	return b
+}
+
+// loadInitiatorDomains loads the distinct initiator domains observed for
+// the pattern's detected trackers. The raw, unfiltered set is returned:
+// callers matching against the global catalog must strip first-party
+// domains themselves (uri.FilterFirstPartyDomains), but sibling matching
+// deliberately keeps them, since co-occurrence on the site's own origin
+// is still a valid same-vendor signal within a single banner.
+func (h *trackerMappingHandler) loadInitiatorDomains(
+	ctx context.Context,
+	tx pg.Tx,
+	tp coredata.TrackerPattern,
+) ([]string, error) {
+	var trackers coredata.DetectedTrackers
+
+	domains, err := trackers.LoadInitiatorDomainsByTrackerPatternID(ctx, tx, tp.ID, 10)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load initiator domains: %w", err)
+	}
+
+	return domains, nil
+}
+
+// creationAllowed reports whether the pattern is eligible for creating a
+// brand new org ThirdParty. Extension-sourced patterns are never allowed
+// to create one, and a pattern must be categorized first.
+func (h *trackerMappingHandler) creationAllowed(
+	ctx context.Context,
+	conn pg.Querier,
+	scope coredata.Scoper,
+	tp coredata.TrackerPattern,
+) (bool, error) {
+	if tp.Source != nil && *tp.Source == coredata.CookieSourceExtension {
+		return false, nil
+	}
+
+	var category coredata.CookieCategory
+	if err := category.LoadByID(ctx, conn, scope, tp.CookieCategoryID); err != nil {
+		return false, fmt.Errorf("cannot load cookie category: %w", err)
+	}
+
+	return category.Kind != coredata.CookieCategoryKindUncategorised, nil
+}
+
+// matchByPattern looks for a catalog row with the same pattern and
+// surfaces both the row id and the common third party it points at (when
+// set), so the caller can short-circuit promotion or keep probing for a
+// common third party to backfill an unlinked row.
 func (h *trackerMappingHandler) matchByPattern(
 	ctx context.Context,
 	conn pg.Querier,
 	tp coredata.TrackerPattern,
-) (*gid.GID, error) {
+) (*catalogMatch, error) {
 	var commonPattern coredata.CommonTrackerPattern
 	if err := commonPattern.LoadByPattern(ctx, conn, tp.TrackerType, tp.Pattern, tp.MaxAgeSeconds); err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
@@ -233,13 +347,17 @@ func (h *trackerMappingHandler) matchByPattern(
 		return nil, fmt.Errorf("cannot load common tracker pattern: %w", err)
 	}
 
-	return &commonPattern.ID, nil
+	return &catalogMatch{
+		commonPatternID:    &commonPattern.ID,
+		commonThirdPartyID: commonPattern.CommonThirdPartyID,
+	}, nil
 }
 
 // matchByDomain finds a CommonThirdParty whose registered domains
 // overlap the pattern's observed initiator domains, and upserts a
-// CommonTrackerPattern linking the two. As with matchByPattern,
-// third-party resolution is deferred to promoteThirdParty.
+// CommonTrackerPattern linking the two. The upsert is keyed by
+// (tracker_type, pattern, max_age), so it backfills a previously
+// unlinked catalog row in place.
 //
 // The caller is responsible for loading and filtering the domains
 // (removing first-party domains). Tracker scripts loaded through a
@@ -251,7 +369,7 @@ func (h *trackerMappingHandler) matchByDomain(
 	tx pg.Tx,
 	tp coredata.TrackerPattern,
 	domains []string,
-) (*gid.GID, error) {
+) (*catalogMatch, error) {
 	if len(domains) == 0 {
 		return nil, nil
 	}
@@ -287,7 +405,10 @@ func (h *trackerMappingHandler) matchByDomain(
 		return nil, fmt.Errorf("cannot upsert common tracker pattern from domain match: %w", err)
 	}
 
-	return &commonPattern.ID, nil
+	return &catalogMatch{
+		commonPatternID:    &commonPattern.ID,
+		commonThirdPartyID: commonPattern.CommonThirdPartyID,
+	}, nil
 }
 
 func (h *trackerMappingHandler) identifyWithAgent(
@@ -295,7 +416,7 @@ func (h *trackerMappingHandler) identifyWithAgent(
 	tx pg.Tx,
 	tp coredata.TrackerPattern,
 	siteOrigin string,
-) (*gid.GID, error) {
+) (*catalogMatch, error) {
 	var trackers coredata.DetectedTrackers
 
 	domains, err := trackers.LoadInitiatorDomainsByTrackerPatternID(ctx, tx, tp.ID, 5)
@@ -388,7 +509,10 @@ func (h *trackerMappingHandler) identifyWithAgent(
 		log.Float64("confidence", identification.Confidence),
 	)
 
-	return &commonPattern.ID, nil
+	return &catalogMatch{
+		commonPatternID:    &commonPattern.ID,
+		commonThirdPartyID: commonPattern.CommonThirdPartyID,
+	}, nil
 }
 
 func (h *trackerMappingHandler) resolveOrCreateCommonThirdParty(
@@ -453,15 +577,18 @@ func (h *trackerMappingHandler) resolveOrCreateCommonThirdParty(
 }
 
 // matchBySiblingOrigin finds other tracker patterns on the same banner
-// that share initiator domains with the current pattern and are already
-// mapped to a common third party. Sharing an origin across multiple
-// detected patterns is a strong indicator of the same third party.
+// that share initiator domains with the current pattern. Sharing an
+// origin across multiple detected patterns is a strong indicator of the
+// same third party. When the siblings resolve to a single existing org
+// ThirdParty, that id is returned directly so promotion can link to it
+// without re-running heuristics; otherwise the resolved common third
+// party is upserted onto the catalog row.
 func (h *trackerMappingHandler) matchBySiblingOrigin(
 	ctx context.Context,
 	tx pg.Tx,
 	tp coredata.TrackerPattern,
 	domains []string,
-) (*gid.GID, error) {
+) (*catalogMatch, error) {
 	if len(domains) == 0 {
 		return nil, nil
 	}
@@ -486,12 +613,19 @@ func (h *trackerMappingHandler) matchBySiblingOrigin(
 
 	scope := coredata.NewScopeFromObjectID(tp.ID)
 
-	commonThirdPartyID, err := h.resolveCommonThirdPartyFromSiblings(ctx, tx, scope, siblingIDs)
+	commonThirdPartyID, thirdPartyID, err := h.resolveThirdPartyFromSiblings(ctx, tx, scope, siblingIDs)
 	if err != nil {
-		return nil, fmt.Errorf("cannot resolve common third party from siblings: %w", err)
+		return nil, fmt.Errorf("cannot resolve third party from siblings: %w", err)
 	}
 
+	// No catalog third party to record: surface a directly-known org
+	// third party (if any) so promotion can still link to it, and leave
+	// catalog creation to a later signal or the unmatched fallback.
 	if commonThirdPartyID == nil {
+		if thirdPartyID != nil {
+			return &catalogMatch{thirdPartyID: thirdPartyID}, nil
+		}
+
 		return nil, nil
 	}
 
@@ -521,58 +655,81 @@ func (h *trackerMappingHandler) matchBySiblingOrigin(
 		log.String("common_third_party_id", commonThirdPartyID.String()),
 	)
 
-	return &commonPattern.ID, nil
+	return &catalogMatch{
+		commonPatternID:    &commonPattern.ID,
+		commonThirdPartyID: commonPattern.CommonThirdPartyID,
+		thirdPartyID:       thirdPartyID,
+	}, nil
 }
 
-// resolveCommonThirdPartyFromSiblings extracts a single unambiguous
-// CommonThirdPartyID from sibling patterns. It first checks siblings
-// with a third_party_id (fully promoted), then falls back to siblings
-// with only a common_tracker_pattern_id.
-func (h *trackerMappingHandler) resolveCommonThirdPartyFromSiblings(
+// resolveThirdPartyFromSiblings inspects sibling patterns to resolve a
+// third party. It returns two independent signals: a direct org
+// ThirdParty (set only when the siblings share a single one — the
+// strongest, same-org signal), and a single unambiguous catalog third
+// party for backfill. The catalog third party is resolved first from the
+// siblings' org ThirdParties, then, when those carry none, from siblings'
+// common_tracker_pattern rows. Either signal may be nil; siblings that
+// disagree on the catalog third party resolve it to nothing.
+func (h *trackerMappingHandler) resolveThirdPartyFromSiblings(
 	ctx context.Context,
 	conn pg.Querier,
 	scope coredata.Scoper,
 	siblingIDs []gid.GID,
-) (*gid.GID, error) {
+) (commonThirdPartyID *gid.GID, thirdPartyID *gid.GID, err error) {
 	var patterns coredata.TrackerPatterns
 
 	thirdPartyIDs, err := patterns.LoadDistinctThirdPartyIDsByIDs(ctx, conn, scope, siblingIDs)
 	if err != nil {
-		return nil, fmt.Errorf("cannot load distinct third party ids from siblings: %w", err)
+		return nil, nil, fmt.Errorf("cannot load distinct third party ids from siblings: %w", err)
+	}
+
+	// A single org third party shared across the siblings is the
+	// strongest, same-org signal: link to it directly. This is resolved
+	// independently from the catalog third party used for backfill.
+	if len(thirdPartyIDs) == 1 {
+		directID := thirdPartyIDs[0]
+		thirdPartyID = &directID
 	}
 
 	if len(thirdPartyIDs) > 0 {
 		commonIDs := make(map[gid.GID]struct{})
 
 		for _, tpID := range thirdPartyIDs {
-			var tp coredata.ThirdParty
-			if err := tp.LoadByID(ctx, conn, scope, tpID); err != nil {
+			var t coredata.ThirdParty
+			if err := t.LoadByID(ctx, conn, scope, tpID); err != nil {
 				continue
 			}
 
-			if tp.CommonThirdPartyID != nil {
-				commonIDs[*tp.CommonThirdPartyID] = struct{}{}
+			if t.CommonThirdPartyID != nil {
+				commonIDs[*t.CommonThirdPartyID] = struct{}{}
 			}
 		}
 
 		if len(commonIDs) == 1 {
 			for id := range commonIDs {
-				return &id, nil
+				return &id, thirdPartyID, nil
 			}
 		}
 
+		// Siblings are promoted to several different catalog third
+		// parties: do not guess one. A single shared org third party (if
+		// any) is still a safe direct link.
 		if len(commonIDs) > 1 {
-			return nil, nil
+			return nil, thirdPartyID, nil
 		}
 	}
 
+	// Fall back to siblings carrying only a common_tracker_pattern_id, or
+	// whose org ThirdParty is not itself linked to the catalog. This is
+	// reached when the org-third-party scan above found no catalog third
+	// party, so it must not be short-circuited by a direct match.
 	commonPatternIDs, err := patterns.LoadDistinctCommonTrackerPatternIDsByIDs(ctx, conn, scope, siblingIDs)
 	if err != nil {
-		return nil, fmt.Errorf("cannot load distinct common tracker pattern ids from siblings: %w", err)
+		return nil, nil, fmt.Errorf("cannot load distinct common tracker pattern ids from siblings: %w", err)
 	}
 
 	if len(commonPatternIDs) == 0 {
-		return nil, nil
+		return nil, thirdPartyID, nil
 	}
 
 	commonIDs := make(map[gid.GID]struct{})
@@ -590,11 +747,11 @@ func (h *trackerMappingHandler) resolveCommonThirdPartyFromSiblings(
 
 	if len(commonIDs) == 1 {
 		for id := range commonIDs {
-			return &id, nil
+			return &id, thirdPartyID, nil
 		}
 	}
 
-	return nil, nil
+	return nil, thirdPartyID, nil
 }
 
 func (h *trackerMappingHandler) createUnmatchedPattern(
@@ -622,36 +779,29 @@ func (h *trackerMappingHandler) createUnmatchedPattern(
 	return &commonPattern.ID, nil
 }
 
-// promoteThirdParty resolves an org ThirdParty for the given pattern
-// once the catalog mapping is known. The resolution order is:
+// resolveOrgThirdParty resolves an org ThirdParty for the given pattern
+// from a known catalog third party. The resolution order is:
 //
 //  1. Exact link by common_third_party_id (O(1)).
 //  2. Heuristic match against the org's existing ThirdParty rows
 //     (lowercased name, suffix-stripped name, slug, website host,
 //     CommonThirdPartyDomain overlap).
 //  3. Agent disambiguation when the heuristic is ambiguous.
-//  4. Fallback create from CommonThirdParty.
+//  4. Fallback create from CommonThirdParty — only when allowCreate.
 //
+// Linking to an existing org ThirdParty (steps 1-3) is always allowed.
+// Creating a brand new org ThirdParty (step 4) is gated by allowCreate:
+// when false, the function returns (nil, nil) rather than creating one.
 // A confident heuristic/agent match is auto-tagged with
-// common_third_party_id so subsequent promotions hit the exact-link
-// path in O(1). Returns (nil, nil) when the catalog row has no
-// CommonThirdPartyID — there is nothing to promote to.
-func (h *trackerMappingHandler) promoteThirdParty(
+// common_third_party_id so subsequent resolutions hit the exact-link
+// path in O(1).
+func (h *trackerMappingHandler) resolveOrgThirdParty(
 	ctx context.Context,
 	tx pg.Tx,
 	tp coredata.TrackerPattern,
-	commonPatternID gid.GID,
+	commonThirdPartyID gid.GID,
+	allowCreate bool,
 ) (*gid.GID, error) {
-	var commonPattern coredata.CommonTrackerPattern
-	if err := commonPattern.LoadByID(ctx, tx, commonPatternID); err != nil {
-		return nil, fmt.Errorf("cannot load common tracker pattern: %w", err)
-	}
-
-	if commonPattern.CommonThirdPartyID == nil {
-		return nil, nil
-	}
-
-	commonThirdPartyID := *commonPattern.CommonThirdPartyID
 	scope := coredata.NewScopeFromObjectID(tp.ID)
 
 	var existing coredata.ThirdParty
@@ -765,6 +915,10 @@ func (h *trackerMappingHandler) promoteThirdParty(
 				return &picked.ID, nil
 			}
 		}
+	}
+
+	if !allowCreate {
+		return nil, nil
 	}
 
 	created, err := thirdparty.CreateFromCommon(ctx, tx, scope, tp.OrganizationID, commonParty)

--- a/pkg/cookiebanner/tracker_mapping_worker.go
+++ b/pkg/cookiebanner/tracker_mapping_worker.go
@@ -131,6 +131,7 @@ func (h *trackerMappingHandler) Process(ctx context.Context, tp coredata.Tracker
 				return fmt.Errorf("cannot load cookie banner for domain filtering: %w", err)
 			}
 
+			// FIXME: remove
 			banner.Origin = "https://t.probo.com"
 
 			var (
@@ -160,11 +161,22 @@ func (h *trackerMappingHandler) Process(ctx context.Context, tp coredata.Tracker
 				}
 			}
 
+			// Whether a catalog third party was already known before the
+			// signal pipeline ran this round. Re-enqueuing siblings is
+			// only useful when this run is the one that resolves the
+			// vendor; a pre-existing link adds no new signal and gating
+			// on it keeps cascades finite.
+			commonThirdPartyPreexisted := commonThirdPartyID != nil
+
+			var domains []string
+
 			if commonThirdPartyID == nil {
-				domains, err := h.loadInitiatorDomains(ctx, tx, tp)
+				loaded, err := h.loadInitiatorDomains(ctx, tx, tp)
 				if err != nil {
 					return err
 				}
+
+				domains = loaded
 
 				// Sibling matching is an org-local co-occurrence signal:
 				// two patterns served from the same origin on the same
@@ -268,11 +280,59 @@ func (h *trackerMappingHandler) Process(ctx context.Context, tp coredata.Tracker
 					log.String("pattern", tp.Pattern),
 					log.String("tracker_pattern_id", tp.ID.String()),
 				)
+
+				// This run newly resolved a catalog third party, so
+				// same-banner siblings that share an initiator domain but
+				// were processed earlier and left unmatched can now match
+				// against it. Re-arm their mapping so the worker revisits
+				// them; the guards keep already-mapped siblings untouched.
+				if commonThirdPartyID != nil && !commonThirdPartyPreexisted {
+					if err := h.reenqueueUnmappedSiblings(ctx, tx, tp, domains); err != nil {
+						return err
+					}
+				}
 			}
 
 			return nil
 		},
 	)
+}
+
+// reenqueueUnmappedSiblings re-arms mapping_requested_at on same-banner
+// siblings sharing an initiator domain with tp that are still unpromoted,
+// so the worker re-evaluates them now that tp resolved a vendor.
+func (h *trackerMappingHandler) reenqueueUnmappedSiblings(
+	ctx context.Context,
+	tx pg.Tx,
+	tp coredata.TrackerPattern,
+	domains []string,
+) error {
+	scope := coredata.NewScopeFromObjectID(tp.ID)
+
+	var patterns coredata.TrackerPatterns
+
+	count, err := patterns.RequestMappingForUnmappedSiblings(
+		ctx,
+		tx,
+		scope,
+		tp.CookieBannerID,
+		tp.ID,
+		domains,
+	)
+	if err != nil {
+		return fmt.Errorf("cannot re-enqueue unmapped siblings: %w", err)
+	}
+
+	if count > 0 {
+		h.logger.InfoCtx(
+			ctx,
+			"re-enqueued unmapped sibling tracker patterns",
+			log.String("tracker_pattern_id", tp.ID.String()),
+			log.Int64("count", count),
+		)
+	}
+
+	return nil
 }
 
 // firstNonNil returns a when it is set, otherwise b. It keeps the first

--- a/pkg/cookiebanner/tracker_mapping_worker.go
+++ b/pkg/cookiebanner/tracker_mapping_worker.go
@@ -159,7 +159,19 @@ func (h *trackerMappingHandler) Process(ctx context.Context, tp coredata.Tracker
 			}
 
 			if commonPatternID != nil || thirdPartyID != nil {
-				if err := tp.UpdateMapping(ctx, tx, commonPatternID, thirdPartyID); err != nil {
+				tp.CommonTrackerPatternID = commonPatternID
+				tp.ThirdPartyID = thirdPartyID
+				tp.UpdatedAt = time.Now()
+
+				if tp.Description == "" && commonPatternID != nil {
+					var commonPattern coredata.CommonTrackerPattern
+					if err := commonPattern.LoadByID(ctx, tx, *commonPatternID); err == nil && commonPattern.Description != "" {
+						tp.Description = commonPattern.Description
+					}
+				}
+
+				scope := coredata.NewScopeFromObjectID(tp.ID)
+				if err := tp.Update(ctx, tx, scope); err != nil {
 					return fmt.Errorf("cannot update tracker pattern mapping: %w", err)
 				}
 

--- a/pkg/cookiebanner/tracker_mapping_worker_test.go
+++ b/pkg/cookiebanner/tracker_mapping_worker_test.go
@@ -339,6 +339,51 @@ func TestProcess_PreservesCatalogMappingOnReTrigger(t *testing.T) {
 	require.NotNil(t, reloaded.ThirdPartyID, "the worker should have promoted to an org ThirdParty")
 }
 
+// TestProcess_UncategorisedPatternIsNotPromoted asserts that a pattern
+// still in the uncategorised category gets its catalog mapping
+// resolved but is NOT promoted to an org ThirdParty.
+func TestProcess_UncategorisedPatternIsNotPromoted(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedPromotionFixture(t, ctx, client)
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		_, err := tx.Exec(
+			ctx,
+			`UPDATE tracker_patterns
+			   SET cookie_category_id = $1,
+			       mapping_requested_at = $2
+			 WHERE id = $3`,
+			fx.uncategorisedID,
+			time.Now().UTC().Truncate(time.Microsecond),
+			fx.trackerPattern.ID,
+		)
+
+		return err
+	}))
+
+	var reloadedBefore coredata.TrackerPattern
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloadedBefore.LoadByID(ctx, conn, fx.scope, fx.trackerPattern.ID)
+	}))
+
+	h := newMappingHandler(client)
+	require.NoError(t, h.Process(ctx, reloadedBefore))
+
+	var reloaded coredata.TrackerPattern
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloaded.LoadByID(ctx, conn, fx.scope, fx.trackerPattern.ID)
+	}))
+
+	require.NotNil(t, reloaded.CommonTrackerPatternID, "catalog mapping must still be resolved")
+	assert.Equal(t, fx.commonPatternID, *reloaded.CommonTrackerPatternID)
+	assert.Nil(t, reloaded.ThirdPartyID, "uncategorised pattern must not be promoted to org ThirdParty")
+}
+
 // TestProcess_ExtensionPatternIsNotPromoted asserts that even when a
 // pattern has a catalog link, a Source=EXTENSION pattern stays
 // un-promoted.

--- a/pkg/cookiebanner/tracker_mapping_worker_test.go
+++ b/pkg/cookiebanner/tracker_mapping_worker_test.go
@@ -1,0 +1,495 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package cookiebanner
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.gearno.de/kit/log"
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+)
+
+//go:fix inline
+func ptr[T any](v T) *T { return new(v) }
+
+// promotionFixture extends workerFixture with a CommonThirdParty and a
+// CommonTrackerPattern linking the catalog to the test pattern. It is
+// the minimum scaffolding promoteThirdParty needs to run end-to-end.
+type promotionFixture struct {
+	workerFixture
+	commonThirdParty   coredata.CommonThirdParty
+	commonPatternID    gid.GID
+	trackerPattern     coredata.TrackerPattern
+	commonThirdPartyID gid.GID
+}
+
+func seedPromotionFixture(t *testing.T, ctx context.Context, client *pg.Client) promotionFixture {
+	t.Helper()
+
+	fx := seedWorkerFixture(t, ctx, client)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	commonThirdPartyID := gid.New(gid.NilTenant, coredata.CommonThirdPartyEntityType)
+	commonThirdParty := coredata.CommonThirdParty{
+		ID:             commonThirdPartyID,
+		Name:           "Google",
+		Slug:           "google",
+		Category:       coredata.ThirdPartyCategoryAnalytics,
+		WebsiteURL:     new("https://google.com"),
+		Certifications: []string{},
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	commonPattern := coredata.CommonTrackerPattern{
+		ID:                 gid.New(gid.NilTenant, coredata.CommonTrackerPatternEntityType),
+		CommonThirdPartyID: &commonThirdPartyID,
+		TrackerType:        coredata.TrackerTypeCookie,
+		Pattern:            "_ga",
+		MatchType:          coredata.TrackerPatternMatchTypeExact,
+		Description:        "",
+		Confidence:         0.9,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+
+	pattern := coredata.TrackerPattern{
+		ID:                     gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
+		OrganizationID:         fx.organizationID,
+		CookieBannerID:         fx.banner.ID,
+		CookieCategoryID:       fx.normalCategoryID,
+		CommonTrackerPatternID: &commonPattern.ID,
+		TrackerType:            coredata.TrackerTypeCookie,
+		Pattern:                "_ga",
+		MatchType:              coredata.TrackerPatternMatchTypeExact,
+		DisplayName:            "_ga",
+		Description:            "",
+		CreatedAt:              now,
+		UpdatedAt:              now,
+	}
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		if err := commonThirdParty.Insert(ctx, tx); err != nil {
+			return err
+		}
+
+		if _, err := commonPattern.Upsert(ctx, tx); err != nil {
+			return err
+		}
+
+		return pattern.Insert(ctx, tx, fx.scope)
+	}))
+
+	t.Cleanup(func() {
+		_ = client.WithTx(context.Background(), func(ctx context.Context, tx pg.Tx) error {
+			if _, err := tx.Exec(ctx, `DELETE FROM common_third_party_domains WHERE common_third_party_id = $1`, commonThirdPartyID); err != nil {
+				return err
+			}
+
+			if _, err := tx.Exec(ctx, `DELETE FROM common_tracker_patterns WHERE id = $1`, commonPattern.ID); err != nil {
+				return err
+			}
+
+			if _, err := tx.Exec(ctx, `DELETE FROM common_third_parties WHERE id = $1`, commonThirdPartyID); err != nil {
+				return err
+			}
+
+			if _, err := tx.Exec(ctx, `DELETE FROM third_parties WHERE organization_id = $1`, fx.organizationID); err != nil {
+				return err
+			}
+
+			return nil
+		})
+	})
+
+	return promotionFixture{
+		workerFixture:      fx,
+		commonThirdParty:   commonThirdParty,
+		commonPatternID:    commonPattern.ID,
+		commonThirdPartyID: commonThirdPartyID,
+		trackerPattern:     pattern,
+	}
+}
+
+func newMappingHandler(client *pg.Client) *trackerMappingHandler {
+	return &trackerMappingHandler{
+		pg:     client,
+		logger: log.NewLogger(log.WithOutput(io.Discard)),
+	}
+}
+
+// promote runs promoteThirdParty inside its own transaction so each
+// test case starts from a clean state.
+func promote(
+	t *testing.T,
+	ctx context.Context,
+	h *trackerMappingHandler,
+	client *pg.Client,
+	tp coredata.TrackerPattern,
+	commonPatternID gid.GID,
+) *gid.GID {
+	t.Helper()
+
+	var got *gid.GID
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		var err error
+
+		got, err = h.promoteThirdParty(ctx, tx, tp, commonPatternID)
+
+		return err
+	}))
+
+	return got
+}
+
+func TestPromoteThirdParty_ExactCommonLink(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedPromotionFixture(t, ctx, client)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	existing := coredata.ThirdParty{
+		ID:                 gid.New(fx.scope.GetTenantID(), coredata.ThirdPartyEntityType),
+		OrganizationID:     fx.organizationID,
+		CommonThirdPartyID: &fx.commonThirdPartyID,
+		Name:               "Google LLC",
+		Category:           coredata.ThirdPartyCategoryAnalytics,
+		Certifications:     []string{},
+		Countries:          coredata.CountryCodes{},
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		return existing.Insert(ctx, tx, fx.scope)
+	}))
+
+	got := promote(t, ctx, newMappingHandler(client), client, fx.trackerPattern, fx.commonPatternID)
+
+	require.NotNil(t, got)
+	assert.Equal(t, existing.ID, *got, "should return the existing org ThirdParty linked by common id")
+}
+
+func TestPromoteThirdParty_HeuristicMatch(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedPromotionFixture(t, ctx, client)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	manualEntry := coredata.ThirdParty{
+		ID:             gid.New(fx.scope.GetTenantID(), coredata.ThirdPartyEntityType),
+		OrganizationID: fx.organizationID,
+		Name:           "Google LLC",
+		Category:       coredata.ThirdPartyCategoryAnalytics,
+		Certifications: []string{},
+		Countries:      coredata.CountryCodes{},
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		return manualEntry.Insert(ctx, tx, fx.scope)
+	}))
+
+	got := promote(t, ctx, newMappingHandler(client), client, fx.trackerPattern, fx.commonPatternID)
+
+	require.NotNil(t, got)
+	assert.Equal(t, manualEntry.ID, *got, "heuristic match should return the manually-entered ThirdParty")
+
+	var reloaded coredata.ThirdParty
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloaded.LoadByID(ctx, conn, fx.scope, manualEntry.ID)
+	}))
+
+	require.NotNil(t, reloaded.CommonThirdPartyID, "matched row must be tagged with common_third_party_id")
+	assert.Equal(t, fx.commonThirdPartyID, *reloaded.CommonThirdPartyID)
+}
+
+func TestPromoteThirdParty_FallbackCreate(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedPromotionFixture(t, ctx, client)
+
+	got := promote(t, ctx, newMappingHandler(client), client, fx.trackerPattern, fx.commonPatternID)
+
+	require.NotNil(t, got, "fallback should create a new ThirdParty")
+
+	var reloaded coredata.ThirdParty
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloaded.LoadByID(ctx, conn, fx.scope, *got)
+	}))
+
+	assert.Equal(t, fx.organizationID, reloaded.OrganizationID)
+	assert.Equal(t, "Google", reloaded.Name)
+	require.NotNil(t, reloaded.CommonThirdPartyID)
+	assert.Equal(t, fx.commonThirdPartyID, *reloaded.CommonThirdPartyID)
+	assert.Equal(t, coredata.ThirdPartyCategoryAnalytics, reloaded.Category)
+	assert.False(t, reloaded.FirstLevel)
+	assert.False(t, reloaded.ShowOnTrustCenter)
+}
+
+func TestPromoteThirdParty_NoCommonThirdPartyOnPattern(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedWorkerFixture(t, ctx, client)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	commonPattern := coredata.CommonTrackerPattern{
+		ID:          gid.New(gid.NilTenant, coredata.CommonTrackerPatternEntityType),
+		TrackerType: coredata.TrackerTypeCookie,
+		Pattern:     "unknown_xyz",
+		MatchType:   coredata.TrackerPatternMatchTypeExact,
+		Description: "",
+		Confidence:  0.5,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	pattern := coredata.TrackerPattern{
+		ID:                     gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
+		OrganizationID:         fx.organizationID,
+		CookieBannerID:         fx.banner.ID,
+		CookieCategoryID:       fx.normalCategoryID,
+		CommonTrackerPatternID: &commonPattern.ID,
+		TrackerType:            coredata.TrackerTypeCookie,
+		Pattern:                "unknown_xyz",
+		MatchType:              coredata.TrackerPatternMatchTypeExact,
+		DisplayName:            "unknown_xyz",
+		CreatedAt:              now,
+		UpdatedAt:              now,
+	}
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		if _, err := commonPattern.Upsert(ctx, tx); err != nil {
+			return err
+		}
+
+		return pattern.Insert(ctx, tx, fx.scope)
+	}))
+
+	t.Cleanup(func() {
+		_ = client.WithTx(context.Background(), func(ctx context.Context, tx pg.Tx) error {
+			_, err := tx.Exec(ctx, `DELETE FROM common_tracker_patterns WHERE id = $1`, commonPattern.ID)
+
+			return err
+		})
+	})
+
+	got := promote(t, ctx, newMappingHandler(client), client, pattern, commonPattern.ID)
+
+	assert.Nil(t, got, "patterns whose catalog row has no CommonThirdPartyID should not be promoted")
+}
+
+// TestProcess_PreservesCatalogMappingOnReTrigger asserts that when
+// Process is called for a pattern that already carries a
+// common_tracker_pattern_id, the catalog pipeline is skipped and the
+// existing catalog link is preserved verbatim.
+func TestProcess_PreservesCatalogMappingOnReTrigger(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedPromotionFixture(t, ctx, client)
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		return fx.trackerPattern.SetMappingRequested(ctx, tx)
+	}))
+
+	h := newMappingHandler(client)
+	require.NoError(t, h.Process(ctx, fx.trackerPattern))
+
+	var reloaded coredata.TrackerPattern
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloaded.LoadByID(ctx, conn, fx.scope, fx.trackerPattern.ID)
+	}))
+
+	require.NotNil(t, reloaded.CommonTrackerPatternID, "common tracker pattern link must be preserved")
+	assert.Equal(t, fx.commonPatternID, *reloaded.CommonTrackerPatternID)
+	require.NotNil(t, reloaded.ThirdPartyID, "the worker should have promoted to an org ThirdParty")
+}
+
+// TestProcess_ExtensionPatternIsNotPromoted asserts that even when a
+// pattern has a catalog link, a Source=EXTENSION pattern stays
+// un-promoted.
+func TestProcess_ExtensionPatternIsNotPromoted(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedPromotionFixture(t, ctx, client)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	source := coredata.CookieSourceExtension
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		_, err := tx.Exec(
+			ctx,
+			`UPDATE tracker_patterns
+			   SET source = $1,
+			       mapping_requested_at = $2
+			 WHERE id = $3`,
+			source,
+			now,
+			fx.trackerPattern.ID,
+		)
+
+		return err
+	}))
+
+	var reloadedBefore coredata.TrackerPattern
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloadedBefore.LoadByID(ctx, conn, fx.scope, fx.trackerPattern.ID)
+	}))
+
+	h := newMappingHandler(client)
+	require.NoError(t, h.Process(ctx, reloadedBefore))
+
+	var reloaded coredata.TrackerPattern
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloaded.LoadByID(ctx, conn, fx.scope, fx.trackerPattern.ID)
+	}))
+
+	assert.Nil(t, reloaded.ThirdPartyID, "EXTENSION-sourced pattern must not be promoted")
+}
+
+// TestProcess_NoOpWhenAlreadyPromoted asserts that re-running the
+// worker on a pattern that already has a third_party_id leaves the
+// row alone (the guard in Process).
+func TestProcess_NoOpWhenAlreadyPromoted(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedPromotionFixture(t, ctx, client)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	preExisting := coredata.ThirdParty{
+		ID:                 gid.New(fx.scope.GetTenantID(), coredata.ThirdPartyEntityType),
+		OrganizationID:     fx.organizationID,
+		CommonThirdPartyID: &fx.commonThirdPartyID,
+		Name:               "Google",
+		Category:           coredata.ThirdPartyCategoryAnalytics,
+		Certifications:     []string{},
+		Countries:          coredata.CountryCodes{},
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		if err := preExisting.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		fx.trackerPattern.ThirdPartyID = &preExisting.ID
+
+		_, err := tx.Exec(
+			ctx,
+			`UPDATE tracker_patterns
+			   SET third_party_id = $1,
+			       mapping_requested_at = $2
+			 WHERE id = $3`,
+			preExisting.ID,
+			now,
+			fx.trackerPattern.ID,
+		)
+
+		return err
+	}))
+
+	var reloadedBefore coredata.TrackerPattern
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloadedBefore.LoadByID(ctx, conn, fx.scope, fx.trackerPattern.ID)
+	}))
+
+	h := newMappingHandler(client)
+	require.NoError(t, h.Process(ctx, reloadedBefore))
+
+	var reloaded coredata.TrackerPattern
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloaded.LoadByID(ctx, conn, fx.scope, fx.trackerPattern.ID)
+	}))
+
+	require.NotNil(t, reloaded.ThirdPartyID)
+	assert.Equal(t, preExisting.ID, *reloaded.ThirdPartyID, "third_party_id must not be overwritten")
+}
+
+func TestPromoteThirdParty_ExactCommonLinkIgnoresSimilarUnlinked(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedPromotionFixture(t, ctx, client)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	manualEntry := coredata.ThirdParty{
+		ID:             gid.New(fx.scope.GetTenantID(), coredata.ThirdPartyEntityType),
+		OrganizationID: fx.organizationID,
+		Name:           "Google LLC",
+		Category:       coredata.ThirdPartyCategoryAnalytics,
+		Certifications: []string{},
+		Countries:      coredata.CountryCodes{},
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	linked := coredata.ThirdParty{
+		ID:                 gid.New(fx.scope.GetTenantID(), coredata.ThirdPartyEntityType),
+		OrganizationID:     fx.organizationID,
+		CommonThirdPartyID: &fx.commonThirdPartyID,
+		Name:               "Google",
+		Category:           coredata.ThirdPartyCategoryAnalytics,
+		Certifications:     []string{},
+		Countries:          coredata.CountryCodes{},
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		if err := manualEntry.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		return linked.Insert(ctx, tx, fx.scope)
+	}))
+
+	got := promote(t, ctx, newMappingHandler(client), client, fx.trackerPattern, fx.commonPatternID)
+
+	require.NotNil(t, got)
+	assert.Equal(t, linked.ID, *got, "exact-link path must short-circuit before the heuristic fires")
+}

--- a/pkg/cookiebanner/tracker_mapping_worker_test.go
+++ b/pkg/cookiebanner/tracker_mapping_worker_test.go
@@ -1425,3 +1425,348 @@ func TestProcess_SiblingPromotionOnFirstPartyOrigin(t *testing.T) {
 	require.NotNil(t, reloadedTarget.ThirdPartyID, "target sharing a first-party origin must be promoted via its sibling")
 	assert.Equal(t, orgThirdParty.ID, *reloadedTarget.ThirdPartyID)
 }
+
+// TestProcess_ReenqueuesUnmappedSiblingOnResolve asserts that when a
+// pattern newly resolves a catalog third party, same-banner siblings
+// that share an initiator domain but are still unpromoted get their
+// mapping re-armed (backward propagation), while the already-promoted
+// sibling that supplied the resolution is left untouched.
+func TestProcess_ReenqueuesUnmappedSiblingOnResolve(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedPromotionFixture(t, ctx, client)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	orgThirdParty := coredata.ThirdParty{
+		ID:                 gid.New(fx.scope.GetTenantID(), coredata.ThirdPartyEntityType),
+		OrganizationID:     fx.organizationID,
+		CommonThirdPartyID: &fx.commonThirdPartyID,
+		Name:               "Google LLC",
+		Category:           coredata.ThirdPartyCategoryAnalytics,
+		Certifications:     []string{},
+		Countries:          coredata.CountryCodes{},
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+
+	mappedSibling := coredata.TrackerPattern{
+		ID:                     gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
+		OrganizationID:         fx.organizationID,
+		CookieBannerID:         fx.banner.ID,
+		CookieCategoryID:       fx.normalCategoryID,
+		CommonTrackerPatternID: &fx.commonPatternID,
+		ThirdPartyID:           &orgThirdParty.ID,
+		TrackerType:            coredata.TrackerTypeCookie,
+		Pattern:                "_gid_reenq",
+		MatchType:              coredata.TrackerPatternMatchTypeExact,
+		DisplayName:            "_gid_reenq",
+		CreatedAt:              now,
+		UpdatedAt:              now,
+	}
+
+	target := coredata.TrackerPattern{
+		ID:               gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
+		OrganizationID:   fx.organizationID,
+		CookieBannerID:   fx.banner.ID,
+		CookieCategoryID: fx.normalCategoryID,
+		TrackerType:      coredata.TrackerTypeCookie,
+		Pattern:          "_ga_reenq_target",
+		MatchType:        coredata.TrackerPatternMatchTypeExact,
+		DisplayName:      "_ga_reenq_target",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+
+	unmappedSibling := coredata.TrackerPattern{
+		ID:               gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
+		OrganizationID:   fx.organizationID,
+		CookieBannerID:   fx.banner.ID,
+		CookieCategoryID: fx.normalCategoryID,
+		TrackerType:      coredata.TrackerTypeCookie,
+		Pattern:          "_unmapped_reenq",
+		MatchType:        coredata.TrackerPatternMatchTypeExact,
+		DisplayName:      "_unmapped_reenq",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+
+	sharedDomain := "reenq-tracker.com"
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		if err := orgThirdParty.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		for _, p := range []coredata.TrackerPattern{mappedSibling, target, unmappedSibling} {
+			if err := p.Insert(ctx, tx, fx.scope); err != nil {
+				return err
+			}
+		}
+
+		for id, identifier := range map[gid.GID]string{
+			mappedSibling.ID:   "_gid_reenq",
+			target.ID:          "_ga_reenq_target",
+			unmappedSibling.ID: "_unmapped_reenq",
+		} {
+			patternID := id
+			det := coredata.DetectedTracker{
+				ID:               gid.New(fx.scope.GetTenantID(), coredata.DetectedTrackerEntityType),
+				CookieBannerID:   fx.banner.ID,
+				TrackerPatternID: &patternID,
+				TrackerType:      coredata.TrackerTypeCookie,
+				Identifier:       identifier,
+				InitiatorDomain:  &sharedDomain,
+				LastDetectedAt:   now,
+				CreatedAt:        now,
+				UpdatedAt:        now,
+			}
+
+			if _, err := det.Upsert(ctx, tx, fx.scope); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}))
+
+	h := newMappingHandler(client)
+	require.NoError(t, h.Process(ctx, target))
+
+	var reloadedTarget coredata.TrackerPattern
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloadedTarget.LoadByID(ctx, conn, fx.scope, target.ID)
+	}))
+
+	require.NotNil(t, reloadedTarget.ThirdPartyID, "target must resolve via its promoted sibling")
+
+	var reloadedUnmapped coredata.TrackerPattern
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloadedUnmapped.LoadByID(ctx, conn, fx.scope, unmappedSibling.ID)
+	}))
+
+	require.NotNil(t, reloadedUnmapped.MappingRequestedAt, "unmapped sibling sharing the origin must be re-enqueued")
+
+	var reloadedMapped coredata.TrackerPattern
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloadedMapped.LoadByID(ctx, conn, fx.scope, mappedSibling.ID)
+	}))
+
+	assert.Nil(t, reloadedMapped.MappingRequestedAt, "already-promoted sibling must not be re-enqueued")
+}
+
+// TestProcess_DoesNotReenqueuePromotedOrExtensionSiblings asserts that
+// the re-enqueue skips siblings that are already promoted or
+// EXTENSION-sourced, while still re-arming a plain unmapped sibling.
+func TestProcess_DoesNotReenqueuePromotedOrExtensionSiblings(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedPromotionFixture(t, ctx, client)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	orgThirdParty := coredata.ThirdParty{
+		ID:                 gid.New(fx.scope.GetTenantID(), coredata.ThirdPartyEntityType),
+		OrganizationID:     fx.organizationID,
+		CommonThirdPartyID: &fx.commonThirdPartyID,
+		Name:               "Google LLC",
+		Category:           coredata.ThirdPartyCategoryAnalytics,
+		Certifications:     []string{},
+		Countries:          coredata.CountryCodes{},
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+
+	mappedSibling := coredata.TrackerPattern{
+		ID:                     gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
+		OrganizationID:         fx.organizationID,
+		CookieBannerID:         fx.banner.ID,
+		CookieCategoryID:       fx.normalCategoryID,
+		CommonTrackerPatternID: &fx.commonPatternID,
+		ThirdPartyID:           &orgThirdParty.ID,
+		TrackerType:            coredata.TrackerTypeCookie,
+		Pattern:                "_gid_guard",
+		MatchType:              coredata.TrackerPatternMatchTypeExact,
+		DisplayName:            "_gid_guard",
+		CreatedAt:              now,
+		UpdatedAt:              now,
+	}
+
+	target := coredata.TrackerPattern{
+		ID:               gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
+		OrganizationID:   fx.organizationID,
+		CookieBannerID:   fx.banner.ID,
+		CookieCategoryID: fx.normalCategoryID,
+		TrackerType:      coredata.TrackerTypeCookie,
+		Pattern:          "_ga_guard_target",
+		MatchType:        coredata.TrackerPatternMatchTypeExact,
+		DisplayName:      "_ga_guard_target",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+
+	plainSibling := coredata.TrackerPattern{
+		ID:               gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
+		OrganizationID:   fx.organizationID,
+		CookieBannerID:   fx.banner.ID,
+		CookieCategoryID: fx.normalCategoryID,
+		TrackerType:      coredata.TrackerTypeCookie,
+		Pattern:          "_plain_guard",
+		MatchType:        coredata.TrackerPatternMatchTypeExact,
+		DisplayName:      "_plain_guard",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+
+	extensionSource := coredata.CookieSourceExtension
+	extensionSibling := coredata.TrackerPattern{
+		ID:               gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
+		OrganizationID:   fx.organizationID,
+		CookieBannerID:   fx.banner.ID,
+		CookieCategoryID: fx.normalCategoryID,
+		TrackerType:      coredata.TrackerTypeCookie,
+		Pattern:          "_ext_guard",
+		MatchType:        coredata.TrackerPatternMatchTypeExact,
+		DisplayName:      "_ext_guard",
+		Source:           &extensionSource,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+
+	sharedDomain := "guard-tracker.com"
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		if err := orgThirdParty.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		patterns := map[gid.GID]string{
+			mappedSibling.ID:    "_gid_guard",
+			target.ID:           "_ga_guard_target",
+			plainSibling.ID:     "_plain_guard",
+			extensionSibling.ID: "_ext_guard",
+		}
+
+		for _, p := range []coredata.TrackerPattern{mappedSibling, target, plainSibling, extensionSibling} {
+			if err := p.Insert(ctx, tx, fx.scope); err != nil {
+				return err
+			}
+		}
+
+		for id, identifier := range patterns {
+			patternID := id
+			det := coredata.DetectedTracker{
+				ID:               gid.New(fx.scope.GetTenantID(), coredata.DetectedTrackerEntityType),
+				CookieBannerID:   fx.banner.ID,
+				TrackerPatternID: &patternID,
+				TrackerType:      coredata.TrackerTypeCookie,
+				Identifier:       identifier,
+				InitiatorDomain:  &sharedDomain,
+				LastDetectedAt:   now,
+				CreatedAt:        now,
+				UpdatedAt:        now,
+			}
+
+			if _, err := det.Upsert(ctx, tx, fx.scope); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}))
+
+	h := newMappingHandler(client)
+	require.NoError(t, h.Process(ctx, target))
+
+	reload := func(id gid.GID) coredata.TrackerPattern {
+		var p coredata.TrackerPattern
+
+		require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+			return p.LoadByID(ctx, conn, fx.scope, id)
+		}))
+
+		return p
+	}
+
+	require.NotNil(t, reload(target.ID).ThirdPartyID, "target must resolve via its promoted sibling")
+	require.NotNil(t, reload(plainSibling.ID).MappingRequestedAt, "plain unmapped sibling must be re-enqueued")
+	assert.Nil(t, reload(mappedSibling.ID).MappingRequestedAt, "promoted sibling must not be re-enqueued")
+	assert.Nil(t, reload(extensionSibling.ID).MappingRequestedAt, "EXTENSION-sourced sibling must not be re-enqueued")
+}
+
+// TestProcess_NoReenqueueWhenCommonThirdPartyPreexisted asserts that the
+// re-trigger path, where the pattern's linked catalog row already carries
+// a common third party, adds no new signal and therefore leaves unmapped
+// siblings untouched (the cascade terminator).
+func TestProcess_NoReenqueueWhenCommonThirdPartyPreexisted(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedPromotionFixture(t, ctx, client)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	unmappedSibling := coredata.TrackerPattern{
+		ID:               gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
+		OrganizationID:   fx.organizationID,
+		CookieBannerID:   fx.banner.ID,
+		CookieCategoryID: fx.normalCategoryID,
+		TrackerType:      coredata.TrackerTypeCookie,
+		Pattern:          "_unmapped_preexist",
+		MatchType:        coredata.TrackerPatternMatchTypeExact,
+		DisplayName:      "_unmapped_preexist",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+
+	sharedDomain := "preexist-tracker.com"
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		if err := unmappedSibling.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		for id, identifier := range map[gid.GID]string{
+			fx.trackerPattern.ID: fx.trackerPattern.Pattern,
+			unmappedSibling.ID:   "_unmapped_preexist",
+		} {
+			patternID := id
+			det := coredata.DetectedTracker{
+				ID:               gid.New(fx.scope.GetTenantID(), coredata.DetectedTrackerEntityType),
+				CookieBannerID:   fx.banner.ID,
+				TrackerPatternID: &patternID,
+				TrackerType:      coredata.TrackerTypeCookie,
+				Identifier:       identifier,
+				InitiatorDomain:  &sharedDomain,
+				LastDetectedAt:   now,
+				CreatedAt:        now,
+				UpdatedAt:        now,
+			}
+
+			if _, err := det.Upsert(ctx, tx, fx.scope); err != nil {
+				return err
+			}
+		}
+
+		return fx.trackerPattern.SetMappingRequested(ctx, tx)
+	}))
+
+	h := newMappingHandler(client)
+	require.NoError(t, h.Process(ctx, fx.trackerPattern))
+
+	var reloadedUnmapped coredata.TrackerPattern
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloadedUnmapped.LoadByID(ctx, conn, fx.scope, unmappedSibling.ID)
+	}))
+
+	assert.Nil(t, reloadedUnmapped.MappingRequestedAt, "re-trigger with a pre-existing common third party must not re-enqueue siblings")
+}

--- a/pkg/cookiebanner/tracker_mapping_worker_test.go
+++ b/pkg/cookiebanner/tracker_mapping_worker_test.go
@@ -28,9 +28,6 @@ import (
 	"go.probo.inc/probo/pkg/gid"
 )
 
-//go:fix inline
-func ptr[T any](v T) *T { return new(v) }
-
 // promotionFixture extends workerFixture with a CommonThirdParty and a
 // CommonTrackerPattern linking the catalog to the test pattern. It is
 // the minimum scaffolding promoteThirdParty needs to run end-to-end.
@@ -252,7 +249,7 @@ func TestPromoteThirdParty_FallbackCreate(t *testing.T) {
 	require.NotNil(t, reloaded.CommonThirdPartyID)
 	assert.Equal(t, fx.commonThirdPartyID, *reloaded.CommonThirdPartyID)
 	assert.Equal(t, coredata.ThirdPartyCategoryAnalytics, reloaded.Category)
-	assert.False(t, reloaded.FirstLevel)
+	assert.True(t, reloaded.FirstLevel)
 	assert.False(t, reloaded.ShowOnTrustCenter)
 }
 

--- a/pkg/cookiebanner/tracker_mapping_worker_test.go
+++ b/pkg/cookiebanner/tracker_mapping_worker_test.go
@@ -30,7 +30,7 @@ import (
 
 // promotionFixture extends workerFixture with a CommonThirdParty and a
 // CommonTrackerPattern linking the catalog to the test pattern. It is
-// the minimum scaffolding promoteThirdParty needs to run end-to-end.
+// the minimum scaffolding resolveOrgThirdParty needs to run end-to-end.
 type promotionFixture struct {
 	workerFixture
 	commonThirdParty   coredata.CommonThirdParty
@@ -45,11 +45,20 @@ func seedPromotionFixture(t *testing.T, ctx context.Context, client *pg.Client) 
 	fx := seedWorkerFixture(t, ctx, client)
 	now := time.Now().UTC().Truncate(time.Microsecond)
 
+	// common_third_parties (name/slug) and common_tracker_patterns
+	// (tracker_type, pattern, max_age_seconds) are global, NOT
+	// tenant-scoped, and both carry unique indexes. Tests run in
+	// parallel, so the catalog rows must be unique per fixture or
+	// concurrent runs collide. The tenant id is unique per fixture and
+	// makes a stable, collision-free suffix.
+	suffix := fx.scope.GetTenantID().String()
+	patternName := "_ga_" + suffix
+
 	commonThirdPartyID := gid.New(gid.NilTenant, coredata.CommonThirdPartyEntityType)
 	commonThirdParty := coredata.CommonThirdParty{
 		ID:             commonThirdPartyID,
-		Name:           "Google",
-		Slug:           "google",
+		Name:           "Google " + suffix,
+		Slug:           "google-" + suffix,
 		Category:       coredata.ThirdPartyCategoryAnalytics,
 		WebsiteURL:     new("https://google.com"),
 		Certifications: []string{},
@@ -61,7 +70,7 @@ func seedPromotionFixture(t *testing.T, ctx context.Context, client *pg.Client) 
 		ID:                 gid.New(gid.NilTenant, coredata.CommonTrackerPatternEntityType),
 		CommonThirdPartyID: &commonThirdPartyID,
 		TrackerType:        coredata.TrackerTypeCookie,
-		Pattern:            "_ga",
+		Pattern:            patternName,
 		MatchType:          coredata.TrackerPatternMatchTypeExact,
 		Description:        "",
 		Confidence:         0.9,
@@ -76,9 +85,9 @@ func seedPromotionFixture(t *testing.T, ctx context.Context, client *pg.Client) 
 		CookieCategoryID:       fx.normalCategoryID,
 		CommonTrackerPatternID: &commonPattern.ID,
 		TrackerType:            coredata.TrackerTypeCookie,
-		Pattern:                "_ga",
+		Pattern:                patternName,
 		MatchType:              coredata.TrackerPatternMatchTypeExact,
-		DisplayName:            "_ga",
+		DisplayName:            patternName,
 		Description:            "",
 		CreatedAt:              now,
 		UpdatedAt:              now,
@@ -134,7 +143,7 @@ func newMappingHandler(client *pg.Client) *trackerMappingHandler {
 	}
 }
 
-// promote runs promoteThirdParty inside its own transaction so each
+// promote runs resolveOrgThirdParty inside its own transaction so each
 // test case starts from a clean state.
 func promote(
 	t *testing.T,
@@ -142,7 +151,8 @@ func promote(
 	h *trackerMappingHandler,
 	client *pg.Client,
 	tp coredata.TrackerPattern,
-	commonPatternID gid.GID,
+	commonThirdPartyID gid.GID,
+	allowCreate bool,
 ) *gid.GID {
 	t.Helper()
 
@@ -151,7 +161,7 @@ func promote(
 	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
 		var err error
 
-		got, err = h.promoteThirdParty(ctx, tx, tp, commonPatternID)
+		got, err = h.resolveOrgThirdParty(ctx, tx, tp, commonThirdPartyID, allowCreate)
 
 		return err
 	}))
@@ -183,7 +193,7 @@ func TestPromoteThirdParty_ExactCommonLink(t *testing.T) {
 		return existing.Insert(ctx, tx, fx.scope)
 	}))
 
-	got := promote(t, ctx, newMappingHandler(client), client, fx.trackerPattern, fx.commonPatternID)
+	got := promote(t, ctx, newMappingHandler(client), client, fx.trackerPattern, fx.commonThirdPartyID, true)
 
 	require.NotNil(t, got)
 	assert.Equal(t, existing.ID, *got, "should return the existing org ThirdParty linked by common id")
@@ -197,10 +207,13 @@ func TestPromoteThirdParty_HeuristicMatch(t *testing.T) {
 	fx := seedPromotionFixture(t, ctx, client)
 
 	now := time.Now().UTC().Truncate(time.Microsecond)
+	// Append a corporate suffix to the catalog name so the heuristic
+	// matches on the suffix-stripped name (score 0.9) rather than an
+	// exact link.
 	manualEntry := coredata.ThirdParty{
 		ID:             gid.New(fx.scope.GetTenantID(), coredata.ThirdPartyEntityType),
 		OrganizationID: fx.organizationID,
-		Name:           "Google LLC",
+		Name:           fx.commonThirdParty.Name + " LLC",
 		Category:       coredata.ThirdPartyCategoryAnalytics,
 		Certifications: []string{},
 		Countries:      coredata.CountryCodes{},
@@ -212,7 +225,7 @@ func TestPromoteThirdParty_HeuristicMatch(t *testing.T) {
 		return manualEntry.Insert(ctx, tx, fx.scope)
 	}))
 
-	got := promote(t, ctx, newMappingHandler(client), client, fx.trackerPattern, fx.commonPatternID)
+	got := promote(t, ctx, newMappingHandler(client), client, fx.trackerPattern, fx.commonThirdPartyID, true)
 
 	require.NotNil(t, got)
 	assert.Equal(t, manualEntry.ID, *got, "heuristic match should return the manually-entered ThirdParty")
@@ -234,7 +247,7 @@ func TestPromoteThirdParty_FallbackCreate(t *testing.T) {
 	ctx := context.Background()
 	fx := seedPromotionFixture(t, ctx, client)
 
-	got := promote(t, ctx, newMappingHandler(client), client, fx.trackerPattern, fx.commonPatternID)
+	got := promote(t, ctx, newMappingHandler(client), client, fx.trackerPattern, fx.commonThirdPartyID, true)
 
 	require.NotNil(t, got, "fallback should create a new ThirdParty")
 
@@ -245,7 +258,7 @@ func TestPromoteThirdParty_FallbackCreate(t *testing.T) {
 	}))
 
 	assert.Equal(t, fx.organizationID, reloaded.OrganizationID)
-	assert.Equal(t, "Google", reloaded.Name)
+	assert.Equal(t, fx.commonThirdParty.Name, reloaded.Name)
 	require.NotNil(t, reloaded.CommonThirdPartyID)
 	assert.Equal(t, fx.commonThirdPartyID, *reloaded.CommonThirdPartyID)
 	assert.Equal(t, coredata.ThirdPartyCategoryAnalytics, reloaded.Category)
@@ -253,58 +266,21 @@ func TestPromoteThirdParty_FallbackCreate(t *testing.T) {
 	assert.False(t, reloaded.ShowOnTrustCenter)
 }
 
-func TestPromoteThirdParty_NoCommonThirdPartyOnPattern(t *testing.T) {
+// TestResolveOrgThirdParty_CreationGated asserts that when no existing
+// org ThirdParty matches the catalog third party, creating a new one is
+// suppressed unless allowCreate is true.
+func TestResolveOrgThirdParty_CreationGated(t *testing.T) {
 	t.Parallel()
 
 	client := newTestPgClient(t)
 	ctx := context.Background()
-	fx := seedWorkerFixture(t, ctx, client)
+	fx := seedPromotionFixture(t, ctx, client)
 
-	now := time.Now().UTC().Truncate(time.Microsecond)
-	commonPattern := coredata.CommonTrackerPattern{
-		ID:          gid.New(gid.NilTenant, coredata.CommonTrackerPatternEntityType),
-		TrackerType: coredata.TrackerTypeCookie,
-		Pattern:     "unknown_xyz",
-		MatchType:   coredata.TrackerPatternMatchTypeExact,
-		Description: "",
-		Confidence:  0.5,
-		CreatedAt:   now,
-		UpdatedAt:   now,
-	}
+	gated := promote(t, ctx, newMappingHandler(client), client, fx.trackerPattern, fx.commonThirdPartyID, false)
+	assert.Nil(t, gated, "creation must be suppressed when allowCreate is false and nothing exists to link")
 
-	pattern := coredata.TrackerPattern{
-		ID:                     gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
-		OrganizationID:         fx.organizationID,
-		CookieBannerID:         fx.banner.ID,
-		CookieCategoryID:       fx.normalCategoryID,
-		CommonTrackerPatternID: &commonPattern.ID,
-		TrackerType:            coredata.TrackerTypeCookie,
-		Pattern:                "unknown_xyz",
-		MatchType:              coredata.TrackerPatternMatchTypeExact,
-		DisplayName:            "unknown_xyz",
-		CreatedAt:              now,
-		UpdatedAt:              now,
-	}
-
-	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
-		if _, err := commonPattern.Upsert(ctx, tx); err != nil {
-			return err
-		}
-
-		return pattern.Insert(ctx, tx, fx.scope)
-	}))
-
-	t.Cleanup(func() {
-		_ = client.WithTx(context.Background(), func(ctx context.Context, tx pg.Tx) error {
-			_, err := tx.Exec(ctx, `DELETE FROM common_tracker_patterns WHERE id = $1`, commonPattern.ID)
-
-			return err
-		})
-	})
-
-	got := promote(t, ctx, newMappingHandler(client), client, pattern, commonPattern.ID)
-
-	assert.Nil(t, got, "patterns whose catalog row has no CommonThirdPartyID should not be promoted")
+	allowed := promote(t, ctx, newMappingHandler(client), client, fx.trackerPattern, fx.commonThirdPartyID, true)
+	require.NotNil(t, allowed, "creation must proceed when allowCreate is true")
 }
 
 // TestProcess_PreservesCatalogMappingOnReTrigger asserts that when
@@ -539,7 +515,9 @@ func TestMatchBySiblingOrigin_SiblingWithThirdPartyID(t *testing.T) {
 		UpdatedAt:        now,
 	}
 
-	initiatorDomain := "www.googletagmanager.com"
+	// Detected trackers store the eTLD+1 (uri.ExtractDomain), so the
+	// sibling lookup matches on that exact value.
+	initiatorDomain := "googletagmanager.com"
 	siblingDetected := coredata.DetectedTracker{
 		ID:               gid.New(fx.scope.GetTenantID(), coredata.DetectedTrackerEntityType),
 		CookieBannerID:   fx.banner.ID,
@@ -590,7 +568,7 @@ func TestMatchBySiblingOrigin_SiblingWithThirdPartyID(t *testing.T) {
 
 	h := newMappingHandler(client)
 
-	var got *gid.GID
+	var got *catalogMatch
 
 	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
 		var err error
@@ -600,12 +578,15 @@ func TestMatchBySiblingOrigin_SiblingWithThirdPartyID(t *testing.T) {
 		return err
 	}))
 
-	require.NotNil(t, got, "sibling origin match should return a common tracker pattern ID")
+	require.NotNil(t, got, "sibling origin match should return a catalog match")
+	require.NotNil(t, got.commonPatternID, "sibling origin match should return a common tracker pattern ID")
+	require.NotNil(t, got.thirdPartyID, "sibling origin match should surface the sibling's org third party directly")
+	assert.Equal(t, orgThirdParty.ID, *got.thirdPartyID)
 
 	var commonPattern coredata.CommonTrackerPattern
 
 	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
-		return commonPattern.LoadByID(ctx, conn, *got)
+		return commonPattern.LoadByID(ctx, conn, *got.commonPatternID)
 	}))
 
 	require.NotNil(t, commonPattern.CommonThirdPartyID)
@@ -622,11 +603,12 @@ func TestMatchBySiblingOrigin_AmbiguousThirdParties(t *testing.T) {
 
 	now := time.Now().UTC().Truncate(time.Microsecond)
 
+	otherSuffix := fx.scope.GetTenantID().String()
 	otherCommonThirdPartyID := gid.New(gid.NilTenant, coredata.CommonThirdPartyEntityType)
 	otherCommonThirdParty := coredata.CommonThirdParty{
 		ID:             otherCommonThirdPartyID,
-		Name:           "Facebook",
-		Slug:           "facebook",
+		Name:           "Facebook " + otherSuffix,
+		Slug:           "facebook-" + otherSuffix,
 		Category:       coredata.ThirdPartyCategoryMarketing,
 		Certifications: []string{},
 		CreatedAt:      now,
@@ -698,7 +680,7 @@ func TestMatchBySiblingOrigin_AmbiguousThirdParties(t *testing.T) {
 		UpdatedAt:        now,
 	}
 
-	sharedDomain := "cdn.shared-tracker.com"
+	sharedDomain := "shared-tracker.com"
 
 	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
 		if err := otherCommonThirdParty.Insert(ctx, tx); err != nil {
@@ -783,7 +765,7 @@ func TestMatchBySiblingOrigin_AmbiguousThirdParties(t *testing.T) {
 
 	h := newMappingHandler(client)
 
-	var got *gid.GID
+	var got *catalogMatch
 
 	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
 		var err error
@@ -824,7 +806,7 @@ func TestMatchBySiblingOrigin_NoSiblings(t *testing.T) {
 
 	h := newMappingHandler(client)
 
-	var got *gid.GID
+	var got *catalogMatch
 
 	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
 		var err error
@@ -865,7 +847,7 @@ func TestMatchBySiblingOrigin_EmptyDomains(t *testing.T) {
 
 	h := newMappingHandler(client)
 
-	var got *gid.GID
+	var got *catalogMatch
 
 	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
 		var err error
@@ -940,7 +922,7 @@ func TestMatchBySiblingOrigin_ConvergentSiblings(t *testing.T) {
 		UpdatedAt:        now,
 	}
 
-	sharedDomain := "analytics.google.com"
+	sharedDomain := "google.com"
 
 	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
 		if err := orgThirdParty.Insert(ctx, tx, fx.scope); err != nil {
@@ -1009,7 +991,7 @@ func TestMatchBySiblingOrigin_ConvergentSiblings(t *testing.T) {
 
 	h := newMappingHandler(client)
 
-	var got *gid.GID
+	var got *catalogMatch
 
 	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
 		var err error
@@ -1020,11 +1002,12 @@ func TestMatchBySiblingOrigin_ConvergentSiblings(t *testing.T) {
 	}))
 
 	require.NotNil(t, got, "multiple siblings converging to same third party should succeed")
+	require.NotNil(t, got.commonPatternID)
 
 	var commonPattern coredata.CommonTrackerPattern
 
 	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
-		return commonPattern.LoadByID(ctx, conn, *got)
+		return commonPattern.LoadByID(ctx, conn, *got.commonPatternID)
 	}))
 
 	require.NotNil(t, commonPattern.CommonThirdPartyID)
@@ -1071,8 +1054,374 @@ func TestPromoteThirdParty_ExactCommonLinkIgnoresSimilarUnlinked(t *testing.T) {
 		return linked.Insert(ctx, tx, fx.scope)
 	}))
 
-	got := promote(t, ctx, newMappingHandler(client), client, fx.trackerPattern, fx.commonPatternID)
+	got := promote(t, ctx, newMappingHandler(client), client, fx.trackerPattern, fx.commonThirdPartyID, true)
 
 	require.NotNil(t, got)
 	assert.Equal(t, linked.ID, *got, "exact-link path must short-circuit before the heuristic fires")
+}
+
+// TestProcess_BackfillsCommonThirdPartyFromSibling asserts that a pattern
+// linked to an unlinked catalog row (no common_third_party_id) gets its
+// catalog row backfilled from a sibling signal, and is promoted directly
+// to the sibling's existing org ThirdParty.
+func TestProcess_BackfillsCommonThirdPartyFromSibling(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedPromotionFixture(t, ctx, client)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	orgThirdParty := coredata.ThirdParty{
+		ID:                 gid.New(fx.scope.GetTenantID(), coredata.ThirdPartyEntityType),
+		OrganizationID:     fx.organizationID,
+		CommonThirdPartyID: &fx.commonThirdPartyID,
+		Name:               "Google LLC",
+		Category:           coredata.ThirdPartyCategoryAnalytics,
+		Certifications:     []string{},
+		Countries:          coredata.CountryCodes{},
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+
+	siblingPattern := coredata.TrackerPattern{
+		ID:                     gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
+		OrganizationID:         fx.organizationID,
+		CookieBannerID:         fx.banner.ID,
+		CookieCategoryID:       fx.normalCategoryID,
+		CommonTrackerPatternID: &fx.commonPatternID,
+		ThirdPartyID:           &orgThirdParty.ID,
+		TrackerType:            coredata.TrackerTypeCookie,
+		Pattern:                "_gid_backfill",
+		MatchType:              coredata.TrackerPatternMatchTypeExact,
+		DisplayName:            "_gid_backfill",
+		CreatedAt:              now,
+		UpdatedAt:              now,
+	}
+
+	unlinkedCommon := coredata.CommonTrackerPattern{
+		ID:          gid.New(gid.NilTenant, coredata.CommonTrackerPatternEntityType),
+		TrackerType: coredata.TrackerTypeCookie,
+		Pattern:     "_ga_backfill",
+		MatchType:   coredata.TrackerPatternMatchTypeExact,
+		Confidence:  0.5,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	target := coredata.TrackerPattern{
+		ID:                     gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
+		OrganizationID:         fx.organizationID,
+		CookieBannerID:         fx.banner.ID,
+		CookieCategoryID:       fx.normalCategoryID,
+		CommonTrackerPatternID: &unlinkedCommon.ID,
+		TrackerType:            coredata.TrackerTypeCookie,
+		Pattern:                "_ga_backfill",
+		MatchType:              coredata.TrackerPatternMatchTypeExact,
+		DisplayName:            "_ga_backfill",
+		CreatedAt:              now,
+		UpdatedAt:              now,
+	}
+
+	initiatorDomain := "googletagmanager.com"
+
+	siblingDetected := coredata.DetectedTracker{
+		ID:               gid.New(fx.scope.GetTenantID(), coredata.DetectedTrackerEntityType),
+		CookieBannerID:   fx.banner.ID,
+		TrackerPatternID: &siblingPattern.ID,
+		TrackerType:      coredata.TrackerTypeCookie,
+		Identifier:       "_gid_backfill",
+		InitiatorDomain:  &initiatorDomain,
+		LastDetectedAt:   now,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+
+	targetDetected := coredata.DetectedTracker{
+		ID:               gid.New(fx.scope.GetTenantID(), coredata.DetectedTrackerEntityType),
+		CookieBannerID:   fx.banner.ID,
+		TrackerPatternID: &target.ID,
+		TrackerType:      coredata.TrackerTypeCookie,
+		Identifier:       "_ga_backfill",
+		InitiatorDomain:  &initiatorDomain,
+		LastDetectedAt:   now,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		if _, err := unlinkedCommon.Upsert(ctx, tx); err != nil {
+			return err
+		}
+
+		if err := orgThirdParty.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		if err := siblingPattern.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		if err := target.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		if _, err := siblingDetected.Upsert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		if _, err := targetDetected.Upsert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		return nil
+	}))
+
+	t.Cleanup(func() {
+		_ = client.WithTx(context.Background(), func(ctx context.Context, tx pg.Tx) error {
+			_, _ = tx.Exec(ctx, `DELETE FROM common_tracker_patterns WHERE id = $1`, unlinkedCommon.ID)
+
+			return nil
+		})
+	})
+
+	h := newMappingHandler(client)
+	require.NoError(t, h.Process(ctx, target))
+
+	var reloadedCommon coredata.CommonTrackerPattern
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloadedCommon.LoadByID(ctx, conn, unlinkedCommon.ID)
+	}))
+
+	require.NotNil(t, reloadedCommon.CommonThirdPartyID, "the unlinked catalog row must be backfilled")
+	assert.Equal(t, fx.commonThirdPartyID, *reloadedCommon.CommonThirdPartyID)
+
+	var reloadedTarget coredata.TrackerPattern
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloadedTarget.LoadByID(ctx, conn, fx.scope, target.ID)
+	}))
+
+	require.NotNil(t, reloadedTarget.ThirdPartyID, "target must be promoted to the sibling's org third party")
+	assert.Equal(t, orgThirdParty.ID, *reloadedTarget.ThirdPartyID)
+	require.NotNil(t, reloadedTarget.CommonTrackerPatternID)
+	assert.Equal(t, unlinkedCommon.ID, *reloadedTarget.CommonTrackerPatternID, "the existing catalog link must be preserved")
+}
+
+// TestProcess_UncategorisedLinksExistingThirdParty asserts that an
+// uncategorised pattern is still linked to an already-existing matching
+// org ThirdParty (linking to an existing party is ungated); only the
+// creation of a new party stays gated, as covered by
+// TestProcess_UncategorisedPatternIsNotPromoted.
+func TestProcess_UncategorisedLinksExistingThirdParty(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedPromotionFixture(t, ctx, client)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	existing := coredata.ThirdParty{
+		ID:                 gid.New(fx.scope.GetTenantID(), coredata.ThirdPartyEntityType),
+		OrganizationID:     fx.organizationID,
+		CommonThirdPartyID: &fx.commonThirdPartyID,
+		Name:               "Google LLC",
+		Category:           coredata.ThirdPartyCategoryAnalytics,
+		Certifications:     []string{},
+		Countries:          coredata.CountryCodes{},
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		if err := existing.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		_, err := tx.Exec(
+			ctx,
+			`UPDATE tracker_patterns
+			   SET cookie_category_id = $1,
+			       mapping_requested_at = $2
+			 WHERE id = $3`,
+			fx.uncategorisedID,
+			now,
+			fx.trackerPattern.ID,
+		)
+
+		return err
+	}))
+
+	var reloadedBefore coredata.TrackerPattern
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloadedBefore.LoadByID(ctx, conn, fx.scope, fx.trackerPattern.ID)
+	}))
+
+	h := newMappingHandler(client)
+	require.NoError(t, h.Process(ctx, reloadedBefore))
+
+	var reloaded coredata.TrackerPattern
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloaded.LoadByID(ctx, conn, fx.scope, fx.trackerPattern.ID)
+	}))
+
+	require.NotNil(t, reloaded.ThirdPartyID, "uncategorised pattern must still link to an existing org third party")
+	assert.Equal(t, existing.ID, *reloaded.ThirdPartyID)
+}
+
+// TestProcess_SiblingPromotionOnFirstPartyOrigin asserts that a pattern
+// detected on the banner's own (first-party) origin is still grouped with
+// its siblings sharing that origin. Sibling matching is an org-local
+// co-occurrence signal and must not be defeated by the first-party domain
+// filter that only protects the global catalog (domain) match.
+func TestProcess_SiblingPromotionOnFirstPartyOrigin(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedPromotionFixture(t, ctx, client)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	orgThirdParty := coredata.ThirdParty{
+		ID:                 gid.New(fx.scope.GetTenantID(), coredata.ThirdPartyEntityType),
+		OrganizationID:     fx.organizationID,
+		CommonThirdPartyID: &fx.commonThirdPartyID,
+		Name:               "Google LLC",
+		Category:           coredata.ThirdPartyCategoryAnalytics,
+		Certifications:     []string{},
+		Countries:          coredata.CountryCodes{},
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+
+	siblingPattern := coredata.TrackerPattern{
+		ID:                     gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
+		OrganizationID:         fx.organizationID,
+		CookieBannerID:         fx.banner.ID,
+		CookieCategoryID:       fx.normalCategoryID,
+		CommonTrackerPatternID: &fx.commonPatternID,
+		ThirdPartyID:           &orgThirdParty.ID,
+		TrackerType:            coredata.TrackerTypeCookie,
+		Pattern:                "_sibling_fp",
+		MatchType:              coredata.TrackerPatternMatchTypeExact,
+		DisplayName:            "_sibling_fp",
+		CreatedAt:              now,
+		UpdatedAt:              now,
+	}
+
+	unlinkedCommon := coredata.CommonTrackerPattern{
+		ID:          gid.New(gid.NilTenant, coredata.CommonTrackerPatternEntityType),
+		TrackerType: coredata.TrackerTypeCookie,
+		Pattern:     "__support__",
+		MatchType:   coredata.TrackerPatternMatchTypeExact,
+		Confidence:  0.5,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	target := coredata.TrackerPattern{
+		ID:                     gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
+		OrganizationID:         fx.organizationID,
+		CookieBannerID:         fx.banner.ID,
+		CookieCategoryID:       fx.normalCategoryID,
+		CommonTrackerPatternID: &unlinkedCommon.ID,
+		TrackerType:            coredata.TrackerTypeCookie,
+		Pattern:                "__support__",
+		MatchType:              coredata.TrackerPatternMatchTypeExact,
+		DisplayName:            "__support__",
+		CreatedAt:              now,
+		UpdatedAt:              now,
+	}
+
+	// The banner origin in seedWorkerFixture is an *.example.com host, so
+	// its eTLD+1 (the first-party domain) is "example.com". Detecting both
+	// patterns on that domain means uri.FilterFirstPartyDomains would strip
+	// it — the regression this test guards against.
+	firstPartyDomain := "example.com"
+
+	siblingDetected := coredata.DetectedTracker{
+		ID:               gid.New(fx.scope.GetTenantID(), coredata.DetectedTrackerEntityType),
+		CookieBannerID:   fx.banner.ID,
+		TrackerPatternID: &siblingPattern.ID,
+		TrackerType:      coredata.TrackerTypeCookie,
+		Identifier:       "_sibling_fp",
+		InitiatorDomain:  &firstPartyDomain,
+		LastDetectedAt:   now,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+
+	targetDetected := coredata.DetectedTracker{
+		ID:               gid.New(fx.scope.GetTenantID(), coredata.DetectedTrackerEntityType),
+		CookieBannerID:   fx.banner.ID,
+		TrackerPatternID: &target.ID,
+		TrackerType:      coredata.TrackerTypeCookie,
+		Identifier:       "__support__",
+		InitiatorDomain:  &firstPartyDomain,
+		LastDetectedAt:   now,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		if _, err := unlinkedCommon.Upsert(ctx, tx); err != nil {
+			return err
+		}
+
+		if err := orgThirdParty.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		if err := siblingPattern.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		if err := target.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		if _, err := siblingDetected.Upsert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		if _, err := targetDetected.Upsert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		return nil
+	}))
+
+	t.Cleanup(func() {
+		_ = client.WithTx(context.Background(), func(ctx context.Context, tx pg.Tx) error {
+			_, _ = tx.Exec(ctx, `DELETE FROM common_tracker_patterns WHERE id = $1`, unlinkedCommon.ID)
+
+			return nil
+		})
+	})
+
+	h := newMappingHandler(client)
+	require.NoError(t, h.Process(ctx, target))
+
+	var reloadedCommon coredata.CommonTrackerPattern
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloadedCommon.LoadByID(ctx, conn, unlinkedCommon.ID)
+	}))
+
+	require.NotNil(t, reloadedCommon.CommonThirdPartyID, "catalog row must be backfilled from the first-party sibling")
+	assert.Equal(t, fx.commonThirdPartyID, *reloadedCommon.CommonThirdPartyID)
+
+	var reloadedTarget coredata.TrackerPattern
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return reloadedTarget.LoadByID(ctx, conn, fx.scope, target.ID)
+	}))
+
+	require.NotNil(t, reloadedTarget.ThirdPartyID, "target sharing a first-party origin must be promoted via its sibling")
+	assert.Equal(t, orgThirdParty.ID, *reloadedTarget.ThirdPartyID)
 }

--- a/pkg/cookiebanner/tracker_mapping_worker_test.go
+++ b/pkg/cookiebanner/tracker_mapping_worker_test.go
@@ -490,6 +490,547 @@ func TestProcess_NoOpWhenAlreadyPromoted(t *testing.T) {
 	assert.Equal(t, preExisting.ID, *reloaded.ThirdPartyID, "third_party_id must not be overwritten")
 }
 
+func TestMatchBySiblingOrigin_SiblingWithThirdPartyID(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedPromotionFixture(t, ctx, client)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	orgThirdParty := coredata.ThirdParty{
+		ID:                 gid.New(fx.scope.GetTenantID(), coredata.ThirdPartyEntityType),
+		OrganizationID:     fx.organizationID,
+		CommonThirdPartyID: &fx.commonThirdPartyID,
+		Name:               "Google LLC",
+		Category:           coredata.ThirdPartyCategoryAnalytics,
+		Certifications:     []string{},
+		Countries:          coredata.CountryCodes{},
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+
+	siblingPattern := coredata.TrackerPattern{
+		ID:                     gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
+		OrganizationID:         fx.organizationID,
+		CookieBannerID:         fx.banner.ID,
+		CookieCategoryID:       fx.normalCategoryID,
+		CommonTrackerPatternID: &fx.commonPatternID,
+		ThirdPartyID:           &orgThirdParty.ID,
+		TrackerType:            coredata.TrackerTypeCookie,
+		Pattern:                "_gid",
+		MatchType:              coredata.TrackerPatternMatchTypeExact,
+		DisplayName:            "_gid",
+		CreatedAt:              now,
+		UpdatedAt:              now,
+	}
+
+	unmappedPattern := coredata.TrackerPattern{
+		ID:               gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
+		OrganizationID:   fx.organizationID,
+		CookieBannerID:   fx.banner.ID,
+		CookieCategoryID: fx.normalCategoryID,
+		TrackerType:      coredata.TrackerTypeCookie,
+		Pattern:          "_ga_unknown",
+		MatchType:        coredata.TrackerPatternMatchTypeExact,
+		DisplayName:      "_ga_unknown",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+
+	initiatorDomain := "www.googletagmanager.com"
+	siblingDetected := coredata.DetectedTracker{
+		ID:               gid.New(fx.scope.GetTenantID(), coredata.DetectedTrackerEntityType),
+		CookieBannerID:   fx.banner.ID,
+		TrackerPatternID: &siblingPattern.ID,
+		TrackerType:      coredata.TrackerTypeCookie,
+		Identifier:       "_gid",
+		InitiatorDomain:  &initiatorDomain,
+		LastDetectedAt:   now,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+
+	unmappedDetected := coredata.DetectedTracker{
+		ID:               gid.New(fx.scope.GetTenantID(), coredata.DetectedTrackerEntityType),
+		CookieBannerID:   fx.banner.ID,
+		TrackerPatternID: &unmappedPattern.ID,
+		TrackerType:      coredata.TrackerTypeCookie,
+		Identifier:       "_ga_unknown",
+		InitiatorDomain:  &initiatorDomain,
+		LastDetectedAt:   now,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		if err := orgThirdParty.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		if err := siblingPattern.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		if err := unmappedPattern.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		if _, err := siblingDetected.Upsert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		if _, err := unmappedDetected.Upsert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		return nil
+	}))
+
+	h := newMappingHandler(client)
+
+	var got *gid.GID
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		var err error
+
+		got, err = h.matchBySiblingOrigin(ctx, tx, unmappedPattern, []string{"googletagmanager.com"})
+
+		return err
+	}))
+
+	require.NotNil(t, got, "sibling origin match should return a common tracker pattern ID")
+
+	var commonPattern coredata.CommonTrackerPattern
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return commonPattern.LoadByID(ctx, conn, *got)
+	}))
+
+	require.NotNil(t, commonPattern.CommonThirdPartyID)
+	assert.Equal(t, fx.commonThirdPartyID, *commonPattern.CommonThirdPartyID)
+	assert.Equal(t, float32(0.7), commonPattern.Confidence)
+}
+
+func TestMatchBySiblingOrigin_AmbiguousThirdParties(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedPromotionFixture(t, ctx, client)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	otherCommonThirdPartyID := gid.New(gid.NilTenant, coredata.CommonThirdPartyEntityType)
+	otherCommonThirdParty := coredata.CommonThirdParty{
+		ID:             otherCommonThirdPartyID,
+		Name:           "Facebook",
+		Slug:           "facebook",
+		Category:       coredata.ThirdPartyCategoryMarketing,
+		Certifications: []string{},
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	orgThirdPartyA := coredata.ThirdParty{
+		ID:                 gid.New(fx.scope.GetTenantID(), coredata.ThirdPartyEntityType),
+		OrganizationID:     fx.organizationID,
+		CommonThirdPartyID: &fx.commonThirdPartyID,
+		Name:               "Google",
+		Category:           coredata.ThirdPartyCategoryAnalytics,
+		Certifications:     []string{},
+		Countries:          coredata.CountryCodes{},
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+
+	orgThirdPartyB := coredata.ThirdParty{
+		ID:                 gid.New(fx.scope.GetTenantID(), coredata.ThirdPartyEntityType),
+		OrganizationID:     fx.organizationID,
+		CommonThirdPartyID: &otherCommonThirdPartyID,
+		Name:               "Facebook",
+		Category:           coredata.ThirdPartyCategoryMarketing,
+		Certifications:     []string{},
+		Countries:          coredata.CountryCodes{},
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+
+	siblingA := coredata.TrackerPattern{
+		ID:               gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
+		OrganizationID:   fx.organizationID,
+		CookieBannerID:   fx.banner.ID,
+		CookieCategoryID: fx.normalCategoryID,
+		ThirdPartyID:     &orgThirdPartyA.ID,
+		TrackerType:      coredata.TrackerTypeCookie,
+		Pattern:          "sibling_a",
+		MatchType:        coredata.TrackerPatternMatchTypeExact,
+		DisplayName:      "sibling_a",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+
+	siblingB := coredata.TrackerPattern{
+		ID:               gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
+		OrganizationID:   fx.organizationID,
+		CookieBannerID:   fx.banner.ID,
+		CookieCategoryID: fx.normalCategoryID,
+		ThirdPartyID:     &orgThirdPartyB.ID,
+		TrackerType:      coredata.TrackerTypeCookie,
+		Pattern:          "sibling_b",
+		MatchType:        coredata.TrackerPatternMatchTypeExact,
+		DisplayName:      "sibling_b",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+
+	unmappedPattern := coredata.TrackerPattern{
+		ID:               gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
+		OrganizationID:   fx.organizationID,
+		CookieBannerID:   fx.banner.ID,
+		CookieCategoryID: fx.normalCategoryID,
+		TrackerType:      coredata.TrackerTypeCookie,
+		Pattern:          "ambiguous_test",
+		MatchType:        coredata.TrackerPatternMatchTypeExact,
+		DisplayName:      "ambiguous_test",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+
+	sharedDomain := "cdn.shared-tracker.com"
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		if err := otherCommonThirdParty.Insert(ctx, tx); err != nil {
+			return err
+		}
+
+		if err := orgThirdPartyA.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		if err := orgThirdPartyB.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		if err := siblingA.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		if err := siblingB.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		if err := unmappedPattern.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		detA := coredata.DetectedTracker{
+			ID:               gid.New(fx.scope.GetTenantID(), coredata.DetectedTrackerEntityType),
+			CookieBannerID:   fx.banner.ID,
+			TrackerPatternID: &siblingA.ID,
+			TrackerType:      coredata.TrackerTypeCookie,
+			Identifier:       "sibling_a",
+			InitiatorDomain:  &sharedDomain,
+			LastDetectedAt:   now,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}
+		if _, err := detA.Upsert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		detB := coredata.DetectedTracker{
+			ID:               gid.New(fx.scope.GetTenantID(), coredata.DetectedTrackerEntityType),
+			CookieBannerID:   fx.banner.ID,
+			TrackerPatternID: &siblingB.ID,
+			TrackerType:      coredata.TrackerTypeCookie,
+			Identifier:       "sibling_b",
+			InitiatorDomain:  &sharedDomain,
+			LastDetectedAt:   now,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}
+		if _, err := detB.Upsert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		detUnmapped := coredata.DetectedTracker{
+			ID:               gid.New(fx.scope.GetTenantID(), coredata.DetectedTrackerEntityType),
+			CookieBannerID:   fx.banner.ID,
+			TrackerPatternID: &unmappedPattern.ID,
+			TrackerType:      coredata.TrackerTypeCookie,
+			Identifier:       "ambiguous_test",
+			InitiatorDomain:  &sharedDomain,
+			LastDetectedAt:   now,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}
+		if _, err := detUnmapped.Upsert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		return nil
+	}))
+
+	t.Cleanup(func() {
+		_ = client.WithTx(context.Background(), func(ctx context.Context, tx pg.Tx) error {
+			_, _ = tx.Exec(ctx, `DELETE FROM common_third_parties WHERE id = $1`, otherCommonThirdPartyID)
+
+			return nil
+		})
+	})
+
+	h := newMappingHandler(client)
+
+	var got *gid.GID
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		var err error
+
+		got, err = h.matchBySiblingOrigin(ctx, tx, unmappedPattern, []string{"shared-tracker.com"})
+
+		return err
+	}))
+
+	assert.Nil(t, got, "ambiguous siblings mapping to different third parties should return nil")
+}
+
+func TestMatchBySiblingOrigin_NoSiblings(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedWorkerFixture(t, ctx, client)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	unmappedPattern := coredata.TrackerPattern{
+		ID:               gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
+		OrganizationID:   fx.organizationID,
+		CookieBannerID:   fx.banner.ID,
+		CookieCategoryID: fx.normalCategoryID,
+		TrackerType:      coredata.TrackerTypeCookie,
+		Pattern:          "lonely_cookie",
+		MatchType:        coredata.TrackerPatternMatchTypeExact,
+		DisplayName:      "lonely_cookie",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		return unmappedPattern.Insert(ctx, tx, fx.scope)
+	}))
+
+	h := newMappingHandler(client)
+
+	var got *gid.GID
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		var err error
+
+		got, err = h.matchBySiblingOrigin(ctx, tx, unmappedPattern, []string{"unique-domain.com"})
+
+		return err
+	}))
+
+	assert.Nil(t, got, "no siblings sharing the domain should return nil")
+}
+
+func TestMatchBySiblingOrigin_EmptyDomains(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedWorkerFixture(t, ctx, client)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	pattern := coredata.TrackerPattern{
+		ID:               gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
+		OrganizationID:   fx.organizationID,
+		CookieBannerID:   fx.banner.ID,
+		CookieCategoryID: fx.normalCategoryID,
+		TrackerType:      coredata.TrackerTypeCookie,
+		Pattern:          "no_domains",
+		MatchType:        coredata.TrackerPatternMatchTypeExact,
+		DisplayName:      "no_domains",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		return pattern.Insert(ctx, tx, fx.scope)
+	}))
+
+	h := newMappingHandler(client)
+
+	var got *gid.GID
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		var err error
+
+		got, err = h.matchBySiblingOrigin(ctx, tx, pattern, nil)
+
+		return err
+	}))
+
+	assert.Nil(t, got, "nil domains should immediately return nil")
+}
+
+func TestMatchBySiblingOrigin_ConvergentSiblings(t *testing.T) {
+	t.Parallel()
+
+	client := newTestPgClient(t)
+	ctx := context.Background()
+	fx := seedPromotionFixture(t, ctx, client)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	orgThirdParty := coredata.ThirdParty{
+		ID:                 gid.New(fx.scope.GetTenantID(), coredata.ThirdPartyEntityType),
+		OrganizationID:     fx.organizationID,
+		CommonThirdPartyID: &fx.commonThirdPartyID,
+		Name:               "Google",
+		Category:           coredata.ThirdPartyCategoryAnalytics,
+		Certifications:     []string{},
+		Countries:          coredata.CountryCodes{},
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+
+	siblingA := coredata.TrackerPattern{
+		ID:               gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
+		OrganizationID:   fx.organizationID,
+		CookieBannerID:   fx.banner.ID,
+		CookieCategoryID: fx.normalCategoryID,
+		ThirdPartyID:     &orgThirdParty.ID,
+		TrackerType:      coredata.TrackerTypeCookie,
+		Pattern:          "converge_a",
+		MatchType:        coredata.TrackerPatternMatchTypeExact,
+		DisplayName:      "converge_a",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+
+	siblingB := coredata.TrackerPattern{
+		ID:               gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
+		OrganizationID:   fx.organizationID,
+		CookieBannerID:   fx.banner.ID,
+		CookieCategoryID: fx.normalCategoryID,
+		ThirdPartyID:     &orgThirdParty.ID,
+		TrackerType:      coredata.TrackerTypeCookie,
+		Pattern:          "converge_b",
+		MatchType:        coredata.TrackerPatternMatchTypeExact,
+		DisplayName:      "converge_b",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+
+	unmappedPattern := coredata.TrackerPattern{
+		ID:               gid.New(fx.scope.GetTenantID(), coredata.TrackerPatternEntityType),
+		OrganizationID:   fx.organizationID,
+		CookieBannerID:   fx.banner.ID,
+		CookieCategoryID: fx.normalCategoryID,
+		TrackerType:      coredata.TrackerTypeCookie,
+		Pattern:          "converge_target",
+		MatchType:        coredata.TrackerPatternMatchTypeExact,
+		DisplayName:      "converge_target",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+
+	sharedDomain := "analytics.google.com"
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		if err := orgThirdParty.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		if err := siblingA.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		if err := siblingB.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		if err := unmappedPattern.Insert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		detA := coredata.DetectedTracker{
+			ID:               gid.New(fx.scope.GetTenantID(), coredata.DetectedTrackerEntityType),
+			CookieBannerID:   fx.banner.ID,
+			TrackerPatternID: &siblingA.ID,
+			TrackerType:      coredata.TrackerTypeCookie,
+			Identifier:       "converge_a",
+			InitiatorDomain:  &sharedDomain,
+			LastDetectedAt:   now,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}
+		if _, err := detA.Upsert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		detB := coredata.DetectedTracker{
+			ID:               gid.New(fx.scope.GetTenantID(), coredata.DetectedTrackerEntityType),
+			CookieBannerID:   fx.banner.ID,
+			TrackerPatternID: &siblingB.ID,
+			TrackerType:      coredata.TrackerTypeCookie,
+			Identifier:       "converge_b",
+			InitiatorDomain:  &sharedDomain,
+			LastDetectedAt:   now,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}
+		if _, err := detB.Upsert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		detUnmapped := coredata.DetectedTracker{
+			ID:               gid.New(fx.scope.GetTenantID(), coredata.DetectedTrackerEntityType),
+			CookieBannerID:   fx.banner.ID,
+			TrackerPatternID: &unmappedPattern.ID,
+			TrackerType:      coredata.TrackerTypeCookie,
+			Identifier:       "converge_target",
+			InitiatorDomain:  &sharedDomain,
+			LastDetectedAt:   now,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}
+		if _, err := detUnmapped.Upsert(ctx, tx, fx.scope); err != nil {
+			return err
+		}
+
+		return nil
+	}))
+
+	h := newMappingHandler(client)
+
+	var got *gid.GID
+
+	require.NoError(t, client.WithTx(ctx, func(ctx context.Context, tx pg.Tx) error {
+		var err error
+
+		got, err = h.matchBySiblingOrigin(ctx, tx, unmappedPattern, []string{"google.com"})
+
+		return err
+	}))
+
+	require.NotNil(t, got, "multiple siblings converging to same third party should succeed")
+
+	var commonPattern coredata.CommonTrackerPattern
+
+	require.NoError(t, client.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		return commonPattern.LoadByID(ctx, conn, *got)
+	}))
+
+	require.NotNil(t, commonPattern.CommonThirdPartyID)
+	assert.Equal(t, fx.commonThirdPartyID, *commonPattern.CommonThirdPartyID)
+}
+
 func TestPromoteThirdParty_ExactCommonLinkIgnoresSimilarUnlinked(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/coredata/common_third_party.go
+++ b/pkg/coredata/common_third_party.go
@@ -507,6 +507,57 @@ func (t CommonThirdParty) Delete(
 	return nil
 }
 
+func (t *CommonThirdParties) LoadByIDs(
+	ctx context.Context,
+	conn pg.Querier,
+	ids []gid.GID,
+) error {
+	q := `
+SELECT
+    id,
+    name,
+    slug,
+    category,
+    headquarter_address,
+    legal_name,
+    website_url,
+    privacy_policy_url,
+    service_level_agreement_url,
+    service_software_agreement_url,
+    data_processing_agreement_url,
+    business_associate_agreement_url,
+    subprocessors_list_url,
+    certifications,
+    status_page_url,
+    terms_of_service_url,
+    security_page_url,
+    trust_page_url,
+    logo_file_id,
+    created_at,
+    updated_at
+FROM
+    common_third_parties
+WHERE
+    id = ANY(@ids)
+`
+
+	args := pgx.StrictNamedArgs{"ids": ids}
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query common third parties: %w", err)
+	}
+
+	parties, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[CommonThirdParty])
+	if err != nil {
+		return fmt.Errorf("cannot collect common third parties: %w", err)
+	}
+
+	*t = parties
+
+	return nil
+}
+
 func (t *CommonThirdParties) LoadAll(
 	ctx context.Context,
 	conn pg.Querier,

--- a/pkg/coredata/common_tracker_pattern.go
+++ b/pkg/coredata/common_tracker_pattern.go
@@ -483,36 +483,3 @@ WHERE
 
 	return nil
 }
-
-// LoadIDsByCommonThirdPartyID returns just the IDs of the common tracker
-// patterns linked to the given common third party. Callers use it to feed
-// a `common_tracker_pattern_id = ANY(...)` filter on tracker_patterns
-// without crossing the entity boundary.
-func (ps *CommonTrackerPatterns) LoadIDsByCommonThirdPartyID(
-	ctx context.Context,
-	conn pg.Querier,
-	commonThirdPartyID gid.GID,
-) ([]gid.GID, error) {
-	q := `
-SELECT
-    id
-FROM
-    common_tracker_patterns
-WHERE
-    common_third_party_id = @common_third_party_id
-`
-
-	args := pgx.StrictNamedArgs{"common_third_party_id": commonThirdPartyID}
-
-	rows, err := conn.Query(ctx, q, args)
-	if err != nil {
-		return nil, fmt.Errorf("cannot query common tracker pattern ids: %w", err)
-	}
-
-	ids, err := pgx.CollectRows(rows, pgx.RowTo[gid.GID])
-	if err != nil {
-		return nil, fmt.Errorf("cannot collect common tracker pattern ids: %w", err)
-	}
-
-	return ids, nil
-}

--- a/pkg/coredata/common_tracker_pattern.go
+++ b/pkg/coredata/common_tracker_pattern.go
@@ -27,16 +27,18 @@ import (
 
 type (
 	CommonTrackerPattern struct {
-		ID                 gid.GID                 `db:"id"`
-		CommonThirdPartyID *gid.GID                `db:"common_third_party_id"`
-		TrackerType        TrackerType             `db:"tracker_type"`
-		Pattern            string                  `db:"pattern"`
-		MatchType          TrackerPatternMatchType `db:"match_type"`
-		Description        string                  `db:"description"`
-		MaxAgeSeconds      *int                    `db:"max_age_seconds"`
-		Confidence         float32                 `db:"confidence"`
-		CreatedAt          time.Time               `db:"created_at"`
-		UpdatedAt          time.Time               `db:"updated_at"`
+		ID                    gid.GID                 `db:"id"`
+		CommonThirdPartyID    *gid.GID                `db:"common_third_party_id"`
+		TrackerType           TrackerType             `db:"tracker_type"`
+		Pattern               string                  `db:"pattern"`
+		MatchType             TrackerPatternMatchType `db:"match_type"`
+		Description           string                  `db:"description"`
+		MaxAgeSeconds         *int                    `db:"max_age_seconds"`
+		Confidence            float32                 `db:"confidence"`
+		EnrichmentRequestedAt *time.Time              `db:"enrichment_requested_at"`
+		EnrichedAt            *time.Time              `db:"enriched_at"`
+		CreatedAt             time.Time               `db:"created_at"`
+		UpdatedAt             time.Time               `db:"updated_at"`
 	}
 
 	CommonTrackerPatterns []*CommonTrackerPattern
@@ -57,6 +59,8 @@ SELECT
     description,
     max_age_seconds,
     confidence,
+    enrichment_requested_at,
+    enriched_at,
     created_at,
     updated_at
 FROM
@@ -104,6 +108,8 @@ SELECT
     description,
     max_age_seconds,
     confidence,
+    enrichment_requested_at,
+    enriched_at,
     created_at,
     updated_at
 FROM
@@ -154,6 +160,8 @@ INSERT INTO common_tracker_patterns (
     description,
     max_age_seconds,
     confidence,
+    enrichment_requested_at,
+    enriched_at,
     created_at,
     updated_at
 ) VALUES (
@@ -165,22 +173,26 @@ INSERT INTO common_tracker_patterns (
     @description,
     @max_age_seconds,
     @confidence,
+    @enrichment_requested_at,
+    @enriched_at,
     @created_at,
     @updated_at
 )
 `
 
 	args := pgx.StrictNamedArgs{
-		"id":                    p.ID,
-		"common_third_party_id": p.CommonThirdPartyID,
-		"tracker_type":          p.TrackerType,
-		"pattern":               p.Pattern,
-		"match_type":            p.MatchType,
-		"description":           p.Description,
-		"max_age_seconds":       p.MaxAgeSeconds,
-		"confidence":            p.Confidence,
-		"created_at":            p.CreatedAt,
-		"updated_at":            p.UpdatedAt,
+		"id":                      p.ID,
+		"common_third_party_id":   p.CommonThirdPartyID,
+		"tracker_type":            p.TrackerType,
+		"pattern":                 p.Pattern,
+		"match_type":              p.MatchType,
+		"description":             p.Description,
+		"max_age_seconds":         p.MaxAgeSeconds,
+		"confidence":              p.Confidence,
+		"enrichment_requested_at": p.EnrichmentRequestedAt,
+		"enriched_at":             p.EnrichedAt,
+		"created_at":              p.CreatedAt,
+		"updated_at":              p.UpdatedAt,
 	}
 
 	_, err := conn.Exec(ctx, q, args)
@@ -195,6 +207,12 @@ func (p *CommonTrackerPattern) Upsert(
 	ctx context.Context,
 	conn pg.Tx,
 ) (inserted bool, err error) {
+	// On insert, a description-less row is immediately queued for the
+	// enrichment worker (enrichment_requested_at = NOW()). On conflict the
+	// enrichment columns are left untouched, and an empty incoming
+	// description never overwrites an existing one — descriptions are owned
+	// by the enrichment worker, so mapping-side upserts must not clobber a
+	// researched description with an empty string.
 	q := `
 INSERT INTO common_tracker_patterns (
     id,
@@ -205,6 +223,8 @@ INSERT INTO common_tracker_patterns (
     description,
     max_age_seconds,
     confidence,
+    enrichment_requested_at,
+    enriched_at,
     created_at,
     updated_at
 ) VALUES (
@@ -216,6 +236,8 @@ INSERT INTO common_tracker_patterns (
     @description,
     @max_age_seconds,
     @confidence,
+    CASE WHEN @description = '' THEN NOW() ELSE NULL END,
+    NULL,
     @created_at,
     @updated_at
 )
@@ -223,7 +245,10 @@ ON CONFLICT (tracker_type, pattern, COALESCE(max_age_seconds, -1)) DO UPDATE
 SET
     common_third_party_id = EXCLUDED.common_third_party_id,
     match_type            = EXCLUDED.match_type,
-    description           = EXCLUDED.description,
+    description           = CASE
+        WHEN EXCLUDED.description = '' THEN common_tracker_patterns.description
+        ELSE EXCLUDED.description
+    END,
     confidence            = EXCLUDED.confidence,
     updated_at            = EXCLUDED.updated_at
 RETURNING
@@ -235,6 +260,8 @@ RETURNING
     description,
     max_age_seconds,
     confidence,
+    enrichment_requested_at,
+    enriched_at,
     created_at,
     updated_at
 `
@@ -303,6 +330,8 @@ SELECT
     description,
     max_age_seconds,
     confidence,
+    enrichment_requested_at,
+    enriched_at,
     created_at,
     updated_at
 FROM
@@ -418,6 +447,8 @@ SELECT
     description,
     max_age_seconds,
     confidence,
+    enrichment_requested_at,
+    enriched_at,
     created_at,
     updated_at
 FROM
@@ -444,6 +475,151 @@ ORDER BY pattern ASC;
 	return nil
 }
 
+// LoadNextForEnrichmentForUpdateSkipLocked claims the next common tracker
+// pattern queued for description enrichment, oldest request first. It
+// mirrors the mapping worker's claim pattern: the row is locked FOR
+// UPDATE SKIP LOCKED so concurrent enrichment workers never pick the same
+// row.
+func (p *CommonTrackerPattern) LoadNextForEnrichmentForUpdateSkipLocked(
+	ctx context.Context,
+	tx pg.Tx,
+) error {
+	q := `
+SELECT
+    id,
+    common_third_party_id,
+    tracker_type,
+    pattern,
+    match_type,
+    description,
+    max_age_seconds,
+    confidence,
+    enrichment_requested_at,
+    enriched_at,
+    created_at,
+    updated_at
+FROM
+    common_tracker_patterns
+WHERE
+    enrichment_requested_at IS NOT NULL
+ORDER BY
+    enrichment_requested_at ASC
+FOR UPDATE SKIP LOCKED
+LIMIT 1;
+`
+
+	rows, err := tx.Query(ctx, q)
+	if err != nil {
+		return fmt.Errorf("cannot query common tracker pattern for enrichment: %w", err)
+	}
+
+	pattern, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[CommonTrackerPattern])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrResourceNotFound
+		}
+
+		return fmt.Errorf("cannot collect common tracker pattern for enrichment: %w", err)
+	}
+
+	*p = pattern
+
+	return nil
+}
+
+// ClearEnrichmentRequestedAt removes the row from the enrichment queue. It
+// bumps updated_at so the stale-recovery clock starts at claim time.
+func (p *CommonTrackerPattern) ClearEnrichmentRequestedAt(
+	ctx context.Context,
+	tx pg.Tx,
+) error {
+	q := `
+UPDATE common_tracker_patterns
+SET
+    enrichment_requested_at = NULL,
+    updated_at = NOW()
+WHERE id = @id
+`
+
+	args := pgx.StrictNamedArgs{"id": p.ID}
+
+	_, err := tx.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot clear enrichment requested at: %w", err)
+	}
+
+	p.EnrichmentRequestedAt = nil
+
+	return nil
+}
+
+// SetEnriched records the researched description and marks the row
+// terminally enriched so it is never re-queued.
+func (p *CommonTrackerPattern) SetEnriched(
+	ctx context.Context,
+	tx pg.Tx,
+	description string,
+) error {
+	q := `
+UPDATE common_tracker_patterns
+SET
+    description = @description,
+    enriched_at = NOW(),
+    enrichment_requested_at = NULL,
+    updated_at = NOW()
+WHERE id = @id
+`
+
+	args := pgx.StrictNamedArgs{
+		"id":          p.ID,
+		"description": description,
+	}
+
+	result, err := tx.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot mark common tracker pattern enriched: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return ErrResourceNotFound
+	}
+
+	p.Description = description
+
+	return nil
+}
+
+// ResetStaleEnrichments re-queues rows whose enrichment was claimed but
+// never completed (no enriched_at, still description-less) and have been
+// idle longer than staleAfter, so a crashed or timed-out enrichment is
+// retried.
+func ResetStaleEnrichments(
+	ctx context.Context,
+	conn pg.Querier,
+	staleAfter time.Duration,
+) error {
+	q := `
+UPDATE common_tracker_patterns
+SET
+    enrichment_requested_at = NOW(),
+    updated_at = NOW()
+WHERE
+    enrichment_requested_at IS NULL
+    AND enriched_at IS NULL
+    AND description = ''
+    AND updated_at < @stale_before
+`
+
+	args := pgx.StrictNamedArgs{"stale_before": time.Now().Add(-staleAfter)}
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot reset stale common tracker pattern enrichments: %w", err)
+	}
+
+	return nil
+}
+
 func (ps *CommonTrackerPatterns) LoadByIDs(
 	ctx context.Context,
 	conn pg.Querier,
@@ -459,6 +635,8 @@ SELECT
     description,
     max_age_seconds,
     confidence,
+    enrichment_requested_at,
+    enriched_at,
     created_at,
     updated_at
 FROM

--- a/pkg/coredata/common_tracker_pattern.go
+++ b/pkg/coredata/common_tracker_pattern.go
@@ -443,3 +443,76 @@ ORDER BY pattern ASC;
 
 	return nil
 }
+
+func (ps *CommonTrackerPatterns) LoadByIDs(
+	ctx context.Context,
+	conn pg.Querier,
+	ids []gid.GID,
+) error {
+	q := `
+SELECT
+    id,
+    common_third_party_id,
+    tracker_type,
+    pattern,
+    match_type,
+    description,
+    max_age_seconds,
+    confidence,
+    created_at,
+    updated_at
+FROM
+    common_tracker_patterns
+WHERE
+    id = ANY(@ids)
+`
+
+	args := pgx.StrictNamedArgs{"ids": ids}
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query common tracker patterns: %w", err)
+	}
+
+	patterns, err := pgx.CollectRows(rows, pgx.RowToAddrOfStructByName[CommonTrackerPattern])
+	if err != nil {
+		return fmt.Errorf("cannot collect common tracker patterns: %w", err)
+	}
+
+	*ps = patterns
+
+	return nil
+}
+
+// LoadIDsByCommonThirdPartyID returns just the IDs of the common tracker
+// patterns linked to the given common third party. Callers use it to feed
+// a `common_tracker_pattern_id = ANY(...)` filter on tracker_patterns
+// without crossing the entity boundary.
+func (ps *CommonTrackerPatterns) LoadIDsByCommonThirdPartyID(
+	ctx context.Context,
+	conn pg.Querier,
+	commonThirdPartyID gid.GID,
+) ([]gid.GID, error) {
+	q := `
+SELECT
+    id
+FROM
+    common_tracker_patterns
+WHERE
+    common_third_party_id = @common_third_party_id
+`
+
+	args := pgx.StrictNamedArgs{"common_third_party_id": commonThirdPartyID}
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query common tracker pattern ids: %w", err)
+	}
+
+	ids, err := pgx.CollectRows(rows, pgx.RowTo[gid.GID])
+	if err != nil {
+		return nil, fmt.Errorf("cannot collect common tracker pattern ids: %w", err)
+	}
+
+	return ids, nil
+}

--- a/pkg/coredata/detected_tracker.go
+++ b/pkg/coredata/detected_tracker.go
@@ -252,6 +252,48 @@ WHERE
 	return nil
 }
 
+func (dts *DetectedTrackers) LoadSiblingPatternIDsByInitiatorDomains(
+	ctx context.Context,
+	conn pg.Querier,
+	cookieBannerID gid.GID,
+	domains []string,
+	excludePatternID gid.GID,
+	limit int,
+) ([]gid.GID, error) {
+	if len(domains) == 0 {
+		return nil, nil
+	}
+
+	q := `
+SELECT DISTINCT tracker_pattern_id
+FROM detected_trackers
+WHERE cookie_banner_id = @cookie_banner_id
+  AND initiator_domain = ANY(@domains)
+  AND tracker_pattern_id IS NOT NULL
+  AND tracker_pattern_id != @exclude_pattern_id
+LIMIT @limit;
+`
+
+	args := pgx.StrictNamedArgs{
+		"cookie_banner_id":   cookieBannerID,
+		"domains":            domains,
+		"exclude_pattern_id": excludePatternID,
+		"limit":              limit,
+	}
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load sibling pattern ids: %w", err)
+	}
+
+	ids, err := pgx.CollectRows(rows, pgx.RowTo[gid.GID])
+	if err != nil {
+		return nil, fmt.Errorf("cannot collect sibling pattern ids: %w", err)
+	}
+
+	return ids, nil
+}
+
 func (dts *DetectedTrackers) RelinkByTrackerPatternID(
 	ctx context.Context,
 	tx pg.Tx,

--- a/pkg/coredata/detected_tracker.go
+++ b/pkg/coredata/detected_tracker.go
@@ -271,6 +271,7 @@ WHERE cookie_banner_id = @cookie_banner_id
   AND initiator_domain = ANY(@domains)
   AND tracker_pattern_id IS NOT NULL
   AND tracker_pattern_id != @exclude_pattern_id
+ORDER BY tracker_pattern_id
 LIMIT @limit;
 `
 

--- a/pkg/coredata/migrations/20260529T091300Z.sql
+++ b/pkg/coredata/migrations/20260529T091300Z.sql
@@ -1,0 +1,31 @@
+-- Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+--
+-- Permission to use, copy, modify, and/or distribute this software for any
+-- purpose with or without fee is hereby granted, provided that the above
+-- copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+-- REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+-- INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+-- LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+-- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+-- The common-pattern enrichment worker fills descriptions on
+-- common_tracker_patterns using an agent with web search, then fans the
+-- result out to every linked tracker pattern. enrichment_requested_at is
+-- the work queue (claimed FOR UPDATE SKIP LOCKED); enriched_at marks a
+-- row as terminally enriched so it is never re-enqueued.
+ALTER TABLE common_tracker_patterns
+    ADD COLUMN enrichment_requested_at TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN enriched_at             TIMESTAMP WITH TIME ZONE;
+
+CREATE INDEX idx_common_tracker_patterns_enrichment
+    ON common_tracker_patterns (enrichment_requested_at)
+    WHERE enrichment_requested_at IS NOT NULL;
+
+-- Enqueue existing description-less rows for a first enrichment pass.
+UPDATE common_tracker_patterns
+SET enrichment_requested_at = NOW()
+WHERE description = '';

--- a/pkg/coredata/third_party.go
+++ b/pkg/coredata/third_party.go
@@ -645,6 +645,7 @@ func (v *ThirdParty) Update(
 	q := `
 UPDATE third_parties
 SET
+	common_third_party_id = @common_third_party_id,
 	name = @name,
 	description = @description,
 	category = @category,
@@ -675,6 +676,7 @@ WHERE %s
 	args := pgx.StrictNamedArgs{
 		"third_party_id":                   v.ID,
 		"updated_at":                       time.Now(),
+		"common_third_party_id":            v.CommonThirdPartyID,
 		"name":                             v.Name,
 		"description":                      v.Description,
 		"category":                         v.Category,

--- a/pkg/coredata/third_party.go
+++ b/pkg/coredata/third_party.go
@@ -1418,7 +1418,6 @@ WHERE
 	%s
 	AND organization_id = @organization_id
 	AND common_third_party_id = @common_third_party_id
-	AND snapshot_id IS NULL
 ORDER BY id ASC
 LIMIT 1;
 `

--- a/pkg/coredata/tracker_pattern.go
+++ b/pkg/coredata/tracker_pattern.go
@@ -1303,3 +1303,40 @@ WHERE
 
 	return result.RowsAffected(), nil
 }
+
+// BackfillDescriptionByCommonTrackerPatternID copies an enriched
+// description onto every tracker pattern linked to the given common
+// pattern that does not yet have one. It is invoked by the common-pattern
+// enrichment worker, a global system process, so it is intentionally not
+// tenant-scoped: a single catalog enrichment fans out to all tenants'
+// linked patterns. The description = ” guard guarantees a pattern that
+// already carries a description is never overwritten. Returns the number
+// of patterns backfilled.
+func (tps *TrackerPatterns) BackfillDescriptionByCommonTrackerPatternID(
+	ctx context.Context,
+	tx pg.Tx,
+	commonTrackerPatternID gid.GID,
+	description string,
+) (int64, error) {
+	q := `
+UPDATE tracker_patterns
+SET
+	description = @description,
+	updated_at = NOW()
+WHERE
+	common_tracker_pattern_id = @common_tracker_pattern_id
+	AND description = ''
+`
+
+	args := pgx.StrictNamedArgs{
+		"common_tracker_pattern_id": commonTrackerPatternID,
+		"description":               description,
+	}
+
+	result, err := tx.Exec(ctx, q, args)
+	if err != nil {
+		return 0, fmt.Errorf("cannot backfill tracker pattern descriptions: %w", err)
+	}
+
+	return result.RowsAffected(), nil
+}

--- a/pkg/coredata/tracker_pattern.go
+++ b/pkg/coredata/tracker_pattern.go
@@ -944,6 +944,80 @@ WHERE
 	return ids, nil
 }
 
+func (tps *TrackerPatterns) LoadDistinctThirdPartyIDsByIDs(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	ids []gid.GID,
+) ([]gid.GID, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	q := `
+SELECT DISTINCT third_party_id
+FROM tracker_patterns
+WHERE
+	%s
+	AND id = ANY(@ids)
+	AND third_party_id IS NOT NULL
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"ids": ids}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query distinct third party ids by pattern ids: %w", err)
+	}
+
+	thirdPartyIDs, err := pgx.CollectRows(rows, pgx.RowTo[gid.GID])
+	if err != nil {
+		return nil, fmt.Errorf("cannot collect distinct third party ids by pattern ids: %w", err)
+	}
+
+	return thirdPartyIDs, nil
+}
+
+func (tps *TrackerPatterns) LoadDistinctCommonTrackerPatternIDsByIDs(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	ids []gid.GID,
+) ([]gid.GID, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	q := `
+SELECT DISTINCT common_tracker_pattern_id
+FROM tracker_patterns
+WHERE
+	%s
+	AND id = ANY(@ids)
+	AND common_tracker_pattern_id IS NOT NULL
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"ids": ids}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query distinct common tracker pattern ids by pattern ids: %w", err)
+	}
+
+	commonPatternIDs, err := pgx.CollectRows(rows, pgx.RowTo[gid.GID])
+	if err != nil {
+		return nil, fmt.Errorf("cannot collect distinct common tracker pattern ids by pattern ids: %w", err)
+	}
+
+	return commonPatternIDs, nil
+}
+
 func (tps *TrackerPatterns) UpdateLastMatchedAt(
 	ctx context.Context,
 	tx pg.Tx,

--- a/pkg/coredata/tracker_pattern.go
+++ b/pkg/coredata/tracker_pattern.go
@@ -1184,3 +1184,68 @@ WHERE id = @id
 
 	return nil
 }
+
+// RequestMappingForUnmappedSiblings re-arms mapping_requested_at on
+// sibling tracker patterns of the same banner that share an initiator
+// domain with the just-mapped pattern but are still unpromoted. It is
+// the backward-propagation counterpart to the mapping worker's
+// sibling-origin matching: when a pattern newly resolves a vendor, its
+// siblings that were processed earlier and left unmatched can now be
+// re-evaluated against it.
+//
+// Only unpromoted (third_party_id IS NULL), not-already-queued
+// (mapping_requested_at IS NULL), non-extension siblings are touched, so
+// a fully mapped banner re-enqueues nothing. detected_trackers is used
+// only as a filtering subquery. Returns the number of siblings
+// re-enqueued.
+func (tps *TrackerPatterns) RequestMappingForUnmappedSiblings(
+	ctx context.Context,
+	tx pg.Tx,
+	scope Scoper,
+	cookieBannerID gid.GID,
+	excludePatternID gid.GID,
+	domains []string,
+) (int64, error) {
+	if len(domains) == 0 {
+		return 0, nil
+	}
+
+	q := `
+UPDATE tracker_patterns
+SET
+	mapping_requested_at = NOW(),
+	updated_at = NOW()
+WHERE
+	%[1]s
+	AND cookie_banner_id = @cookie_banner_id
+	AND id != @exclude_pattern_id
+	AND third_party_id IS NULL
+	AND mapping_requested_at IS NULL
+	AND (source IS NULL OR source != @extension_source)
+	AND id IN (
+		SELECT DISTINCT tracker_pattern_id
+		FROM detected_trackers
+		WHERE %[1]s
+			AND cookie_banner_id = @cookie_banner_id
+			AND initiator_domain = ANY(@domains)
+			AND tracker_pattern_id IS NOT NULL
+	)
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"cookie_banner_id":   cookieBannerID,
+		"exclude_pattern_id": excludePatternID,
+		"extension_source":   CookieSourceExtension,
+		"domains":            domains,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	result, err := tx.Exec(ctx, q, args)
+	if err != nil {
+		return 0, fmt.Errorf("cannot request mapping for unmapped siblings: %w", err)
+	}
+
+	return result.RowsAffected(), nil
+}

--- a/pkg/coredata/tracker_pattern.go
+++ b/pkg/coredata/tracker_pattern.go
@@ -505,6 +505,8 @@ func (tp *TrackerPattern) Update(
 	q := `
 UPDATE tracker_patterns
 SET
+	common_tracker_pattern_id = @common_tracker_pattern_id,
+	third_party_id = @third_party_id,
 	cookie_category_id = @cookie_category_id,
 	display_name = @display_name,
 	max_age_seconds = @max_age_seconds,
@@ -521,15 +523,17 @@ WHERE
 	q = fmt.Sprintf(q, scope.SQLFragment())
 
 	args := pgx.StrictNamedArgs{
-		"id":                 tp.ID,
-		"cookie_category_id": tp.CookieCategoryID,
-		"display_name":       tp.DisplayName,
-		"max_age_seconds":    tp.MaxAgeSeconds,
-		"description":        tp.Description,
-		"excluded":           tp.Excluded,
-		"source":             tp.Source,
-		"last_matched_at":    tp.LastMatchedAt,
-		"updated_at":         tp.UpdatedAt,
+		"id":                        tp.ID,
+		"common_tracker_pattern_id": tp.CommonTrackerPatternID,
+		"third_party_id":            tp.ThirdPartyID,
+		"cookie_category_id":        tp.CookieCategoryID,
+		"display_name":              tp.DisplayName,
+		"max_age_seconds":           tp.MaxAgeSeconds,
+		"description":               tp.Description,
+		"excluded":                  tp.Excluded,
+		"source":                    tp.Source,
+		"last_matched_at":           tp.LastMatchedAt,
+		"updated_at":                tp.UpdatedAt,
 	}
 	maps.Copy(args, scope.SQLArguments())
 
@@ -1103,43 +1107,6 @@ WHERE id = @id
 	if err != nil {
 		return fmt.Errorf("cannot set mapping requested: %w", err)
 	}
-
-	return nil
-}
-
-func (tp *TrackerPattern) UpdateMapping(
-	ctx context.Context,
-	tx pg.Tx,
-	commonTrackerPatternID *gid.GID,
-	thirdPartyID *gid.GID,
-) error {
-	q := `
-UPDATE tracker_patterns
-SET
-	common_tracker_pattern_id = @common_tracker_pattern_id,
-	third_party_id = @third_party_id,
-	mapping_requested_at = NULL,
-	updated_at = @updated_at
-WHERE id = @id
-`
-
-	now := time.Now()
-	args := pgx.StrictNamedArgs{
-		"id":                        tp.ID,
-		"common_tracker_pattern_id": commonTrackerPatternID,
-		"third_party_id":            thirdPartyID,
-		"updated_at":                now,
-	}
-
-	_, err := tx.Exec(ctx, q, args)
-	if err != nil {
-		return fmt.Errorf("cannot update tracker pattern mapping: %w", err)
-	}
-
-	tp.CommonTrackerPatternID = commonTrackerPatternID
-	tp.ThirdPartyID = thirdPartyID
-	tp.MappingRequestedAt = nil
-	tp.UpdatedAt = now
 
 	return nil
 }

--- a/pkg/coredata/tracker_pattern.go
+++ b/pkg/coredata/tracker_pattern.go
@@ -864,6 +864,82 @@ WHERE
 	return count, nil
 }
 
+// LoadDistinctThirdPartyIDsByCookieBannerID returns the distinct non-null
+// `third_party_id` values referenced by tracker patterns of the given
+// banner. Callers feed it to ThirdParty.GetByIDs to power per-banner
+// pickers without crossing the entity boundary.
+func (tps *TrackerPatterns) LoadDistinctThirdPartyIDsByCookieBannerID(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	cookieBannerID gid.GID,
+) ([]gid.GID, error) {
+	q := `
+SELECT DISTINCT third_party_id
+FROM tracker_patterns
+WHERE
+	%s
+	AND cookie_banner_id = @cookie_banner_id
+	AND third_party_id IS NOT NULL
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"cookie_banner_id": cookieBannerID}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query distinct third party ids: %w", err)
+	}
+
+	ids, err := pgx.CollectRows(rows, pgx.RowTo[gid.GID])
+	if err != nil {
+		return nil, fmt.Errorf("cannot collect distinct third party ids: %w", err)
+	}
+
+	return ids, nil
+}
+
+// LoadDistinctCommonTrackerPatternIDsByCookieBannerID returns the
+// distinct non-null `common_tracker_pattern_id` values referenced by
+// tracker patterns of the given banner. Callers chain this with
+// CommonTrackerPatterns.LoadByIDs and CommonThirdParties.LoadByIDs to
+// resolve the linked common third parties without JOINs.
+func (tps *TrackerPatterns) LoadDistinctCommonTrackerPatternIDsByCookieBannerID(
+	ctx context.Context,
+	conn pg.Querier,
+	scope Scoper,
+	cookieBannerID gid.GID,
+) ([]gid.GID, error) {
+	q := `
+SELECT DISTINCT common_tracker_pattern_id
+FROM tracker_patterns
+WHERE
+	%s
+	AND cookie_banner_id = @cookie_banner_id
+	AND common_tracker_pattern_id IS NOT NULL
+	AND third_party_id IS NULL
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{"cookie_banner_id": cookieBannerID}
+	maps.Copy(args, scope.SQLArguments())
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot query distinct common tracker pattern ids: %w", err)
+	}
+
+	ids, err := pgx.CollectRows(rows, pgx.RowTo[gid.GID])
+	if err != nil {
+		return nil, fmt.Errorf("cannot collect distinct common tracker pattern ids: %w", err)
+	}
+
+	return ids, nil
+}
+
 func (tps *TrackerPatterns) UpdateLastMatchedAt(
 	ctx context.Context,
 	tx pg.Tx,

--- a/pkg/coredata/tracker_pattern.go
+++ b/pkg/coredata/tracker_pattern.go
@@ -555,6 +555,60 @@ WHERE
 	return nil
 }
 
+// UpdateMapping writes only the columns the tracker-mapping worker
+// resolves — common_tracker_pattern_id, third_party_id and an enriched
+// description — leaving the user-editable fields (display_name,
+// excluded, cookie_category_id, max_age_seconds, source, last_matched_at)
+// untouched.
+//
+// The worker loads the pattern in its claim transaction and commits the
+// resolution in a separate, later transaction, so a full-row Update
+// would write back stale values and clobber any concurrent edit made in
+// between. The description is only filled when still empty in the
+// database, so a concurrently set description is never overwritten.
+func (tp *TrackerPattern) UpdateMapping(
+	ctx context.Context,
+	tx pg.Tx,
+	scope Scoper,
+) error {
+	q := `
+UPDATE tracker_patterns
+SET
+	common_tracker_pattern_id = @common_tracker_pattern_id,
+	third_party_id = @third_party_id,
+	description = CASE
+		WHEN description = '' THEN @description
+		ELSE description
+	END,
+	updated_at = @updated_at
+WHERE
+	%s
+	AND id = @id
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"id":                        tp.ID,
+		"common_tracker_pattern_id": tp.CommonTrackerPatternID,
+		"third_party_id":            tp.ThirdPartyID,
+		"description":               tp.Description,
+		"updated_at":                tp.UpdatedAt,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	result, err := tx.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot update tracker pattern mapping: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return ErrResourceNotFound
+	}
+
+	return nil
+}
+
 func (tp *TrackerPattern) Delete(
 	ctx context.Context,
 	tx pg.Tx,

--- a/pkg/coredata/tracker_pattern_filter.go
+++ b/pkg/coredata/tracker_pattern_filter.go
@@ -20,14 +20,14 @@ import (
 )
 
 type TrackerPatternFilter struct {
-	matchType               *TrackerPatternMatchType
-	cookieCategoryID        *gid.GID
-	excluded                *bool
-	query                   *string
-	source                  *CookieSource
-	trackerType             *TrackerType
-	thirdPartyID            *gid.GID
-	commonTrackerPatternIDs []gid.GID
+	matchType          *TrackerPatternMatchType
+	cookieCategoryID   *gid.GID
+	excluded           *bool
+	query              *string
+	source             *CookieSource
+	trackerType        *TrackerType
+	thirdPartyID       *gid.GID
+	commonThirdPartyID *gid.GID
 }
 
 func NewTrackerPatternFilter(
@@ -62,14 +62,8 @@ func (f *TrackerPatternFilter) WithThirdPartyID(thirdPartyID *gid.GID) *TrackerP
 	return f
 }
 
-// WithCommonTrackerPatternIDs constrains the result to tracker patterns
-// whose `common_tracker_pattern_id` is in the given set. Callers
-// pre-resolve this list (typically via
-// CommonTrackerPatterns.LoadIDsByCommonThirdPartyID) so the filter stays
-// inside the tracker_patterns table. Passing an empty (non-nil) slice
-// yields no rows.
-func (f *TrackerPatternFilter) WithCommonTrackerPatternIDs(ids []gid.GID) *TrackerPatternFilter {
-	f.commonTrackerPatternIDs = ids
+func (f *TrackerPatternFilter) WithCommonThirdPartyID(id *gid.GID) *TrackerPatternFilter {
+	f.commonThirdPartyID = id
 	return f
 }
 
@@ -130,9 +124,12 @@ func (f *TrackerPatternFilter) SQLFragment() string {
 	END
 	AND
 	CASE
-		WHEN @has_common_tracker_pattern_ids_filter::boolean = false THEN TRUE
-		WHEN @has_common_tracker_pattern_ids_filter::boolean = true THEN
-			common_tracker_pattern_id = ANY(@filter_common_tracker_pattern_ids::text[])
+		WHEN @has_common_third_party_id_filter::boolean = false THEN TRUE
+		WHEN @has_common_third_party_id_filter::boolean = true THEN
+			common_tracker_pattern_id IN (
+				SELECT id FROM common_tracker_patterns
+				WHERE common_third_party_id = @filter_common_third_party_id::text
+			)
 		ELSE TRUE
 	END
 )`
@@ -144,21 +141,21 @@ func (f *TrackerPatternFilter) SQLArguments() pgx.StrictNamedArgs {
 	}
 
 	args := pgx.StrictNamedArgs{
-		"has_match_type_filter":                 false,
-		"filter_match_type":                     nil,
-		"has_cookie_category_id_filter":         false,
-		"filter_cookie_category_id":             nil,
-		"has_excluded_filter":                   false,
-		"filter_excluded":                       nil,
-		"filter_query":                          nil,
-		"has_source_filter":                     false,
-		"filter_source":                         nil,
-		"has_tracker_type_filter":               false,
-		"filter_tracker_type":                   nil,
-		"has_third_party_id_filter":             false,
-		"filter_third_party_id":                 nil,
-		"has_common_tracker_pattern_ids_filter": false,
-		"filter_common_tracker_pattern_ids":     []gid.GID{},
+		"has_match_type_filter":            false,
+		"filter_match_type":                nil,
+		"has_cookie_category_id_filter":    false,
+		"filter_cookie_category_id":        nil,
+		"has_excluded_filter":              false,
+		"filter_excluded":                  nil,
+		"filter_query":                     nil,
+		"has_source_filter":                false,
+		"filter_source":                    nil,
+		"has_tracker_type_filter":          false,
+		"filter_tracker_type":              nil,
+		"has_third_party_id_filter":        false,
+		"filter_third_party_id":            nil,
+		"has_common_third_party_id_filter": false,
+		"filter_common_third_party_id":     nil,
 	}
 
 	if f.matchType != nil {
@@ -195,9 +192,9 @@ func (f *TrackerPatternFilter) SQLArguments() pgx.StrictNamedArgs {
 		args["filter_third_party_id"] = *f.thirdPartyID
 	}
 
-	if f.commonTrackerPatternIDs != nil {
-		args["has_common_tracker_pattern_ids_filter"] = true
-		args["filter_common_tracker_pattern_ids"] = f.commonTrackerPatternIDs
+	if f.commonThirdPartyID != nil {
+		args["has_common_third_party_id_filter"] = true
+		args["filter_common_third_party_id"] = *f.commonThirdPartyID
 	}
 
 	return args

--- a/pkg/coredata/tracker_pattern_filter.go
+++ b/pkg/coredata/tracker_pattern_filter.go
@@ -20,12 +20,14 @@ import (
 )
 
 type TrackerPatternFilter struct {
-	matchType        *TrackerPatternMatchType
-	cookieCategoryID *gid.GID
-	excluded         *bool
-	query            *string
-	source           *CookieSource
-	trackerType      *TrackerType
+	matchType               *TrackerPatternMatchType
+	cookieCategoryID        *gid.GID
+	excluded                *bool
+	query                   *string
+	source                  *CookieSource
+	trackerType             *TrackerType
+	thirdPartyID            *gid.GID
+	commonTrackerPatternIDs []gid.GID
 }
 
 func NewTrackerPatternFilter(
@@ -52,6 +54,22 @@ func (f *TrackerPatternFilter) WithSource(source *CookieSource) *TrackerPatternF
 
 func (f *TrackerPatternFilter) WithTrackerType(trackerType *TrackerType) *TrackerPatternFilter {
 	f.trackerType = trackerType
+	return f
+}
+
+func (f *TrackerPatternFilter) WithThirdPartyID(thirdPartyID *gid.GID) *TrackerPatternFilter {
+	f.thirdPartyID = thirdPartyID
+	return f
+}
+
+// WithCommonTrackerPatternIDs constrains the result to tracker patterns
+// whose `common_tracker_pattern_id` is in the given set. Callers
+// pre-resolve this list (typically via
+// CommonTrackerPatterns.LoadIDsByCommonThirdPartyID) so the filter stays
+// inside the tracker_patterns table. Passing an empty (non-nil) slice
+// yields no rows.
+func (f *TrackerPatternFilter) WithCommonTrackerPatternIDs(ids []gid.GID) *TrackerPatternFilter {
+	f.commonTrackerPatternIDs = ids
 	return f
 }
 
@@ -103,6 +121,20 @@ func (f *TrackerPatternFilter) SQLFragment() string {
 			tracker_type = @filter_tracker_type::tracker_type
 		ELSE TRUE
 	END
+	AND
+	CASE
+		WHEN @has_third_party_id_filter::boolean = false THEN TRUE
+		WHEN @has_third_party_id_filter::boolean = true THEN
+			third_party_id = @filter_third_party_id::text
+		ELSE TRUE
+	END
+	AND
+	CASE
+		WHEN @has_common_tracker_pattern_ids_filter::boolean = false THEN TRUE
+		WHEN @has_common_tracker_pattern_ids_filter::boolean = true THEN
+			common_tracker_pattern_id = ANY(@filter_common_tracker_pattern_ids::text[])
+		ELSE TRUE
+	END
 )`
 }
 
@@ -112,17 +144,21 @@ func (f *TrackerPatternFilter) SQLArguments() pgx.StrictNamedArgs {
 	}
 
 	args := pgx.StrictNamedArgs{
-		"has_match_type_filter":         false,
-		"filter_match_type":             nil,
-		"has_cookie_category_id_filter": false,
-		"filter_cookie_category_id":     nil,
-		"has_excluded_filter":           false,
-		"filter_excluded":               nil,
-		"filter_query":                  nil,
-		"has_source_filter":             false,
-		"filter_source":                 nil,
-		"has_tracker_type_filter":       false,
-		"filter_tracker_type":           nil,
+		"has_match_type_filter":                 false,
+		"filter_match_type":                     nil,
+		"has_cookie_category_id_filter":         false,
+		"filter_cookie_category_id":             nil,
+		"has_excluded_filter":                   false,
+		"filter_excluded":                       nil,
+		"filter_query":                          nil,
+		"has_source_filter":                     false,
+		"filter_source":                         nil,
+		"has_tracker_type_filter":               false,
+		"filter_tracker_type":                   nil,
+		"has_third_party_id_filter":             false,
+		"filter_third_party_id":                 nil,
+		"has_common_tracker_pattern_ids_filter": false,
+		"filter_common_tracker_pattern_ids":     []gid.GID{},
 	}
 
 	if f.matchType != nil {
@@ -152,6 +188,16 @@ func (f *TrackerPatternFilter) SQLArguments() pgx.StrictNamedArgs {
 	if f.trackerType != nil {
 		args["has_tracker_type_filter"] = true
 		args["filter_tracker_type"] = string(*f.trackerType)
+	}
+
+	if f.thirdPartyID != nil {
+		args["has_third_party_id_filter"] = true
+		args["filter_third_party_id"] = *f.thirdPartyID
+	}
+
+	if f.commonTrackerPatternIDs != nil {
+		args["has_common_tracker_pattern_ids_filter"] = true
+		args["filter_common_tracker_pattern_ids"] = f.commonTrackerPatternIDs
 	}
 
 	return args

--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -745,6 +745,7 @@ func (impl *Implm) Run(
 		commonPatternEnrichmentWorker := cookiebanner.NewCommonPatternEnrichmentWorker(pgClient, l, trackerAgentsCfg)
 
 		var commonPatternEnrichmentWorkerCtx context.Context
+
 		commonPatternEnrichmentWorkerCtx, stopCommonPatternEnrichmentWorker = context.WithCancel(context.Background())
 
 		wg.Go(

--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -313,7 +313,7 @@ func (impl *Implm) Run(
 		return err
 	}
 
-	trackerMappingCfg, err := impl.buildTrackerMappingConfig(l, tp, r)
+	trackerMappingCfg, thirdPartyDisambiguationCfg, err := impl.buildTrackerMappingConfig(l, tp, r)
 	if err != nil {
 		return err
 	}
@@ -725,7 +725,7 @@ func (impl *Implm) Run(
 		},
 	)
 
-	trackerMappingWorker := cookiebanner.NewTrackerMappingWorker(pgClient, l, trackerMappingCfg)
+	trackerMappingWorker := cookiebanner.NewTrackerMappingWorker(pgClient, l, trackerMappingCfg, thirdPartyDisambiguationCfg)
 	trackerMappingWorkerCtx, stopTrackerMappingWorker := context.WithCancel(context.Background())
 
 	wg.Go(

--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -313,7 +313,7 @@ func (impl *Implm) Run(
 		return err
 	}
 
-	trackerMappingCfg, thirdPartyDisambiguationCfg, err := impl.buildTrackerMappingConfig(l, tp, r)
+	trackerAgentsCfg, thirdPartyDisambiguationCfg, err := impl.buildTrackerAgentsConfig(l, tp, r)
 	if err != nil {
 		return err
 	}
@@ -725,7 +725,7 @@ func (impl *Implm) Run(
 		},
 	)
 
-	trackerMappingWorker := cookiebanner.NewTrackerMappingWorker(pgClient, l, trackerMappingCfg, thirdPartyDisambiguationCfg)
+	trackerMappingWorker := cookiebanner.NewTrackerMappingWorker(pgClient, l, trackerAgentsCfg, thirdPartyDisambiguationCfg)
 	trackerMappingWorkerCtx, stopTrackerMappingWorker := context.WithCancel(context.Background())
 
 	wg.Go(
@@ -735,6 +735,26 @@ func (impl *Implm) Run(
 			}
 		},
 	)
+
+	// The common-pattern enrichment worker needs an LLM client (it
+	// researches descriptions via the agent), so it is only started when
+	// the tracker agents are configured.
+	stopCommonPatternEnrichmentWorker := func() {}
+
+	if trackerAgentsCfg.LLMClient != nil {
+		commonPatternEnrichmentWorker := cookiebanner.NewCommonPatternEnrichmentWorker(pgClient, l, trackerAgentsCfg)
+
+		var commonPatternEnrichmentWorkerCtx context.Context
+		commonPatternEnrichmentWorkerCtx, stopCommonPatternEnrichmentWorker = context.WithCancel(context.Background())
+
+		wg.Go(
+			func() {
+				if err := commonPatternEnrichmentWorker.Run(commonPatternEnrichmentWorkerCtx); err != nil {
+					cancel(fmt.Errorf("common pattern enrichment worker crashed: %w", err))
+				}
+			},
+		)
+	}
 
 	mailingListWorker := mailman.NewMailingListWorker(mailmanService, pgClient, l.Named("mailing-list-worker"))
 	mailingListWorkerCtx, stopMailingListWorker := context.WithCancel(context.Background())
@@ -805,6 +825,7 @@ func (impl *Implm) Run(
 	stopESignService()
 	stopTrackerPatternAnalysisWorker()
 	stopTrackerMappingWorker()
+	stopCommonPatternEnrichmentWorker()
 	stopMailingListWorker()
 	stopEvidenceDescriptionWorker()
 	stopDocumentPDFWorker()

--- a/pkg/probod/tracker_agents.go
+++ b/pkg/probod/tracker_agents.go
@@ -24,25 +24,26 @@ import (
 	"go.probo.inc/probo/pkg/thirdparty"
 )
 
-// buildTrackerMappingConfig wires the tracker-mapping agent (catalog
-// identification) and the third-party disambiguation agent that the
-// tracker-mapping worker uses to promote patterns to org ThirdParties.
-// Both are opt-in: deployments that do not set
-// `llm.tracker-mapping.provider` get zero configs (nil LLM client) so
-// the worker runs without agent fallback.
+// buildTrackerAgentsConfig wires the tracker agents that share one LLM
+// client and model: the tracker-mapping agent (catalog identification),
+// the common-pattern enrichment agent (description research), and the
+// third-party disambiguation agent that the tracker-mapping worker uses
+// to promote patterns to org ThirdParties. All are opt-in: deployments
+// that do not set `llm.tracker-mapping.provider` get zero configs (nil
+// LLM client) so the workers run without agent fallback.
 //
-// Both agents are sourced from the same `tracker-mapping` config slot
+// The agents are sourced from the same `tracker-mapping` config slot
 // because they share the LLM client, model, and lifecycle. The
 // disambiguation agent has no Firecrawl/DB tools, so its config
 // surface is narrower and it lives in the cross-domain pkg/thirdparty
 // package.
-func (impl *Implm) buildTrackerMappingConfig(
+func (impl *Implm) buildTrackerAgentsConfig(
 	l *log.Logger,
 	tp trace.TracerProvider,
 	r prometheus.Registerer,
-) (cookiebanner.TrackerMappingConfig, thirdparty.DisambiguationConfig, error) {
+) (cookiebanner.TrackerAgentsConfig, thirdparty.DisambiguationConfig, error) {
 	if impl.cfg.Agents.TrackerMapping.Provider == "" {
-		return cookiebanner.TrackerMappingConfig{}, thirdparty.DisambiguationConfig{}, nil
+		return cookiebanner.TrackerAgentsConfig{}, thirdparty.DisambiguationConfig{}, nil
 	}
 
 	agentCfg, llmClient, err := impl.resolveAgentClient(
@@ -53,10 +54,10 @@ func (impl *Implm) buildTrackerMappingConfig(
 		r,
 	)
 	if err != nil {
-		return cookiebanner.TrackerMappingConfig{}, thirdparty.DisambiguationConfig{}, fmt.Errorf("cannot resolve tracker mapping agent client: %w", err)
+		return cookiebanner.TrackerAgentsConfig{}, thirdparty.DisambiguationConfig{}, fmt.Errorf("cannot resolve tracker mapping agent client: %w", err)
 	}
 
-	mappingCfg := cookiebanner.TrackerMappingConfig{
+	trackerAgentsCfg := cookiebanner.TrackerAgentsConfig{
 		LLMClient:       llmClient,
 		Model:           agentCfg.ModelName,
 		FirecrawlAPIKey: impl.cfg.Agents.Tools.FirecrawlAPIKey,
@@ -67,5 +68,5 @@ func (impl *Implm) buildTrackerMappingConfig(
 		Model:     agentCfg.ModelName,
 	}
 
-	return mappingCfg, disambiguationCfg, nil
+	return trackerAgentsCfg, disambiguationCfg, nil
 }

--- a/pkg/probod/tracker_mapping.go
+++ b/pkg/probod/tracker_mapping.go
@@ -21,18 +21,28 @@ import (
 	"go.gearno.de/kit/log"
 	"go.opentelemetry.io/otel/trace"
 	"go.probo.inc/probo/pkg/cookiebanner"
+	"go.probo.inc/probo/pkg/thirdparty"
 )
 
-// buildTrackerMappingConfig wires the tracker-mapping agent. It is opt-in:
-// deployments that do not set `llm.tracker-mapping.provider` get a zero
-// config (nil LLM client) so the worker runs without agent fallback.
+// buildTrackerMappingConfig wires the tracker-mapping agent (catalog
+// identification) and the third-party disambiguation agent that the
+// tracker-mapping worker uses to promote patterns to org ThirdParties.
+// Both are opt-in: deployments that do not set
+// `llm.tracker-mapping.provider` get zero configs (nil LLM client) so
+// the worker runs without agent fallback.
+//
+// Both agents are sourced from the same `tracker-mapping` config slot
+// because they share the LLM client, model, and lifecycle. The
+// disambiguation agent has no Firecrawl/DB tools, so its config
+// surface is narrower and it lives in the cross-domain pkg/thirdparty
+// package.
 func (impl *Implm) buildTrackerMappingConfig(
 	l *log.Logger,
 	tp trace.TracerProvider,
 	r prometheus.Registerer,
-) (cookiebanner.TrackerMappingConfig, error) {
+) (cookiebanner.TrackerMappingConfig, thirdparty.DisambiguationConfig, error) {
 	if impl.cfg.Agents.TrackerMapping.Provider == "" {
-		return cookiebanner.TrackerMappingConfig{}, nil
+		return cookiebanner.TrackerMappingConfig{}, thirdparty.DisambiguationConfig{}, nil
 	}
 
 	agentCfg, llmClient, err := impl.resolveAgentClient(
@@ -43,12 +53,19 @@ func (impl *Implm) buildTrackerMappingConfig(
 		r,
 	)
 	if err != nil {
-		return cookiebanner.TrackerMappingConfig{}, fmt.Errorf("cannot resolve tracker mapping agent client: %w", err)
+		return cookiebanner.TrackerMappingConfig{}, thirdparty.DisambiguationConfig{}, fmt.Errorf("cannot resolve tracker mapping agent client: %w", err)
 	}
 
-	return cookiebanner.TrackerMappingConfig{
+	mappingCfg := cookiebanner.TrackerMappingConfig{
 		LLMClient:       llmClient,
 		Model:           agentCfg.ModelName,
 		FirecrawlAPIKey: impl.cfg.Agents.Tools.FirecrawlAPIKey,
-	}, nil
+	}
+
+	disambiguationCfg := thirdparty.DisambiguationConfig{
+		LLMClient: llmClient,
+		Model:     agentCfg.ModelName,
+	}
+
+	return mappingCfg, disambiguationCfg, nil
 }

--- a/pkg/server/api/console/v1/cookie_banner_resolvers.go
+++ b/pkg/server/api/console/v1/cookie_banner_resolvers.go
@@ -16,6 +16,7 @@ import (
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/page"
 	"go.probo.inc/probo/pkg/probo"
+	"go.probo.inc/probo/pkg/server/api/authn"
 	"go.probo.inc/probo/pkg/server/api/console/v1/dataloader"
 	"go.probo.inc/probo/pkg/server/api/console/v1/schema"
 	"go.probo.inc/probo/pkg/server/api/console/v1/types"
@@ -1271,6 +1272,78 @@ func (r *trackerPatternResolver) DetectedCount(ctx context.Context, obj *types.T
 	}
 
 	return count, nil
+}
+
+// ThirdParty is the resolver for the thirdParty field.
+func (r *trackerPatternResolver) ThirdParty(ctx context.Context, obj *types.TrackerPattern) (*types.ThirdParty, error) {
+	if obj.ThirdPartyID == nil {
+		return nil, nil
+	}
+
+	if _, err := r.authorize(ctx, *obj.ThirdPartyID, probo.ActionThirdPartyGet); err != nil {
+		return nil, err
+	}
+
+	loaders := dataloader.FromContext(ctx)
+
+	tp, err := loaders.ThirdParty.Load(ctx, *obj.ThirdPartyID)
+	if err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) || errors.Is(err, dataloadgen.ErrNotFound) {
+			return nil, nil
+		}
+
+		r.logger.ErrorCtx(ctx, "cannot get tracker pattern third party", log.Error(err))
+
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	return types.NewThirdParty(tp), nil
+}
+
+// CommonThirdParty is the resolver for the commonThirdParty field.
+//
+// The org-scoped thirdParty takes priority: when ThirdPartyID is set we
+// short-circuit to nil so the chained common-tracker-pattern lookup is
+// never paid for.
+func (r *trackerPatternResolver) CommonThirdParty(ctx context.Context, obj *types.TrackerPattern) (*types.CommonThirdParty, error) {
+	if obj.ThirdPartyID != nil || obj.CommonTrackerPatternID == nil {
+		return nil, nil
+	}
+
+	identity := authn.IdentityFromContext(ctx)
+	if _, err := r.authorize(ctx, identity.ID, probo.ActionCommonThirdPartyGet); err != nil {
+		return nil, err
+	}
+
+	loaders := dataloader.FromContext(ctx)
+
+	pattern, err := loaders.CommonTrackerPattern.Load(ctx, *obj.CommonTrackerPatternID)
+	if err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) || errors.Is(err, dataloadgen.ErrNotFound) {
+			return nil, nil
+		}
+
+		r.logger.ErrorCtx(ctx, "cannot get common tracker pattern", log.Error(err))
+
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	if pattern.CommonThirdPartyID == nil {
+		return nil, nil
+	}
+
+	party, err := loaders.CommonThirdParty.Load(ctx, *pattern.CommonThirdPartyID)
+	if err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) || errors.Is(err, dataloadgen.ErrNotFound) {
+			return nil, nil
+		}
+
+		r.logger.ErrorCtx(ctx, "cannot get common third party", log.Error(err))
+
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	return types.NewCommonThirdParty(party), nil
 }
 
 // DetectedTrackers is the resolver for the detectedTrackers field.

--- a/pkg/server/api/console/v1/cookie_banner_resolvers.go
+++ b/pkg/server/api/console/v1/cookie_banner_resolvers.go
@@ -14,6 +14,7 @@ import (
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/cookiebanner"
 	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/page"
 	"go.probo.inc/probo/pkg/probo"
 	"go.probo.inc/probo/pkg/server/api/authn"
@@ -210,6 +211,25 @@ func (r *cookieBannerResolver) TrackerPatterns(ctx context.Context, obj *types.C
 	if filter != nil {
 		coredataFilter = coredata.NewTrackerPatternFilter(nil, filter.CookieCategoryID, nil)
 		coredataFilter = coredataFilter.WithQuery(filter.Query).WithSource(filter.Source).WithTrackerType(filter.TrackerType)
+
+		if filter.ThirdPartyID != nil {
+			switch filter.ThirdPartyID.EntityType() {
+			case coredata.ThirdPartyEntityType:
+				coredataFilter = coredataFilter.WithThirdPartyID(filter.ThirdPartyID)
+			case coredata.CommonThirdPartyEntityType:
+				ids, err := r.cookieBanner.LoadCommonTrackerPatternIDsByCommonThirdPartyID(ctx, *filter.ThirdPartyID)
+				if err != nil {
+					r.logger.ErrorCtx(ctx, "cannot resolve common third party tracker patterns", log.Error(err))
+					return nil, gqlutils.Internal(ctx)
+				}
+				if ids == nil {
+					ids = []gid.GID{}
+				}
+				coredataFilter = coredataFilter.WithCommonTrackerPatternIDs(ids)
+			default:
+				return nil, gqlutils.Invalidf(ctx, "thirdPartyId must reference a ThirdParty or CommonThirdParty")
+			}
+		}
 	}
 
 	patterns, err := r.cookieBanner.ListTrackerPatternsForBanner(ctx, scope, obj.ID, cursor, coredataFilter)
@@ -221,6 +241,101 @@ func (r *cookieBannerResolver) TrackerPatterns(ctx context.Context, obj *types.C
 	p := page.NewPage(patterns, cursor)
 
 	return types.NewTrackerPatternConnectionWithFilter(p, r, obj.ID, filter), nil
+}
+
+// LinkedThirdParties is the resolver for the linkedThirdParties field.
+//
+// Aggregates the deduped union of third parties linked to the banner's
+// tracker patterns: the org-scoped ThirdParty values reached through
+// the direct foreign key, plus the global CommonThirdParty values
+// reached indirectly through CommonTrackerPattern. The two sources are
+// independent, so a tracker pattern that has both ThirdPartyID and
+// CommonTrackerPatternID contributes the org-scoped link only — the
+// commonThirdParty resolver follows the same priority and we want the
+// banner-level filter to mirror it.
+func (r *cookieBannerResolver) LinkedThirdParties(ctx context.Context, obj *types.CookieBanner) ([]types.TrackerPatternThirdPartyLink, error) {
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionTrackerPatternList); err != nil {
+		return nil, err
+	}
+
+	scope := coredata.NewScopeFromObjectID(obj.ID)
+
+	thirdPartyIDs, err := r.cookieBanner.LoadDistinctThirdPartyIDsByCookieBannerID(ctx, scope, obj.ID)
+	if err != nil {
+		r.logger.ErrorCtx(ctx, "cannot list banner third party links", log.Error(err))
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	commonPatternIDs, err := r.cookieBanner.LoadDistinctCommonTrackerPatternIDsByCookieBannerID(ctx, scope, obj.ID)
+	if err != nil {
+		r.logger.ErrorCtx(ctx, "cannot list banner common tracker pattern links", log.Error(err))
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	out := make([]types.TrackerPatternThirdPartyLink, 0, len(thirdPartyIDs)+len(commonPatternIDs))
+	loaders := dataloader.FromContext(ctx)
+
+	if len(thirdPartyIDs) > 0 {
+		if _, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyGet); err != nil {
+			return nil, err
+		}
+
+		tps, loadErr := loaders.ThirdParty.LoadAll(ctx, thirdPartyIDs)
+		var loadErrs dataloadgen.ErrorSlice
+		if loadErr != nil && !errors.As(loadErr, &loadErrs) {
+			r.logger.ErrorCtx(ctx, "cannot get third parties", log.Error(loadErr))
+			return nil, gqlutils.Internal(ctx)
+		}
+		for i, tp := range tps {
+			if loadErrs != nil && loadErrs[i] != nil {
+				if errors.Is(loadErrs[i], coredata.ErrResourceNotFound) || errors.Is(loadErrs[i], dataloadgen.ErrNotFound) {
+					continue
+				}
+				r.logger.ErrorCtx(ctx, "cannot get third party", log.Error(loadErrs[i]))
+				return nil, gqlutils.Internal(ctx)
+			}
+			out = append(out, types.NewThirdParty(tp))
+		}
+	}
+
+	if len(commonPatternIDs) > 0 {
+		identity := authn.IdentityFromContext(ctx)
+		if _, err := r.authorize(ctx, identity.ID, probo.ActionCommonThirdPartyGet); err != nil {
+			return nil, err
+		}
+
+		patterns, err := r.cookieBanner.GetCommonTrackerPatternsByIDs(ctx, commonPatternIDs...)
+		if err != nil {
+			r.logger.ErrorCtx(ctx, "cannot get common tracker patterns", log.Error(err))
+			return nil, gqlutils.Internal(ctx)
+		}
+
+		seen := make(map[gid.GID]struct{}, len(patterns))
+		commonThirdPartyIDs := make([]gid.GID, 0, len(patterns))
+		for _, p := range patterns {
+			if p.CommonThirdPartyID == nil {
+				continue
+			}
+			if _, ok := seen[*p.CommonThirdPartyID]; ok {
+				continue
+			}
+			seen[*p.CommonThirdPartyID] = struct{}{}
+			commonThirdPartyIDs = append(commonThirdPartyIDs, *p.CommonThirdPartyID)
+		}
+
+		if len(commonThirdPartyIDs) > 0 {
+			parties, err := r.thirdParty.GetCommonThirdPartiesByIDs(ctx, commonThirdPartyIDs...)
+			if err != nil {
+				r.logger.ErrorCtx(ctx, "cannot get common third parties", log.Error(err))
+				return nil, gqlutils.Internal(ctx)
+			}
+			for _, p := range parties {
+				out = append(out, types.NewCommonThirdParty(p))
+			}
+		}
+	}
+
+	return out, nil
 }
 
 // UncategorisedTrackerResources is the resolver for the uncategorisedTrackerResources field.

--- a/pkg/server/api/console/v1/cookie_banner_resolvers.go
+++ b/pkg/server/api/console/v1/cookie_banner_resolvers.go
@@ -49,7 +49,8 @@ func (r *cookieBannerResolver) Organization(ctx context.Context, obj *types.Cook
 
 // Categories is the resolver for the categories field.
 func (r *cookieBannerResolver) Categories(ctx context.Context, obj *types.CookieBanner, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.CookieCategoryOrderBy, filter *types.CookieCategoryFilter) (*types.CookieCategoryConnection, error) {
-	if _, err := r.authorize(ctx, obj.ID, probo.ActionCookieCategoryList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionCookieCategoryList)
+	if err != nil {
 		return nil, err
 	}
 
@@ -65,7 +66,6 @@ func (r *cookieBannerResolver) Categories(ctx context.Context, obj *types.Cookie
 	}
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	var excludeKind *coredata.CookieCategoryKind
 	if filter != nil {
@@ -189,7 +189,8 @@ func (r *cookieBannerResolver) ConsentRecords(ctx context.Context, obj *types.Co
 
 // TrackerPatterns is the resolver for the trackerPatterns field.
 func (r *cookieBannerResolver) TrackerPatterns(ctx context.Context, obj *types.CookieBanner, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TrackerPatternOrderBy, filter *types.TrackerPatternFilter) (*types.TrackerPatternConnection, error) {
-	if _, err := r.authorize(ctx, obj.ID, probo.ActionTrackerPatternList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionTrackerPatternList)
+	if err != nil {
 		return nil, err
 	}
 
@@ -205,7 +206,6 @@ func (r *cookieBannerResolver) TrackerPatterns(ctx context.Context, obj *types.C
 	}
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	coredataFilter := coredata.NewTrackerPatternFilter(nil, nil, nil)
 	if filter != nil {
@@ -254,11 +254,10 @@ func (r *cookieBannerResolver) TrackerPatterns(ctx context.Context, obj *types.C
 // commonThirdParty resolver follows the same priority and we want the
 // banner-level filter to mirror it.
 func (r *cookieBannerResolver) LinkedThirdParties(ctx context.Context, obj *types.CookieBanner) ([]types.TrackerPatternThirdPartyLink, error) {
-	if _, err := r.authorize(ctx, obj.ID, probo.ActionTrackerPatternList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyList)
+	if err != nil {
 		return nil, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	thirdPartyIDs, err := r.cookieBanner.LoadDistinctThirdPartyIDsByCookieBannerID(ctx, scope, obj.ID)
 	if err != nil {
@@ -276,10 +275,6 @@ func (r *cookieBannerResolver) LinkedThirdParties(ctx context.Context, obj *type
 	loaders := dataloader.FromContext(ctx)
 
 	if len(thirdPartyIDs) > 0 {
-		if _, err := r.authorize(ctx, obj.ID, probo.ActionThirdPartyGet); err != nil {
-			return nil, err
-		}
-
 		tps, loadErr := loaders.ThirdParty.LoadAll(ctx, thirdPartyIDs)
 		var loadErrs dataloadgen.ErrorSlice
 		if loadErr != nil && !errors.As(loadErr, &loadErrs) {
@@ -300,7 +295,7 @@ func (r *cookieBannerResolver) LinkedThirdParties(ctx context.Context, obj *type
 
 	if len(commonPatternIDs) > 0 {
 		identity := authn.IdentityFromContext(ctx)
-		if _, err := r.authorize(ctx, identity.ID, probo.ActionCommonThirdPartyGet); err != nil {
+		if _, err := r.authorize(ctx, identity.ID, probo.ActionCommonThirdPartyList); err != nil {
 			return nil, err
 		}
 
@@ -340,7 +335,8 @@ func (r *cookieBannerResolver) LinkedThirdParties(ctx context.Context, obj *type
 
 // UncategorisedTrackerResources is the resolver for the uncategorisedTrackerResources field.
 func (r *cookieBannerResolver) UncategorisedTrackerResources(ctx context.Context, obj *types.CookieBanner, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TrackerResourceOrderBy, filter *types.TrackerResourceFilter) (*types.TrackerResourceConnection, error) {
-	if _, err := r.authorize(ctx, obj.ID, probo.ActionTrackerResourceList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionTrackerResourceList)
+	if err != nil {
 		return nil, err
 	}
 
@@ -356,7 +352,6 @@ func (r *cookieBannerResolver) UncategorisedTrackerResources(ctx context.Context
 	}
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	coredataFilter := coredata.NewTrackerResourceFilter(nil, nil)
 	if filter != nil {
@@ -465,7 +460,8 @@ func (r *cookieCategoryResolver) CookieBanner(ctx context.Context, obj *types.Co
 
 // TrackerPatterns is the resolver for the trackerPatterns field.
 func (r *cookieCategoryResolver) TrackerPatterns(ctx context.Context, obj *types.CookieCategory, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TrackerPatternOrderBy) (*types.TrackerPatternConnection, error) {
-	if _, err := r.authorize(ctx, obj.ID, probo.ActionTrackerPatternList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionTrackerPatternList)
+	if err != nil {
 		return nil, err
 	}
 
@@ -481,7 +477,6 @@ func (r *cookieCategoryResolver) TrackerPatterns(ctx context.Context, obj *types
 	}
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	patterns, err := r.cookieBanner.ListTrackerPatternsForCategory(ctx, scope, obj.ID, cursor)
 	if err != nil {
@@ -496,7 +491,8 @@ func (r *cookieCategoryResolver) TrackerPatterns(ctx context.Context, obj *types
 
 // TrackerResources is the resolver for the trackerResources field.
 func (r *cookieCategoryResolver) TrackerResources(ctx context.Context, obj *types.CookieCategory, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.TrackerResourceOrderBy) (*types.TrackerResourceConnection, error) {
-	if _, err := r.authorize(ctx, obj.ID, probo.ActionTrackerResourceList); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionTrackerResourceList)
+	if err != nil {
 		return nil, err
 	}
 
@@ -512,7 +508,6 @@ func (r *cookieCategoryResolver) TrackerResources(ctx context.Context, obj *type
 	}
 
 	cursor := types.NewCursor(first, after, last, before, pageOrderBy)
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	resources, err := r.cookieBanner.ListTrackerResourcesForCategory(ctx, scope, obj.ID, cursor)
 	if err != nil {

--- a/pkg/server/api/console/v1/cookie_banner_resolvers.go
+++ b/pkg/server/api/console/v1/cookie_banner_resolvers.go
@@ -222,9 +222,11 @@ func (r *cookieBannerResolver) TrackerPatterns(ctx context.Context, obj *types.C
 					r.logger.ErrorCtx(ctx, "cannot resolve common third party tracker patterns", log.Error(err))
 					return nil, gqlutils.Internal(ctx)
 				}
+
 				if ids == nil {
 					ids = []gid.GID{}
 				}
+
 				coredataFilter = coredataFilter.WithCommonTrackerPatternIDs(ids)
 			default:
 				return nil, gqlutils.Invalidf(ctx, "thirdPartyId must reference a ThirdParty or CommonThirdParty")
@@ -276,19 +278,24 @@ func (r *cookieBannerResolver) LinkedThirdParties(ctx context.Context, obj *type
 
 	if len(thirdPartyIDs) > 0 {
 		tps, loadErr := loaders.ThirdParty.LoadAll(ctx, thirdPartyIDs)
+
 		var loadErrs dataloadgen.ErrorSlice
 		if loadErr != nil && !errors.As(loadErr, &loadErrs) {
 			r.logger.ErrorCtx(ctx, "cannot get third parties", log.Error(loadErr))
 			return nil, gqlutils.Internal(ctx)
 		}
+
 		for i, tp := range tps {
 			if loadErrs != nil && loadErrs[i] != nil {
 				if errors.Is(loadErrs[i], coredata.ErrResourceNotFound) || errors.Is(loadErrs[i], dataloadgen.ErrNotFound) {
 					continue
 				}
+
 				r.logger.ErrorCtx(ctx, "cannot get third party", log.Error(loadErrs[i]))
+
 				return nil, gqlutils.Internal(ctx)
 			}
+
 			out = append(out, types.NewThirdParty(tp))
 		}
 	}
@@ -306,14 +313,17 @@ func (r *cookieBannerResolver) LinkedThirdParties(ctx context.Context, obj *type
 		}
 
 		seen := make(map[gid.GID]struct{}, len(patterns))
+
 		commonThirdPartyIDs := make([]gid.GID, 0, len(patterns))
 		for _, p := range patterns {
 			if p.CommonThirdPartyID == nil {
 				continue
 			}
+
 			if _, ok := seen[*p.CommonThirdPartyID]; ok {
 				continue
 			}
+
 			seen[*p.CommonThirdPartyID] = struct{}{}
 			commonThirdPartyIDs = append(commonThirdPartyIDs, *p.CommonThirdPartyID)
 		}
@@ -324,6 +334,7 @@ func (r *cookieBannerResolver) LinkedThirdParties(ctx context.Context, obj *type
 				r.logger.ErrorCtx(ctx, "cannot get common third parties", log.Error(err))
 				return nil, gqlutils.Internal(ctx)
 			}
+
 			for _, p := range parties {
 				out = append(out, types.NewCommonThirdParty(p))
 			}

--- a/pkg/server/api/console/v1/cookie_banner_resolvers.go
+++ b/pkg/server/api/console/v1/cookie_banner_resolvers.go
@@ -217,17 +217,7 @@ func (r *cookieBannerResolver) TrackerPatterns(ctx context.Context, obj *types.C
 			case coredata.ThirdPartyEntityType:
 				coredataFilter = coredataFilter.WithThirdPartyID(filter.ThirdPartyID)
 			case coredata.CommonThirdPartyEntityType:
-				ids, err := r.cookieBanner.LoadCommonTrackerPatternIDsByCommonThirdPartyID(ctx, *filter.ThirdPartyID)
-				if err != nil {
-					r.logger.ErrorCtx(ctx, "cannot resolve common third party tracker patterns", log.Error(err))
-					return nil, gqlutils.Internal(ctx)
-				}
-
-				if ids == nil {
-					ids = []gid.GID{}
-				}
-
-				coredataFilter = coredataFilter.WithCommonTrackerPatternIDs(ids)
+				coredataFilter = coredataFilter.WithCommonThirdPartyID(filter.ThirdPartyID)
 			default:
 				return nil, gqlutils.Invalidf(ctx, "thirdPartyId must reference a ThirdParty or CommonThirdParty")
 			}

--- a/pkg/server/api/console/v1/dataloader/dataloader.go
+++ b/pkg/server/api/console/v1/dataloader/dataloader.go
@@ -29,6 +29,7 @@ import (
 	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/probo"
 	"go.probo.inc/probo/pkg/server/api/authn"
+	"go.probo.inc/probo/pkg/thirdparty"
 )
 
 type (
@@ -51,26 +52,29 @@ type (
 	}
 
 	Loaders struct {
-		Organization   *dataloadgen.Loader[gid.GID, *coredata.Organization]
-		Framework      *dataloadgen.Loader[gid.GID, *coredata.Framework]
-		Control        *dataloadgen.Loader[gid.GID, *coredata.Control]
-		ThirdParty     *dataloadgen.Loader[gid.GID, *coredata.ThirdParty]
-		Document       *dataloadgen.Loader[gid.GID, *coredata.Document]
-		Profile        *dataloadgen.Loader[gid.GID, *coredata.MembershipProfile]
-		Risk           *dataloadgen.Loader[gid.GID, *coredata.Risk]
-		Measure        *dataloadgen.Loader[gid.GID, *coredata.Measure]
-		Task           *dataloadgen.Loader[gid.GID, *coredata.Task]
-		File           *dataloadgen.Loader[gid.GID, *coredata.File]
-		Report         *dataloadgen.Loader[gid.GID, *coredata.Report]
-		CookieBanner   *dataloadgen.Loader[gid.GID, *coredata.CookieBanner]
-		CookieCategory *dataloadgen.Loader[gid.GID, *coredata.CookieCategory]
-		Authorize      *dataloadgen.Loader[AuthorizeKey, AuthorizeResult]
+		Organization         *dataloadgen.Loader[gid.GID, *coredata.Organization]
+		Framework            *dataloadgen.Loader[gid.GID, *coredata.Framework]
+		Control              *dataloadgen.Loader[gid.GID, *coredata.Control]
+		ThirdParty           *dataloadgen.Loader[gid.GID, *coredata.ThirdParty]
+		Document             *dataloadgen.Loader[gid.GID, *coredata.Document]
+		Profile              *dataloadgen.Loader[gid.GID, *coredata.MembershipProfile]
+		Risk                 *dataloadgen.Loader[gid.GID, *coredata.Risk]
+		Measure              *dataloadgen.Loader[gid.GID, *coredata.Measure]
+		Task                 *dataloadgen.Loader[gid.GID, *coredata.Task]
+		File                 *dataloadgen.Loader[gid.GID, *coredata.File]
+		Report               *dataloadgen.Loader[gid.GID, *coredata.Report]
+		CookieBanner         *dataloadgen.Loader[gid.GID, *coredata.CookieBanner]
+		CookieCategory       *dataloadgen.Loader[gid.GID, *coredata.CookieCategory]
+		CommonTrackerPattern *dataloadgen.Loader[gid.GID, *coredata.CommonTrackerPattern]
+		CommonThirdParty     *dataloadgen.Loader[gid.GID, *coredata.CommonThirdParty]
+		Authorize            *dataloadgen.Loader[AuthorizeKey, AuthorizeResult]
 	}
 
 	batchFetcher struct {
 		probo        *probo.Service
 		iam          *iam.Service
 		cookieBanner *cookiebanner.Service
+		thirdParty   *thirdparty.Service
 	}
 )
 
@@ -80,11 +84,16 @@ func FromContext(ctx context.Context) *Loaders {
 	return ctx.Value(loadersKey).(*Loaders)
 }
 
-func NewMiddleware(proboSvc *probo.Service, iamSvc *iam.Service, cookieBannerSvc *cookiebanner.Service) func(http.Handler) http.Handler {
+func NewMiddleware(proboSvc *probo.Service, iamSvc *iam.Service, cookieBannerSvc *cookiebanner.Service, thirdPartySvc *thirdparty.Service) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
-				f := &batchFetcher{probo: proboSvc, iam: iamSvc, cookieBanner: cookieBannerSvc}
+				f := &batchFetcher{
+					probo:        proboSvc,
+					iam:          iamSvc,
+					cookieBanner: cookieBannerSvc,
+					thirdParty:   thirdPartySvc,
+				}
 				loaders := f.newLoaders()
 				ctx := context.WithValue(r.Context(), loadersKey, loaders)
 				next.ServeHTTP(w, r.WithContext(ctx))
@@ -95,19 +104,21 @@ func NewMiddleware(proboSvc *probo.Service, iamSvc *iam.Service, cookieBannerSvc
 
 func (f *batchFetcher) newLoaders() *Loaders {
 	return &Loaders{
-		Organization:   dataloadgen.NewMappedLoader(f.fetchOrganizations),
-		Framework:      dataloadgen.NewMappedLoader(f.fetchFrameworks),
-		Control:        dataloadgen.NewMappedLoader(f.fetchControls),
-		ThirdParty:     dataloadgen.NewMappedLoader(f.fetchThirdParties),
-		Document:       dataloadgen.NewMappedLoader(f.fetchDocuments),
-		Profile:        dataloadgen.NewMappedLoader(f.fetchProfiles),
-		Risk:           dataloadgen.NewMappedLoader(f.fetchRisks),
-		Measure:        dataloadgen.NewMappedLoader(f.fetchMeasures),
-		Task:           dataloadgen.NewMappedLoader(f.fetchTasks),
-		File:           dataloadgen.NewMappedLoader(f.fetchFiles),
-		Report:         dataloadgen.NewMappedLoader(f.fetchReports),
-		CookieBanner:   dataloadgen.NewMappedLoader(f.fetchCookieBanners),
-		CookieCategory: dataloadgen.NewMappedLoader(f.fetchCookieCategories),
+		Organization:         dataloadgen.NewMappedLoader(f.fetchOrganizations),
+		Framework:            dataloadgen.NewMappedLoader(f.fetchFrameworks),
+		Control:              dataloadgen.NewMappedLoader(f.fetchControls),
+		ThirdParty:           dataloadgen.NewMappedLoader(f.fetchThirdParties),
+		Document:             dataloadgen.NewMappedLoader(f.fetchDocuments),
+		Profile:              dataloadgen.NewMappedLoader(f.fetchProfiles),
+		Risk:                 dataloadgen.NewMappedLoader(f.fetchRisks),
+		Measure:              dataloadgen.NewMappedLoader(f.fetchMeasures),
+		Task:                 dataloadgen.NewMappedLoader(f.fetchTasks),
+		File:                 dataloadgen.NewMappedLoader(f.fetchFiles),
+		Report:               dataloadgen.NewMappedLoader(f.fetchReports),
+		CookieBanner:         dataloadgen.NewMappedLoader(f.fetchCookieBanners),
+		CookieCategory:       dataloadgen.NewMappedLoader(f.fetchCookieCategories),
+		CommonTrackerPattern: dataloadgen.NewMappedLoader(f.fetchCommonTrackerPatterns),
+		CommonThirdParty:     dataloadgen.NewMappedLoader(f.fetchCommonThirdParties),
 		Authorize: dataloadgen.NewMappedLoader(
 			f.fetchAuthorizes,
 			dataloadgen.WithoutCache(),
@@ -317,6 +328,34 @@ func (f *batchFetcher) fetchCookieCategories(ctx context.Context, keys []gid.GID
 
 	result := make(map[gid.GID]*coredata.CookieCategory, len(categories))
 	for _, v := range categories {
+		result[v.ID] = v
+	}
+
+	return result, nil
+}
+
+func (f *batchFetcher) fetchCommonTrackerPatterns(ctx context.Context, keys []gid.GID) (map[gid.GID]*coredata.CommonTrackerPattern, error) {
+	patterns, err := f.cookieBanner.GetCommonTrackerPatternsByIDs(ctx, keys...)
+	if err != nil {
+		return nil, fmt.Errorf("cannot batch load common tracker patterns: %w", err)
+	}
+
+	result := make(map[gid.GID]*coredata.CommonTrackerPattern, len(patterns))
+	for _, v := range patterns {
+		result[v.ID] = v
+	}
+
+	return result, nil
+}
+
+func (f *batchFetcher) fetchCommonThirdParties(ctx context.Context, keys []gid.GID) (map[gid.GID]*coredata.CommonThirdParty, error) {
+	parties, err := f.thirdParty.GetCommonThirdPartiesByIDs(ctx, keys...)
+	if err != nil {
+		return nil, fmt.Errorf("cannot batch load common third parties: %w", err)
+	}
+
+	result := make(map[gid.GID]*coredata.CommonThirdParty, len(parties))
+	for _, v := range parties {
 		result[v.ID] = v
 	}
 

--- a/pkg/server/api/console/v1/document_resolvers.go
+++ b/pkg/server/api/console/v1/document_resolvers.go
@@ -683,13 +683,12 @@ func (r *employeeDocumentResolver) Signed(ctx context.Context, obj *types.Employ
 
 // ApprovalState is the resolver for the approvalState field.
 func (r *employeeDocumentResolver) ApprovalState(ctx context.Context, obj *types.EmployeeDocument) (*coredata.DocumentVersionApprovalDecisionState, error) {
-	if _, err := r.authorize(ctx, obj.ID, probo.ActionEmployeeDocumentGet); err != nil {
+	scope, err := r.authorize(ctx, obj.ID, probo.ActionEmployeeDocumentGet)
+	if err != nil {
 		return nil, err
 	}
 
 	identity := authn.IdentityFromContext(ctx)
-
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	state, err := r.probo.Documents.GetViewerApprovalState(ctx, scope, obj.ID, identity.ID)
 	if err != nil {
@@ -791,12 +790,12 @@ func (r *employeeDocumentVersionResolver) Signed(ctx context.Context, obj *types
 
 // ApprovalDecision is the resolver for the approvalDecision field.
 func (r *employeeDocumentVersionResolver) ApprovalDecision(ctx context.Context, obj *types.EmployeeDocumentVersion) (*types.DocumentVersionApprovalDecision, error) {
-	if _, err := r.authorize(ctx, obj.DocumentID, probo.ActionEmployeeDocumentGet); err != nil {
+	scope, err := r.authorize(ctx, obj.DocumentID, probo.ActionEmployeeDocumentGet)
+	if err != nil {
 		return nil, err
 	}
 
 	identity := authn.IdentityFromContext(ctx)
-	scope := coredata.NewScopeFromObjectID(obj.ID)
 
 	decision, err := r.probo.DocumentApprovals.GetViewerDecision(ctx, scope, obj.ID, identity.ID)
 	if err != nil {

--- a/pkg/server/api/console/v1/graphql/cookie_banner.graphql
+++ b/pkg/server/api/console/v1/graphql/cookie_banner.graphql
@@ -32,6 +32,10 @@ enum CookieSource
         @goEnum(
             value: "go.probo.inc/probo/pkg/coredata.CookieSourcePreExisting"
         )
+    HTTP
+        @goEnum(
+            value: "go.probo.inc/probo/pkg/coredata.CookieSourceHTTP"
+        )
     EXTENSION
         @goEnum(
             value: "go.probo.inc/probo/pkg/coredata.CookieSourceExtension"

--- a/pkg/server/api/console/v1/graphql/cookie_banner.graphql
+++ b/pkg/server/api/console/v1/graphql/cookie_banner.graphql
@@ -167,6 +167,15 @@ type CookieBanner implements Node {
         filter: TrackerPatternFilter
     ): TrackerPatternConnection @goField(forceResolver: true)
 
+    """
+    The deduped union of third parties referenced by the banner's
+    tracker patterns, both org-scoped (ThirdParty) and global
+    (CommonThirdParty). Powers the third-party filter combobox on the
+    trackers list page.
+    """
+    linkedThirdParties: [TrackerPatternThirdPartyLink!]!
+        @goField(forceResolver: true)
+
     uncategorisedTrackerResources(
         first: Int
         after: CursorKey
@@ -318,6 +327,14 @@ type TrackerPatternConnection
     pageInfo: PageInfo!
 }
 
+"""
+A third party associated with a banner's tracker patterns. Either the
+tenant-managed ThirdParty (when a pattern was promoted to the org
+catalog) or the global CommonThirdParty linked through a common
+tracker pattern.
+"""
+union TrackerPatternThirdPartyLink = ThirdParty | CommonThirdParty
+
 type TrackerPatternEdge {
     cursor: CursorKey!
     node: TrackerPattern!
@@ -339,6 +356,14 @@ input TrackerPatternFilter
     source: CookieSource
     trackerType: TrackerType
     cookieCategoryId: ID
+    """
+    Filter to tracker patterns linked to a single third party. Accepts
+    either an org-scoped ThirdParty GID (matched against third_party_id)
+    or a global CommonThirdParty GID (matched against the indirect link
+    through common_tracker_patterns). The dispatch happens at the
+    resolver based on the GID entity-type prefix.
+    """
+    thirdPartyId: ID
 }
 
 type DetectedTracker implements Node {

--- a/pkg/server/api/console/v1/graphql/cookie_banner.graphql
+++ b/pkg/server/api/console/v1/graphql/cookie_banner.graphql
@@ -263,7 +263,10 @@ enum TrackerPatternOrderField
         )
 }
 
-type TrackerPattern implements Node {
+type TrackerPattern implements Node
+    @goModel(
+        model: "go.probo.inc/probo/pkg/server/api/console/v1/types.TrackerPattern"
+    ) {
     id: ID!
     cookieCategory: CookieCategory @goField(forceResolver: true)
     trackerType: TrackerType!
@@ -278,6 +281,22 @@ type TrackerPattern implements Node {
     lastMatchedAt: Datetime
     createdAt: Datetime!
     updatedAt: Datetime!
+
+    """
+    The org-scoped third party this pattern is mapped to, if any. Set
+    when the mapping worker promoted the pattern to a tenant-managed
+    ThirdParty record. When this field is non-null, commonThirdParty is
+    always null.
+    """
+    thirdParty: ThirdParty @goField(forceResolver: true)
+
+    """
+    The global third party this pattern is mapped to via the common
+    tracker-pattern catalog. Null when the pattern has its own
+    org-scoped thirdParty, when it has not been mapped, or when the
+    matched common pattern has no common third party.
+    """
+    commonThirdParty: CommonThirdParty @goField(forceResolver: true)
 
     detectedTrackers(
         first: Int

--- a/pkg/server/api/console/v1/organization_resolvers.go
+++ b/pkg/server/api/console/v1/organization_resolvers.go
@@ -1394,7 +1394,8 @@ func (r *profileResolver) Permission(ctx context.Context, obj *types.Profile, ac
 
 // TotalCount is the resolver for the totalCount field.
 func (r *profileConnectionResolver) TotalCount(ctx context.Context, obj *types.ProfileConnection) (int, error) {
-	if _, err := r.authorize(ctx, obj.ParentID, iam.ActionMembershipProfileList); err != nil {
+	scope, err := r.authorize(ctx, obj.ParentID, iam.ActionMembershipProfileList)
+	if err != nil {
 		return 0, err
 	}
 
@@ -1408,8 +1409,6 @@ func (r *profileConnectionResolver) TotalCount(ctx context.Context, obj *types.P
 
 		return count, nil
 	case *documentVersionResolver:
-		scope := coredata.NewScopeFromObjectID(obj.ParentID)
-
 		count, err := r.probo.Documents.CountVersionApprovers(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count document version approvers", log.Error(err))

--- a/pkg/server/api/console/v1/resolver.go
+++ b/pkg/server/api/console/v1/resolver.go
@@ -107,7 +107,7 @@ func NewMux(
 		r.Use(authn.NewAPIKeyMiddleware(iamSvc, tokenSecret))
 		r.Use(authn.NewOAuth2AccessTokenMiddleware(iamSvc))
 		r.Use(authn.NewIdentityPresenceMiddleware())
-		r.Use(dataloader.NewMiddleware(proboSvc, iamSvc, cookieBannerSvc))
+		r.Use(dataloader.NewMiddleware(proboSvc, iamSvc, cookieBannerSvc, thirdPartySvc))
 
 		r.Handle("/graphql", graphqlHandler)
 

--- a/pkg/server/api/console/v1/risk_resolvers.go
+++ b/pkg/server/api/console/v1/risk_resolvers.go
@@ -500,8 +500,6 @@ func (r *riskConnectionResolver) TotalCount(ctx context.Context, obj *types.Risk
 
 		return count, nil
 	case *riskAssessmentScenarioResolver:
-		scope := coredata.NewScopeFromObjectID(obj.ParentID)
-
 		count, err := r.riskManagement.CountRisksForScenarioID(ctx, scope, obj.ParentID)
 		if err != nil {
 			r.logger.ErrorCtx(ctx, "cannot count scenario risks", log.Error(err))

--- a/pkg/server/api/console/v1/types/common_third_party.go
+++ b/pkg/server/api/console/v1/types/common_third_party.go
@@ -37,6 +37,8 @@ type CommonThirdParty struct {
 	LogoFileID                 *gid.GID                    `json:"logoFileId,omitempty"`
 }
 
+func (CommonThirdParty) IsTrackerPatternThirdPartyLink() {}
+
 func NewCommonThirdParty(c *coredata.CommonThirdParty) *CommonThirdParty {
 	return &CommonThirdParty{
 		ID:                         c.ID,

--- a/pkg/server/api/console/v1/types/tracker_pattern.go
+++ b/pkg/server/api/console/v1/types/tracker_pattern.go
@@ -15,6 +15,8 @@
 package types
 
 import (
+	"time"
+
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/page"
@@ -22,6 +24,39 @@ import (
 
 type (
 	TrackerPatternOrderBy OrderBy[coredata.TrackerPatternOrderField]
+
+	// TrackerPattern is the Go model bound to the GraphQL TrackerPattern
+	// type via @goModel. The first block contains the fields gqlgen
+	// fulfills directly from the model; resolver-only fields
+	// (cookieCategory, detectedTrackers, thirdParty, commonThirdParty,
+	// detectedCount, permission) are populated by the resolver.
+	//
+	// ThirdPartyID and CommonTrackerPatternID are not exposed in
+	// GraphQL — they are foreign-key handles the resolver uses to load
+	// the linked third party (org-scoped or via the common catalog)
+	// without re-querying coredata.
+	TrackerPattern struct {
+		ID            gid.GID                          `json:"id"`
+		TrackerType   coredata.TrackerType             `json:"trackerType"`
+		Pattern       string                           `json:"pattern"`
+		MatchType     coredata.TrackerPatternMatchType `json:"matchType"`
+		DisplayName   string                           `json:"displayName"`
+		MaxAgeSeconds *int                             `json:"maxAgeSeconds,omitempty"`
+		Description   string                           `json:"description"`
+		Source        *coredata.CookieSource           `json:"source,omitempty"`
+		Excluded      bool                             `json:"excluded"`
+		LastMatchedAt *time.Time                       `json:"lastMatchedAt,omitempty"`
+		CreatedAt     time.Time                        `json:"createdAt"`
+		UpdatedAt     time.Time                        `json:"updatedAt"`
+
+		CookieCategory   *CookieCategory            `json:"cookieCategory,omitempty"`
+		DetectedTrackers *DetectedTrackerConnection `json:"detectedTrackers,omitempty"`
+		DetectedCount    int                        `json:"detectedCount"`
+		Permission       bool                       `json:"permission"`
+
+		ThirdPartyID           *gid.GID `json:"-"`
+		CommonTrackerPatternID *gid.GID `json:"-"`
+	}
 
 	TrackerPatternConnection struct {
 		TotalCount int
@@ -40,6 +75,9 @@ type (
 		CookieCategoryID *gid.GID
 	}
 )
+
+func (TrackerPattern) IsNode()          {}
+func (t TrackerPattern) GetID() gid.GID { return t.ID }
 
 func NewTrackerPatternConnection(
 	p *page.Page[*coredata.TrackerPattern, coredata.TrackerPatternOrderField],
@@ -89,16 +127,18 @@ func NewTrackerPatternNode(tp *coredata.TrackerPattern) *TrackerPattern {
 				ID: tp.CookieBannerID,
 			},
 		},
-		TrackerType:   tp.TrackerType,
-		Pattern:       tp.Pattern,
-		MatchType:     tp.MatchType,
-		DisplayName:   tp.DisplayName,
-		MaxAgeSeconds: tp.MaxAgeSeconds,
-		Description:   tp.Description,
-		Source:        tp.Source,
-		Excluded:      tp.Excluded,
-		LastMatchedAt: tp.LastMatchedAt,
-		CreatedAt:     tp.CreatedAt,
-		UpdatedAt:     tp.UpdatedAt,
+		TrackerType:            tp.TrackerType,
+		Pattern:                tp.Pattern,
+		MatchType:              tp.MatchType,
+		DisplayName:            tp.DisplayName,
+		MaxAgeSeconds:          tp.MaxAgeSeconds,
+		Description:            tp.Description,
+		Source:                 tp.Source,
+		Excluded:               tp.Excluded,
+		LastMatchedAt:          tp.LastMatchedAt,
+		CreatedAt:              tp.CreatedAt,
+		UpdatedAt:              tp.UpdatedAt,
+		ThirdPartyID:           tp.ThirdPartyID,
+		CommonTrackerPatternID: tp.CommonTrackerPatternID,
 	}
 }

--- a/pkg/server/api/console/v1/types/tracker_pattern.go
+++ b/pkg/server/api/console/v1/types/tracker_pattern.go
@@ -73,6 +73,7 @@ type (
 		Source           *coredata.CookieSource
 		TrackerType      *coredata.TrackerType
 		CookieCategoryID *gid.GID
+		ThirdPartyID     *gid.GID
 	}
 )
 

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -1670,12 +1670,12 @@ func (r *Resolver) UpdateControlTool(ctx context.Context, req *mcp.CallToolReque
 }
 
 func (r *Resolver) LinkControlTool(ctx context.Context, req *mcp.CallToolRequest, input *types.LinkControlInput) (*mcp.CallToolResult, types.LinkControlOutput, error) {
-	scope := coredata.NewScopeFromObjectID(input.ControlID)
 	svc := r.proboSvc
 
 	switch input.ResourceID.EntityType() {
 	case coredata.MeasureEntityType:
-		if _, err := r.Authorize(ctx, input.ControlID, probo.ActionControlMeasureMappingCreate); err != nil {
+		scope, err := r.Authorize(ctx, input.ControlID, probo.ActionControlMeasureMappingCreate)
+		if err != nil {
 			return nil, types.LinkControlOutput{}, err
 		}
 
@@ -1683,7 +1683,8 @@ func (r *Resolver) LinkControlTool(ctx context.Context, req *mcp.CallToolRequest
 			return nil, types.LinkControlOutput{}, fmt.Errorf("failed to link control to measure: %w", err)
 		}
 	case coredata.DocumentEntityType:
-		if _, err := r.Authorize(ctx, input.ControlID, probo.ActionControlDocumentMappingCreate); err != nil {
+		scope, err := r.Authorize(ctx, input.ControlID, probo.ActionControlDocumentMappingCreate)
+		if err != nil {
 			return nil, types.LinkControlOutput{}, err
 		}
 
@@ -1691,7 +1692,8 @@ func (r *Resolver) LinkControlTool(ctx context.Context, req *mcp.CallToolRequest
 			return nil, types.LinkControlOutput{}, fmt.Errorf("failed to link control to document: %w", err)
 		}
 	case coredata.AuditEntityType:
-		if _, err := r.Authorize(ctx, input.ControlID, probo.ActionControlAuditMappingCreate); err != nil {
+		scope, err := r.Authorize(ctx, input.ControlID, probo.ActionControlAuditMappingCreate)
+		if err != nil {
 			return nil, types.LinkControlOutput{}, err
 		}
 
@@ -1699,7 +1701,8 @@ func (r *Resolver) LinkControlTool(ctx context.Context, req *mcp.CallToolRequest
 			return nil, types.LinkControlOutput{}, fmt.Errorf("failed to link control to audit: %w", err)
 		}
 	case coredata.ObligationEntityType:
-		if _, err := r.Authorize(ctx, input.ControlID, probo.ActionControlObligationMappingCreate); err != nil {
+		scope, err := r.Authorize(ctx, input.ControlID, probo.ActionControlObligationMappingCreate)
+		if err != nil {
 			return nil, types.LinkControlOutput{}, err
 		}
 
@@ -1714,12 +1717,12 @@ func (r *Resolver) LinkControlTool(ctx context.Context, req *mcp.CallToolRequest
 }
 
 func (r *Resolver) UnlinkControlTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UnlinkControlInput) (*mcp.CallToolResult, types.UnlinkControlOutput, error) {
-	scope := coredata.NewScopeFromObjectID(input.ControlID)
 	svc := r.proboSvc
 
 	switch input.ResourceID.EntityType() {
 	case coredata.MeasureEntityType:
-		if _, err := r.Authorize(ctx, input.ControlID, probo.ActionControlMeasureMappingDelete); err != nil {
+		scope, err := r.Authorize(ctx, input.ControlID, probo.ActionControlMeasureMappingDelete)
+		if err != nil {
 			return nil, types.UnlinkControlOutput{}, err
 		}
 
@@ -1727,7 +1730,8 @@ func (r *Resolver) UnlinkControlTool(ctx context.Context, req *mcp.CallToolReque
 			return nil, types.UnlinkControlOutput{}, fmt.Errorf("failed to unlink control from measure: %w", err)
 		}
 	case coredata.DocumentEntityType:
-		if _, err := r.Authorize(ctx, input.ControlID, probo.ActionControlDocumentMappingDelete); err != nil {
+		scope, err := r.Authorize(ctx, input.ControlID, probo.ActionControlDocumentMappingDelete)
+		if err != nil {
 			return nil, types.UnlinkControlOutput{}, err
 		}
 
@@ -1735,7 +1739,8 @@ func (r *Resolver) UnlinkControlTool(ctx context.Context, req *mcp.CallToolReque
 			return nil, types.UnlinkControlOutput{}, fmt.Errorf("failed to unlink control from document: %w", err)
 		}
 	case coredata.AuditEntityType:
-		if _, err := r.Authorize(ctx, input.ControlID, probo.ActionControlAuditMappingDelete); err != nil {
+		scope, err := r.Authorize(ctx, input.ControlID, probo.ActionControlAuditMappingDelete)
+		if err != nil {
 			return nil, types.UnlinkControlOutput{}, err
 		}
 
@@ -1743,7 +1748,8 @@ func (r *Resolver) UnlinkControlTool(ctx context.Context, req *mcp.CallToolReque
 			return nil, types.UnlinkControlOutput{}, fmt.Errorf("failed to unlink control from audit: %w", err)
 		}
 	case coredata.ObligationEntityType:
-		if _, err := r.Authorize(ctx, input.ControlID, probo.ActionControlObligationMappingDelete); err != nil {
+		scope, err := r.Authorize(ctx, input.ControlID, probo.ActionControlObligationMappingDelete)
+		if err != nil {
 			return nil, types.UnlinkControlOutput{}, err
 		}
 
@@ -1908,12 +1914,12 @@ func (r *Resolver) ListRiskObligationsTool(ctx context.Context, req *mcp.CallToo
 }
 
 func (r *Resolver) LinkRiskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.LinkRiskInput) (*mcp.CallToolResult, types.LinkRiskOutput, error) {
-	scope := coredata.NewScopeFromObjectID(input.RiskID)
 	svc := r.proboSvc
 
 	switch input.ResourceID.EntityType() {
 	case coredata.DocumentEntityType:
-		if _, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskDocumentMappingCreate); err != nil {
+		scope, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskDocumentMappingCreate)
+		if err != nil {
 			return nil, types.LinkRiskOutput{}, err
 		}
 
@@ -1921,7 +1927,8 @@ func (r *Resolver) LinkRiskTool(ctx context.Context, req *mcp.CallToolRequest, i
 			return nil, types.LinkRiskOutput{}, fmt.Errorf("failed to link risk to document: %w", err)
 		}
 	case coredata.MeasureEntityType:
-		if _, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskMeasureMappingCreate); err != nil {
+		scope, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskMeasureMappingCreate)
+		if err != nil {
 			return nil, types.LinkRiskOutput{}, err
 		}
 
@@ -1929,7 +1936,8 @@ func (r *Resolver) LinkRiskTool(ctx context.Context, req *mcp.CallToolRequest, i
 			return nil, types.LinkRiskOutput{}, fmt.Errorf("failed to link risk to measure: %w", err)
 		}
 	case coredata.ObligationEntityType:
-		if _, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskObligationMappingCreate); err != nil {
+		scope, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskObligationMappingCreate)
+		if err != nil {
 			return nil, types.LinkRiskOutput{}, err
 		}
 
@@ -1944,12 +1952,12 @@ func (r *Resolver) LinkRiskTool(ctx context.Context, req *mcp.CallToolRequest, i
 }
 
 func (r *Resolver) UnlinkRiskTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UnlinkRiskInput) (*mcp.CallToolResult, types.UnlinkRiskOutput, error) {
-	scope := coredata.NewScopeFromObjectID(input.RiskID)
 	svc := r.proboSvc
 
 	switch input.ResourceID.EntityType() {
 	case coredata.DocumentEntityType:
-		if _, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskDocumentMappingDelete); err != nil {
+		scope, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskDocumentMappingDelete)
+		if err != nil {
 			return nil, types.UnlinkRiskOutput{}, err
 		}
 
@@ -1957,7 +1965,8 @@ func (r *Resolver) UnlinkRiskTool(ctx context.Context, req *mcp.CallToolRequest,
 			return nil, types.UnlinkRiskOutput{}, fmt.Errorf("failed to unlink risk from document: %w", err)
 		}
 	case coredata.MeasureEntityType:
-		if _, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskMeasureMappingDelete); err != nil {
+		scope, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskMeasureMappingDelete)
+		if err != nil {
 			return nil, types.UnlinkRiskOutput{}, err
 		}
 
@@ -1965,7 +1974,8 @@ func (r *Resolver) UnlinkRiskTool(ctx context.Context, req *mcp.CallToolRequest,
 			return nil, types.UnlinkRiskOutput{}, fmt.Errorf("failed to unlink risk from measure: %w", err)
 		}
 	case coredata.ObligationEntityType:
-		if _, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskObligationMappingDelete); err != nil {
+		scope, err := r.Authorize(ctx, input.RiskID, probo.ActionRiskObligationMappingDelete)
+		if err != nil {
 			return nil, types.UnlinkRiskOutput{}, err
 		}
 
@@ -2305,7 +2315,8 @@ func (r *Resolver) UpdateDocumentTool(ctx context.Context, req *mcp.CallToolRequ
 }
 
 func (r *Resolver) ListDocumentVersionsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListDocumentVersionsInput) (*mcp.CallToolResult, types.ListDocumentVersionsOutput, error) {
-	if _, err := r.Authorize(ctx, input.DocumentID, probo.ActionDocumentVersionList); err != nil {
+	scope, err := r.Authorize(ctx, input.DocumentID, probo.ActionDocumentVersionList)
+	if err != nil {
 		return nil, types.ListDocumentVersionsOutput{}, err
 	}
 
@@ -2322,7 +2333,6 @@ func (r *Resolver) ListDocumentVersionsTool(ctx context.Context, req *mcp.CallTo
 	}
 
 	cursor := types.NewCursor(input.Size, input.Cursor, pageOrderBy)
-	scope := coredata.NewScopeFromObjectID(input.DocumentID)
 	svc := r.proboSvc
 
 	versionFilter := coredata.NewDocumentVersionFilter()
@@ -2636,12 +2646,12 @@ func (r *Resolver) ListMeasureEvidencesTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) LinkMeasureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.LinkMeasureInput) (*mcp.CallToolResult, types.LinkMeasureOutput, error) {
-	scope := coredata.NewScopeFromObjectID(input.MeasureID)
 	svc := r.proboSvc
 
 	switch input.ResourceID.EntityType() {
 	case coredata.ControlEntityType:
-		if _, err := r.Authorize(ctx, input.MeasureID, probo.ActionControlMeasureMappingCreate); err != nil {
+		scope, err := r.Authorize(ctx, input.MeasureID, probo.ActionControlMeasureMappingCreate)
+		if err != nil {
 			return nil, types.LinkMeasureOutput{}, err
 		}
 
@@ -2649,7 +2659,8 @@ func (r *Resolver) LinkMeasureTool(ctx context.Context, req *mcp.CallToolRequest
 			return nil, types.LinkMeasureOutput{}, fmt.Errorf("failed to link measure to control: %w", err)
 		}
 	case coredata.RiskEntityType:
-		if _, err := r.Authorize(ctx, input.MeasureID, probo.ActionRiskMeasureMappingCreate); err != nil {
+		scope, err := r.Authorize(ctx, input.MeasureID, probo.ActionRiskMeasureMappingCreate)
+		if err != nil {
 			return nil, types.LinkMeasureOutput{}, err
 		}
 
@@ -2657,7 +2668,8 @@ func (r *Resolver) LinkMeasureTool(ctx context.Context, req *mcp.CallToolRequest
 			return nil, types.LinkMeasureOutput{}, fmt.Errorf("failed to link measure to risk: %w", err)
 		}
 	case coredata.DocumentEntityType:
-		if _, err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureDocumentMappingCreate); err != nil {
+		scope, err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureDocumentMappingCreate)
+		if err != nil {
 			return nil, types.LinkMeasureOutput{}, err
 		}
 
@@ -2665,7 +2677,8 @@ func (r *Resolver) LinkMeasureTool(ctx context.Context, req *mcp.CallToolRequest
 			return nil, types.LinkMeasureOutput{}, fmt.Errorf("failed to link measure to document: %w", err)
 		}
 	case coredata.ThirdPartyEntityType:
-		if _, err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureThirdPartyMappingCreate); err != nil {
+		scope, err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureThirdPartyMappingCreate)
+		if err != nil {
 			return nil, types.LinkMeasureOutput{}, err
 		}
 
@@ -2680,12 +2693,12 @@ func (r *Resolver) LinkMeasureTool(ctx context.Context, req *mcp.CallToolRequest
 }
 
 func (r *Resolver) UnlinkMeasureTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UnlinkMeasureInput) (*mcp.CallToolResult, types.UnlinkMeasureOutput, error) {
-	scope := coredata.NewScopeFromObjectID(input.MeasureID)
 	svc := r.proboSvc
 
 	switch input.ResourceID.EntityType() {
 	case coredata.ControlEntityType:
-		if _, err := r.Authorize(ctx, input.MeasureID, probo.ActionControlMeasureMappingDelete); err != nil {
+		scope, err := r.Authorize(ctx, input.MeasureID, probo.ActionControlMeasureMappingDelete)
+		if err != nil {
 			return nil, types.UnlinkMeasureOutput{}, err
 		}
 
@@ -2693,7 +2706,8 @@ func (r *Resolver) UnlinkMeasureTool(ctx context.Context, req *mcp.CallToolReque
 			return nil, types.UnlinkMeasureOutput{}, fmt.Errorf("failed to unlink measure from control: %w", err)
 		}
 	case coredata.RiskEntityType:
-		if _, err := r.Authorize(ctx, input.MeasureID, probo.ActionRiskMeasureMappingDelete); err != nil {
+		scope, err := r.Authorize(ctx, input.MeasureID, probo.ActionRiskMeasureMappingDelete)
+		if err != nil {
 			return nil, types.UnlinkMeasureOutput{}, err
 		}
 
@@ -2701,7 +2715,8 @@ func (r *Resolver) UnlinkMeasureTool(ctx context.Context, req *mcp.CallToolReque
 			return nil, types.UnlinkMeasureOutput{}, fmt.Errorf("failed to unlink measure from risk: %w", err)
 		}
 	case coredata.DocumentEntityType:
-		if _, err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureDocumentMappingDelete); err != nil {
+		scope, err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureDocumentMappingDelete)
+		if err != nil {
 			return nil, types.UnlinkMeasureOutput{}, err
 		}
 
@@ -2709,7 +2724,8 @@ func (r *Resolver) UnlinkMeasureTool(ctx context.Context, req *mcp.CallToolReque
 			return nil, types.UnlinkMeasureOutput{}, fmt.Errorf("failed to unlink measure from document: %w", err)
 		}
 	case coredata.ThirdPartyEntityType:
-		if _, err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureThirdPartyMappingDelete); err != nil {
+		scope, err := r.Authorize(ctx, input.MeasureID, probo.ActionMeasureThirdPartyMappingDelete)
+		if err != nil {
 			return nil, types.UnlinkMeasureOutput{}, err
 		}
 
@@ -5418,11 +5434,11 @@ func (r *Resolver) PublishThirdPartyListTool(ctx context.Context, req *mcp.CallT
 }
 
 func (r *Resolver) ListCookieBannersTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListCookieBannersInput) (*mcp.CallToolResult, types.ListCookieBannersOutput, error) {
-	if _, err := r.Authorize(ctx, input.OrganizationID, probo.ActionCookieBannerList); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionCookieBannerList)
+	if err != nil {
 		return nil, types.ListCookieBannersOutput{}, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieBannerOrderField]{Field: coredata.CookieBannerOrderFieldCreatedAt, Direction: page.OrderDirectionDesc})
 
 	banners, err := r.cookieBanner.ListCookieBannersForOrganization(ctx, scope, input.OrganizationID, cursor, coredata.NewCookieBannerFilter(nil))
@@ -5436,11 +5452,10 @@ func (r *Resolver) ListCookieBannersTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) GetCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetCookieBannerInput) (*mcp.CallToolResult, types.GetCookieBannerOutput, error) {
-	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerGet)
+	if err != nil {
 		return nil, types.GetCookieBannerOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	banner, err := r.cookieBanner.GetCookieBanner(ctx, scope, input.ID)
 	if err != nil {
@@ -5451,11 +5466,10 @@ func (r *Resolver) GetCookieBannerTool(ctx context.Context, req *mcp.CallToolReq
 }
 
 func (r *Resolver) AddCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddCookieBannerInput) (*mcp.CallToolResult, types.AddCookieBannerOutput, error) {
-	if _, err := r.Authorize(ctx, input.OrganizationID, probo.ActionCookieBannerCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.OrganizationID, probo.ActionCookieBannerCreate)
+	if err != nil {
 		return nil, types.AddCookieBannerOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.OrganizationID)
 
 	banner, err := r.cookieBanner.CreateCookieBanner(ctx, scope, cookiebanner.CreateCookieBannerRequest{
 		OrganizationID:    input.OrganizationID,
@@ -5473,11 +5487,10 @@ func (r *Resolver) AddCookieBannerTool(ctx context.Context, req *mcp.CallToolReq
 }
 
 func (r *Resolver) UpdateCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateCookieBannerInput) (*mcp.CallToolResult, types.UpdateCookieBannerOutput, error) {
-	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerUpdate)
+	if err != nil {
 		return nil, types.UpdateCookieBannerOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	updateReq := cookiebanner.UpdateCookieBannerRequest{CookieBannerID: input.ID}
 	if v := UnwrapOmittable(input.Name); v != nil && *v != nil {
@@ -5522,11 +5535,10 @@ func (r *Resolver) DeleteCookieBannerTool(ctx context.Context, req *mcp.CallTool
 }
 
 func (r *Resolver) ActivateCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ActivateCookieBannerInput) (*mcp.CallToolResult, types.ActivateCookieBannerOutput, error) {
-	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerActivate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerActivate)
+	if err != nil {
 		return nil, types.ActivateCookieBannerOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	banner, err := r.cookieBanner.ActivateCookieBanner(ctx, scope, input.ID)
 	if err != nil {
@@ -5537,11 +5549,10 @@ func (r *Resolver) ActivateCookieBannerTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) DeactivateCookieBannerTool(ctx context.Context, req *mcp.CallToolRequest, input *types.DeactivateCookieBannerInput) (*mcp.CallToolResult, types.DeactivateCookieBannerOutput, error) {
-	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerDeactivate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionCookieBannerDeactivate)
+	if err != nil {
 		return nil, types.DeactivateCookieBannerOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	banner, err := r.cookieBanner.DeactivateCookieBanner(ctx, scope, input.ID)
 	if err != nil {
@@ -5552,11 +5563,10 @@ func (r *Resolver) DeactivateCookieBannerTool(ctx context.Context, req *mcp.Call
 }
 
 func (r *Resolver) ListCookieCategoriesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListCookieCategoriesInput) (*mcp.CallToolResult, types.ListCookieCategoriesOutput, error) {
-	if _, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieCategoryList); err != nil {
+	scope, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieCategoryList)
+	if err != nil {
 		return nil, types.ListCookieCategoriesOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieCategoryOrderField]{Field: coredata.CookieCategoryOrderFieldRank, Direction: page.OrderDirectionAsc})
 
 	categories, err := r.cookieBanner.ListCategoriesForBanner(ctx, scope, input.CookieBannerID, cursor, coredata.NewCookieCategoryFilter(new(coredata.CookieCategoryKindUncategorised)))
@@ -5570,11 +5580,10 @@ func (r *Resolver) ListCookieCategoriesTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) GetCookieCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetCookieCategoryInput) (*mcp.CallToolResult, types.GetCookieCategoryOutput, error) {
-	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieCategoryGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionCookieCategoryGet)
+	if err != nil {
 		return nil, types.GetCookieCategoryOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	category, err := r.cookieBanner.GetCookieCategory(ctx, scope, input.ID)
 	if err != nil {
@@ -5585,11 +5594,10 @@ func (r *Resolver) GetCookieCategoryTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) AddCookieCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddCookieCategoryInput) (*mcp.CallToolResult, types.AddCookieCategoryOutput, error) {
-	if _, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieCategoryCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieCategoryCreate)
+	if err != nil {
 		return nil, types.AddCookieCategoryOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 
 	category, err := r.cookieBanner.CreateCookieCategory(ctx, scope, cookiebanner.CreateCookieCategoryRequest{
 		CookieBannerID: input.CookieBannerID,
@@ -5606,11 +5614,10 @@ func (r *Resolver) AddCookieCategoryTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) UpdateCookieCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateCookieCategoryInput) (*mcp.CallToolResult, types.UpdateCookieCategoryOutput, error) {
-	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieCategoryUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionCookieCategoryUpdate)
+	if err != nil {
 		return nil, types.UpdateCookieCategoryOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	updateReq := cookiebanner.UpdateCookieCategoryRequest{CookieCategoryID: input.ID}
 	if v := UnwrapOmittable(input.Name); v != nil && *v != nil {
@@ -5647,13 +5654,12 @@ func (r *Resolver) DeleteCookieCategoryTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) ReorderCookieCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ReorderCookieCategoryInput) (*mcp.CallToolResult, types.ReorderCookieCategoryOutput, error) {
-	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieCategoryUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionCookieCategoryUpdate)
+	if err != nil {
 		return nil, types.ReorderCookieCategoryOutput{}, err
 	}
 
-	scope := coredata.NewScopeFromObjectID(input.ID)
-
-	_, err := r.cookieBanner.ReorderCookieCategory(ctx, scope, cookiebanner.ReorderCookieCategoryRequest{
+	_, err = r.cookieBanner.ReorderCookieCategory(ctx, scope, cookiebanner.ReorderCookieCategoryRequest{
 		CookieCategoryID: input.ID,
 		Rank:             input.Rank,
 	})
@@ -5670,11 +5676,10 @@ func (r *Resolver) ReorderCookieCategoryTool(ctx context.Context, req *mcp.CallT
 }
 
 func (r *Resolver) ListTrackerPatternsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListTrackerPatternsInput) (*mcp.CallToolResult, types.ListTrackerPatternsOutput, error) {
-	if _, err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerPatternList); err != nil {
+	scope, err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerPatternList)
+	if err != nil {
 		return nil, types.ListTrackerPatternsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.TrackerPatternOrderField]{Field: coredata.TrackerPatternOrderFieldCreatedAt, Direction: page.OrderDirectionAsc})
 
 	patterns, err := r.cookieBanner.ListTrackerPatternsForCategory(ctx, scope, input.CookieCategoryID, cursor)
@@ -5688,11 +5693,10 @@ func (r *Resolver) ListTrackerPatternsTool(ctx context.Context, req *mcp.CallToo
 }
 
 func (r *Resolver) GetTrackerPatternTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetTrackerPatternInput) (*mcp.CallToolResult, types.GetTrackerPatternOutput, error) {
-	if _, err := r.Authorize(ctx, input.ID, probo.ActionTrackerPatternGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionTrackerPatternGet)
+	if err != nil {
 		return nil, types.GetTrackerPatternOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	pattern, err := r.cookieBanner.GetTrackerPattern(ctx, scope, input.ID)
 	if err != nil {
@@ -5703,11 +5707,10 @@ func (r *Resolver) GetTrackerPatternTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) AddTrackerPatternTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddTrackerPatternInput) (*mcp.CallToolResult, types.AddTrackerPatternOutput, error) {
-	if _, err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerPatternCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerPatternCreate)
+	if err != nil {
 		return nil, types.AddTrackerPatternOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
 
 	pattern, err := r.cookieBanner.CreateTrackerPattern(ctx, scope, cookiebanner.CreateTrackerPatternRequest{
 		CookieCategoryID: input.CookieCategoryID,
@@ -5726,11 +5729,10 @@ func (r *Resolver) AddTrackerPatternTool(ctx context.Context, req *mcp.CallToolR
 }
 
 func (r *Resolver) UpdateTrackerPatternTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateTrackerPatternInput) (*mcp.CallToolResult, types.UpdateTrackerPatternOutput, error) {
-	if _, err := r.Authorize(ctx, input.ID, probo.ActionTrackerPatternUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionTrackerPatternUpdate)
+	if err != nil {
 		return nil, types.UpdateTrackerPatternOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	updateReq := cookiebanner.UpdateTrackerPatternRequest{TrackerPatternID: input.ID}
 	if input.MaxAgeSeconds.IsSet() {
@@ -5768,11 +5770,10 @@ func (r *Resolver) DeleteTrackerPatternTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) MoveTrackerPatternToCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.MoveTrackerPatternToCategoryInput) (*mcp.CallToolResult, types.MoveTrackerPatternToCategoryOutput, error) {
-	if _, err := r.Authorize(ctx, input.TrackerPatternID, probo.ActionTrackerPatternUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.TrackerPatternID, probo.ActionTrackerPatternUpdate)
+	if err != nil {
 		return nil, types.MoveTrackerPatternToCategoryOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.TrackerPatternID)
 
 	result, err := r.cookieBanner.MoveTrackerPatternToCategory(ctx, scope, cookiebanner.MoveTrackerPatternToCategoryRequest{
 		TrackerPatternID:       input.TrackerPatternID,
@@ -5786,11 +5787,10 @@ func (r *Resolver) MoveTrackerPatternToCategoryTool(ctx context.Context, req *mc
 }
 
 func (r *Resolver) PublishCookieBannerVersionTool(ctx context.Context, req *mcp.CallToolRequest, input *types.PublishCookieBannerVersionInput) (*mcp.CallToolResult, types.PublishCookieBannerVersionOutput, error) {
-	if _, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerVersionPublish); err != nil {
+	scope, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerVersionPublish)
+	if err != nil {
 		return nil, types.PublishCookieBannerVersionOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 
 	version, err := r.cookieBanner.PublishCookieBannerVersion(ctx, scope, input.CookieBannerID)
 	if err != nil {
@@ -5801,11 +5801,10 @@ func (r *Resolver) PublishCookieBannerVersionTool(ctx context.Context, req *mcp.
 }
 
 func (r *Resolver) ListCookieBannerVersionsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListCookieBannerVersionsInput) (*mcp.CallToolResult, types.ListCookieBannerVersionsOutput, error) {
-	if _, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerVersionList); err != nil {
+	scope, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerVersionList)
+	if err != nil {
 		return nil, types.ListCookieBannerVersionsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieBannerVersionOrderField]{Field: coredata.CookieBannerVersionOrderFieldCreatedAt, Direction: page.OrderDirectionDesc})
 
 	versions, err := r.cookieBanner.ListCookieBannerVersionsForBanner(ctx, scope, input.CookieBannerID, cursor)
@@ -5819,11 +5818,10 @@ func (r *Resolver) ListCookieBannerVersionsTool(ctx context.Context, req *mcp.Ca
 }
 
 func (r *Resolver) UpsertCookieBannerTranslationTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpsertCookieBannerTranslationInput) (*mcp.CallToolResult, types.UpsertCookieBannerTranslationOutput, error) {
-	if _, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieBannerUpdate)
+	if err != nil {
 		return nil, types.UpsertCookieBannerTranslationOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 
 	translation, err := r.cookieBanner.UpsertCookieBannerTranslation(ctx, scope, cookiebanner.UpsertCookieBannerTranslationRequest{
 		CookieBannerID: input.CookieBannerID,
@@ -5838,11 +5836,10 @@ func (r *Resolver) UpsertCookieBannerTranslationTool(ctx context.Context, req *m
 }
 
 func (r *Resolver) ListCookieConsentRecordsTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListCookieConsentRecordsInput) (*mcp.CallToolResult, types.ListCookieConsentRecordsOutput, error) {
-	if _, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieConsentRecordList); err != nil {
+	scope, err := r.Authorize(ctx, input.CookieBannerID, probo.ActionCookieConsentRecordList)
+	if err != nil {
 		return nil, types.ListCookieConsentRecordsOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieBannerID)
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieConsentRecordOrderField]{Field: coredata.CookieConsentRecordOrderFieldCreatedAt, Direction: page.OrderDirectionDesc})
 
 	var action *coredata.CookieConsentAction
@@ -5865,11 +5862,10 @@ func (r *Resolver) ListCookieConsentRecordsTool(ctx context.Context, req *mcp.Ca
 }
 
 func (r *Resolver) GetCookieConsentRecordTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetCookieConsentRecordInput) (*mcp.CallToolResult, types.GetCookieConsentRecordOutput, error) {
-	if _, err := r.Authorize(ctx, input.ID, probo.ActionCookieConsentRecordList); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionCookieConsentRecordList)
+	if err != nil {
 		return nil, types.GetCookieConsentRecordOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	record, err := r.cookieBanner.GetCookieConsentRecord(ctx, scope, input.ID)
 	if err != nil {
@@ -6064,11 +6060,10 @@ func (r *Resolver) PublishDocumentTool(ctx context.Context, req *mcp.CallToolReq
 }
 
 func (r *Resolver) ListTrackerResourcesTool(ctx context.Context, req *mcp.CallToolRequest, input *types.ListTrackerResourcesInput) (*mcp.CallToolResult, types.ListTrackerResourcesOutput, error) {
-	if _, err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerResourceList); err != nil {
+	scope, err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerResourceList)
+	if err != nil {
 		return nil, types.ListTrackerResourcesOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.TrackerResourceOrderField]{Field: coredata.TrackerResourceOrderFieldCreatedAt, Direction: page.OrderDirectionAsc})
 
 	resources, err := r.cookieBanner.ListTrackerResourcesForCategory(ctx, scope, input.CookieCategoryID, cursor)
@@ -6082,11 +6077,10 @@ func (r *Resolver) ListTrackerResourcesTool(ctx context.Context, req *mcp.CallTo
 }
 
 func (r *Resolver) GetTrackerResourceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.GetTrackerResourceInput) (*mcp.CallToolResult, types.GetTrackerResourceOutput, error) {
-	if _, err := r.Authorize(ctx, input.ID, probo.ActionTrackerResourceGet); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionTrackerResourceGet)
+	if err != nil {
 		return nil, types.GetTrackerResourceOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	resource, err := r.cookieBanner.GetTrackerResource(ctx, scope, input.ID)
 	if err != nil {
@@ -6097,11 +6091,10 @@ func (r *Resolver) GetTrackerResourceTool(ctx context.Context, req *mcp.CallTool
 }
 
 func (r *Resolver) AddTrackerResourceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.AddTrackerResourceInput) (*mcp.CallToolResult, types.AddTrackerResourceOutput, error) {
-	if _, err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerResourceCreate); err != nil {
+	scope, err := r.Authorize(ctx, input.CookieCategoryID, probo.ActionTrackerResourceCreate)
+	if err != nil {
 		return nil, types.AddTrackerResourceOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.CookieCategoryID)
 
 	description := ""
 	if input.Description != nil {
@@ -6124,11 +6117,10 @@ func (r *Resolver) AddTrackerResourceTool(ctx context.Context, req *mcp.CallTool
 }
 
 func (r *Resolver) UpdateTrackerResourceTool(ctx context.Context, req *mcp.CallToolRequest, input *types.UpdateTrackerResourceInput) (*mcp.CallToolResult, types.UpdateTrackerResourceOutput, error) {
-	if _, err := r.Authorize(ctx, input.ID, probo.ActionTrackerResourceUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.ID, probo.ActionTrackerResourceUpdate)
+	if err != nil {
 		return nil, types.UpdateTrackerResourceOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.ID)
 
 	updateReq := cookiebanner.UpdateTrackerResourceRequest{TrackerResourceID: input.ID}
 	if v := UnwrapOmittable(input.DisplayName); v != nil && *v != nil {
@@ -6165,11 +6157,10 @@ func (r *Resolver) DeleteTrackerResourceTool(ctx context.Context, req *mcp.CallT
 }
 
 func (r *Resolver) MoveTrackerResourceToCategoryTool(ctx context.Context, req *mcp.CallToolRequest, input *types.MoveTrackerResourceToCategoryInput) (*mcp.CallToolResult, types.MoveTrackerResourceToCategoryOutput, error) {
-	if _, err := r.Authorize(ctx, input.TrackerResourceID, probo.ActionTrackerResourceUpdate); err != nil {
+	scope, err := r.Authorize(ctx, input.TrackerResourceID, probo.ActionTrackerResourceUpdate)
+	if err != nil {
 		return nil, types.MoveTrackerResourceToCategoryOutput{}, err
 	}
-
-	scope := coredata.NewScopeFromObjectID(input.TrackerResourceID)
 
 	result, err := r.cookieBanner.MoveTrackerResourceToCategory(ctx, scope, cookiebanner.MoveTrackerResourceToCategoryRequest{
 		TrackerResourceID:      input.TrackerResourceID,

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -5567,6 +5567,7 @@ func (r *Resolver) ListCookieCategoriesTool(ctx context.Context, req *mcp.CallTo
 	if err != nil {
 		return nil, types.ListCookieCategoriesOutput{}, err
 	}
+
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieCategoryOrderField]{Field: coredata.CookieCategoryOrderFieldRank, Direction: page.OrderDirectionAsc})
 
 	categories, err := r.cookieBanner.ListCategoriesForBanner(ctx, scope, input.CookieBannerID, cursor, coredata.NewCookieCategoryFilter(new(coredata.CookieCategoryKindUncategorised)))
@@ -5680,6 +5681,7 @@ func (r *Resolver) ListTrackerPatternsTool(ctx context.Context, req *mcp.CallToo
 	if err != nil {
 		return nil, types.ListTrackerPatternsOutput{}, err
 	}
+
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.TrackerPatternOrderField]{Field: coredata.TrackerPatternOrderFieldCreatedAt, Direction: page.OrderDirectionAsc})
 
 	patterns, err := r.cookieBanner.ListTrackerPatternsForCategory(ctx, scope, input.CookieCategoryID, cursor)
@@ -5805,6 +5807,7 @@ func (r *Resolver) ListCookieBannerVersionsTool(ctx context.Context, req *mcp.Ca
 	if err != nil {
 		return nil, types.ListCookieBannerVersionsOutput{}, err
 	}
+
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieBannerVersionOrderField]{Field: coredata.CookieBannerVersionOrderFieldCreatedAt, Direction: page.OrderDirectionDesc})
 
 	versions, err := r.cookieBanner.ListCookieBannerVersionsForBanner(ctx, scope, input.CookieBannerID, cursor)
@@ -5840,6 +5843,7 @@ func (r *Resolver) ListCookieConsentRecordsTool(ctx context.Context, req *mcp.Ca
 	if err != nil {
 		return nil, types.ListCookieConsentRecordsOutput{}, err
 	}
+
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.CookieConsentRecordOrderField]{Field: coredata.CookieConsentRecordOrderFieldCreatedAt, Direction: page.OrderDirectionDesc})
 
 	var action *coredata.CookieConsentAction
@@ -6064,6 +6068,7 @@ func (r *Resolver) ListTrackerResourcesTool(ctx context.Context, req *mcp.CallTo
 	if err != nil {
 		return nil, types.ListTrackerResourcesOutput{}, err
 	}
+
 	cursor := types.NewCursor(input.Size, input.Cursor, page.OrderBy[coredata.TrackerResourceOrderField]{Field: coredata.TrackerResourceOrderFieldCreatedAt, Direction: page.OrderDirectionAsc})
 
 	resources, err := r.cookieBanner.ListTrackerResourcesForCategory(ctx, scope, input.CookieCategoryID, cursor)

--- a/pkg/thirdparty/disambiguation_agent.go
+++ b/pkg/thirdparty/disambiguation_agent.go
@@ -1,0 +1,209 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package thirdparty
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.gearno.de/kit/log"
+	"go.probo.inc/probo/pkg/agent"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/llm"
+)
+
+//go:embed prompts/disambiguation.txt.tmpl
+var disambiguationPrompt string
+
+const (
+	// disambiguationConfidenceThreshold is the floor below which we
+	// treat the agent's pick as "no confident match" even when it
+	// returned a non-nil matched_id. Mirrors the conservative bias
+	// described in the prompt.
+	disambiguationConfidenceThreshold = 0.6
+
+	// disambiguationTimeout caps a single disambiguation run. The
+	// agent has no tools and a single turn, so this is mostly a
+	// guard against a hung LLM provider, not a real budget.
+	disambiguationTimeout = 60 * time.Second
+)
+
+// DisambiguationConfig configures the third-party disambiguation
+// agent. The agent has no DB tools and no web-search tools: the
+// candidate list is supplied entirely in the prompt and the agent
+// only picks among it.
+type DisambiguationConfig struct {
+	LLMClient *llm.Client
+	Model     string
+}
+
+// DisambiguationResult is the structured output the disambiguation
+// agent returns when picking the best existing org ThirdParty for a
+// catalog entry.
+type DisambiguationResult struct {
+	MatchedID  *string `json:"matched_id"  jsonschema:"GID of the org third party that best matches, or null if none of the candidates is a confident match."`
+	Confidence float64 `json:"confidence"  jsonschema:"Confidence level from 0.0 to 1.0. Below 0.6 means 'no confident match' and matched_id MUST be null."`
+	Reasoning  string  `json:"reasoning"   jsonschema:"One short sentence describing the rationale."`
+}
+
+// BuildDisambiguationAgent wires the agent that picks the best
+// existing org ThirdParty for a catalog entry. It deliberately has
+// no tools: the candidate list is supplied in the prompt and the
+// agent must only choose among it.
+func BuildDisambiguationAgent(
+	cfg DisambiguationConfig,
+	logger *log.Logger,
+) *agent.Agent {
+	outputType, err := agent.NewOutputType[DisambiguationResult]("third_party_disambiguation")
+	if err != nil {
+		panic(fmt.Sprintf("thirdparty: cannot build disambiguation output type: %s", err))
+	}
+
+	return agent.New(
+		"third-party-disambiguation",
+		cfg.LLMClient,
+		agent.WithInstructions(disambiguationPrompt),
+		agent.WithModel(cfg.Model),
+		agent.WithOutputType(outputType),
+		agent.WithMaxTurns(1),
+		agent.WithLogger(logger),
+	)
+}
+
+// Disambiguate runs the agent against the given catalog third party
+// and candidate list, and returns the matched candidate's ID — or
+// nil when the agent picks "none", returns a confidence below the
+// threshold, or fails. Errors from the agent itself are returned;
+// "no confident match" is not an error.
+//
+// The matched candidate is identified by string equality against the
+// IDs supplied in `candidates`; we never invent IDs from the agent's
+// output, so a model that hallucinates an ID is treated as "none".
+func Disambiguate(
+	ctx context.Context,
+	a *agent.Agent,
+	logger *log.Logger,
+	commonParty coredata.CommonThirdParty,
+	commonDomains coredata.CommonThirdPartyDomains,
+	candidates []ScoredCandidate,
+) (*gid.GID, error) {
+	if a == nil || len(candidates) == 0 {
+		return nil, nil
+	}
+
+	prompt := buildDisambiguationPrompt(commonParty, commonDomains, candidates)
+
+	agentCtx, cancel := context.WithTimeout(ctx, disambiguationTimeout)
+	defer cancel()
+
+	result, err := agent.RunTyped[DisambiguationResult](
+		agentCtx,
+		a,
+		[]llm.Message{
+			{
+				Role:  llm.RoleUser,
+				Parts: []llm.Part{llm.TextPart{Text: prompt}},
+			},
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot run disambiguation agent: %w", err)
+	}
+
+	out := result.Output
+
+	if out.MatchedID == nil || *out.MatchedID == "" {
+		return nil, nil
+	}
+
+	if out.Confidence < disambiguationConfidenceThreshold {
+		logger.InfoCtx(
+			ctx,
+			"disambiguation agent below confidence threshold",
+			log.String("matched_id", *out.MatchedID),
+			log.Float64("confidence", out.Confidence),
+		)
+
+		return nil, nil
+	}
+
+	for _, c := range candidates {
+		if c.ThirdParty.ID.String() == *out.MatchedID {
+			id := c.ThirdParty.ID
+
+			return &id, nil
+		}
+	}
+
+	logger.WarnCtx(
+		ctx,
+		"disambiguation agent returned id not in candidate list",
+		log.String("matched_id", *out.MatchedID),
+	)
+
+	return nil, nil
+}
+
+// buildDisambiguationPrompt formats the catalog third party and the
+// heuristic-ranked candidate list into the user message for the
+// disambiguation agent. The prompt is intentionally compact: the
+// agent only needs ids, names, websites, and the heuristic score to
+// decide.
+func buildDisambiguationPrompt(
+	commonParty coredata.CommonThirdParty,
+	commonDomains coredata.CommonThirdPartyDomains,
+	candidates []ScoredCandidate,
+) string {
+	var b strings.Builder
+
+	b.WriteString("Catalog third party:\n")
+	fmt.Fprintf(&b, "  name: %s\n", commonParty.Name)
+
+	if commonParty.WebsiteURL != nil && *commonParty.WebsiteURL != "" {
+		fmt.Fprintf(&b, "  website: %s\n", *commonParty.WebsiteURL)
+	}
+
+	if len(commonDomains) > 0 {
+		domains := make([]string, len(commonDomains))
+		for i, d := range commonDomains {
+			domains[i] = d.Domain
+		}
+
+		fmt.Fprintf(&b, "  domains: %s\n", strings.Join(domains, ", "))
+	}
+
+	b.WriteString("\nCandidate organisation third parties (heuristic-ranked):\n")
+
+	for i, c := range candidates {
+		fmt.Fprintf(&b, "- id: %s\n", c.ThirdParty.ID.String())
+		fmt.Fprintf(&b, "  name: %s\n", c.ThirdParty.Name)
+
+		if c.ThirdParty.WebsiteURL != nil && *c.ThirdParty.WebsiteURL != "" {
+			fmt.Fprintf(&b, "  website: %s\n", *c.ThirdParty.WebsiteURL)
+		}
+
+		fmt.Fprintf(&b, "  heuristic_score: %.2f\n", c.Score)
+
+		if i < len(candidates)-1 {
+			b.WriteString("\n")
+		}
+	}
+
+	return b.String()
+}

--- a/pkg/thirdparty/match.go
+++ b/pkg/thirdparty/match.go
@@ -219,9 +219,10 @@ func LinkToCommon(
 // CreateFromCommon inserts a new org ThirdParty seeded from the catalog
 // row (name, category, addresses, URLs, certifications, …). The new row
 // has common_third_party_id pointed at commonParty, an empty Countries
-// list, and ShowOnTrustCenter / FirstLevel both false — mirroring the
-// front-end CreateThirdPartyDialog's "pick from catalog" seeding shape
-// so the result is indistinguishable from a manual creation.
+// list, ShowOnTrustCenter false, and FirstLevel true — the caller has
+// already confirmed the vendor is actively present on the
+// organization's cookie banner, which makes it a first-level third
+// party by definition.
 //
 // Deliberately bypasses any service-level webhook emission: callers
 // that need a webhook for the implicit creation should emit it
@@ -257,7 +258,7 @@ func CreateFromCommon(
 		SecurityPageURL:               commonParty.SecurityPageURL,
 		TrustPageURL:                  commonParty.TrustPageURL,
 		ShowOnTrustCenter:             false,
-		FirstLevel:                    false,
+		FirstLevel:                    true,
 		CreatedAt:                     now,
 		UpdatedAt:                     now,
 	}

--- a/pkg/thirdparty/match.go
+++ b/pkg/thirdparty/match.go
@@ -1,0 +1,274 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package thirdparty
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/slug"
+	"go.probo.inc/probo/pkg/uri"
+)
+
+// Heuristic thresholds for matching a CommonThirdParty to an existing
+// org ThirdParty. Exported so callers can short-circuit explicitly
+// (skip the agent, fall back to creating, etc.) instead of duplicating
+// magic numbers.
+const (
+	// HighConfidenceScore is the floor at which a heuristic match
+	// is treated as obvious (exact name, suffix-stripped name, slug
+	// equality). Callers typically link without consulting the
+	// agent at this score.
+	HighConfidenceScore = 0.85
+
+	// MinAgentScore is the floor below which a candidate is
+	// statistical noise and should not be shown to the
+	// disambiguation agent. Below this, callers typically prefer
+	// to create a fresh row over asking the model to pick among
+	// weak candidates.
+	MinAgentScore = 0.6
+
+	// MaxAgentCandidates caps the candidate list shown to the
+	// disambiguation agent. The list is heuristic-ranked, so the
+	// top few are the only ones worth the agent's tokens.
+	MaxAgentCandidates = 5
+)
+
+// ScoredCandidate is a scored heuristic-match candidate. It is the
+// unified currency between the heuristic ranker (RankCandidates) and
+// the disambiguation agent (Disambiguate): the agent renders the
+// `ThirdParty` fields plus the score directly into its prompt, with
+// no intermediate DTO.
+type ScoredCandidate struct {
+	ThirdParty *coredata.ThirdParty
+	Score      float64
+}
+
+// corporateSuffixes are the legal-form noise words stripped when
+// comparing third-party names heuristically. The list is intentionally
+// short and conservative: matching "Foo Inc" to "Foo" is safe, but
+// stripping "Group" or "Services" would over-match unrelated entries.
+//
+// Order matters: stripCorporateSuffixes returns on the first match,
+// so longer / comma-prefixed forms must come before their shorter
+// siblings (", inc." before " inc.", which itself comes before " inc").
+var corporateSuffixes = []string{
+	" incorporated",
+	" corporation",
+	", inc.",
+	", inc",
+	" l.l.c.",
+	" s.a.s.",
+	" inc.",
+	" inc",
+	" llc",
+	" ltd.",
+	" ltd",
+	" limited",
+	" gmbh",
+	" s.a.",
+	" sas",
+	" sa",
+	" ag",
+	" plc",
+	" corp.",
+	" corp",
+	" co.",
+	" co",
+	" b.v.",
+	" bv",
+}
+
+// RankCandidates ranks org ThirdParty rows by how likely each is to
+// represent the given CommonThirdParty. Returned slice is sorted by
+// descending score; only candidates with score > 0 are kept. Pure
+// function: no I/O, deterministic on its inputs.
+//
+// Scoring (highest match wins; website-host overlap can lift a name
+// miss to 0.8):
+//
+//   - exact lowercase name                                      = 1.0
+//   - lowercase name with corporate suffix stripped, equal      = 0.9
+//   - slug equality (slug.Make on the org's name)               = 0.85
+//   - website host (eTLD+1) overlap with the catalog domain set = 0.8
+func RankCandidates(
+	commonParty coredata.CommonThirdParty,
+	commonDomains coredata.CommonThirdPartyDomains,
+	candidates coredata.ThirdParties,
+) []ScoredCandidate {
+	commonName := strings.ToLower(strings.TrimSpace(commonParty.Name))
+	commonStripped := stripCorporateSuffixes(commonName)
+	commonSlug := commonParty.Slug
+
+	commonHost := ""
+	if commonParty.WebsiteURL != nil {
+		commonHost = uri.ExtractDomain(*commonParty.WebsiteURL)
+	}
+
+	commonDomainSet := make(map[string]struct{}, len(commonDomains))
+	for _, d := range commonDomains {
+		commonDomainSet[strings.ToLower(d.Domain)] = struct{}{}
+	}
+
+	if commonHost != "" {
+		commonDomainSet[commonHost] = struct{}{}
+	}
+
+	scored := make([]ScoredCandidate, 0, len(candidates))
+
+	for _, tp := range candidates {
+		score := 0.0
+
+		orgName := strings.ToLower(strings.TrimSpace(tp.Name))
+		orgStripped := stripCorporateSuffixes(orgName)
+
+		switch {
+		case orgName != "" && orgName == commonName:
+			score = 1.0
+		case orgStripped != "" && orgStripped == commonStripped:
+			score = 0.9
+		case commonSlug != "" && slug.Make(tp.Name) == commonSlug:
+			score = 0.85
+		}
+
+		if tp.WebsiteURL != nil {
+			orgHost := uri.ExtractDomain(*tp.WebsiteURL)
+			if orgHost != "" {
+				if _, hit := commonDomainSet[orgHost]; hit {
+					if score < 0.8 {
+						score = 0.8
+					}
+				}
+			}
+		}
+
+		if score == 0 {
+			continue
+		}
+
+		scored = append(scored, ScoredCandidate{
+			ThirdParty: tp,
+			Score:      score,
+		})
+	}
+
+	sort.SliceStable(scored, func(i, j int) bool {
+		return scored[i].Score > scored[j].Score
+	})
+
+	return scored
+}
+
+// stripCorporateSuffixes removes a single trailing legal-form suffix
+// from a lowercased name. Only one suffix is stripped to avoid
+// mangling names that happen to end in two stop-words (e.g. "Foo Inc
+// LLC" → "Foo Inc", not "Foo").
+func stripCorporateSuffixes(lowerName string) string {
+	for _, s := range corporateSuffixes {
+		if before, ok := strings.CutSuffix(lowerName, s); ok {
+			return strings.TrimSpace(before)
+		}
+	}
+
+	return lowerName
+}
+
+// LinkToCommon writes common_third_party_id onto an org ThirdParty so
+// future matches against the same CommonThirdParty can short-circuit
+// to the exact-link path in O(1). No-op when the field is already set
+// to commonID; otherwise writes the field via ThirdParty.Update and
+// updates the receiver in place.
+func LinkToCommon(
+	ctx context.Context,
+	tx pg.Tx,
+	scope coredata.Scoper,
+	orgThirdParty *coredata.ThirdParty,
+	commonID gid.GID,
+) error {
+	if orgThirdParty.CommonThirdPartyID != nil && *orgThirdParty.CommonThirdPartyID == commonID {
+		return nil
+	}
+
+	orgThirdParty.CommonThirdPartyID = &commonID
+
+	if err := orgThirdParty.Update(ctx, tx, scope); err != nil {
+		return fmt.Errorf("cannot update third party with common id: %w", err)
+	}
+
+	return nil
+}
+
+// CreateFromCommon inserts a new org ThirdParty seeded from the catalog
+// row (name, category, addresses, URLs, certifications, …). The new row
+// has common_third_party_id pointed at commonParty, an empty Countries
+// list, and ShowOnTrustCenter / FirstLevel both false — mirroring the
+// front-end CreateThirdPartyDialog's "pick from catalog" seeding shape
+// so the result is indistinguishable from a manual creation.
+//
+// Deliberately bypasses any service-level webhook emission: callers
+// that need a webhook for the implicit creation should emit it
+// themselves.
+func CreateFromCommon(
+	ctx context.Context,
+	tx pg.Tx,
+	scope coredata.Scoper,
+	organizationID gid.GID,
+	commonParty coredata.CommonThirdParty,
+) (*coredata.ThirdParty, error) {
+	commonID := commonParty.ID
+	now := time.Now()
+
+	tp := &coredata.ThirdParty{
+		ID:                            gid.New(scope.GetTenantID(), coredata.ThirdPartyEntityType),
+		OrganizationID:                organizationID,
+		CommonThirdPartyID:            &commonID,
+		Name:                          commonParty.Name,
+		Category:                      commonParty.Category,
+		HeadquarterAddress:            commonParty.HeadquarterAddress,
+		LegalName:                     commonParty.LegalName,
+		WebsiteURL:                    commonParty.WebsiteURL,
+		PrivacyPolicyURL:              commonParty.PrivacyPolicyURL,
+		ServiceLevelAgreementURL:      commonParty.ServiceLevelAgreementURL,
+		DataProcessingAgreementURL:    commonParty.DataProcessingAgreementURL,
+		BusinessAssociateAgreementURL: commonParty.BusinessAssociateAgreementURL,
+		SubprocessorsListURL:          commonParty.SubprocessorsListURL,
+		Certifications:                commonParty.Certifications,
+		Countries:                     coredata.CountryCodes{},
+		StatusPageURL:                 commonParty.StatusPageURL,
+		TermsOfServiceURL:             commonParty.TermsOfServiceURL,
+		SecurityPageURL:               commonParty.SecurityPageURL,
+		TrustPageURL:                  commonParty.TrustPageURL,
+		ShowOnTrustCenter:             false,
+		FirstLevel:                    false,
+		CreatedAt:                     now,
+		UpdatedAt:                     now,
+	}
+
+	if tp.Certifications == nil {
+		tp.Certifications = []string{}
+	}
+
+	if err := tp.Insert(ctx, tx, scope); err != nil {
+		return nil, fmt.Errorf("cannot insert org third party: %w", err)
+	}
+
+	return tp, nil
+}

--- a/pkg/thirdparty/match.go
+++ b/pkg/thirdparty/match.go
@@ -194,8 +194,9 @@ func stripCorporateSuffixes(lowerName string) string {
 // LinkToCommon writes common_third_party_id onto an org ThirdParty so
 // future matches against the same CommonThirdParty can short-circuit
 // to the exact-link path in O(1). No-op when the field is already set
-// to commonID; otherwise writes the field via ThirdParty.Update and
-// updates the receiver in place.
+// (to any value) — we never overwrite an existing catalog link because
+// a heuristic or agent false-positive must not corrupt a previous,
+// possibly more accurate, association.
 func LinkToCommon(
 	ctx context.Context,
 	tx pg.Tx,
@@ -203,7 +204,7 @@ func LinkToCommon(
 	orgThirdParty *coredata.ThirdParty,
 	commonID gid.GID,
 ) error {
-	if orgThirdParty.CommonThirdPartyID != nil && *orgThirdParty.CommonThirdPartyID == commonID {
+	if orgThirdParty.CommonThirdPartyID != nil {
 		return nil
 	}
 

--- a/pkg/thirdparty/match_test.go
+++ b/pkg/thirdparty/match_test.go
@@ -23,9 +23,6 @@ import (
 	"go.probo.inc/probo/pkg/gid"
 )
 
-//go:fix inline
-func ptr[T any](v T) *T { return new(v) }
-
 func TestStripCorporateSuffixes(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/thirdparty/match_test.go
+++ b/pkg/thirdparty/match_test.go
@@ -1,0 +1,181 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package thirdparty
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+)
+
+//go:fix inline
+func ptr[T any](v T) *T { return new(v) }
+
+func TestStripCorporateSuffixes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "llc suffix", in: "google llc", want: "google"},
+		{name: "comma inc", in: "stripe, inc", want: "stripe"},
+		{name: "inc dot", in: "meta inc.", want: "meta"},
+		{name: "ltd", in: "deepmind ltd", want: "deepmind"},
+		{name: "gmbh", in: "n8n gmbh", want: "n8n"},
+		{name: "no suffix", in: "cloudflare", want: "cloudflare"},
+		{name: "trailing space", in: "github  inc", want: "github"},
+		{name: "only one suffix stripped", in: "foo inc llc", want: "foo inc"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, stripCorporateSuffixes(tt.in))
+		})
+	}
+}
+
+func TestRankCandidates(t *testing.T) {
+	t.Parallel()
+
+	tenantID := gid.NewTenantID()
+
+	mkTP := func(name, website string) *coredata.ThirdParty {
+		tp := &coredata.ThirdParty{
+			ID:   gid.New(tenantID, coredata.ThirdPartyEntityType),
+			Name: name,
+		}
+
+		if website != "" {
+			tp.WebsiteURL = new(website)
+		}
+
+		return tp
+	}
+
+	t.Run("exact name match scores 1.0", func(t *testing.T) {
+		t.Parallel()
+
+		common := coredata.CommonThirdParty{Name: "Google", Slug: "google"}
+		got := RankCandidates(common, nil, coredata.ThirdParties{
+			mkTP("Google", ""),
+			mkTP("Stripe", ""),
+		})
+
+		require.Len(t, got, 1)
+		assert.Equal(t, 1.0, got[0].Score)
+		assert.Equal(t, "Google", got[0].ThirdParty.Name)
+	})
+
+	t.Run("suffix-stripped name scores 0.9", func(t *testing.T) {
+		t.Parallel()
+
+		common := coredata.CommonThirdParty{Name: "Google", Slug: "google"}
+		got := RankCandidates(common, nil, coredata.ThirdParties{
+			mkTP("Google LLC", ""),
+		})
+
+		require.Len(t, got, 1)
+		assert.Equal(t, 0.9, got[0].Score)
+	})
+
+	t.Run("slug equality scores 0.85", func(t *testing.T) {
+		t.Parallel()
+
+		common := coredata.CommonThirdParty{Name: "Google", Slug: "google"}
+		got := RankCandidates(common, nil, coredata.ThirdParties{
+			mkTP("google!", ""),
+		})
+
+		require.Len(t, got, 1)
+		assert.Equal(t, 0.85, got[0].Score)
+	})
+
+	t.Run("website host overlap scores 0.8 when name does not match", func(t *testing.T) {
+		t.Parallel()
+
+		common := coredata.CommonThirdParty{
+			Name:       "Google Analytics",
+			Slug:       "google-analytics",
+			WebsiteURL: new("https://google.com"),
+		}
+
+		got := RankCandidates(common, nil, coredata.ThirdParties{
+			mkTP("Sundar's Search Co", "https://www.google.com/about"),
+		})
+
+		require.Len(t, got, 1)
+		assert.Equal(t, 0.8, got[0].Score)
+	})
+
+	t.Run("domain set overlap scores 0.8", func(t *testing.T) {
+		t.Parallel()
+
+		common := coredata.CommonThirdParty{Name: "Stripe", Slug: "stripe"}
+		domains := coredata.CommonThirdPartyDomains{
+			{Domain: "stripe.com"},
+			{Domain: "stripe.network"},
+		}
+
+		got := RankCandidates(common, domains, coredata.ThirdParties{
+			mkTP("Payment Processor", "https://api.stripe.com/v1"),
+		})
+
+		require.Len(t, got, 1)
+		assert.Equal(t, 0.8, got[0].Score)
+	})
+
+	t.Run("no match returns empty", func(t *testing.T) {
+		t.Parallel()
+
+		common := coredata.CommonThirdParty{Name: "Stripe", Slug: "stripe"}
+		got := RankCandidates(common, nil, coredata.ThirdParties{
+			mkTP("Acme", "https://acme.example"),
+			mkTP("Widgets Inc", "https://widgets.example"),
+		})
+
+		assert.Empty(t, got)
+	})
+
+	t.Run("ranks descending by score", func(t *testing.T) {
+		t.Parallel()
+
+		common := coredata.CommonThirdParty{
+			Name:       "Google",
+			Slug:       "google",
+			WebsiteURL: new("https://google.com"),
+		}
+
+		got := RankCandidates(common, nil, coredata.ThirdParties{
+			mkTP("Random", "https://google.com"),
+			mkTP("Google", ""),
+			mkTP("Google LLC", ""),
+		})
+
+		require.Len(t, got, 3)
+		assert.Equal(t, "Google", got[0].ThirdParty.Name)
+		assert.Equal(t, 1.0, got[0].Score)
+		assert.Equal(t, "Google LLC", got[1].ThirdParty.Name)
+		assert.Equal(t, 0.9, got[1].Score)
+		assert.Equal(t, "Random", got[2].ThirdParty.Name)
+		assert.Equal(t, 0.8, got[2].Score)
+	})
+}

--- a/pkg/thirdparty/prompts/disambiguation.txt.tmpl
+++ b/pkg/thirdparty/prompts/disambiguation.txt.tmpl
@@ -1,0 +1,25 @@
+<role>
+You are a third-party catalog matcher. The product groups web trackers under a global catalog of "common" third parties (Google Analytics, Stripe, Meta Pixel, …). Each customer organisation also maintains its own list of "third parties" — sometimes seeded from the catalog, sometimes typed manually. Your only job is to decide whether one of the organisation's existing third parties already represents a given catalog entry, so we don't create a duplicate.
+</role>
+
+<task>
+You are given:
+- A catalog third party: name, website, and known domains.
+- A small list of candidate organisation third parties: each with a stable id, a name, and (optionally) a website.
+
+Pick the candidate that best represents the catalog third party, or none.
+
+Return a structured JSON response with:
+- matched_id: the candidate id, or null if none of them is a confident match.
+- confidence: 0.0 to 1.0; below 0.6 means "no confident match" (set matched_id to null in that case).
+- reasoning: one short sentence describing the rationale.
+</task>
+
+<instructions>
+1. The candidates have already been ranked by a heuristic; the list is small (usually a handful). Use that as a hint, but do not trust it blindly.
+2. Treat corporate suffixes (LLC, Inc, Ltd, GmbH, SA, …) as noise. "Google" and "Google LLC" are the same company.
+3. Treat brand/product names as the same when the parent company is obvious: "Google Analytics" maps to "Google" if the org only has the parent. Only do this when the catalog domains plainly match the parent's domains.
+4. Website hostnames and known domains are the strongest signal. If the catalog domain (or its eTLD+1) matches a candidate's website host, they are almost certainly the same.
+5. Be conservative. If two candidates look plausible and you cannot rule one out, return matched_id=null with confidence < 0.6 — we will create a fresh org third party from the catalog rather than risk a wrong link.
+6. Do not invent ids. Return only ids that appear verbatim in the candidate list.
+</instructions>

--- a/pkg/thirdparty/service.go
+++ b/pkg/thirdparty/service.go
@@ -50,6 +50,29 @@ func (s *Service) GenerateLogoURL(
 	return &url, nil
 }
 
+func (s *Service) GetCommonThirdPartiesByIDs(
+	ctx context.Context,
+	ids ...gid.GID,
+) (coredata.CommonThirdParties, error) {
+	var parties coredata.CommonThirdParties
+
+	err := s.pg.WithConn(
+		ctx,
+		func(ctx context.Context, conn pg.Querier) error {
+			if err := parties.LoadByIDs(ctx, conn, ids); err != nil {
+				return fmt.Errorf("cannot load common third parties by ids: %w", err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return parties, nil
+}
+
 func (s *Service) Search(ctx context.Context, name string) ([]*coredata.CommonThirdParty, error) {
 	var parties coredata.CommonThirdParties
 

--- a/pkg/uri/uri.go
+++ b/pkg/uri/uri.go
@@ -102,3 +102,26 @@ func ExtractDomain(rawURL string) string {
 
 	return domain
 }
+
+// FilterFirstPartyDomains removes domains that match the eTLD+1 of
+// siteOrigin. Tracker scripts loaded through a first-party proxy (e.g.
+// t.probo.com proxying PostHog on a probo.com site) share the site's
+// eTLD+1 and carry no signal about the actual third party. siteOrigin
+// is a full URL such as "https://app.probo.com". The input domains are
+// expected to be eTLD+1 strings (as produced by ExtractDomain).
+func FilterFirstPartyDomains(domains []string, siteOrigin string) []string {
+	siteDomain := ExtractDomain(siteOrigin)
+	if siteDomain == "" {
+		return domains
+	}
+
+	filtered := make([]string, 0, len(domains))
+
+	for _, d := range domains {
+		if d != siteDomain {
+			filtered = append(filtered, d)
+		}
+	}
+
+	return filtered
+}

--- a/pkg/uri/uri_test.go
+++ b/pkg/uri/uri_test.go
@@ -291,3 +291,76 @@ func TestExtractDomain(t *testing.T) {
 		)
 	}
 }
+
+func TestFilterFirstPartyDomains(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		domains    []string
+		siteOrigin string
+		want       []string
+	}{
+		{
+			name:       "removes site domain from proxy",
+			domains:    []string{"probo.com", "posthog.com"},
+			siteOrigin: "https://app.probo.com",
+			want:       []string{"posthog.com"},
+		},
+		{
+			name:       "keeps all third-party domains",
+			domains:    []string{"stripe.com", "google.com"},
+			siteOrigin: "https://app.probo.com",
+			want:       []string{"stripe.com", "google.com"},
+		},
+		{
+			name:       "removes only matching domain",
+			domains:    []string{"example.com", "googletagmanager.com", "example.com"},
+			siteOrigin: "https://www.example.com",
+			want:       []string{"googletagmanager.com"},
+		},
+		{
+			name:       "all domains are first party",
+			domains:    []string{"probo.com"},
+			siteOrigin: "https://t.probo.com",
+			want:       []string{},
+		},
+		{
+			name:       "empty domains list",
+			domains:    []string{},
+			siteOrigin: "https://probo.com",
+			want:       []string{},
+		},
+		{
+			name:       "nil domains list",
+			domains:    nil,
+			siteOrigin: "https://probo.com",
+			want:       []string{},
+		},
+		{
+			name:       "invalid site origin preserves all",
+			domains:    []string{"probo.com", "stripe.com"},
+			siteOrigin: "not-a-url",
+			want:       []string{"probo.com", "stripe.com"},
+		},
+		{
+			name:       "empty site origin preserves all",
+			domains:    []string{"probo.com", "stripe.com"},
+			siteOrigin: "",
+			want:       []string{"probo.com", "stripe.com"},
+		},
+		{
+			name:       "co.uk site origin",
+			domains:    []string{"example.co.uk", "analytics.google.com"},
+			siteOrigin: "https://shop.example.co.uk",
+			want:       []string{"analytics.google.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, FilterFirstPartyDomains(tt.domains, tt.siteOrigin))
+		})
+	}
+}


### PR DESCRIPTION
ENG-416



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes moved tracker patterns to org third parties, adds third‑party links and filtering in the banner UI, exposes HTTP as a cookie source, and streamlines row actions with inline recategorization. Adds a common‑pattern enrichment worker; mapping re-triggers on source promotions, backfills descriptions from the catalog, and narrows agent confidence to vendor attribution.

### Coredata **`+729`** **`-69`**
- Batch loaders for common third parties and common tracker patterns; tracker updates now write `common_tracker_pattern_id` and `third_party_id`.
- Filter adds a single `thirdPartyId` (resolver dispatch) and a subquery for common third parties.
- Deterministic sibling-origin lookup; migration to support enrichment/backfill.

### Service **`+1810`** **`-181`**
- New common-pattern enrichment agent/worker: researches descriptions and fans them out to linked patterns.
- Mapping: sibling-origin match, catalog domain match with first-party proxy filtering, disambiguation agent, re-enqueue unmapped siblings, scoped writes, skip uncategorised, set FirstLevel on auto-created parties, re-trigger on source promotions; rename `TrackerMappingConfig` to `TrackerAgentsConfig`.
- Agent confidence now measures vendor attribution only; gate checks `third_party_confidence` and stores a fixed source confidence.

### GraphQL API **`+372`** **`-62`**
- Add `TrackerPattern.thirdParty` and `commonThirdParty`; `CookieBanner.linkedThirdParties`; unified `thirdPartyId` filter.
- Add dataloaders; pass scope from authorize.
- Declare `CookieSource.HTTP` so the value round-trips.

### MCP **`+99`** **`-103`**
- Tool resolvers use the scope from `Authorize`; per-case auth cleanup.

### App: console **`+318`** **`-214`**
- Inline category select for patterns and resources with confirm on promote/link; consolidate actions into one dropdown.
- Add Max Age column to patterns and Category column to resources; wider description input; compact action column.
- Show third party in trackers list and details; third‑party filter via `linkedThirdParties`; shared badges from `@probo/helpers`, render HTTP source.

### Agents **`+170`** **`-13`**
- Rules/docs: always use authorize-returned scope; allow filter subqueries; agent file-naming guidance.

### Tests **`+2023`** **`-0`**
- Mapping worker tests, third-party matcher tests, and `pkg/uri` first-party filtering tests.

### Package: helpers **`+49`** **`-0`**
- Add `getTrackerTypeBadge` and `getTrackerSourceBadge`; export from `@probo/helpers`.

<sup>Written for commit 1b8bd1895eb2d4dda32bbe687a0e66a37617250a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





