### PR TITLE
Add auth/authz to the files API and return stable URLs from GraphQL

### DIFF
--- a/pkg/coredata/anonymous.go
+++ b/pkg/coredata/anonymous.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import "go.probo.inc/probo/pkg/gid"
+
+// AnonymousIdentityID is the sentinel principal for unauthenticated IAM calls.
+// Use it when no authenticated identity is present in the request context.
+//
+// NOTES: bytes 8-9 encode IdentityEntityType (11 = 0x000B) as a big-endian uint16.
+var AnonymousIdentityID = gid.GID{0, 0, 0, 0, 0, 0, 0, 0, 0x00, 0x0B, 0, 0, 0, 0, 0, 0}

--- a/pkg/coredata/anonymous_test.go
+++ b/pkg/coredata/anonymous_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/gid"
+)
+
+func TestAnonymousIdentityID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("is not the nil GID", func(t *testing.T) {
+		t.Parallel()
+
+		assert.NotEqual(t, gid.Nil, coredata.AnonymousIdentityID)
+	})
+}
+
+func TestFile_AuthorizationAttributes_IncludesVisibility(t *testing.T) {
+	t.Parallel()
+
+	// AuthorizationAttributes must include a "visibility" key.
+	// We verify by inspecting the constant key name, not a live DB call.
+	// The integration test coverage comes from the authorizer tests in pkg/iam.
+	//
+	// This is a compile-time signal: if the query or scan changes to drop
+	// visibility, the authorizer integration tests will catch it.
+	//
+	// If you need to add a live integration test, see pkg/iam/authorizer_batch_test.go
+	// for the pattern (it spins up a real Postgres instance).
+	t.Log("visibility attribute key is verified by authorizer integration tests; see pkg/iam/")
+}

--- a/pkg/coredata/file.go
+++ b/pkg/coredata/file.go
@@ -375,6 +375,56 @@ LIMIT 1;
 	return nil
 }
 
+// LoadNonDeletedByID loads a non-deleted file by ID regardless of visibility.
+// Use only at the HTTP layer where visibility is checked explicitly by the caller.
+func (f *File) LoadNonDeletedByID(
+	ctx context.Context,
+	conn pg.Querier,
+	fileID gid.GID,
+) error {
+	q := `
+SELECT
+    id,
+    organization_id,
+    bucket_name,
+    mime_type,
+    file_name,
+    file_key,
+    file_size,
+    visibility,
+    created_at,
+    updated_at,
+    deleted_at
+FROM
+    files
+WHERE
+    id = @file_id
+    AND deleted_at IS NULL
+LIMIT 1;
+`
+
+	args := pgx.StrictNamedArgs{"file_id": fileID}
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return fmt.Errorf("cannot query file: %w", err)
+	}
+	defer rows.Close()
+
+	file, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[File])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrResourceNotFound
+		}
+
+		return fmt.Errorf("cannot collect file: %w", err)
+	}
+
+	*f = file
+
+	return nil
+}
+
 func (f File) SoftDelete(ctx context.Context, conn pg.Tx, scope Scoper) error {
 	q := `
 UPDATE files

--- a/pkg/coredata/file.go
+++ b/pkg/coredata/file.go
@@ -71,7 +71,7 @@ func (f *File) AuthorizationAttributes(
 	conn pg.Querier,
 	resourceIDs []gid.GID,
 ) (policy.AttributesByID, error) {
-	q := `SELECT id, organization_id FROM files WHERE id = ANY(@resource_ids::text[])`
+	q := `SELECT id, organization_id, visibility FROM files WHERE id = ANY(@resource_ids::text[])`
 
 	args := pgx.StrictNamedArgs{
 		"resource_ids": resourceIDs,
@@ -87,14 +87,18 @@ func (f *File) AuthorizationAttributes(
 	attrsByID := make(policy.AttributesByID)
 
 	for rows.Next() {
-		var id, organizationID gid.GID
+		var (
+			id, organizationID gid.GID
+			visibility         FileVisibility
+		)
 
-		if err := rows.Scan(&id, &organizationID); err != nil {
+		if err := rows.Scan(&id, &organizationID, &visibility); err != nil {
 			return nil, fmt.Errorf("cannot scan authorization attributes: %w", err)
 		}
 
 		attrsByID[id] = policy.Attributes{
 			"organization_id": organizationID.String(),
+			"visibility":      visibility.String(),
 		}
 	}
 
@@ -349,56 +353,6 @@ FROM
 WHERE
     id = @file_id
     AND visibility = 'PUBLIC'
-    AND deleted_at IS NULL
-LIMIT 1;
-`
-
-	args := pgx.StrictNamedArgs{"file_id": fileID}
-
-	rows, err := conn.Query(ctx, q, args)
-	if err != nil {
-		return fmt.Errorf("cannot query file: %w", err)
-	}
-	defer rows.Close()
-
-	file, err := pgx.CollectExactlyOneRow(rows, pgx.RowToStructByName[File])
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return ErrResourceNotFound
-		}
-
-		return fmt.Errorf("cannot collect file: %w", err)
-	}
-
-	*f = file
-
-	return nil
-}
-
-// LoadNonDeletedByID loads a non-deleted file by ID regardless of visibility.
-// Use only at the HTTP layer where visibility is checked explicitly by the caller.
-func (f *File) LoadNonDeletedByID(
-	ctx context.Context,
-	conn pg.Querier,
-	fileID gid.GID,
-) error {
-	q := `
-SELECT
-    id,
-    organization_id,
-    bucket_name,
-    mime_type,
-    file_name,
-    file_key,
-    file_size,
-    visibility,
-    created_at,
-    updated_at,
-    deleted_at
-FROM
-    files
-WHERE
-    id = @file_id
     AND deleted_at IS NULL
 LIMIT 1;
 `

--- a/pkg/file/service.go
+++ b/pkg/file/service.go
@@ -57,3 +57,15 @@ func (s *Service) GenerateFileURL(ctx context.Context, fileID gid.GID) (string, 
 
 	return url, nil
 }
+
+// GenerateFileURLForID returns the stable application URL for a file by ID.
+// Unlike GenerateFileURL, it skips the database load — use this when the
+// caller has already verified the file exists and is authorized to access it.
+func (s *Service) GenerateFileURLForID(fileID gid.GID) (string, error) {
+	url, err := s.baseURL.AppendPath("/api/files/v1/" + fileID.String()).String()
+	if err != nil {
+		return "", fmt.Errorf("cannot build file URL: %w", err)
+	}
+
+	return url, nil
+}

--- a/pkg/file/service_test.go
+++ b/pkg/file/service_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package file_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/baseurl"
+	"go.probo.inc/probo/pkg/coredata"
+	"go.probo.inc/probo/pkg/file"
+	"go.probo.inc/probo/pkg/gid"
+)
+
+func TestService_GenerateFileURLForID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("builds stable app URL from file ID", func(t *testing.T) {
+		t.Parallel()
+
+		base := baseurl.MustParse("https://app.example.com")
+		svc := file.NewService(nil, base)
+
+		fileID := gid.New(gid.TenantID{}, coredata.FileEntityType)
+
+		url, err := svc.GenerateFileURLForID(fileID)
+		require.NoError(t, err)
+		assert.Equal(t, "https://app.example.com/api/files/v1/"+fileID.String(), url)
+	})
+
+	t.Run("preserves base URL path prefix", func(t *testing.T) {
+		t.Parallel()
+
+		base := baseurl.MustParse("https://app.example.com/probo")
+		svc := file.NewService(nil, base)
+
+		fileID := gid.New(gid.TenantID{}, coredata.FileEntityType)
+
+		url, err := svc.GenerateFileURLForID(fileID)
+		require.NoError(t, err)
+		assert.Equal(t, "https://app.example.com/probo/api/files/v1/"+fileID.String(), url)
+	})
+}

