### PR TITLE
Normalize MCP profile email lists

### DIFF
--- a/pkg/server/api/mcp/v1/types/profile_test.go
+++ b/pkg/server/api/mcp/v1/types/profile_test.go
@@ -15,29 +15,25 @@
 package types
 
 import (
+	"encoding/json"
+	"testing"
+
 	"go.probo.inc/probo/pkg/coredata"
-	"go.probo.inc/probo/pkg/mail"
 )
 
-func NewProfile(p *coredata.MembershipProfile) *Profile {
-	additionalEmailAddresses := p.AdditionalEmailAddresses
-	if additionalEmailAddresses == nil {
-		additionalEmailAddresses = mail.Addrs{}
+func TestNewProfileEncodesEmptyAdditionalEmailAddresses(t *testing.T) {
+	profile := NewProfile(&coredata.MembershipProfile{})
+
+	if profile.AdditionalEmailAddresses == nil {
+		t.Fatal("expected additional email addresses to be non-nil")
 	}
 
-	return &Profile{
-		ID:                       p.ID,
-		OrganizationID:           p.OrganizationID,
-		FullName:                 p.FullName,
-		EmailAddress:             p.EmailAddress,
-		AdditionalEmailAddresses: additionalEmailAddresses,
-		Kind:                     p.Kind,
-		Source:                   p.Source,
-		State:                    p.State,
-		Position:                 p.Position,
-		ContractStartDate:        p.ContractStartDate,
-		ContractEndDate:          p.ContractEndDate,
-		CreatedAt:                p.CreatedAt,
-		UpdatedAt:                p.UpdatedAt,
+	data, err := json.Marshal(profile.AdditionalEmailAddresses)
+	if err != nil {
+		t.Fatalf("cannot marshal additional email addresses: %v", err)
+	}
+
+	if string(data) != "[]" {
+		t.Fatalf("expected empty additional email addresses to marshal as [], got %s", data)
 	}
 }

--- a/pkg/server/api/mcp/v1/types/profile_test.go
+++ b/pkg/server/api/mcp/v1/types/profile_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Probo Inc <hello@probo.com>.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+func TestNewProfileEncodesEmptyAdditionalEmailAddresses(t *testing.T) {
+	profile := NewProfile(&coredata.MembershipProfile{})
+
+	if profile.AdditionalEmailAddresses == nil {
+		t.Fatal("expected additional email addresses to be non-nil")
+	}
+
+	data, err := json.Marshal(profile.AdditionalEmailAddresses)
+	if err != nil {
+		t.Fatalf("cannot marshal additional email addresses: %v", err)
+	}
+
+	if string(data) != "[]" {
+		t.Fatalf("expected empty additional email addresses to marshal as [], got %s", data)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Normalize nil MCP profile additional email slices to empty slices before returning tool output
- Add a regression test proving empty additional email addresses marshal as `[]`

## Tests
- `go test ./pkg/server/api/mcp/v1/types`
- `go test ./pkg/server/api/mcp/v1`
- `make go-fmt`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f0aff8b-af5b-48c2-9092-d595af056018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f0aff8b-af5b-48c2-9092-d595af056018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize MCP profile email lists by converting nil `AdditionalEmailAddresses` to an empty slice so JSON always encodes as `[]`. Adds a regression test to lock this behavior.

### Tests **`+45`** **`-0`**
- Added `profile_test.go` verifying `NewProfile` sets non-nil `AdditionalEmailAddresses` and marshals to `[]`.

<sup>Written for commit 3dae2d495b646d284e72f69b38f03c68d627d901. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

