### PR TITLE
Review solo Heroku accounts via app collaborators

### DIFF
--- a/pkg/accessreview/drivers/heroku.go
+++ b/pkg/accessreview/drivers/heroku.go
@@ -25,9 +25,28 @@ import (
 	"go.probo.inc/probo/pkg/coredata"
 )
 
-// HerokuDriver fetches team members from the Heroku Platform API using
-// a pre-authenticated HTTP client (Bearer token). Pagination is via
-// Heroku's Range / Next-Range header pair (RFC 7233 style).
+const (
+	// herokuPersonalAccountSlug is the reserved org-picker slug for a
+	// personal Heroku account (one with no Team). Heroku Teams are an
+	// opt-in paid construct, so a solo account has nothing in GET /teams;
+	// selecting this entry runs the driver in personal mode (app owner +
+	// collaborators) instead of team-member mode.
+	herokuPersonalAccountSlug = "@personal"
+
+	// herokuPersonalAccountDisplayName is the picker label and source name
+	// shown for a personal Heroku account.
+	herokuPersonalAccountDisplayName = "Personal account"
+)
+
+// HerokuDriver fetches members from the Heroku Platform API using a
+// pre-authenticated HTTP client (Bearer token). Pagination is via Heroku's
+// Range / Next-Range header pair (RFC 7233 style).
+//
+// The driver runs in one of two modes:
+//   - team mode (teamID set): list the members of GET /teams/{id}/members.
+//   - personal mode (teamID empty or the personal-account slug): a solo
+//     Heroku account has no Team, so access is granted per-app; enumerate
+//     the personal apps' owners and collaborators instead.
 //
 // Notes on data quality:
 //   - The team-members endpoint does not expose suspension state, so
