### PR TITLE
Cookie & tracking technologies policy generation

### DIFF
--- a/apps/console/src/pages/organizations/cookie-banners/configuration/CookieBannerConfigLayout.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/CookieBannerConfigLayout.tsx
@@ -235,13 +235,13 @@ export default function CookieBannerConfigLayout({ queryRef }: CookieBannerConfi
       </PageHeader>
 
       <Tabs>
-        <TabLink to={`/organizations/${organizationId}/cookie-banners/${cookieBannerId}/settings`}>
-          <IconSettingsGear2 size={20} />
-          {__("Settings")}
-        </TabLink>
         <TabLink to={`/organizations/${organizationId}/cookie-banners/${cookieBannerId}/display`}>
           <IconPageTextLine size={20} />
           {__("Display")}
+        </TabLink>
+        <TabLink to={`/organizations/${organizationId}/cookie-banners/${cookieBannerId}/settings`}>
+          <IconSettingsGear2 size={20} />
+          {__("Settings")}
         </TabLink>
         <TabLink to={`/organizations/${organizationId}/cookie-banners/${cookieBannerId}/translations`}>
           <IconGlobe size={20} />

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/CookieBannerConfigLayout.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/CookieBannerConfigLayout.tsx
@@ -29,7 +29,7 @@ import {
   useToast,
 } from "@probo/ui";
 import { type PreloadedQuery, useMutation, usePreloadedQuery } from "react-relay";
-import { Outlet, useParams } from "react-router";
+import { Link, Outlet, useParams } from "react-router";
 import { graphql } from "relay-runtime";
 
 import type { CookieBannerConfigLayoutActivateMutation } from "#/__generated__/core/CookieBannerConfigLayoutActivateMutation.graphql";
@@ -51,6 +51,9 @@ export const cookieBannerConfigLayoutQuery = graphql`
           id
           version
           state
+        }
+        policyDocument {
+          id
         }
       }
     }
@@ -214,6 +217,17 @@ export default function CookieBannerConfigLayout({ queryRef }: CookieBannerConfi
                 <IconSquareBehindSquare2 size={16} />
               </button>
             </span>
+            {banner.policyDocument && (
+              <>
+                <span className="text-border-primary">·</span>
+                <Link
+                  to={`/organizations/${organizationId}/documents/${banner.policyDocument.id}`}
+                  className="font-medium text-txt-primary underline"
+                >
+                  {__("Cookie Policy")}
+                </Link>
+              </>
+            )}
           </span>
         )}
       >

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/display/_components/AddCookieRow.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/display/_components/AddCookieRow.tsx
@@ -58,10 +58,16 @@ export function AddCookieRow({
   return (
     <Tr>
       <Td className="pr-3">
-        <Input
-          {...register("name")}
-          placeholder={__("Cookie name")}
-        />
+        <div className="flex flex-col gap-2 min-w-0 max-w-xs">
+          <Input
+            {...register("name")}
+            placeholder={__("Cookie name")}
+          />
+          <Input
+            {...register("description")}
+            placeholder={__("Description")}
+          />
+        </div>
       </Td>
       <Td />
       <Td className="pr-3">
@@ -76,12 +82,6 @@ export function AddCookieRow({
               onUnitChange={u => field.onChange({ ...field.value, unit: u })}
             />
           )}
-        />
-      </Td>
-      <Td className="pr-3">
-        <Input
-          {...register("description")}
-          placeholder={__("Description")}
         />
       </Td>
       <Td>

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/display/_components/CategorySection.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/display/_components/CategorySection.tsx
@@ -13,7 +13,7 @@
 // PERFORMANCE OF THIS SOFTWARE.
 
 import { EyeIcon, EyeSlashIcon } from "@phosphor-icons/react";
-import { formatError, type GraphQLError, humanizeSeconds } from "@probo/helpers";
+import { formatError, getTrackerTypeBadge, type GraphQLError, humanizeSeconds } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
 import {
   Badge,
@@ -76,10 +76,10 @@ export const categorySectionFragment = graphql`
         node {
           id
           displayName
+          trackerType
           maxAgeSeconds
           description
           excluded
-          source
           ...EditCookieRowFragment
         }
       }
@@ -136,10 +136,10 @@ const createPatternMutation = graphql`
         node {
           id
           displayName
+          trackerType
           maxAgeSeconds
           description
           excluded
-          source
           ...EditCookieRowFragment
         }
       }
@@ -759,9 +759,8 @@ export function CategorySection({ categoryKey, connectionId }: CategorySectionPr
         <Thead>
           <Tr>
             <Th>{__("Name")}</Th>
-            <Th>{__("Source")}</Th>
+            <Th>{__("Type")}</Th>
             <Th>{__("Duration")}</Th>
-            <Th>{__("Description")}</Th>
             <Th className="w-20" />
           </Tr>
         </Thead>
@@ -780,25 +779,23 @@ export function CategorySection({ categoryKey, connectionId }: CategorySectionPr
               : (
                   <Tr key={pattern.id} className={pattern.excluded ? "opacity-80" : undefined}>
                     <Td>
-                      <code className="text-sm font-mono">{pattern.displayName}</code>
+                      <div className="flex flex-col min-w-0 max-w-xs">
+                        <code className="text-sm font-mono">{pattern.displayName}</code>
+                        {pattern.description && (
+                          <span className="text-xs text-txt-tertiary wrap-break-word line-clamp-1">
+                            {pattern.description}
+                          </span>
+                        )}
+                      </div>
                     </Td>
                     <Td>
-                      <Badge
-                        variant={pattern.source === "SCRIPT" ? "info" : "neutral"}
-                        title={
-                          pattern.source === "SCRIPT"
-                            ? __("Set by a script at runtime")
-                            : __("Already present when the page was loaded")
-                        }
-                      >
-                        {pattern.source === "SCRIPT" ? __("Script") : __("Pre-existing")}
-                      </Badge>
+                      {(() => {
+                        const typeBadge = getTrackerTypeBadge(pattern.trackerType, __);
+                        return <Badge variant={typeBadge.variant}>{typeBadge.label}</Badge>;
+                      })()}
                     </Td>
                     <Td className="text-sm text-muted-foreground">
                       {humanizeSeconds(pattern.maxAgeSeconds ?? null)}
-                    </Td>
-                    <Td className="text-sm text-muted-foreground">
-                      {pattern.description}
                     </Td>
                     <Td>
                       <div className="flex items-center gap-1">

--- a/apps/console/src/pages/organizations/cookie-banners/configuration/display/_components/EditCookieRow.tsx
+++ b/apps/console/src/pages/organizations/cookie-banners/configuration/display/_components/EditCookieRow.tsx
@@ -12,9 +12,9 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import { fromMaxAgeSeconds, toMaxAgeSeconds } from "@probo/helpers";
+import { fromMaxAgeSeconds, getTrackerTypeBadge, toMaxAgeSeconds } from "@probo/helpers";
 import { useTranslate } from "@probo/i18n";
-import { Button, DurationInput, Input, Td, Toggle, Tr } from "@probo/ui";
+import { Badge, Button, DurationInput, Input, Td, Toggle, Tr } from "@probo/ui";
 import { Controller, useForm } from "react-hook-form";
 import { useFragment } from "react-relay";
 import { graphql } from "relay-runtime";
@@ -26,6 +26,7 @@ import type { CookieEntry } from "./CategorySection";
 export const editCookieRowFragment = graphql`
   fragment EditCookieRowFragment on TrackerPattern {
     displayName
+    trackerType
     maxAgeSeconds
     description
     excluded
@@ -72,26 +73,36 @@ export function EditCookieRow({
     });
   };
 
