### PR TITLE
Highlight magic link expiry

### DIFF
--- a/apps/trust/src/pages/auth/MagicLinkExpiredPage.tsx
+++ b/apps/trust/src/pages/auth/MagicLinkExpiredPage.tsx
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+import { usePageTitle } from "@probo/hooks";
+import { useTranslate } from "@probo/i18n";
+import { Button } from "@probo/ui";
+import { useNavigate } from "react-router";
+
+export default function MagicLinkExpiredPage() {
+  const { __ } = useTranslate();
+  const navigate = useNavigate();
+
+  usePageTitle(__("Link Expired"));
+
+  return (
+    <div className="space-y-6 w-full max-w-md mx-auto pt-8">
+      <div className="space-y-2 text-center">
+        <h1 className="text-3xl font-bold">{__("Link Expired")}</h1>
+        <p className="text-txt-tertiary">
+          {__(
+            "This magic link has expired. Magic links are only valid for 15 minutes. Please request a new one.",
+          )}
+        </p>
+      </div>
+      <div className="flex justify-center">
+        <Button
+          className="w-xs h-10"
+          onClick={() => void navigate("/connect")}
+        >
+          {__("Request a new link")}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/trust/src/pages/auth/VerifyMagicLinkPage.tsx
+++ b/apps/trust/src/pages/auth/VerifyMagicLinkPage.tsx
@@ -18,7 +18,7 @@ import { useTranslate } from "@probo/i18n";
 import { useToast } from "@probo/ui";
 import { useCallback, useEffect, useRef } from "react";
 import { useMutation } from "react-relay";
-import { Link, useSearchParams } from "react-router";
+import { Link, useNavigate, useSearchParams } from "react-router";
 import { graphql } from "relay-runtime";
 
 import { getPathPrefix } from "#/utils/pathPrefix";
@@ -36,6 +36,7 @@ const verifyMagicLinkMutation = graphql`
 export default function VerifyMagicLinkPagePageMutation() {
   const { __ } = useTranslate();
   const { toast } = useToast();
+  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const submittedRef = useRef<boolean>(false);
 
@@ -59,17 +60,16 @@ export default function VerifyMagicLinkPagePageMutation() {
               window.location.href = window.location.origin + getPathPrefix();
               return;
             }
-          }
 
-          const hasExpiredToken = errors.some(
-            err => err.message === "token has expired",
-          );
+            if (err.extensions?.code === "TOKEN_EXPIRED") {
+              void navigate("/magic-link-expired");
+              return;
+            }
+          }
 
           toast({
             title: __("Error"),
-            description: hasExpiredToken
-              ? __("This magic link has expired. Please request a new one.")
-              : formatError(__("Failed to connect"), errors),
+            description: formatError(__("Failed to connect"), errors),
             variant: "error",
           });
           return;
@@ -102,7 +102,7 @@ export default function VerifyMagicLinkPagePageMutation() {
         });
       },
     });
-  }, [__, toast, verifyMagicLink]);
+  }, [__, navigate, toast, verifyMagicLink]);
 
   useEffect(() => {
     const token = searchParams.get("token");

--- a/apps/trust/src/routes.tsx
+++ b/apps/trust/src/routes.tsx
@@ -54,6 +54,10 @@ const routes = [
         Component: lazy(() => import("#/pages/auth/VerifyMagicLinkPage")),
       },
       {
+        path: "/magic-link-expired",
+        Component: lazy(() => import("#/pages/auth/MagicLinkExpiredPage")),
+      },
+      {
         path: "/full-name",
         Component: lazy(() => import("#/pages/auth/FullNamePage")),
       },

--- a/packages/emails/src/MagicLink.tsx
+++ b/packages/emails/src/MagicLink.tsx
@@ -18,7 +18,6 @@ import EmailLayout, {
   bodyText,
   button,
   buttonContainer,
-  footerText,
 } from "./components/EmailLayout";
 
 export const MagicLink = () => {
@@ -32,11 +31,29 @@ export const MagicLink = () => {
         </Button>
       </Section>
 
-      <Text style={footerText}>
-        This link will expire in {"{{.DurationInMinutes}}"} minutes.
-      </Text>
+      <Section style={expiryBox}>
+        <Text style={expiryText}>
+          {"⚠️ This link expires in {{.DurationInMinutes}} minutes. Use it promptly after receiving this email."}
+        </Text>
+      </Section>
     </EmailLayout>
   );
+};
+
+const expiryBox: React.CSSProperties = {
+  backgroundColor: "#fff8e1",
+  border: "1px solid #f9a825",
+  borderRadius: "6px",
+  padding: "12px 16px",
+  marginTop: "8px",
+};
+
+const expiryText: React.CSSProperties = {
+  margin: "0",
+  color: "#7a5900",
+  fontSize: "14px",
+  fontWeight: "600",
+  lineHeight: "20px",
 };
 
 export default MagicLink;

--- a/packages/emails/templates/magic-link.txt
+++ b/packages/emails/templates/magic-link.txt
@@ -6,7 +6,7 @@ Please use this link to connect to {{.OrganizationName}}'s Compliance Page:
 
 {{.MagicLinkURL}}
 
-This link will expire in {{.DurationInMinutes}} minutes.
+IMPORTANT: This link expires in {{.DurationInMinutes}} minutes. Use it promptly after receiving this email.
 
 {{.SenderCompanyHeadquarterAddress}}
 Powered By Prob

--- a/pkg/server/api/trust/v1/auth_resolvers.go
+++ b/pkg/server/api/trust/v1/auth_resolvers.go
@@ -59,7 +59,7 @@ func (r *mutationResolver) VerifyMagicLink(ctx context.Context, input types.Veri
 	email, err := r.iam.AuthService.GetMagicLinkEmail(ctx, input.Token)
 	if err != nil {
 		if _, ok := errors.AsType[*iam.ErrExpiredToken](err); ok {
-			return nil, gqlutils.Invalid(ctx, err)
+			return nil, gqlutils.TokenExpired(ctx, err)
 		}
 
 		if _, ok := errors.AsType[*iam.ErrInvalidToken](err); ok {
@@ -80,7 +80,7 @@ func (r *mutationResolver) VerifyMagicLink(ctx context.Context, input types.Veri
 		identity, session, continueURL, err = r.iam.AuthService.OpenSessionWithMagicLink(ctx, input.Token)
 		if err != nil {
 			if _, ok := errors.AsType[*iam.ErrExpiredToken](err); ok {
-				return nil, gqlutils.Invalid(ctx, err)
+				return nil, gqlutils.TokenExpired(ctx, err)
 			}
 
 			if _, ok := errors.AsType[*iam.ErrInvalidToken](err); ok {
@@ -102,7 +102,7 @@ func (r *mutationResolver) VerifyMagicLink(ctx context.Context, input types.Veri
 		identity, session, continueURL, err = r.iam.AuthService.OpenSessionWithMagicLink(ctx, input.Token)
 		if err != nil {
 			if _, ok := errors.AsType[*iam.ErrExpiredToken](err); ok {
-				return nil, gqlutils.Invalid(ctx, err)
+				return nil, gqlutils.TokenExpired(ctx, err)
 			}
 
 			if _, ok := errors.AsType[*iam.ErrInvalidToken](err); ok {

--- a/pkg/server/gqlutils/errors.go
+++ b/pkg/server/gqlutils/errors.go
@@ -142,6 +142,14 @@ func Conflictf(ctx context.Context, format string, a ...any) *gqlerror.Error {
 	return Conflict(ctx, fmt.Errorf(format, a...))
 }
 
+func TokenExpired(ctx context.Context, err error) *gqlerror.Error {
+	return &gqlerror.Error{
+		Message:    err.Error(),
+		Path:       graphql.GetPath(ctx),
+		Extensions: map[string]any{"code": "TOKEN_EXPIRED"},
+	}
+}
+
 func Invalid(ctx context.Context, err error) *gqlerror.Error {
 	var details map[string]any
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make magic link expiry clear and add a dedicated flow for expired links. Emails now show a prominent warning, and expired tokens redirect users to an in-app page with a clear CTA.

### GraphQL API **`+11`** **`-3`**
- Add `gqlutils.TokenExpired` to return GraphQL errors with code TOKEN_EXPIRED.
- Update `VerifyMagicLink` resolver to use TOKEN_EXPIRED for expired tokens.

### App: trust **`+59`** **`-9`**
- Add `/magic-link-expired` page with a clear message and “Request a new link” button.
- Redirect to this page when verification returns TOKEN_EXPIRED; register the route.

### Package: `emails` **`+22`** **`-5`**
- Replace small footer note with a yellow callout in the HTML email highlighting expiry.
- Update plain-text email to start with “IMPORTANT” and emphasize prompt use.

<sup>Written for commit 1d36123ead699f89ac769c0740518c9f6c1d1442. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