@@ -36,6 +55,8 @@ import (
 //     the API still reports `two_factor_authentication`. The driver
 //     populates MFAStatus from that field and lets the access-review
 //     UI surface federation context separately.
+//   - The collaborators endpoint does not expose MFA, so personal-mode
+//     records leave MFAStatus unknown.
 type HerokuDriver struct {
 	httpClient *http.Client
 	teamID     string
@@ -69,101 +90,239 @@ type herokuTeamMember struct {
 	} `json:"user"`
 }
 
-func (d *HerokuDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error) {
-	var records []AccountRecord
+type herokuApp struct {
+	ID    string `json:"id"`
+	Owner struct {
+		ID    string `json:"id"`
+		Email string `json:"email"`
+	} `json:"owner"`
+	// Team is nil for personal apps and set for team-owned apps; we use it
+	// to keep personal mode scoped to the user's own apps.
+	Team *struct {
+		ID string `json:"id"`
+	} `json:"team"`
+}
 
+type herokuCollaborator struct {
+	Role      string `json:"role"`
+	CreatedAt string `json:"created_at"`
+	User      struct {
+		ID    string `json:"id"`
+		Email string `json:"email"`
+	} `json:"user"`
+}
+
+func (d *HerokuDriver) ListAccounts(ctx context.Context) ([]AccountRecord, error) {
+	if d.teamID == "" || d.teamID == herokuPersonalAccountSlug {
+		return d.listPersonalAccounts(ctx)
+	}
+
+	return d.listTeamMembers(ctx)
+}
+
+func (d *HerokuDriver) listTeamMembers(ctx context.Context) ([]AccountRecord, error) {
 	endpoint, err := url.JoinPath("https://api.heroku.com", "teams", url.PathEscape(d.teamID), "members")
 	if err != nil {
 		return nil, fmt.Errorf("cannot build heroku members URL: %w", err)
 	}
 
-	rangeHeader := ""
+	members, err := herokuListAll[herokuTeamMember](ctx, d.httpClient, endpoint, "members")
+	if err != nil {
+		return nil, fmt.Errorf("cannot list heroku team members: %w", err)
+	}
 
-	for range maxPaginationPages {
-		members, nextRange, err := d.queryMembers(ctx, endpoint, rangeHeader)
-		if err != nil {
-			return nil, err
+	var records []AccountRecord
+
+	for _, m := range members {
+		email := m.Email
+		if email == "" {
+			email = m.User.Email
 		}
 
-		for _, m := range members {
-			email := m.Email
-			if email == "" {
-				email = m.User.Email
+		fullName := m.User.Name
+
+		mfaStatus := coredata.MFAStatusDisabled
+		if m.TwoFactorAuthentication {
+			mfaStatus = coredata.MFAStatusEnabled
+		}
+
+		isAdmin := m.Role == "admin" || m.Role == "owner"
+
+		externalID := m.User.ID
+		if externalID == "" {
+			externalID = m.ID
+		}
+
+		record := AccountRecord{
+			Email:       email,
+			FullName:    fullName,
+			Role:        m.Role,
+			IsAdmin:     isAdmin,
+			MFAStatus:   mfaStatus,
+			AuthMethod:  coredata.AccessEntryAuthMethodUnknown,
+			AccountType: coredata.AccessEntryAccountTypeUser,
+			ExternalID:  externalID,
+		}
+
+		if m.CreatedAt != "" {
+			if t, err := time.Parse(time.RFC3339, m.CreatedAt); err == nil {
+				record.CreatedAt = &t
+			}
+		}
+
+		records = append(records, record)
+	}
+
+	return records, nil
+}
+
+// listPersonalAccounts enumerates the people with access to a personal
+// (non-team) Heroku account: the owner of each personal app plus every
+// collaborator on it, deduplicated by Heroku user ID. Personal accounts
+// have no Team, so there are no team members to list; access is granted
+// per-app via collaborators.
+func (d *HerokuDriver) listPersonalAccounts(ctx context.Context) ([]AccountRecord, error) {
+	// GET /apps returns every app the token can see, both owned and
+	// collaborated-on. We skip team-owned apps below (those belong to a
+	// team-scoped review); the remaining personal apps are the account
+	// under review. Scoping strictly to apps the connector owns would need
+	// the account ID from GET /account, which requires the identity OAuth
+	// scope we deliberately do not request.
+	apps, err := herokuListAll[herokuApp](ctx, d.httpClient, "https://api.heroku.com/apps", "apps")
+	if err != nil {
+		return nil, fmt.Errorf("cannot list heroku personal apps: %w", err)
+	}
+
+	var records []AccountRecord
+
+	// Dedupe by Heroku user ID across all apps: a user collaborating on
+	// several apps is one account in the review. An admin grant on any
+	// app wins.
+	seen := make(map[string]int)
+
+	upsert := func(rec AccountRecord) {
+		key := rec.ExternalID
+		if key == "" {
+			key = rec.Email
+		}
+
+		if key == "" {
+			return
+		}
+
+		if i, ok := seen[key]; ok {
+			if rec.IsAdmin {
+				records[i].IsAdmin = true
 			}
 
-			fullName := m.User.Name
+			return
+		}
 
-			mfaStatus := coredata.MFAStatusDisabled
-			if m.TwoFactorAuthentication {
-				mfaStatus = coredata.MFAStatusEnabled
-			}
+		seen[key] = len(records)
+		records = append(records, rec)
+	}
 
-			isAdmin := m.Role == "admin" || m.Role == "owner"
+	for _, app := range apps {
+		// Skip team-owned apps; those belong to a team-scoped review.
+		if app.Team != nil {
+			continue
+		}
 
-			externalID := m.User.ID
-			if externalID == "" {
-				externalID = m.ID
-			}
+		// The owner always has access, whether or not they also appear in
+		// the collaborators list.
+		upsert(herokuPersonalRecord(app.Owner.ID, app.Owner.Email, "owner", true))
 
-			record := AccountRecord{
-				Email:       email,
-				FullName:    fullName,
-				Role:        m.Role,
-				IsAdmin:     isAdmin,
-				MFAStatus:   mfaStatus,
-				AuthMethod:  coredata.AccessEntryAuthMethodUnknown,
-				AccountType: coredata.AccessEntryAccountTypeUser,
-				ExternalID:  externalID,
-			}
+		endpoint, err := url.JoinPath("https://api.heroku.com", "apps", url.PathEscape(app.ID), "collaborators")
+		if err != nil {
+			return nil, fmt.Errorf("cannot build heroku collaborators URL: %w", err)
+		}
 
-			if m.CreatedAt != "" {
-				if t, err := time.Parse(time.RFC3339, m.CreatedAt); err == nil {
+		collaborators, err := herokuListAll[herokuCollaborator](ctx, d.httpClient, endpoint, "collaborators")
+		if err != nil {
+			return nil, fmt.Errorf("cannot list heroku collaborators for app %q: %w", app.ID, err)
+		}
+
+		for _, c := range collaborators {
+			record := herokuPersonalRecord(c.User.ID, c.User.Email, c.Role, c.Role == "admin" || c.Role == "owner")
+
+			if c.CreatedAt != "" {
+				if t, err := time.Parse(time.RFC3339, c.CreatedAt); err == nil {
 					record.CreatedAt = &t
 				}
 			}
 
-			records = append(records, record)
+			upsert(record)
+		}
+	}
+
+	return records, nil
+}
+
+// herokuPersonalRecord builds an AccountRecord for a person with access to a
+// personal Heroku app. These endpoints expose no display name or MFA signal,
+// so the email doubles as the full name and MFA is left unknown.
+func herokuPersonalRecord(externalID, email, role string, isAdmin bool) AccountRecord {
+	return AccountRecord{
+		Email:       email,
+		FullName:    email,
+		Role:        role,
+		IsAdmin:     isAdmin,
+		MFAStatus:   coredata.MFAStatusUnknown,
+		AuthMethod:  coredata.AccessEntryAuthMethodUnknown,
+		AccountType: coredata.AccessEntryAccountTypeUser,
+		ExternalID:  externalID,
+	}
+}
+
+// herokuListAll fetches every page of a Heroku collection endpoint,
+// following the Range / Next-Range pagination header pair, and decodes each
+// page into T. label names the resource in error messages (e.g. "members").
+func herokuListAll[T any](ctx context.Context, client *http.Client, endpoint, label string) ([]T, error) {
+	var all []T
+
+	rangeHeader := ""
+
+	for range maxPaginationPages {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+		if err != nil {
+			return nil, fmt.Errorf("cannot create heroku %s request: %w", label, err)
 		}
 
+		req.Header.Set("Accept", "application/vnd.heroku+json; version=3")
+
+		if rangeHeader != "" {
+			req.Header.Set("Range", rangeHeader)
+		}
+
+		httpResp, err := client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("cannot execute heroku %s request: %w", label, err)
+		}
+
+		// Heroku returns 206 Partial Content for ranged responses with more
+		// pages, and 200 OK for the final/only page.
+		if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+			_ = httpResp.Body.Close()
+			return nil, fmt.Errorf("cannot fetch heroku %s: unexpected status %d", label, httpResp.StatusCode)
+		}
+
+		var page []T
+		if err := json.NewDecoder(httpResp.Body).Decode(&page); err != nil {
+			_ = httpResp.Body.Close()
+			return nil, fmt.Errorf("cannot decode heroku %s response: %w", label, err)
+		}
+
+		nextRange := httpResp.Header.Get("Next-Range")
+		_ = httpResp.Body.Close()
+
+		all = append(all, page...)
+
 		if nextRange == "" {
-			return records, nil
+			return all, nil
 		}
 
 		rangeHeader = nextRange
 	}
 
-	return nil, fmt.Errorf("cannot list all heroku accounts: %w", ErrPaginationLimitReached)
-}
-
-func (d *HerokuDriver) queryMembers(ctx context.Context, endpoint, rangeHeader string) ([]herokuTeamMember, string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return nil, "", fmt.Errorf("cannot create heroku members request: %w", err)
-	}
-
-	req.Header.Set("Accept", "application/vnd.heroku+json; version=3")
-
-	if rangeHeader != "" {
-		req.Header.Set("Range", rangeHeader)
-	}
-
-	httpResp, err := d.httpClient.Do(req)
-	if err != nil {
-		return nil, "", fmt.Errorf("cannot execute heroku members request: %w", err)
-	}
-
-	defer func() { _ = httpResp.Body.Close() }()
-
-	// Heroku returns 206 Partial Content for ranged responses with more
-	// pages, and 200 OK for the final/only page.
-	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
-		return nil, "", fmt.Errorf("cannot fetch heroku members: unexpected status %d", httpResp.StatusCode)
-	}
-
-	var members []herokuTeamMember
-	if err := json.NewDecoder(httpResp.Body).Decode(&members); err != nil {
-		return nil, "", fmt.Errorf("cannot decode heroku members response: %w", err)
-	}
-
-	return members, httpResp.Header.Get("Next-Range"), nil
+	return nil, fmt.Errorf("cannot list all heroku %s: %w", label, ErrPaginationLimitReached)
 }

--- a/pkg/accessreview/drivers/heroku_test.go
+++ b/pkg/accessreview/drivers/heroku_test.go
@@ -16,6 +16,8 @@ package drivers
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -48,4 +50,135 @@ func TestHerokuDriver(t *testing.T) {
 	assert.Equal(t, coredata.MFAStatusEnabled, r.MFAStatus)
 	assert.True(t, r.IsAdmin)
 	require.NotNil(t, r.CreatedAt)
+}
+
+// TestHerokuDriverPersonalAccount exercises personal mode (empty teamID): a
+// solo account with no Team is reviewed via its apps' owner + collaborators.
+// It verifies the owner is always included, collaborators are deduped across
+// apps, and team-owned apps are skipped.
+func TestHerokuDriverPersonalAccount(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/apps":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[
+				{"id":"app-1","name":"one","owner":{"id":"u-alice","email":"alice@example.com"},"team":null},
+				{"id":"app-2","name":"two","owner":{"id":"u-alice","email":"alice@example.com"},"team":null},
+				{"id":"app-3","name":"teamed","owner":{"id":"u-x","email":"x@example.com"},"team":{"id":"team-1"}}
+			]`))
+		case "/apps/app-1/collaborators":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[
+				{"id":"c-1","role":"owner","user":{"id":"u-alice","email":"alice@example.com"}},
+				{"id":"c-2","role":"member","user":{"id":"u-bob","email":"bob@example.com"}}
+			]`))
+		case "/apps/app-2/collaborators":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[
+				{"id":"c-3","role":"member","user":{"id":"u-bob","email":"bob@example.com"}},
+				{"id":"c-4","role":"member","user":{"id":"u-carol","email":"carol@example.com"}}
+			]`))
+		default:
+			t.Errorf("unexpected request to %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: &hostRewriter{target: srv.URL}}
+
+	records, err := NewHerokuDriver(client, "").ListAccounts(context.Background())
+	require.NoError(t, err)
+
+	byEmail := make(map[string]AccountRecord, len(records))
+	for _, r := range records {
+		byEmail[r.Email] = r
+	}
+
+	require.Len(t, records, 3)
+	assert.Contains(t, byEmail, "alice@example.com")
+	assert.Contains(t, byEmail, "bob@example.com")
+	assert.Contains(t, byEmail, "carol@example.com")
+
+	assert.True(t, byEmail["alice@example.com"].IsAdmin)
+	assert.Equal(t, "owner", byEmail["alice@example.com"].Role)
+	assert.False(t, byEmail["bob@example.com"].IsAdmin)
+}
+
+// TestHerokuDriverPersonalAccountSlug verifies the reserved personal-account
+// slug routes to personal mode just like an empty teamID.
+func TestHerokuDriverPersonalAccountSlug(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/apps":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"id":"app-1","name":"one","owner":{"id":"u-alice","email":"alice@example.com"},"team":null}]`))
+		case "/apps/app-1/collaborators":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			t.Errorf("unexpected request to %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: &hostRewriter{target: srv.URL}}
+
+	records, err := NewHerokuDriver(client, herokuPersonalAccountSlug).ListAccounts(context.Background())
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, "alice@example.com", records[0].Email)
+}
+
+// TestHerokuDriverPersonalAccountErrors verifies non-2xx responses on the
+// personal-mode endpoints propagate as errors rather than empty results.
+func TestHerokuDriverPersonalAccountErrors(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		appsCode  int
+		collabFor string
+	}{
+		{name: "apps list fails", appsCode: http.StatusInternalServerError},
+		{name: "collaborators fail", appsCode: http.StatusOK, collabFor: "app-1"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+
+				switch r.URL.Path {
+				case "/apps":
+					w.WriteHeader(tc.appsCode)
+					_, _ = w.Write([]byte(`[{"id":"app-1","name":"one","owner":{"id":"u-alice","email":"alice@example.com"},"team":null}]`))
+				case "/apps/app-1/collaborators":
+					w.WriteHeader(http.StatusForbidden)
+					_, _ = w.Write([]byte(`{"id":"forbidden"}`))
+				default:
+					t.Errorf("unexpected request to %s", r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer srv.Close()
+
+			client := &http.Client{Transport: &hostRewriter{target: srv.URL}}
+
+			_, err := NewHerokuDriver(client, "").ListAccounts(context.Background())
+			require.Error(t, err)
+		})
+	}
 }

