### PR TITLE
Add Global vendor country region

### DIFF
--- a/packages/helpers/src/countries.ts
+++ b/packages/helpers/src/countries.ts
@@ -14,8 +14,9 @@
 
 type Translator = (s: string) => string;
 
-// ISO 3166-1 alpha-2 country codes
+// ISO 3166-1 alpha-2 country codes and supported regions.
 export const countries = [
+    "GLOBAL",
     "AD", "AE", "AF", "AG", "AI", "AL", "AM", "AO", "AQ", "AR",
     "AS", "AT", "AU", "AW", "AX", "AZ", "BA", "BB", "BD", "BE",
     "BF", "BG", "BH", "BI", "BJ", "BL", "BM", "BN", "BO", "BQ",
@@ -46,6 +47,7 @@ export const countries = [
 export type CountryCode = typeof countries[number];
 
 const countryNames: Record<CountryCode, (t: Translator) => string> = {
+    "GLOBAL": (__) => __("Global"),
     "AD": (__) => __("Andorra"),
     "AE": (__) => __("United Arab Emirates"),
     "AF": (__) => __("Afghanistan"),

--- a/packages/n8n-node/nodes/Probo/actions/thirdParty/create.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/thirdParty/create.operation.ts
@@ -169,7 +169,7 @@ export const description: INodeProperties[] = [
 				name: 'countries',
 				type: 'string',
 				default: '',
-				description: 'Comma-separated list of country codes',
+				description: 'Comma-separated list of country or region codes',
 			},
 			{
 				displayName: 'Data Processing Agreement URL',

--- a/packages/n8n-node/nodes/Probo/actions/thirdParty/update.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/thirdParty/update.operation.ts
@@ -181,7 +181,7 @@ export const description: INodeProperties[] = [
 				name: 'countries',
 				type: 'string',
 				default: '',
-				description: 'Comma-separated list of country codes',
+				description: 'Comma-separated list of country or region codes',
 			},
 			{
 				displayName: 'Data Processing Agreement URL',

--- a/pkg/coredata/country_code.go
+++ b/pkg/coredata/country_code.go
@@ -26,6 +26,10 @@ type (
 )
 
 const (
+	CountryCodeGlobal CountryCode = "GLOBAL"
+)
+
+const (
 	CountryCodeAD CountryCode = "AD"
 	CountryCodeAE CountryCode = "AE"
 	CountryCodeAF CountryCode = "AF"
@@ -286,6 +290,7 @@ var (
 func (v CountryCode) IsValid() bool {
 	switch v {
 	case
+		CountryCodeGlobal,
 		CountryCodeAD,
 		CountryCodeAE,
 		CountryCodeAF,

--- a/pkg/coredata/migrations/20260528T182700Z.sql
+++ b/pkg/coredata/migrations/20260528T182700Z.sql
@@ -1,0 +1,16 @@
+-- Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+--
+-- Permission to use, copy, modify, and/or distribute this software for any
+-- purpose with or without fee is hereby granted, provided that the above
+-- copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+-- REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+-- INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+-- LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+-- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+-- Add the Global region to vendor country selections.
+ALTER TYPE country_code ADD VALUE 'GLOBAL' BEFORE 'AD';

--- a/pkg/server/api/console/v1/graphql/base.graphql
+++ b/pkg/server/api/console/v1/graphql/base.graphql
@@ -45,6 +45,7 @@ enum OrderDirection
 
 enum CountryCode
     @goModel(model: "go.probo.inc/probo/pkg/coredata.CountryCode") {
+    GLOBAL @goEnum(value: "go.probo.inc/probo/pkg/coredata.CountryCodeGlobal")
     AD @goEnum(value: "go.probo.inc/probo/pkg/coredata.CountryCodeAD")
     AE @goEnum(value: "go.probo.inc/probo/pkg/coredata.CountryCodeAE")
     AF @goEnum(value: "go.probo.inc/probo/pkg/coredata.CountryCodeAF")

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -218,6 +218,7 @@ components:
     CountryCode:
       type: string
       enum:
+        - GLOBAL
         - AD
         - AE
         - AF
@@ -828,7 +829,7 @@ components:
           type: array
           items:
             type: string
-          description: Countries (ISO 3166-1 alpha-2 country codes)
+          description: Countries or regions (ISO 3166-1 alpha-2 country codes, EU, or GLOBAL)
         business_owner_id:
           anyOf:
             - $ref: "#/components/schemas/GID"
@@ -1054,7 +1055,7 @@ components:
           type: array
           items:
             type: string
-          description: Countries (ISO 3166-1 alpha-2 country codes)
+          description: Countries or regions (ISO 3166-1 alpha-2 country codes, EU, or GLOBAL)
         business_owner_id:
           $ref: "#/components/schemas/GID"
           description: Business owner ID
@@ -1155,7 +1156,7 @@ components:
           type: array
           items:
             type: string
-          description: Countries (ISO 3166-1 alpha-2 country codes)
+          description: Countries or regions (ISO 3166-1 alpha-2 country codes, EU, or GLOBAL)
         business_owner_id:
           $ref: "#/components/schemas/GID"
           description: Business owner ID

--- a/pkg/server/api/trust/v1/graphql/base.graphql
+++ b/pkg/server/api/trust/v1/graphql/base.graphql
@@ -55,6 +55,7 @@ type PageInfo {
 
 enum CountryCode
   @goModel(model: "go.probo.inc/probo/pkg/coredata.CountryCode") {
+  GLOBAL @goEnum(value: "go.probo.inc/probo/pkg/coredata.CountryCodeGlobal")
   AD @goEnum(value: "go.probo.inc/probo/pkg/coredata.CountryCodeAD")
   AE @goEnum(value: "go.probo.inc/probo/pkg/coredata.CountryCodeAE")
   AF @goEnum(value: "go.probo.inc/probo/pkg/coredata.CountryCodeAF")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `GLOBAL` as an accepted vendor country/region value in coredata, GraphQL, and MCP schemas
- Add a migration for the `country_code` enum
- Show Global in the shared country picker and update API descriptions that mention country codes

## Testing
- `make go-fmt`
- `CGO_ENABLED=0 GOOS= go generate ./pkg/server/api/console/v1 ./pkg/server/api/trust/v1 ./pkg/server/api/mcp/v1`
- `make test MODULE=./pkg/coredata` (6 skipped: no migrated test database configured)
- `make relay`
- `npm --workspace @probo/console run check`
- `npm --workspace @probo/trust run check`
- `npm --workspace @probo/n8n-nodes-probo run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-353](https://linear.app/probo/issue/ENG-353/add-the-region-global-in-vendor-countries)

<div><a href="https://cursor.com/agents/bc-86e3ff3a-d402-481d-a6f8-55cee3f07041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86e3ff3a-d402-481d-a6f8-55cee3f07041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GLOBAL as a supported vendor country/region across core data, GraphQL, MCP, and shared UI pickers. Satisfies ENG-353 by updating schemas and adding a migration to extend the `country_code` enum.

### Coredata **`+21`** **`-0`**
- Added `CountryCodeGlobal` and included it in validation.
- Migration adds 'GLOBAL' to the `country_code` enum.

### GraphQL API **`+2`** **`-0`**
- Exposed `GLOBAL` in the `CountryCode` enum for console and trust GraphQL schemas.

### MCP **`+4`** **`-3`**
- Added `GLOBAL` to the `CountryCode` enum.
- Updated descriptions to allow countries or regions (ISO alpha-2, EU, or GLOBAL).

### Package: helpers **`+3`** **`-1`**
- Added `GLOBAL` to the countries list and name map for the shared picker.

### Package: n8n-node **`+2`** **`-2`**
- Updated field descriptions to “country or region codes” in create/update operations.

<sup>Written for commit 29d8181b2c43ba0a3bff572447775bbe93a2aa88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1252?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

