### PR TITLE
Split inactive profile state

### DIFF
--- a/apps/console/src/hooks/graph/PeopleGraph.ts
+++ b/apps/console/src/hooks/graph/PeopleGraph.ts
@@ -18,7 +18,7 @@ import {
 } from "react-relay";
 import { graphql } from "relay-runtime";
 
-import type { PeopleGraphQuery } from "#/__generated__/core/PeopleGraphQuery.graphql";
+import type { PeopleGraphQuery, ProfileFilter } from "#/__generated__/core/PeopleGraphQuery.graphql";
 
 /* eslint-disable relay/unused-fields */
 
@@ -51,11 +51,15 @@ export function usePeople(
   organizationId: string,
   { contractEnded }: { contractEnded?: boolean } = {},
 ) {
+  const filter: ProfileFilter = contractEnded !== undefined
+    ? { contractEnded, states: ["ACTIVE", "PENDING"] }
+    : { states: ["ACTIVE", "PENDING"] };
+
   const data = useLazyLoadQuery<PeopleGraphQuery>(
     peopleQuery,
     {
       organizationId: organizationId,
-      filter: contractEnded !== undefined ? { contractEnded } : null,
+      filter,
     },
     { fetchPolicy: "network-only" },
   );

--- a/apps/console/src/pages/iam/organizations/people/PersonPage.tsx
+++ b/apps/console/src/pages/iam/organizations/people/PersonPage.tsx
@@ -139,7 +139,7 @@ export function PersonPage(props: { queryRef: PreloadedQuery<PersonPageQuery> })
     );
   };
 