--- a/pkg/accessreview/drivers/name_resolver.go
+++ b/pkg/accessreview/drivers/name_resolver.go
@@ -726,6 +726,12 @@ func (r *herokuNameResolver) ResolveInstanceName(ctx context.Context) (string, e
 		return "", nil
 	}
 
+	// A personal account has no Team to name; short-circuit before hitting
+	// GET /teams/@personal, which 404s and would loop the source-name worker.
+	if r.teamID == herokuPersonalAccountSlug {
+		return herokuPersonalAccountDisplayName, nil
+	}
+
 	endpoint, err := url.JoinPath("https://api.heroku.com", "teams", url.PathEscape(r.teamID))
 	if err != nil {
 		return "", fmt.Errorf("cannot build heroku team URL: %w", err)

--- a/pkg/accessreview/drivers/name_resolver_test.go
+++ b/pkg/accessreview/drivers/name_resolver_test.go
@@ -248,6 +248,42 @@ func TestTailscaleNameResolver(t *testing.T) {
 	}
 }
 
+func TestHerokuNameResolver(t *testing.T) {
+	t.Parallel()
+
+	t.Run("personal-account slug returns a name without an HTTP call", func(t *testing.T) {
+		t.Parallel()
+
+		client := &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			t.Fatalf("resolver should not make an HTTP call for a personal account")
+			return nil, nil
+		})}
+
+		got, err := NewHerokuNameResolver(client, herokuPersonalAccountSlug).ResolveInstanceName(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "Personal account", got)
+	})
+
+	t.Run("team slug resolves the team name", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "/teams/acme", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"name":"Acme Inc"}`))
+		}))
+		defer srv.Close()
+
+		client := &http.Client{Transport: &hostRewriter{target: srv.URL}}
+
+		got, err := NewHerokuNameResolver(client, "acme").ResolveInstanceName(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "Acme Inc", got)
+	})
+}
+
 // roundTripperFunc adapts a function into an http.RoundTripper, useful for
 // asserting that a resolver short-circuits before making any HTTP call.
 type roundTripperFunc func(*http.Request) (*http.Response, error)

--- a/pkg/accessreview/drivers/organizations.go
+++ b/pkg/accessreview/drivers/organizations.go
@@ -245,7 +245,11 @@ func ListBitbucketOrganizations(ctx context.Context, httpClient *http.Client) ([
 }
 
 // ListHerokuOrganizations fetches the teams the authenticated Heroku
-// user belongs to.
+// user belongs to, and always appends a synthetic "Personal account"
+// entry. Heroku Teams are an opt-in paid construct, so a solo account has
+// no team to discover; the personal entry lets the picker offer personal
+// mode (app owner + collaborators) instead of dead-ending at a free-text
+// slug the user cannot fill.
 func ListHerokuOrganizations(ctx context.Context, httpClient *http.Client) ([]Organization, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.heroku.com/teams", nil)
 	if err != nil {
@@ -273,15 +277,20 @@ func ListHerokuOrganizations(ctx context.Context, httpClient *http.Client) ([]Or
 		return nil, fmt.Errorf("cannot decode heroku organizations response: %w", err)
 	}
 
-	result := make([]Organization, len(teams))
-	for i, t := range teams {
+	result := make([]Organization, 0, len(teams)+1)
+	for _, t := range teams {
 		displayName := t.Name
 		if displayName == "" {
 			displayName = t.ID
 		}
 
-		result[i] = Organization{Slug: t.ID, DisplayName: displayName}
+		result = append(result, Organization{Slug: t.ID, DisplayName: displayName})
 	}
+
+	result = append(result, Organization{
+		Slug:        herokuPersonalAccountSlug,
+		DisplayName: herokuPersonalAccountDisplayName,
+	})
 
 	return result, nil
 }

--- a/pkg/connector/provider/heroku.go
+++ b/pkg/connector/provider/heroku.go
@@ -38,10 +38,9 @@ func herokuRegistration() *Registration {
 				return nil, fmt.Errorf("cannot read heroku connector settings: %w", err)
 			}
 
-			if s.TeamID == "" {
-				return nil, fmt.Errorf("cannot create heroku driver: team_id is required")
-			}
-
+			// TeamID may be empty or the personal-account slug for a solo
+			// Heroku account (no Team); the driver runs in personal mode
+			// (app owner + collaborators) in that case.
 			return drivers.NewHerokuDriver(c, s.TeamID), nil
 		},
 		NewNameResolver: func(ctx context.Context, c *http.Client, conn *coredata.Connector, logger *log.Logger) drivers.NameResolver {


### PR DESCRIPTION
## Problem

A solo Heroku connector shows a free-text "Organization Slug" field while every other provider shows a dropdown. The cause is structural, not a UI bug: discovery (`ListHerokuOrganizations` → `GET /teams`) is already wired with `NeedsPicker: true`, and the frontend only falls back to the text input when `providerOrganizations` is empty.

A **personal/solo Heroku account has no Team** — Heroku Teams are an opt-in paid construct ([Heroku docs](https://help.heroku.com/1CBGQE3H/heroku-personal-accounts-vs-team-accounts)) — so `GET /teams` legitimately returns `[]`. The text field is then a dead end: there's no team ID to type, and the driver only knew how to hit `GET /teams/{id}/members`. So solo accounts couldn't be reviewed at all.

## Fix

For a personal account, access is granted per app via **collaborators**. This PR adds a personal mode and surfaces it through the existing picker pattern:

- **Driver** (`heroku.go`): when no team is configured, enumerate the user's personal apps (`GET /apps`, skipping team-owned ones) and collect each app's **owner + collaborators**, deduped by Heroku user ID. Yields just the owner when there are no collaborators. Stays within the current `read` OAuth scope (no `GET /account`, no reconnect). The Range/Next-Range pagination shared by the members/apps/collaborators endpoints is factored into one `herokuListAll` helper.
- **Picker** (`organizations.go`): always append a synthetic **"Personal account"** entry, so solo accounts get a dropdown (with one option) instead of the free-text dead end. Team accounts see their teams **+** Personal account.
- **Provider** (`provider/heroku.go`): drop the `team_id`-required guard so an empty / personal-account slug selects personal mode.
- **Name resolver** (`name_resolver.go`): short-circuit the personal-account slug to a static name. Without this, `GET /teams/@personal` 404s and loops the source-name worker — the same failure mode as the stale-Sentry-slug fix.

## Tests

- `TestHerokuDriverPersonalAccount` — owner always included, collaborators deduped across apps, team-owned apps skipped (httptest, no real token).
- `TestHerokuDriverPersonalAccountSlug` — reserved slug routes to personal mode.
- `TestHerokuNameResolver` — personal slug resolves without an HTTP call; team slug still hits `GET /teams/{id}`.
- Existing `TestHerokuDriver` (cassette) still passes — the pagination refactor is behavior-preserving.

## Verification needed against a real token

The collaborator/app JSON field names and whether the owner is already present in the collaborators list could not be confirmed against the (perpetually-truncating) live API reference — that's why the owner is added explicitly rather than relying on the collaborators list. A cassette recorded against a real Heroku token (per the driver test workflow) should pin/confirm the exact shapes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables access reviews for solo Heroku accounts by listing personal apps and their collaborators when no team is selected. Adds a "Personal account" picker option and resolves it without an API call; team-mode remains unchanged.

### Service **`+414`** **`-72`**
- Add personal mode in the Heroku driver: when `team_id` is empty or `@personal`, list personal apps, include owner + collaborators, skip team-owned apps, dedupe by user ID, and let any admin grant win.
- Factor shared Range/Next-Range pagination into `herokuListAll` for members, apps, and collaborators.
- Always append "Personal account" to the Heroku org picker.
- Short-circuit `@personal` to "Personal account" in the name resolver to avoid 404 loops.
- Allow empty team in the Heroku provider so the driver can run in personal mode.
- Tests: cover personal mode, slug routing, resolver, and error paths; existing team-mode tests stay green.

<sup>Written for commit e0c53e7a518abcad13b44d3f812e52d20075dcdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1254?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