+  const typeBadge = getTrackerTypeBadge(cookie.trackerType, __);
+
   return (
     <Tr>
       <Td className="pr-3">
-        <div className="flex items-center gap-2">
-          <Controller
-            name="excluded"
-            control={control}
-            render={({ field }) => (
-              <Toggle
-                size="sm"
-                checked={!field.value}
-                onChange={checked => field.onChange(!checked)}
-                title={__("Include this cookie in the banner")}
-              />
-            )}
+        <div className="flex flex-col gap-2 min-w-0 max-w-xs">
+          <div className="flex items-center gap-2">
+            <Controller
+              name="excluded"
+              control={control}
+              render={({ field }) => (
+                <Toggle
+                  size="sm"
+                  checked={!field.value}
+                  onChange={checked => field.onChange(!checked)}
+                  title={__("Include this cookie in the banner")}
+                />
+              )}
+            />
+            <code className="text-sm font-mono">{cookie.displayName}</code>
+          </div>
+          <Input
+            {...register("description")}
+            placeholder={__("Description")}
           />
-          <code className="text-sm font-mono">{cookie.displayName}</code>
         </div>
       </Td>
-      <Td />
+      <Td>
+        <Badge variant={typeBadge.variant}>{typeBadge.label}</Badge>
+      </Td>
       <Td className="pr-3">
         <Controller
           name="duration"
@@ -104,12 +115,6 @@ export function EditCookieRow({
               onUnitChange={u => field.onChange({ ...field.value, unit: u })}
             />
           )}
-        />
-      </Td>
-      <Td className="pr-3">
-        <Input
-          {...register("description")}
-          placeholder={__("Description")}
         />
       </Td>
       <Td>

--- a/packages/cookie-banner/src/components/cookie-list.ts
+++ b/packages/cookie-banner/src/components/cookie-list.ts
@@ -14,7 +14,7 @@
 
 import type { CookieItem } from "../types";
 import { humanizeDuration } from "../cookie-utils";
-import { getCookieDetailLabels } from "../i18n";
+import { getCookieDetailLabels, getTrackerTypeLabel, interpolate } from "../i18n";
 import { ProboElement } from "./base";
 import type { ProboCategory } from "./category";
 import type { ProboCookieBannerRoot } from "./cookie-banner-root";
@@ -55,18 +55,27 @@ export class ProboCookieList extends ProboElement {
       ? humanizeDuration(cookie.max_age_seconds, lang)
       : humanizeDuration(0, lang);
 
+    const type = getTrackerTypeLabel(cookie.tracker_type);
+
     const wrapper = document.createElement("probo-cookie");
     wrapper.setAttribute("name", cookie.name);
     const clone = this.template.content.cloneNode(true) as DocumentFragment;
     this.fillSlots(clone, {
       name: cookie.name,
+      type,
       duration,
       description: cookie.description,
     });
     this.fillLabels(clone, labels, {
+      type,
       description: cookie.description,
       duration,
     });
+
+    const typeEl = clone.querySelector<HTMLElement>(".cookie-type");
+    if (typeEl && labels.label_type) {
+      typeEl.setAttribute("aria-label", interpolate(labels.label_type, { value: type }));
+    }
 
     wrapper.appendChild(clone);
     this.appendChild(wrapper);

--- a/packages/cookie-banner/src/i18n.ts
+++ b/packages/cookie-banner/src/i18n.ts
@@ -43,14 +43,28 @@ export function interpolate(
 }
 
 const COOKIE_DETAIL_LABELS: Record<string, Record<string, string>> = {
-  en: { label_description: "Description: {{value}}", label_duration: "Duration: {{value}}" },
-  fr: { label_description: "Description : {{value}}", label_duration: "Durée : {{value}}" },
-  de: { label_description: "Beschreibung: {{value}}", label_duration: "Dauer: {{value}}" },
-  es: { label_description: "Descripción: {{value}}", label_duration: "Duración: {{value}}" },
+  en: { label_type: "Type: {{value}}", label_description: "Description: {{value}}", label_duration: "Duration: {{value}}" },
+  fr: { label_type: "Type : {{value}}", label_description: "Description : {{value}}", label_duration: "Durée : {{value}}" },
+  de: { label_type: "Typ: {{value}}", label_description: "Beschreibung: {{value}}", label_duration: "Dauer: {{value}}" },
+  es: { label_type: "Tipo: {{value}}", label_description: "Descripción: {{value}}", label_duration: "Duración: {{value}}" },
 };
 
 export function getCookieDetailLabels(lang: string): Record<string, string> {
   return COOKIE_DETAIL_LABELS[lang] ?? COOKIE_DETAIL_LABELS.en;
+}
+
+// Tracker type names are Web platform API names (proper nouns), so they are
+// not translated; only the surrounding "Type:" label is localized.
+const TRACKER_TYPE_LABELS: Record<string, string> = {
+  COOKIE: "Cookie",
+  LOCAL_STORAGE: "Local storage",
+  SESSION_STORAGE: "Session storage",
+  INDEXED_DB: "IndexedDB",
+  CACHE_STORAGE: "Cache storage",
+};
+
+export function getTrackerTypeLabel(type: string): string {
+  return TRACKER_TYPE_LABELS[type] ?? type;
 }
 
 const GPC_LABELS: Record<string, string> = {

--- a/packages/cookie-banner/src/themed-banner/styles.ts
+++ b/packages/cookie-banner/src/themed-banner/styles.ts
@@ -353,6 +353,10 @@ export const THEMED_STYLES = `
     font-family: monospace;
   }
 
+  .cookie-type {
+    font-size: calc(var(--_font-size) - 3px);
+  }
+
   .cookie-detail {
     color: var(--_text);
     font-weight: 500;

--- a/packages/cookie-banner/src/themed-banner/themed-banner.ts
+++ b/packages/cookie-banner/src/themed-banner/themed-banner.ts
@@ -99,6 +99,7 @@ export class ProboThemedBanner extends HTMLElement {
                     <template>
                       <div class="cookie-item">
                         <span class="cookie-name" data-slot="name"></span>
+                        <span class="cookie-detail cookie-type" data-label="label_type"><span data-slot="type"></span></span>
                         <span class="cookie-detail" data-label="label_description"><span data-slot="description"></span></span>
                         <span class="cookie-detail" data-label="label_duration"><span data-slot="duration"></span></span>
                       </div>

--- a/packages/cookie-banner/src/types.ts
+++ b/packages/cookie-banner/src/types.ts
@@ -14,8 +14,16 @@
 
 import type { BannerTexts } from "./i18n";
 
+export type TrackerType =
+  | "COOKIE"
+  | "LOCAL_STORAGE"
+  | "SESSION_STORAGE"
+  | "INDEXED_DB"
+  | "CACHE_STORAGE";
+
 export interface CookieItem {
   name: string;
+  tracker_type: TrackerType;
   max_age_seconds: number | null;
   description: string;
 }

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -964,6 +964,11 @@ func (s *Service) PublishCookieBannerVersion(
 				return fmt.Errorf("cannot publish version: %w", err)
 			}
 
+			banner := coredata.CookieBanner{ID: bannerID}
+			if err := banner.SetPolicyGenerationRequested(ctx, tx); err != nil {
+				return fmt.Errorf("cannot request cookie policy generation: %w", err)
+			}
+
 			return nil
 		},
 	)

--- a/pkg/cookiebanner/service.go
+++ b/pkg/cookiebanner/service.go
@@ -966,7 +966,7 @@ func (s *Service) PublishCookieBannerVersion(
 
 			banner := coredata.CookieBanner{ID: bannerID}
 			if err := banner.SetPolicyGenerationRequested(ctx, tx); err != nil {
-				return fmt.Errorf("cannot request cookie policy generation: %w", err)
+				return fmt.Errorf("cannot request tracker policy generation: %w", err)
 			}
 
 			return nil

--- a/pkg/cookiebanner/service_test.go
+++ b/pkg/cookiebanner/service_test.go
@@ -43,7 +43,7 @@ func TestSnapshotsEqual(t *testing.T) {
 					Description: "Analytics cookies",
 					Kind:        coredata.CookieCategoryKindNormal,
 					Cookies: coredata.CookieItems{
-						{Name: "_ga", MaxAgeSeconds: &maxAge, Description: "Google Analytics"},
+						{Name: "_ga", TrackerType: coredata.TrackerTypeCookie, MaxAgeSeconds: &maxAge, Description: "Google Analytics"},
 					},
 					GCMConsentTypes: []string{"analytics_storage"},
 					PostHogConsent:  false,

--- a/pkg/cookiebanner/snapshot.go
+++ b/pkg/cookiebanner/snapshot.go
@@ -80,14 +80,11 @@ func buildSnapshot(
 	cookiesByCategory := make(map[gid.GID]coredata.CookieItems)
 
 	for _, p := range allPatterns {
-		if p.TrackerType != coredata.TrackerTypeCookie {
-			continue
-		}
-
 		cookiesByCategory[p.CookieCategoryID] = append(
 			cookiesByCategory[p.CookieCategoryID],
 			coredata.CookieItem{
 				Name:          p.DisplayName,
+				TrackerType:   p.TrackerType,
 				MaxAgeSeconds: p.MaxAgeSeconds,
 				Description:   p.Description,
 			},

--- a/pkg/coredata/cookie_banner.go
+++ b/pkg/coredata/cookie_banner.go
@@ -31,19 +31,21 @@ import (
 
 type (
 	CookieBanner struct {
-		ID                         gid.GID           `db:"id"`
-		OrganizationID             gid.GID           `db:"organization_id"`
-		Name                       string            `db:"name"`
-		Origin                     string            `db:"origin"`
-		State                      CookieBannerState `db:"state"`
-		PrivacyPolicyURL           *string           `db:"privacy_policy_url"`
-		CookiePolicyURL            string            `db:"cookie_policy_url"`
-		ConsentExpiryDays          int               `db:"consent_expiry_days"`
-		ShowBranding               bool              `db:"show_branding"`
-		DefaultLanguage            string            `db:"default_language"`
-		PatternAnalysisRequestedAt *time.Time        `db:"pattern_analysis_requested_at"`
-		CreatedAt                  time.Time         `db:"created_at"`
-		UpdatedAt                  time.Time         `db:"updated_at"`
+		ID                          gid.GID           `db:"id"`
+		OrganizationID              gid.GID           `db:"organization_id"`
+		Name                        string            `db:"name"`
+		Origin                      string            `db:"origin"`
+		State                       CookieBannerState `db:"state"`
+		PrivacyPolicyURL            *string           `db:"privacy_policy_url"`
+		CookiePolicyURL             string            `db:"cookie_policy_url"`
+		ConsentExpiryDays           int               `db:"consent_expiry_days"`
+		ShowBranding                bool              `db:"show_branding"`
+		DefaultLanguage             string            `db:"default_language"`
+		PatternAnalysisRequestedAt  *time.Time        `db:"pattern_analysis_requested_at"`
+		PolicyDocumentID            *gid.GID          `db:"policy_document_id"`
+		PolicyGenerationRequestedAt *time.Time        `db:"policy_generation_requested_at"`
+		CreatedAt                   time.Time         `db:"created_at"`
+		UpdatedAt                   time.Time         `db:"updated_at"`
 	}
 
 	CookieBanners []*CookieBanner
@@ -116,6 +118,8 @@ SELECT
 	show_branding,
 	default_language,
 	pattern_analysis_requested_at,
+	policy_document_id,
+	policy_generation_requested_at,
 	created_at,
 	updated_at
 FROM
@@ -168,6 +172,8 @@ SELECT
 	show_branding,
 	default_language,
 	pattern_analysis_requested_at,
+	policy_document_id,
+	policy_generation_requested_at,
 	created_at,
 	updated_at
 FROM
@@ -221,6 +227,8 @@ SELECT
 	show_branding,
 	default_language,
 	pattern_analysis_requested_at,
+	policy_document_id,
+	policy_generation_requested_at,
 	created_at,
 	updated_at
 FROM
@@ -278,6 +286,8 @@ SELECT
 	show_branding,
 	default_language,
 	pattern_analysis_requested_at,
+	policy_document_id,
+	policy_generation_requested_at,
 	created_at,
 	updated_at
 FROM
@@ -328,6 +338,8 @@ SELECT
 	show_branding,
 	default_language,
 	pattern_analysis_requested_at,
+	policy_document_id,
+	policy_generation_requested_at,
 	created_at,
 	updated_at
 FROM
@@ -414,6 +426,8 @@ INSERT INTO cookie_banners (
 	show_branding,
 	default_language,
 	pattern_analysis_requested_at,
+	policy_document_id,
+	policy_generation_requested_at,
 	created_at,
 	updated_at
 ) VALUES (
@@ -429,26 +443,30 @@ INSERT INTO cookie_banners (
 	@show_branding,
 	@default_language,
 	@pattern_analysis_requested_at,
+	@policy_document_id,
+	@policy_generation_requested_at,
 	@created_at,
 	@updated_at
 )
 `
 
 	args := pgx.StrictNamedArgs{
-		"id":                            b.ID,
-		"tenant_id":                     scope.GetTenantID(),
-		"organization_id":               b.OrganizationID,
-		"name":                          b.Name,
-		"origin":                        b.Origin,
-		"state":                         b.State,
-		"privacy_policy_url":            b.PrivacyPolicyURL,
-		"cookie_policy_url":             b.CookiePolicyURL,
-		"consent_expiry_days":           b.ConsentExpiryDays,
-		"show_branding":                 b.ShowBranding,
-		"default_language":              b.DefaultLanguage,
-		"pattern_analysis_requested_at": b.PatternAnalysisRequestedAt,
-		"created_at":                    b.CreatedAt,
-		"updated_at":                    b.UpdatedAt,
+		"id":                             b.ID,
+		"tenant_id":                      scope.GetTenantID(),
+		"organization_id":                b.OrganizationID,
+		"name":                           b.Name,
+		"origin":                         b.Origin,
+		"state":                          b.State,
+		"privacy_policy_url":             b.PrivacyPolicyURL,
+		"cookie_policy_url":              b.CookiePolicyURL,
+		"consent_expiry_days":            b.ConsentExpiryDays,
+		"show_branding":                  b.ShowBranding,
+		"default_language":               b.DefaultLanguage,
+		"pattern_analysis_requested_at":  b.PatternAnalysisRequestedAt,
+		"policy_document_id":             b.PolicyDocumentID,
+		"policy_generation_requested_at": b.PolicyGenerationRequestedAt,
+		"created_at":                     b.CreatedAt,
+		"updated_at":                     b.UpdatedAt,
 	}
 
 	_, err := tx.Exec(ctx, q, args)
@@ -480,6 +498,7 @@ SET
 	consent_expiry_days = @consent_expiry_days,
 	show_branding = @show_branding,
 	default_language = @default_language,
+	policy_document_id = @policy_document_id,
 	updated_at = @updated_at
 WHERE
 	%s
@@ -497,6 +516,7 @@ WHERE
 		"consent_expiry_days": b.ConsentExpiryDays,
 		"show_branding":       b.ShowBranding,
 		"default_language":    b.DefaultLanguage,
+		"policy_document_id":  b.PolicyDocumentID,
 		"updated_at":          b.UpdatedAt,
 	}
 	maps.Copy(args, scope.SQLArguments())
@@ -600,6 +620,8 @@ SELECT
 	show_branding,
 	default_language,
 	pattern_analysis_requested_at,
+	policy_document_id,
+	policy_generation_requested_at,
 	created_at,
 	updated_at
 FROM
@@ -669,6 +691,99 @@ WHERE id = @id
 	_, err := tx.Exec(ctx, q, args)
 	if err != nil {
 		return fmt.Errorf("cannot set pattern analysis requested: %w", err)
+	}
+
+	return nil
+}
+
+func (b *CookieBanner) LoadNextForPolicyGenerationForUpdateSkipLocked(
+	ctx context.Context,
+	tx pg.Tx,
+) error {
+	q := `
+SELECT
+	id,
+	organization_id,
+	name,
+	origin,
+	state,
+	privacy_policy_url,
+	cookie_policy_url,
+	consent_expiry_days,
+	show_branding,
+	default_language,
+	pattern_analysis_requested_at,
+	policy_document_id,
+	policy_generation_requested_at,
+	created_at,
+	updated_at
+FROM
+	cookie_banners
+WHERE
+	policy_generation_requested_at IS NOT NULL
+ORDER BY
+	policy_generation_requested_at ASC
+FOR UPDATE SKIP LOCKED
+LIMIT 1;
+`
+
+	rows, err := tx.Query(ctx, q)
+	if err != nil {
+		return fmt.Errorf("cannot query cookie banners for policy generation: %w", err)
+	}
+
+	banner, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[CookieBanner])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrResourceNotFound
+		}
+
+		return fmt.Errorf("cannot collect cookie banner: %w", err)
+	}
+
+	*b = banner
+
+	return nil
+}
+
+func (b *CookieBanner) ClearPolicyGenerationRequestedAt(
+	ctx context.Context,
+	tx pg.Tx,
+) error {
+	q := `
+UPDATE cookie_banners
+SET policy_generation_requested_at = NULL
+WHERE id = @id
+`
+
+	args := pgx.StrictNamedArgs{"id": b.ID}
+
+	_, err := tx.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot clear policy generation requested at: %w", err)
+	}
+
+	b.PolicyGenerationRequestedAt = nil
+
+	return nil
+}
+
+func (b *CookieBanner) SetPolicyGenerationRequested(
+	ctx context.Context,
+	tx pg.Tx,
+) error {
+	q := `
+UPDATE cookie_banners
+SET policy_generation_requested_at = NOW()
+WHERE id = @id
+  AND policy_generation_requested_at IS NULL
+`
+
+	args := pgx.StrictNamedArgs{"id": b.ID}
+
+	_, err := tx.Exec(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot set policy generation requested: %w", err)
 	}
 
 	return nil

--- a/pkg/coredata/cookie_banner_version.go
+++ b/pkg/coredata/cookie_banner_version.go
@@ -126,6 +126,18 @@ func (v *CookieBannerVersion) GetSnapshot() (CookieBannerVersionSnapshot, error)
 		return snapshot, fmt.Errorf("cannot unmarshal cookie banner version snapshot: %w", err)
 	}
 
