### PR TITLE
Mark dev topbar logo

### DIFF
--- a/apps/console/src/components/AppLayout.tsx
+++ b/apps/console/src/components/AppLayout.tsx
@@ -12,21 +12,27 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import { Skeleton } from "@probo/ui";
-import { Outlet } from "react-router";
+import { Layout, Logo } from "@probo/ui";
+import type { ComponentProps } from "react";
 
-import { AppLayout } from "#/components/AppLayout";
+type Props = ComponentProps<typeof Layout>;
 
-export function ViewerLayoutLoading() {
+function DevTopbarLogo() {
   return (
-    <AppLayout
-      headerTrailing={(
-        <div className="ml-auto">
-          <Skeleton className="w-32 h-8" />
-        </div>
-      )}
-    >
-      <Outlet />
-    </AppLayout>
+    <span className="flex items-center gap-1.5 text-txt-primary">
+      <Logo className="w-12 h-5 shrink-0" />
+      <span className="rounded-sm border border-border-warning bg-warning px-1.5 py-0.5 text-[10px] font-semibold leading-none text-txt-warning">
+        DEV
+      </span>
+    </span>
+  );
+}
+
+export function AppLayout({ logo, ...props }: Props) {
+  return (
+    <Layout
+      {...props}
+      logo={logo ?? (import.meta.env.DEV ? <DevTopbarLogo /> : undefined)}
+    />
   );
 }

--- a/apps/console/src/pages/iam/memberships/ViewerLayout.tsx
+++ b/apps/console/src/pages/iam/memberships/ViewerLayout.tsx
@@ -12,12 +12,13 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import { Layout, Skeleton } from "@probo/ui";
+import { Skeleton } from "@probo/ui";
 import { Suspense } from "react";
 import { graphql, type PreloadedQuery, usePreloadedQuery } from "react-relay";
 import { Outlet } from "react-router";
 
 import type { ViewerLayoutQuery } from "#/__generated__/iam/ViewerLayoutQuery.graphql";
+import { AppLayout } from "#/components/AppLayout";
 
 import { ViewerDropdown } from "./_components/ViewerDropdown";
 
@@ -41,7 +42,7 @@ export function ViewerLayout(props: {
   );
 
   return (
-    <Layout
+    <AppLayout
       headerTrailing={(
         <div className="ml-auto">
           <Suspense fallback={<Skeleton className="w-32 h-8" />}>
@@ -51,6 +52,6 @@ export function ViewerLayout(props: {
       )}
     >
       <Outlet />
-    </Layout>
+    </AppLayout>
   );
 }

--- a/apps/console/src/pages/iam/organizations/ViewerMembershipLayout.tsx
+++ b/apps/console/src/pages/iam/organizations/ViewerMembershipLayout.tsx
@@ -12,12 +12,13 @@
 // OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 // PERFORMANCE OF THIS SOFTWARE.
 
-import { Layout, Skeleton } from "@probo/ui";
+import { Skeleton } from "@probo/ui";
 import { Suspense } from "react";
 import { graphql, type PreloadedQuery, usePreloadedQuery } from "react-relay";
 import { Outlet } from "react-router";
 
 import type { ViewerMembershipLayoutQuery } from "#/__generated__/iam/ViewerMembershipLayoutQuery.graphql";
+import { AppLayout } from "#/components/AppLayout";
 import { CoreRelayProvider } from "#/providers/CoreRelayProvider";
 import { CurrentUser } from "#/providers/CurrentUser";
 
@@ -66,7 +67,7 @@ export function ViewerMembershipLayout(props: {
   }
 
   return (
-    <Layout
+    <AppLayout
       headerLeading={(
         <MembershipsDropdown organizationFKey={organization} />
       )}
@@ -88,6 +89,6 @@ export function ViewerMembershipLayout(props: {
           <Outlet context={organization.viewer.membership.role} />
         </CurrentUser>
       </CoreRelayProvider>
-    </Layout>
+    </AppLayout>
   );
 }

--- a/packages/ui/src/Layouts/Layout.tsx
+++ b/packages/ui/src/Layouts/Layout.tsx
@@ -33,6 +33,7 @@ import { ConfirmDialog } from "../Molecules/Dialog/ConfirmDialog";
 type Props = PropsWithChildren<{
   headerLeading?: ReactNode;
   headerTrailing: ReactNode;
+  logo?: ReactNode;
   sidebar?: ReactNode;
 }>;
 
@@ -43,6 +44,7 @@ const LayoutContext = createContext({
 export function Layout({
   headerLeading,
   headerTrailing,
+  logo,
   sidebar,
   children,
 }: Props) {
@@ -58,7 +60,7 @@ export function Layout({
       <div className="text-txt-primary bg-level-0 min-h-screen">
         <header className="fixed top-0 z-2 left-0 right-0 px-4 flex items-center border-b border-border-solid h-12 bg-level-0">
           <Link to="/">
-            <Logo className="w-12 h-5" />
+            {logo ?? <Logo className="w-12 h-5" />}
           </Link>
           {headerLeading && (
             <>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a shared layout logo override for topbar branding.
- Use a console app wrapper to display a DEV badge next to the Probo logo when Vite runs in development mode.

## Testing
- `make relay`
- `npm run check --workspace @probo/console`
- `npm run check --workspace @probo/ui` (fails: existing `packages/ui/src/Foundation.stories.tsx` missing required `socialName` prop)
- `npm run lint --workspace @probo/console && npm run lint --workspace @probo/ui` (passes with two existing console Relay unused-field warnings)
- `npm run build --workspace @probo/console`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-436](https://linear.app/probo/issue/ENG-436/change-topbar-probo-logo-on-dev-server)

<div><a href="https://cursor.com/agents/bc-ba739ca7-10a8-4b21-a5b9-1cb0dbc8bb1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba739ca7-10a8-4b21-a5b9-1cb0dbc8bb1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a DEV badge next to the topbar Probo logo when running the console app in development. Adds a console `AppLayout` and a `logo` override in `@probo/ui`’s `Layout` to satisfy Linear ENG-436.

### App: console **`+51`** **`-9`**
- Added `AppLayout` that sets a custom dev-only topbar logo using `import.meta.env.DEV`.
- Updated viewer layouts to use `AppLayout` without changing existing header content.

### Package: ui **`+3`** **`-1`**
- `Layout` now accepts an optional `logo` prop and renders it instead of the default `Logo` when provided.

<sup>Written for commit df6e74197d6a9adb82ae2d567000039a17c2cbad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

