### PR TITLE
Fix files upload to set organization ID

### DIFF
--- a/pkg/coredata/migrations/20260608T135336Z.sql
+++ b/pkg/coredata/migrations/20260608T135336Z.sql
@@ -1,0 +1,51 @@
+-- Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+--
+-- Permission to use, copy, modify, and/or distribute this software for any
+-- purpose with or without fee is hereby granted, provided that the above
+-- copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+-- REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+-- INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+-- LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+-- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+-- Backfill organization_id on logo files that were inserted with the nil GID.
+-- Before the fix in CreateOrganization/UpdateOrganization, the OrganizationID
+-- field was omitted from the File struct, causing the nil GID
+-- (AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA) to be stored instead of the actual org ID.
+
+UPDATE files
+SET organization_id = o.id
+FROM organizations o
+WHERE files.organization_id = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+  AND (
+    files.id = o.logo_file_id
+    OR files.id = o.horizontal_logo_file_id
+  );
+
+UPDATE files
+SET organization_id = tc.organization_id
+FROM trust_centers tc
+WHERE files.organization_id = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+  AND (
+    files.id = tc.logo_file_id
+    OR files.id = tc.dark_logo_file_id
+  );
+
+UPDATE files
+SET organization_id = tcr.organization_id
+FROM trust_center_references tcr
+WHERE files.organization_id = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+  AND files.id = tcr.logo_file_id;
+
+UPDATE files
+SET organization_id = f.organization_id
+FROM frameworks f
+WHERE files.organization_id = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+  AND (
+    files.id = f.light_logo_file_id
+    OR files.id = f.dark_logo_file_id
+  );

--- a/pkg/coredata/migrations/20260608T140141Z.sql
+++ b/pkg/coredata/migrations/20260608T140141Z.sql
@@ -1,0 +1,23 @@
+-- Copyright (c) 2026 Probo Inc <hello@getprobo.com>.
+--
+-- Permission to use, copy, modify, and/or distribute this software for any
+-- purpose with or without fee is hereby granted, provided that the above
+-- copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+-- REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+-- INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+-- LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+-- OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+-- Backfill organization_id on NDA files that were inserted with the nil GID.
+-- Before the fix in TrustCenterService.UploadNDA, the OrganizationID field
+-- was omitted from the File struct.
+
+UPDATE files
+SET organization_id = tc.organization_id
+FROM trust_centers tc
+WHERE files.organization_id = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+  AND files.id = tc.non_disclosure_agreement_file_id;

