### PR TITLE
Add SMTP_HELLO_NAME to fix EHLO rejection by Google Workspace relay

### DIFF
--- a/contrib/helm/charts/probo/templates/deployment.yaml
+++ b/contrib/helm/charts/probo/templates/deployment.yaml
@@ -225,6 +225,10 @@ spec:
             {{- end }}
             - name: SMTP_TLS_REQUIRED
               value: {{ .Values.probo.mailer.smtp.tlsRequired | quote }}
+            {{- if .Values.probo.mailer.smtp.helloName }}
+            - name: SMTP_HELLO_NAME
+              value: {{ .Values.probo.mailer.smtp.helloName | quote }}
+            {{- end }}
             # OpenAI Integration
             {{- if .Values.probo.openai.apiKey }}
             - name: OPENAI_API_KEY

--- a/contrib/helm/charts/probo/values-production.yaml.example
+++ b/contrib/helm/charts/probo/values-production.yaml.example
@@ -157,6 +157,9 @@ probo:
       user: "apikey"
       password: "CHANGE_ME_SMTP_PASSWORD"
       tlsRequired: true
+      # Set to your server's hostname when the relay requires a specific EHLO/HELO
+      # identity (e.g. Google Workspace smtp-relay.gmail.com rejects "localhost").
+      # helloName: "mail.example.com"
 
   # OpenAI integration for AI features (optional)
   openai:

--- a/contrib/helm/charts/probo/values.yaml
+++ b/contrib/helm/charts/probo/values.yaml
@@ -251,11 +251,13 @@ probo:
       user: ""
       password: ""
       tlsRequired: true
+      helloName: ""
 #    smtp:
 #      addr: "localhost:1025"
 #      user: ""
 #      password: ""
 #      tlsRequired: false
+#      helloName: ""
 
   # OpenAI integration (optional)
   openai:

--- a/pkg/bootstrap/builder.go
+++ b/pkg/bootstrap/builder.go
@@ -166,6 +166,7 @@ func (b *Builder) Build() (*probodconfig.FullConfig, error) {
 						User:        b.getEnv("SMTP_USER"),
 						Password:    b.getEnv("SMTP_PASSWORD"),
 						TLSRequired: b.getEnvBoolOrDefault("SMTP_TLS_REQUIRED", false),
+						HelloName:   b.getEnv("SMTP_HELLO_NAME"),
 					},
 				},
 				Slack: probodconfig.SlackConfig{

--- a/pkg/bootstrap/builder_test.go
+++ b/pkg/bootstrap/builder_test.go
@@ -192,6 +192,7 @@ func TestBuilder_Build_Defaults(t *testing.T) {
 	assert.Equal(t, "no-reply@notification.getprobo.com", cfg.Probod.Notifications.Mailer.SenderEmail)
 	assert.Equal(t, "localhost:1025", cfg.Probod.Notifications.Mailer.SMTP.Addr)
 	assert.False(t, cfg.Probod.Notifications.Mailer.SMTP.TLSRequired)
+	assert.Empty(t, cfg.Probod.Notifications.Mailer.SMTP.HelloName)
 	assert.Equal(t, 60, cfg.Probod.Notifications.Mailer.MailerInterval)
 	assert.Equal(t, 60, cfg.Probod.Notifications.Slack.SenderInterval)
 	assert.Empty(t, cfg.Probod.Notifications.Slack.SigningSecret)

--- a/pkg/mailer/mailer.go
+++ b/pkg/mailer/mailer.go
@@ -49,6 +49,7 @@ type (
 		User        string
 		Password    string
 		TLSRequired bool
+		HelloName   string
 	}
 
 	SendingWorkerOption func(*sendingHandler)
@@ -318,6 +319,12 @@ func (h *sendingHandler) sendMail(ctx context.Context, to []string, msg []byte) 
 	}
 
 	defer func() { _ = c.Quit() }()
+
+	if h.smtp.HelloName != "" {
+		if err := c.Hello(h.smtp.HelloName); err != nil {
+			return fmt.Errorf("SMTP EHLO error: %w", err)
+		}
+	}
 
 	if h.smtp.TLSRequired {
 		if err := c.StartTLS(&tls.Config{ServerName: host}); err != nil {

--- a/pkg/mailer/mailer.go
+++ b/pkg/mailer/mailer.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"net/smtp"
+	"os"
 	"time"
 
 	"github.com/jhillyerd/enmime"
@@ -320,10 +321,15 @@ func (h *sendingHandler) sendMail(ctx context.Context, to []string, msg []byte) 
 
 	defer func() { _ = c.Quit() }()
 
-	if h.smtp.HelloName != "" {
-		if err := c.Hello(h.smtp.HelloName); err != nil {
-			return fmt.Errorf("SMTP EHLO error: %w", err)
+	helloName := h.smtp.HelloName
+	if helloName == "" {
+		if helloName, err = os.Hostname(); err != nil {
+			helloName = "localhost"
 		}
+	}
+
+	if err := c.Hello(helloName); err != nil {
+		return fmt.Errorf("SMTP EHLO error: %w", err)
 	}
 
 	if h.smtp.TLSRequired {

--- a/pkg/probod/probod.go
+++ b/pkg/probod/probod.go
@@ -654,6 +654,7 @@ func (impl *Implm) Run(
 			User:        impl.cfg.Notifications.Mailer.SMTP.User,
 			Password:    impl.cfg.Notifications.Mailer.SMTP.Password,
 			TLSRequired: impl.cfg.Notifications.Mailer.SMTP.TLSRequired,
+			HelloName:   impl.cfg.Notifications.Mailer.SMTP.HelloName,
 		},
 		l.Named("sending-worker"),
 		[]mailer.SendingWorkerOption{

--- a/pkg/probodconfig/mailer_config.go
+++ b/pkg/probodconfig/mailer_config.go
@@ -26,4 +26,5 @@ type SMTPConfig struct {
 	User        string `json:"user"`
 	Password    string `json:"password"`
 	TLSRequired bool   `json:"tls-required"`
+	HelloName   string `json:"hello-name"`
 }


### PR DESCRIPTION
## Summary

- Adds a new optional `SMTP_HELLO_NAME` config field that operators can set to control the EHLO/HELO identity sent to the SMTP relay.
- When set, `c.Hello(helloName)` is called before `StartTLS`/auth, satisfying strict relay policies (e.g. Google Workspace `smtp-relay.gmail.com` rejects `localhost`).
- When unset, behavior is unchanged (Go's default `localhost` identity is used).

Fixes #1284.

## Changes

- `pkg/probodconfig/mailer_config.go` -- `HelloName` field on `SMTPConfig`
- `pkg/mailer/mailer.go` -- `HelloName` field on `mailer.SMTPConfig`; `c.Hello()` call in `sendMail`
- `pkg/bootstrap/builder.go` -- maps `SMTP_HELLO_NAME` env var
- `pkg/probod/probod.go` -- passes `HelloName` through to the mailer worker
- `pkg/bootstrap/builder_test.go` -- asserts the field defaults to empty
- `contrib/helm/charts/probo/values.yaml` -- `helloName: ""` under `probo.mailer.smtp`
- `contrib/helm/charts/probo/templates/deployment.yaml` -- conditional `SMTP_HELLO_NAME` env var
- `contrib/helm/charts/probo/values-production.yaml.example` -- documents the field with a commented example

## Test plan

- [ ] Bootstrap test passes (`go test ./pkg/bootstrap/`)
- [ ] Mailer package compiles and vets cleanly (`go vet ./pkg/mailer/`)
- [ ] Deploy against `smtp-relay.gmail.com:587` with `SMTP_HELLO_NAME=mail.example.com` and confirm emails are delivered without TLS/EHLO rejection
- [ ] Verify existing deployments without `SMTP_HELLO_NAME` set continue to work unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional `SMTP_HELLO_NAME` to control the EHLO/HELO identity and always send it before TLS/auth to satisfy strict relays like Google Workspace. When unset, the mailer uses `os.Hostname()` and falls back to `localhost`. Fixes #1284.

### Service **`+16`** **`-0`**
- Added `HelloName` to SMTP config and wired through `builder`, `probod`, and `mailer`.
- Mailer calls `c.Hello()` with `SMTP_HELLO_NAME` or `os.Hostname()` (fallback `localhost`) before `StartTLS`.

### Tests **`+1`** **`-0`**
- Asserted default `HelloName` is empty in bootstrap config.

### Other **`+9`** **`-0`**
- Helm: added `helloName` to values, docs, and conditional `SMTP_HELLO_NAME` env in deployment.

<sup>Written for commit 320a86670dbf067abf8002d4e3b8ea9237dc5377. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

