### PR TITLE
Fix Sentry name resolver flooding on stale org slugs

### DIFF
--- a/pkg/accessreview/drivers/name_resolver.go
+++ b/pkg/accessreview/drivers/name_resolver.go
@@ -471,6 +471,13 @@ func (r *sentryNameResolver) ResolveInstanceName(ctx context.Context) (string, e
 
 	defer func() { _ = httpResp.Body.Close() }()
 
+	// 404 means the stored slug is no longer visible to this token.
+	// Treat as terminal so the worker stops looping; other non-2xx
+	// stay retryable for token refresh / transient outages.
+	if httpResp.StatusCode == http.StatusNotFound {
+		return "", nil
+	}
+
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		return "", fmt.Errorf("cannot fetch sentry organization: unexpected status %d", httpResp.StatusCode)
 	}

--- a/pkg/accessreview/drivers/name_resolver_test.go
+++ b/pkg/accessreview/drivers/name_resolver_test.go
@@ -102,3 +102,93 @@ func TestNotionNameResolver(t *testing.T) {
 		})
 	}
 }
+
+func TestSentryNameResolver(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty slug returns nothing without HTTP call", func(t *testing.T) {
+		t.Parallel()
+
+		client := &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			t.Fatalf("resolver should not make an HTTP call for an empty slug")
+			return nil, nil
+		})}
+
+		got, err := NewSentryNameResolver(client, "").ResolveInstanceName(context.Background())
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	cases := []struct {
+		name    string
+		status  int
+		body    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "200 returns name",
+			status: http.StatusOK,
+			body:   `{"slug":"acme","name":"Acme Inc"}`,
+			want:   "Acme Inc",
+		},
+		{
+			name:   "404 is terminal (no error, no name)",
+			status: http.StatusNotFound,
+			body:   `{"detail":"The requested resource does not exist"}`,
+			want:   "",
+		},
+		{
+			name:    "401 is retryable",
+			status:  http.StatusUnauthorized,
+			body:    `{"detail":"Authentication credentials were not provided."}`,
+			wantErr: true,
+		},
+		{
+			name:    "403 is retryable",
+			status:  http.StatusForbidden,
+			body:    `{"detail":"You do not have permission to perform this action."}`,
+			wantErr: true,
+		},
+		{
+			name:    "500 is retryable",
+			status:  http.StatusInternalServerError,
+			body:    `{"detail":"Internal Server Error"}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "/api/0/organizations/acme", r.URL.Path)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			client := &http.Client{Transport: &hostRewriter{target: srv.URL}}
+
+			got, err := NewSentryNameResolver(client, "acme").ResolveInstanceName(context.Background())
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// roundTripperFunc adapts a function into an http.RoundTripper, useful for
+// asserting that a resolver short-circuits before making any HTTP call.
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}

--- a/pkg/accessreview/drivers/sentry.go
+++ b/pkg/accessreview/drivers/sentry.go
@@ -17,6 +17,7 @@ package drivers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -25,6 +26,10 @@ import (
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/rfc5988"
 )
+
+// errSentryOrgNotAccessible signals a 404 scoped under an organization
+// slug; Sentry uses 404 (not 403) so this also covers revoked memberships.
+var errSentryOrgNotAccessible = errors.New("sentry organization is not accessible by this connector's token")
 
 // SentryDriver fetches organization members from Sentry via Bearer
 // token-authenticated REST API requests.
@@ -97,6 +102,10 @@ func (d *SentryDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error
 	for range maxPaginationPages {
 		members, linkHeader, err := d.queryMembers(ctx, nextURL)
 		if err != nil {
+			if errors.Is(err, errSentryOrgNotAccessible) {
+				return nil, fmt.Errorf("sentry organization %q is not accessible; reconnect the connector with the correct organization: %w", orgSlug, err)
+			}
+
 			return nil, err
 		}
 
@@ -177,6 +186,10 @@ func (d *SentryDriver) queryMembers(ctx context.Context, url string) ([]sentryMe
 	defer func() {
 		_ = httpResp.Body.Close()
 	}()
+
+	if httpResp.StatusCode == http.StatusNotFound {
+		return nil, "", errSentryOrgNotAccessible
+	}
 
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		return nil, "", fmt.Errorf("cannot fetch sentry members: unexpected status %d", httpResp.StatusCode)

--- a/pkg/accessreview/drivers/sentry.go
+++ b/pkg/accessreview/drivers/sentry.go
@@ -64,29 +64,9 @@ func NewSentryDriver(httpClient *http.Client, orgSlug string) *SentryDriver {
 }
 
 func (d *SentryDriver) resolveOrgSlug(ctx context.Context) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://sentry.io/api/0/organizations/?member=true", nil)
+	orgs, err := ListSentryOrganizations(ctx, d.httpClient)
 	if err != nil {
-		return "", fmt.Errorf("cannot create sentry organizations request: %w", err)
-	}
-
-	req.Header.Set("Accept", "application/json")
-
-	resp, err := d.httpClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("cannot fetch sentry organizations: %w", err)
-	}
-
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("cannot fetch sentry organizations: status %d", resp.StatusCode)
-	}
-
-	var orgs []struct {
-		Slug string `json:"slug"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&orgs); err != nil {
-		return "", fmt.Errorf("cannot decode sentry organizations response: %w", err)
+		return "", fmt.Errorf("cannot resolve sentry organization slug: %w", err)
 	}
 
 	if len(orgs) == 0 {

--- a/pkg/accessreview/drivers/sentry_test.go
+++ b/pkg/accessreview/drivers/sentry_test.go
@@ -16,6 +16,8 @@ package drivers
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -44,4 +46,35 @@ func TestSentryDriver(t *testing.T) {
 	assert.NotEmpty(t, r.FullName)
 	assert.NotEmpty(t, r.ExternalID)
 	assert.NotEmpty(t, r.Role)
+}
+
+func TestSentryDriverListAccountsAutoDiscoversSlug(t *testing.T) {
+	t.Parallel()
+
+	const discoveredSlug = "discovered-org"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/api/0/organizations/":
+			assert.Equal(t, "true", r.URL.Query().Get("member"))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"slug":"` + discoveredSlug + `","name":"Discovered Org"}]`))
+		case "/api/0/organizations/" + discoveredSlug + "/members":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"id":"42","email":"alice@example.com","name":"Alice","orgRole":"member"}]`))
+		default:
+			t.Errorf("unexpected request to %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: &hostRewriter{target: srv.URL}}
+
+	records, err := NewSentryDriver(client, "").ListAccounts(context.Background())
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, "alice@example.com", records[0].Email)
 }

