### PR TITLE
Hide stale pending signatures from exports

### DIFF
--- a/e2e/console/user_test.go
+++ b/e2e/console/user_test.go
@@ -16,6 +16,7 @@ package console_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -394,6 +395,79 @@ func TestUser_DeactivateUserCancelsSignatureRequests(t *testing.T) {
 	}, &deactivateResult)
 	require.NoError(t, err)
 	require.True(t, deactivateResult.DeactivateUser.Success)
+
+	assertRequestedSignatureCount(t, owner, documentVersionID, 0)
+}
+
+func TestUser_EndedContractCancelsSignatureRequests(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+	signer := testutil.NewClientInOrg(t, testutil.RoleViewer, owner)
+
+	docID, _ := createTestDocument(t, owner)
+	approveTestDocument(t, owner, docID)
+
+	var versionResult struct {
+		Node struct {
+			Versions struct {
+				Edges []struct {
+					Node struct {
+						ID string `json:"id"`
+					} `json:"node"`
+				} `json:"edges"`
+			} `json:"versions"`
+		} `json:"node"`
+	}
+
+	err := owner.Execute(`
+		query($id: ID!) {
+			node(id: $id) {
+				... on Document {
+					versions(first: 1, orderBy: { field: CREATED_AT, direction: DESC }) {
+						edges { node { id } }
+					}
+				}
+			}
+		}
+	`, map[string]any{"id": docID}, &versionResult)
+	require.NoError(t, err)
+	require.NotEmpty(t, versionResult.Node.Versions.Edges)
+
+	documentVersionID := versionResult.Node.Versions.Edges[0].Node.ID
+	signerProfileID := signer.GetProfileID().String()
+
+	_, err = owner.Do(`
+		mutation($input: RequestSignatureInput!) {
+			requestSignature(input: $input) {
+				documentVersionSignatureEdge { node { id } }
+			}
+		}
+	`, map[string]any{
+		"input": map[string]any{
+			"documentVersionId": documentVersionID,
+			"signatoryId":       signerProfileID,
+		},
+	})
+	require.NoError(t, err)
+
+	assertRequestedSignatureCount(t, owner, documentVersionID, 1)
+
+	contractEndDate := time.Now().Add(-24 * time.Hour).Format(time.RFC3339)
+	_, err = owner.DoConnect(`
+		mutation($input: UpdateUserInput!) {
+			updateUser(input: $input) {
+				profile { id }
+			}
+		}
+	`, map[string]any{
+		"input": map[string]any{
+			"id":                       signerProfileID,
+			"fullName":                 "Ended Contract Signer",
+			"additionalEmailAddresses": []string{},
+			"contractEndDate":          contractEndDate,
+		},
+	})
+	require.NoError(t, err)
 
 	assertRequestedSignatureCount(t, owner, documentVersionID, 0)
 }

--- a/pkg/coredata/document_version_signature.go
+++ b/pkg/coredata/document_version_signature.go
@@ -433,6 +433,18 @@ signatures_with_people AS (
 	FROM document_version_signatures dvs
 	INNER JOIN major_versions mv ON dvs.document_version_id = mv.id
 	INNER JOIN iam_membership_profiles p ON dvs.signed_by_profile_id = p.id
+	WHERE
+		dvs.state = 'SIGNED'
+		OR (
+			p.state = 'ACTIVE'
+			AND (p.contract_end_date IS NULL OR p.contract_end_date >= CURRENT_DATE)
+			AND EXISTS (
+				SELECT 1
+				FROM iam_memberships m
+				WHERE m.identity_id = p.identity_id
+					AND m.organization_id = p.organization_id
+			)
+		)
 )
 SELECT
 	id,

--- a/pkg/coredata/document_version_signature_filter.go
+++ b/pkg/coredata/document_version_signature_filter.go
@@ -62,12 +62,12 @@ func (f *DocumentVersionSignatureFilter) SQLFragment() string {
             (
                 @active_contract::boolean = TRUE
                 AND (
-                    p.contract_end_date IS NULL OR p.contract_end_date > NOW()
+                    p.contract_end_date IS NULL OR p.contract_end_date >= CURRENT_DATE
                 )
             ) OR (
                 @active_contract::boolean = FALSE
                 AND (
-                    p.contract_end_date IS NOT NULL AND p.contract_end_date <= NOW()
+                    p.contract_end_date IS NOT NULL AND p.contract_end_date < CURRENT_DATE
                 )
             )
         )

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -1102,10 +1102,18 @@ func (s *OrganizationService) UpdateUser(ctx context.Context, req *UpdateUserReq
 				profile.ContractEndDate = *req.ContractEndDate
 			}
 
-			profile.UpdatedAt = time.Now()
+			now := time.Now()
+			profile.UpdatedAt = now
 
 			if err := profile.Update(ctx, conn, scope); err != nil {
 				return fmt.Errorf("cannot update profile: %w", err)
+			}
+
+			if profile.ContractEndDate != nil && profile.ContractEndDate.Before(now) {
+				signatures := &coredata.DocumentVersionSignatures{}
+				if err := signatures.DeleteRequestedBySignatory(ctx, conn, scope, profile.ID); err != nil {
+					return fmt.Errorf("cannot delete requested signatures: %w", err)
+				}
 			}
 
 			membership := &coredata.Membership{}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Keep completed signatures in export signature pages while excluding pending requests for inactive, expired, or non-member profiles.
- Align document signature active-contract filtering with the profile list's current-date semantics.
- Cancel pending signature requests when a user update sets an already-ended contract date.
- Add e2e coverage for contract-end cleanup of pending signature requests.

## Testing
- `make go-fmt`
- `go test ./pkg/coredata ./pkg/iam -run 'TestNonExistent'`
- `go test ./pkg/probo -run TestNonExistent`
- `go test -c ./e2e/console -o /tmp/console-e2e.test`

Full e2e execution requires a live `PROBO_E2E_BINARY` test stack.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-425](https://linear.app/probo/issue/ENG-425/signature-listing-on-export)

<div><a href="https://cursor.com/agents/bc-d268b038-73fc-451a-bd9e-432a6bf40a73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d268b038-73fc-451a-bd9e-432a6bf40a73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix export signature listings to exclude stale pending requests for inactive, expired, or non-member profiles, while keeping completed signatures. Also cancels pending requests when a user’s contract has already ended and aligns active-contract checks to current-date semantics (ENG-425).

### Coredata **`+14`** **`-2`**
- Export query now returns SIGNED signatures or those from ACTIVE members with a non-expired contract and org membership.
- Active-contract filter switches from NOW() to CURRENT_DATE to match profile list behavior.

### Service **`+9`** **`-1`**
- On `UpdateUser`, cancel all pending signature requests when the profile’s contract end date is in the past.

### Tests **`+74`** **`-0`**
- Add e2e test confirming past contract end dates immediately cancel pending signature requests.

<sup>Written for commit 503abcbc9d446de071df4899b6a7867b60e58e12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1263?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

