### PR TITLE
Reject last owner demotion

### DIFF
--- a/e2e/console/user_test.go
+++ b/e2e/console/user_test.go
@@ -115,6 +115,109 @@ func TestUser_UpdateMembership(t *testing.T) {
 	assert.Equal(t, "VIEWER", mutationResult.UpdateMembership.Membership.Role)
 }
 
+func TestUser_UpdateMembershipRejectsLastOwnerDemotion(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+
+	queryMembers := `
+		query($id: ID!) {
+			node(id: $id) {
+				... on Organization {
+					members(first: 10) {
+						edges {
+							node {
+								id
+								identity { id }
+								role
+							}
+						}
+					}
+				}
+			}
+		}
+	`
+
+	var membersResult struct {
+		Node struct {
+			Members struct {
+				Edges []struct {
+					Node struct {
+						ID       string `json:"id"`
+						Identity struct {
+							ID string `json:"id"`
+						} `json:"identity"`
+						Role string `json:"role"`
+					} `json:"node"`
+				} `json:"edges"`
+			} `json:"members"`
+		} `json:"node"`
+	}
+
+	err := owner.ExecuteConnect(queryMembers, map[string]any{
+		"id": owner.GetOrganizationID().String(),
+	}, &membersResult)
+	require.NoError(t, err)
+
+	var ownerMembershipID string
+	for _, edge := range membersResult.Node.Members.Edges {
+		if edge.Node.Identity.ID == owner.GetUserID().String() {
+			ownerMembershipID = edge.Node.ID
+			assert.Equal(t, "OWNER", edge.Node.Role)
+			break
+		}
+	}
+
+	require.NotEmpty(t, ownerMembershipID, "Should find owner member")
+
+	mutation := `
+		mutation($input: UpdateMembershipInput!) {
+			updateMembership(input: $input) {
+				membership {
+					id
+					role
+				}
+			}
+		}
+	`
+
+	err = owner.ExecuteConnect(mutation, map[string]any{
+		"input": map[string]any{
+			"organizationId": owner.GetOrganizationID().String(),
+			"membershipId":   ownerMembershipID,
+			"role":           "VIEWER",
+		},
+	}, nil)
+	testutil.RequireErrorCode(t, err, "CONFLICT")
+
+	var gqlErrors testutil.GraphQLErrors
+	require.ErrorAs(t, err, &gqlErrors)
+	assert.Equal(t, "cannot demote last active owner", gqlErrors[0].Message)
+
+	queryMembership := `
+		query($id: ID!) {
+			node(id: $id) {
+				... on Membership {
+					id
+					role
+				}
+			}
+		}
+	`
+
+	var membershipResult struct {
+		Node struct {
+			ID   string `json:"id"`
+			Role string `json:"role"`
+		} `json:"node"`
+	}
+
+	err = owner.ExecuteConnect(queryMembership, map[string]any{
+		"id": ownerMembershipID,
+	}, &membershipResult)
+	require.NoError(t, err)
+	assert.Equal(t, "OWNER", membershipResult.Node.Role)
+}
+
 func TestUser_RemoveUser(t *testing.T) {
 	t.Parallel()
 	owner := testutil.NewClient(t, testutil.RoleOwner)

--- a/e2e/console/user_test.go
+++ b/e2e/console/user_test.go
@@ -159,6 +159,7 @@ func TestUser_UpdateMembershipRejectsLastOwnerDemotion(t *testing.T) {
 	require.NoError(t, err)
 
 	var ownerMembershipID string
+
 	for _, edge := range profilesResult.Node.Profiles.Edges {
 		if edge.Node.Membership.Role == "OWNER" {
 			ownerMembershipID = edge.Node.Membership.ID

--- a/e2e/console/user_test.go
+++ b/e2e/console/user_test.go
@@ -119,16 +119,17 @@ func TestUser_UpdateMembershipRejectsLastOwnerDemotion(t *testing.T) {
 	t.Parallel()
 	owner := testutil.NewClient(t, testutil.RoleOwner)
 
-	queryMembers := `
+	queryProfiles := `
 		query($id: ID!) {
 			node(id: $id) {
 				... on Organization {
-					members(first: 10) {
+					profiles(first: 10) {
 						edges {
 							node {
-								id
-								identity { id }
-								role
+								membership {
+									id
+									role
+								}
 							}
 						}
 					}
@@ -137,32 +138,31 @@ func TestUser_UpdateMembershipRejectsLastOwnerDemotion(t *testing.T) {
 		}
 	`
 
-	var membersResult struct {
+	var profilesResult struct {
 		Node struct {
-			Members struct {
+			Profiles struct {
 				Edges []struct {
 					Node struct {
-						ID       string `json:"id"`
-						Identity struct {
-							ID string `json:"id"`
-						} `json:"identity"`
-						Role string `json:"role"`
+						Membership struct {
+							ID   string `json:"id"`
+							Role string `json:"role"`
+						} `json:"membership"`
 					} `json:"node"`
 				} `json:"edges"`
-			} `json:"members"`
+			} `json:"profiles"`
 		} `json:"node"`
 	}
 
-	err := owner.ExecuteConnect(queryMembers, map[string]any{
+	err := owner.ExecuteConnect(queryProfiles, map[string]any{
 		"id": owner.GetOrganizationID().String(),
-	}, &membersResult)
+	}, &profilesResult)
 	require.NoError(t, err)
 
 	var ownerMembershipID string
-	for _, edge := range membersResult.Node.Members.Edges {
-		if edge.Node.Identity.ID == owner.GetUserID().String() {
-			ownerMembershipID = edge.Node.ID
-			assert.Equal(t, "OWNER", edge.Node.Role)
+	for _, edge := range profilesResult.Node.Profiles.Edges {
+		if edge.Node.Membership.Role == "OWNER" {
+			ownerMembershipID = edge.Node.Membership.ID
+
 			break
 		}
 	}

--- a/pkg/server/api/connect/v1/membership_resolvers.go
+++ b/pkg/server/api/connect/v1/membership_resolvers.go
@@ -63,6 +63,10 @@ func (r *mutationResolver) UpdateMembership(ctx context.Context, input types.Upd
 
 	membership, err := r.iam.OrganizationService.UpdateMembership(ctx, input.OrganizationID, input.MembershipID, input.Role)
 	if err != nil {
+		if _, ok := errors.AsType[*iam.ErrLastActiveOwner](err); ok {
+			return nil, gqlutils.Conflictf(ctx, "cannot demote last active owner")
+		}
+
 		r.logger.ErrorCtx(ctx, "cannot update membership", log.Error(err))
 		return nil, gqlutils.Internal(ctx)
 	}

--- a/pkg/server/api/connect/v1/membership_resolvers.go
+++ b/pkg/server/api/connect/v1/membership_resolvers.go
@@ -68,6 +68,7 @@ func (r *mutationResolver) UpdateMembership(ctx context.Context, input types.Upd
 		}
 
 		r.logger.ErrorCtx(ctx, "cannot update membership", log.Error(err))
+
 		return nil, gqlutils.Internal(ctx)
 	}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- return a conflict for membership updates that would demote the last active owner
- add an e2e regression for sole-owner self-demotion attempts
- fix the regression test to use the Connect schema's `profiles` connection and satisfy Go whitespace lint

## Tests
- `make go-fmt`
- `go test ./pkg/server/api/connect/v1 ./pkg/iam`
- CI `lint-go` passed on commit `d522f1d`
- CI `test-e2e` passed on commit `d522f1d`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-294](https://linear.app/probo/issue/ENG-294/last-owner-in-organization-can-demote-themselves-causing-permanent-org)

<div><a href="https://cursor.com/agents/bc-65c3a109-c86c-4221-8ba2-8024a4a91424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65c3a109-c86c-4221-8ba2-8024a4a91424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents demoting the last active organization owner (ENG-294). The Connect GraphQL mutation now returns a conflict on such updates, and an e2e test verifies the role stays OWNER.

### GraphQL API **`+5`** **`-0`**
- Return CONFLICT when `updateMembership` would demote the last active owner.
- Map `iam.ErrLastActiveOwner` to user-facing message: "cannot demote last active owner".

### Tests **`+104`** **`-0`**
- Add e2e for sole-owner self-demotion; expect CONFLICT and role remains OWNER.
- Use Connect `profiles` connection; adjust whitespace and variable declarations to satisfy lint.

<sup>Written for commit 0136e34986c04115d1e73b4c22d93a3fff380afb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1257?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