--- a/pkg/accessreview/drivers/sentry_test.go
+++ b/pkg/accessreview/drivers/sentry_test.go
@@ -48,6 +48,27 @@ func TestSentryDriver(t *testing.T) {
 	assert.NotEmpty(t, r.Role)
 }
 
+func TestSentryDriverListAccountsStaleSlug(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/0/organizations/acme-old/members", r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"detail":"The requested resource does not exist"}`))
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: &hostRewriter{target: srv.URL}}
+
+	_, err := NewSentryDriver(client, "acme-old").ListAccounts(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"acme-old"`)
+	assert.Contains(t, err.Error(), "not accessible")
+	assert.Contains(t, err.Error(), "reconnect")
+	assert.ErrorIs(t, err, errSentryOrgNotAccessible)
+}
+
 func TestSentryDriverListAccountsAutoDiscoversSlug(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

In production (`eu-west-1`), one access source has been flooding the `probod.access-review.source-name` worker for the past 12h+ at ~5 errors/sec:

```
cannot resolve instance name for source Ud_g6HmaAAa0P:
cannot fetch sentry organization: unexpected status 404
```

Root cause: `kit/worker` drains tasks in a tight inner loop per tick; when `Process` returns an error the row stays unsynced and `Claim` returns the same row immediately. `sentryNameResolver` classified every non-2xx as retryable, but a 404 on `/api/0/organizations/{slug}` means the stored slug is no longer visible to the OAuth token (org renamed/deleted, membership revoked) — a permanent failure that loops bounded only by Sentry's HTTP RTT.

The same stale-slug condition also hits `SentryDriver.ListAccounts` on every campaign sync, surfacing as an opaque `"unexpected status 404"` LastError with no hint that the connector needs reconnection.

Three commits:

1. **Reuse `ListSentryOrganizations` in Sentry driver** — pure refactor. `resolveOrgSlug` was duplicating the helper already consumed by the OAuth picker; consolidating prevents the two call sites from drifting.
2. **Stop source-name worker from looping on stale Sentry slug** — `sentryNameResolver` now returns `("", nil)` on 404 (matching `openai`/`intercom` resolvers), so the worker marks the row synced and the flood stops. Other non-2xx (401/403/5xx) stay retryable so OAuth refresh and transient outages still get another chance.
3. **Surface stale Sentry slug in `ListAccounts` error** — adds `errSentryOrgNotAccessible` sentinel; `queryMembers` returns it on 404 and `ListAccounts` wraps with the slug + a directive to reconnect. `errors.Is` chain preserved.

No auto-recovery: picking a different visible org would silently rebind the source to the wrong tenant.

## Follow-ups (out of scope)

- Worker-level backoff / `attempts` column for repeatedly-failing name-sync rows.
- Auto-persisting a recovered slug via `SetOrganizationSettings` — explicit design decision, not a side effect of name resolution.
- Surfacing `LastError` to the customer in the UI if it isn't already.

## Test plan

- [x] `go test ./pkg/accessreview/drivers/... -run 'Sentry' -count=1 -race` — 11 paths pass (existing VCR test + 6 resolver cases + stale-slug + auto-discover smoke)
- [x] `go vet ./pkg/accessreview/...` clean
- [x] `gofmt -l pkg/accessreview/` clean
- [ ] Post-deploy: re-query VictoriaLogs for `region:"eu-west-1" AND error:"unexpected status 404" AND service:"probod"` — flood for `source_id="Ud_g6H=0P"` should stop within ~10s of the next worker tick.
- [ ] Post-deploy: confirm in psql that the row has `name_synced_at IS NOT NULL` and keeps its generic display name.
- [ ] Customer should now see a self-describing `LastError` on the next campaign sync attempt, pointing at reconnection rather than `unexpected status 404`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Sentry name resolver flooding on stale org slugs by treating 404s as terminal and surfacing a clear, actionable error. Refactors the Sentry driver to reuse org discovery and adds targeted tests.

### Service **`+166`** **`-22`**
- Name resolver: treat 404 from /api/0/organizations/{slug} as terminal; return "", nil so the worker stops re-claiming and the flood ends.
- Driver: on 404 in members query, return a sentinel `errSentryOrgNotAccessible`; `ListAccounts` wraps with the slug and a “reconnect the connector” message while keeping `errors.Is`.
- Refactor: `resolveOrgSlug` now uses `ListSentryOrganizations` (no behavior change), removing duplicated HTTP/parsing code.
- Tests: added cases for empty-slug short-circuit and 200/404/401/403/500 responses, plus stale-slug and auto-discovery flows under `pkg/accessreview/drivers`.

<sup>Written for commit 93d8d20dbf8ef507b0e999a366917b71e9e3bff9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1250?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