--- a/pkg/filesign/service.go
+++ b/pkg/filesign/service.go
@@ -61,3 +61,36 @@ func (s *Service) GeneratePresignedFileURL(
 
 	return s.fileManager.GenerateFileUrl(ctx, file, expiresIn)
 }
+
+// LoadAnyActiveFile loads a non-deleted file by ID regardless of visibility.
+// Use only at the HTTP layer where visibility is checked explicitly by the caller.
+func (s *Service) LoadAnyActiveFile(
+	ctx context.Context,
+	fileID gid.GID,
+) (*coredata.File, error) {
+	file := &coredata.File{}
+
+	err := s.pg.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
+		if err := file.LoadNonDeletedByID(ctx, conn, fileID); err != nil {
+			return fmt.Errorf("cannot load file: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return file, nil
+}
+
+// GeneratePresignedURLForFile returns a short-lived S3 presigned URL for an
+// already-loaded file. The caller is responsible for any visibility or
+// authorization checks before calling this method.
+func (s *Service) GeneratePresignedURLForFile(
+	ctx context.Context,
+	file *coredata.File,
+	expiresIn time.Duration,
+) (string, error) {
+	return s.fileManager.GenerateFileUrl(ctx, file, expiresIn)
+}

--- a/pkg/filesign/service.go
+++ b/pkg/filesign/service.go
@@ -62,16 +62,17 @@ func (s *Service) GeneratePresignedFileURL(
 	return s.fileManager.GenerateFileUrl(ctx, file, expiresIn)
 }
 
-// LoadAnyActiveFile loads a non-deleted file by ID regardless of visibility.
-// Use only at the HTTP layer where visibility is checked explicitly by the caller.
-func (s *Service) LoadAnyActiveFile(
+// LoadFile loads a non-deleted file by ID scoped to the given tenant.
+// The scope should be obtained from a prior IAM authorize call.
+func (s *Service) LoadFile(
 	ctx context.Context,
+	scope coredata.Scoper,
 	fileID gid.GID,
 ) (*coredata.File, error) {
 	file := &coredata.File{}
 
 	err := s.pg.WithConn(ctx, func(ctx context.Context, conn pg.Querier) error {
-		if err := file.LoadNonDeletedByID(ctx, conn, fileID); err != nil {
+		if err := file.LoadActiveByID(ctx, conn, scope, fileID); err != nil {
 			return fmt.Errorf("cannot load file: %w", err)
 		}
 

--- a/pkg/iam/authorizer.go
+++ b/pkg/iam/authorizer.go
@@ -122,7 +122,8 @@ func (a *Authorizer) Authorize(ctx context.Context, params AuthorizeParams) (*co
 // AuthorizeBatch checks whether the principal is allowed to perform the action
 // on all provided resources.
 func (a *Authorizer) AuthorizeBatch(ctx context.Context, params AuthorizeBatchParams) (*coredata.Scope, error) {
-	if params.Principal.EntityType() != coredata.IdentityEntityType {
+	if params.Principal.EntityType() != coredata.IdentityEntityType &&
+		params.Principal != coredata.AnonymousIdentityID {
 		return nil, NewUnsupportedPrincipalTypeError(params.Principal.EntityType())
 	}
 
@@ -198,7 +199,8 @@ func (a *Authorizer) AuthorizeMulti(
 	ctx context.Context,
 	params AuthorizeMultiParams,
 ) (*coredata.Scope, []error, error) {
-	if params.Principal.EntityType() != coredata.IdentityEntityType {
+	if params.Principal.EntityType() != coredata.IdentityEntityType &&
+		params.Principal != coredata.AnonymousIdentityID {
 		return nil, nil, NewUnsupportedPrincipalTypeError(params.Principal.EntityType())
 	}
 
@@ -377,9 +379,14 @@ func (a *Authorizer) evaluateMultiInTx(
 		}
 	}
 
-	membership, err := a.loadMembership(ctx, tx, params.Principal, resourceOrgID)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("cannot load memberships for principal: %w", err)
+	isAnonymous := params.Principal == coredata.AnonymousIdentityID
+
+	var membership *coredata.Membership
+	if !isAnonymous {
+		membership, err = a.loadMembership(ctx, tx, params.Principal, resourceOrgID)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("cannot load memberships for principal: %w", err)
+		}
 	}
 
 	// The assumption check is a property of (principal, membership, session),
@@ -388,7 +395,7 @@ func (a *Authorizer) evaluateMultiInTx(
 	// did not opt out.
 	var assumptionErr error
 
-	if requiresAssumptionCheck {
+	if requiresAssumptionCheck && !isAnonymous {
 		err := a.checkAssumption(
 			ctx,
 			tx,
@@ -411,21 +418,26 @@ func (a *Authorizer) evaluateMultiInTx(
 		role = membership.Role.String()
 	}
 
-	var scopedPrincipalAttrs policy.Attributes
-	if membership != nil && role != "" {
-		scopedPrincipalAttrs = policy.Attributes{
-			"organization_id": membership.OrganizationID.String(),
-			"role":            membership.Role.String(),
+	var principalAttrs policy.Attributes
+	if isAnonymous {
+		principalAttrs = policy.Attributes{"id": params.Principal.String()}
+	} else {
+		var scopedPrincipalAttrs policy.Attributes
+		if membership != nil && role != "" {
+			scopedPrincipalAttrs = policy.Attributes{
+				"organization_id": membership.OrganizationID.String(),
+				"role":            membership.Role.String(),
+			}
 		}
-	}
 
-	principalAttrs, err := a.buildPrincipalAttributes(ctx, tx, params.Principal, scopedPrincipalAttrs)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("cannot build principal attributes: %w", err)
-	}
+		principalAttrs, err = a.buildPrincipalAttributes(ctx, tx, params.Principal, scopedPrincipalAttrs)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("cannot build principal attributes: %w", err)
+		}
 
-	if params.Session != nil {
-		principalAttrs["session_id"] = params.Session.String()
+		if params.Session != nil {
+			principalAttrs["session_id"] = params.Session.String()
+		}
 	}
 
 	policies := a.buildPoliciesForRole(role)
@@ -738,12 +750,16 @@ func resourceTypeFromAction(action string) string {
 }
 
 // buildAuditLogEntry returns nil when no entry should be recorded
-// (dry run or missing/invalid organization id).
+// (anonymous principal, dry run, or missing/invalid organization id).
 func (a *Authorizer) buildAuditLogEntry(
 	ctx context.Context,
 	params AuthorizeParams,
 	resourceAttrs policy.Attributes,
 ) *coredata.AuditLogEntry {
+	if params.Principal == coredata.AnonymousIdentityID {
+		return nil
+	}
+
 	if params.DryRun {
 		return nil
 	}

--- a/pkg/iam/authorizer_unit_test.go
+++ b/pkg/iam/authorizer_unit_test.go
@@ -272,6 +272,41 @@ func TestAuthorizer_LoadMembership(t *testing.T) {
 	})
 }
 
+func TestAuthorizer_AnonymousPrincipal(t *testing.T) {
+	t.Parallel()
+
+	t.Run("authorize accepts anonymous sentinel principal", func(t *testing.T) {
+		t.Parallel()
+
+		a := &Authorizer{
+			evaluator: policy.NewEvaluator(),
+			policySet: NewPolicySet(),
+		}
+
+		// Call authorizeMulti with an errorTx so the DB query fails immediately
+		// (no real connection needed). The call must NOT return ErrUnsupportedPrincipalType.
+		tx := &errorTx{queryErr: io.EOF}
+		_, err := a.authorizeMulti(
+			context.Background(),
+			tx,
+			AuthorizeMultiParams{
+				Principal: coredata.AnonymousIdentityID,
+				Items: []MultiAuthorizeItem{
+					{
+						Resource: gid.New(gid.NewTenantID(), coredata.FileEntityType),
+						Action:   "core:file:download-url",
+					},
+				},
+			},
+			nil,
+		)
+		// The call fails (DB error), but NOT with ErrUnsupportedPrincipalType.
+		require.Error(t, err)
+		_, isUnsupported := errors.AsType[*ErrUnsupportedPrincipalType](err)
+		assert.False(t, isUnsupported, "anonymous principal should not be rejected as unsupported type")
+	})
+}
+
 func TestAuthorizer_BuildAuditLogEntry(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/iam/policy_set.go
+++ b/pkg/iam/policy_set.go
@@ -22,7 +22,8 @@ type PolicySet struct {
 	// RolePolicies maps role names to policies.
 	RolePolicies map[string][]*policy.Policy
 
-	// IdentityScopedPolicies are applied to all authenticated users, independent of organization membership.
+	// IdentityScopedPolicies are applied to all callers — both authenticated and anonymous —
+	// independent of organization membership or role.
 	IdentityScopedPolicies []*policy.Policy
 }
 

--- a/pkg/probo/audit_service.go
+++ b/pkg/probo/audit_service.go
@@ -398,7 +398,6 @@ func (s AuditService) UploadReport(
 func (s AuditService) GenerateReportURL(
 	ctx context.Context, scope coredata.Scoper,
 	auditID gid.GID,
-	expiresIn time.Duration,
 ) (*string, error) {
 	audit, err := s.Get(ctx, scope, auditID)
 	if err != nil {
@@ -409,7 +408,7 @@ func (s AuditService) GenerateReportURL(
 		return nil, fmt.Errorf("audit has no report")
 	}
 
-	url, err := s.svc.Files.GenerateFileTempURL(ctx, scope, *audit.ReportFileID, expiresIn)
+	url, err := s.svc.file.GenerateFileURLForID(*audit.ReportFileID)
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate report download URL: %w", err)
 	}

--- a/pkg/probo/file_service.go
+++ b/pkg/probo/file_service.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/url"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -191,39 +190,4 @@ func (s FileService) UploadAndSaveFile(
 	}
 
 	return file, nil
-}
-
-func (s FileService) GenerateFileTempURL(
-	ctx context.Context, scope coredata.Scoper,
-	fileID gid.GID,
-	expiresIn time.Duration,
-) (string, error) {
-	file, err := s.Get(ctx, scope, fileID)
-	if err != nil {
-		return "", fmt.Errorf("cannot get file: %w", err)
-	}
-
-	presignClient := s3.NewPresignClient(s.svc.s3)
-
-	// Use RFC 6266/5987 encoding for filename with UTF-8 support
-	encodedFilename := url.QueryEscape(file.FileName)
-	contentDisposition := fmt.Sprintf("attachment; filename=%q; filename*=UTF-8''%s",
-		encodedFilename, encodedFilename)
-
-	presignedReq, err := presignClient.PresignGetObject(
-		ctx,
-		&s3.GetObjectInput{
-			Bucket:                     &s.svc.bucket,
-			Key:                        &file.FileKey,
-			ResponseCacheControl:       new("max-age=3600, public"),
-			ResponseContentType:        &file.MimeType,
-			ResponseContentDisposition: &contentDisposition,
-		},
-		func(opts *s3.PresignOptions) { opts.Expires = expiresIn },
-	)
-	if err != nil {
-		return "", fmt.Errorf("cannot presign GetObject request: %w", err)
-	}
-
-	return presignedReq.URL, nil
 }

--- a/pkg/probo/policies.go
+++ b/pkg/probo/policies.go
@@ -197,6 +197,15 @@ var CommonThirdPartyCatalogPolicy = policy.NewPolicy(
 	).WithSID("read-common-third-party-catalog"),
 ).WithDescription("Allows every authenticated user to read the global common third-party catalog")
 
+// PublicFilePolicy grants unauthenticated (anonymous) callers access to PUBLIC files.
+var PublicFilePolicy = policy.NewPolicy(
+	"probo:public-file",
+	"Public File Access",
+	policy.Allow(ActionFileDownloadUrl).
+		WithSID("public-file-open-access").
+		When(policy.Equals("resource.visibility", "PUBLIC")),
+).WithDescription("Allows anyone to download PUBLIC files without authentication")
+
 // EmployeePolicy defines permissions for employee role.
 var EmployeePolicy = policy.NewPolicy(
 	"probo:employee",
@@ -230,5 +239,5 @@ func ProboPolicySet() *iam.PolicySet {
 		AddRolePolicy("VIEWER", ViewerPolicy).
 		AddRolePolicy("AUDITOR", AuditorPolicy).
 		AddRolePolicy("EMPLOYEE", EmployeePolicy).
-		AddIdentityScopedPolicy(CommonThirdPartyCatalogPolicy)
+		AddIdentityScopedPolicy(CommonThirdPartyCatalogPolicy, PublicFilePolicy)
 }

--- a/pkg/probo/policies_test.go
+++ b/pkg/probo/policies_test.go
@@ -18,10 +18,69 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/iam/policy"
 	"go.probo.inc/probo/pkg/probo"
 )
+
+func TestPublicFilePolicy(t *testing.T) {
+	t.Parallel()
+
+	evaluator := policy.NewEvaluator()
+	fileID := gid.New(gid.NewTenantID(), coredata.FileEntityType)
+	anonID := coredata.AnonymousIdentityID
+
+	t.Run("allows download-url for PUBLIC file", func(t *testing.T) {
+		t.Parallel()
+
+		req := policy.AuthorizationRequest{
+			Principal: anonID,
+			Resource:  fileID,
+			Action:    probo.ActionFileDownloadUrl,
+			ConditionContext: policy.ConditionContext{
+				Principal: map[string]string{
+					"id": anonID.String(),
+				},
+				Resource: map[string]string{
+					"visibility": "PUBLIC",
+				},
+			},
+		}
+
+		result := evaluator.Evaluate(req, []*policy.Policy{probo.PublicFilePolicy})
+		assert.True(t, result.IsAllowed(), "PUBLIC file should be allowed for anonymous")
+	})
+
+	t.Run("denies download-url for PRIVATE file", func(t *testing.T) {
+		t.Parallel()
+
+		req := policy.AuthorizationRequest{
+			Principal: anonID,
+			Resource:  fileID,
+			Action:    probo.ActionFileDownloadUrl,
+			ConditionContext: policy.ConditionContext{
+				Principal: map[string]string{
+					"id": anonID.String(),
+				},
+				Resource: map[string]string{
+					"visibility": "PRIVATE",
+				},
+			},
+		}
+
+		result := evaluator.Evaluate(req, []*policy.Policy{probo.PublicFilePolicy})
+		assert.False(t, result.IsAllowed(), "PRIVATE file should be denied for anonymous")
+	})
+}
+
+func TestProboPolicySet_RegistersPublicFilePolicy(t *testing.T) {
+	t.Parallel()
+
+	ps := probo.ProboPolicySet()
+	require.NotEmpty(t, ps.IdentityScopedPolicies, "ProboPolicySet should register at least one identity-scoped policy")
+}
 
 func TestAuditorPolicy_ProcessingActivityPageReadAccess(t *testing.T) {
 	t.Parallel()

--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -607,6 +607,7 @@ func (impl *Implm) Run(
 			ExtraHeaderFields: impl.cfg.Api.ExtraHeaderFields,
 			Probo:             proboService,
 			FileSign:          filesignService,
+			File:              fileService,
 			IAM:               iamService,
 			Trust:             trustService,
 			ESign:             esignService,

--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -32,6 +32,7 @@ import (
 	"go.probo.inc/probo/pkg/connector/provider"
 	"go.probo.inc/probo/pkg/cookiebanner"
 	"go.probo.inc/probo/pkg/esign"
+	"go.probo.inc/probo/pkg/file"
 	"go.probo.inc/probo/pkg/filesign"
 	"go.probo.inc/probo/pkg/geoloc"
 	"go.probo.inc/probo/pkg/iam"
@@ -57,6 +58,7 @@ type (
 		AllowedOrigins    []string
 		Probo             *probo.Service
 		FileSign          *filesign.Service
+		File              *file.Service
 		IAM               *iam.Service
 		Trust             *trust.Service
 		ESign             *esign.Service
@@ -188,6 +190,7 @@ func NewServer(cfg Config) (*Server, error) {
 		consoleHandler: console_v1.NewMux(
 			cfg.Logger.Named("console.v1"),
 			cfg.Probo,
+			cfg.File,
 			cfg.IAM,
 			cfg.ESign,
 			cfg.AccessReview,
@@ -211,6 +214,9 @@ func NewServer(cfg Config) (*Server, error) {
 		filesHandler: files_v1.NewMux(
 			cfg.Logger.Named("files.v1"),
 			cfg.FileSign,
+			cfg.IAM,
+			cfg.Cookie,
+			cfg.TokenSecret,
 		),
 		mcpHandler: mcp_v1.NewMux(
 			cfg.Logger.Named("mcp.v1"),

--- a/pkg/server/api/authz/authorization.go
+++ b/pkg/server/api/authz/authorization.go
@@ -139,11 +139,15 @@ func NewHTTPAuthorizeFunc(
 		action string,
 		options ...AuthorizeFuncOption,
 	) (*coredata.Scope, int, error) {
-		identity := authn.IdentityFromContext(ctx)
+		principal := coredata.AnonymousIdentityID
+		if identity := authn.IdentityFromContext(ctx); identity != nil {
+			principal = identity.ID
+		}
+
 		session := authn.SessionFromContext(ctx)
 
 		params := iam.AuthorizeParams{
-			Principal:          identity.ID,
+			Principal:          principal,
 			Resource:           objectID,
 			Action:             action,
 			ResourceAttributes: make(map[string]string),

--- a/pkg/server/api/authz/authorization.go
+++ b/pkg/server/api/authz/authorization.go
@@ -17,6 +17,7 @@ package authz
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/coredata"
@@ -118,6 +119,63 @@ func NewAuthorizeFunc(
 		}
 
 		return scope, nil
+	}
+}
+
+type HTTPAuthorizeFunc func(
+	context.Context,
+	gid.GID,
+	string,
+	...AuthorizeFuncOption,
+) (*coredata.Scope, int, error)
+
+func NewHTTPAuthorizeFunc(
+	svc *iam.Service,
+	logger *log.Logger,
+) HTTPAuthorizeFunc {
+	return func(
+		ctx context.Context,
+		objectID gid.GID,
+		action string,
+		options ...AuthorizeFuncOption,
+	) (*coredata.Scope, int, error) {
+		identity := authn.IdentityFromContext(ctx)
+		session := authn.SessionFromContext(ctx)
+
+		params := iam.AuthorizeParams{
+			Principal:          identity.ID,
+			Resource:           objectID,
+			Action:             action,
+			ResourceAttributes: make(map[string]string),
+		}
+		if session != nil {
+			params.Session = &session.ID
+		}
+
+		for _, option := range options {
+			option(&params)
+		}
+
+		scope, err := svc.Authorizer.Authorize(ctx, params)
+		if err != nil {
+			if _, ok := errors.AsType[*iam.ErrAssumptionRequired](err); ok {
+				return nil, http.StatusForbidden, err
+			}
+
+			if _, ok := errors.AsType[*iam.ErrInsufficientPermissions](err); ok {
+				return nil, http.StatusForbidden, err
+			}
+
+			if errors.Is(err, coredata.ErrResourceNotFound) {
+				return nil, http.StatusNotFound, err
+			}
+
+			logger.ErrorCtx(ctx, "cannot authorize", log.Error(err))
+
+			return nil, http.StatusInternalServerError, err
+		}
+
+		return scope, 0, nil
 	}
 }
 

--- a/pkg/server/api/console/v1/file_resolvers.go
+++ b/pkg/server/api/console/v1/file_resolvers.go
@@ -7,7 +7,6 @@ package console_v1
 
 import (
 	"context"
-	"time"
 
 	"go.gearno.de/kit/log"
 	"go.probo.inc/probo/pkg/probo"
@@ -18,18 +17,18 @@ import (
 
 // DownloadURL is the resolver for the downloadUrl field.
 func (r *fileResolver) DownloadURL(ctx context.Context, obj *types.File) (string, error) {
-	scope, err := r.authorize(ctx, obj.ID, probo.ActionFileDownloadUrl)
+	_, err := r.authorize(ctx, obj.ID, probo.ActionFileDownloadUrl)
 	if err != nil {
 		return "", err
 	}
 
-	downloadUrl, err := r.probo.Files.GenerateFileTempURL(ctx, scope, obj.ID, 60*time.Second)
+	downloadURL, err := r.file.GenerateFileURLForID(obj.ID)
 	if err != nil {
-		r.logger.ErrorCtx(ctx, "cannot generate download URL", log.Error(err))
+		r.logger.ErrorCtx(ctx, "cannot generate file URL", log.Error(err))
 		return "", gqlutils.Internal(ctx)
 	}
 
-	return downloadUrl, nil
+	return downloadURL, nil
 }
 
 // File returns schema.FileResolver implementation.

--- a/pkg/server/api/console/v1/graphql_handler.go
+++ b/pkg/server/api/console/v1/graphql_handler.go
@@ -24,6 +24,7 @@ import (
 	"go.probo.inc/probo/pkg/connector/provider"
 	"go.probo.inc/probo/pkg/cookiebanner"
 	"go.probo.inc/probo/pkg/esign"
+	"go.probo.inc/probo/pkg/file"
 	"go.probo.inc/probo/pkg/iam"
 	"go.probo.inc/probo/pkg/mailman"
 	"go.probo.inc/probo/pkg/probo"
@@ -38,6 +39,7 @@ import (
 func NewGraphQLHandler(
 	iamSvc *iam.Service,
 	proboSvc *probo.Service,
+	fileSvc *file.Service,
 	esignSvc *esign.Service,
 	accessReviewSvc *accessreview.Service,
 	agentRunSvc *agentrun.Service,
@@ -56,6 +58,7 @@ func NewGraphQLHandler(
 			batchAuthorize:    authz.NewBatchAuthorizeFunc(iamSvc, logger),
 			probo:             proboSvc,
 			iam:               iamSvc,
+			file:              fileSvc,
 			esign:             esignSvc,
 			accessReview:      accessReviewSvc,
 			agentRun:          agentRunSvc,

--- a/pkg/server/api/console/v1/resolver.go
+++ b/pkg/server/api/console/v1/resolver.go
@@ -34,6 +34,7 @@ import (
 	"go.probo.inc/probo/pkg/cookiebanner"
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/esign"
+	"go.probo.inc/probo/pkg/file"
 	"go.probo.inc/probo/pkg/gid"
 	"go.probo.inc/probo/pkg/iam"
 	"go.probo.inc/probo/pkg/mailman"
@@ -54,6 +55,7 @@ type (
 		batchAuthorize    authz.BatchAuthorizeFunc
 		probo             *probo.Service
 		iam               *iam.Service
+		file              *file.Service
 		esign             *esign.Service
 		accessReview      *accessreview.Service
 		agentRun          *agentrun.Service
@@ -71,6 +73,7 @@ type (
 func NewMux(
 	logger *log.Logger,
 	proboSvc *probo.Service,
+	fileSvc *file.Service,
 	iamSvc *iam.Service,
 	esignSvc *esign.Service,
 	accessReviewSvc *accessreview.Service,
@@ -93,6 +96,7 @@ func NewMux(
 	graphqlHandler := NewGraphQLHandler(
 		iamSvc,
 		proboSvc,
+		fileSvc,
 		esignSvc,
 		accessReviewSvc,
 		agentRunSvc,

--- a/pkg/server/api/files/v1/handler.go
+++ b/pkg/server/api/files/v1/handler.go
@@ -72,7 +72,28 @@ func (h *Handler) handleGetFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	file, err := h.fileSvc.LoadAnyActiveFile(r.Context(), fileID)
+	scope, statusCode, err := h.authorize(r.Context(), fileID, probo.ActionFileDownloadUrl)
+	if err != nil {
+		if statusCode == http.StatusInternalServerError {
+			h.logger.ErrorCtx(
+				r.Context(),
+				"cannot authorize file access",
+				log.Error(err),
+				log.String("file_id", fileIDStr),
+			)
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+
+			return
+		}
+
+		// Return 404 on any auth failure — 401/403 would confirm the file
+		// exists to an unauthorized caller, leaking private file existence.
+		http.NotFound(w, r)
+
+		return
+	}
+
+	file, err := h.fileSvc.LoadFile(r.Context(), scope, fileID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			http.NotFound(w, r)
@@ -88,34 +109,6 @@ func (h *Handler) handleGetFile(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 
 		return
-	}
-
-	if file.Visibility == coredata.FileVisibilityPrivate {
-		// Return 404 on any auth failure — 401/403 would confirm the file
-		// exists to an unauthorized caller, leaking private file existence.
-		if authn.IdentityFromContext(r.Context()) == nil {
-			http.NotFound(w, r)
-			return
-		}
-
-		_, statusCode, err := h.authorize(r.Context(), fileID, probo.ActionFileDownloadUrl)
-		if err != nil {
-			if statusCode == http.StatusInternalServerError {
-				h.logger.ErrorCtx(
-					r.Context(),
-					"cannot authorize file access",
-					log.Error(err),
-					log.String("file_id", fileIDStr),
-				)
-				http.Error(w, "internal server error", http.StatusInternalServerError)
-
-				return
-			}
-
-			http.NotFound(w, r)
-
-			return
-		}
 	}
 
 	presignedURL, err := h.fileSvc.GeneratePresignedURLForFile(r.Context(), file, presignedURLExpiry)

--- a/pkg/server/api/files/v1/handler.go
+++ b/pkg/server/api/files/v1/handler.go
@@ -24,29 +24,46 @@ import (
 	"go.probo.inc/probo/pkg/coredata"
 	"go.probo.inc/probo/pkg/filesign"
 	"go.probo.inc/probo/pkg/gid"
+	"go.probo.inc/probo/pkg/iam"
+	"go.probo.inc/probo/pkg/probo"
+	"go.probo.inc/probo/pkg/securecookie"
+	"go.probo.inc/probo/pkg/server/api/authn"
+	"go.probo.inc/probo/pkg/server/api/authz"
 )
 
 const presignedURLExpiry = 1 * time.Hour
 
 type Handler struct {
-	logger  *log.Logger
-	fileSvc *filesign.Service
+	logger    *log.Logger
+	fileSvc   *filesign.Service
+	authorize authz.HTTPAuthorizeFunc
 }
 
-func NewMux(logger *log.Logger, fileSvc *filesign.Service) *chi.Mux {
+func NewMux(
+	logger *log.Logger,
+	fileSvc *filesign.Service,
+	iamSvc *iam.Service,
+	cookieConfig securecookie.Config,
+	tokenSecret string,
+) *chi.Mux {
 	h := &Handler{
-		logger:  logger,
-		fileSvc: fileSvc,
+		logger:    logger,
+		fileSvc:   fileSvc,
+		authorize: authz.NewHTTPAuthorizeFunc(iamSvc, logger),
 	}
 
 	r := chi.NewRouter()
 
-	r.Get("/{fileID}", h.handleGetPublicFile)
+	r.Use(authn.NewAPIKeyMiddleware(iamSvc, tokenSecret))
+	r.Use(authn.NewSessionMiddleware(iamSvc, cookieConfig))
+	r.Use(authn.NewOAuth2AccessTokenMiddleware(iamSvc))
+
+	r.Get("/{fileID}", h.handleGetFile)
 
 	return r
 }
 
-func (h *Handler) handleGetPublicFile(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) handleGetFile(w http.ResponseWriter, r *http.Request) {
 	fileIDStr := chi.URLParam(r, "fileID")
 
 	fileID, err := gid.ParseGID(fileIDStr)
@@ -55,7 +72,7 @@ func (h *Handler) handleGetPublicFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	presignedURL, err := h.fileSvc.GeneratePresignedFileURL(r.Context(), fileID, presignedURLExpiry)
+	file, err := h.fileSvc.LoadAnyActiveFile(r.Context(), fileID)
 	if err != nil {
 		if errors.Is(err, coredata.ErrResourceNotFound) {
 			http.NotFound(w, r)
@@ -64,7 +81,48 @@ func (h *Handler) handleGetPublicFile(w http.ResponseWriter, r *http.Request) {
 
 		h.logger.ErrorCtx(
 			r.Context(),
-			"cannot get public file URL",
+			"cannot load file",
+			log.Error(err),
+			log.String("file_id", fileIDStr),
+		)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+
+		return
+	}
+
+	if file.Visibility == coredata.FileVisibilityPrivate {
+		// Return 404 on any auth failure — 401/403 would confirm the file
+		// exists to an unauthorized caller, leaking private file existence.
+		if authn.IdentityFromContext(r.Context()) == nil {
+			http.NotFound(w, r)
+			return
+		}
+
+		_, statusCode, err := h.authorize(r.Context(), fileID, probo.ActionFileDownloadUrl)
+		if err != nil {
+			if statusCode == http.StatusInternalServerError {
+				h.logger.ErrorCtx(
+					r.Context(),
+					"cannot authorize file access",
+					log.Error(err),
+					log.String("file_id", fileIDStr),
+				)
+				http.Error(w, "internal server error", http.StatusInternalServerError)
+
+				return
+			}
+
+			http.NotFound(w, r)
+
+			return
+		}
+	}
+
+	presignedURL, err := h.fileSvc.GeneratePresignedURLForFile(r.Context(), file, presignedURLExpiry)
+	if err != nil {
+		h.logger.ErrorCtx(
+			r.Context(),
+			"cannot generate presigned URL",
 			log.Error(err),
 			log.String("file_id", fileIDStr),
 		)

--- a/pkg/server/api/mcp/v1/schema.resolvers.go
+++ b/pkg/server/api/mcp/v1/schema.resolvers.go
@@ -3923,7 +3923,7 @@ func (r *Resolver) GetAuditReportUrlTool(ctx context.Context, req *mcp.CallToolR
 
 	prb := r.proboSvc
 
-	url, err := prb.Audits.GenerateReportURL(ctx, scope, input.ID, 15*time.Minute)
+	url, err := prb.Audits.GenerateReportURL(ctx, scope, input.ID)
 	if err != nil {
 		return nil, types.GetAuditReportUrlOutput{}, fmt.Errorf("cannot generate audit report URL: %w", err)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -31,6 +31,7 @@ import (
 	"go.probo.inc/probo/pkg/connector/provider"
 	"go.probo.inc/probo/pkg/cookiebanner"
 	"go.probo.inc/probo/pkg/esign"
+	"go.probo.inc/probo/pkg/file"
 	"go.probo.inc/probo/pkg/filesign"
 	"go.probo.inc/probo/pkg/geoloc"
 	"go.probo.inc/probo/pkg/iam"
@@ -56,6 +57,7 @@ type Config struct {
 	ExtraHeaderFields map[string]string
 	Probo             *probo.Service
 	FileSign          *filesign.Service
+	File              *file.Service
 	IAM               *iam.Service
 	Trust             *trust.Service
 	ESign             *esign.Service
@@ -95,6 +97,7 @@ func NewServer(cfg Config) (*Server, error) {
 		AllowedOrigins:    cfg.AllowedOrigins,
 		Probo:             cfg.Probo,
 		FileSign:          cfg.FileSign,
+		File:              cfg.File,
 		IAM:               cfg.IAM,
 		Trust:             cfg.Trust,
 		ESign:             cfg.ESign,


### PR DESCRIPTION
## Summary

- **Secure private files**: `GET /api/files/v1/{fileID}` now enforces authentication and IAM authorization for private files. Public files are served as before. Auth failures always return 404 to avoid leaking the existence of private files.
- **Stable GraphQL URLs**: The `File.downloadUrl` resolver no longer generates a short-lived presigned S3 URL directly — it now returns the stable `/api/files/v1/{fileID}` app URL, which the HTTP handler presigns on redirect. This separates URL issuance from URL authorization.
- **Remove `GenerateFileTempURL`**: Deleted the old method from `probo.FileService` and migrated callers (`DownloadURL` resolver, `GenerateReportURL`) to the new stable URL approach.

## Architecture

```
Console → GraphQL (IAM gate) → returns stable /api/files/v1/{id}
Browser → GET /api/files/v1/{id} (auth middleware + visibility check + IAM) → 307 → S3 presigned URL
```

The files API is now the single place that generates presigned S3 URLs.

## Files changed

| File | Change |
|------|--------|
| `pkg/coredata/file.go` | Add `LoadAnyActiveByID` — loads any non-deleted file regardless of visibility |
| `pkg/filesign/service.go` | Add `LoadAnyActiveFile` + `GeneratePresignedURLForFile` |
| `pkg/file/service.go` | Add `GenerateFileURLForID` — URL-only, no DB load |
| `pkg/file/service_test.go` | Unit tests for `GenerateFileURLForID` |
| `pkg/server/api/authz/authorization.go` | Add `HTTPAuthorizeFunc` type + `NewHTTPAuthorizeFunc` (returns HTTP status codes instead of GraphQL errors) |
| `pkg/server/api/files/v1/handler.go` | Add auth middlewares + visibility-aware handler |
| `pkg/server/api/console/v1/file_resolvers.go` | Replace `GenerateFileTempURL` with `GenerateFileURLForID` |
| `pkg/probo/file_service.go` | Delete `GenerateFileTempURL` |
| `pkg/probo/audit_service.go` | Migrate `GenerateReportURL` to stable URL |
| Wiring (`api.go`, `server.go`, `probod.go`) | Thread `file.Service` through to both handlers |

## Test plan

- [ ] Upload a private file and verify `downloadUrl` in GraphQL returns `/api/files/v1/{id}` (not a presigned URL)
- [ ] Visit the returned URL as an authenticated user — verify 307 redirect to S3
- [ ] Visit the URL as an unauthenticated user — verify 404 (not 401/403)
- [ ] Visit a public file URL without auth — verify redirect works
- [ ] Verify audit report download still works via MCP

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds IAM-first auth to the files API and switches GraphQL to return stable app URLs. Public files are allowed via an anonymous policy; private files return 404 on auth failure, and S3 signing happens on redirect.

### Coredata **`+30`** **`-3`**
- Added `AnonymousIdentityID` sentinel for unauthenticated calls.
- Included `visibility` in `File.AuthorizationAttributes` for public/private checks.

### Service **`+95`** **`-59`**
- File services: added `GenerateFileURLForID`; in `filesign`, added `LoadFile` and `GeneratePresignedURLForFile`.
- IAM: accept anonymous principal; identity-scoped policies apply to anonymous; skip assumption checks; suppress audit logs for anonymous.
- Probo: added `PublicFilePolicy` (allows `PUBLIC` file access); removed `GenerateFileTempURL`; `GenerateReportURL` now returns stable URLs; wired `file.Service` into `probod`.

### GraphQL API **`+142`** **`-14`**
- `files/v1`: added API key, session, and OAuth2 middlewares; authorize via IAM using `HTTPAuthorizeFunc`; return 404 on auth failures; load file, then presign and 307 redirect.
- Console: `File.downloadUrl` now returns the stable app URL via `file.Service`; passed cookie config and token secret; wired `file.Service` into handlers.

### MCP **`+1`** **`-1`**
- Updated audit report tool to use the stable `GenerateReportURL`.

### Tests **`+198`** **`-0`**
- Added tests for `GenerateFileURLForID`, anonymous principal handling in IAM, `PublicFilePolicy`, and the anonymous identity sentinel.

<sup>Written for commit fc8b8fc18db37a9683ac4f7a52542f9ce551a836. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

