### PR TITLE
Restore unarchived documents as drafts

### DIFF
--- a/e2e/console/document_test.go
+++ b/e2e/console/document_test.go
@@ -286,6 +286,118 @@ func TestDocument_Create_Validation(t *testing.T) {
 	}
 }
 
+func TestDocument_UnarchivePublishedDocumentCreatesDraft(t *testing.T) {
+	t.Parallel()
+	owner := testutil.NewClient(t, testutil.RoleOwner)
+
+	docID, _ := createTestDocument(t, owner)
+
+	var publishResult struct {
+		PublishDocument struct {
+			DocumentVersion struct {
+				Status string `json:"status"`
+			} `json:"documentVersion"`
+		} `json:"publishDocument"`
+	}
+
+	err := owner.Execute(`
+		mutation PublishDocument($input: PublishDocumentInput!) {
+			publishDocument(input: $input) {
+				documentVersion {
+					status
+				}
+			}
+		}
+	`, map[string]any{
+		"input": map[string]any{
+			"documentId": docID,
+			"minor":      false,
+			"changelog":  "Initial publication",
+		},
+	}, &publishResult)
+	require.NoError(t, err)
+	assert.Equal(t, "PUBLISHED", publishResult.PublishDocument.DocumentVersion.Status)
+
+	var archiveResult struct {
+		ArchiveDocument struct {
+			Document struct {
+				Status     string  `json:"status"`
+				ArchivedAt *string `json:"archivedAt"`
+			} `json:"document"`
+		} `json:"archiveDocument"`
+	}
+
+	err = owner.Execute(`
+		mutation ArchiveDocument($input: ArchiveDocumentInput!) {
+			archiveDocument(input: $input) {
+				document {
+					status
+					archivedAt
+				}
+			}
+		}
+	`, map[string]any{
+		"input": map[string]any{
+			"documentId": docID,
+		},
+	}, &archiveResult)
+	require.NoError(t, err)
+	assert.Equal(t, "ARCHIVED", archiveResult.ArchiveDocument.Document.Status)
+	require.NotNil(t, archiveResult.ArchiveDocument.Document.ArchivedAt)
+
+	var unarchiveResult struct {
+		UnarchiveDocument struct {
+			Document struct {
+				Status     string  `json:"status"`
+				ArchivedAt *string `json:"archivedAt"`
+				Versions   struct {
+					Edges []struct {
+						Node struct {
+							Status string `json:"status"`
+							Major  int    `json:"major"`
+							Minor  int    `json:"minor"`
+						} `json:"node"`
+					} `json:"edges"`
+				} `json:"versions"`
+			} `json:"document"`
+		} `json:"unarchiveDocument"`
+	}
+
+	err = owner.Execute(`
+		mutation UnarchiveDocument($input: UnarchiveDocumentInput!) {
+			unarchiveDocument(input: $input) {
+				document {
+					status
+					archivedAt
+					versions(first: 2, orderBy: { field: CREATED_AT, direction: DESC }) {
+						edges {
+							node {
+								status
+								major
+								minor
+							}
+						}
+					}
+				}
+			}
+		}
+	`, map[string]any{
+		"input": map[string]any{
+			"documentId": docID,
+		},
+	}, &unarchiveResult)
+	require.NoError(t, err)
+
+	document := unarchiveResult.UnarchiveDocument.Document
+	assert.Equal(t, "ACTIVE", document.Status)
+	assert.Nil(t, document.ArchivedAt)
+	require.Len(t, document.Versions.Edges, 2)
+	assert.Equal(t, "DRAFT", document.Versions.Edges[0].Node.Status)
+	assert.Equal(t, 1, document.Versions.Edges[0].Node.Major)
+	assert.Equal(t, 1, document.Versions.Edges[0].Node.Minor)
+	assert.Equal(t, "PUBLISHED", document.Versions.Edges[1].Node.Status)
+}
+
 func TestDocument_Update(t *testing.T) {
 	t.Parallel()
 	owner := testutil.NewClient(t, testutil.RoleOwner)

--- a/pkg/probo/document_service.go
+++ b/pkg/probo/document_service.go
@@ -1289,15 +1289,37 @@ func (s *DocumentService) BulkUnarchive(
 	documentIDs []gid.GID,
 ) error {
 	documents := coredata.Documents{}
+	archivedDocuments := coredata.Documents{}
 
 	for _, documentID := range documentIDs {
 		documents = append(documents, &coredata.Document{ID: documentID})
 	}
 
-	return s.svc.pg.WithConn(
+	return s.svc.pg.WithTx(
 		ctx,
-		func(ctx context.Context, conn pg.Querier) error {
-			return documents.BulkUnarchive(ctx, conn, scope)
+		func(ctx context.Context, tx pg.Tx) error {
+			for _, documentID := range documentIDs {
+				document := &coredata.Document{}
+				if err := document.LoadByID(ctx, tx, scope, documentID); err != nil {
+					return fmt.Errorf("cannot load document %q: %w", documentID, err)
+				}
+
+				if document.ArchivedAt != nil {
+					archivedDocuments = append(archivedDocuments, document)
+				}
+			}
+
+			if err := documents.BulkUnarchive(ctx, tx, scope); err != nil {
+				return err
+			}
+
+			for _, document := range archivedDocuments {
+				if err := s.ensureLatestDocumentVersionDraftInTx(ctx, scope, tx, document); err != nil {
+					return err
+				}
+			}
+
+			return nil
 		},
 	)
 }
@@ -2016,6 +2038,10 @@ func (s *DocumentService) Unarchive(
 				return fmt.Errorf("cannot unarchive document: %w", err)
 			}
 
+			if err := s.ensureLatestDocumentVersionDraftInTx(ctx, scope, tx, document); err != nil {
+				return err
+			}
+
 			return nil
 		},
 	)
@@ -2024,6 +2050,79 @@ func (s *DocumentService) Unarchive(
 	}
 
 	return document, nil
+}
+
+func (s *DocumentService) ensureLatestDocumentVersionDraftInTx(
+	ctx context.Context, scope coredata.Scoper,
+	tx pg.Tx,
+	document *coredata.Document,
+) error {
+	latestVersion := &coredata.DocumentVersion{}
+	if err := latestVersion.LoadLatestVersion(ctx, tx, scope, document.ID); err != nil {
+		return fmt.Errorf("cannot load latest document version: %w", err)
+	}
+
+	switch latestVersion.Status {
+	case coredata.DocumentVersionStatusDraft:
+		return nil
+	case coredata.DocumentVersionStatusPendingApproval:
+		return s.voidPendingDocumentApprovalInTx(ctx, scope, tx, document, latestVersion)
+	case coredata.DocumentVersionStatusPublished:
+		if _, err := s.createDraftInTx(ctx, scope, tx, document, latestVersion); err != nil {
+			return err
+		}
+
+		return nil
+	default:
+		return fmt.Errorf("unsupported document version status %q", latestVersion.Status)
+	}
+}
+
+func (s *DocumentService) voidPendingDocumentApprovalInTx(
+	ctx context.Context, scope coredata.Scoper,
+	tx pg.Tx,
+	document *coredata.Document,
+	documentVersion *coredata.DocumentVersion,
+) error {
+	quorum := &coredata.DocumentVersionApprovalQuorum{}
+	if err := quorum.LoadLastByDocumentVersionID(ctx, tx, scope, documentVersion.ID); err != nil {
+		return fmt.Errorf("cannot load approval quorum: %w", err)
+	}
+
+	if quorum.Status != coredata.DocumentVersionApprovalQuorumStatusPending {
+		return nil
+	}
+
+	now := time.Now()
+
+	quorum.Status = coredata.DocumentVersionApprovalQuorumStatusVoided
+	quorum.UpdatedAt = now
+
+	if err := quorum.Update(ctx, tx, scope); err != nil {
+		return fmt.Errorf("cannot update approval quorum: %w", err)
+	}
+
+	decisions := &coredata.DocumentVersionApprovalDecisions{}
+	if err := decisions.VoidPendingByQuorumID(ctx, tx, scope, quorum.ID, now); err != nil {
+		return fmt.Errorf("cannot void pending decisions: %w", err)
+	}
+
+	documentVersion.Status = coredata.DocumentVersionStatusDraft
+	if document.CurrentPublishedMajor != nil {
+		documentVersion.Major = *document.CurrentPublishedMajor
+		documentVersion.Minor = *document.CurrentPublishedMinor + 1
+	} else {
+		documentVersion.Major = 0
+		documentVersion.Minor = 1
+	}
+
+	documentVersion.UpdatedAt = now
+
+	if err := documentVersion.Update(ctx, tx, scope); err != nil {
+		return fmt.Errorf("cannot update document version status: %w", err)
+	}
+
+	return nil
 }
 
 func (s *DocumentService) CancelSignatureRequest(

--- a/pkg/probo/document_service.go
+++ b/pkg/probo/document_service.go
@@ -1310,12 +1310,12 @@ func (s *DocumentService) BulkUnarchive(
 			}
 
 			if err := documents.BulkUnarchive(ctx, tx, scope); err != nil {
-				return err
+				return fmt.Errorf("cannot bulk unarchive documents: %w", err)
 			}
 
 			for _, document := range archivedDocuments {
 				if err := s.ensureLatestDocumentVersionDraftInTx(ctx, scope, tx, document); err != nil {
-					return err
+					return fmt.Errorf("cannot restore unarchived document draft: %w", err)
 				}
 			}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Ensure unarchiving a published document creates a latest draft version.
- Apply the same draft restoration behavior to bulk unarchive for documents that were archived.
- Wrap bulk unarchive errors with contextual messages.
- Add console e2e coverage for publishing, archiving, and unarchiving a document.

## Testing
- `make go-fmt`
- `make bin/probod`
- `go test ./pkg/probo -run TestDoesNotExist -count=0`
- `go test -c ./e2e/console -o /tmp/console.test`
- Attempted: `PROBO_E2E_BINARY=/workspace/bin/probod PROBO_E2E_CONFIG=/workspace/e2e/console/testdata/config.yaml go test ./e2e/console -run TestDocument_UnarchivePublishedDocumentCreatesDraft -count=1` (blocked: local PostgreSQL/Docker stack unavailable; `docker` is not installed in this environment)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1ff74c2-fe7f-47fc-9fa6-70e0fe3aeda9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1ff74c2-fe7f-47fc-9fa6-70e0fe3aeda9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unarchiving a document now restores a latest draft for both single and bulk actions. Adds console e2e coverage to verify publish → archive → unarchive creates a draft and reactivates the document.

### Service **`+102`** **`-3`**
- Bulk and single unarchive run in a transaction, ensure the latest version is a draft, and wrap errors with context.
- Pending approvals are voided and converted to a draft with the next minor (or 0.1 if none).
- From a published version, a new draft is created after unarchive.

### Tests **`+112`** **`-0`**
- Added e2e test confirming unarchiving a published document creates draft v1.1 and sets status to ACTIVE.

<sup>Written for commit 295bf81ec36cace97f659ae953579608028a5798. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