--- a/pkg/iam/organization_service.go
+++ b/pkg/iam/organization_service.go
@@ -630,15 +630,16 @@ func (s *OrganizationService) CreateOrganization(
 		)
 
 		logoFile = &coredata.File{
-			ID:         fileID,
-			BucketName: s.bucket,
-			MimeType:   contentType,
-			FileName:   filename,
-			FileKey:    objectKey.String(),
-			FileSize:   req.LogoFile.Size,
-			Visibility: coredata.FileVisibilityPublic,
-			CreatedAt:  now,
-			UpdatedAt:  now,
+			ID:             fileID,
+			OrganizationID: organization.ID,
+			BucketName:     s.bucket,
+			MimeType:       contentType,
+			FileName:       filename,
+			FileKey:        objectKey.String(),
+			FileSize:       req.LogoFile.Size,
+			Visibility:     coredata.FileVisibilityPublic,
+			CreatedAt:      now,
+			UpdatedAt:      now,
 		}
 
 		fileSize, err := s.fm.PutFile(
@@ -667,15 +668,16 @@ func (s *OrganizationService) CreateOrganization(
 		)
 
 		horizontalLogoFile = &coredata.File{
-			ID:         fileID,
-			BucketName: s.bucket,
-			MimeType:   contentType,
-			FileName:   filename,
-			FileKey:    objectKey.String(),
-			FileSize:   req.HorizontalLogoFile.Size,
-			Visibility: coredata.FileVisibilityPublic,
-			CreatedAt:  now,
-			UpdatedAt:  now,
+			ID:             fileID,
+			OrganizationID: organization.ID,
+			BucketName:     s.bucket,
+			MimeType:       contentType,
+			FileName:       filename,
+			FileKey:        objectKey.String(),
+			FileSize:       req.HorizontalLogoFile.Size,
+			Visibility:     coredata.FileVisibilityPublic,
+			CreatedAt:      now,
+			UpdatedAt:      now,
 		}
 
 		fileSize, err := s.fm.PutFile(
@@ -809,15 +811,16 @@ func (s *OrganizationService) UpdateOrganization(ctx context.Context, organizati
 		)
 
 		logoFile = &coredata.File{
-			ID:         fileID,
-			BucketName: s.bucket,
-			MimeType:   contentType,
-			FileName:   filename,
-			FileKey:    objectKey.String(),
-			FileSize:   (*req.LogoFile).Size,
-			Visibility: coredata.FileVisibilityPublic,
-			CreatedAt:  now,
-			UpdatedAt:  now,
+			ID:             fileID,
+			OrganizationID: organizationID,
+			BucketName:     s.bucket,
+			MimeType:       contentType,
+			FileName:       filename,
+			FileKey:        objectKey.String(),
+			FileSize:       (*req.LogoFile).Size,
+			Visibility:     coredata.FileVisibilityPublic,
+			CreatedAt:      now,
+			UpdatedAt:      now,
 		}
 
 		fileSize, err := s.fm.PutFile(
@@ -846,15 +849,16 @@ func (s *OrganizationService) UpdateOrganization(ctx context.Context, organizati
 		)
 
 		horizontalLogoFile = &coredata.File{
-			ID:         fileID,
-			BucketName: s.bucket,
-			MimeType:   contentType,
-			FileName:   filename,
-			FileKey:    objectKey.String(),
-			FileSize:   (*req.HorizontalLogoFile).Size,
-			Visibility: coredata.FileVisibilityPublic,
-			CreatedAt:  now,
-			UpdatedAt:  now,
+			ID:             fileID,
+			OrganizationID: organizationID,
+			BucketName:     s.bucket,
+			MimeType:       contentType,
+			FileName:       filename,
+			FileKey:        objectKey.String(),
+			FileSize:       (*req.HorizontalLogoFile).Size,
+			Visibility:     coredata.FileVisibilityPublic,
+			CreatedAt:      now,
+			UpdatedAt:      now,
 		}
 
 		fileSize, err := s.fm.PutFile(

--- a/pkg/probo/framework_service.go
+++ b/pkg/probo/framework_service.go
@@ -565,14 +565,15 @@ func (s FrameworkService) Import(
 				contentType := "image/svg+xml"
 
 				fileRecord := &coredata.File{
-					ID:         fileID,
-					BucketName: s.svc.bucket,
-					MimeType:   contentType,
-					FileName:   filename,
-					FileKey:    objectKey.String(),
-					Visibility: coredata.FileVisibilityPublic,
-					CreatedAt:  now,
-					UpdatedAt:  now,
+					ID:             fileID,
+					OrganizationID: organization.ID,
+					BucketName:     s.svc.bucket,
+					MimeType:       contentType,
+					FileName:       filename,
+					FileKey:        objectKey.String(),
+					Visibility:     coredata.FileVisibilityPublic,
+					CreatedAt:      now,
+					UpdatedAt:      now,
 				}
 
 				fileSize, err := s.svc.fileManager.PutFile(ctx, fileRecord, strings.NewReader(logo), map[string]string{

--- a/pkg/probo/organization_service.go
+++ b/pkg/probo/organization_service.go
@@ -305,14 +305,15 @@ func (s OrganizationService) Update(
 				}
 
 				fileRecord := &coredata.File{
-					ID:         fileID,
-					BucketName: s.svc.bucket,
-					MimeType:   contentType,
-					FileName:   filename,
-					FileKey:    objectKey.String(),
-					Visibility: coredata.FileVisibilityPublic,
-					CreatedAt:  now,
-					UpdatedAt:  now,
+					ID:             fileID,
+					OrganizationID: organization.ID,
+					BucketName:     s.svc.bucket,
+					MimeType:       contentType,
+					FileName:       filename,
+					FileKey:        objectKey.String(),
+					Visibility:     coredata.FileVisibilityPublic,
+					CreatedAt:      now,
+					UpdatedAt:      now,
 				}
 
 				fileSize, err = s.svc.fileManager.PutFile(
@@ -368,14 +369,15 @@ func (s OrganizationService) Update(
 				}
 
 				fileRecord := &coredata.File{
-					ID:         fileID,
-					BucketName: s.svc.bucket,
-					MimeType:   contentType,
-					FileName:   filename,
-					FileKey:    objectKey.String(),
-					Visibility: coredata.FileVisibilityPublic,
-					CreatedAt:  now,
-					UpdatedAt:  now,
+					ID:             fileID,
+					OrganizationID: organization.ID,
+					BucketName:     s.svc.bucket,
+					MimeType:       contentType,
+					FileName:       filename,
+					FileKey:        objectKey.String(),
+					Visibility:     coredata.FileVisibilityPublic,
+					CreatedAt:      now,
+					UpdatedAt:      now,
 				}
 
 				fileSize, err = s.svc.fileManager.PutFile(

--- a/pkg/probo/trust_center_reference_service.go
+++ b/pkg/probo/trust_center_reference_service.go
@@ -391,15 +391,16 @@ func (s TrustCenterReferenceService) uploadLogoFile(
 	}
 
 	fileRecord := &coredata.File{
-		ID:         fileID,
-		BucketName: s.svc.bucket,
-		MimeType:   contentType,
-		FileName:   filename,
-		FileKey:    objectKey.String(),
-		FileSize:   fileSize,
-		Visibility: coredata.FileVisibilityPublic,
-		CreatedAt:  now,
-		UpdatedAt:  now,
+		ID:             fileID,
+		OrganizationID: trustCenter.OrganizationID,
+		BucketName:     s.svc.bucket,
+		MimeType:       contentType,
+		FileName:       filename,
+		FileKey:        objectKey.String(),
+		FileSize:       fileSize,
+		Visibility:     coredata.FileVisibilityPublic,
+		CreatedAt:      now,
+		UpdatedAt:      now,
 	}
 
 	if err := fileRecord.Insert(ctx, tx, scope); err != nil {

--- a/pkg/probo/trust_center_service.go
+++ b/pkg/probo/trust_center_service.go
@@ -264,15 +264,16 @@ func (s TrustCenterService) UploadNDA(
 			fileID := gid.New(scope.GetTenantID(), coredata.FileEntityType)
 
 			file = &coredata.File{
-				ID:         fileID,
-				BucketName: s.svc.bucket,
-				MimeType:   mimeType,
-				FileName:   req.FileName,
-				FileKey:    objectKey.String(),
-				FileSize:   *headOutput.ContentLength,
-				Visibility: coredata.FileVisibilityPrivate,
-				CreatedAt:  now,
-				UpdatedAt:  now,
+				ID:             fileID,
+				OrganizationID: trustCenter.OrganizationID,
+				BucketName:     s.svc.bucket,
+				MimeType:       mimeType,
+				FileName:       req.FileName,
+				FileKey:        objectKey.String(),
+				FileSize:       *headOutput.ContentLength,
+				Visibility:     coredata.FileVisibilityPrivate,
+				CreatedAt:      now,
+				UpdatedAt:      now,
 			}
 
 			if err := file.Insert(ctx, conn, scope); err != nil {


### PR DESCRIPTION
## Fix missing `organization_id` on logo and NDA file records

### Problem

When creating `File` records for organization logos, trust center logos, framework logos, trust center reference logos, and NDA documents, the `OrganizationID` field was omitted from the struct literal. This caused the nil GID (`AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA`) to be persisted in the `organization_id` column instead of the actual organization ID, breaking authorization attribute lookups on those files.

### What changed

**Code fixes** — `OrganizationID` added to `File` struct literals in six locations:

| File | Field |
|------|-------|
| `pkg/iam/organization_service.go` | org logo + horizontal logo (create & update) |
| `pkg/probo/organization_service.go` | org logo + horizontal logo |
| `pkg/probo/trust_center_reference_service.go` | reference logo |
| `pkg/probo/framework_service.go` | framework light + dark logo |
| `pkg/probo/trust_center_service.go` | NDA document |

**Backfill migrations** — two migrations restore existing rows:

- `20260608T135336Z.sql` — backfills files referenced by `organizations`, `trust_centers`, `trust_center_references`, and `frameworks` logo columns
- `20260608T140141Z.sql` — backfills files referenced by `trust_centers.non_disclosure_agreement_file_id`

The condition `organization_id = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'` (the nil GID) ensures only affected rows are touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing `organization_id` on uploaded logo and NDA files so authorization checks work. Also fixes partial logo updates during org edits and backfills rows saved with the nil GID.

### Coredata **`+74`** **`-0`**
- Backfill `organization_id` for logo files referenced by `organizations`, `trust_centers`, `trust_center_references`, and `frameworks`.
- Backfill NDA files in `trust_centers`. Only updates rows with the nil GID (`AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA`).

### Service **`+87`** **`-78`**
- Set `OrganizationID` when creating/updating org logos in `pkg/iam/organization_service.go`; fix partial logo updates.
- Set `OrganizationID` for org logos in `pkg/probo/organization_service.go`.
- Set `OrganizationID` for framework light/dark logos in `pkg/probo/framework_service.go`.
- Set `OrganizationID` for trust center reference logos in `pkg/probo/trust_center_reference_service.go`.
- Set `OrganizationID` for NDA uploads in `pkg/probo/trust_center_service.go`.

<sup>Written for commit 89ee20284541340aaa889d39282eb1668eed747f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/getprobo/probo/pull/1312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

