### PR TITLE
Override uuid to ^14.0.0 to resolve @n8n/node-cli conflicts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2376,7 +2376,7 @@
         "js-yaml": "^4.1.1",
         "jsonpointer": "^5.0.1",
         "openapi-types": "^12.1.3",
-        "uuid": "^10.0.0",
+        "uuid": "^14.0.0",
         "yaml": "^2.8.3",
         "zod": "^3.25.76 || ^4"
       },
@@ -2458,7 +2458,7 @@
         "js-yaml": "^4.1.1",
         "langsmith": ">=0.4.0 <1.0.0",
         "math-expression-evaluator": "^2.0.0",
-        "uuid": "^10.0.0",
+        "uuid": "^14.0.0",
         "zod": "^3.25.76 || ^4"
       },
       "engines": {
@@ -2951,7 +2951,7 @@
         "js-yaml": "^4.1.1",
         "jsonpointer": "^5.0.1",
         "openapi-types": "^12.1.3",
-        "uuid": "^10.0.0",
+        "uuid": "^14.0.0",
         "yaml": "^2.8.3",
         "zod": "^3.25.76 || ^4"
       },
@@ -3036,25 +3036,11 @@
         "langsmith": ">=0.5.0 <1.0.0",
         "mustache": "^4.2.0",
         "p-queue": "^6.6.2",
-        "uuid": "^11.1.0",
+        "uuid": "^14.0.0",
         "zod": "^3.25.76 || ^4"
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/@langchain/core/node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@langchain/langgraph": {
@@ -3067,7 +3053,7 @@
         "@langchain/langgraph-checkpoint": "^1.0.1",
         "@langchain/langgraph-sdk": "~1.8.9",
         "@standard-schema/spec": "1.1.0",
-        "uuid": "^10.0.0"
+        "uuid": "^14.0.0"
       },
       "engines": {
         "node": ">=18"
@@ -3090,7 +3076,7 @@
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "uuid": "^10.0.0"
+        "uuid": "^14.0.0"
       },
       "engines": {
         "node": ">=18"
@@ -3109,7 +3095,7 @@
         "@types/json-schema": "^7.0.15",
         "p-queue": "^9.0.1",
         "p-retry": "^7.1.1",
-        "uuid": "^13.0.0"
+        "uuid": "^14.0.0"
       },
       "peerDependencies": {
         "@langchain/core": "^1.1.16",
@@ -3171,20 +3157,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
-      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/@langchain/openai": {
@@ -3314,7 +3286,7 @@
         "langsmith": ">=0.5.0 <1.0.0",
         "mustache": "^4.2.0",
         "p-queue": "^6.6.2",
-        "uuid": "^11.1.0",
+        "uuid": "^14.0.0",
         "zod": "^3.25.76 || ^4"
       },
       "engines": {
@@ -3329,20 +3301,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@n8n/ai-utilities/node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/zod": {
@@ -14297,7 +14255,7 @@
         "@langchain/langgraph": "^1.1.2",
         "@langchain/langgraph-checkpoint": "^1.0.0",
         "langsmith": ">=0.5.0 <1.0.0",
-        "uuid": "^11.1.0",
+        "uuid": "^14.0.0",
         "zod": "^3.25.76 || ^4"
       },
       "engines": {
@@ -14305,20 +14263,6 @@
       },
       "peerDependencies": {
         "@langchain/core": "^1.1.31"
-      }
-    },
-    "node_modules/langchain/node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/langsmith": {
@@ -15334,7 +15278,7 @@
         "roughjs": "^4.6.6",
         "stylis": "^4.3.6",
         "ts-dedent": "^2.2.0",
-        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+        "uuid": "^14.0.0"
       }
     },
     "node_modules/mermaid/node_modules/marked": {
@@ -15347,19 +15291,6 @@
       },
       "engines": {
         "node": ">= 20"
-      }
-    },
-    "node_modules/mermaid/node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/micromark": {
@@ -16080,7 +16011,7 @@
         "recast": "0.22.0",
         "title-case": "3.0.3",
         "transliteration": "2.3.5",
-        "uuid": "10.0.0",
+        "uuid": "^14.0.0",
         "xml2js": "0.6.2",
         "zod": "3.25.67"
       }
@@ -19956,17 +19887,17 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      },
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
+      ]
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "@langchain/community": "^1.1.25",
     "lodash": "^4.18.1",
     "lodash-es": "^4.18.1",
-    "axios": "^1.16.0"
+    "axios": "^1.16.0",
+    "uuid": "^14.0.0"
   },
   "license": "MIT",
   "packageManager": "npm@11.8.0",


### PR DESCRIPTION
@n8n/node-cli pulls LangChain and n8n-workflow packages that require incompatible uuid versions (^10, ^11, ^13). Force uuid 14.0.0 via npm overrides and refresh the lockfile so audit can apply the security fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes on `uuid@^14.0.0` to resolve version conflicts from `@n8n/node-cli` and allow `npm audit` to apply the security fix.

### Other **`+21`** **`-89`**
- Add `uuid@^14.0.0` to root deps and refresh the lockfile to dedupe older `uuid` versions across LangChain packages, `@n8n/ai-utilities`, and `mermaid` to a single `uuid@14`.

<sup>Written for commit 21abcc619e0dc54dba14231cb2e3d15798e65dfc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