+	// Snapshots created before tracker types were captured only ever held
+	// cookie-type trackers, so their cookie items carry an empty tracker
+	// type. Backfill them as cookies so downstream consumers (policy
+	// generation, GraphQL, served banner config) see a valid type.
+	for i := range snapshot.Categories {
+		for j := range snapshot.Categories[i].Cookies {
+			if snapshot.Categories[i].Cookies[j].TrackerType == "" {
+				snapshot.Categories[i].Cookies[j].TrackerType = TrackerTypeCookie
+			}
+		}
+	}
+
 	return snapshot, nil
 }
 

--- a/pkg/coredata/cookie_category.go
+++ b/pkg/coredata/cookie_category.go
@@ -33,9 +33,10 @@ import (
 
 type (
 	CookieItem struct {
-		Name          string `json:"name"`
-		MaxAgeSeconds *int   `json:"max_age_seconds"`
-		Description   string `json:"description"`
+		Name          string      `json:"name"`
+		TrackerType   TrackerType `json:"tracker_type"`
+		MaxAgeSeconds *int        `json:"max_age_seconds"`
+		Description   string      `json:"description"`
 	}
 
 	CookieItems []CookieItem
@@ -80,13 +81,22 @@ var cookieDurationUnits = [...]cookieDurationUnit{
 	{1, "second", 0},
 }
 
-// HumanizedDuration renders the cookie's max-age into a human-readable lifetime
-// using the same snapping and composition rules as the banner's
-// humanizeDuration helper. A nil or non-positive max-age denotes a session
-// cookie that is cleared when the browser closes.
+// HumanizedDuration renders the tracker's max-age into a human-readable
+// lifetime using the same snapping and composition rules as the banner's
+// humanizeDuration helper. A nil or non-positive max-age has no fixed
+// expiry, so the lifetime is described by the tracker type: session cookies
+// are cleared when the browser closes, session storage is cleared when the
+// tab closes, and the remaining storage technologies persist until cleared.
 func (c CookieItem) HumanizedDuration() string {
 	if c.MaxAgeSeconds == nil || *c.MaxAgeSeconds <= 0 {
-		return "Session"
+		switch c.TrackerType {
+		case TrackerTypeSessionStorage:
+			return "Until the tab is closed"
+		case TrackerTypeLocalStorage, TrackerTypeIndexedDB, TrackerTypeCacheStorage:
+			return "Persistent"
+		default:
+			return "Session"
+		}
 	}
 
 	remaining := *c.MaxAgeSeconds

--- a/pkg/coredata/cookie_category.go
+++ b/pkg/coredata/cookie_category.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -39,6 +40,12 @@ type (
 
 	CookieItems []CookieItem
 
+	cookieDurationUnit struct {
+		secs int
+		name string
+		snap int
+	}
+
 	CookieCategory struct {
 		ID              gid.GID            `db:"id"`
 		OrganizationID  gid.GID            `db:"organization_id"`
@@ -56,6 +63,67 @@ type (
 
 	CookieCategories []*CookieCategory
 )
+
+// cookieDurationUnits mirrors DURATION_UNITS in
+// packages/cookie-banner/src/cookie-utils.ts (and the snap table used by the
+// pattern-analysis worker) so durations rendered server-side match exactly what
+// visitors see in the consent banner. snap is the per-unit buffer: when the
+// remainder is within snap seconds of the next whole unit, round up instead of
+// carrying into smaller units.
+var cookieDurationUnits = [...]cookieDurationUnit{
+	{365 * 24 * 3600, "year", 21 * 24 * 3600},
+	{30 * 24 * 3600, "month", 2 * 24 * 3600},
+	{7 * 24 * 3600, "week", 12 * 3600},
+	{24 * 3600, "day", 2 * 3600},
+	{3600, "hour", 5 * 60},
+	{60, "minute", 5},
+	{1, "second", 0},
+}
+
+// HumanizedDuration renders the cookie's max-age into a human-readable lifetime
+// using the same snapping and composition rules as the banner's
+// humanizeDuration helper. A nil or non-positive max-age denotes a session
+// cookie that is cleared when the browser closes.
+func (c CookieItem) HumanizedDuration() string {
+	if c.MaxAgeSeconds == nil || *c.MaxAgeSeconds <= 0 {
+		return "Session"
+	}
+
+	remaining := *c.MaxAgeSeconds
+
+	var parts []string
+
+	for _, u := range cookieDurationUnits {
+		if remaining < u.secs-u.snap {
+			continue
+		}
+
+		count := remaining / u.secs
+
+		leftover := remaining - count*u.secs
+		switch {
+		case leftover >= u.secs-u.snap:
+			count++
+			remaining = 0
+		case leftover <= u.snap:
+			remaining = 0
+		default:
+			remaining = leftover
+		}
+
+		if count == 1 {
+			parts = append(parts, fmt.Sprintf("1 %s", u.name))
+		} else {
+			parts = append(parts, fmt.Sprintf("%d %ss", count, u.name))
+		}
+	}
+
+	if len(parts) == 0 {
+		return "Session"
+	}
+
+	return strings.Join(parts, ", ")
+}
 
 func (c CookieItems) MarshalJSON() ([]byte, error) {
 	if c == nil {

--- a/pkg/coredata/migrations/20260602T161910Z.sql
+++ b/pkg/coredata/migrations/20260602T161910Z.sql
@@ -16,7 +16,7 @@ ALTER TABLE cookie_banners
     ADD COLUMN policy_document_id TEXT,
     ADD COLUMN policy_generation_requested_at TIMESTAMP WITH TIME ZONE;
 
--- Backfill: any banner that already has a published version gets its cookie
+-- Backfill: any banner that already has a published version gets its tracker
 -- policy generated on the worker's first pass.
 UPDATE cookie_banners
 SET policy_generation_requested_at = NOW()

--- a/pkg/coredata/migrations/20260602T161910Z.sql
+++ b/pkg/coredata/migrations/20260602T161910Z.sql
@@ -1,0 +1,27 @@
+-- Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+--
+-- Permission to use, copy, modify, and/or distribute this software for any
+-- purpose with or without fee is hereby granted, provided that the above
+-- copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+-- REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+-- INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+-- LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+-- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+ALTER TABLE cookie_banners
+    ADD COLUMN policy_document_id TEXT,
+    ADD COLUMN policy_generation_requested_at TIMESTAMP WITH TIME ZONE;
+
+-- Backfill: any banner that already has a published version gets its cookie
+-- policy generated on the worker's first pass.
+UPDATE cookie_banners
+SET policy_generation_requested_at = NOW()
+WHERE id IN (
+    SELECT DISTINCT cookie_banner_id
+    FROM cookie_banner_versions
+    WHERE state = 'PUBLISHED'
+);

--- a/pkg/coredata/tracker_type.go
+++ b/pkg/coredata/tracker_type.go
@@ -63,6 +63,26 @@ func (v TrackerType) String() string {
 	return string(v)
 }
 
+// Label returns a human-readable name for the tracker type, suitable for
+// display in visitor-facing documents such as the cookie and tracking
+// technologies policy.
+func (v TrackerType) Label() string {
+	switch v {
+	case TrackerTypeCookie:
+		return "Cookie"
+	case TrackerTypeLocalStorage:
+		return "Local storage"
+	case TrackerTypeSessionStorage:
+		return "Session storage"
+	case TrackerTypeIndexedDB:
+		return "IndexedDB"
+	case TrackerTypeCacheStorage:
+		return "Cache storage"
+	default:
+		return string(v)
+	}
+}
+
 func (v TrackerType) MarshalText() ([]byte, error) {
 	return []byte(v.String()), nil
 }

--- a/pkg/docgen/generator.go
+++ b/pkg/docgen/generator.go
@@ -469,6 +469,35 @@ type (
 		ValidFrom  string
 		ValidUntil string
 	}
+
+	TrackerPolicyData struct {
+		OrganizationName  string
+		WebsiteOrigin     string
+		GeneratedAt       time.Time
+		PrivacyPolicyURL  string
+		ConsentExpiryDays int
+		Categories        []TrackerPolicyCategory
+		ThirdParties      []TrackerPolicyThirdParty
+	}
+
+	TrackerPolicyCategory struct {
+		Name        string
+		Description string
+		Necessary   bool
+		Trackers    []TrackerPolicyTracker
+	}
+
+	TrackerPolicyTracker struct {
+		Name     string
+		Purpose  string
+		Duration string
+	}
+
+	TrackerPolicyThirdParty struct {
+		Name             string
+		Description      string
+		PrivacyPolicyURL string
+	}
 )
 
 func BoolLabel(v bool) string {

--- a/pkg/docgen/generator.go
+++ b/pkg/docgen/generator.go
@@ -489,6 +489,7 @@ type (
 
 	TrackerPolicyTracker struct {
 		Name     string
+		Type     string
 		Purpose  string
 		Duration string
 	}

--- a/pkg/probo/templates/tracker_policy.md.tmpl
+++ b/pkg/probo/templates/tracker_policy.md.tmpl
@@ -1,4 +1,4 @@
-# Cookie and Tracking Technologies Policy
+# Cookie and Tracking Technologies Policy for {{ .WebsiteOrigin }}
 
 _Last updated: {{ formatDate .GeneratedAt }}_
 

--- a/pkg/probo/templates/tracker_policy.md.tmpl
+++ b/pkg/probo/templates/tracker_policy.md.tmpl
@@ -6,17 +6,17 @@ This Cookie and Tracking Technologies Policy explains how {{ .OrganizationName }
 {{ if .PrivacyPolicyURL }}
 This policy is part of, and should be read together with, our [Privacy Policy]({{ .PrivacyPolicyURL }}).
 {{ end }}
-## What are cookies and tracking technologies?
+{{ $section := 0 }}{{ $section = add $section 1 }}## {{ $section }}. What are cookies and tracking technologies?
 
 Cookies are small data files that are placed on your device when you visit a website. We also use other technologies that store or retrieve information on your device in a similar way, including browser local storage and session storage, IndexedDB, cache storage, pixels, and software development kits. In this policy we refer to all of these collectively as "trackers".
 
 Trackers set by the website owner are called "first-party" trackers. Trackers set by parties other than the website owner are called "third-party" trackers, and they enable features or functionality provided on or through the Website, such as analytics and content from external services.
 
-## Why we use trackers
+{{ $section = add $section 1 }}## {{ $section }}. Why we use trackers
 
 We use trackers for several reasons. Some are strictly necessary for technical reasons in order for the Website to operate. Others help us understand how the Website is used and improve your experience. We only place non-essential trackers on your device with your consent, and you can withdraw that consent at any time.
 
-## The trackers we use
+{{ $section = add $section 1 }}## {{ $section }}. The trackers we use
 
 The tables below describe the categories of trackers we use on the Website, the purpose of the trackers within each category, and how long each one remains on your device. This list reflects the trackers in our current banner configuration and is updated automatically whenever that configuration changes.
 {{ range .Categories }}
@@ -31,28 +31,28 @@ The tables below describe the categories of trackers we use on the Website, the 
 {{ end }}{{ else }}
 We are not currently using any trackers in this category.
 {{ end }}{{ end }}
-{{ if .ThirdParties }}## Third parties that set trackers
+{{ if .ThirdParties }}{{ $section = add $section 1 }}## {{ $section }}. Third parties that set trackers
 
 Some trackers described above are placed by third-party services that we rely on to operate and improve the Website. These third parties may use trackers to collect information about your activity across different websites. We encourage you to review their privacy notices to understand how they process your data.
 {{ range .ThirdParties }}
 - **{{ .Name }}**{{ with .Description }} — {{ . }}{{ end }}{{ with .PrivacyPolicyURL }} ([Privacy Policy]({{ . }})){{ end }}
 {{ end }}{{ end }}
-## How to control trackers
+{{ $section = add $section 1 }}## {{ $section }}. How to control trackers
 
 You can decide whether to accept or reject non-essential trackers at any time through the consent banner displayed on the Website. You can also set or update your preferences by reopening the banner from the Website. Strictly necessary trackers cannot be disabled because the Website cannot function properly without them.
 
 Most web browsers additionally allow you to control cookies and clear locally stored data through their settings. If you choose to reject or delete trackers through your browser, some parts of the Website may no longer function as intended. Your consent choices are remembered for up to {{ .ConsentExpiryDays }} days, after which we will ask for your preferences again.
 
-## Your privacy rights
+{{ $section = add $section 1 }}## {{ $section }}. Your privacy rights
 
 Depending on where you live, data protection and privacy laws give you rights over how trackers are used. Under the EU and UK General Data Protection Regulation (GDPR and UK GDPR) and the Swiss Federal Act on Data Protection (FADP), we ask for your consent before setting any non-essential tracker, and you may withdraw that consent at any time without affecting the lawfulness of processing carried out beforehand.
 
 Under the California Consumer Privacy Act, as amended by the California Privacy Rights Act (CCPA/CPRA), and comparable laws in other jurisdictions, certain uses of trackers may be considered a "sale" or "sharing" of personal information. Where that is the case, you have the right to opt out, and you can exercise that right through the consent banner on the Website. We aim to honor recognised browser-based opt-out signals where required by applicable law.
 
-## Changes to this policy
+{{ $section = add $section 1 }}## {{ $section }}. Changes to this policy
 
 We may update this policy from time to time to reflect changes to the trackers we use or for other operational, legal, or regulatory reasons. This policy is regenerated automatically when our tracker configuration changes, so please revisit it periodically. The date at the top indicates when it was last updated.
 
-## Contact us
+{{ $section = add $section 1 }}## {{ $section }}. Contact us
 
 If you have any questions about our use of cookies or other tracking technologies, please contact us using the details available on the Website.

--- a/pkg/probo/templates/tracker_policy.md.tmpl
+++ b/pkg/probo/templates/tracker_policy.md.tmpl
@@ -1,0 +1,58 @@
+# Cookie and Tracking Technologies Policy
+
+_Last updated: {{ formatDate .GeneratedAt }}_
+
+This Cookie and Tracking Technologies Policy explains how {{ .OrganizationName }} ("we", "us", or "our") uses cookies and other tracking technologies to recognise you when you visit {{ .WebsiteOrigin }} (the "Website"). It explains what these technologies are and why we use them, as well as the rights and choices you have to control them.
+{{ if .PrivacyPolicyURL }}
+This policy is part of, and should be read together with, our [Privacy Policy]({{ .PrivacyPolicyURL }}).
+{{ end }}
+## What are cookies and tracking technologies?
+
+Cookies are small data files that are placed on your device when you visit a website. We also use other technologies that store or retrieve information on your device in a similar way, including browser local storage and session storage, IndexedDB, cache storage, pixels, and software development kits. In this policy we refer to all of these collectively as "trackers".
+
+Trackers set by the website owner are called "first-party" trackers. Trackers set by parties other than the website owner are called "third-party" trackers, and they enable features or functionality provided on or through the Website, such as analytics and content from external services.
+
+## Why we use trackers
+
+We use trackers for several reasons. Some are strictly necessary for technical reasons in order for the Website to operate. Others help us understand how the Website is used and improve your experience. We only place non-essential trackers on your device with your consent, and you can withdraw that consent at any time.
+
+## The trackers we use
+
+The tables below describe the categories of trackers we use on the Website, the purpose of the trackers within each category, and how long each one remains on your device. This list reflects the trackers in our current banner configuration and is updated automatically whenever that configuration changes.
+{{ range .Categories }}
+### {{ .Name }}{{ if .Necessary }} (always active){{ end }}
+
+{{ with .Description }}{{ . }}
+{{ else }}Trackers in this category support the functionality described by its name.
+{{ end }}{{ if .Trackers }}
+| Tracker | Purpose | Duration |
+| --- | --- | --- |
+{{ range .Trackers }}| {{ .Name }} | {{ .Purpose }} | {{ .Duration }} |
+{{ end }}{{ else }}
+We are not currently using any trackers in this category.
+{{ end }}{{ end }}
+{{ if .ThirdParties }}## Third parties that set trackers
+
+Some trackers described above are placed by third-party services that we rely on to operate and improve the Website. These third parties may use trackers to collect information about your activity across different websites. We encourage you to review their privacy notices to understand how they process your data.
+{{ range .ThirdParties }}
+- **{{ .Name }}**{{ with .Description }} — {{ . }}{{ end }}{{ with .PrivacyPolicyURL }} ([Privacy Policy]({{ . }})){{ end }}
+{{ end }}{{ end }}
+## How to control trackers
+
+You can decide whether to accept or reject non-essential trackers at any time through the consent banner displayed on the Website. You can also set or update your preferences by reopening the banner from the Website. Strictly necessary trackers cannot be disabled because the Website cannot function properly without them.
+
+Most web browsers additionally allow you to control cookies and clear locally stored data through their settings. If you choose to reject or delete trackers through your browser, some parts of the Website may no longer function as intended. Your consent choices are remembered for up to {{ .ConsentExpiryDays }} days, after which we will ask for your preferences again.
+
+## Your privacy rights
+
+Depending on where you live, data protection and privacy laws give you rights over how trackers are used. Under the EU and UK General Data Protection Regulation (GDPR and UK GDPR) and the Swiss Federal Act on Data Protection (FADP), we ask for your consent before setting any non-essential tracker, and you may withdraw that consent at any time without affecting the lawfulness of processing carried out beforehand.
+
+Under the California Consumer Privacy Act, as amended by the California Privacy Rights Act (CCPA/CPRA), and comparable laws in other jurisdictions, certain uses of trackers may be considered a "sale" or "sharing" of personal information. Where that is the case, you have the right to opt out, and you can exercise that right through the consent banner on the Website. We aim to honor recognised browser-based opt-out signals where required by applicable law.
+
+## Changes to this policy
+
+We may update this policy from time to time to reflect changes to the trackers we use or for other operational, legal, or regulatory reasons. This policy is regenerated automatically when our tracker configuration changes, so please revisit it periodically. The date at the top indicates when it was last updated.
+
+## Contact us
+
+If you have any questions about our use of cookies or other tracking technologies, please contact us using the details available on the Website.

--- a/pkg/probo/templates/tracker_policy.md.tmpl
+++ b/pkg/probo/templates/tracker_policy.md.tmpl
@@ -25,9 +25,9 @@ The tables below describe the categories of trackers we use on the Website, the 
 {{ with .Description }}{{ . }}
 {{ else }}Trackers in this category support the functionality described by its name.
 {{ end }}{{ if .Trackers }}
-| Tracker | Purpose | Duration |
-| --- | --- | --- |
-{{ range .Trackers }}| {{ .Name }} | {{ .Purpose }} | {{ .Duration }} |
+| Tracker | Type | Purpose | Duration |
+| --- | --- | --- | --- |
+{{ range .Trackers }}| {{ .Name }} | {{ .Type }} | {{ .Purpose }} | {{ .Duration }} |
 {{ end }}{{ else }}
 We are not currently using any trackers in this category.
 {{ end }}{{ end }}

--- a/pkg/probo/tracker_policy_document.go
+++ b/pkg/probo/tracker_policy_document.go
@@ -191,6 +191,7 @@ func (s *GeneratedDocumentService) buildTrackerPolicyDocumentData(
 		for _, cookie := range c.Cookies {
 			trackers = append(trackers, docgen.TrackerPolicyTracker{
 				Name:     sanitizeTrackerCell(cookie.Name),
+				Type:     cookie.TrackerType.Label(),
 				Purpose:  trackerPurpose(cookie.Description),
 				Duration: cookie.HumanizedDuration(),
 			})

--- a/pkg/probo/tracker_policy_document.go
+++ b/pkg/probo/tracker_policy_document.go
@@ -1,0 +1,294 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package probo
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"text/template"
+	"time"
+
+	"go.gearno.de/kit/pg"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/docgen"
+	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/prosemirror"
+)
+
+var trackerPolicyTemplate = template.Must(
+	template.New("tracker_policy.md.tmpl").
+		Funcs(template.FuncMap{
+			"formatDate": func(t time.Time) string {
+				return t.Format("January 2, 2006")
+			},
+		}).
+		ParseFS(Templates, "templates/tracker_policy.md.tmpl"),
+)
+
+// BuildTrackerPolicyDocument renders the tracker policy markdown template for
+// the given data and converts it into the ProseMirror JSON expected by
+// DocumentVersion.Content.
+func BuildTrackerPolicyDocument(data docgen.TrackerPolicyData) (string, error) {
+	var buf bytes.Buffer
+	if err := trackerPolicyTemplate.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("cannot execute tracker policy template: %w", err)
+	}
+
+	node, err := prosemirror.ParseMarkdown(buf.String())
+	if err != nil {
+		return "", fmt.Errorf("cannot convert tracker policy markdown: %w", err)
+	}
+
+	out, err := json.Marshal(node)
+	if err != nil {
+		return "", fmt.Errorf("cannot marshal tracker policy prosemirror node: %w", err)
+	}
+
+	return string(out), nil
+}
+
+// PublishTrackerPolicy generates (or regenerates) the cookie and tracking
+// technologies policy document for a banner from its latest published version
+// snapshot. The document is stored as a GENERATED document that is PRIVATE in
+// the trust center by default, and is linked to the banner through
+// cookie_banners.policy_document_id.
+func (s *GeneratedDocumentService) PublishTrackerPolicy(
+	ctx context.Context,
+	scope coredata.Scoper,
+	cookieBannerID gid.GID,
+) (*coredata.Document, *coredata.DocumentVersion, error) {
+	var (
+		document        *coredata.Document
+		documentVersion *coredata.DocumentVersion
+	)
+
+	err := s.svc.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			banner := &coredata.CookieBanner{}
+			if err := banner.LoadByID(ctx, tx, scope, cookieBannerID); err != nil {
+				return fmt.Errorf("cannot load cookie banner: %w", err)
+			}
+
+			organization := &coredata.Organization{}
+			if err := organization.LoadByID(ctx, tx, scope, banner.OrganizationID); err != nil {
+				return fmt.Errorf("cannot load organization: %w", err)
+			}
+
+			documentData, err := s.buildTrackerPolicyDocumentData(ctx, scope, tx, organization, banner)
+			if err != nil {
+				return fmt.Errorf("cannot build document data: %w", err)
+			}
+
+			prosemirrorJSON, err := BuildTrackerPolicyDocument(documentData)
+			if err != nil {
+				return fmt.Errorf("cannot build prosemirror document: %w", err)
+			}
+
+			now := time.Now()
+
+			var existingDoc *coredata.Document
+
+			if banner.PolicyDocumentID != nil {
+				doc := &coredata.Document{}
+
+				err = doc.LoadByID(ctx, tx, scope, *banner.PolicyDocumentID)
+				if err != nil && !errors.Is(err, coredata.ErrResourceNotFound) {
+					return fmt.Errorf("cannot load tracker policy document: %w", err)
+				}
+
+				if err == nil && doc.ArchivedAt == nil {
+					existingDoc = doc
+				} else {
+					banner.PolicyDocumentID = nil
+					banner.UpdatedAt = now
+
+					if err := banner.Update(ctx, tx, scope); err != nil {
+						return fmt.Errorf("cannot clear tracker policy document reference: %w", err)
+					}
+				}
+			}
+
+			if existingDoc == nil {
+				documentID := gid.New(scope.GetTenantID(), coredata.DocumentEntityType)
+
+				document = &coredata.Document{
+					ID:                    documentID,
+					OrganizationID:        banner.OrganizationID,
+					WriteMode:             coredata.DocumentWriteModeGenerated,
+					TrustCenterVisibility: coredata.TrustCenterVisibilityPrivate,
+					Status:                coredata.DocumentStatusActive,
+					CreatedAt:             now,
+					UpdatedAt:             now,
+				}
+
+				if err := document.Insert(ctx, tx, scope); err != nil {
+					return fmt.Errorf("cannot insert document: %w", err)
+				}
+
+				banner.PolicyDocumentID = &documentID
+				banner.UpdatedAt = now
+
+				if err := banner.Update(ctx, tx, scope); err != nil {
+					return fmt.Errorf("cannot update tracker policy document reference: %w", err)
+				}
+			} else {
+				document = existingDoc
+			}
+
+			documentVersionID := gid.New(scope.GetTenantID(), coredata.DocumentVersionEntityType)
+			documentVersion = &coredata.DocumentVersion{
+				ID:             documentVersionID,
+				OrganizationID: banner.OrganizationID,
+				DocumentID:     document.ID,
+				Title:          "Cookie and Tracking Technologies Policy",
+				Content:        prosemirrorJSON,
+				Classification: coredata.DocumentClassificationPublic,
+				DocumentType:   coredata.DocumentTypePolicy,
+				Orientation:    coredata.DocumentVersionOrientationPortrait,
+				CreatedAt:      now,
+				UpdatedAt:      now,
+			}
+
+			return s.publishOrRequestApproval(ctx, scope, tx, document, documentVersion, banner.OrganizationID, nil, false, now)
+		},
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return document, documentVersion, nil
+}
+
+func (s *GeneratedDocumentService) buildTrackerPolicyDocumentData(
+	ctx context.Context, scope coredata.Scoper,
+	conn pg.Querier,
+	organization *coredata.Organization,
+	banner *coredata.CookieBanner,
+) (docgen.TrackerPolicyData, error) {
+	version := &coredata.CookieBannerVersion{}
+	if err := version.LoadLatestPublishedByCookieBannerID(ctx, conn, scope, banner.ID); err != nil {
+		return docgen.TrackerPolicyData{}, fmt.Errorf("cannot load latest published version: %w", err)
+	}
+
+	snapshot, err := version.GetSnapshot()
+	if err != nil {
+		return docgen.TrackerPolicyData{}, fmt.Errorf("cannot decode snapshot: %w", err)
+	}
+
+	categories := make([]docgen.TrackerPolicyCategory, 0, len(snapshot.Categories))
+	for _, c := range snapshot.Categories {
+		trackers := make([]docgen.TrackerPolicyTracker, 0, len(c.Cookies))
+		for _, cookie := range c.Cookies {
+			trackers = append(trackers, docgen.TrackerPolicyTracker{
+				Name:     sanitizeTrackerCell(cookie.Name),
+				Purpose:  trackerPurpose(cookie.Description),
+				Duration: cookie.HumanizedDuration(),
+			})
+		}
+
+		categories = append(categories, docgen.TrackerPolicyCategory{
+			Name:        strings.TrimSpace(c.Name),
+			Description: strings.TrimSpace(c.Description),
+			Necessary:   c.Kind == coredata.CookieCategoryKindNecessary,
+			Trackers:    trackers,
+		})
+	}
+
+	thirdParties, err := s.buildTrackerPolicyThirdParties(ctx, scope, conn, banner.ID)
+	if err != nil {
+		return docgen.TrackerPolicyData{}, err
+	}
+
+	privacyPolicyURL := ""
+	if snapshot.PrivacyPolicyURL != nil {
+		privacyPolicyURL = strings.TrimSpace(*snapshot.PrivacyPolicyURL)
+	}
+
+	return docgen.TrackerPolicyData{
+		OrganizationName:  organization.Name,
+		WebsiteOrigin:     banner.Origin,
+		GeneratedAt:       time.Now(),
+		PrivacyPolicyURL:  privacyPolicyURL,
+		ConsentExpiryDays: snapshot.ConsentExpiryDays,
+		Categories:        categories,
+		ThirdParties:      thirdParties,
+	}, nil
+}
+
+func (s *GeneratedDocumentService) buildTrackerPolicyThirdParties(
+	ctx context.Context, scope coredata.Scoper,
+	conn pg.Querier,
+	cookieBannerID gid.GID,
+) ([]docgen.TrackerPolicyThirdParty, error) {
+	var patterns coredata.TrackerPatterns
+
+	thirdPartyIDs, err := patterns.LoadDistinctThirdPartyIDsByCookieBannerID(ctx, conn, scope, cookieBannerID)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load distinct third party ids: %w", err)
+	}
+
+	if len(thirdPartyIDs) == 0 {
+		return nil, nil
+	}
+
+	var thirdParties coredata.ThirdParties
+	if err := thirdParties.LoadByIDs(ctx, conn, scope, thirdPartyIDs); err != nil {
+		return nil, fmt.Errorf("cannot load third parties: %w", err)
+	}
+
+	rows := make([]docgen.TrackerPolicyThirdParty, 0, len(thirdParties))
+	for _, tp := range thirdParties {
+		row := docgen.TrackerPolicyThirdParty{Name: strings.TrimSpace(tp.Name)}
+
+		if tp.Description != nil {
+			row.Description = collapseWhitespace(*tp.Description)
+		}
+
+		if tp.PrivacyPolicyURL != nil {
+			row.PrivacyPolicyURL = strings.TrimSpace(*tp.PrivacyPolicyURL)
+		}
+
+		rows = append(rows, row)
+	}
+
+	return rows, nil
+}
+
+// trackerPurpose returns a table-safe purpose string for a tracker, falling
+// back to a neutral label when no enriched description is available.
+func trackerPurpose(description string) string {
+	cell := sanitizeTrackerCell(description)
+	if cell == "" {
+		return "Not specified"
+	}
+
+	return cell
+}
+
+// sanitizeTrackerCell makes free-form text safe to embed in a markdown table
+// cell: it collapses whitespace (including newlines) and escapes pipe
+// characters so they do not break the column layout.
+func sanitizeTrackerCell(s string) string {
+	return strings.ReplaceAll(collapseWhitespace(s), "|", "\\|")
+}
+
+func collapseWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}

--- a/pkg/probo/tracker_policy_document.go
+++ b/pkg/probo/tracker_policy_document.go
@@ -155,7 +155,7 @@ func (s *GeneratedDocumentService) PublishTrackerPolicy(
 				ID:             documentVersionID,
 				OrganizationID: banner.OrganizationID,
 				DocumentID:     document.ID,
-				Title:          "Cookie and Tracking Technologies Policy",
+				Title:          fmt.Sprintf("Cookie and Tracking Technologies Policy — %s", banner.Origin),
 				Content:        prosemirrorJSON,
 				Classification: coredata.DocumentClassificationPublic,
 				DocumentType:   coredata.DocumentTypePolicy,

--- a/pkg/probo/tracker_policy_document.go
+++ b/pkg/probo/tracker_policy_document.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"text/template"
 	"time"
@@ -73,27 +74,54 @@ func (s *GeneratedDocumentService) PublishTrackerPolicy(
 	scope coredata.Scoper,
 	cookieBannerID gid.GID,
 ) error {
+	// Phase 1: collect data and render the prosemirror document outside any
+	// write transaction. Template rendering, markdown parsing, and JSON
+	// marshaling are CPU work that should not hold a write transaction open.
+	var (
+		organizationID gid.GID
+		bannerOrigin   string
+		documentData   docgen.TrackerPolicyData
+	)
+
+	err := s.svc.pg.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		banner := &coredata.CookieBanner{}
+		if err := banner.LoadByID(ctx, conn, scope, cookieBannerID); err != nil {
+			return fmt.Errorf("cannot load cookie banner: %w", err)
+		}
+
+		organization := &coredata.Organization{}
+		if err := organization.LoadByID(ctx, conn, scope, banner.OrganizationID); err != nil {
+			return fmt.Errorf("cannot load organization: %w", err)
+		}
+
+		var err error
+
+		documentData, err = s.buildTrackerPolicyDocumentData(ctx, scope, conn, organization, banner)
+		if err != nil {
+			return fmt.Errorf("cannot build document data: %w", err)
+		}
+
+		organizationID = banner.OrganizationID
+		bannerOrigin = banner.Origin
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	prosemirrorJSON, err := BuildTrackerPolicyDocument(documentData)
+	if err != nil {
+		return fmt.Errorf("cannot build prosemirror document: %w", err)
+	}
+
+	// Phase 2: persist the document and version in a write transaction.
 	return s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			banner := &coredata.CookieBanner{}
 			if err := banner.LoadByID(ctx, tx, scope, cookieBannerID); err != nil {
-				return fmt.Errorf("cannot load cookie banner: %w", err)
-			}
-
-			organization := &coredata.Organization{}
-			if err := organization.LoadByID(ctx, tx, scope, banner.OrganizationID); err != nil {
-				return fmt.Errorf("cannot load organization: %w", err)
-			}
-
-			documentData, err := s.buildTrackerPolicyDocumentData(ctx, scope, tx, organization, banner)
-			if err != nil {
-				return fmt.Errorf("cannot build document data: %w", err)
-			}
-
-			prosemirrorJSON, err := BuildTrackerPolicyDocument(documentData)
-			if err != nil {
-				return fmt.Errorf("cannot build prosemirror document: %w", err)
+				return fmt.Errorf("cannot reload cookie banner: %w", err)
 			}
 
 			now := time.Now()
@@ -128,7 +156,7 @@ func (s *GeneratedDocumentService) PublishTrackerPolicy(
 
 				document = &coredata.Document{
 					ID:                    documentID,
-					OrganizationID:        banner.OrganizationID,
+					OrganizationID:        organizationID,
 					WriteMode:             coredata.DocumentWriteModeGenerated,
 					TrustCenterVisibility: coredata.TrustCenterVisibilityPrivate,
 					Status:                coredata.DocumentStatusActive,
@@ -153,9 +181,9 @@ func (s *GeneratedDocumentService) PublishTrackerPolicy(
 			documentVersionID := gid.New(scope.GetTenantID(), coredata.DocumentVersionEntityType)
 			documentVersion := &coredata.DocumentVersion{
 				ID:             documentVersionID,
-				OrganizationID: banner.OrganizationID,
+				OrganizationID: organizationID,
 				DocumentID:     document.ID,
-				Title:          fmt.Sprintf("Cookie and Tracking Technologies Policy — %s", banner.Origin),
+				Title:          fmt.Sprintf("Cookie and Tracking Technologies Policy — %s", bannerOrigin),
 				Content:        prosemirrorJSON,
 				Classification: coredata.DocumentClassificationPublic,
 				DocumentType:   coredata.DocumentTypePolicy,
@@ -164,7 +192,7 @@ func (s *GeneratedDocumentService) PublishTrackerPolicy(
 				UpdatedAt:      now,
 			}
 
-			return s.publishOrRequestApproval(ctx, scope, tx, document, documentVersion, banner.OrganizationID, nil, false, now)
+			return s.publishOrRequestApproval(ctx, scope, tx, document, documentVersion, organizationID, nil, false, now)
 		},
 	)
 }
@@ -261,6 +289,21 @@ func (s *GeneratedDocumentService) buildTrackerPolicyThirdParties(
 
 		rows = append(rows, row)
 	}
+
+	// LoadByIDs returns rows in an unspecified order (no ORDER BY), so sort
+	// here to keep the generated policy document deterministic across
+	// regenerations.
+	slices.SortFunc(rows, func(a, b docgen.TrackerPolicyThirdParty) int {
+		if c := strings.Compare(a.Name, b.Name); c != 0 {
+			return c
+		}
+
+		if c := strings.Compare(a.Description, b.Description); c != 0 {
+			return c
+		}
+
+		return strings.Compare(a.PrivacyPolicyURL, b.PrivacyPolicyURL)
+	})
 
 	return rows, nil
 }

--- a/pkg/probo/tracker_policy_document.go
+++ b/pkg/probo/tracker_policy_document.go
@@ -72,13 +72,8 @@ func (s *GeneratedDocumentService) PublishTrackerPolicy(
 	ctx context.Context,
 	scope coredata.Scoper,
 	cookieBannerID gid.GID,
-) (*coredata.Document, *coredata.DocumentVersion, error) {
-	var (
-		document        *coredata.Document
-		documentVersion *coredata.DocumentVersion
-	)
-
-	err := s.svc.pg.WithTx(
+) error {
+	return s.svc.pg.WithTx(
 		ctx,
 		func(ctx context.Context, tx pg.Tx) error {
 			banner := &coredata.CookieBanner{}
@@ -103,7 +98,10 @@ func (s *GeneratedDocumentService) PublishTrackerPolicy(
 
 			now := time.Now()
 
-			var existingDoc *coredata.Document
+			var (
+				document    *coredata.Document
+				existingDoc *coredata.Document
+			)
 
 			if banner.PolicyDocumentID != nil {
 				doc := &coredata.Document{}
@@ -153,7 +151,7 @@ func (s *GeneratedDocumentService) PublishTrackerPolicy(
 			}
 
 			documentVersionID := gid.New(scope.GetTenantID(), coredata.DocumentVersionEntityType)
-			documentVersion = &coredata.DocumentVersion{
+			documentVersion := &coredata.DocumentVersion{
 				ID:             documentVersionID,
 				OrganizationID: banner.OrganizationID,
 				DocumentID:     document.ID,
@@ -169,11 +167,6 @@ func (s *GeneratedDocumentService) PublishTrackerPolicy(
 			return s.publishOrRequestApproval(ctx, scope, tx, document, documentVersion, banner.OrganizationID, nil, false, now)
 		},
 	)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return document, documentVersion, nil
 }
 
 func (s *GeneratedDocumentService) buildTrackerPolicyDocumentData(

--- a/pkg/probo/tracker_policy_document.go
+++ b/pkg/probo/tracker_policy_document.go
@@ -38,6 +38,9 @@ var trackerPolicyTemplate = template.Must(
 			"formatDate": func(t time.Time) string {
 				return t.Format("January 2, 2006")
 			},
+			"add": func(a, b int) int {
+				return a + b
+			},
 		}).
 		ParseFS(Templates, "templates/tracker_policy.md.tmpl"),
 )

--- a/pkg/probo/tracker_policy_worker.go
+++ b/pkg/probo/tracker_policy_worker.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package probo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.gearno.de/kit/log"
+	"go.gearno.de/kit/pg"
+	"go.gearno.de/kit/worker"
+	"go.probo.inc/probo/pkg/coredata"
+)
+
+type trackerPolicyHandler struct {
+	generatedDocuments *GeneratedDocumentService
+	pg                 *pg.Client
+	logger             *log.Logger
+}
+
+// NewTrackerPolicyWorker returns a worker that regenerates a banner's cookie
+// and tracking technologies policy document whenever a banner version is
+// published. Publishing sets policy_generation_requested_at on the banner; this
+// worker claims those banners, clears the flag, and rebuilds the policy from
+// the latest published snapshot.
+func NewTrackerPolicyWorker(
+	generatedDocuments *GeneratedDocumentService,
+	pgClient *pg.Client,
+	logger *log.Logger,
+	opts ...worker.Option,
+) *worker.Worker[coredata.CookieBanner] {
+	h := &trackerPolicyHandler{
+		generatedDocuments: generatedDocuments,
+		pg:                 pgClient,
+		logger:             logger,
+	}
+
+	return worker.New(
+		"tracker-policy-worker",
+		h,
+		logger,
+		opts...,
+	)
+}
+
+func (h *trackerPolicyHandler) Claim(ctx context.Context) (coredata.CookieBanner, error) {
+	var banner coredata.CookieBanner
+
+	if err := h.pg.WithTx(
+		ctx,
+		func(ctx context.Context, tx pg.Tx) error {
+			if err := banner.LoadNextForPolicyGenerationForUpdateSkipLocked(ctx, tx); err != nil {
+				return err
+			}
+
+			return banner.ClearPolicyGenerationRequestedAt(ctx, tx)
+		},
+	); err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) {
+			return coredata.CookieBanner{}, worker.ErrNoTask
+		}
+
+		return coredata.CookieBanner{}, fmt.Errorf("cannot claim tracker policy task: %w", err)
+	}
+
+	return banner, nil
+}
+
+func (h *trackerPolicyHandler) Process(ctx context.Context, banner coredata.CookieBanner) error {
+	scope := coredata.NewScopeFromObjectID(banner.ID)
+
+	if err := h.generatedDocuments.PublishTrackerPolicy(ctx, scope, banner.ID); err != nil {
+		// A banner can lose its published version between the publish that
+		// armed the flag and this run (e.g. it was deleted). There is nothing
+		// to generate in that case, so skip rather than fail the task.
+		if errors.Is(err, coredata.ErrResourceNotFound) {
+			h.logger.InfoCtx(
+				ctx,
+				"skipping tracker policy generation: no published version",
+				log.String("banner_id", banner.ID.String()),
+			)
+
+			return nil
+		}
+
+		return fmt.Errorf("cannot generate tracker policy: %w", err)
+	}
+
+	h.logger.InfoCtx(
+		ctx,
+		"generated tracker policy document",
+		log.String("banner_id", banner.ID.String()),
+	)
+
+	return nil
+}

--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -732,6 +732,17 @@ func (impl *Implm) Run(
 		},
 	)
 
+	trackerPolicyWorker := probo.NewTrackerPolicyWorker(proboService.GeneratedDocuments, pgClient, l)
+	trackerPolicyWorkerCtx, stopTrackerPolicyWorker := context.WithCancel(context.Background())
+
+	wg.Go(
+		func() {
+			if err := trackerPolicyWorker.Run(trackerPolicyWorkerCtx); err != nil {
+				cancel(fmt.Errorf("tracker policy worker crashed: %w", err))
+			}
+		},
+	)
+
 	trackerMappingWorker := cookiebanner.NewTrackerMappingWorker(
 		pgClient,
 		l,
@@ -870,6 +881,7 @@ func (impl *Implm) Run(
 	stopWebhookSender()
 	stopESignService()
 	stopTrackerPatternAnalysisWorker()
+	stopTrackerPolicyWorker()
 	stopTrackerMappingWorker()
 	stopCommonPatternEnrichmentWorker()
 	stopMailingListWorker()

--- a/pkg/server/api/console/v1/cookie_banner_resolvers.go
+++ b/pkg/server/api/console/v1/cookie_banner_resolvers.go
@@ -143,6 +143,32 @@ func (r *cookieBannerResolver) LatestVersion(ctx context.Context, obj *types.Coo
 	}, nil
 }
 
+// PolicyDocument is the resolver for the policyDocument field.
+func (r *cookieBannerResolver) PolicyDocument(ctx context.Context, obj *types.CookieBanner) (*types.Document, error) {
+	if obj.PolicyDocument == nil {
+		return nil, nil
+	}
+
+	if _, err := r.authorize(ctx, obj.ID, probo.ActionDocumentGet); err != nil {
+		return nil, err
+	}
+
+	loaders := dataloader.FromContext(ctx)
+
+	document, err := loaders.Document.Load(ctx, obj.PolicyDocument.ID)
+	if err != nil {
+		if errors.Is(err, coredata.ErrResourceNotFound) || errors.Is(err, dataloadgen.ErrNotFound) {
+			return nil, nil
+		}
+
+		r.logger.ErrorCtx(ctx, "cannot get policy document", log.Error(err))
+
+		return nil, gqlutils.Internal(ctx)
+	}
+
+	return types.NewDocument(document), nil
+}
+
 // ConsentRecords is the resolver for the consentRecords field.
 func (r *cookieBannerResolver) ConsentRecords(ctx context.Context, obj *types.CookieBanner, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.CookieConsentRecordOrderBy, filter *types.CookieConsentRecordFilter) (*types.CookieConsentRecordConnection, error) {
 	scope, err := r.authorize(ctx, obj.ID, probo.ActionCookieConsentRecordList)

--- a/pkg/server/api/console/v1/cookie_banner_resolvers.go
+++ b/pkg/server/api/console/v1/cookie_banner_resolvers.go
@@ -416,6 +416,7 @@ func (r *cookieBannerVersionResolver) Categories(ctx context.Context, obj *types
 		for j, c := range cat.Cookies {
 			cookies[j] = &types.CookieBannerVersionCookie{
 				Name:          c.Name,
+				TrackerType:   c.TrackerType,
 				MaxAgeSeconds: c.MaxAgeSeconds,
 				Description:   c.Description,
 			}

--- a/pkg/server/api/console/v1/graphql/cookie_banner.graphql
+++ b/pkg/server/api/console/v1/graphql/cookie_banner.graphql
@@ -543,6 +543,7 @@ type CookieBannerVersionCategory {
 
 type CookieBannerVersionCookie {
     name: String!
+    trackerType: TrackerType!
     maxAgeSeconds: Int
     description: String!
 }

--- a/pkg/server/api/console/v1/graphql/cookie_banner.graphql
+++ b/pkg/server/api/console/v1/graphql/cookie_banner.graphql
@@ -153,6 +153,8 @@ type CookieBanner implements Node {
 
     latestVersion: CookieBannerVersion @goField(forceResolver: true)
 
+    policyDocument: Document @goField(forceResolver: true)
+
     consentRecords(
         first: Int
         after: CursorKey

--- a/pkg/server/api/console/v1/types/cookie_banner.go
+++ b/pkg/server/api/console/v1/types/cookie_banner.go
@@ -61,7 +61,7 @@ func NewCookieBannerEdge(b *coredata.CookieBanner, orderBy coredata.CookieBanner
 }
 
 func NewCookieBanner(b *coredata.CookieBanner) *CookieBanner {
-	return &CookieBanner{
+	banner := &CookieBanner{
 		ID: b.ID,
 		Organization: &Organization{
 			ID: b.OrganizationID,
@@ -77,6 +77,12 @@ func NewCookieBanner(b *coredata.CookieBanner) *CookieBanner {
 		CreatedAt:         b.CreatedAt,
 		UpdatedAt:         b.UpdatedAt,
 	}
+
+	if b.PolicyDocumentID != nil {
+		banner.PolicyDocument = &Document{ID: *b.PolicyDocumentID}
+	}
+
+	return banner
 }
 
 func NewCookieBannerTranslation(t *coredata.CookieBannerTranslation) *CookieBannerTranslation {


### PR DESCRIPTION
ENG-365


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generates a Cookie and Tracking Technologies Policy from the latest published banner and keeps it up to date after each publish. The console links to the generated policy; tracker lists and the policy show type with accessible labels, non-cookie storage is included, titles include the website origin, and sections are numbered.

### Coredata **`+282`** **`-30`**
- Added `policy_document_id` and `policy_generation_requested_at` to `cookie_banners`, with read/write and backfill for published banners.
- Added work schedulers/claimers; `CookieItem` now has `TrackerType` and `HumanizedDuration` that handles non-cookie storage.
- Backfilled empty tracker types as cookies in `CookieBannerVersion.GetSnapshot`; added `TrackerType.Label()`.

### Service **`+549`** **`-4`**
- Triggered generation in `PublishCookieBannerVersion` so only published versions request work.
- Added docgen types and markdown template; `BuildTrackerPolicyDocument` outputs ProseMirror JSON and numbers top-level sections.
- Implemented `GeneratedDocumentService.PublishTrackerPolicy`; moved data gather/render outside the write transaction; title includes banner origin; sorted third-party rows.
- Snapshot now carries tracker types and keeps non-cookie trackers; duration respects type when no max-age applies.
- Added a poll worker to regenerate the policy and wired it into `pkg/probod` with crash propagation and graceful shutdown.

### GraphQL API **`+37`** **`-1`**
- Exposed `trackerType` on `CookieBannerVersionCookie`.
- Added `policyDocument` on `CookieBanner` with a resolver that returns the linked document when present.

### Tests **`+1`** **`-1`**
- Updated snapshot test to include `trackerType` for cookies.

### App: console **`+72`** **`-56`**
- Moved the Display tab before Settings in the banner configuration.
- Added a header link to the generated cookie policy when available.
- Replaced the Source column with a Type badge and moved descriptions inline under the name; updated add/edit rows to match.

### Package: cookie-banner **`+41`** **`-5`**
- Added `tracker_type` to `CookieItem` and rendered tracker type in the list and themed banner with localized “Type:” and an `aria-label`.
- Added canonical tracker type labels and a small style tweak for the type line.

<sup>Written for commit 9c4b6aff1860a567953050fbf82fbaa6dff184f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



