### PR TITLE
Add document archive row action

### DIFF
--- a/apps/console/src/pages/organizations/documents/_components/DocumentList.tsx
+++ b/apps/console/src/pages/organizations/documents/_components/DocumentList.tsx
@@ -173,7 +173,7 @@ export function DocumentList(props: {
   const canSendAnySignatureNotifications = documents.some(
     ({ canSendSigningNotifications }) => canSendSigningNotifications,
   );
-  const hasAnyAction = tab === "ARCHIVED" ? canUnarchiveAny || canDeleteAny : canDeleteAny || canUpdateAny;
+  const hasAnyAction = tab === "ARCHIVED" ? canUnarchiveAny || canDeleteAny : canArchiveAny || canDeleteAny || canUpdateAny;
 
   useEffect(() => {
     onConnectionIdChange(connectionId);

--- a/apps/console/src/pages/organizations/documents/_components/DocumentListItem.tsx
+++ b/apps/console/src/pages/organizations/documents/_components/DocumentListItem.tsx
@@ -12,21 +12,43 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import { formatDate, getDocumentClassificationLabel, getDocumentTypeLabel, sprintf } from "@probo/helpers";
+import {
+  formatDate,
+  formatError,
+  getDocumentClassificationLabel,
+  getDocumentTypeLabel,
+  sprintf,
+} from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
-import { ActionDropdown, Badge, Checkbox, DropdownItem, IconTrashCan, Td, Tr, useConfirm } from "@probo/ui";
+import {
+  ActionDropdown,
+  Badge,
+  Checkbox,
+  DropdownItem,
+  IconArchive,
+  IconTrashCan,
+  Td,
+  Tr,
+  useConfirm,
+  useToast,
+} from "@probo/ui";
 import { useFragment, useMutation } from "react-relay";
-import { type DataID, graphql } from "relay-runtime";
+import { ConnectionHandler, type DataID, graphql } from "relay-runtime";
 
+import type { DocumentListItem_archiveMutation } from "#/__generated__/core/DocumentListItem_archiveMutation.graphql";
 import type { DocumentListItem_deleteMutation } from "#/__generated__/core/DocumentListItem_deleteMutation.graphql";
+import type { DocumentListItem_unarchiveMutation } from "#/__generated__/core/DocumentListItem_unarchiveMutation.graphql";
 import type { DocumentListItemFragment$key } from "#/__generated__/core/DocumentListItemFragment.graphql";
 import { useOrganizationId } from "#/hooks/useOrganizationId";
 
 const fragment = graphql`
   fragment DocumentListItemFragment on Document {
     id
+    status
     updatedAt
+    canArchive: permission(action: "core:document:archive")
     canDelete: permission(action: "core:document:delete")
+    canUnarchive: permission(action: "core:document:unarchive")
     defaultApprovers {
       id
       fullName
@@ -66,6 +88,23 @@ const fragment = graphql`
   }
 `;
 
+const archiveDocumentMutation = graphql`
+  mutation DocumentListItem_archiveMutation(
+    $input: ArchiveDocumentInput!
+  ) {
+    archiveDocument(input: $input) {
+      document {
+        id
+        status
+        archivedAt
+        canArchive: permission(action: "core:document:archive")
+        canUnarchive: permission(action: "core:document:unarchive")
+        canDelete: permission(action: "core:document:delete")
+      }
+    }
+  }
+`;
+
 const deleteDocumentMutation = graphql`
   mutation DocumentListItem_deleteMutation(
     $input: DeleteDocumentInput!
@@ -73,6 +112,23 @@ const deleteDocumentMutation = graphql`
   ) {
     deleteDocument(input: $input) {
       deletedDocumentId @deleteEdge(connections: $connections)
+    }
+  }
+`;
+
+const unarchiveDocumentMutation = graphql`
+  mutation DocumentListItem_unarchiveMutation(
+    $input: UnarchiveDocumentInput!
+  ) {
+    unarchiveDocument(input: $input) {
+      document {
+        id
+        status
+        archivedAt
+        canArchive: permission(action: "core:document:archive")
+        canUnarchive: permission(action: "core:document:unarchive")
+        canDelete: permission(action: "core:document:delete")
+      }
     }
   }
 `;
@@ -94,7 +150,10 @@ export function DocumentListItem(props: {
 
   const organizationId = useOrganizationId();
   const { __ } = useTranslate();
+  const { toast } = useToast();
+  const [archiveDocument, isArchiving] = useMutation<DocumentListItem_archiveMutation>(archiveDocumentMutation);
   const [deleteDocument] = useMutation<DocumentListItem_deleteMutation>(deleteDocumentMutation);
+  const [unarchiveDocument, isUnarchiving] = useMutation<DocumentListItem_unarchiveMutation>(unarchiveDocumentMutation);
   const confirm = useConfirm();
   const document = useFragment<DocumentListItemFragment$key>(
     fragment,
@@ -116,6 +175,51 @@ export function DocumentListItem(props: {
     PENDING_APPROVAL: __("Pending approval"),
     PUBLISHED: __("Published"),
   } as const;
+
+  const handleArchive = () => {
+    confirm(
+      () =>
+        new Promise<void>((resolve) => {
+          archiveDocument({
+            variables: { input: { documentId: document.id } },
+            updater(store) {
+              const conn = store.get(connectionId);
+              if (conn) {
+                ConnectionHandler.deleteNode(conn, document.id);
+              }
+            },
+            onCompleted(_, errors) {
+              if (errors?.length) {
+                toast({
+                  title: __("Error"),
+                  description: formatError(__("Failed to archive document"), errors),
+                  variant: "error",
+                });
+              } else {
+                toast({
+                  title: __("Success"),
+                  description: __("Document archived successfully."),
+                  variant: "success",
+                });
+              }
+              resolve();
+            },
+            onError(error) {
+              toast({ title: __("Error"), description: error.message, variant: "error" });
+              resolve();
+            },
+          });
+        }),
+      {
+        message: sprintf(
+          __("This will archive the document \"%s\". It will no longer be editable."),
+          lastVersion.title,
+        ),
+        variant: "danger",
+        label: __("Archive"),
+      },
+    );
+  };
 
   const handleDelete = () => {
     confirm(
@@ -140,6 +244,41 @@ export function DocumentListItem(props: {
       },
     );
   };
+
+  const handleUnarchive = () => {
+    unarchiveDocument({
+      variables: { input: { documentId: document.id } },
+      updater(store) {
+        const conn = store.get(connectionId);
+        if (conn) {
+          ConnectionHandler.deleteNode(conn, document.id);
+        }
+      },
+      onCompleted(_, errors) {
+        if (errors?.length) {
+          toast({
+            title: __("Error"),
+            description: formatError(__("Failed to unarchive document"), errors),
+            variant: "error",
+          });
+          return;
+        }
+        toast({
+          title: __("Success"),
+          description: __("Document unarchived successfully."),
+          variant: "success",
+        });
+      },
+      onError(error) {
+        toast({ title: __("Error"), description: error.message, variant: "error" });
+      },
+    });
+  };
+
+  const hasRowAction
+    = (document.canArchive && document.status === "ACTIVE")
+      || (document.canUnarchive && document.status === "ARCHIVED")
+      || document.canDelete;
 
   return (
     <Tr
@@ -190,17 +329,37 @@ export function DocumentListItem(props: {
       </Td>
       {hasAnyAction && (
         <Td noLink width={50} className="text-end w-18">
-          <ActionDropdown>
-            {document.canDelete && (
-              <DropdownItem
-                variant="danger"
-                icon={IconTrashCan}
-                onClick={handleDelete}
-              >
-                {__("Delete")}
-              </DropdownItem>
-            )}
-          </ActionDropdown>
+          {hasRowAction && (
+            <ActionDropdown>
+              {document.canArchive && document.status === "ACTIVE" && (
+                <DropdownItem
+                  icon={IconArchive}
+                  disabled={isArchiving}
+                  onClick={handleArchive}
+                >
+                  {__("Archive")}
+                </DropdownItem>
+              )}
+              {document.canUnarchive && document.status === "ARCHIVED" && (
+                <DropdownItem
+                  icon={IconArchive}
+                  disabled={isUnarchiving}
+                  onClick={handleUnarchive}
+                >
+                  {__("Unarchive")}
+                </DropdownItem>
+              )}
+              {document.canDelete && (
+                <DropdownItem
+                  variant="danger"
+                  icon={IconTrashCan}
+                  onClick={handleDelete}
+                >
+                  {__("Delete")}
+                </DropdownItem>
+              )}
+            </ActionDropdown>
+          )}
         </Td>
       )}
     </Tr>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add archive and unarchive actions to document list row dropdowns
- remove archived/unarchived rows from the current filtered Relay connection
- show the row action column for archive-only active document permissions

## Testing
- `make relay`
- `npm --workspace @probo/console run check`
- `npm --workspace @probo/console run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca294888-1eb4-4ac8-85ac-d983010364d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca294888-1eb4-4ac8-85ac-d983010364d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add archive and unarchive actions to document list rows in the console. Rows update immediately by removing the item from the current Relay connection, and the action column now shows when users only have archive rights.

### App: console **`+174`** **`-15`**
- Add Archive/Unarchive row actions with `IconArchive`; keep Delete.
- Add `DocumentListItem_archiveMutation` and `DocumentListItem_unarchiveMutation`; use `ConnectionHandler.deleteNode` to remove the row from the current list.
- Load `status`, `canArchive`, `canUnarchive`, `canDelete`; show the action cell only if any action exists; include `canArchiveAny` for the active tab.
- Add confirm for Archive; show success/error via `useToast` and `formatError`; use components from `@probo/ui`.

<sup>Written for commit 4084554daaaa51076c8399e4cee050b96ec84eaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

