### PR TITLE
Allow ordering profiles by email address

### DIFF
--- a/apps/console/src/pages/iam/organizations/people/_components/PeopleList.tsx
+++ b/apps/console/src/pages/iam/organizations/people/_components/PeopleList.tsx
@@ -104,7 +104,7 @@ export function PeopleList(props: {
           <SortableTh field="FULL_NAME" onOrderChange={handleOrderChange}>{__("Name")}</SortableTh>
           <SortableTh field="STATE">{__("Status")}</SortableTh>
           <SortableTh field="EMAIL_ADDRESS" onOrderChange={handleOrderChange}>{__("Email")}</SortableTh>
-          {canManageRoles && <SortableTh field="ROLE" onOrderChange={handleOrderChange}>{__("Role")}</SortableTh>}
+          {canManageRoles && <Th>{__("Role")}</Th>}
           <SortableTh field="CREATED_AT" onOrderChange={handleOrderChange}>{__("Created on")}</SortableTh>
           <Th></Th>
         </Tr>

--- a/pkg/coredata/membership_profile.go
+++ b/pkg/coredata/membership_profile.go
@@ -77,6 +77,8 @@ func (p MembershipProfile) CursorKey(orderBy MembershipProfileOrderField) page.C
 		return page.NewCursorKey(p.ID, p.CreatedAt)
 	case MembershipProfileOrderFieldFullName:
 		return page.NewCursorKey(p.ID, p.FullName)
+	case MembershipProfileOrderFieldEmailAddress:
+		return page.NewCursorKey(p.ID, p.EmailAddress)
 	case MembershipProfileOrderFieldKind:
 		return page.NewCursorKey(p.ID, p.Kind)
 	case MembershipProfileOrderFieldOrganizationName:

--- a/pkg/coredata/membership_profile_order_field.go
+++ b/pkg/coredata/membership_profile_order_field.go
@@ -28,6 +28,7 @@ type (
 const (
 	MembershipProfileOrderFieldCreatedAt        MembershipProfileOrderField = "CREATED_AT"
 	MembershipProfileOrderFieldFullName         MembershipProfileOrderField = "FULL_NAME"
+	MembershipProfileOrderFieldEmailAddress     MembershipProfileOrderField = "EMAIL_ADDRESS"
 	MembershipProfileOrderFieldKind             MembershipProfileOrderField = "KIND"
 	MembershipProfileOrderFieldOrganizationName MembershipProfileOrderField = "ORGANIZATION_NAME"
 	MembershipProfileOrderFieldState            MembershipProfileOrderField = "STATE"
@@ -44,6 +45,7 @@ func MembershipProfileOrderFields() []MembershipProfileOrderField {
 	return []MembershipProfileOrderField{
 		MembershipProfileOrderFieldCreatedAt,
 		MembershipProfileOrderFieldFullName,
+		MembershipProfileOrderFieldEmailAddress,
 		MembershipProfileOrderFieldKind,
 		MembershipProfileOrderFieldOrganizationName,
 		MembershipProfileOrderFieldState,
@@ -55,6 +57,7 @@ func (v MembershipProfileOrderField) IsValid() bool {
 	case
 		MembershipProfileOrderFieldCreatedAt,
 		MembershipProfileOrderFieldFullName,
+		MembershipProfileOrderFieldEmailAddress,
 		MembershipProfileOrderFieldKind,
 		MembershipProfileOrderFieldOrganizationName,
 		MembershipProfileOrderFieldState:

--- a/pkg/server/api/connect/v1/graphql/profile.graphql
+++ b/pkg/server/api/connect/v1/graphql/profile.graphql
@@ -53,6 +53,10 @@ enum ProfileOrderField
     @goEnum(
       value: "go.probo.inc/probo/pkg/coredata.MembershipProfileOrderFieldCreatedAt"
     )
+  EMAIL_ADDRESS
+    @goEnum(
+      value: "go.probo.inc/probo/pkg/coredata.MembershipProfileOrderFieldEmailAddress"
+    )
   KIND @goEnum(value: "go.probo.inc/probo/pkg/coredata.MembershipProfileOrderFieldKind")
   ORGANIZATION_NAME
     @goEnum(

--- a/pkg/server/api/console/v1/graphql/organization.graphql
+++ b/pkg/server/api/console/v1/graphql/organization.graphql
@@ -40,6 +40,10 @@ enum ProfileOrderField
         @goEnum(
             value: "go.probo.inc/probo/pkg/coredata.MembershipProfileOrderFieldCreatedAt"
         )
+    EMAIL_ADDRESS
+        @goEnum(
+            value: "go.probo.inc/probo/pkg/coredata.MembershipProfileOrderFieldEmailAddress"
+        )
     KIND @goEnum(value: "go.probo.inc/probo/pkg/coredata.MembershipProfileOrderFieldKind")
 }
 

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -167,6 +167,7 @@ components:
       enum:
         - CREATED_AT
         - FULL_NAME
+        - EMAIL_ADDRESS
         - KIND
       go.probo.inc/mcpgen/type: go.probo.inc/probo/pkg/coredata.MembershipProfileOrderField
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `EMAIL_ADDRESS` to `MembershipProfileOrderField` so profile order input accepts it
- support email-based cursor key generation for `MembershipProfile` pagination
- expose `EMAIL_ADDRESS` in both connect and console GraphQL `ProfileOrderField` enums
- update MCP `ProfileOrderField` enum to keep API surfaces aligned

## Validation
- `go test ./pkg/coredata`
- `go generate ./pkg/server/api/console/v1` *(fails due pre-existing missing asset: `packages/emails/emails.go:37:12: pattern dist: no matching files found`)*
- `go test ./pkg/server/api/connect/v1/types ./pkg/server/api/console/v1/types` *(console side fails with same missing `packages/emails/dist` asset)*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f94d4a03-4824-4879-98d7-26f78208f0d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f94d4a03-4824-4879-98d7-26f78208f0d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds email-based ordering for membership profiles and disables role sorting in the console people list. This enables stable email sorting with correct pagination and avoids runtime errors from unsupported role sorting.

### Coredata **`+5`** **`-0`**
Added `EMAIL_ADDRESS` to `MembershipProfileOrderField`, its validation list, and cursor key generation using `EmailAddress`.

### GraphQL API **`+8`** **`-0`**
Exposed `EMAIL_ADDRESS` in `ProfileOrderField` enums for `connect` and `console` schemas.

### MCP **`+1`** **`-0`**
Updated the profile order enum to include `EMAIL_ADDRESS`.

### App: console **`+1`** **`-1`**
Disabled sorting for the Role column in PeopleList to prevent unsupported order errors; the header stays visible but is not sortable.

<sup>Written for commit 87f0295b6bbf8e9c8506a441749d5e7b5694155c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1251?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