-  const canArchive = person.canDelete && person.source !== "SCIM" && person.state !== "INACTIVE";
+  const canArchive = person.canDelete && person.source !== "SCIM" && person.state !== "DEACTIVATED";
   const canRemove = person.canDelete && person.source !== "SCIM";
 
   return (

--- a/apps/console/src/pages/iam/organizations/people/_components/PeopleListItem.tsx
+++ b/apps/console/src/pages/iam/organizations/people/_components/PeopleListItem.tsx
@@ -133,10 +133,11 @@ export function PeopleListItem(props: {
   const profile = useFragment<PeopleListItemFragment$key>(fragment, fKey);
   const lastInvitation = profile.lastInvitation.edges[0]?.node;
 
-  const isInactive = profile.state === "INACTIVE";
+  const isActive = profile.state === "ACTIVE";
+  const isInactive = !isActive;
 
-  const canSendActivationMail = isInactive && profile.source !== "SCIM" && profile.canInvite;
-  const canArchive = profile.canDelete && profile.source !== "SCIM" && profile.state !== "INACTIVE";
+  const canSendActivationMail = !isActive && profile.source !== "SCIM" && profile.canInvite;
+  const canArchive = profile.canDelete && profile.source !== "SCIM" && profile.state !== "DEACTIVATED";
   const canRemove = profile.canDelete && profile.source !== "SCIM";
 
   const [inviteUser]
@@ -259,7 +260,7 @@ export function PeopleListItem(props: {
         <span className="font-semibold">{profile.fullName}</span>
       </Td>
       <Td>
-        <Badge variant={profile.state === "INACTIVE" ? "neutral" : "success"}>{profile.state}</Badge>
+        <Badge variant={isActive ? "success" : "neutral"}>{profile.state}</Badge>
       </Td>
       <Td className={clsx(
         isMutating && "opacity-60 pointer-events-none",

--- a/e2e/console/user_test.go
+++ b/e2e/console/user_test.go
@@ -423,7 +423,7 @@ func TestUser_ArchiveUser(t *testing.T) {
 	}
 
 	require.NotEmpty(t, archivedUserState, "Should still find archived user")
-	assert.Equal(t, "INACTIVE", archivedUserState)
+	assert.Equal(t, "DEACTIVATED", archivedUserState)
 }
 
 func TestUser_DeactivateUserCancelsSignatureRequests(t *testing.T) {

--- a/packages/n8n-node/nodes/Probo/actions/document/getAllSignatures.operation.ts
+++ b/packages/n8n-node/nodes/Probo/actions/document/getAllSignatures.operation.ts
@@ -99,8 +99,9 @@ export const description: INodeProperties[] = [
 				description: 'Filter by signatory profile state',
 				options: [
 					{ name: 'Any', value: '' },
+					{ name: 'Pending', value: 'PENDING' },
 					{ name: 'Active', value: 'ACTIVE' },
-					{ name: 'Inactive', value: 'INACTIVE' },
+					{ name: 'Deactivated', value: 'DEACTIVATED' },
 				],
 			},
 		],

--- a/pkg/cmd/user/list/list.go
+++ b/pkg/cmd/user/list/list.go
@@ -140,7 +140,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			if flagState != "" {
-				if err := cmdutil.ValidateEnum("state", flagState, []string{"ACTIVE", "INACTIVE"}); err != nil {
+				if err := cmdutil.ValidateEnum("state", flagState, []string{"PENDING", "ACTIVE", "DEACTIVATED"}); err != nil {
 					return err
 				}
 
@@ -235,7 +235,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&flagOrder, "order-by", "", "Order by field (FULL_NAME, CREATED_AT, KIND)")
 	cmd.Flags().StringVar(&flagOrderDir, "order-direction", "DESC", "Sort direction (ASC, DESC)")
 	cmd.Flags().StringVar(&flagContractEnded, "contract-ended", "", "Filter by contract status (true or false)")
-	cmd.Flags().StringVar(&flagState, "state", "", "Filter by profile state (ACTIVE or INACTIVE)")
+	cmd.Flags().StringVar(&flagState, "state", "", "Filter by profile state (PENDING, ACTIVE, DEACTIVATED)")
 	flagOutput = cmdutil.AddOutputFlag(cmd)
 
 	return cmd

--- a/pkg/coredata/membership_profile.go
+++ b/pkg/coredata/membership_profile.go
@@ -64,6 +64,8 @@ type (
 		EnterpriseOrganization   *string       `db:"enterprise_organization"`
 		Division                 *string       `db:"division"`
 		ManagerValue             *string       `db:"manager_value"`
+		ActivatedAt              *time.Time    `db:"activated_at"`
+		DeactivatedAt            *time.Time    `db:"deactivated_at"`
 		CreatedAt                time.Time     `db:"created_at"`
 		UpdatedAt                time.Time     `db:"updated_at"`
 	}
@@ -88,6 +90,26 @@ func (p MembershipProfile) CursorKey(orderBy MembershipProfileOrderField) page.C
 	}
 
 	panic(fmt.Sprintf("unsupported order by: %s", orderBy))
+}
+
+func (p *MembershipProfile) MarkPending(now time.Time) {
+	p.State = ProfileStatePending
+	p.ActivatedAt = nil
+	p.DeactivatedAt = nil
+	p.UpdatedAt = now
+}
+
+func (p *MembershipProfile) MarkActive(now time.Time) {
+	p.State = ProfileStateActive
+	p.ActivatedAt = &now
+	p.DeactivatedAt = nil
+	p.UpdatedAt = now
+}
+
+func (p *MembershipProfile) MarkDeactivated(now time.Time) {
+	p.State = ProfileStateDeactivated
+	p.DeactivatedAt = &now
+	p.UpdatedAt = now
 }
 
 func (p *MembershipProfile) AuthorizationAttributes(
@@ -183,6 +205,8 @@ SELECT
     p.enterprise_organization,
     p.division,
     p.manager_value,
+    p.activated_at,
+    p.deactivated_at,
     p.created_at,
     p.updated_at
 FROM
@@ -260,6 +284,8 @@ SELECT
     p.enterprise_organization,
     p.division,
     p.manager_value,
+    p.activated_at,
+    p.deactivated_at,
     p.created_at,
     p.updated_at
 FROM
@@ -341,6 +367,8 @@ SELECT
     p.enterprise_organization,
     p.division,
     p.manager_value,
+    p.activated_at,
+    p.deactivated_at,
     p.created_at,
     p.updated_at
 FROM
@@ -421,6 +449,8 @@ SELECT
     p.enterprise_organization,
     p.division,
     p.manager_value,
+    p.activated_at,
+    p.deactivated_at,
     p.created_at,
     p.updated_at
 FROM
@@ -494,6 +524,8 @@ WITH profiles AS (
         p.enterprise_organization,
         p.division,
         p.manager_value,
+        p.activated_at,
+        p.deactivated_at,
         p.created_at,
         p.updated_at
     FROM
@@ -537,6 +569,8 @@ SELECT
     enterprise_organization,
     division,
     manager_value,
+    activated_at,
+    deactivated_at,
     created_at,
     updated_at
 FROM profiles
@@ -607,6 +641,8 @@ WITH profiles AS (
         p.enterprise_organization,
         p.division,
         p.manager_value,
+        p.activated_at,
+        p.deactivated_at,
         p.created_at,
         p.updated_at
     FROM
@@ -650,6 +686,8 @@ SELECT
     enterprise_organization,
     division,
     manager_value,
+    activated_at,
+    deactivated_at,
     created_at,
     updated_at
 FROM profiles
@@ -719,6 +757,8 @@ WITH profiles AS (
         p.enterprise_organization,
         p.division,
         p.manager_value,
+        p.activated_at,
+        p.deactivated_at,
         p.created_at,
         p.updated_at
     FROM
@@ -761,6 +801,8 @@ SELECT
     p.enterprise_organization,
     p.division,
     p.manager_value,
+    p.activated_at,
+    p.deactivated_at,
     p.created_at,
     p.updated_at
 FROM profiles p
@@ -842,6 +884,8 @@ profiles AS (
         mp.enterprise_organization,
         mp.division,
         mp.manager_value,
+        mp.activated_at,
+        mp.deactivated_at,
         mp.created_at,
         mp.updated_at
     FROM
@@ -884,6 +928,8 @@ SELECT
     p.enterprise_organization,
     p.division,
     p.manager_value,
+    p.activated_at,
+    p.deactivated_at,
     p.created_at,
     p.updated_at
 FROM profiles p
@@ -1000,6 +1046,8 @@ SELECT
     p.enterprise_organization,
     p.division,
     p.manager_value,
+    p.activated_at,
+    p.deactivated_at,
     p.created_at,
     p.updated_at
 FROM
@@ -1175,6 +1223,8 @@ INSERT INTO
         enterprise_organization,
         division,
         manager_value,
+        activated_at,
+        deactivated_at,
         created_at,
         updated_at
     )
@@ -1210,6 +1260,8 @@ VALUES (
     @enterprise_organization,
     @division,
     @manager_value,
+    @activated_at,
+    @deactivated_at,
     @created_at,
     @updated_at
 )
@@ -1247,6 +1299,8 @@ VALUES (
 		"enterprise_organization":    p.EnterpriseOrganization,
 		"division":                   p.Division,
 		"manager_value":              p.ManagerValue,
+		"activated_at":               p.ActivatedAt,
+		"deactivated_at":             p.DeactivatedAt,
 		"created_at":                 p.CreatedAt,
 		"updated_at":                 p.UpdatedAt,
 	}
@@ -1305,6 +1359,8 @@ SET
     enterprise_organization = @enterprise_organization,
     division = @division,
     manager_value = @manager_value,
+    activated_at = @activated_at,
+    deactivated_at = @deactivated_at,
     updated_at = @updated_at
 WHERE
     id = @id
@@ -1343,6 +1399,8 @@ WHERE
 		"enterprise_organization":    p.EnterpriseOrganization,
 		"division":                   p.Division,
 		"manager_value":              p.ManagerValue,
+		"activated_at":               p.ActivatedAt,
+		"deactivated_at":             p.DeactivatedAt,
 		"updated_at":                 p.UpdatedAt,
 	}
 	maps.Copy(args, scope.SQLArguments())

--- a/pkg/coredata/membership_profile_filter.go
+++ b/pkg/coredata/membership_profile_filter.go
@@ -30,7 +30,7 @@ type (
 		email                 *mail.Addr
 		userName              *string
 		externalID            *string
-		state                 *ProfileState
+		states                ProfileStateValues
 		source                *ProfileSource
 	}
 )
@@ -72,12 +72,17 @@ func (f *MembershipProfileFilter) WithExternalID(externalID string) *MembershipP
 }
 
 func (f *MembershipProfileFilter) WithState(state ProfileState) *MembershipProfileFilter {
-	f.state = &state
+	f.states = ProfileStateValues{state}
 	return f
 }
 
-func (f *MembershipProfileFilter) State() *ProfileState {
-	return f.state
+func (f *MembershipProfileFilter) WithStates(states ...ProfileState) *MembershipProfileFilter {
+	f.states = ProfileStateValues(states)
+	return f
+}
+
+func (f *MembershipProfileFilter) States() []ProfileState {
+	return f.states
 }
 
 func (f *MembershipProfileFilter) WithSource(source ProfileSource) *MembershipProfileFilter {
@@ -98,7 +103,7 @@ func (f *MembershipProfileFilter) SQLArguments() pgx.StrictNamedArgs {
 		"with_trust_center_access": f.withTrustCenterAccess,
 		"contract_ended":           f.contractEnded,
 		"current_date":             f.currentDate,
-		"filter_state":             f.state,
+		"filter_states":            f.states,
 		"filter_source":            f.source,
 	}
 }
@@ -141,8 +146,8 @@ AND (
 )
 AND (
 	CASE
-		WHEN @filter_state::text IS NOT NULL THEN
-			p.state = @filter_state::membership_state
+		WHEN @filter_states::membership_state[] IS NOT NULL THEN
+			p.state = ANY(@filter_states::membership_state[])
 		ELSE TRUE
 	END
 )

--- a/pkg/coredata/migrations/20260603T113930Z.sql
+++ b/pkg/coredata/migrations/20260603T113930Z.sql
@@ -1,0 +1,64 @@
+-- Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+--
+-- Permission to use, copy, modify, and/or distribute this software for any
+-- purpose with or without fee is hereby granted, provided that the above
+-- copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+-- REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+-- INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+-- LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+-- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+ALTER TABLE iam_membership_profiles
+    ADD COLUMN activated_at TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN deactivated_at TIMESTAMP WITH TIME ZONE;
+
+ALTER TABLE iam_memberships
+    ALTER COLUMN state DROP DEFAULT;
+
+ALTER TABLE iam_membership_profiles
+    ALTER COLUMN state DROP DEFAULT;
+
+ALTER TYPE membership_state RENAME TO membership_state_old;
+CREATE TYPE membership_state AS ENUM ('PENDING', 'ACTIVE', 'DEACTIVATED');
+
+ALTER TABLE iam_memberships
+    ALTER COLUMN state TYPE membership_state
+    USING CASE
+        WHEN state::text = 'ACTIVE' THEN 'ACTIVE'::membership_state
+        ELSE 'DEACTIVATED'::membership_state
+    END;
+
+ALTER TABLE iam_membership_profiles
+    ALTER COLUMN state TYPE membership_state
+    USING CASE
+        WHEN state::text = 'ACTIVE' THEN 'ACTIVE'::membership_state
+        WHEN source = 'SCIM' THEN 'DEACTIVATED'::membership_state
+        WHEN EXISTS (
+            SELECT 1
+            FROM iam_invitations i
+            WHERE i.user_id = iam_membership_profiles.id
+              AND i.accepted_at IS NULL
+              AND (
+                  i.expires_at >= NOW()
+                  OR i.created_at >= NOW() - INTERVAL '7 days'
+              )
+        ) THEN 'PENDING'::membership_state
+        ELSE 'DEACTIVATED'::membership_state
+    END;
+
+DROP TYPE membership_state_old;
+
+UPDATE iam_membership_profiles
+SET activated_at = updated_at
+WHERE state = 'ACTIVE';
+
+UPDATE iam_membership_profiles
+SET deactivated_at = NOW()
+WHERE state = 'DEACTIVATED';
+
+ALTER TABLE iam_memberships
+    ALTER COLUMN state SET DEFAULT 'ACTIVE';

--- a/pkg/coredata/migrations/20260603T113930Z.sql
+++ b/pkg/coredata/migrations/20260603T113930Z.sql
@@ -16,41 +16,35 @@ ALTER TABLE iam_membership_profiles
     ADD COLUMN activated_at TIMESTAMP WITH TIME ZONE,
     ADD COLUMN deactivated_at TIMESTAMP WITH TIME ZONE;
 
-ALTER TABLE iam_memberships
-    ALTER COLUMN state DROP DEFAULT;
-
 ALTER TABLE iam_membership_profiles
     ALTER COLUMN state DROP DEFAULT;
 
 ALTER TYPE membership_state RENAME TO membership_state_old;
 CREATE TYPE membership_state AS ENUM ('PENDING', 'ACTIVE', 'DEACTIVATED');
 
-ALTER TABLE iam_memberships
-    ALTER COLUMN state TYPE membership_state
-    USING CASE
-        WHEN state::text = 'ACTIVE' THEN 'ACTIVE'::membership_state
-        ELSE 'DEACTIVATED'::membership_state
-    END;
-
 ALTER TABLE iam_membership_profiles
     ALTER COLUMN state TYPE membership_state
     USING CASE
         WHEN state::text = 'ACTIVE' THEN 'ACTIVE'::membership_state
-        WHEN source = 'SCIM' THEN 'DEACTIVATED'::membership_state
-        WHEN EXISTS (
-            SELECT 1
-            FROM iam_invitations i
-            WHERE i.user_id = iam_membership_profiles.id
-              AND i.accepted_at IS NULL
-              AND (
-                  i.expires_at >= NOW()
-                  OR i.created_at >= NOW() - INTERVAL '7 days'
-              )
-        ) THEN 'PENDING'::membership_state
         ELSE 'DEACTIVATED'::membership_state
     END;
 
 DROP TYPE membership_state_old;
+
+UPDATE iam_membership_profiles
+SET state = 'PENDING'
+WHERE state = 'DEACTIVATED'
+  AND source != 'SCIM'
+  AND EXISTS (
+      SELECT 1
+      FROM iam_invitations i
+      WHERE i.user_id = iam_membership_profiles.id
+        AND i.accepted_at IS NULL
+        AND (
+            i.expires_at >= NOW()
+            OR i.created_at >= NOW() - INTERVAL '7 days'
+        )
+  );
 
 UPDATE iam_membership_profiles
 SET activated_at = updated_at
@@ -59,6 +53,3 @@ WHERE state = 'ACTIVE';
 UPDATE iam_membership_profiles
 SET deactivated_at = NOW()
 WHERE state = 'DEACTIVATED';
-
-ALTER TABLE iam_memberships
-    ALTER COLUMN state SET DEFAULT 'ACTIVE';

--- a/pkg/coredata/profile_state.go
+++ b/pkg/coredata/profile_state.go
@@ -15,15 +15,21 @@
 package coredata
 
 import (
+	"database/sql/driver"
 	"encoding"
 	"fmt"
+	"strings"
 )
 
-type ProfileState string
+type (
+	ProfileState       string
+	ProfileStateValues []ProfileState
+)
 
 const (
-	ProfileStateActive   ProfileState = "ACTIVE"
-	ProfileStateInactive ProfileState = "INACTIVE"
+	ProfileStatePending     ProfileState = "PENDING"
+	ProfileStateActive      ProfileState = "ACTIVE"
+	ProfileStateDeactivated ProfileState = "DEACTIVATED"
 )
 
 var (
@@ -34,16 +40,18 @@ var (
 
 func ProfileStates() []ProfileState {
 	return []ProfileState{
+		ProfileStatePending,
 		ProfileStateActive,
-		ProfileStateInactive,
+		ProfileStateDeactivated,
 	}
 }
 
 func (v ProfileState) IsValid() bool {
 	switch v {
 	case
+		ProfileStatePending,
 		ProfileStateActive,
-		ProfileStateInactive:
+		ProfileStateDeactivated:
 		return true
 	}
 
@@ -67,4 +75,25 @@ func (v *ProfileState) UnmarshalText(text []byte) error {
 	*v = val
 
 	return nil
+}
+
+func (states ProfileStateValues) Value() (driver.Value, error) {
+	if len(states) == 0 {
+		return nil, nil
+	}
+
+	var result strings.Builder
+	result.WriteString("{")
+
+	for i, state := range states {
+		if i > 0 {
+			result.WriteString(",")
+		}
+
+		fmt.Fprintf(&result, "%q", state.String())
+	}
+
+	result.WriteString("}")
+
+	return result.String(), nil
 }

--- a/pkg/iam/auth_service.go
+++ b/pkg/iam/auth_service.go
@@ -171,9 +171,8 @@ func (s *AuthService) ActivateAccount(
 				return NewUserManagedBySCIMError(profile.ID)
 			}
 
-			if profile.State == coredata.ProfileStateInactive {
-				profile.State = coredata.ProfileStateActive
-				profile.UpdatedAt = now
+			if profile.State == coredata.ProfileStatePending {
+				profile.MarkActive(now)
 
 				if err := profile.Update(ctx, tx, scope); err != nil {
 					return fmt.Errorf("cannot update user: %w", err)

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -432,9 +432,8 @@ func (s *OrganizationService) ArchiveUser(
 
 			now := time.Now()
 
-			if profile.State != coredata.ProfileStateInactive {
-				profile.State = coredata.ProfileStateInactive
-				profile.UpdatedAt = now
+			if profile.State != coredata.ProfileStateDeactivated {
+				profile.MarkDeactivated(now)
 
 				if err := profile.Update(ctx, tx, scope); err != nil {
 					return fmt.Errorf("cannot update profile state: %w", err)
@@ -497,6 +496,13 @@ func (s *OrganizationService) InviteUser(
 
 			if profile.Source == coredata.ProfileSourceSCIM {
 				return NewUserManagedBySCIMError(profile.ID)
+			}
+
+			if profile.State == coredata.ProfileStateDeactivated {
+				profile.MarkPending(now)
+				if err := profile.Update(ctx, tx, scope); err != nil {
+					return fmt.Errorf("cannot update profile state: %w", err)
+				}
 			}
 
 			err = invitation.Insert(ctx, tx, scope)
@@ -577,6 +583,7 @@ func (s *OrganizationService) CreateOrganization(
 			OrganizationID: organization.ID,
 			Source:         coredata.ProfileSourceManual,
 			State:          coredata.ProfileStateActive,
+			ActivatedAt:    &now,
 			CreatedAt:      now,
 			UpdatedAt:      now,
 		}
@@ -1021,8 +1028,8 @@ func (s *OrganizationService) CreateUser(ctx context.Context, req *CreateUserReq
 				Kind:                     req.Kind,
 				AdditionalEmailAddresses: req.AdditionalEmailAddresses,
 				Position:                 req.Position,
-				// User is created inactive
-				State:     coredata.ProfileStateInactive,
+				// User is pending until they accept an invitation.
+				State:     coredata.ProfileStatePending,
 				CreatedAt: now,
 				UpdatedAt: now,
 			}
@@ -1166,14 +1173,21 @@ func (s *OrganizationService) UpdateUserState(
 				return fmt.Errorf("cannot load profile: %w", err)
 			}
 
-			profile.State = state
-			profile.UpdatedAt = time.Now()
+			now := time.Now()
+			switch state {
+			case coredata.ProfileStatePending:
+				profile.MarkPending(now)
+			case coredata.ProfileStateActive:
+				profile.MarkActive(now)
+			case coredata.ProfileStateDeactivated:
+				profile.MarkDeactivated(now)
+			}
 
 			if err := profile.Update(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot update profile: %w", err)
 			}
 
-			if state == coredata.ProfileStateInactive {
+			if state == coredata.ProfileStateDeactivated {
 				signatures := &coredata.DocumentVersionSignatures{}
 				if err := signatures.DeleteRequestedBySignatory(ctx, tx, scope, profile.ID); err != nil {
 					return fmt.Errorf("cannot delete requested signatures: %w", err)

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -500,6 +500,7 @@ func (s *OrganizationService) InviteUser(
 
 			if profile.State == coredata.ProfileStateDeactivated {
 				profile.MarkPending(now)
+
 				if err := profile.Update(ctx, tx, scope); err != nil {
 					return fmt.Errorf("cannot update profile state: %w", err)
 				}
@@ -1174,6 +1175,7 @@ func (s *OrganizationService) UpdateUserState(
 			}
 
 			now := time.Now()
+
 			switch state {
 			case coredata.ProfileStatePending:
 				profile.MarkPending(now)

--- a/pkg/iam/saml/service.go
+++ b/pkg/iam/saml/service.go
@@ -309,6 +309,7 @@ func (s *Service) HandleAssertion(
 					OrganizationID: config.OrganizationID,
 					Source:         coredata.ProfileSourceSAML,
 					State:          coredata.ProfileStateActive,
+					ActivatedAt:    &now,
 					FullName:       fullname,
 					CreatedAt:      now,
 					UpdatedAt:      now,
@@ -319,7 +320,7 @@ func (s *Service) HandleAssertion(
 					return fmt.Errorf("cannot insert membership profile: %w", err)
 				}
 			} else {
-				if profile.State == coredata.ProfileStateInactive {
+				if profile.State == coredata.ProfileStateDeactivated {
 					return NewUserInactiveError(profile.ID)
 				}
 			}

--- a/pkg/iam/scim/service.go
+++ b/pkg/iam/scim/service.go
@@ -790,6 +790,7 @@ func applyUserAttributes(
 		profile.State = state
 		profile.UpdatedAt = now
 	}
+
 	profile.FullName = attrs.FullName
 	profile.Position = &attrs.Title
 	profile.UserName = &attrs.UserName

--- a/pkg/iam/scim/service.go
+++ b/pkg/iam/scim/service.go
@@ -143,7 +143,7 @@ func (s *Service) CreateUser(
 
 	profileState := coredata.ProfileStateActive
 	if !attrs.Active {
-		profileState = coredata.ProfileStateInactive
+		profileState = coredata.ProfileStateDeactivated
 	}
 
 	var externalIdPtr *string
@@ -493,8 +493,8 @@ func (s *Service) updateUser(
 				return fmt.Errorf("cannot load membership: %w", err)
 			}
 
-			shouldReactivate := attrs.Active != nil && *attrs.Active && profile.State == coredata.ProfileStateInactive
-			shouldDeactivate := attrs.Active != nil && !*attrs.Active && profile.State == coredata.ProfileStateActive
+			shouldReactivate := attrs.Active != nil && *attrs.Active && profile.State == coredata.ProfileStateDeactivated
+			shouldDeactivate := attrs.Active != nil && !*attrs.Active && profile.State != coredata.ProfileStateDeactivated
 
 			if attrs.FullName != "" {
 				profile.FullName = attrs.FullName
@@ -705,11 +705,9 @@ func (s *Service) updateUser(
 			}
 
 			if shouldReactivate {
-				profile.State = coredata.ProfileStateActive
-				profile.UpdatedAt = now
+				profile.MarkActive(now)
 			} else if shouldDeactivate {
-				profile.State = coredata.ProfileStateInactive
-				profile.UpdatedAt = now
+				profile.MarkDeactivated(now)
 			}
 
 			if profile.Source != coredata.ProfileSourceSCIM {
@@ -783,7 +781,15 @@ func applyUserAttributes(
 	now time.Time,
 ) {
 	profile.Source = coredata.ProfileSourceSCIM
-	profile.State = state
+	switch {
+	case state == coredata.ProfileStateActive && profile.State != coredata.ProfileStateActive:
+		profile.MarkActive(now)
+	case state == coredata.ProfileStateDeactivated && profile.State != coredata.ProfileStateDeactivated:
+		profile.MarkDeactivated(now)
+	default:
+		profile.State = state
+		profile.UpdatedAt = now
+	}
 	profile.FullName = attrs.FullName
 	profile.Position = &attrs.Title
 	profile.UserName = &attrs.UserName
@@ -805,7 +811,6 @@ func applyUserAttributes(
 	profile.EnterpriseOrganization = ref.RefOrNil(attrs.EnterpriseOrganization)
 	profile.Division = ref.RefOrNil(attrs.Division)
 	profile.ManagerValue = ref.RefOrNil(attrs.ManagerValue)
-	profile.UpdatedAt = now
 
 	if attrs.UserType != "" {
 		kind := attrs.UserType
@@ -903,13 +908,12 @@ func (s *Service) deactivateProfileInTx(
 	profile *coredata.MembershipProfile,
 	membership *coredata.Membership,
 ) error {
-	if profile.State == coredata.ProfileStateInactive {
+	if profile.State == coredata.ProfileStateDeactivated {
 		return nil
 	}
 
 	now := time.Now()
-	profile.State = coredata.ProfileStateInactive
-	profile.UpdatedAt = now
+	profile.MarkDeactivated(now)
 
 	if err := profile.Update(ctx, tx, scope); err != nil {
 		return fmt.Errorf("cannot deactivate profile: %w", err)

--- a/pkg/iam/session_service.go
+++ b/pkg/iam/session_service.go
@@ -358,7 +358,7 @@ func (s SessionService) OpenPasswordChildSessionForOrganization(
 				return fmt.Errorf("cannot load profile: %w", err)
 			}
 
-			if profile.State == coredata.ProfileStateInactive {
+			if profile.State == coredata.ProfileStateDeactivated {
 				return NewUserInactiveError(profile.ID)
 			}
 
@@ -463,7 +463,7 @@ func (s SessionService) OpenSAMLChildSessionForOrganization(
 				return fmt.Errorf("cannot load profile: %w", err)
 			}
 
-			if profile.State == coredata.ProfileStateInactive {
+			if profile.State == coredata.ProfileStateDeactivated {
 				return NewUserInactiveError(profile.ID)
 			}
 
@@ -552,7 +552,7 @@ func (s SessionService) AssumeOrganizationSession(
 				return fmt.Errorf("cannot load profile: %w", err)
 			}
 
-			if profile.State == coredata.ProfileStateInactive {
+			if profile.State == coredata.ProfileStateDeactivated {
 				return NewUserInactiveError(profile.ID)
 			}
 

--- a/pkg/server/api/connect/v1/graphql/profile.graphql
+++ b/pkg/server/api/connect/v1/graphql/profile.graphql
@@ -30,9 +30,10 @@ type Profile implements Node {
 
 enum ProfileState
   @goModel(model: "go.probo.inc/probo/pkg/coredata.ProfileState") {
+  PENDING @goEnum(value: "go.probo.inc/probo/pkg/coredata.ProfileStatePending")
   ACTIVE @goEnum(value: "go.probo.inc/probo/pkg/coredata.ProfileStateActive")
-  INACTIVE
-    @goEnum(value: "go.probo.inc/probo/pkg/coredata.ProfileStateInactive")
+  DEACTIVATED
+    @goEnum(value: "go.probo.inc/probo/pkg/coredata.ProfileStateDeactivated")
 }
 
 enum ProfileSource
@@ -71,6 +72,7 @@ enum ProfileOrderField
 input ProfileFilter {
   contractEnded: Boolean
   state: ProfileState
+  states: [ProfileState!]
 }
 
 input ProfileOrder

--- a/pkg/server/api/connect/v1/identity_resolvers.go
+++ b/pkg/server/api/connect/v1/identity_resolvers.go
@@ -34,6 +34,7 @@ func (r *identityResolver) Profiles(ctx context.Context, obj *types.Identity, fi
 		if len(filter.States) > 0 {
 			filters.WithStates(filter.States...)
 		}
+
 		if filter.State != nil {
 			filters.WithState(*filter.State)
 		}

--- a/pkg/server/api/connect/v1/identity_resolvers.go
+++ b/pkg/server/api/connect/v1/identity_resolvers.go
@@ -31,6 +31,9 @@ func (r *identityResolver) Profiles(ctx context.Context, obj *types.Identity, fi
 	filters := coredata.NewMembershipProfileFilter(nil).WithMembership()
 	if filter != nil {
 		filters = coredata.NewMembershipProfileFilter(filter.ContractEnded).WithMembership()
+		if len(filter.States) > 0 {
+			filters.WithStates(filter.States...)
+		}
 		if filter.State != nil {
 			filters.WithState(*filter.State)
 		}

--- a/pkg/server/api/connect/v1/profile_resolvers.go
+++ b/pkg/server/api/connect/v1/profile_resolvers.go
@@ -64,7 +64,7 @@ func (r *mutationResolver) DeactivateUser(ctx context.Context, input types.Deact
 	_, err := r.iam.OrganizationService.UpdateUserState(
 		ctx,
 		input.ProfileID,
-		coredata.ProfileStateInactive,
+		coredata.ProfileStateDeactivated,
 	)
 	if err != nil {
 		r.logger.ErrorCtx(ctx, "cannot deactivate profile", log.Error(err))

--- a/pkg/server/api/console/v1/graphql/organization.graphql
+++ b/pkg/server/api/console/v1/graphql/organization.graphql
@@ -9,9 +9,10 @@ type OrganizationContext {
 
 enum ProfileState
   @goModel(model: "go.probo.inc/probo/pkg/coredata.ProfileState") {
+  PENDING @goEnum(value: "go.probo.inc/probo/pkg/coredata.ProfileStatePending")
   ACTIVE @goEnum(value: "go.probo.inc/probo/pkg/coredata.ProfileStateActive")
-  INACTIVE
-    @goEnum(value: "go.probo.inc/probo/pkg/coredata.ProfileStateInactive")
+  DEACTIVATED
+    @goEnum(value: "go.probo.inc/probo/pkg/coredata.ProfileStateDeactivated")
 }
 
 type Profile implements Node {
@@ -58,6 +59,7 @@ input ProfileOrder
 input ProfileFilter {
     contractEnded: Boolean
     state: ProfileState
+    states: [ProfileState!]
 }
 
 type ProfileConnection

--- a/pkg/server/api/console/v1/organization_resolvers.go
+++ b/pkg/server/api/console/v1/organization_resolvers.go
@@ -124,6 +124,7 @@ func (r *organizationResolver) Profiles(ctx context.Context, obj *types.Organiza
 		if len(filter.States) > 0 {
 			filters.WithStates(filter.States...)
 		}
+
 		if filter.State != nil {
 			filters.WithState(*filter.State)
 		}

--- a/pkg/server/api/console/v1/organization_resolvers.go
+++ b/pkg/server/api/console/v1/organization_resolvers.go
@@ -121,6 +121,9 @@ func (r *organizationResolver) Profiles(ctx context.Context, obj *types.Organiza
 	filters := coredata.NewMembershipProfileFilter(nil).WithMembership()
 	if filter != nil {
 		filters = coredata.NewMembershipProfileFilter(filter.ContractEnded).WithMembership()
+		if len(filter.States) > 0 {
+			filters.WithStates(filter.States...)
+		}
 		if filter.State != nil {
 			filters.WithState(*filter.State)
 		}

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -2764,6 +2764,9 @@ func (r *Resolver) ListUsersTool(ctx context.Context, req *mcp.CallToolRequest, 
 	filter := coredata.NewMembershipProfileFilter(nil).WithMembership()
 	if input.Filter != nil {
 		filter = coredata.NewMembershipProfileFilter(input.Filter.ContractEnded).WithMembership()
+		if len(input.Filter.States) > 0 {
+			filter.WithStates(input.Filter.States...)
+		}
 		if input.Filter.State != nil {
 			filter.WithState(*input.Filter.State)
 		}

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -2767,6 +2767,7 @@ func (r *Resolver) ListUsersTool(ctx context.Context, req *mcp.CallToolRequest, 
 		if len(input.Filter.States) > 0 {
 			filter.WithStates(input.Filter.States...)
 		}
+
 		if input.Filter.State != nil {
 			filter.WithState(*input.Filter.State)
 		}

--- a/pkg/server/api/mcp/v1/specification.yaml
+++ b/pkg/server/api/mcp/v1/specification.yaml
@@ -184,8 +184,9 @@ components:
     ProfileState:
       type: string
       enum:
+        - PENDING
         - ACTIVE
-        - INACTIVE
+        - DEACTIVATED
       go.probo.inc/mcpgen/type: go.probo.inc/probo/pkg/coredata.ProfileState
 
     ProfileSource:
@@ -512,7 +513,7 @@ components:
           description: Profile source (MANUAL, SCIM, or SAML)
         state:
           $ref: "#/components/schemas/ProfileState"
-          description: Profile state (ACTIVE or INACTIVE)
+          description: Profile state (PENDING, ACTIVE, or DEACTIVATED)
         position:
           type:
             - string
@@ -564,7 +565,12 @@ components:
               description: Filter by contract status. True returns only users with ended contracts, false returns only users with active or no contract.
             state:
               $ref: "#/components/schemas/ProfileState"
-              description: Filter by profile state (ACTIVE or INACTIVE)
+              description: Filter by profile state (PENDING, ACTIVE, or DEACTIVATED)
+            states:
+              type: array
+              items:
+                $ref: "#/components/schemas/ProfileState"
+              description: Filter by profile states (PENDING, ACTIVE, or DEACTIVATED)
 
     ListUsersOutput:
       type: object

--- a/pkg/trust/service.go
+++ b/pkg/trust/service.go
@@ -424,6 +424,7 @@ func (s *Service) ProvisionMember(
 					EmailAddress:   identity.EmailAddress,
 					Source:         coredata.ProfileSourceManual,
 					State:          coredata.ProfileStateActive,
+					ActivatedAt:    &now,
 					FullName:       identity.FullName,
 					CreatedAt:      now,
 					UpdatedAt:      now,

--- a/pkg/trust/trust_center_access_service.go
+++ b/pkg/trust/trust_center_access_service.go
@@ -417,9 +417,7 @@ func (s *TrustCenterAccessService) GrantByIDs(
 		}
 
 		if shouldSendEmail {
-			profile.State = coredata.ProfileStateActive
-
-			profile.UpdatedAt = now
+			profile.MarkActive(now)
 			if err := profile.Update(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot update profile: %w", err)
 			}

--- a/pkg/trust/trust_center_access_service.go
+++ b/pkg/trust/trust_center_access_service.go
@@ -418,6 +418,7 @@ func (s *TrustCenterAccessService) GrantByIDs(
 
 		if shouldSendEmail {
 			profile.MarkActive(now)
+
 			if err := profile.Update(ctx, tx, scope); err != nil {
 				return fmt.Errorf("cannot update profile: %w", err)
 			}


### PR DESCRIPTION
- [x] archive = deactivate?
- [x] should we alllow deactivated to access compliance portal? Meaning we don't gate the login there.

## Summary

* Replace profile `INACTIVE` semantics with `PENDING`, `ACTIVE`, and `DEACTIVATED`, including activation/deactivation timestamps and data migration classification from invitation recency.
* Update profile lifecycle transitions for create, invite/reinvite, activation, archive/deactivate, SCIM, SAML, sessions, and trust-center activation.
* Add multi-state profile filters across coredata, GraphQL, MCP, and console owner pickers so assets/data/risks can assign active or pending members.

## Verification

* `go generate ./pkg/server/api/connect/v1 && go generate ./pkg/server/api/console/v1 && go generate ./pkg/server/api/mcp/v1`
* `make relay`
* `make go-fmt`
* `go test ./pkg/coredata ./pkg/iam ./pkg/server/api/console/v1 ./pkg/server/api/connect/v1 ./pkg/server/api/mcp/v1 ./pkg/trust ./pkg/cmd/user/list`
* `npm --workspace @probo/console run check`
* `npm --workspace @probo/n8n-nodes-probo run lint`

Linear Issue: [ENG-450](https://linear.app/probo/issue/ENG-450/allow-assigning-assets-data-and-risks-to-inactive-members)

<img src="https://camo.githubusercontent.com/ae5336cc4565ed7dd126cd5bfcb9f6a53979c32e32819e23ffd98524f0526bc9/68747470733a2f2f637572736f722e636f6d2f6173736574732f696d616765732f6f70656e2d696e2d7765622d6461726b2e706e67 " alt="Open in Web" width="114" data-linear-height="28" /> <img src="https://camo.githubusercontent.com/583722e75417432aa96019715ba989e7851c00ce91b7725e7246cf7c45b1dae9/68747470733a2f2f637572736f722e636f6d2f6173736574732f696d616765732f6f70656e2d696e2d637572736f722d6461726b2e706e67 " alt="Open in Cursor" width="131" data-linear-height="28" />

---

## Summary by cubic

Split the old INACTIVE profile state into PENDING, ACTIVE, and DEACTIVATED so pending members can be assigned assets/data/risks. Adds activation/deactivation timestamps, migrates existing data, and updates filters, APIs, services, and UI to match. Addresses Linear [ENG-450](https://linear.app/probo/issue/ENG-450/allow-assigning-assets-data-and-risks-to-inactive-members).

### Coredata `+159` `-12`

* Added PENDING/ACTIVE/DEACTIVATED and helpers (MarkPending/Active/Deactivated).
* Added activated_at/deactivated_at fields and queries.
* Migration converts prior states, classifies pending from recent invites, and backfills timestamps.
* Profile filter supports multi-state queries.

### Service `+50` `-29`

* Updated IAM, session, SCIM, SAML, trust, and org creation to new states; manual create defaults to PENDING; re-invite moves DEACTIVATED to PENDING.
* Block DEACTIVATED from starting sessions; activation/deactivation set timestamps.
* Deactivation still cancels outstanding signature requests.

### GraphQL API `+17` `-5`

* Schemas expose PENDING/ACTIVE/DEACTIVATED and a states\[\] filter.
* Resolvers pass multi-state filters through.

### MCP `+13` `-3`

* Spec and resolvers updated for new states and states\[\] filtering.

### prb (CLI) `+2` `-2`

* list --state accepts PENDING, ACTIVE, DEACTIVATED and updates help text.

### App: console `+12` `-7`

* People list/person page reflect DEACTIVATED; badges show ACTIVE vs others.
* PeopleGraph filters to \["ACTIVE","PENDING"\] for assignments.

### Package: `n8n-node` `+2` `-1`

* Signature filtering options include Pending and Deactivated.

### Tests `+1` `-1`

* E2E assertions updated to expect DEACTIVATED.

Written for commit c2258170ad9260f704d4e2338d13944a69060196. Summary will update on new commits.

![Review in cubic](https://camo.githubusercontent.com/99ec6b69d037ff3079d829ef143efe3aa4749e49c96b6ab71f62d0b45723b32b/68747470733a2f2f63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)