### PR TITLE
Cancel signature requests on deactivation

### DIFF
--- a/e2e/console/user_test.go
+++ b/e2e/console/user_test.go
@@ -321,6 +321,114 @@ func TestUser_ArchiveUser(t *testing.T) {
 	assert.Equal(t, "INACTIVE", archivedUserState)
 }
 
+func TestUser_DeactivateUserCancelsSignatureRequests(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	signer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+
+	docID, _ := createTestDocument(t, owner)
+	approveTestDocument(t, owner, docID)
+
+	var versionResult struct {
+		Node struct {
+			Versions struct {
+				Edges []struct {
+					Node struct {
+						ID string `json:"id"`
+					} `json:"node"`
+				} `json:"edges"`
+			} `json:"versions"`
+		} `json:"node"`
+	}
+
+	err := owner.Execute(`
+		query($id: ID!) {
+			node(id: $id) {
+				... on Document {
+					versions(first: 1, orderBy: { field: CREATED_AT, direction: DESC }) {
+						edges { node { id } }
+					}
+				}
+			}
+		}
+	`, map[string]any{"id": docID}, &versionResult)
+	require.NoError(t, err)
+	require.NotEmpty(t, versionResult.Node.Versions.Edges)
+
+	documentVersionID := versionResult.Node.Versions.Edges[0].Node.ID
+	signerProfileID := signer.GetProfileID().String()
+
+	_, err = owner.Do(`
+		mutation($input: RequestSignatureInput!) {
+			requestSignature(input: $input) {
+				documentVersionSignatureEdge { node { id } }
+			}
+		}
+	`, map[string]any{
+		"input": map[string]any{
+			"documentVersionId": documentVersionID,
+			"signatoryId":       signerProfileID,
+		},
+	})
+	require.NoError(t, err)
+
+	assertRequestedSignatureCount(t, owner, documentVersionID, 1)
+
+	var deactivateResult struct {
+		DeactivateUser struct {
+			Success bool `json:"success"`
+		} `json:"deactivateUser"`
+	}
+
+	err = owner.ExecuteConnect(`
+		mutation($input: DeactivateUserInput!) {
+			deactivateUser(input: $input) {
+				success
+			}
+		}
+	`, map[string]any{
+		"input": map[string]any{
+			"organizationId": owner.GetOrganizationID().String(),
+			"profileId":      signerProfileID,
+		},
+	}, &deactivateResult)
+	require.NoError(t, err)
+	require.True(t, deactivateResult.DeactivateUser.Success)
+
+	assertRequestedSignatureCount(t, owner, documentVersionID, 0)
+}
+
+func assertRequestedSignatureCount(
+	t *testing.T,
+	owner *testutil.Client,
+	documentVersionID string,
+	expected int,
+) {
+	t.Helper()
+
+	var result struct {
+		Node struct {
+			Signatures struct {
+				TotalCount int `json:"totalCount"`
+			} `json:"signatures"`
+		} `json:"node"`
+	}
+
+	err := owner.Execute(`
+		query($id: ID!) {
+			node(id: $id) {
+				... on DocumentVersion {
+					signatures(first: 10, filter: { states: [REQUESTED] }) {
+						totalCount
+					}
+				}
+			}
+		}
+	`, map[string]any{"id": documentVersionID}, &result)
+	require.NoError(t, err)
+	assert.Equal(t, expected, result.Node.Signatures.TotalCount)
+}
+
 func TestUser_RemoveOwner(t *testing.T) {
 	t.Parallel()
 	owner := testutil.NewClient(t, testutil.RoleOwner)

--- a/pkg/coredata/document_version_signature.go
+++ b/pkg/coredata/document_version_signature.go
@@ -373,6 +373,36 @@ WHERE
 	return nil
 }
 
+func (pvss *DocumentVersionSignatures) DeleteRequestedBySignatory(
+	ctx context.Context,
+	conn pg.Tx,
+	scope Scoper,
+	signatoryID gid.GID,
+) error {
+	q := `
+DELETE FROM document_version_signatures
+WHERE
+	%s
+	AND signed_by_profile_id = @signatory_id
+	AND state = @state
+`
+
+	q = fmt.Sprintf(q, scope.SQLFragment())
+
+	args := pgx.StrictNamedArgs{
+		"signatory_id": signatoryID,
+		"state":        DocumentVersionSignatureStateRequested,
+	}
+	maps.Copy(args, scope.SQLArguments())
+
+	_, err := conn.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot delete requested document version signatures: %w", err)
+	}
+
+	return nil
+}
+
 func (pvss *DocumentVersionSignaturesWithPeople) LoadByDocumentVersionIDWithPeople(
 	ctx context.Context,
 	conn pg.Querier,

--- a/pkg/coredata/document_version_signature.go
+++ b/pkg/coredata/document_version_signature.go
@@ -395,8 +395,7 @@ WHERE
 	}
 	maps.Copy(args, scope.SQLArguments())
 
