### PR TITLE
Add all-branch Trivy Docker image scan

### DIFF
--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -1,0 +1,78 @@
+name: "Trivy scan"
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: "read"
+
+concurrency:
+  group: "trivy-scan-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  # Build the probod Docker image locally and scan it with Trivy on every
+  # branch and pull request. Mirrors the release scan settings but prints a
+  # human-readable table so vulnerabilities are visible directly in the logs.
+  scan-docker:
+    name: "scan-docker"
+    runs-on: "runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/extras=s3-cache"
+    permissions:
+      contents: "read"
+    steps:
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6
+        with:
+          submodules: recursive
+      - uses: "runs-on/action@742bf56072eb4845a0f94b3394673e4903c90ff0" # v2
+      - uses: "./.github/actions/setup"
+        with:
+          node: "false"
+      - name: "Create placeholder dist files"
+        run: |
+          mkdir -p apps/console/dist apps/trust/dist packages/emails/dist
+          echo dev-server > apps/console/dist/index.html
+          echo dev-server > apps/trust/dist/index.html
+          echo dev-server > packages/emails/dist/placeholder
+      - name: "Generate Go code"
+        run: |
+          go generate ./pkg/server/api/connect/v1
+          go generate ./pkg/server/api/console/v1
+          go generate ./pkg/server/api/trust/v1
+          go generate ./pkg/server/api/mcp/v1
+      - name: "Build binaries"
+        env:
+          CGO_ENABLED: "0"
+          GOOS: "linux"
+          GOARCH: "amd64"
+        run: |
+          go build -ldflags "-s -w -X 'main.version=scan' -X 'main.env=prod'" \
+            -gcflags="-e" -o "linux/amd64/probod" ./cmd/probod/main.go
+          go build -ldflags "-s -w" \
+            -gcflags="-e" -o "linux/amd64/probod-bootstrap" ./cmd/probod-bootstrap/main.go
+      - name: "Prepare binaries"
+        run: "chmod +x linux/amd64/*"
+      - uses: "docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd" # v4.0.0
+      - name: "Build Docker image"
+        run: |
+          docker buildx build \
+            --platform "linux/amd64" \
+            --tag "probo/probo:scan" \
+            --load \
+            .
+      - name: "Cache Trivy database"
+        uses: "runs-on/cache@a5f51d6f3fece787d03b7b4e981c82538a0654ed" # v4
+        with:
+          path: ~/.cache/trivy
+          key: "trivy-db-scan-${{ github.run_id }}"
+          restore-keys: "trivy-db-scan-"
+      - name: "Trivy scan Docker image"
+        uses: "aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25" # 0.36.0
+        with:
+          image-ref: "probo/probo:scan"
+          format: "table"
+          exit-code: 1
+          ignore-unfixed: true
+          vuln-type: "os,library"
+          severity: "CRITICAL,HIGH"
+          cache-dir: ~/.cache/trivy


### PR DESCRIPTION
The Docker image vulnerability scan previously ran only at release time, where it uploads SARIF and so never surfaced the offending packages in the step log. Add a dedicated workflow that builds the probod image locally and scans it on every branch push and pull request, mirroring the release gate (CRITICAL/HIGH, fixable, os and library) but emitting a table so vulnerabilities are visible directly in CI.

Build with placeholder frontend assets and the default public Ubuntu base so the job needs no Harbor credentials and runs on fork PRs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a GitHub Actions workflow that builds the `probod` Docker image and runs a Trivy scan on every push and PR. It mirrors the release scan gates but prints a readable table in CI so vulnerabilities are visible early.

### Other **`+78`** **`-0`**
- Add `.github/workflows/trivy-scan.yaml` with a dedicated Docker image scan job.
- Build Linux/amd64 `probod` and `probod-bootstrap`, then scan with `aquasecurity/trivy-action`.
- Match release gates: severity CRITICAL,HIGH; vuln types os, library; ignore-unfixed; fail on findings.
- Output table format to CI logs and cache the Trivy DB for faster runs.
- Use placeholder frontend assets and the public Ubuntu base so it runs on forks without Harbor creds.

<sup>Written for commit d8ab2a038603ef814f954fe0890fa096dbdd104e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

