### PR TITLE
Fix contrib/seed.sh script

### DIFF
--- a/contrib/seed.sh
+++ b/contrib/seed.sh
@@ -26,7 +26,6 @@ FULL_NAME="Seed Admin"
 ORG_NAME="Acme Corp"
 
 # Helpers
-
 gql_connect() {
   local query="$1"
   local variables="${2:-"{}"}"
@@ -59,6 +58,9 @@ prb_api() {
   check_error "$resp" "$context"
   echo "$resp"
 }
+
+curl -sf -o /dev/null "$BASE_URL/healthz" \
+  || { echo "ERROR: API at $BASE_URL is not available" >&2; exit 1; }
 
 echo "==> Bootstrapping user and organization..."
 vars=$(jo input="$(jo \
@@ -144,7 +146,7 @@ create_person() {
     fullName="$full_name" \
     role=EMPLOYEE \
     kind=EMPLOYEE \
-    additionalEmailAddresses="$(jo -a)" \
+    additionalEmailAddresses="$(jo -a < /dev/null)" \
     position="$position" \
   )")
   resp=$(gql_connect '


### PR DESCRIPTION
`jo -a` is waiting on stdin; adding `< /dev/null` allows to generate an empty array without waiting on stdin.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `contrib/seed.sh` seeding script to prevent stdin hangs and fail fast if the API is down. Improves reliability for local and CI bootstrapping.

### Other **`+4`** **`-2`**
- Add API health check via GET `/healthz`; exit with a clear error if unavailable.
- Feed `/dev/null` to `jo -a` when building `additionalEmailAddresses` to emit an empty array without waiting on stdin.

<sup>Written for commit 018e5cfda8688eebd42080950323208d49871c7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

