### PR TITLE
Allow auditors to read the organization context

### DIFF
--- a/pkg/probo/policies.go
+++ b/pkg/probo/policies.go
@@ -133,6 +133,8 @@ var AuditorPolicy = policy.NewPolicy(
 		ActionOrganizationGetHorizontalLogoUrl,
 	).WithSID("org-read-access").When(organizationCondition),
 
+	policy.Allow(ActionOrganizationContextGet).WithSID("organization-context-read").When(organizationCondition),
+
 	policy.Allow(
 		ActionThirdPartyGet, ActionThirdPartyList,
 		ActionThirdPartyContactGet, ActionThirdPartyContactList,

--- a/pkg/probo/policies_test.go
+++ b/pkg/probo/policies_test.go
@@ -73,3 +73,30 @@ func TestAuditorPolicy_ProcessingActivityPageReadAccess(t *testing.T) {
 		})
 	}
 }
+
+func TestAuditorPolicy_OrganizationContextReadAccess(t *testing.T) {
+	t.Parallel()
+
+	organizationID := gid.New(gid.NewTenantID(), 1)
+	evaluator := policy.NewEvaluator()
+	conditionContext := policy.ConditionContext{
+		Principal: map[string]string{
+			"organization_id": organizationID.String(),
+		},
+		Resource: map[string]string{
+			"organization_id": organizationID.String(),
+		},
+	}
+
+	result := evaluator.Evaluate(
+		policy.AuthorizationRequest{
+			Principal:        organizationID,
+			Resource:         organizationID,
+			Action:           probo.ActionOrganizationContextGet,
+			ConditionContext: conditionContext,
+		},
+		[]*policy.Policy{probo.AuditorPolicy},
+	)
+
+	assert.True(t, result.IsAllowed())
+}


### PR DESCRIPTION
[ENG-468](https://linear.app/probo/issue/ENG-468/context-is-not-visible-to-auditors-in-the-console)

Auditors could not see the Context page in the console because AuditorPolicy was missing core:organization-context:get. Grant the read action (mirroring ViewerPolicy) so the sidebar item appears and the context resolver succeeds for auditors.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows auditors to read the organization context so the Console Context page appears and loads. Addresses ENG-468 by granting read permission in `AuditorPolicy` and adding a test.

### Tests **`+27`** **`-0`**
- Added `TestAuditorPolicy_OrganizationContextReadAccess` to assert `ActionOrganizationContextGet` is allowed for the same organization via `policy.Evaluator`.

### Service **`+2`** **`-0`**
- Granted `ActionOrganizationContextGet` in `AuditorPolicy` (SID `organization-context-read`), scoped by `organizationCondition`.

<sup>Written for commit 400800fd4153fb7247d1e3b94ff6c9563a02df9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