-	_, err := conn.Exec(ctx, q, args)
-	if err != nil {
+	if _, err := conn.Exec(ctx, q, args); err != nil {
 		return fmt.Errorf("cannot delete requested document version signatures: %w", err)
 	}
 

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -425,6 +425,11 @@ func (s *OrganizationService) ArchiveUser(
 				return fmt.Errorf("cannot expire pending invitations: %w", err)
 			}
 
+			signatures := &coredata.DocumentVersionSignatures{}
+			if err := signatures.DeleteRequestedBySignatory(ctx, tx, scope, profile.ID); err != nil {
+				return fmt.Errorf("cannot delete requested signatures: %w", err)
+			}
+
 			now := time.Now()
 
 			if profile.State != coredata.ProfileStateInactive {
@@ -1159,6 +1164,13 @@ func (s *OrganizationService) UpdateUserState(
 
 			if err := profile.Update(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot update profile: %w", err)
+			}
+
+			if state == coredata.ProfileStateInactive {
+				signatures := &coredata.DocumentVersionSignatures{}
+				if err := signatures.DeleteRequestedBySignatory(ctx, tx, scope, profile.ID); err != nil {
+					return fmt.Errorf("cannot delete requested signatures: %w", err)
+				}
 			}
 
 			return nil

--- a/pkg/iam/scim/service.go
+++ b/pkg/iam/scim/service.go
@@ -299,6 +299,11 @@ func (s *Service) CreateUser(
 			); err != nil {
 				return fmt.Errorf("cannot expire pending invitations: %w", err)
 			}
+
+			signatures := &coredata.DocumentVersionSignatures{}
+			if err := signatures.DeleteRequestedBySignatory(ctx, tx, scope, profile.ID); err != nil {
+				return fmt.Errorf("cannot delete requested signatures: %w", err)
+			}
 		}
 
 		membership = &coredata.Membership{}
@@ -728,6 +733,11 @@ func (s *Service) updateUser(
 					onlyPending,
 				); err != nil {
 					return fmt.Errorf("cannot expire pending invitations: %w", err)
+				}
+
+				signatures := &coredata.DocumentVersionSignatures{}
+				if err := signatures.DeleteRequestedBySignatory(ctx, tx, scope, profile.ID); err != nil {
+					return fmt.Errorf("cannot delete requested signatures: %w", err)
 				}
 			}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Delete requested document signature records for a profile when the profile is deactivated or archived.
- Apply the same cleanup to SCIM inactive transitions.
- Add a console e2e test covering signature cancellation after user deactivation.

## Tests
- `make go-fmt`
- `go test ./pkg/coredata ./pkg/iam/...`
- `PROBO_E2E_BINARY=/workspace/bin/probod PROBO_E2E_CONFIG=/workspace/e2e/console/testdata/config.yaml CGO_ENABLED=1 go test -count=1 -run TestUser_DeactivateUserCancelsSignatureRequests ./e2e/console` *(fails locally: Postgres at localhost:5432 is not running)*
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-404](https://linear.app/probo/issue/ENG-404/cancel-signature-requests-when-disabling-an-account)

<div><a href="https://cursor.com/agents/bc-918c1229-be88-43b6-bccc-c82bb2d9b08d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-918c1229-be88-43b6-bccc-c82bb2d9b08d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancel pending document signature requests when a user is deactivated or archived, including SCIM deprovisioning. Adds an e2e test for this behavior; satisfies ENG-404.

### Coredata **`+29`** **`-0`**
- Add `DeleteRequestedBySignatory` to `DocumentVersionSignatures` to remove `REQUESTED` signatures by signatory within a scope.

### Service **`+22`** **`-0`**
- Call cleanup on archive and `INACTIVE` transitions in `pkg/iam/organization_service.go`.
- Apply the same for SCIM deactivations in `pkg/iam/scim/service.go` with inline error handling.

### Tests **`+108`** **`-0`**
- Add e2e test to request a signature, deactivate the signer, and verify no `REQUESTED` signatures remain.

<sup>Written for commit 72c35a99678cc72e849ffc66fc234f0ade86482e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1258?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

